### PR TITLE
CHAOS-3144: convert the coordinator grant surface to an advisory report

### DIFF
--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -669,9 +669,40 @@ is false today.
 `rolePostureQuery` asserts `count(required_tables) = count(required_table_privileges)`
 with **no leniency** (`domain_authorization.go:194`), and `required_tables` JOINs
 `pg_class`. The GRANT side is `to_regclass`-guarded and skips a missing table silently.
-So a posture row for a table the test database does not create makes the readiness check
-fail while the grant reports success. Adding a new table to either posture therefore
-requires a matching `CREATE TABLE` in **two** places — `startGrantHarness`
-(`internal/storage/postgres/domain_grant_reconciliation_integration_test.go:209`, shared
-by all 22 in-package grant tests) and `cmd/dev-health-workerctl/main_integration_test.go`,
-which builds its own.
+So a posture row for a table the test database does not create makes the readiness
+check fail while the grant reports success.
+
+**Adding a table to either posture requires a matching `CREATE TABLE` in THREE
+places.** An earlier revision of this section said two; that was wrong, and the
+correction matters because the third is the coordinator-exclusive one:
+
+1. `reconciliationTables()` **or** the inline DDL block in `startGrantHarness`
+   (`domain_grant_reconciliation_integration_test.go`) — the domain/shared tables.
+2. `coordinatorExclusiveDDL()`
+   (`coordinator_statement_privileges_integration_test.go`) — coordinator-exclusive
+   tables. **This is the one the earlier count missed**, by grepping literal
+   `CREATE TABLE public.` in a single file.
+3. `cmd/dev-health-workerctl/main_integration_test.go`, which builds its own harness.
+
+Across sources 1 and 2 the harness creates **42 distinct relations**.
+
+#### And a fourth place that needs no edit, which is the more interesting gap
+
+`role_posture_integration_test.go` does **not** use `startGrantHarness` at all. Its
+four tests each start their own container and create their own roles with synthetic
+names. Three of them use synthetic postures and are unaffected by a real posture
+row. The fourth,
+`TestDomainAndCoordinatorPosturesSatisfyAttributionAgainstTheRealManifest`, builds
+its table set as the **union of both real postures**, so a new posture row is picked
+up automatically with a generic column shape and needs no edit.
+
+That auto-adaptation is worth understanding rather than trusting: it derives grants
+through a local `grantStatementsForPosture()` helper, **not** through
+`runtimeGrantStatements` or the real migration path. So it cannot notice a grant the
+real migration fails to issue — it proves the posture is self-consistent, not that
+the migration provisions it.
+
+The shape to recognise: **coverage that exists somewhere, asserted as coverage
+everywhere.** A posture row is exercised against the real migration path only via
+sources 1–3; the test that adapts automatically is the one testing something else.
+That is the same failure family that made the coordinator checker advisory.

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -207,6 +207,18 @@ hand, not grant blind.
 
 ## Privilege-implication rule: locking clauses need no write statement
 
+> **This section was right, and the checker disagreed with it for a while.** The
+> rule below (verified on Postgres 16) says a role holding only `SELECT`+`INSERT`
+> is denied a `SHARE ROW EXCLUSIVE` lock. `internal/domaingrants` nonetheless
+> modelled every mode above `ACCESS SHARE` as "any one of INSERT/UPDATE/DELETE",
+> and a test later asserted that as correct — contradicting this document. Both are
+> now fixed and re-measured on Postgres 18.4, which **agrees** with the rule below
+> and additionally pins `ROW SHARE`/`ROW EXCLUSIVE`, which this section does not
+> cover. See "LOCK TABLE privilege requirements are MODE-dependent" for the full
+> measured table. Lesson: when the analyzer and this manifest disagree, the
+> manifest was derived from measurement and the analyzer may be carrying a
+> documented-but-unmodelled approximation.
+
 A DML-verb grep (`INSERT|UPDATE|DELETE`) undercounts required privileges.
 Two Postgres locking constructs imply write-level grants with no write verb
 anywhere in the reaching Go statement — both verified empirically against a
@@ -416,14 +428,145 @@ turns out no coordinator path touches them, that is a posture *over*-declaration
 separate finding — route it to the posture lane rather than tightening it here, since a
 wrong tightening fails closed in production.
 
+### LOCK TABLE privilege requirements are MODE-dependent (measured, not documented)
+
+The first version of this gate modelled `LOCK TABLE` as "any one of
+INSERT/UPDATE/DELETE" for every mode above `ACCESS SHARE`, and a test asserted that
+INSERT alone satisfies a `SHARE ROW EXCLUSIVE` lock. **Both were wrong**, and the
+test was the worse half: the pre-existing analyzer had *documented* this
+imprecision as a known gap, and the test converted it into an authoritative rule.
+
+Measured against PostgreSQL 18.4, one grant set per candidate privilege, one query
+per mode, **with the controls that isolate each denial to the lock clause** — an
+empty transaction, and the identical read with only the lock removed. Without those
+controls a `DENIED` result is a denial plus a guess about its cause.
+
+| statement | SELECT | +INSERT | +UPDATE | +DELETE |
+|---|---|---|---|---|
+| C1 empty transaction (control) | ok | ok | ok | ok |
+| C2 read, **no lock** (control) | ok | ok | ok | ok |
+| `ACCESS SHARE` | ok | ok | ok | ok |
+| `ROW SHARE` | DENIED | ok | ok | ok |
+| `ROW EXCLUSIVE` | DENIED | ok | ok | ok |
+| `SHARE UPDATE EXCLUSIVE` | DENIED | DENIED | ok | ok |
+| `SHARE` | DENIED | DENIED | ok | ok |
+| `SHARE ROW EXCLUSIVE` | DENIED | DENIED | ok | ok |
+| `EXCLUSIVE` | DENIED | DENIED | ok | ok |
+| `ACCESS EXCLUSIVE` | DENIED | DENIED | ok | ok |
+
+Three tiers, not two. **INSERT satisfies `ROW SHARE` and `ROW EXCLUSIVE` and
+nothing stricter.** And `ROW SHARE` requires a write privilege even though the
+PostgreSQL `LOCK` documentation says it needs only SELECT — measured, so the table
+above wins over the docs.
+
+`LockRequirement` records the demand as a **disjunction** (any one of a
+mode-specific set) rather than a `PrivilegeSet` entry, because every `PrivilegeSet`
+member is an independent requirement and folding UPDATE in produced a real false
+positive on jobroute's SELECT+INSERT grant. Unrecognized modes fail **closed** at
+the strictest tier: both predecessors of this rule failed *open*.
+
+There are now four distinct rules in this area and none may be collapsed into
+another: `ACCESS SHARE` (SELECT), `ROW SHARE`/`ROW EXCLUSIVE` (any of I/U/D),
+stricter modes (U/D only), and `SELECT ... FOR UPDATE` (UPDATE specifically,
+handled as an ordinary privilege).
+
+**Generalisation worth carrying:** this was a privilege requirement attributed to
+the wrong clause of a compound statement. The same error shape appeared the same
+day in the reports lane — `INSERT ... ON CONFLICT DO NOTHING RETURNING x` needs
+SELECT because of the **`RETURNING`**, not the conflict arbiter. For any claim of
+the form "clause X implies privilege Y", split the clauses and measure each variant
+against a role holding exactly the privilege under test, with a control that
+removes only the suspect clause.
+
+### Attribution can be INVERTED by a parameter name, not just incomplete
+
+A pool-typed parameter is a seed root by **spelling** (`domainPool`,
+`coordinatorPool`), and spelling can contradict reality. `build(domainPool *pgxpool.Pool)`
+called only with the coordinator pool was seeded by the DOMAIN run from its name
+while the coordinator run's barrier discarded it — so downstream SQL looked
+domain-**exclusive**, and role-exclusive evidence is precisely what this gate
+escalates to CRITICAL. It would have directed the grant to the wrong role with
+confidence, and every "is it granted somewhere" check would still pass.
+
+`buildPoolParamRoles` fixes this: a role-agnostic pass records which roles are
+actually passed to each pool-typed parameter at its call sites, and **call-site
+evidence outranks the name**. Where no call site resolves, the name still applies —
+the convention is the only signal left, and suppressing it would trade a false
+attribution for a false absence. Every override is reported, because it means a
+naming convention lied and the reader should know that rather than assume the
+surface shrank.
+
+### Incompleteness GATES, and is per (table, privilege)
+
+Enumerating what was not verified is not enough — a printout nobody must act on is
+indistinguishable from having checked. Two changes:
+
+- **Pair granularity.** A table-level list hid the case that matters most: if
+  SELECT stays visible while an UPDATE path goes dark, the table is nonempty, so a
+  table-level list omits it and the exact `(table, UPDATE)` gap appears in *no*
+  output at all.
+- **Enforcement.** A posture privilege with no derived call site for its own role
+  must be acknowledged in `acknowledgedBlindSpots` with a reason, or the gate
+  fails; and a stale acknowledgement fails too, so the list cannot outlive the
+  blind spot.
+
+Three exclusions are legitimate and are recorded rather than silently applied:
+SELECT is *synthesized* onto every posture row by `loadPosture`, so its absence on
+a write-only table is a representation artifact; a privilege that satisfies a
+derived LOCK is justified by that lock even though a disjunction cannot be recorded
+as evidence; and third-party function-typed fields (`encoding/json`'s
+`scanner.step`, pgx's `QueuedQuery.Fn`) are filtered out because gating on them
+would be pure noise. Running the enforcement for the first time surfaced all three
+as bugs in the check itself.
+
+### Fail-closed must not become fail-SILENT
+
+A function-typed field with two implementations is correctly excluded from
+resolution — but the exclusion used to vanish from every output, because the
+`Unresolved` record's callee is the bare field name and the incompleteness filter
+dropped it along with third-party methods. Conflicts are now first-class
+(`FuncValueConflicts`), reported at the tainted call site, and gated. The filter
+also keeps bare callee names, which cannot be third-party by construction.
+
 ### Transaction-span veto
 
 A transaction cannot span two pools, so every table one touches must be authorized for
 the single role whose pool runs it. `transactionStraddleFindings` reports a group whose
-tables land on opposite sides of the partition, distinguishing a `txorigin:`-traced
-group (provably one transaction) from the coarse same-function-body fallback. This is
-the check that catches a straddle before it becomes a runtime 42501 rather than
-presenting as a routing problem.
+tables land on opposite sides of the partition.
+
+It is **blocking only when both premises are proven**: that the statements really share
+one transaction (a `txorigin:`-traced group, not the coarse same-function-body fallback
+this package's own comment calls unproven), and that the transaction really runs on that
+role's pool (at least one evidence site the other role does not also have). Either
+premise missing downgrades it to advisory — emitting CRITICAL on a guess would tell
+maintainers to dual-grant, which is the same over-widening the per-privilege path
+already refuses.
+
+The lock path routes through that identical downgrade, via one shared `exclusiveTo`
+helper rather than a copy: a copy is how one path ends up still accepting what the
+other rejects.
+
+### Reachability is static wiring, not runtime activation (decision)
+
+The derivation walks every function that is *wired*, including code behind a
+checked-in activation flag that is currently false — `cmd/dev-health-scheduler`'s
+`activation.goOwnsMarkers` gate returns before opening any PostgreSQL client, yet the
+scheduler's coordinator tables are still derived and still demanded. Deliberate:
+
+- Grants ready **before** activation are the point of this epic. Runtime-reachability
+  derivation would read "green, nothing needed" until someone flips the flag, then
+  produce a pile of CRITICALs at the worst moment.
+- Coverage must not depend on configuration, or the gate's strength varies with a
+  boolean and a flag flip silently changes what CI verifies.
+- The error direction is survivable: deriving dormant code can only ever ask for
+  privileges that code will need once active, so the failure mode is an over-grant —
+  a visible, reviewable row — rather than an outage.
+
+Residual risk, stated rather than hidden: a seam that is wired but never activated
+accretes grants permanently, and nothing here distinguishes "not yet" from
+"abandoned". Mitigated by review pressure (such rows surface in the misattribution and
+no-derived-evidence advisories), not by changing the reachability model. If a seam is
+dead, delete the wiring — that is the signal this analyzer reads.
 
 ### Known-open findings carry a ticket and expire
 

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -323,7 +323,31 @@ future role-attribution extension and grants-finisher2's posture manifest
 must both reference — coordinate before either side hard-codes it
 independently.
 
-## The coordinator grant surface is now DERIVED and gated (CHAOS-3033)
+## The coordinator grant surface is DERIVED and ADVISORY (CHAOS-3033)
+
+> **This is a report, not a gate, and that is deliberate.** The coordinator check
+> prints its findings and fails on nothing.
+> `TestDomainGrantSurfaceMatchesQuerySurface` continues to gate the domain role
+> exactly as before. **A passing coordinator run is not evidence that
+> `CoordinatorPosture()` is correct.**
+>
+> Why: three adversarial review rounds each found new places where *the analysis
+> cannot see something and the check passes anyway* — unresolved callees,
+> unresolved interface dispatch, function-valued fields with no single target,
+> dynamic SQL, unparsed statements, non-convergence, unrecognised lock forms,
+> quoted identifiers. Each was fixed where it was found and reappeared elsewhere.
+> That is one defect with many addresses, discovered one review at a time.
+>
+> An advisory tool that is sometimes wrong is useful: it puts derived evidence in
+> front of a reviewer who can weigh it. A **gate** that passes when the analysis is
+> blind is worse than no gate, because it *licenses* the hand-written rows it was
+> built to check — which is how this epic produced green tickets over dormant code
+> in the first place.
+>
+> **Promoting it to a gate requires the blind-spot closure argument**: a partition
+> of everything the analysis can fail to see, with each cell either failing the
+> check or documented as safe to accept **per site** (not per file), and a test per
+> cell demonstrating the failure. Tracked as **CHAOS-3164**.
 
 `TestRoleGrantSurfacesMatchQuerySurfaces` (`internal/domaingrants/role_surface_test.go`)
 derives, per connection pool, which `(table, privilege)` pairs the reachable Go code
@@ -544,28 +568,38 @@ attribution for a false absence. Every override is reported, because it means a
 naming convention lied and the reader should know that rather than assume the
 surface shrank.
 
-### Incompleteness GATES, and is per (table, privilege)
+### Incompleteness is REPORTED, per (table, privilege)
 
-Enumerating what was not verified is not enough — a printout nobody must act on is
-indistinguishable from having checked. Two changes:
+Enumerating what was not verified is the point of the advisory posture — the
+report's value is precisely that it says what it could not see.
 
 - **Pair granularity.** A table-level list hid the case that matters most: if
   SELECT stays visible while an UPDATE path goes dark, the table is nonempty, so a
   table-level list omits it and the exact `(table, UPDATE)` gap appears in *no*
   output at all.
-- **Enforcement.** A posture privilege with no derived call site for its own role
-  must be acknowledged in `acknowledgedBlindSpots` with a reason, or the gate
-  fails; and a stale acknowledgement fails too, so the list cannot outlive the
-  blind spot.
+- **One report, category-tagged.** `AdvisoryReport` returns every line from a
+  single function, tagged by category, and a test asserts every category still
+  emits. When each category was printed by its own loop in the test, a unit test
+  could prove a value reached the data structure while the loop that printed it was
+  deletable with everything still green — and for a tool whose only output is its
+  report, a category that stopped being printed is indistinguishable from one with
+  nothing to say.
+- **`WIRING-HOP` is reported.** It marks where pool taint *stopped*, so any SQL
+  beyond it is invisible. It was collected for three review rounds and never
+  surfaced, which made it the largest unstated hole in the output.
 
-Three exclusions are legitimate and are recorded rather than silently applied:
-SELECT is *synthesized* onto every posture row by `loadPosture`, so its absence on
-a write-only table is a representation artifact; a privilege that satisfies a
-derived LOCK is justified by that lock even though a disjunction cannot be recorded
-as evidence; and third-party function-typed fields (`encoding/json`'s
-`scanner.step`, pgx's `QueuedQuery.Fn`) are filtered out because gating on them
-would be pure noise. Running the enforcement for the first time surfaced all three
-as bugs in the check itself.
+Three exclusions from the "needs acknowledgement" annotation are legitimate and
+recorded rather than silently applied: SELECT is *synthesized* onto every posture
+row by `loadPosture`, so its absence on a write-only table is a representation
+artifact; a privilege that satisfies a derived LOCK is justified by that lock when
+it is the *sole* satisfying privilege held; and third-party function-typed fields
+(`encoding/json`'s `scanner.step`, pgx's `QueuedQuery.Fn`) are filtered out because
+reporting them would be pure noise.
+
+**Known limitation, carried into the closure argument**: dynamic-SQL
+acknowledgements are keyed by FILE, so a new dynamic statement in an already-
+acknowledged file is accepted without review. Per-site acknowledgement is part of
+the partition task (CHAOS-3164), not a patch.
 
 ### Fail-closed must not become fail-SILENT
 
@@ -611,20 +645,24 @@ accretes grants permanently, and nothing here distinguishes "not yet" from
 no-derived-evidence advisories), not by changing the reachability model. If a seam is
 dead, delete the wiring — that is the signal this analyzer reads.
 
-### Known-open findings carry a ticket and expire
+### Known-open findings carry a ticket
 
-`knownOpenCriticals` records CRITICALs accepted as real whose fix belongs to another
-lane. It is not a suppression list: an entry matches exactly one
-`(role, table, privilege)`, every entry must name a ticket, and an entry that **stops
-reproducing fails the gate** ("stale, delete it") so it cannot outlive the fix. Emptying
-it is the goal state.
+`knownOpenCriticals` records CRITICALs accepted as real whose fix belongs to
+another lane. Entries match exactly one `(role, table, privilege)`, must name a
+ticket, and are reported under their own category so "someone is fixing this" is
+never flattened into "unreviewed".
 
-Current entry — found by this gate's first run: **coordinator `sync_dispatch_outbox`
-INSERT** (CHAOS-3079). `syncreconciler.Materializer.Step` runs on the coordinator pool
-(`cmd/dev-health-reconciler/dependencies.go:208`) and executes four
-`INSERT INTO public.sync_dispatch_outbox` (`materializer.go:125/235/345/450`) while
-`coordinatorPosture()` declares `allow_insert=false`. Latent only because
-`checkedInReconcilerActivation.syncMutation` is false today.
+Under the advisory posture its expiry property is **suspended**: nothing fails, so
+a stale entry is reported rather than enforced. Restoring enforcement is part of
+promoting the check to a gate.
+
+Current entry — found by this checker's first run: **coordinator
+`sync_dispatch_outbox` INSERT** (CHAOS-3079). `syncreconciler.Materializer.Step`
+runs on the coordinator pool (`cmd/dev-health-reconciler/dependencies.go:208`) and
+executes four `INSERT INTO public.sync_dispatch_outbox`
+(`materializer.go:125/235/345/450`) while `coordinatorPosture()` declares
+`allow_insert=false`. Latent only because `checkedInReconcilerActivation.syncMutation`
+is false today.
 
 ### Harness consequence of adding a posture row
 

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -207,17 +207,17 @@ hand, not grant blind.
 
 ## Privilege-implication rule: locking clauses need no write statement
 
-> **This section was right, and the checker disagreed with it for a while.** The
-> rule below (verified on Postgres 16) says a role holding only `SELECT`+`INSERT`
-> is denied a `SHARE ROW EXCLUSIVE` lock. `internal/domaingrants` nonetheless
-> modelled every mode above `ACCESS SHARE` as "any one of INSERT/UPDATE/DELETE",
-> and a test later asserted that as correct — contradicting this document. Both are
-> now fixed and re-measured on Postgres 18.4, which **agrees** with the rule below
-> and additionally pins `ROW SHARE`/`ROW EXCLUSIVE`, which this section does not
-> cover. See "LOCK TABLE privilege requirements are MODE-dependent" for the full
-> measured table. Lesson: when the analyzer and this manifest disagree, the
-> manifest was derived from measurement and the analyzer may be carrying a
-> documented-but-unmodelled approximation.
+> **This section was right, and the checker disagreed with it through three
+> successive wrong models.** The rule below (verified on Postgres 16) says a role
+> holding only `SELECT`+`INSERT` is denied a `SHARE ROW EXCLUSIVE` lock.
+> `internal/domaingrants` nonetheless modelled every mode above `ACCESS SHARE` as
+> "any one of INSERT/UPDATE/DELETE", and a test later asserted that as correct —
+> contradicting this document. It is now derived from `LockTableAclCheck` directly;
+> see "LOCK privilege requirements: one OR-mask per mode" below for the structure,
+> the full measured table, and the additional correction that the demand is a
+> DISJUNCTION rather than a conjunction with SELECT. Lesson: when the analyzer and
+> this manifest disagree, the manifest was derived from measurement and the
+> analyzer may be carrying a documented-but-unmodelled approximation.
 
 A DML-verb grep (`INSERT|UPDATE|DELETE`) undercounts required privileges.
 Two Postgres locking constructs imply write-level grants with no write verb
@@ -428,57 +428,105 @@ turns out no coordinator path touches them, that is a posture *over*-declaration
 separate finding — route it to the posture lane rather than tightening it here, since a
 wrong tightening fails closed in production.
 
-### LOCK TABLE privilege requirements are MODE-dependent (measured, not documented)
+### LOCK privilege requirements: one OR-mask per mode, derived from the backend
 
-The first version of this gate modelled `LOCK TABLE` as "any one of
-INSERT/UPDATE/DELETE" for every mode above `ACCESS SHARE`, and a test asserted that
-INSERT alone satisfies a `SHARE ROW EXCLUSIVE` lock. **Both were wrong**, and the
-test was the worse half: the pre-existing analyzer had *documented* this
-imprecision as a known gap, and the test converted it into an authoritative rule.
+Three attempts at this rule produced three different wrong answers, each a
+different KIND of wrong. That pattern — not any single defect — is why the model
+was finally re-derived from `LockTableAclCheck`
+(`src/backend/commands/lockcmds.c`) rather than reconstructed from prose again:
 
-Measured against PostgreSQL 18.4, one grant set per candidate privilege, one query
-per mode, **with the controls that isolate each denial to the lock clause** — an
-empty transaction, and the identical read with only the lock removed. Without those
-controls a `DENIED` result is a denial plus a guess about its cause.
+```
+aclmask =  (mode == AccessShareLock)  ? ACL_SELECT
+        : ((mode <= RowExclusiveLock) ? ACL_INSERT : 0)
+aclmask |= ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_MAINTAIN
+pg_class_aclcheck(rel, user, aclmask)     // ANY bit suffices
+```
 
-| statement | SELECT | +INSERT | +UPDATE | +DELETE |
-|---|---|---|---|---|
-| C1 empty transaction (control) | ok | ok | ok | ok |
-| C2 read, **no lock** (control) | ok | ok | ok | ok |
-| `ACCESS SHARE` | ok | ok | ok | ok |
-| `ROW SHARE` | DENIED | ok | ok | ok |
-| `ROW EXCLUSIVE` | DENIED | ok | ok | ok |
-| `SHARE UPDATE EXCLUSIVE` | DENIED | DENIED | ok | ok |
-| `SHARE` | DENIED | DENIED | ok | ok |
-| `SHARE ROW EXCLUSIVE` | DENIED | DENIED | ok | ok |
-| `EXCLUSIVE` | DENIED | DENIED | ok | ok |
-| `ACCESS EXCLUSIVE` | DENIED | DENIED | ok | ok |
+**It is ONE disjunction per mode.** Not "SELECT and a write privilege". A
+lock-only path authorized by `UPDATE` alone needs no `SELECT`, and asserting one
+over-grants — the exact failure the two-role split exists to prevent.
 
-Three tiers, not two. **INSERT satisfies `ROW SHARE` and `ROW EXCLUSIVE` and
-nothing stricter.** And `ROW SHARE` requires a write privilege even though the
-PostgreSQL `LOCK` documentation says it needs only SELECT — measured, so the table
-above wins over the docs.
+Measured on PostgreSQL 18.4 with each privilege granted **alone** and the `LOCK`
+executed as the only statement in its transaction:
 
-`LockRequirement` records the demand as a **disjunction** (any one of a
-mode-specific set) rather than a `PrivilegeSet` entry, because every `PrivilegeSet`
-member is an independent requirement and folding UPDATE in produced a real false
-positive on jobroute's SELECT+INSERT grant. Unrecognized modes fail **closed** at
-the strictest tier: both predecessors of this rule failed *open*.
+| mode (lock only) | NONE | SELECT | INSERT | UPDATE | DELETE | TRUNCATE | MAINTAIN | REFERENCES | TRIGGER |
+|---|---|---|---|---|---|---|---|---|---|
+| `ACCESS SHARE` | DENIED | ok | ok | ok | ok | ok | ok | DENIED | DENIED |
+| `ROW SHARE` | DENIED | DENIED | ok | ok | ok | ok | ok | DENIED | DENIED |
+| `ROW EXCLUSIVE` | DENIED | DENIED | ok | ok | ok | ok | ok | DENIED | DENIED |
+| `SHARE UPDATE EXCLUSIVE` … `ACCESS EXCLUSIVE` | DENIED | DENIED | DENIED | ok | ok | ok | ok | DENIED | DENIED |
+| **mode omitted** | DENIED | DENIED | DENIED | ok | ok | ok | ok | DENIED | DENIED |
 
-There are now four distinct rules in this area and none may be collapsed into
-another: `ACCESS SHARE` (SELECT), `ROW SHARE`/`ROW EXCLUSIVE` (any of I/U/D),
-stricter modes (U/D only), and `SELECT ... FOR UPDATE` (UPDATE specifically,
-handled as an ordinary privilege).
+**Correction to a claim previously recorded here (and amplified in review): the
+PostgreSQL documentation is NOT wrong about `ROW SHARE`.** The docs say the
+INSERT-class applies to "ROW EXCLUSIVE **or a less-conflicting mode**", which
+*includes* `ROW SHARE` — matching the measurement exactly. The earlier note
+asserting the docs were wrong was a misreading of the docs, not a finding. A wrong
+"the docs are wrong" note is worse than the original confusion, because it teaches
+the next reader to distrust the correct source.
 
-**Generalisation worth carrying:** this was a privilege requirement attributed to
-the wrong clause of a compound statement. The same error shape appeared the same
-day in the reports lane — `INSERT ... ON CONFLICT DO NOTHING RETURNING x` needs
-SELECT because of the **`RETURNING`**, not the conflict arbiter. For any claim of
-the form "clause X implies privilege Y", split the clauses and measure each variant
-against a role holding exactly the privilege under test, with a control that
-removes only the suspect clause.
+#### Two measurement confounds, both of which hid the wrong operator
+
+The earlier probe got the *tiers* right and the *operator* wrong, and could not
+have caught it:
+
+1. **Every grant set began with `SELECT`.** A conjunction and a disjunction
+   containing SELECT are then indistinguishable. Adding SELECT to every fixture
+   made the conjunction unfalsifiable.
+2. **The probe appended a read after the `LOCK`.** So no grant set *without*
+   SELECT could ever reach the lock's own ACL check.
+
+The method (control rows isolating the denial to the clause under test) was right;
+the fixtures defeated it. The general form: **when testing whether X is required,
+no fixture may hold X for an unrelated reason.**
+
+#### The grammar was a fail-open
+
+The previous regex recognised `LOCK TABLE <one target> IN <mode> MODE` and
+silently derived **nothing** for the other eight shapes PostgreSQL accepts —
+optional `TABLE`, multiple comma-separated targets, `ONLY`, a trailing `*`, an
+omitted mode (defaulting to `ACCESS EXCLUSIVE`), `NOWAIT`, arbitrary whitespace.
+`LOCK public.a, public.b` in coordinator-only code would derive neither table nor
+privilege, CI would pass, and production would return 42501.
+
+A parser that ignores what it cannot recognise is the worst possible shape for a
+fail-closed tool. `parseLockStatements` now handles all nine forms, and **a LOCK
+it cannot fully read is a recorded fact that FAILS the gate** — its target may
+never enter the derived surface at all, so an absence is not a safe default.
+
+#### Unknown modes now genuinely fail closed
+
+The previous version gave an unrecognised mode a *guessed* strict privilege set
+and called that fail-closed. It was not: the comparator only reported the mode when
+the **guess** was unsatisfied, so a role already holding `UPDATE` passed silently
+with no manual-verification finding. **A guess that happens to be satisfied is
+indistinguishable from knowledge.** An unrecognised mode is now refused and
+reported.
+
+### Transaction straddles are ADVISORY — co-residency is inferred, never proven
+
+A `txorigin:` group means every statement's `pgx.Tx` traced back to the same
+`Begin()` **source position**. That is a fact about where the handle came from, not
+about what executes: `buildTxOrigins` performs no control-flow analysis, so two
+**mutually exclusive branches** after one `Begin` — an `if`/`else`, an early
+return, a `switch` — carry the same origin and were reported as a single
+transaction touching both sides of the partition.
+
+Calling that "proven" was wrong, and a premise labelled proven is worse than one
+labelled inferred, because nobody re-checks it.
+
+**Decision: downgrade rather than do the path analysis.** A straddle finding can
+only push a posture *wider* (dual-grant these tables), and an over-grant emitted
+on an inference is precisely what the two-role split exists to prevent — the same
+reasoning that makes the `remaining_metric_*` over-approximation advisory. The
+blocking signal is not lost: a table genuinely missing from the executing role's
+posture still produces its own per-privilege CRITICAL when its evidence is
+role-exclusive. What becomes advisory is the transaction *framing*, which is a
+review aid. The traced/coarse distinction is still reported, because it tells a
+reader how much weight the grouping carries.
 
 ### Attribution can be INVERTED by a parameter name, not just incomplete
+
 
 A pool-typed parameter is a seed root by **spelling** (`domainPool`,
 `coordinatorPool`), and spelling can contradict reality. `build(domainPool *pgxpool.Pool)`
@@ -530,21 +578,16 @@ also keeps bare callee names, which cannot be third-party by construction.
 
 ### Transaction-span veto
 
-A transaction cannot span two pools, so every table one touches must be authorized for
-the single role whose pool runs it. `transactionStraddleFindings` reports a group whose
-tables land on opposite sides of the partition.
+A transaction cannot span two pools, so every table one touches must be authorized
+for the single role whose pool runs it. `transactionStraddleFindings` reports a
+group whose tables land on opposite sides of the partition — **always as an
+ADVISORY**, for the reason given in "Transaction straddles are ADVISORY" above:
+co-residency is inferred at both precisions, and a finding that can only widen a
+posture must not block on an inference.
 
-It is **blocking only when both premises are proven**: that the statements really share
-one transaction (a `txorigin:`-traced group, not the coarse same-function-body fallback
-this package's own comment calls unproven), and that the transaction really runs on that
-role's pool (at least one evidence site the other role does not also have). Either
-premise missing downgrades it to advisory — emitting CRITICAL on a guess would tell
-maintainers to dual-grant, which is the same over-widening the per-privilege path
-already refuses.
-
-The lock path routes through that identical downgrade, via one shared `exclusiveTo`
-helper rather than a copy: a copy is how one path ends up still accepting what the
-other rejects.
+The lock path routes through the identical shared-evidence downgrade, via one
+`exclusiveTo` helper rather than a copy: a copy is how one path ends up still
+accepting what the other rejects.
 
 ### Reachability is static wiring, not runtime activation (decision)
 

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -310,3 +310,144 @@ this table." This is the whitelist `TestDomainGrantSurfaceMatchesQuerySurface`'s
 future role-attribution extension and grants-finisher2's posture manifest
 must both reference — coordinate before either side hard-codes it
 independently.
+
+## The coordinator grant surface is now DERIVED and gated (CHAOS-3033)
+
+`TestRoleGrantSurfacesMatchQuerySurfaces` (`internal/domaingrants/role_surface_test.go`)
+derives, per connection pool, which `(table, privilege)` pairs the reachable Go code
+needs, and checks each against that role's own posture. It runs alongside
+`TestDomainGrantSurfaceMatchesQuerySurface`, which keeps its distinct job: the
+domain role's *two* hand-maintained artefacts (`runtimeGrantStatements` and
+`DomainPosture`) drifted from the code while agreeing with each other. Neither gate
+replaces the other.
+
+**The coordinator has only ONE list, so its failure surface is different.**
+`coordinatorGrantStatements` (`internal/storage/river/migrate.go`) is parameterized on
+`options.CoordinatorGrants`, and the only production caller —
+`cmd/dev-health-worker-migrate/main.go:198 coordinatorGrants()` — projects
+`CoordinatorPosture()` field-for-field. A list-vs-list disagreement is therefore
+structurally impossible for the coordinator, and `GroundTruth.Grants` is left nil for
+it rather than synthesized from the posture and compared against itself.
+
+### One deriver, parameterized per role — not a second copy
+
+`DeriveForRole(root, role)` runs the same analyzer with a different syntactic seed set
+(`poolRoleSeeds`). Both pools are wired through the same three shapes (a
+`*pgxpool.Pool` field, a getter, a bare identifier), so the entire role-specific part
+of the analysis is a name table. Every hardening pass — interprocedural SQL constant
+folding, cross-function `pgx.Tx` origin tracing, unique-implementer devirtualization,
+LOCK-implies-write — applies to both roles because there is one implementation of each.
+
+A **taint barrier** stops the other role's pool root before `exprTainted`'s permissive
+fall-throughs (a selector off a tainted base is tainted; a receiver with any tainted
+field is tainted). Without it, `pools.Coordinator = coordinatorPool` taints the
+`RuntimePools` field, the receiver heuristic taints `p` in every method, and `p.Domain`
+comes back coordinator-tainted purely for being selected off a tainted base. Measured:
+the barrier changes nothing on the current tree. It is kept as a guard and pinned by
+`TestBarrierStopsTaintFromTheOtherRolesPool`, because its absence only becomes harmful
+the moment someone adds a multi-pool struct that reaches a SQL sink.
+
+### The blind spot that made the coordinator surface untrustworthy, and its fix
+
+Taint died at calls through **function-typed struct fields** — this repo's DI idiom (a
+composition struct of `func` fields, filled by a package-level `var`, invoked through
+the field). `info.Selections` yields a `*types.Var`, not a `*types.Func`, so callee
+resolution failed and everything downstream was invisible.
+
+That hid the **entire scheduler and fixed-engine surface — 8 of `CoordinatorPosture()`'s
+19 tables** (`scheduled_jobs`, `scheduled_sync_occurrences`,
+`fixed_schedule_occurrences`, `organizations`, `sync_configurations`,
+`remaining_metric_runs`, `remaining_metric_partitions`,
+`work_graph_execution_requests`). The reconciler's equivalent hops only *appeared* to
+work because `buildSyncMutationPipeline` happens to name its parameter
+`coordinatorPool` and re-seeds by convention. **A gate whose completeness rests on a
+parameter name is not a gate** — the three scheduler hops are the proof: they carried
+the coordinator pool with their parameter named `pool` and nothing caught it.
+
+`internal/domaingrants/funcvalue.go` resolves both forms (a named function reference,
+and a function literal — the latter requiring package-level literals to be registered
+as pseudo-functions, since nothing else walks them), fail-closed when a field has two
+distinct targets. Coordinator surface: **11 → 18 tables**. Domain surface: **unchanged
+at 32 tables with identical advisories**, verified before and after — which is luck
+about this tree's parameter naming, not a property of the design.
+
+`TestFuncValueTargetsResolveTheKnownWiringHops` pins the resolved **target** per field
+rather than a count, precisely so a future `pool` → `coordinatorPool` rename cannot
+make the test keep passing while the mechanism it exists to pin has stopped working.
+
+### Attribution: what is proven, and what is deliberately advisory
+
+A two-role posture has a failure mode one role does not — a privilege granted to the
+**wrong** role, which every "is it granted somewhere" check passes.
+
+- **CRITICAL** only where at least one proving call site is reachable **only** through
+  that role's pool. Real code, real 42501.
+- **ADVISORY** where every proving site is **shared** with the other role. Taint is
+  tracked per `(type, field)`, not per construction site, so a repository type
+  constructed from both pools has its whole method surface attributed to both.
+  `internal/jobs/metrics/remaining` is the live instance: the tool derives UPDATE for
+  the coordinator, and `coordinatorPosture()`'s hand-derived `{S,I}` is correctly
+  **narrower**. **Do not widen a posture on a shared-evidence finding** — a hand
+  derivation from the construction site is more precise there.
+- **ADVISORY**, never silent: a posture row this role has no evidence for while another
+  role does — a misattribution candidate. The negative direction ("role B must not hold
+  X") is *not* statically provable against an under-approximation; it is proven at
+  runtime by the union of each role calling `CheckRolePosture` against its own manifest,
+  whose catch-all inspects the calling role. See that function's doc comment.
+
+**On the dual-grant whitelist above:** `RoleReport.SharedPairs` makes the shared set
+visible and checkable, but it is *not* a drop-in replacement for the table-level
+whitelist. It is pair-level (so `sync_dispatch_transport_routes`, shared with different
+privileges per role, has no shared pair); it cannot distinguish a genuine dual-grant
+from a dual-constructed-type artifact (`remaining_metric_*`); and it inherits the
+derivation's blind spots (`organizations` is a real dual-grant with no derived
+coordinator evidence). Treat it as review input, and keep the manifest authoritative.
+
+### Silence is not confirmation
+
+`IncompleteRoleSurface` is first-class output: posture tables with no derived call site,
+in-module wiring hops where taint stopped, and non-constant SQL sites, per role. A table
+this tool cannot analyze must never look identical to one it checked and approved — that
+equivalence is what licenses hand-written rows.
+
+Still unverified on the coordinator side: **`organizations`** and
+**`work_graph_execution_requests`** have posture rows with no derived evidence. If it
+turns out no coordinator path touches them, that is a posture *over*-declaration and a
+separate finding — route it to the posture lane rather than tightening it here, since a
+wrong tightening fails closed in production.
+
+### Transaction-span veto
+
+A transaction cannot span two pools, so every table one touches must be authorized for
+the single role whose pool runs it. `transactionStraddleFindings` reports a group whose
+tables land on opposite sides of the partition, distinguishing a `txorigin:`-traced
+group (provably one transaction) from the coarse same-function-body fallback. This is
+the check that catches a straddle before it becomes a runtime 42501 rather than
+presenting as a routing problem.
+
+### Known-open findings carry a ticket and expire
+
+`knownOpenCriticals` records CRITICALs accepted as real whose fix belongs to another
+lane. It is not a suppression list: an entry matches exactly one
+`(role, table, privilege)`, every entry must name a ticket, and an entry that **stops
+reproducing fails the gate** ("stale, delete it") so it cannot outlive the fix. Emptying
+it is the goal state.
+
+Current entry — found by this gate's first run: **coordinator `sync_dispatch_outbox`
+INSERT** (CHAOS-3079). `syncreconciler.Materializer.Step` runs on the coordinator pool
+(`cmd/dev-health-reconciler/dependencies.go:208`) and executes four
+`INSERT INTO public.sync_dispatch_outbox` (`materializer.go:125/235/345/450`) while
+`coordinatorPosture()` declares `allow_insert=false`. Latent only because
+`checkedInReconcilerActivation.syncMutation` is false today.
+
+### Harness consequence of adding a posture row
+
+`rolePostureQuery` asserts `count(required_tables) = count(required_table_privileges)`
+with **no leniency** (`domain_authorization.go:194`), and `required_tables` JOINs
+`pg_class`. The GRANT side is `to_regclass`-guarded and skips a missing table silently.
+So a posture row for a table the test database does not create makes the readiness check
+fail while the grant reports success. Adding a new table to either posture therefore
+requires a matching `CREATE TABLE` in **two** places — `startGrantHarness`
+(`internal/storage/postgres/domain_grant_reconciliation_integration_test.go:209`, shared
+by all 22 in-package grant tests) and `cmd/dev-health-workerctl/main_integration_test.go`,
+which builds its own.

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -702,7 +702,14 @@ through a local `grantStatementsForPosture()` helper, **not** through
 real migration fails to issue — it proves the posture is self-consistent, not that
 the migration provisions it.
 
-The shape to recognise: **coverage that exists somewhere, asserted as coverage
-everywhere.** A posture row is exercised against the real migration path only via
-sources 1–3; the test that adapts automatically is the one testing something else.
-That is the same failure family that made the coordinator checker advisory.
+The shape to recognise, stated plainly because it is the reusable part:
+**coverage that adapts automatically while testing something else is worse than
+absent coverage, because it stays green through the failure it appears to cover.**
+
+Absent coverage at least looks absent. This test picks up a new posture row with no
+edit, which reads as "already covered" — while the thing it actually verifies is
+posture self-consistency, not migration provisioning. A posture row is exercised
+against the real migration path only via sources 1–3.
+
+That is the same failure family that made the coordinator checker advisory: not a
+wrong answer, but a green signal whose meaning is narrower than its appearance.

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -348,6 +348,25 @@ independently.
 > of everything the analysis can fail to see, with each cell either failing the
 > check or documented as safe to accept **per site** (not per file), and a test per
 > cell demonstrating the failure. Tracked as **CHAOS-3164**.
+>
+> **How to read the report:**
+> `go run ./cmd/dev-health-grantcheck -roles`
+>
+> That command is the report's real delivery channel, and it exists because the test
+> alone is not one. `TestReportCoordinatorGrantSurface` emits everything through
+> `t.Log`, and `ci/check_go.sh` runs `go test -mod=readonly ./...` **without `-v`** —
+> which discards a passing package's logs entirely. In CI the report was therefore
+> invisible: consumers saw a zero exit and a package-level `ok` and nothing else,
+> which is exactly the "advisory output read as a pass" failure the advisory posture
+> was supposed to make impossible. **A report whose only channel is suppressed output
+> is not a report.**
+>
+> The command always exits **0**, including when it reports CRITICAL findings. A
+> nonzero exit would make it a gate by the back door. Read the report; do not read
+> the exit code.
+>
+> Not yet wired into CI as a published artifact — see the note at the end of this
+> section.
 
 `TestRoleGrantSurfacesMatchQuerySurfaces` (`internal/domaingrants/role_surface_test.go`)
 derives, per connection pool, which `(table, privilege)` pairs the reachable Go code

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -25,6 +25,12 @@ Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration-vet|integrat
   contract
          Validate the job contract tree and, when DEV_HEALTH_CONTRACT_BASE is
          set, reject breaking in-place changes against that directory.
+  grant-advisory
+         Publish the per-role grant-surface ADVISORY report into the log. Reports
+         only -- it never fails the build on findings, by design. Included in
+         `fast` and `all` because the report has no other delivery channel: the
+         test that produces it uses t.Log, and `go test` without -v discards a
+         passing package's output.
   integration-vet
          Compile-check every package under the integration build tag, across
          the WHOLE tree. No Docker required. This is what would have caught a
@@ -41,9 +47,10 @@ Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration-vet|integrat
          real containers, except the (small, justified) INTEGRATION_DENYLIST.
          Inclusion is the default; exclusion is the explicit, loud exception.
   fast   Run fmt, vet, test, build, contract, integration-vet, and
-         integration-coverage checks.
+         integration-coverage checks, then publish the grant advisory report.
   all    Run fmt, vet, test, race, build, contract, integration-vet, and
-         integration-coverage checks (default).
+         integration-coverage checks, then publish the grant advisory report
+         (default).
 EOF
 }
 
@@ -199,6 +206,26 @@ check_build() {
   printf 'go build: worktree unchanged\n'
   cleanup_go_build_output
   trap - EXIT
+}
+
+# check_grant_advisory publishes the per-role grant-surface ADVISORY report into
+# the CI log. It is NOT a gate and cannot fail the build on findings: the command
+# exits 0 even when it reports CRITICAL ones, deliberately (see
+# cmd/dev-health-grantcheck's doc comment and internal/domaingrants.AdvisoryReport).
+#
+# It exists because the report had NO delivery channel. Its content is produced by
+# TestReportCoordinatorGrantSurface through t.Log, and check_test below runs
+# `go test ./...` WITHOUT -v, which discards a passing package's logs entirely. So
+# CI showed a zero exit and a package-level "ok" and none of the report -- which is
+# exactly the "advisory output read as a pass" failure the advisory posture exists
+# to prevent. A report whose only channel is suppressed output is not a report.
+#
+# An EXECUTION failure (build break, analysis error) is still nonzero and still
+# fails, because that means the report was not produced at all -- which is a
+# different thing from the report having nothing to say.
+check_grant_advisory() {
+  printf '\n== grant-surface ADVISORY report (reports only; never fails on findings) ==\n'
+  ( cd "${ROOT}" && GOWORK=off go run -mod=readonly ./cmd/dev-health-grantcheck -roles )
 }
 
 check_contract() {
@@ -403,6 +430,9 @@ case "${1:-all}" in
   contract)
     check_contract
     ;;
+  grant-advisory)
+    check_grant_advisory
+    ;;
   integration-vet)
     check_integration_vet
     ;;
@@ -420,6 +450,7 @@ case "${1:-all}" in
     check_contract
     check_integration_vet
     check_integration_coverage
+    check_grant_advisory
     ;;
   all)
     check_format
@@ -430,6 +461,7 @@ case "${1:-all}" in
     check_contract
     check_integration_vet
     check_integration_coverage
+    check_grant_advisory
     ;;
   -h|--help|help)
     usage

--- a/cmd/dev-health-grantcheck/main.go
+++ b/cmd/dev-health-grantcheck/main.go
@@ -8,12 +8,28 @@
 // same analysis can be re-run standalone to regenerate a report, without
 // depending on `go test`'s output format.
 //
+// It also emits the COORDINATOR role's ADVISORY report (-roles), which exists
+// because that report has no other delivery channel. The coordinator analysis is
+// advisory (see internal/domaingrants.AdvisoryReport), so it is delivered through
+// t.Log -- and ci/check_go.sh runs `go test -mod=readonly ./...` WITHOUT -v, which
+// suppresses a passing test's logs entirely. In CI the coordinator report was
+// therefore invisible: consumers saw a zero exit status and a package-level "ok"
+// and nothing else, which is precisely the "advisory output read as a pass" failure
+// the advisory posture was supposed to make impossible. A report whose only channel
+// is suppressed output is not a report.
+//
 // Usage:
 //
 //	go run ./cmd/dev-health-grantcheck [-root <module dir>] [-format text|markdown]
+//	go run ./cmd/dev-health-grantcheck -roles [-root <module dir>]
 //
-// Exit status is 1 if any CRITICAL finding is present, 0 otherwise
-// (ADVISORY-only or clean). Same pass/fail contract as the test.
+// Exit status for the DOMAIN check is 1 if any CRITICAL finding is present, 0
+// otherwise -- the same pass/fail contract as the gating test.
+//
+// Exit status for -roles is ALWAYS 0, including when it reports CRITICAL findings.
+// That is deliberate and is the whole point: the coordinator surface gates nothing,
+// so a nonzero exit would make it a gate by the back door. Read the report; do not
+// read the exit code.
 package main
 
 import (
@@ -29,12 +45,26 @@ import (
 func main() {
 	root := flag.String("root", ".", "module root directory (containing go.mod)")
 	format := flag.String("format", "text", "output format: text or markdown")
+	roles := flag.Bool("roles", false,
+		"emit the per-role ADVISORY report (coordinator + domain) instead of the domain gate check; "+
+			"always exits 0, because this surface gates nothing")
 	flag.Parse()
 
 	absRoot, err := absPath(*root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "dev-health-grantcheck: %v\n", err)
 		os.Exit(2)
+	}
+
+	if *roles {
+		if err := printRoleAdvisoryReport(absRoot); err != nil {
+			fmt.Fprintf(os.Stderr, "dev-health-grantcheck: %v\n", err)
+			os.Exit(2)
+		}
+		// Deliberately exit 0 even with CRITICAL findings present: see the package
+		// doc comment. A nonzero exit here would silently turn an advisory report
+		// into a gate, which is the decision this posture exists to avoid.
+		return
 	}
 
 	derived, err := domaingrants.Derive(absRoot)
@@ -122,4 +152,55 @@ func privilegeLabel(f domaingrants.Finding) string {
 		return ""
 	}
 	return f.Privilege.String()
+}
+
+// printRoleAdvisoryReport writes the full per-role advisory report to stdout.
+//
+// This is the coordinator report's ONLY non-suppressed delivery channel. The test
+// that produces the same content does so through t.Log, which `go test` discards
+// for a passing package unless -v is passed -- and CI does not pass it.
+func printRoleAdvisoryReport(root string) error {
+	inputs := make([]domaingrants.RoleInput, 0, len(domaingrants.AllPoolRoles))
+	for _, role := range domaingrants.AllPoolRoles {
+		derived, err := domaingrants.DeriveForRole(root, role)
+		if err != nil {
+			return fmt.Errorf("deriving %s surface: %w", role, err)
+		}
+		truth, err := domaingrants.LoadGroundTruthForRole(role)
+		if err != nil {
+			return fmt.Errorf("loading %s ground truth: %w", role, err)
+		}
+		inputs = append(inputs, domaingrants.RoleInput{Role: role, Derived: derived, Truth: truth})
+	}
+	report, err := domaingrants.CompareRoles(inputs)
+	if err != nil {
+		return fmt.Errorf("comparing roles: %w", err)
+	}
+
+	const banner = "ADVISORY REPORT -- THIS GATES NOTHING."
+	fmt.Println("=====================================================================")
+	fmt.Println(banner)
+	fmt.Println("Everything below is REPORTED, not asserted. A clean run is NOT evidence")
+	fmt.Println("that CoordinatorPosture() is correct, and this command exits 0 even when")
+	fmt.Println("it reports CRITICAL findings. The domain role is gated separately by")
+	fmt.Println("TestDomainGrantSurfaceMatchesQuerySurface. Promoting this to a gate")
+	fmt.Println("requires the blind-spot closure argument tracked in CHAOS-3164.")
+	fmt.Println("=====================================================================")
+
+	byCategory := map[domaingrants.AdvisoryCategory][]string{}
+	for _, line := range domaingrants.AdvisoryReport(report) {
+		byCategory[line.Category] = append(byCategory[line.Category], line.Text)
+	}
+	for _, category := range domaingrants.AllAdvisoryCategories {
+		entries := byCategory[category]
+		fmt.Printf("\n=== %s (%d) ===\n", category, len(entries))
+		for _, entry := range entries {
+			fmt.Printf("    %s\n", entry)
+		}
+	}
+	fmt.Println()
+	fmt.Println("=====================================================================")
+	fmt.Println(banner + " Exit status is 0 regardless of the above.")
+	fmt.Println("=====================================================================")
+	return nil
 }

--- a/internal/domaingrants/analyze.go
+++ b/internal/domaingrants/analyze.go
@@ -1198,7 +1198,23 @@ func isPgxPoolPtr(t types.Type) bool {
 // barrier is what makes a per-role surface meaningful rather than a
 // union-of-all-pools surface wearing one role's name.
 func (a *analyzer) exprTainted(expr ast.Expr, info *types.Info, locals map[string]bool) bool {
-	if a.isBarrierExpr(expr, info) {
+	// The barrier applies to STRUCTURAL roots -- a selector or getter that IS the
+	// other role's pool -- and deliberately NOT to bare identifiers.
+	//
+	// A local or parameter's taint is established by real propagation (an argument
+	// at a call site, an assignment from a tainted expression), and its NAME is
+	// incidental to that. Barring it by name reproduces the very defect the
+	// call-site pass was added to fix, in mirror image: `build(domainPool *Pool)`
+	// called only with the coordinator pool is genuinely coordinator-tainted, and
+	// a name-based barrier would delete that taint and lose the SQL from BOTH
+	// surfaces -- the domain run suppresses it by call-site evidence, the
+	// coordinator run by spelling. Caught by the control half of
+	// TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence, which
+	// asserts the SQL lands on the coordinator rather than merely leaving domain.
+	//
+	// Structural roots still need the barrier: `pools.Domain` inside a method whose
+	// receiver is tainted must not read as this role's pool.
+	if _, isIdent := expr.(*ast.Ident); !isIdent && a.isBarrierExpr(expr, info) {
 		return false
 	}
 	switch e := expr.(type) {

--- a/internal/domaingrants/analyze.go
+++ b/internal/domaingrants/analyze.go
@@ -39,13 +39,14 @@ type TableSurface struct {
 	Table      string
 	Privileges PrivilegeSet
 	Evidence   []Evidence
-	// RequiresAnyWriteLock and its evidence: see
-	// StatementResult.RequiresAnyWriteLock's doc comment (sql.go). Checked
-	// separately from Privileges because Postgres's requirement here is
-	// "at least one of INSERT/UPDATE/DELETE", not a single specific
-	// privilege.
-	RequiresAnyWriteLock bool
-	WriteLockEvidence    []Evidence
+	// LockRequirement is the strictest explicit LOCK TABLE demand on this table,
+	// or nil if it is never LOCKed (or only in ACCESS SHARE mode, which SELECT
+	// alone satisfies). Checked separately from Privileges because Postgres's
+	// demand here is a DISJUNCTION -- any one of a mode-specific set -- not a
+	// single required privilege. See LockRequirement in sql.go for the measured
+	// mode-to-privilege mapping.
+	LockRequirement   *LockRequirement
+	WriteLockEvidence []Evidence
 }
 
 // DynamicSite is a SQL-shaped call (X.Exec/Query/QueryRow/... on a
@@ -100,6 +101,15 @@ type DerivedSurface struct {
 	// field (funcvalue.go), for the same auditability reason Devirtualized
 	// exists: both are deliberately narrow unique-target shortcuts.
 	FuncValueResolved []FuncValueResolvedCallSite
+	// FuncValueConflicts are tainted calls through a function-typed field this
+	// pass refused to resolve (two implementations, or an unresolvable value).
+	// Each is an unanalyzed hole reached by pool-tainted arguments.
+	FuncValueConflicts []FuncValueConflictSite
+	// NameSeedOverrides are places a parameter named after THIS role's pool was
+	// NOT treated as a seed, because its call sites pass a different role's pool.
+	// Reported because it is a correction of a naming convention, and the reader
+	// should know the convention lied rather than assume the surface shrank.
+	NameSeedOverrides []NameSeedOverride
 	UnresolvedTx      []UnresolvedTxSite
 	rootModule        string
 }
@@ -135,6 +145,10 @@ var AllPoolRoles = []PoolRole{RoleDomain, RoleCoordinator}
 // tracing, devirtualization, LOCK-implies-write) applies to both roles because
 // there is only one implementation of each.
 type roleSeeds struct {
+	// role is which pool this set identifies. Carried on the set itself so a
+	// check that consults call-site evidence can ask "was I derived for this
+	// role" without a second parameter threaded to every caller.
+	role PoolRole
 	// fields are SelectorExpr .Sel names of *pgxpool.Pool type, e.g.
 	// `pools.Domain`, `storage.domainPool`, `pools.Coordinator`.
 	fields map[string]bool
@@ -155,11 +169,13 @@ type roleSeeds struct {
 // and make its surface look trivially satisfied.
 var poolRoleSeeds = map[PoolRole]roleSeeds{
 	RoleDomain: {
+		role:    RoleDomain,
 		fields:  map[string]bool{"Domain": true, "domainPool": true},
 		getters: map[string]bool{"DomainPool": true},
 		idents:  map[string]bool{"domainPool": true},
 	},
 	RoleCoordinator: {
+		role:    RoleCoordinator,
 		fields:  map[string]bool{"Coordinator": true, "coordinatorPool": true},
 		getters: map[string]bool{"CoordinatorPool": true},
 		idents:  map[string]bool{"coordinatorPool": true},
@@ -324,6 +340,18 @@ type analyzer struct {
 	funcValueTargets  map[funcValueKey]funcValueTarget
 	funcValueScopes   []funcValueScope
 	funcValueResolved []FuncValueResolvedCallSite
+	// funcValueConflicts records fields deliberately left unresolved, with the
+	// reason; funcValueConflictSites records the tainted CALL SITES that hit one.
+	// Both exist so an exclusion is reported rather than silent -- see
+	// buildFuncValueTargets.
+	funcValueConflicts     map[funcValueKey]string
+	funcValueConflictSites []FuncValueConflictSite
+
+	// poolParamRoles is role-agnostic call-site evidence for pool-typed
+	// parameters; nameSeedOverrides records where it overruled a name-based seed.
+	// See buildPoolParamRoles.
+	poolParamRoles    map[*types.Func]map[int]map[PoolRole]bool
+	nameSeedOverrides []NameSeedOverride
 
 	// txOriginParam[fn][paramIndex] holds the origin ID (a "file:line"
 	// string naming the specific `.Begin(ctx)` call site) of a pgx.Tx-typed
@@ -393,6 +421,39 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 // field), so labelling it would mean rewriting the fixed point rather than
 // parameterizing it; and separate runs make the two surfaces independently
 // auditable, which is what the bidirectional attribution check compares.
+//
+// # DECISION: reachability is STATIC WIRING, not runtime activation
+//
+// This walks every function that is wired, including code behind a checked-in
+// activation flag that is currently false -- cmd/dev-health-scheduler's
+// `activation.goOwnsMarkers` gate (main.go:126) returns before opening any
+// PostgreSQL client, yet this analyzer still derives the scheduler's coordinator
+// tables and the gate still demands them. That is DELIBERATE, and it is a
+// tradeoff rather than an oversight, so it is recorded here at the seam.
+//
+// Why static wiring wins:
+//
+//   - Grants that are ready BEFORE activation are the entire point. This epic
+//     exists because flipping a flag produced 42501s (CHAOS-3099/3100/3101). If
+//     derivation followed runtime reachability, the gate would read "green,
+//     nothing needed" right up until someone flips the flag and then produce a
+//     pile of CRITICALs at the worst possible moment. Deriving dormant surface is
+//     what lets a flip be a no-op.
+//   - Coverage must not depend on configuration. Otherwise the gate's STRENGTH
+//     varies with a boolean somewhere, a flag flip silently becomes a change to
+//     what CI verifies, and "the gate is green" stops having a fixed meaning.
+//     That is a worse trap than the one it would avoid.
+//   - The error direction is survivable. Deriving dormant code can only ask for
+//     privileges that code will need once activated, so the failure mode is an
+//     OVER-grant. An over-grant is a visible, reviewable row in a posture file;
+//     an under-grant is an outage found in production.
+//
+// The residual risk, stated rather than hidden: a seam that is wired but never
+// activated accretes grants permanently, and nothing here can distinguish "not
+// yet activated" from "abandoned". The mitigation is review pressure -- such rows
+// show up in the misattribution and no-derived-evidence advisories -- not a change
+// to the reachability model. If a seam is truly dead, delete the wiring; that is
+// the signal this analyzer reads.
 func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 	seeds, ok := poolRoleSeeds[role]
 	if !ok {
@@ -502,6 +563,7 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 			"go/packages load likely failed silently", moduleDir)
 	}
 	a.buildImplementers(pkgs)
+	a.buildPoolParamRoles()
 	a.buildFuncValueTargets()
 	a.buildSQLParamConstants()
 	a.buildTxOrigins()
@@ -521,6 +583,8 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 		a.seedSeen = map[string]bool{}
 		a.unresolvedTx = nil
 		a.funcValueResolved = nil
+		a.funcValueConflictSites = nil
+		a.nameSeedOverrides = nil
 		for fn, ctx := range a.funcDecls {
 			a.walkFunc(fn, ctx)
 		}
@@ -547,15 +611,17 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 	}
 
 	return &DerivedSurface{
-		Role:              role,
-		Tables:            a.tables,
-		Dynamic:           a.dynamic,
-		Unresolved:        a.unresolved,
-		SeedSites:         a.seedSites,
-		Devirtualized:     a.devirt,
-		FuncValueResolved: a.funcValueResolved,
-		UnresolvedTx:      dedupUnresolvedTx(a.unresolvedTx),
-		rootModule:        moduleDir,
+		Role:               role,
+		Tables:             a.tables,
+		Dynamic:            a.dynamic,
+		Unresolved:         a.unresolved,
+		SeedSites:          a.seedSites,
+		Devirtualized:      a.devirt,
+		FuncValueResolved:  a.funcValueResolved,
+		FuncValueConflicts: a.funcValueConflictSites,
+		NameSeedOverrides:  a.nameSeedOverrides,
+		UnresolvedTx:       dedupUnresolvedTx(a.unresolvedTx),
+		rootModule:         moduleDir,
 	}, nil
 }
 
@@ -1186,18 +1252,20 @@ func (a *analyzer) recordSeed(expr ast.Expr) {
 }
 
 func (a *analyzer) walkFunc(fn *types.Func, ctx funcCtx) {
-	a.walkBody(ctx, a.taintedParam[fn])
+	a.walkBody(ctx, a.taintedParam[fn], fn)
 }
 
 // walkFuncLit walks a package-level function literal's body with the taint
 // facts recorded for ITS parameters. See analyzer.funcLits.
 func (a *analyzer) walkFuncLit(lit *ast.FuncLit, ctx funcCtx) {
-	a.walkBody(ctx, a.taintedLitParam[lit])
+	// A literal has no *types.Func, so it has no call-site parameter evidence to
+	// consult; nil disables the name-override check for its body.
+	a.walkBody(ctx, a.taintedLitParam[lit], nil)
 }
 
 // walkBody is the shared walk for both forms. tainted is the caller's
 // already-known per-parameter-index taint for this body.
-func (a *analyzer) walkBody(ctx funcCtx, tainted map[int]bool) {
+func (a *analyzer) walkBody(ctx funcCtx, tainted map[int]bool, fn *types.Func) {
 	sig := ctx.funcType()
 	body := ctx.body()
 	if sig == nil || body == nil {
@@ -1247,6 +1315,14 @@ func (a *analyzer) walkBody(ctx funcCtx, tainted map[int]bool) {
 
 	isTainted := func(expr ast.Expr) bool {
 		if a.isSeedExpr(expr, ctx.info) {
+			// Call-site evidence OUTRANKS the parameter's name. A parameter spelled
+			// like this role's pool but only ever passed another role's pool is not
+			// a seed here -- treating it as one inverts attribution, which is worse
+			// than missing it. See buildPoolParamRoles.
+			if a.nameSeedContradicted(expr, ctx, fn) {
+				a.recordNameSeedOverride(expr, ctx, fn)
+				return a.exprTainted(expr, ctx.info, locals)
+			}
 			a.recordSeed(expr)
 			return true
 		}
@@ -1576,13 +1652,19 @@ func (a *analyzer) recordSQLText(sqlText string, pos token.Position, txGroup str
 			})
 		}
 	}
-	for table := range stmt.RequiresAnyWriteLock {
+	for table, requirement := range stmt.LockRequirements {
 		surface := a.tables[table]
 		if surface == nil {
 			surface = &TableSurface{Table: table}
 			a.tables[table] = surface
 		}
-		surface.RequiresAnyWriteLock = true
+		// Keep the STRICTEST demand across every LOCK site on this table: two
+		// call sites may lock the same table in different modes, and the weaker
+		// one must never mask the stronger one's requirement.
+		if surface.LockRequirement == nil || requirement.rank > surface.LockRequirement.rank {
+			held := requirement
+			surface.LockRequirement = &held
+		}
 		surface.WriteLockEvidence = append(surface.WriteLockEvidence, Evidence{
 			File: a.relFile(pos), Line: pos.Line, Statement: normalized,
 		})

--- a/internal/domaingrants/analyze.go
+++ b/internal/domaingrants/analyze.go
@@ -105,6 +105,10 @@ type DerivedSurface struct {
 	// pass refused to resolve (two implementations, or an unresolvable value).
 	// Each is an unanalyzed hole reached by pool-tainted arguments.
 	FuncValueConflicts []FuncValueConflictSite
+	// UnparsedLocks are LOCK statements the parser could not fully understand.
+	// Each is a hole with a table-shaped consequence: an unparsed LOCK may demand
+	// a privilege on a table that never appears in this surface at all.
+	UnparsedLocks []UnparsedLockSite
 	// NameSeedOverrides are places a parameter named after THIS role's pool was
 	// NOT treated as a seed, because its call sites pass a different role's pool.
 	// Reported because it is a correction of a naming convention, and the reader
@@ -352,6 +356,7 @@ type analyzer struct {
 	// See buildPoolParamRoles.
 	poolParamRoles    map[*types.Func]map[int]map[PoolRole]bool
 	nameSeedOverrides []NameSeedOverride
+	unparsedLocks     []UnparsedLockSite
 
 	// txOriginParam[fn][paramIndex] holds the origin ID (a "file:line"
 	// string naming the specific `.Begin(ctx)` call site) of a pgx.Tx-typed
@@ -368,6 +373,15 @@ type analyzer struct {
 	// they commit together). Built once, independent of taint state, same
 	// fixed-point shape as buildSQLParamConstants.
 	txOriginParam map[*types.Func]map[int]string
+}
+
+// UnparsedLockSite is one LOCK statement the parser refused. Reported, never
+// swallowed: a parser that silently ignores what it cannot recognise is the
+// worst possible shape for a tool whose job is to fail closed.
+type UnparsedLockSite struct {
+	File      string
+	Line      int
+	Statement string
 }
 
 // DevirtualizedCallSite records every place the analyzer resolved an
@@ -585,6 +599,7 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 		a.funcValueResolved = nil
 		a.funcValueConflictSites = nil
 		a.nameSeedOverrides = nil
+		a.unparsedLocks = nil
 		for fn, ctx := range a.funcDecls {
 			a.walkFunc(fn, ctx)
 		}
@@ -620,6 +635,7 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 		FuncValueResolved:  a.funcValueResolved,
 		FuncValueConflicts: a.funcValueConflictSites,
 		NameSeedOverrides:  a.nameSeedOverrides,
+		UnparsedLocks:      a.unparsedLocks,
 		UnresolvedTx:       dedupUnresolvedTx(a.unresolvedTx),
 		rootModule:         moduleDir,
 	}, nil
@@ -1667,6 +1683,15 @@ func (a *analyzer) recordSQLText(sqlText string, pos token.Position, txGroup str
 		}
 		surface.WriteLockEvidence = append(surface.WriteLockEvidence, Evidence{
 			File: a.relFile(pos), Line: pos.Line, Statement: normalized,
+		})
+	}
+	for _, text := range stmt.UnparsedLocks {
+		// A LOCK the parser could not understand may demand a privilege on a
+		// table that never enters the derived surface at all, so this is recorded
+		// as a first-class fact and fails the gate. Swallowing it is the shape
+		// that let `LOCK a, b` derive nothing and pass CI.
+		a.unparsedLocks = append(a.unparsedLocks, UnparsedLockSite{
+			File: a.relFile(pos), Line: pos.Line, Statement: text,
 		})
 	}
 }

--- a/internal/domaingrants/analyze.go
+++ b/internal/domaingrants/analyze.go
@@ -354,9 +354,13 @@ type analyzer struct {
 	// poolParamRoles is role-agnostic call-site evidence for pool-typed
 	// parameters; nameSeedOverrides records where it overruled a name-based seed.
 	// See buildPoolParamRoles.
-	poolParamRoles    map[*types.Func]map[int]map[PoolRole]bool
-	nameSeedOverrides []NameSeedOverride
-	unparsedLocks     []UnparsedLockSite
+	poolParamRoles map[*types.Func]map[int]map[PoolRole]bool
+	// poolParamIncomplete marks parameters whose call-site evidence is a LOWER
+	// BOUND (some argument could not be classified). Such evidence must never
+	// override a seed name -- see nameSeedContradicted.
+	poolParamIncomplete map[*types.Func]map[int]bool
+	nameSeedOverrides   []NameSeedOverride
+	unparsedLocks       []UnparsedLockSite
 
 	// txOriginParam[fn][paramIndex] holds the origin ID (a "file:line"
 	// string naming the specific `.Begin(ctx)` call site) of a pgx.Tx-typed
@@ -577,7 +581,9 @@ func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
 			"go/packages load likely failed silently", moduleDir)
 	}
 	a.buildImplementers(pkgs)
-	a.buildPoolParamRoles()
+	if err := a.buildPoolParamRoles(); err != nil {
+		return nil, err
+	}
 	a.buildFuncValueTargets()
 	a.buildSQLParamConstants()
 	a.buildTxOrigins()

--- a/internal/domaingrants/analyze.go
+++ b/internal/domaingrants/analyze.go
@@ -86,27 +86,188 @@ type UnresolvedTxSite struct {
 	Function string
 }
 
-// DerivedSurface is the full result of statically deriving the domain-pool
-// query surface.
+// DerivedSurface is the full result of statically deriving one pool's query
+// surface. Which pool is recorded in Role -- the derivation is identical
+// modulo the syntactic seed roots (see PoolRole and roleSeeds).
 type DerivedSurface struct {
+	Role          PoolRole
 	Tables        map[string]*TableSurface
 	Dynamic       []DynamicSite
 	Unresolved    []UnresolvedCallSite
-	SeedSites     []Evidence // where a *.Domain/.domainPool/.DomainPool() root was found, for auditing tool scope
+	SeedSites     []Evidence // where a pool root for Role was found, for auditing tool scope
 	Devirtualized []DevirtualizedCallSite
-	UnresolvedTx  []UnresolvedTxSite
-	rootModule    string
+	// FuncValueResolved is every call resolved through a function-typed struct
+	// field (funcvalue.go), for the same auditability reason Devirtualized
+	// exists: both are deliberately narrow unique-target shortcuts.
+	FuncValueResolved []FuncValueResolvedCallSite
+	UnresolvedTx      []UnresolvedTxSite
+	rootModule        string
 }
 
+// PoolRole names one of the Postgres connection pools this module opens, and
+// therefore one of the least-privilege database roles whose grant surface has
+// to be derived. Option B of CHAOS-3033 split the single domain role into
+// domain + coordinator (see CoordinatorPosture in
+// internal/storage/postgres/domain_authorization.go); the queue-control pool
+// is a third, pre-existing role that River owns and this checker does not
+// model.
+type PoolRole string
+
+const (
+	// RoleDomain is the pool every always-on worker profile uses.
+	RoleDomain PoolRole = "domain"
+	// RoleCoordinator is the control-plane pool the reconciler, scheduler and
+	// workerctl binaries use (CHAOS-3114).
+	RoleCoordinator PoolRole = "coordinator"
+)
+
+// AllPoolRoles is every role this checker derives a surface for, in a stable
+// order. Anything iterating roles MUST use this rather than a literal list,
+// so adding a fourth pool cannot be half-wired.
+var AllPoolRoles = []PoolRole{RoleDomain, RoleCoordinator}
+
+// roleSeeds is the syntactic root set that identifies one pool. Both pools are
+// wired through the same three shapes in this codebase, so the whole
+// difference between deriving the domain surface and deriving the coordinator
+// surface is which names appear here -- which is why this is a
+// parameterization of one deriver and NOT a second copy of it. A copy would
+// drift; every hardening pass (interprocedural SQL constant folding, tx-origin
+// tracing, devirtualization, LOCK-implies-write) applies to both roles because
+// there is only one implementation of each.
+type roleSeeds struct {
+	// fields are SelectorExpr .Sel names of *pgxpool.Pool type, e.g.
+	// `pools.Domain`, `storage.domainPool`, `pools.Coordinator`.
+	fields map[string]bool
+	// getters are CallExpr selector names returning *pgxpool.Pool, e.g.
+	// `database.DomainPool()`, `database.CoordinatorPool()`.
+	getters map[string]bool
+	// idents are bare identifier names of *pgxpool.Pool type -- locals and
+	// parameters the wiring code names after the pool it received, e.g.
+	// `coordinatorPool, err := pools.CoordinatorPool()` and the
+	// `coordinatorPool *pgxpool.Pool` parameters it is then threaded through.
+	idents map[string]bool
+}
+
+// poolRoleSeeds is the whole role-specific part of the analysis. Every name
+// here is a real wiring site in this repo; see roleSeedEvidence in
+// grant_surface_test.go for the assertion that each one still matches at
+// least one live site, so a rename cannot silently empty a role's root set
+// and make its surface look trivially satisfied.
+var poolRoleSeeds = map[PoolRole]roleSeeds{
+	RoleDomain: {
+		fields:  map[string]bool{"Domain": true, "domainPool": true},
+		getters: map[string]bool{"DomainPool": true},
+		idents:  map[string]bool{"domainPool": true},
+	},
+	RoleCoordinator: {
+		fields:  map[string]bool{"Coordinator": true, "coordinatorPool": true},
+		getters: map[string]bool{"CoordinatorPool": true},
+		idents:  map[string]bool{"coordinatorPool": true},
+	},
+}
+
+// seedsFor returns the seed set for role, and the union of every OTHER role's
+// seed set as a taint BARRIER.
+//
+// The barrier is what makes a per-role derivation mean anything. Without it,
+// `exprTainted`'s deliberately-permissive fall-throughs (a SelectorExpr off an
+// already-tainted base is tainted; a receiver with any tainted field taints
+// the whole receiver) leak the other pool into this role's surface: in a
+// coordinator run, `pools.Coordinator = coordinatorPool` taints the
+// RuntimePools "Coordinator" field, the receiver-seeding heuristic then taints
+// the whole `p` receiver in every *RuntimePools method, and `p.Domain` inside
+// one of those methods comes back tainted purely because it is selected off a
+// tainted base. That over-approximation is harmless in a one-role world (it
+// only ever argues for a grant the single role already needs) but it is
+// actively wrong here: it would claim coordinator needs the domain surface,
+// which both licenses an over-grant and makes the bidirectional attribution
+// check report the entire shared surface as a leak.
+//
+// Barrier-first ordering matters: the other role's root is checked BEFORE the
+// permissive fall-throughs, so the partition is cut at exactly the syntactic
+// boundary the wiring code already maintains.
+func seedsFor(role PoolRole) (seeds roleSeeds, barrier roleSeeds) {
+	barrier = roleSeeds{
+		fields:  map[string]bool{},
+		getters: map[string]bool{},
+		idents:  map[string]bool{},
+	}
+	for other, otherSeeds := range poolRoleSeeds {
+		if other == role {
+			continue
+		}
+		for name := range otherSeeds.fields {
+			barrier.fields[name] = true
+		}
+		for name := range otherSeeds.getters {
+			barrier.getters[name] = true
+		}
+		for name := range otherSeeds.idents {
+			barrier.idents[name] = true
+		}
+	}
+	return poolRoleSeeds[role], barrier
+}
+
+// isBarrierExpr reports whether expr is another role's pool root, in which
+// case taint must stop here rather than fall through to the permissive
+// derived-from-a-tainted-base rules. See seedsFor's doc comment.
+func (a *analyzer) isBarrierExpr(expr ast.Expr, info *types.Info) bool {
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		return a.barrier.fields[e.Sel.Name] && isPgxPoolPtr(info.TypeOf(e))
+	case *ast.CallExpr:
+		if sel, ok := e.Fun.(*ast.SelectorExpr); ok {
+			return a.barrier.getters[sel.Sel.Name] && isPgxPoolPtr(info.TypeOf(e))
+		}
+	case *ast.Ident:
+		return a.barrier.idents[e.Name] && isPgxPoolPtr(info.TypeOf(e))
+	}
+	return false
+}
+
+// funcCtx is one analyzable function body. Exactly one of decl or lit is set:
+// decl for an ordinary declared function or method, lit for a function
+// LITERAL declared at package level (see analyzer.funcLits for why those need
+// their own entry). litName is the synthetic display name used for a lit's
+// TxGroup, since a lit has no declared name.
 type funcCtx struct {
-	decl *ast.FuncDecl
-	info *types.Info
-	pkg  *packages.Package
-	file string
+	decl    *ast.FuncDecl
+	lit     *ast.FuncLit
+	litName string
+	info    *types.Info
+	pkg     *packages.Package
+	file    string
+}
+
+// funcType is the signature AST of whichever form this context holds.
+func (c funcCtx) funcType() *ast.FuncType {
+	if c.decl != nil {
+		return c.decl.Type
+	}
+	if c.lit != nil {
+		return c.lit.Type
+	}
+	return nil
+}
+
+// body is the statement list of whichever form this context holds.
+func (c funcCtx) body() *ast.BlockStmt {
+	if c.decl != nil {
+		return c.decl.Body
+	}
+	if c.lit != nil {
+		return c.lit.Body
+	}
+	return nil
 }
 
 type analyzer struct {
-	fset         *token.FileSet
+	fset *token.FileSet
+	// seeds are this run's pool roots; barrier is every other role's roots,
+	// where taint must stop. See seedsFor.
+	seeds        roleSeeds
+	barrier      roleSeeds
 	rootModule   string
 	funcDecls    map[*types.Func]funcCtx
 	taintedParam map[*types.Func]map[int]bool
@@ -143,6 +304,26 @@ type analyzer struct {
 	// Built once, independent of taint state (a pure syntactic property of
 	// call sites), before the taint fixed-point loop.
 	sqlParamConstants map[*types.Func]map[int][]string
+
+	// funcLits holds function literals declared at PACKAGE level (in a var or
+	// const declaration, typically as a field of a DI composition struct).
+	// They need their own entry because they are not inside any FuncDecl body,
+	// so the main walk never visits them at all -- unlike a literal nested in
+	// a function, which its enclosing body's walk already covers. Registering
+	// only package-level literals is what keeps this from double-walking (and
+	// therefore double-recording evidence for) the nested ones.
+	funcLits map[*ast.FuncLit]funcCtx
+	// taintedLitParam is taintedParam for those literals, keyed by AST node
+	// since a literal has no *types.Func.
+	taintedLitParam map[*ast.FuncLit]map[int]bool
+
+	// funcValueTargets resolves a function-typed struct field to its single
+	// implementation; funcValueScopes are the files that pass scans; and
+	// funcValueResolved is the audit trail of calls it resolved. See
+	// funcvalue.go for the shape this closes and why.
+	funcValueTargets  map[funcValueKey]funcValueTarget
+	funcValueScopes   []funcValueScope
+	funcValueResolved []FuncValueResolvedCallSite
 
 	// txOriginParam[fn][paramIndex] holds the origin ID (a "file:line"
 	// string naming the specific `.Begin(ctx)` call site) of a pgx.Tx-typed
@@ -189,14 +370,40 @@ var isSQLMethod = map[string]bool{
 	"SendBatch": true,
 }
 
-// Derive loads the Go module rooted at moduleDir and statically derives the
-// per-table privilege surface reachable through the Postgres domain
-// connection pool, starting from every "*.Domain" / "*.domainPool" /
-// "*.DomainPool()" root found anywhere under moduleDir (not limited to a
-// fixed list of cmd/ directories -- see the handoff README for why that
-// matters: cmd/dev-health-reconciler and cmd/dev-health-scheduler also wire
-// the domain pool and are not optional).
+// Derive derives the DOMAIN pool's surface. It is DeriveForRole(moduleDir,
+// RoleDomain) and exists only so the original single-role call sites keep
+// working unchanged.
 func Derive(moduleDir string) (*DerivedSurface, error) {
+	return DeriveForRole(moduleDir, RoleDomain)
+}
+
+// DeriveForRole loads the Go module rooted at moduleDir and statically derives
+// the per-table privilege surface reachable through role's Postgres connection
+// pool, starting from every pool root for that role (see poolRoleSeeds) found
+// anywhere under moduleDir -- not limited to a fixed list of cmd/ directories.
+// That breadth is load-bearing for BOTH roles: cmd/dev-health-reconciler and
+// cmd/dev-health-scheduler wire the domain pool and are not optional, and the
+// coordinator pool is threaded through `coordinatorPool *pgxpool.Pool`
+// parameters in those same dependency-construction files rather than being
+// re-fetched from a getter at each use.
+//
+// Roles are derived in SEPARATE runs (separate analyzer instances, separate
+// taint state) rather than one run with role-labelled taint. Two reasons: the
+// taint lattice is a single boolean per (function, parameter) and per (type,
+// field), so labelling it would mean rewriting the fixed point rather than
+// parameterizing it; and separate runs make the two surfaces independently
+// auditable, which is what the bidirectional attribution check compares.
+func DeriveForRole(moduleDir string, role PoolRole) (*DerivedSurface, error) {
+	seeds, ok := poolRoleSeeds[role]
+	if !ok {
+		return nil, fmt.Errorf("domaingrants: unknown pool role %q", role)
+	}
+	if len(seeds.fields) == 0 && len(seeds.getters) == 0 && len(seeds.idents) == 0 {
+		return nil, fmt.Errorf("domaingrants: pool role %q has an empty seed set, "+
+			"which would derive an empty surface and make every check on it vacuously pass", role)
+	}
+	_, barrier := seedsFor(role)
+
 	cfg := &packages.Config{
 		Dir: moduleDir,
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
@@ -220,13 +427,17 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 	}
 
 	a := &analyzer{
-		fset:         nil,
-		rootModule:   moduleDir,
-		funcDecls:    map[*types.Func]funcCtx{},
-		taintedParam: map[*types.Func]map[int]bool{},
-		taintedField: map[*types.Named]map[string]bool{},
-		tables:       map[string]*TableSurface{},
-		seedSeen:     map[string]bool{},
+		fset:            nil,
+		seeds:           seeds,
+		barrier:         barrier,
+		rootModule:      moduleDir,
+		funcDecls:       map[*types.Func]funcCtx{},
+		funcLits:        map[*ast.FuncLit]funcCtx{},
+		taintedParam:    map[*types.Func]map[int]bool{},
+		taintedLitParam: map[*ast.FuncLit]map[int]bool{},
+		taintedField:    map[*types.Named]map[string]bool{},
+		tables:          map[string]*TableSurface{},
+		seedSeen:        map[string]bool{},
 	}
 
 	packages.Visit(pkgs, nil, func(p *packages.Package) {
@@ -243,7 +454,32 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 			if strings.HasSuffix(filename, "_test.go") {
 				continue
 			}
+			a.funcValueScopes = append(a.funcValueScopes,
+				funcValueScope{node: file, info: p.TypesInfo})
 			for _, decl := range file.Decls {
+				// Function literals in package-level declarations are inside no
+				// FuncDecl body, so nothing else ever walks them. Register only
+				// the OUTERMOST one in each declaration: a literal nested inside
+				// another is reached by the outer literal's own walk, and
+				// registering both would record its evidence twice.
+				if gen, ok := decl.(*ast.GenDecl); ok {
+					ast.Inspect(gen, func(n ast.Node) bool {
+						lit, ok := n.(*ast.FuncLit)
+						if !ok {
+							return true
+						}
+						pos := a.fset.Position(lit.Pos())
+						a.funcLits[lit] = funcCtx{
+							lit:     lit,
+							litName: fmt.Sprintf("funclit@%s:%d", a.relFile(pos), pos.Line),
+							info:    p.TypesInfo,
+							pkg:     p,
+							file:    filename,
+						}
+						return false
+					})
+					continue
+				}
 				fd, ok := decl.(*ast.FuncDecl)
 				if !ok || fd.Body == nil {
 					continue
@@ -266,6 +502,7 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 			"go/packages load likely failed silently", moduleDir)
 	}
 	a.buildImplementers(pkgs)
+	a.buildFuncValueTargets()
 	a.buildSQLParamConstants()
 	a.buildTxOrigins()
 
@@ -283,8 +520,12 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 		a.seedSites = nil
 		a.seedSeen = map[string]bool{}
 		a.unresolvedTx = nil
+		a.funcValueResolved = nil
 		for fn, ctx := range a.funcDecls {
 			a.walkFunc(fn, ctx)
+		}
+		for lit, ctx := range a.funcLits {
+			a.walkFuncLit(lit, ctx)
 		}
 		if debugConvergence {
 			totalParams, totalFields := 0, 0
@@ -306,13 +547,15 @@ func Derive(moduleDir string) (*DerivedSurface, error) {
 	}
 
 	return &DerivedSurface{
-		Tables:        a.tables,
-		Dynamic:       a.dynamic,
-		Unresolved:    a.unresolved,
-		SeedSites:     a.seedSites,
-		Devirtualized: a.devirt,
-		UnresolvedTx:  dedupUnresolvedTx(a.unresolvedTx),
-		rootModule:    moduleDir,
+		Role:              role,
+		Tables:            a.tables,
+		Dynamic:           a.dynamic,
+		Unresolved:        a.unresolved,
+		SeedSites:         a.seedSites,
+		Devirtualized:     a.devirt,
+		FuncValueResolved: a.funcValueResolved,
+		UnresolvedTx:      dedupUnresolvedTx(a.unresolvedTx),
+		rootModule:        moduleDir,
 	}, nil
 }
 
@@ -509,7 +752,7 @@ func (a *analyzer) buildSQLParamConstants() {
 					if tv := ctx.info.Types[arg]; tv.Value != nil && tv.Value.Kind() == constant.String {
 						values = []string{constant.StringVal(tv.Value)}
 					} else if id, ok := arg.(*ast.Ident); ok && currentFn != nil {
-						if pIdx := paramIndex(ctx.decl, id.Name); pIdx >= 0 {
+						if pIdx := paramIndex(ctx.funcType(), id.Name); pIdx >= 0 {
 							values = a.sqlParamConstants[currentFn][pIdx] // nil if not yet resolved
 						}
 					}
@@ -566,14 +809,14 @@ func (a *analyzer) buildSQLParamConstants() {
 }
 
 // paramIndex returns the positional index of a parameter named name in
-// decl's parameter list, or -1 if not found. Accounts for grouped names
+// sig.s parameter list, or -1 if not found. Accounts for grouped names
 // (`a, b string`).
-func paramIndex(decl *ast.FuncDecl, name string) int {
-	if decl.Type.Params == nil {
+func paramIndex(sig *ast.FuncType, name string) int {
+	if sig == nil || sig.Params == nil {
 		return -1
 	}
 	idx := 0
-	for _, field := range decl.Type.Params.List {
+	for _, field := range sig.Params.List {
 		if len(field.Names) == 0 {
 			idx++
 			continue
@@ -589,14 +832,14 @@ func paramIndex(decl *ast.FuncDecl, name string) int {
 }
 
 // paramNameAt returns the name of the parameter at positional index idx in
-// decl's parameter list, or "" if idx is out of range or the parameter is
+// sig.s parameter list, or "" if idx is out of range or the parameter is
 // unnamed (`_` or bare type with no identifier).
-func paramNameAt(decl *ast.FuncDecl, idx int) string {
-	if decl.Type.Params == nil {
+func paramNameAt(sig *ast.FuncType, idx int) string {
+	if sig == nil || sig.Params == nil {
 		return ""
 	}
 	pos := 0
-	for _, field := range decl.Type.Params.List {
+	for _, field := range sig.Params.List {
 		if len(field.Names) == 0 {
 			if pos == idx {
 				return ""
@@ -679,7 +922,7 @@ func (a *analyzer) buildTxOrigins() {
 			localOrigin := map[string]string{}
 			if currentFn != nil {
 				for idx, origin := range a.txOriginParam[currentFn] {
-					if name := paramNameAt(ctx.decl, idx); name != "" {
+					if name := paramNameAt(ctx.funcType(), idx); name != "" {
 						localOrigin[name] = origin
 					}
 				}
@@ -769,6 +1012,10 @@ func (a *analyzer) resolveParamConstantSQL(sqlArg ast.Expr, ctx funcCtx) ([]stri
 	if !ok {
 		return nil, false
 	}
+	if ctx.decl == nil {
+		// buildSQLParamConstants indexes declared functions only.
+		return nil, false
+	}
 	fnObj, ok := ctx.info.Defs[ctx.decl.Name]
 	if !ok {
 		return nil, false
@@ -777,7 +1024,7 @@ func (a *analyzer) resolveParamConstantSQL(sqlArg ast.Expr, ctx funcCtx) ([]stri
 	if !ok {
 		return nil, false
 	}
-	idx := paramIndex(ctx.decl, ident.Name)
+	idx := paramIndex(ctx.funcType(), ident.Name)
 	if idx < 0 {
 		return nil, false
 	}
@@ -852,13 +1099,20 @@ func isPgxPoolPtr(t types.Type) bool {
 	return named.Obj().Name() == "Pool" && strings.HasSuffix(named.Obj().Pkg().Path(), "pgxpool")
 }
 
-// exprTainted decides whether expr's value is derived from the domain pool,
-// given the current global taint facts (taintedField, and -- via the
-// caller's seed detection -- the "*.Domain"/"*.domainPool"/"*.DomainPool()"
-// syntactic roots) plus this function's local taint set (locals: params
-// already known tainted, and any local variable this same walk has already
-// assigned from a tainted expression).
+// exprTainted decides whether expr's value is derived from THIS run's pool
+// (a.seeds), given the current global taint facts (taintedField, and -- via
+// the caller's seed detection -- the syntactic roots) plus this function's
+// local taint set (locals: params already known tainted, and any local
+// variable this same walk has already assigned from a tainted expression).
+//
+// Another role's pool root short-circuits to false before any of the
+// permissive fall-throughs below: see seedsFor's doc comment for why that
+// barrier is what makes a per-role surface meaningful rather than a
+// union-of-all-pools surface wearing one role's name.
 func (a *analyzer) exprTainted(expr ast.Expr, info *types.Info, locals map[string]bool) bool {
+	if a.isBarrierExpr(expr, info) {
+		return false
+	}
 	switch e := expr.(type) {
 	case nil:
 		return false
@@ -869,7 +1123,7 @@ func (a *analyzer) exprTainted(expr ast.Expr, info *types.Info, locals map[strin
 	case *ast.Ident:
 		return locals[e.Name]
 	case *ast.SelectorExpr:
-		if (e.Sel.Name == "Domain" || e.Sel.Name == "domainPool") && isPgxPoolPtr(info.TypeOf(e)) {
+		if a.seeds.fields[e.Sel.Name] && isPgxPoolPtr(info.TypeOf(e)) {
 			return true
 		}
 		if named := namedTypeOf(info.TypeOf(e.X)); named != nil {
@@ -885,7 +1139,7 @@ func (a *analyzer) exprTainted(expr ast.Expr, info *types.Info, locals map[strin
 		return a.exprTainted(e.X, info, locals)
 	case *ast.CallExpr:
 		if sel, ok := e.Fun.(*ast.SelectorExpr); ok &&
-			sel.Sel.Name == "DomainPool" && isPgxPoolPtr(info.TypeOf(e)) {
+			a.seeds.getters[sel.Sel.Name] && isPgxPoolPtr(info.TypeOf(e)) {
 			return true
 		}
 		// Calling an already-tainted function value (a method on a tainted
@@ -932,11 +1186,27 @@ func (a *analyzer) recordSeed(expr ast.Expr) {
 }
 
 func (a *analyzer) walkFunc(fn *types.Func, ctx funcCtx) {
+	a.walkBody(ctx, a.taintedParam[fn])
+}
+
+// walkFuncLit walks a package-level function literal's body with the taint
+// facts recorded for ITS parameters. See analyzer.funcLits.
+func (a *analyzer) walkFuncLit(lit *ast.FuncLit, ctx funcCtx) {
+	a.walkBody(ctx, a.taintedLitParam[lit])
+}
+
+// walkBody is the shared walk for both forms. tainted is the caller's
+// already-known per-parameter-index taint for this body.
+func (a *analyzer) walkBody(ctx funcCtx, tainted map[int]bool) {
+	sig := ctx.funcType()
+	body := ctx.body()
+	if sig == nil || body == nil {
+		return
+	}
 	locals := map[string]bool{}
-	if ctx.decl.Type.Params != nil {
+	if sig.Params != nil {
 		idx := 0
-		tainted := a.taintedParam[fn]
-		for _, field := range ctx.decl.Type.Params.List {
+		for _, field := range sig.Params.List {
 			names := field.Names
 			if len(names) == 0 {
 				idx++
@@ -965,7 +1235,9 @@ func (a *analyzer) walkFunc(fn *types.Func, ctx funcCtx) {
 	// codebase's DI style. Slightly over-inclusive by design (a method that
 	// happens not to touch the tainted field on a tainted receiver is still
 	// treated as tainted) -- see the handoff README.
-	if ctx.decl.Recv != nil && len(ctx.decl.Recv.List) == 1 && len(ctx.decl.Recv.List[0].Names) == 1 {
+	// A function literal has no receiver, so this only applies to the decl form.
+	if ctx.decl != nil && ctx.decl.Recv != nil &&
+		len(ctx.decl.Recv.List) == 1 && len(ctx.decl.Recv.List[0].Names) == 1 {
 		recvName := ctx.decl.Recv.List[0].Names[0].Name
 		recvNamed := namedTypeOf(ctx.info.TypeOf(ctx.decl.Recv.List[0].Type))
 		if recvName != "_" && recvNamed != nil && len(a.taintedField[recvNamed]) > 0 {
@@ -981,7 +1253,7 @@ func (a *analyzer) walkFunc(fn *types.Func, ctx funcCtx) {
 		return a.exprTainted(expr, ctx.info, locals)
 	}
 
-	ast.Inspect(ctx.decl.Body, func(n ast.Node) bool {
+	ast.Inspect(body, func(n ast.Node) bool {
 		switch node := n.(type) {
 		case *ast.AssignStmt:
 			a.handleAssign(node, ctx, locals, isTainted)
@@ -994,25 +1266,29 @@ func (a *analyzer) walkFunc(fn *types.Func, ctx funcCtx) {
 	})
 }
 
-// isSeedExpr is the syntactic domain-pool root: a "*.Domain" or
-// "*.domainPool" field of pgxpool.Pool type, or a "*.DomainPool()" call
-// returning one. See the handoff README for the wiring sites this matches
-// and why (cmd/dev-health-worker's postgresDatabase.pools.Domain,
+// isSeedExpr is the syntactic pool root for THIS run's role: a seed-named
+// field of pgxpool.Pool type, a seed-named getter call returning one, or a
+// seed-named bare identifier of that type. See poolRoleSeeds for the names and
+// the wiring sites they match -- for the domain role,
+// cmd/dev-health-worker's postgresDatabase.pools.Domain,
 // cmd/dev-health-workerctl's pools.Domain, cmd/dev-health-reconciler's and
-// cmd/dev-health-scheduler's DomainPool() getters, cmd/dev-health-stream-runner's
-// storage.domainPool).
+// cmd/dev-health-scheduler's DomainPool() getters, and
+// cmd/dev-health-stream-runner's storage.domainPool; for the coordinator role,
+// RuntimePools.Coordinator, the reconciler's and scheduler's CoordinatorPool()
+// getters, and the `coordinatorPool` locals/parameters those and
+// cmd/dev-health-workerctl thread the pool through.
 func (a *analyzer) isSeedExpr(expr ast.Expr, info *types.Info) bool {
 	switch e := expr.(type) {
 	case *ast.SelectorExpr:
-		if (e.Sel.Name == "Domain" || e.Sel.Name == "domainPool") && isPgxPoolPtr(info.TypeOf(e)) {
+		if a.seeds.fields[e.Sel.Name] && isPgxPoolPtr(info.TypeOf(e)) {
 			return true
 		}
 	case *ast.CallExpr:
-		if sel, ok := e.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "DomainPool" && isPgxPoolPtr(info.TypeOf(e)) {
+		if sel, ok := e.Fun.(*ast.SelectorExpr); ok && a.seeds.getters[sel.Sel.Name] && isPgxPoolPtr(info.TypeOf(e)) {
 			return true
 		}
 	case *ast.Ident:
-		if e.Name == "domainPool" && isPgxPoolPtr(info.TypeOf(e)) {
+		if a.seeds.idents[e.Name] && isPgxPoolPtr(info.TypeOf(e)) {
 			return true
 		}
 	}
@@ -1124,6 +1400,13 @@ func (a *analyzer) handleCall(call *ast.CallExpr, ctx funcCtx, locals map[string
 		return
 	}
 	if callee == nil {
+		// A call through a function-typed struct field lands here (the
+		// selection resolves to a *types.Var, not a *types.Func). Resolve it to
+		// the field's single implementation before giving up -- see
+		// funcvalue.go for why this hop is load-bearing.
+		if isSel && a.propagateIntoFuncValue(call, sel, ctx, isTainted) {
+			return
+		}
 		a.recordUnresolved(call, ctx, calleeDisplay, "callee could not be resolved to a function (dynamic call through a variable/field of function type)")
 		return
 	}
@@ -1230,10 +1513,12 @@ func (a *analyzer) recordSQLSite(call *ast.CallExpr, ctx funcCtx, recvExpr ast.E
 // buildTxOrigins couldn't resolve it unambiguously). See
 // Evidence.TxGroup's doc comment.
 func (a *analyzer) txGroupKey(ctx funcCtx, recvExpr ast.Expr) string {
-	if id, ok := recvExpr.(*ast.Ident); ok {
+	// buildTxOrigins only indexes declared functions, so a function literal
+	// falls straight through to the coarse grouping below.
+	if id, ok := recvExpr.(*ast.Ident); ok && ctx.decl != nil {
 		if fnObj, ok := ctx.info.Defs[ctx.decl.Name]; ok {
 			if fn, ok := fnObj.(*types.Func); ok {
-				if idx := paramIndex(ctx.decl, id.Name); idx >= 0 {
+				if idx := paramIndex(ctx.funcType(), id.Name); idx >= 0 {
 					if origin, ok := a.txOriginParam[fn][idx]; ok {
 						return "txorigin:" + origin
 					}
@@ -1260,6 +1545,9 @@ func (a *analyzer) txGroupKey(ctx funcCtx, recvExpr ast.Expr) string {
 // txGroupFallbackName returns the "[Receiver.]FuncName" the coarse,
 // same-function-body TxGroup fallback uses.
 func txGroupFallbackName(ctx funcCtx) string {
+	if ctx.decl == nil {
+		return ctx.litName
+	}
 	name := ctx.decl.Name.Name
 	if ctx.decl.Recv != nil && len(ctx.decl.Recv.List) == 1 {
 		if named := namedTypeOf(ctx.info.TypeOf(ctx.decl.Recv.List[0].Type)); named != nil {
@@ -1310,6 +1598,10 @@ func (a *analyzer) recordSQLText(sqlText string, pos token.Position, txGroup str
 // resolution would be worse than none (it would silently under-report the
 // unresolved elements as if they didn't exist).
 func (a *analyzer) resolveLoopTableSQL(sqlArg ast.Expr, ctx funcCtx) ([]string, bool) {
+	body := ctx.body()
+	if body == nil {
+		return nil, false
+	}
 	sel, ok := sqlArg.(*ast.SelectorExpr)
 	if !ok {
 		return nil, false
@@ -1319,7 +1611,7 @@ func (a *analyzer) resolveLoopTableSQL(sqlArg ast.Expr, ctx funcCtx) ([]string, 
 		return nil, false
 	}
 	var lit *ast.CompositeLit
-	ast.Inspect(ctx.decl.Body, func(n ast.Node) bool {
+	ast.Inspect(body, func(n ast.Node) bool {
 		if lit != nil {
 			return false
 		}
@@ -1343,7 +1635,7 @@ func (a *analyzer) resolveLoopTableSQL(sqlArg ast.Expr, ctx funcCtx) ([]string, 
 		// assigned to `steps`. Resolve by finding the RangeStmt whose Value
 		// is rangeVar and whose X is this identifier.
 		found := false
-		ast.Inspect(ctx.decl.Body, func(rn ast.Node) bool {
+		ast.Inspect(body, func(rn ast.Node) bool {
 			if found {
 				return false
 			}

--- a/internal/domaingrants/clause_coverage_test.go
+++ b/internal/domaingrants/clause_coverage_test.go
@@ -344,41 +344,6 @@ func TestFuncValueConflictReachesTheGate(t *testing.T) {
 	}
 }
 
-// --- H6.f: the strictest mode must win ACROSS call sites ----------------------
-//
-// The same-statement case was covered; two separate call sites locking one table
-// in different modes was not.
-func TestStrictestLockModeWinsAcrossSeparateCallSites(t *testing.T) {
-	weak, _ := lockRequirementForMode("ROW EXCLUSIVE")
-	strong, _ := lockRequirementForMode("ACCESS EXCLUSIVE")
-	if !(strong.rank > weak.rank) {
-		t.Fatalf("ACCESS EXCLUSIVE must outrank ROW EXCLUSIVE: %d vs %d", strong.rank, weak.rank)
-	}
-
-	// Whichever order the analyzer visits the two sites in, the surface must end
-	// up demanding the STRICT one. Both orders asserted, because the fixed point
-	// iterates a map and the order is not stable.
-	for _, order := range [][]LockRequirement{{weak, strong}, {strong, weak}} {
-		surface := &TableSurface{Table: "outbox"}
-		for _, requirement := range order {
-			if surface.LockRequirement == nil || requirement.rank > surface.LockRequirement.rank {
-				held := requirement
-				surface.LockRequirement = &held
-			}
-		}
-		if surface.LockRequirement.Mode != "ACCESS EXCLUSIVE" {
-			t.Errorf("strictest mode did not win (order %v/%v): got %s",
-				order[0].Mode, order[1].Mode, surface.LockRequirement.Mode)
-		}
-		var selectInsert PrivilegeSet
-		selectInsert.add(PrivSelect)
-		selectInsert.add(PrivInsert)
-		if lockSatisfiedBy(*surface.LockRequirement, selectInsert) {
-			t.Error("after escalation INSERT must no longer satisfy the lock")
-		}
-	}
-}
-
 // --- H1.a: the override only applies to THIS role's seed names ---------------
 func TestNameOverrideOnlyAppliesToSeedNamedParameters(t *testing.T) {
 	poolType := fakePoolType()
@@ -393,11 +358,160 @@ func TestNameOverrideOnlyAppliesToSeedNamedParameters(t *testing.T) {
 	ctx := funcCtx{decl: decl, info: info}
 
 	domainSeeds, domainBarrier := seedsFor(RoleDomain)
-	a := &analyzer{seeds: domainSeeds, barrier: domainBarrier}
-	// Even with call-site evidence naming only the coordinator, a parameter that
-	// was never a name-based seed has nothing to override -- reporting one would
-	// be a phantom correction of a convention that was never applied.
-	if a.nameSeedContradicted(use, ctx, nil) {
-		t.Error("the override must only fire for parameters this role would have seeded BY NAME")
+	// A REAL *types.Func with call-site evidence naming only the coordinator. An
+	// earlier version of this test passed fn=nil, which short-circuits on the
+	// `fn == nil` clause and MASKED the clause under test -- the mutation removing
+	// the seed-name check survived. Every sibling clause must be satisfied so the
+	// clause under test is the only thing that can decide the result.
+	fn := types.NewFunc(token.NoPos, nil, "build", nil)
+	a := &analyzer{
+		seeds: domainSeeds, barrier: domainBarrier,
+		poolParamRoles: map[*types.Func]map[int]map[PoolRole]bool{
+			fn: {0: {RoleCoordinator: true}},
+		},
+	}
+	// The parameter is `pool`, which is not a seed name for any role, so the domain
+	// run never seeded it by name and there is nothing to override. Firing here
+	// would be a phantom correction of a convention that was never applied.
+	if a.nameSeedContradicted(use, ctx, fn) {
+		t.Error("the override must only fire for parameters this role would have seeded BY NAME; " +
+			"`pool` is not a seed name, so no name-based seed exists to contradict")
+	}
+	// Control: the SAME state with a seed-named parameter MUST fire, proving the
+	// negative above comes from the seed-name clause and not from something else.
+	seedNamed := ast.NewIdent("domainPool")
+	seedCtx := funcCtx{
+		decl: &ast.FuncDecl{Name: ast.NewIdent("build"),
+			Type: &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{{
+				Names: []*ast.Ident{ast.NewIdent("domainPool")}, Type: ast.NewIdent("ignored"),
+			}}}},
+			Body: &ast.BlockStmt{}},
+		info: &types.Info{Types: map[ast.Expr]types.TypeAndValue{seedNamed: {Type: poolType}}},
+	}
+	if !a.nameSeedContradicted(seedNamed, seedCtx, fn) {
+		t.Error("control failed: a seed-named parameter with contradicting call sites must fire")
+	}
+}
+
+// TestStrictestLockModeWinsViaRecordSQLText exercises the PRODUCTION escalation
+// line rather than a reimplementation of it.
+//
+// The first version of this test rebuilt the "keep the stricter rank" comparison
+// inside the test body, so it passed while analyze.go's own copy was mutated away.
+// A test that reimplements the logic it is checking cannot fail with it.
+func TestStrictestLockModeWinsViaRecordSQLText(t *testing.T) {
+	// Two SEPARATE recordSQLText calls, as two distinct call sites would produce.
+	// Both orders, because the analyzer walks a map and the order is not stable.
+	for _, order := range [][]string{
+		{"LOCK TABLE public.outbox IN ROW EXCLUSIVE MODE", "LOCK TABLE public.outbox IN ACCESS EXCLUSIVE MODE"},
+		{"LOCK TABLE public.outbox IN ACCESS EXCLUSIVE MODE", "LOCK TABLE public.outbox IN ROW EXCLUSIVE MODE"},
+	} {
+		fset := token.NewFileSet()
+		file := fset.AddFile("internal/x/y.go", -1, 4096)
+		a := &analyzer{fset: fset, rootModule: "/", tables: map[string]*TableSurface{}}
+		for i, sql := range order {
+			a.recordSQLText(sql, fset.Position(file.Pos(10*(i+1))), "tx")
+		}
+		surface := a.tables["outbox"]
+		if surface == nil || surface.LockRequirement == nil {
+			t.Fatalf("no lock requirement recorded for order %v", order)
+		}
+		if surface.LockRequirement.Mode != "ACCESS EXCLUSIVE" {
+			t.Errorf("order %v: strictest mode did not win across call sites, got %s",
+				order, surface.LockRequirement.Mode)
+		}
+		var selectInsert PrivilegeSet
+		selectInsert.add(PrivSelect)
+		selectInsert.add(PrivInsert)
+		if lockSatisfiedBy(*surface.LockRequirement, selectInsert) {
+			t.Errorf("order %v: INSERT must not satisfy the escalated requirement", order)
+		}
+	}
+}
+
+// TestTracedStraddleWithSharedEvidenceIsAdvisory covers the straddle's ATTRIBUTION
+// premise on its own. The coarse-grouping test has traced=false, so `attributed`
+// never decided anything there and the mutations neutralising it survived. Here
+// co-residency IS proven and only the attribution is missing.
+func TestTracedStraddleWithSharedEvidenceIsAdvisory(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	const traced = "txorigin:internal/shared/repo.go:5"
+	// Both roles derive the SAME traced group at the SAME sites -- a type fed by
+	// both pools -- so neither role can claim the transaction.
+	build := func(role PoolRole) *DerivedSurface {
+		coord := &TableSurface{Table: "coord_table"}
+		coord.Privileges.add(PrivSelect)
+		coord.Evidence = append(coord.Evidence, Evidence{
+			File: "internal/shared/repo.go", Line: 10, Privilege: PrivSelect,
+			TxGroup: traced, Statement: "SELECT 1",
+		})
+		dom := &TableSurface{Table: "domain_table"}
+		dom.Privileges.add(PrivSelect)
+		dom.Evidence = append(dom.Evidence, Evidence{
+			File: "internal/shared/repo.go", Line: 11, Privilege: PrivSelect,
+			TxGroup: traced, Statement: "SELECT 1",
+		})
+		return &DerivedSurface{Role: role,
+			Tables: map[string]*TableSurface{"coord_table": coord, "domain_table": dom}}
+	}
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: build(RoleDomain),
+			Truth: truthWith(map[string]PrivilegeSet{"domain_table": selectOnly})},
+		{Role: RoleCoordinator, Derived: build(RoleCoordinator),
+			Truth: truthWith(map[string]PrivilegeSet{"coord_table": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range report.Findings {
+		if f.Severity == Critical && strings.Contains(f.Summary, "STRADDLES") {
+			t.Errorf("a traced straddle whose every evidence site is SHARED between roles was reported "+
+				"CRITICAL. Co-residency is proven but attribution is not, so blocking tells maintainers "+
+				"to dual-grant on a guess about whose pool runs it: %s", f.Summary)
+		}
+	}
+	joined := strings.Join(findingSummaries(report, Advisory), "\n")
+	if !strings.Contains(joined, "SHARED with another role") {
+		t.Errorf("expected the straddle to downgrade citing shared evidence, got:\n%s", joined)
+	}
+}
+
+// TestLockWithNoEvidenceStaysCritical pins the `othersLock` clause of the lock
+// downgrade. It guards a degenerate state -- a LockRequirement recorded with no
+// lock evidence -- which production never produces (analyze.go sets both together)
+// but which a future refactor could. Without the clause that state would silently
+// DOWNGRADE, turning a missing grant into an advisory.
+func TestLockWithNoEvidenceStaysCritical(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	requirement, _ := lockRequirementForMode("SHARE ROW EXCLUSIVE")
+	held := requirement
+	// LockRequirement set, WriteLockEvidence deliberately empty.
+	s := &TableSurface{Table: "outbox", LockRequirement: &held}
+	s.Privileges.add(PrivSelect)
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+		{Role: RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator, Tables: map[string]*TableSurface{"outbox": s}},
+			Truth:   truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a lock requirement with no recorded evidence must stay CRITICAL: with no sites there " +
+			"is nothing to call shared, so downgrading would hide a denial behind an advisory")
 	}
 }

--- a/internal/domaingrants/clause_coverage_test.go
+++ b/internal/domaingrants/clause_coverage_test.go
@@ -58,7 +58,7 @@ func TestLockDowngradeRequiresBothExclusivityAndOtherRoleLocking(t *testing.T) {
 	}
 	found := false
 	for _, f := range report.Findings {
-		if f.Severity == Critical && f.Role == RoleCoordinator && strings.Contains(f.Summary, "LOCK TABLE") {
+		if f.Severity == Critical && f.Role == RoleCoordinator && strings.Contains(f.Summary, "LOCK IN") {
 			found = true
 		}
 	}
@@ -506,7 +506,7 @@ func TestLockWithNoEvidenceStaysCritical(t *testing.T) {
 	}
 	found := false
 	for _, f := range report.Findings {
-		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK IN") {
 			found = true
 		}
 	}

--- a/internal/domaingrants/clause_coverage_test.go
+++ b/internal/domaingrants/clause_coverage_test.go
@@ -1,0 +1,403 @@
+package domaingrants
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+// This file exists because of a measurement error in how this package's own tests
+// were validated.
+//
+// Mutating each new predicate as a UNIT reported 13/13 mutations killed. Mutating
+// the same predicates CLAUSE BY CLAUSE reported 12/26 -- nine individual clauses
+// were dead, dominated by their siblings, or had no test that could distinguish
+// them. A compound condition mutated wholesale changes behaviour for some input,
+// so some test fails, so the verdict is KILLED -- and that verdict says nothing
+// about whether any particular clause matters.
+//
+// Every test below targets exactly one surviving clause, with the sibling clauses
+// holding their real values so the clause under test is the only difference.
+
+// --- H3.a: the lock downgrade needs BOTH clauses -------------------------------
+//
+// `len(exclusive) == 0 && othersLock`. The existing shared-evidence test has both
+// true, so dropping the exclusivity clause changed nothing. This case has
+// othersLock TRUE and an exclusive site present: the finding must stay CRITICAL,
+// because this role provably locks the table somewhere the other role does not.
+func TestLockDowngradeRequiresBothExclusivityAndOtherRoleLocking(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	lockAt := func(role PoolRole, sites ...int) *DerivedSurface {
+		requirement, _ := lockRequirementForMode("SHARE ROW EXCLUSIVE")
+		held := requirement
+		s := &TableSurface{Table: "outbox", LockRequirement: &held}
+		s.Privileges.add(PrivSelect)
+		for _, line := range sites {
+			s.WriteLockEvidence = append(s.WriteLockEvidence, Evidence{
+				File: "internal/shared/repo.go", Line: line,
+				Statement: "LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE",
+			})
+		}
+		return &DerivedSurface{Role: role, Tables: map[string]*TableSurface{"outbox": s}}
+	}
+
+	// Domain locks at line 42. Coordinator locks at 42 AND at 99 -- so 99 is
+	// coordinator-exclusive even though the roles share 42.
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: lockAt(RoleDomain, 42),
+			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
+		{Role: RoleCoordinator, Derived: lockAt(RoleCoordinator, 42, 99),
+			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, f := range report.Findings {
+		if f.Severity == Critical && f.Role == RoleCoordinator && strings.Contains(f.Summary, "LOCK TABLE") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the coordinator has a LOCK site the domain role does not, so the finding must stay " +
+			"CRITICAL -- downgrading merely because the OTHER role also locks the table would hide a " +
+			"real, role-exclusive denial")
+	}
+}
+
+// --- H3.c: the straddle needs the traced-co-residency premise ------------------
+//
+// The existing straddle test uses a "txorigin:" group, so `traced` was already
+// true and forcing it true changed nothing. A COARSE group must downgrade.
+func TestTransactionStraddleWithCoarseGroupingIsAdvisory(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// Same shape as the CRITICAL straddle test, but the TxGroup is the coarse
+	// package-qualified fallback rather than a traced Begin() origin.
+	const coarse = "github.com/full-chaos/dev-health-ops/internal/mat.Materializer.Step"
+	surface := surfaceWith(RoleCoordinator, "coord_table", PrivSelect, "internal/mat.go", 10, coarse)
+	domainOwned := &TableSurface{Table: "domain_table"}
+	domainOwned.Privileges.add(PrivSelect)
+	domainOwned.Evidence = append(domainOwned.Evidence, Evidence{
+		File: "internal/mat.go", Line: 11, Privilege: PrivSelect,
+		TxGroup: coarse, Statement: "SELECT 1",
+	})
+	surface.Tables["domain_table"] = domainOwned
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"domain_table": selectOnly})},
+		{Role: RoleCoordinator, Derived: surface,
+			Truth: truthWith(map[string]PrivilegeSet{"coord_table": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range report.Findings {
+		if f.Severity == Critical && strings.Contains(f.Summary, "STRADDLES") {
+			t.Errorf("a straddle grouped only by the COARSE same-function-body fallback was reported "+
+				"CRITICAL. That grouping is explicitly not proof of co-residency, so blocking on it "+
+				"tells maintainers to dual-grant on a guess: %s", f.Summary)
+		}
+	}
+	joined := strings.Join(findingSummaries(report, Advisory), "\n")
+	if !strings.Contains(joined, "COARSE") {
+		t.Errorf("expected an ADVISORY naming the coarse grouping, got:\n%s", joined)
+	}
+}
+
+// --- H5.d: implied-SELECT needs the has-other-evidence clause -----------------
+//
+// SELECT is synthesized onto every posture row, so a WRITE-only table legitimately
+// lacks derived SELECT evidence. But a table with NO evidence at all must NOT be
+// excused that way -- that is a genuine blind spot, and marking it implied would
+// silently drop it from the gate.
+func TestImpliedSelectOnlyExcusesTablesThatHaveOtherEvidence(t *testing.T) {
+	var selectInsert PrivilegeSet
+	selectInsert.add(PrivSelect)
+	selectInsert.add(PrivInsert)
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// writes_only: posture says SELECT+INSERT, derivation proves INSERT only.
+	writesOnly := &TableSurface{Table: "writes_only"}
+	writesOnly.Privileges.add(PrivInsert)
+	writesOnly.Evidence = append(writesOnly.Evidence, Evidence{
+		File: "internal/w.go", Line: 1, Privilege: PrivInsert, Statement: "INSERT", TxGroup: "tx",
+	})
+	// invisible: posture says SELECT, derivation proves nothing at all.
+	derived := &DerivedSurface{Role: RoleCoordinator,
+		Tables: map[string]*TableSurface{"writes_only": writesOnly}}
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+		{Role: RoleCoordinator, Derived: derived,
+			Truth: truthWith(map[string]PrivilegeSet{"writes_only": selectInsert, "invisible": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var coordinator IncompleteRoleSurface
+	for _, s := range report.Incomplete {
+		if s.Role == RoleCoordinator {
+			coordinator = s
+		}
+	}
+	byTable := map[string]PostureGapWithoutEvidence{}
+	for _, gap := range coordinator.UndeclaredByEvidence {
+		byTable[gap.Table] = gap
+	}
+
+	if got, ok := byTable["writes_only"]; !ok || !got.ImpliedSelect {
+		t.Errorf("a table with INSERT evidence must have its missing SELECT marked as implied by the "+
+			"posture model, not treated as a blind spot: %+v", got)
+	}
+	if got, ok := byTable["invisible"]; !ok || got.ImpliedSelect {
+		t.Errorf("a table with NO evidence at all must NOT be excused as implied-SELECT -- that is a "+
+			"real blind spot and excusing it drops it from the gate: %+v", got)
+	}
+
+	// And the invisible one must actually reach the failure path.
+	unacknowledged, _, _ := PartitionBlindSpots(report.Incomplete)
+	if !strings.Contains(strings.Join(unacknowledged, "\n"), "invisible") {
+		t.Errorf("the no-evidence table must be gated as unacknowledged, got %v", unacknowledged)
+	}
+	if strings.Contains(strings.Join(unacknowledged, "\n"), "writes_only") {
+		t.Errorf("the write-only table's implied SELECT must NOT be gated, got %v", unacknowledged)
+	}
+}
+
+// --- H5.e: stale acknowledged blind spots must be reported --------------------
+//
+// The equivalent property for knownOpenCriticals had a test; this one did not, so
+// deleting the staleness check entirely was invisible.
+func TestStaleAcknowledgedBlindSpotIsReported(t *testing.T) {
+	// No incompleteness at all: every real acknowledgement must report stale,
+	// because the gaps they excuse no longer exist.
+	unacknowledged, stale, _ := PartitionBlindSpots(nil)
+	if len(unacknowledged) != 0 {
+		t.Fatalf("no incompleteness should mean nothing unacknowledged, got %v", unacknowledged)
+	}
+	if len(stale) != len(acknowledgedBlindSpots) {
+		t.Fatalf("expected all %d acknowledgements reported stale against an empty incompleteness set, "+
+			"got %d -- without this the list silently outlives the blind spots it excuses",
+			len(acknowledgedBlindSpots), len(stale))
+	}
+	// And every entry must carry a reason.
+	_, _, unreasoned := PartitionBlindSpots(nil)
+	if len(unreasoned) != 0 {
+		t.Errorf("acknowledgements without a reason: %v", unreasoned)
+	}
+}
+
+// --- H5.f: pair granularity, on the exact case codex named --------------------
+//
+// SELECT stays visible while the UPDATE path goes dark. Under table granularity
+// the table is nonempty, so it contributes NO gap and the (table, UPDATE) hole
+// appears in no output at all.
+func TestPairGranularityCatchesADarkUpdatePathOnAVisibleTable(t *testing.T) {
+	var selectUpdate PrivilegeSet
+	selectUpdate.add(PrivSelect)
+	selectUpdate.add(PrivUpdate)
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// The posture authorizes SELECT+UPDATE; the derivation proves only SELECT.
+	partly := &TableSurface{Table: "half_visible"}
+	partly.Privileges.add(PrivSelect)
+	partly.Evidence = append(partly.Evidence, Evidence{
+		File: "internal/p.go", Line: 5, Privilege: PrivSelect, Statement: "SELECT 1", TxGroup: "tx",
+	})
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+		{Role: RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator,
+				Tables: map[string]*TableSurface{"half_visible": partly}},
+			Truth: truthWith(map[string]PrivilegeSet{"half_visible": selectUpdate})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, s := range report.Incomplete {
+		for _, gap := range s.UndeclaredByEvidence {
+			if s.Role == RoleCoordinator && gap.Table == "half_visible" && gap.Privilege == PrivUpdate {
+				found = true
+				if gap.ImpliedSelect {
+					t.Error("UPDATE must never be excused as an implied SELECT")
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("the (half_visible, UPDATE) gap was not enumerated. The table still has SELECT evidence, " +
+			"so a table-level check treats it as seen and this exact hole vanishes from every output -- " +
+			"which is why the enumeration is per (table, privilege)")
+	}
+
+	unacknowledged, _, _ := PartitionBlindSpots(report.Incomplete)
+	if !strings.Contains(strings.Join(unacknowledged, "\n"), "half_visible UPDATE") {
+		t.Errorf("the dark UPDATE path must reach the failure path, got %v", unacknowledged)
+	}
+}
+
+// --- H4.b: the two-implementation refusal, tested directly --------------------
+//
+// No in-module field in this repo has two production builders, so this branch
+// cannot be reached end-to-end. It is the whole point of fail-closed resolution,
+// so it is tested against the extracted decision function instead of left dead.
+func TestResolveTargetConflictRefusesTwoImplementations(t *testing.T) {
+	// A real FileSet and well-formed literals: `display` renders a file:line, so a
+	// bare &ast.FuncLit{} (nil Type, no position) is a state the producer never
+	// creates and panics here. Same discipline as the Callee="" fix -- a test whose
+	// input the production path cannot produce proves nothing.
+	fset := token.NewFileSet()
+	file := fset.AddFile("cmd/x/dependencies.go", -1, 4096)
+	newLit := func(offset int) *ast.FuncLit {
+		return &ast.FuncLit{
+			Type: &ast.FuncType{Func: file.Pos(offset), Params: &ast.FieldList{}},
+			Body: &ast.BlockStmt{},
+		}
+	}
+	a := &analyzer{fset: fset, rootModule: "/"}
+	first := funcValueTarget{lit: newLit(10)}
+	second := funcValueTarget{lit: newLit(20)}
+
+	// First assignment: accepted.
+	got, reason := a.resolveTargetConflict(funcValueTarget{}, false, first)
+	if reason != "" || !got.sameAs(first) {
+		t.Fatalf("a single assignment must be accepted, got %+v reason=%q", got, reason)
+	}
+
+	// Same target again: still accepted, no conflict (the fixed point revisits
+	// sites, so idempotence matters).
+	if _, reason := a.resolveTargetConflict(first, true, first); reason != "" {
+		t.Errorf("re-observing the SAME target must not conflict: %q", reason)
+	}
+
+	// A DIFFERENT target: refused, with a reason naming both.
+	got, reason = a.resolveTargetConflict(first, true, second)
+	if reason == "" {
+		t.Fatal("two different implementations must be refused -- picking one would analyze a body " +
+			"that may not be the one that runs")
+	}
+	if !got.empty() {
+		t.Error("a refused field must resolve to NOTHING, not to one of the candidates")
+	}
+	if !strings.Contains(reason, "MORE THAN ONE") {
+		t.Errorf("the reason must say what happened, since it is the only thing reported: %q", reason)
+	}
+
+	// An unresolvable value: also refused, with a DIFFERENT reason, so the report
+	// can distinguish "two builders" from "cannot see the value".
+	_, unresolvable := a.resolveTargetConflict(funcValueTarget{}, false, funcValueTarget{})
+	if unresolvable == "" || strings.Contains(unresolvable, "MORE THAN ONE") {
+		t.Errorf("an unresolvable assignment needs its own distinct reason: %q", unresolvable)
+	}
+}
+
+// --- H4.a: a recorded conflict must reach the failure path --------------------
+func TestFuncValueConflictReachesTheGate(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: surfaceWith(RoleDomain, "t", PrivSelect, "internal/d.go", 1, "tx"),
+			Truth: truthWith(map[string]PrivilegeSet{"t": selectOnly})},
+		{Role: RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator,
+				Tables: map[string]*TableSurface{},
+				FuncValueConflicts: []FuncValueConflictSite{
+					{File: "cmd/x/dependencies.go", Line: 7, Field: "sources.newRepository",
+						Reason: "assigned MORE THAN ONE implementation"},
+					// Third-party: must be filtered, or the gate is pure noise.
+					{File: "../../pkg/mod/encoding/json/stream.go", Line: 1, Field: "scanner.step",
+						Reason: "assigned MORE THAN ONE implementation"},
+				}},
+			Truth: truthWith(map[string]PrivilegeSet{"t": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var coordinator IncompleteRoleSurface
+	for _, s := range report.Incomplete {
+		if s.Role == RoleCoordinator {
+			coordinator = s
+		}
+	}
+	if len(coordinator.FuncValueConflicts) != 1 {
+		t.Fatalf("expected exactly the in-module conflict to survive filtering, got %+v",
+			coordinator.FuncValueConflicts)
+	}
+	if coordinator.FuncValueConflicts[0].Field != "sources.newRepository" {
+		t.Errorf("the wrong conflict survived: %+v", coordinator.FuncValueConflicts[0])
+	}
+}
+
+// --- H6.f: the strictest mode must win ACROSS call sites ----------------------
+//
+// The same-statement case was covered; two separate call sites locking one table
+// in different modes was not.
+func TestStrictestLockModeWinsAcrossSeparateCallSites(t *testing.T) {
+	weak, _ := lockRequirementForMode("ROW EXCLUSIVE")
+	strong, _ := lockRequirementForMode("ACCESS EXCLUSIVE")
+	if !(strong.rank > weak.rank) {
+		t.Fatalf("ACCESS EXCLUSIVE must outrank ROW EXCLUSIVE: %d vs %d", strong.rank, weak.rank)
+	}
+
+	// Whichever order the analyzer visits the two sites in, the surface must end
+	// up demanding the STRICT one. Both orders asserted, because the fixed point
+	// iterates a map and the order is not stable.
+	for _, order := range [][]LockRequirement{{weak, strong}, {strong, weak}} {
+		surface := &TableSurface{Table: "outbox"}
+		for _, requirement := range order {
+			if surface.LockRequirement == nil || requirement.rank > surface.LockRequirement.rank {
+				held := requirement
+				surface.LockRequirement = &held
+			}
+		}
+		if surface.LockRequirement.Mode != "ACCESS EXCLUSIVE" {
+			t.Errorf("strictest mode did not win (order %v/%v): got %s",
+				order[0].Mode, order[1].Mode, surface.LockRequirement.Mode)
+		}
+		var selectInsert PrivilegeSet
+		selectInsert.add(PrivSelect)
+		selectInsert.add(PrivInsert)
+		if lockSatisfiedBy(*surface.LockRequirement, selectInsert) {
+			t.Error("after escalation INSERT must no longer satisfy the lock")
+		}
+	}
+}
+
+// --- H1.a: the override only applies to THIS role's seed names ---------------
+func TestNameOverrideOnlyAppliesToSeedNamedParameters(t *testing.T) {
+	poolType := fakePoolType()
+	// A pool-typed parameter named something that is NOT a seed name for any role.
+	param := ast.NewIdent("pool")
+	funcType := &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{{
+		Names: []*ast.Ident{param}, Type: ast.NewIdent("ignored"),
+	}}}}
+	decl := &ast.FuncDecl{Name: ast.NewIdent("build"), Type: funcType, Body: &ast.BlockStmt{}}
+	use := ast.NewIdent("pool")
+	info := &types.Info{Types: map[ast.Expr]types.TypeAndValue{use: {Type: poolType}}}
+	ctx := funcCtx{decl: decl, info: info}
+
+	domainSeeds, domainBarrier := seedsFor(RoleDomain)
+	a := &analyzer{seeds: domainSeeds, barrier: domainBarrier}
+	// Even with call-site evidence naming only the coordinator, a parameter that
+	// was never a name-based seed has nothing to override -- reporting one would
+	// be a phantom correction of a convention that was never applied.
+	if a.nameSeedContradicted(use, ctx, nil) {
+		t.Error("the override must only fire for parameters this role would have seeded BY NAME")
+	}
+}

--- a/internal/domaingrants/compare.go
+++ b/internal/domaingrants/compare.go
@@ -172,19 +172,25 @@ func Compare(derived *DerivedSurface, gt *GroundTruth) *Report {
 				})
 			}
 		}
-		if surface.RequiresAnyWriteLock && !columnScoped {
-			// Postgres requires at least one of INSERT/UPDATE/DELETE for a
-			// LOCK TABLE mode stricter than ROW EXCLUSIVE -- ANY one, not a
-			// specific privilege (see TableSurface.RequiresAnyWriteLock's
-			// doc comment). Only flag if the granted set truly has none of
-			// the three; already-granted INSERT/UPDATE/DELETE for other
-			// reasons silently satisfies this.
-			if !granted.Has(PrivInsert) && !granted.Has(PrivUpdate) && !granted.Has(PrivDelete) {
+		if surface.LockRequirement != nil && !columnScoped {
+			// Postgres's LOCK demand is a DISJUNCTION over a MODE-SPECIFIC set,
+			// not "any write privilege": INSERT satisfies ROW SHARE and ROW
+			// EXCLUSIVE and nothing stricter. See LockRequirement in sql.go for
+			// the measured mapping. An earlier version of this check accepted any
+			// of INSERT/UPDATE/DELETE for every mode, which passed a SELECT+INSERT
+			// posture against a SHARE ROW EXCLUSIVE lock -- the CHAOS-3113 defect
+			// family exactly.
+			requirement := *surface.LockRequirement
+			if !lockSatisfiedBy(requirement, granted) {
+				unknown := ""
+				if requirement.Unknown {
+					unknown = " (mode UNRECOGNIZED by this analyzer, assumed strictest -- verify by hand)"
+				}
 				report.Findings = append(report.Findings, Finding{
 					Severity: Critical, Table: table,
 					Summary: fmt.Sprintf(
-						"table %q: LOCK TABLE in an exclusive-ish mode requires at least one of INSERT/UPDATE/DELETE, but runtimeGrantStatements grants none of them",
-						table,
+						"table %q: LOCK TABLE IN %s MODE requires at least one of %s%s, but runtimeGrantStatements grants none of them",
+						table, requirement.Mode, privilegeSetNames(requirement.Satisfying), unknown,
 					),
 					Evidence: surface.WriteLockEvidence,
 				})
@@ -345,11 +351,23 @@ func isFullyCovered(surface *TableSurface, gt *GroundTruth) bool {
 			return false
 		}
 	}
-	if surface.RequiresAnyWriteLock &&
-		!granted.Has(PrivInsert) && !granted.Has(PrivUpdate) && !granted.Has(PrivDelete) {
+	if surface.LockRequirement != nil && !lockSatisfiedBy(*surface.LockRequirement, granted) {
 		return false
 	}
 	return true
+}
+
+// lockSatisfiedBy reports whether held contains ANY ONE privilege the lock mode
+// accepts. Single definition on purpose: three call sites checked this
+// disjunction, and an inlined copy is how one of them ends up still accepting
+// INSERT for a mode that does not.
+func lockSatisfiedBy(requirement LockRequirement, held PrivilegeSet) bool {
+	for p := Privilege(0); p < numPrivileges; p++ {
+		if requirement.Satisfying.Has(p) && held.Has(p) {
+			return true
+		}
+	}
+	return false
 }
 
 func pluralTables(tables []string) string {

--- a/internal/domaingrants/compare.go
+++ b/internal/domaingrants/compare.go
@@ -182,15 +182,11 @@ func Compare(derived *DerivedSurface, gt *GroundTruth) *Report {
 			// family exactly.
 			requirement := *surface.LockRequirement
 			if !lockSatisfiedBy(requirement, granted) {
-				unknown := ""
-				if requirement.Unknown {
-					unknown = " (mode UNRECOGNIZED by this analyzer, assumed strictest -- verify by hand)"
-				}
 				report.Findings = append(report.Findings, Finding{
 					Severity: Critical, Table: table,
 					Summary: fmt.Sprintf(
-						"table %q: LOCK TABLE IN %s MODE requires at least one of %s%s, but runtimeGrantStatements grants none of them",
-						table, requirement.Mode, privilegeSetNames(requirement.Satisfying), unknown,
+						"table %q: LOCK IN %s MODE requires at least ONE of %s -- a disjunction, NOT a conjunction with SELECT -- but runtimeGrantStatements grants none of them",
+						table, requirement.Mode, privilegeSetNames(requirement.Satisfying),
 					),
 					Evidence: surface.WriteLockEvidence,
 				})

--- a/internal/domaingrants/compare.go
+++ b/internal/domaingrants/compare.go
@@ -30,7 +30,11 @@ func (s Severity) String() string {
 // Finding is one row of the comparison between the derived query surface and
 // the two hand-maintained artefacts.
 type Finding struct {
-	Severity  Severity
+	Severity Severity
+	// Role is which pool/database role this finding is about. Empty for the
+	// single-role Compare path; always set by CompareRoles, because "which role"
+	// is the whole point once there is more than one.
+	Role      PoolRole
 	Table     string
 	Privilege Privilege
 	Summary   string

--- a/internal/domaingrants/funcvalue.go
+++ b/internal/domaingrants/funcvalue.go
@@ -161,6 +161,28 @@ func (a *analyzer) buildPoolParamRoles() {
 	}
 }
 
+// resolveTargetConflict is the fail-closed decision for one function-typed
+// field: given what was already recorded and one more observed assignment,
+// either keep a single target or refuse with a REASON.
+//
+// Extracted as a pure function so it can be tested directly. Clause-by-clause
+// mutation testing showed the two-implementation branch was exercised by NO test:
+// this repo has no in-module field with two production builders, so end-to-end
+// coverage is impossible, and a wholesale mutation still reported KILLED while
+// this specific branch was dead.
+func (a *analyzer) resolveTargetConflict(existing funcValueTarget, seen bool, incoming funcValueTarget) (funcValueTarget, string) {
+	if incoming.empty() {
+		return funcValueTarget{}, "assigned a value this analyzer cannot resolve to a function body " +
+			"(a further field, a call result, or a parameter)"
+	}
+	if seen && !existing.sameAs(incoming) {
+		return funcValueTarget{}, fmt.Sprintf(
+			"assigned MORE THAN ONE implementation (%s and %s), so neither is analyzed",
+			a.display(existing), a.display(incoming))
+	}
+	return incoming, ""
+}
+
 // NameSeedOverride records one place the naming convention was overruled by
 // call-site evidence.
 type NameSeedOverride struct {
@@ -313,21 +335,14 @@ func (a *analyzer) buildFuncValueTargets() {
 		if _, conflicted := a.funcValueConflicts[key]; conflicted {
 			return
 		}
-		if target.empty() {
-			a.funcValueConflicts[key] = "assigned a value this analyzer cannot resolve to a function body " +
-				"(a further field, a call result, or a parameter)"
-			delete(a.funcValueTargets, key)
-			return
-		}
 		existing, seen := a.funcValueTargets[key]
-		if seen && !existing.sameAs(target) {
-			a.funcValueConflicts[key] = fmt.Sprintf(
-				"assigned MORE THAN ONE implementation (%s and %s), so neither is analyzed",
-				a.display(existing), a.display(target))
+		resolved, reason := a.resolveTargetConflict(existing, seen, target)
+		if reason != "" {
+			a.funcValueConflicts[key] = reason
 			delete(a.funcValueTargets, key)
 			return
 		}
-		a.funcValueTargets[key] = target
+		a.funcValueTargets[key] = resolved
 	}
 
 	// resolveValue turns the right-hand side of a function-typed assignment

--- a/internal/domaingrants/funcvalue.go
+++ b/internal/domaingrants/funcvalue.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
+	"sort"
 )
 
 // This file closes the analyzer's function-VALUE blind spot: taint that dies
@@ -44,6 +45,180 @@ import (
 // and is reported as unresolved, rather than picking one and guessing. Only
 // non-test files contribute targets, so a test double cannot widen or poison
 // the production surface.
+
+// buildPoolParamRoles records, for every *pgxpool.Pool-typed PARAMETER of an
+// in-module function, which pool roles are actually passed to it at its call
+// sites. It is deliberately ROLE-AGNOSTIC -- computed once from poolRoleSeeds for
+// every role, independent of which role the current run is deriving -- because
+// its whole purpose is to let one run see what the other run's evidence says.
+//
+// It exists to close an ATTRIBUTION INVERSION, which is worse than the
+// incompleteness this package already documents. A parameter is a seed root by
+// SPELLING (`coordinatorPool`, `domainPool`), and spelling can contradict
+// reality: `build(domainPool *pgxpool.Pool)` called only with the coordinator
+// pool is seeded by the DOMAIN run purely from its name, while the coordinator
+// run's barrier discards it. The downstream SQL then looks domain-EXCLUSIVE, and
+// the gate confidently directs the privilege to the WRONG role -- a false
+// attribution, not merely a missing one, and role attribution is the central
+// correctness property of the split.
+//
+// So: call-site evidence outranks the name. When the observed roles for a
+// parameter are non-empty and exclude the role being derived, the name-based seed
+// is suppressed for that run (see nameSeedContradicted). When no call site can be
+// resolved, the name still applies -- the convention is the only signal left, and
+// dropping it would lose real surface.
+func (a *analyzer) buildPoolParamRoles() {
+	a.poolParamRoles = map[*types.Func]map[int]map[PoolRole]bool{}
+
+	// roleOfExpr answers "which role's pool is this expression, syntactically?"
+	// for every role at once.
+	roleOfExpr := func(expr ast.Expr, info *types.Info) []PoolRole {
+		var out []PoolRole
+		for role, seeds := range poolRoleSeeds {
+			match := false
+			switch e := expr.(type) {
+			case *ast.SelectorExpr:
+				match = seeds.fields[e.Sel.Name] && isPgxPoolPtr(info.TypeOf(e))
+			case *ast.CallExpr:
+				if sel, ok := e.Fun.(*ast.SelectorExpr); ok {
+					match = seeds.getters[sel.Sel.Name] && isPgxPoolPtr(info.TypeOf(e))
+				}
+			case *ast.Ident:
+				match = seeds.idents[e.Name] && isPgxPoolPtr(info.TypeOf(e))
+			}
+			if match {
+				out = append(out, role)
+			}
+		}
+		return out
+	}
+
+	record := func(fn *types.Func, idx int, roles []PoolRole) bool {
+		if len(roles) == 0 {
+			return false
+		}
+		if a.poolParamRoles[fn] == nil {
+			a.poolParamRoles[fn] = map[int]map[PoolRole]bool{}
+		}
+		if a.poolParamRoles[fn][idx] == nil {
+			a.poolParamRoles[fn][idx] = map[PoolRole]bool{}
+		}
+		changed := false
+		for _, role := range roles {
+			if !a.poolParamRoles[fn][idx][role] {
+				a.poolParamRoles[fn][idx][role] = true
+				changed = true
+			}
+		}
+		return changed
+	}
+
+	const maxIterations = 12
+	for iter := 0; iter < maxIterations; iter++ {
+		changed := false
+		for _, ctx := range a.funcDecls {
+			var currentFn *types.Func
+			if obj, ok := ctx.info.Defs[ctx.decl.Name]; ok {
+				currentFn, _ = obj.(*types.Func)
+			}
+			ast.Inspect(ctx.decl.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				callee := simpleCalleeFunc(call, ctx.info)
+				if callee == nil {
+					return true
+				}
+				sig, ok := callee.Type().(*types.Signature)
+				if !ok {
+					return true
+				}
+				for i, arg := range call.Args {
+					if i >= sig.Params().Len() || !isPgxPoolPtr(sig.Params().At(i).Type()) {
+						continue
+					}
+					roles := roleOfExpr(arg, ctx.info)
+					// Forward the enclosing function's own parameter roles, so a
+					// pool threaded through several hops keeps its provenance.
+					if id, isIdent := arg.(*ast.Ident); isIdent && currentFn != nil {
+						if idx := paramIndex(ctx.funcType(), id.Name); idx >= 0 {
+							for role := range a.poolParamRoles[currentFn][idx] {
+								roles = append(roles, role)
+							}
+						}
+					}
+					if record(callee, i, roles) {
+						changed = true
+					}
+				}
+				return true
+			})
+		}
+		if !changed {
+			break
+		}
+	}
+}
+
+// NameSeedOverride records one place the naming convention was overruled by
+// call-site evidence.
+type NameSeedOverride struct {
+	File string
+	Line int
+	// Name is the parameter whose spelling suggested this run's pool.
+	Name string
+	// Function is the enclosing function.
+	Function string
+	// ObservedRoles are the roles actually passed at the parameter's call sites.
+	ObservedRoles []string
+}
+
+func (a *analyzer) recordNameSeedOverride(expr ast.Expr, ctx funcCtx, fn *types.Func) {
+	id, ok := expr.(*ast.Ident)
+	if !ok || fn == nil {
+		return
+	}
+	idx := paramIndex(ctx.funcType(), id.Name)
+	if idx < 0 {
+		return
+	}
+	var observed []string
+	for role := range a.poolParamRoles[fn][idx] {
+		observed = append(observed, string(role))
+	}
+	sort.Strings(observed)
+	pos := a.fset.Position(expr.Pos())
+	override := NameSeedOverride{
+		File: a.relFile(pos), Line: pos.Line, Name: id.Name,
+		Function: txGroupFallbackName(ctx), ObservedRoles: observed,
+	}
+	for _, existing := range a.nameSeedOverrides {
+		if existing.File == override.File && existing.Line == override.Line {
+			return
+		}
+	}
+	a.nameSeedOverrides = append(a.nameSeedOverrides, override)
+}
+
+// nameSeedContradicted reports whether expr is an identifier that would be a seed
+// for this run PURELY by its name, while the call-site evidence for that
+// parameter names only OTHER roles. See buildPoolParamRoles.
+func (a *analyzer) nameSeedContradicted(expr ast.Expr, ctx funcCtx, fn *types.Func) bool {
+	id, ok := expr.(*ast.Ident)
+	if !ok || fn == nil || !a.seeds.idents[id.Name] {
+		return false
+	}
+	idx := paramIndex(ctx.funcType(), id.Name)
+	if idx < 0 {
+		return false // a local, not a parameter: no call sites to consult
+	}
+	observed := a.poolParamRoles[fn][idx]
+	if len(observed) == 0 {
+		return false // no resolvable call site: the name is the only signal left
+	}
+	return !observed[a.seeds.role]
+}
 
 // funcValueScope is one file buildFuncValueTargets scans for function-typed
 // field assignments. Scanning whole files (rather than only function bodies)
@@ -98,6 +273,17 @@ type FuncValueResolvedCallSite struct {
 	Target string
 }
 
+// FuncValueConflictSite is a tainted call through a function-typed field this
+// pass deliberately refused to resolve. Every one is a hole in the surface: the
+// arguments are pool-tainted, so real SQL may lie beyond it, and nothing past
+// this point was analyzed.
+type FuncValueConflictSite struct {
+	File   string
+	Line   int
+	Field  string // "OwnerType.fieldName"
+	Reason string
+}
+
 // buildFuncValueTargets resolves each function-typed field to its single
 // implementation, or to nothing when the module assigns it more than one.
 //
@@ -112,20 +298,32 @@ type FuncValueResolvedCallSite struct {
 // not read the same as "nothing goes here".
 func (a *analyzer) buildFuncValueTargets() {
 	a.funcValueTargets = map[funcValueKey]funcValueTarget{}
-	conflict := map[funcValueKey]bool{}
+	a.funcValueConflicts = map[funcValueKey]string{}
 
+	// Excluding a field is only half of fail-closed. The exclusion has to be
+	// REPORTED, or "two production builders, neither analyzed" is
+	// indistinguishable from "no such field" and CI stays green over a surface
+	// nothing examined. That is fail-SILENT, and it is what a.funcValueConflicts
+	// exists to prevent -- the reason is carried so the report can say which of
+	// the two shapes happened.
 	record := func(key funcValueKey, target funcValueTarget) {
-		if key.owner == nil || key.field == "" || conflict[key] {
+		if key.owner == nil || key.field == "" {
+			return
+		}
+		if _, conflicted := a.funcValueConflicts[key]; conflicted {
 			return
 		}
 		if target.empty() {
-			conflict[key] = true
+			a.funcValueConflicts[key] = "assigned a value this analyzer cannot resolve to a function body " +
+				"(a further field, a call result, or a parameter)"
 			delete(a.funcValueTargets, key)
 			return
 		}
 		existing, seen := a.funcValueTargets[key]
 		if seen && !existing.sameAs(target) {
-			conflict[key] = true
+			a.funcValueConflicts[key] = fmt.Sprintf(
+				"assigned MORE THAN ONE implementation (%s and %s), so neither is analyzed",
+				a.display(existing), a.display(target))
 			delete(a.funcValueTargets, key)
 			return
 		}
@@ -248,6 +446,23 @@ func (a *analyzer) propagateIntoFuncValue(
 ) bool {
 	target := a.resolveFuncValueField(sel, ctx.info)
 	if target.empty() {
+		// Deliberately excluded, so say so at the CALL SITE. Reporting only the
+		// field would leave a reader unable to tell whether any tainted call ever
+		// reaches it; reporting only Unresolved loses it entirely, because that
+		// record's callee is the bare field name and the incompleteness filter
+		// cannot tell such a name from a third-party method.
+		if owner := namedTypeOf(ctx.info.TypeOf(sel.X)); owner != nil {
+			key := funcValueKey{owner: owner, field: sel.Sel.Name}
+			if reason, conflicted := a.funcValueConflicts[key]; conflicted {
+				pos := a.fset.Position(call.Pos())
+				a.funcValueConflictSites = append(a.funcValueConflictSites, FuncValueConflictSite{
+					File:   a.relFile(pos),
+					Line:   pos.Line,
+					Field:  owner.Obj().Name() + "." + sel.Sel.Name,
+					Reason: reason,
+				})
+			}
+		}
 		return false
 	}
 	for i, arg := range call.Args {

--- a/internal/domaingrants/funcvalue.go
+++ b/internal/domaingrants/funcvalue.go
@@ -67,8 +67,9 @@ import (
 // is suppressed for that run (see nameSeedContradicted). When no call site can be
 // resolved, the name still applies -- the convention is the only signal left, and
 // dropping it would lose real surface.
-func (a *analyzer) buildPoolParamRoles() {
+func (a *analyzer) buildPoolParamRoles() error {
 	a.poolParamRoles = map[*types.Func]map[int]map[PoolRole]bool{}
+	a.poolParamIncomplete = map[*types.Func]map[int]bool{}
 
 	// roleOfExpr answers "which role's pool is this expression, syntactically?"
 	// for every role at once.
@@ -93,6 +94,17 @@ func (a *analyzer) buildPoolParamRoles() {
 		return out
 	}
 
+	markIncomplete := func(fn *types.Func, idx int) bool {
+		if a.poolParamIncomplete[fn] == nil {
+			a.poolParamIncomplete[fn] = map[int]bool{}
+		}
+		if a.poolParamIncomplete[fn][idx] {
+			return false
+		}
+		a.poolParamIncomplete[fn][idx] = true
+		return true
+	}
+
 	record := func(fn *types.Func, idx int, roles []PoolRole) bool {
 		if len(roles) == 0 {
 			return false
@@ -113,8 +125,7 @@ func (a *analyzer) buildPoolParamRoles() {
 		return changed
 	}
 
-	const maxIterations = 12
-	for iter := 0; iter < maxIterations; iter++ {
+	for iter := 0; iter < poolParamMaxIterations; iter++ {
 		changed := false
 		for _, ctx := range a.funcDecls {
 			var currentFn *types.Func
@@ -141,11 +152,32 @@ func (a *analyzer) buildPoolParamRoles() {
 					roles := roleOfExpr(arg, ctx.info)
 					// Forward the enclosing function's own parameter roles, so a
 					// pool threaded through several hops keeps its provenance.
+					forwarded := false
 					if id, isIdent := arg.(*ast.Ident); isIdent && currentFn != nil {
 						if idx := paramIndex(ctx.funcType(), id.Name); idx >= 0 {
+							if a.poolParamIncomplete[currentFn][idx] {
+								// The source parameter's own evidence is partial, so
+								// anything forwarded from it is partial too.
+								if markIncomplete(callee, i) {
+									changed = true
+								}
+							}
 							for role := range a.poolParamRoles[currentFn][idx] {
 								roles = append(roles, role)
+								forwarded = true
 							}
+						}
+					}
+					// An argument this pass cannot classify makes the parameter's
+					// evidence INCOMPLETE. Silently skipping it was the defect: a
+					// partial set then looked authoritative, and a parameter reached
+					// by one recognised coordinator call and one unrecognised domain
+					// call recorded only {coordinator} -- suppressing the correct
+					// domain seed and making its SQL disappear. A false ABSENCE,
+					// which is the failure this whole mechanism was meant to avoid.
+					if len(roles) == 0 && !forwarded {
+						if markIncomplete(callee, i) {
+							changed = true
 						}
 					}
 					if record(callee, i, roles) {
@@ -156,10 +188,20 @@ func (a *analyzer) buildPoolParamRoles() {
 			})
 		}
 		if !changed {
-			break
+			return nil
 		}
 	}
+	// Exhausting the iteration cap means the facts were still growing when the
+	// loop stopped, so the recorded evidence is a partial snapshot of unknown
+	// completeness -- and partial evidence here silently overrides parameter
+	// names. Stopping quietly is the same swallow-don't-report shape as the LOCK
+	// parser's, so this is an error rather than a truncation.
+	return fmt.Errorf("domaingrants: pool-parameter role propagation did not converge within %d iterations; "+
+		"the collected call-site evidence is incomplete and must not be used to override seed names", poolParamMaxIterations)
 }
+
+// poolParamMaxIterations bounds the call-site role fixed point.
+const poolParamMaxIterations = 12
 
 // resolveTargetConflict is the fail-closed decision for one function-typed
 // field: given what was already recorded and one more observed assignment,
@@ -234,6 +276,15 @@ func (a *analyzer) nameSeedContradicted(expr ast.Expr, ctx funcCtx, fn *types.Fu
 	idx := paramIndex(ctx.funcType(), id.Name)
 	if idx < 0 {
 		return false // a local, not a parameter: no call sites to consult
+	}
+	if a.poolParamIncomplete[fn][idx] {
+		// At least one call site passed an argument this pass could not classify,
+		// so the observed set is a LOWER BOUND, not the full picture. A lower
+		// bound must never override the name: `build(domainPool)` reached by one
+		// direct coordinator call and one domain call through an alias would
+		// otherwise record only {coordinator}, suppress the domain seed, and make
+		// that SQL vanish from the domain surface entirely.
+		return false
 	}
 	observed := a.poolParamRoles[fn][idx]
 	if len(observed) == 0 {

--- a/internal/domaingrants/funcvalue.go
+++ b/internal/domaingrants/funcvalue.go
@@ -1,0 +1,276 @@
+package domaingrants
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+)
+
+// This file closes the analyzer's function-VALUE blind spot: taint that dies
+// at a call through a function-typed struct field.
+//
+// The shape is this repo's dependency-injection idiom. A composition struct
+// declares function-typed fields, a package-level var fills them in, and the
+// builder is invoked through the field:
+//
+//	type schedulerRuntimeSources struct {
+//	        newFixedLoop   func(*pgxpool.Pool, *health.Registry) (fixedScheduleRuntime, error)
+//	        newRepository  func(*pgxpool.Pool) (schedulersync.HandoffStepper, error)
+//	}
+//	var productionSchedulerRuntimeSources = schedulerRuntimeSources{
+//	        newFixedLoop:  buildFixedScheduleLoop,                      // FORM 1: named func
+//	        newRepository: func(pool *pgxpool.Pool) (...) { ... },      // FORM 2: func literal
+//	}
+//	...
+//	loop, err := sources.newFixedLoop(coordinatorPool, registry)       // callee unresolvable
+//
+// At that last line handleCall's callee resolution fails: info.Selections
+// yields a *types.Var (a struct field), not a *types.Func, so taint stops and
+// nothing the builder reaches is ever analyzed.
+//
+// Why this mattered enough to fix rather than document: it hid the ENTIRE
+// scheduler and fixed-engine query surface from the coordinator derivation --
+// 8 of CoordinatorPosture()'s 19 tables (scheduled_jobs,
+// scheduled_sync_occurrences, fixed_schedule_occurrences, organizations,
+// sync_configurations, remaining_metric_runs, remaining_metric_partitions,
+// work_graph_execution_requests). The reconciler's equivalent hops
+// (sources.buildRelay, sources.buildSyncMutation) only appeared to work
+// because buildSyncMutationPipeline happens to NAME its parameter
+// `coordinatorPool`, which re-seeds by naming convention. A gate whose
+// completeness rests on a parameter name is not a gate.
+//
+// Discipline: fail-closed, matching buildSQLParamConstants and buildTxOrigins.
+// A field with two distinct targets anywhere in the module resolves to NOTHING
+// and is reported as unresolved, rather than picking one and guessing. Only
+// non-test files contribute targets, so a test double cannot widen or poison
+// the production surface.
+
+// funcValueScope is one file buildFuncValueTargets scans for function-typed
+// field assignments. Scanning whole files (rather than only function bodies)
+// is what reaches the package-level `var productionXSources = XSources{...}`
+// composite literals where these fields are actually filled in.
+type funcValueScope struct {
+	node ast.Node
+	info *types.Info
+}
+
+// funcValueKey identifies one function-typed field: the named struct type that
+// declares it, plus the field name.
+type funcValueKey struct {
+	owner *types.Named
+	field string
+}
+
+// funcValueTarget is the single resolved implementation behind a
+// function-typed field. Exactly one of fn (Form 1, a declared function) or lit
+// (Form 2, a function literal) is set.
+type funcValueTarget struct {
+	fn  *types.Func
+	lit *ast.FuncLit
+}
+
+func (t funcValueTarget) empty() bool { return t.fn == nil && t.lit == nil }
+
+func (t funcValueTarget) sameAs(other funcValueTarget) bool {
+	return t.fn == other.fn && t.lit == other.lit
+}
+
+// display names the target for the audit trail.
+func (a *analyzer) display(t funcValueTarget) string {
+	if t.fn != nil {
+		return t.fn.FullName()
+	}
+	if t.lit != nil {
+		pos := a.fset.Position(t.lit.Pos())
+		return fmt.Sprintf("func literal at %s:%d", a.relFile(pos), pos.Line)
+	}
+	return "<none>"
+}
+
+// FuncValueResolvedCallSite records every call this pass resolved, so the
+// report can show exactly where the (deliberately narrow) unique-target
+// shortcut was taken -- the same auditability DevirtualizedCallSite provides
+// for the unique-implementer shortcut.
+type FuncValueResolvedCallSite struct {
+	File   string
+	Line   int
+	Field  string // "OwnerType.fieldName"
+	Target string
+}
+
+// buildFuncValueTargets resolves each function-typed field to its single
+// implementation, or to nothing when the module assigns it more than one.
+//
+// Sources of an assignment, both handled:
+//   - a keyed entry in a composite literal of the owning struct type
+//     (`schedulerRuntimeSources{newFixedLoop: buildFixedScheduleLoop}`)
+//   - a plain assignment to the field (`sources.newFixedLoop = someBuilder`)
+//
+// A value that is neither a resolvable declared function nor a function
+// literal (a further field, a call result, a parameter) marks the field
+// CONFLICTED rather than being ignored: "we could not see what goes here" must
+// not read the same as "nothing goes here".
+func (a *analyzer) buildFuncValueTargets() {
+	a.funcValueTargets = map[funcValueKey]funcValueTarget{}
+	conflict := map[funcValueKey]bool{}
+
+	record := func(key funcValueKey, target funcValueTarget) {
+		if key.owner == nil || key.field == "" || conflict[key] {
+			return
+		}
+		if target.empty() {
+			conflict[key] = true
+			delete(a.funcValueTargets, key)
+			return
+		}
+		existing, seen := a.funcValueTargets[key]
+		if seen && !existing.sameAs(target) {
+			conflict[key] = true
+			delete(a.funcValueTargets, key)
+			return
+		}
+		a.funcValueTargets[key] = target
+	}
+
+	// resolveValue turns the right-hand side of a function-typed assignment
+	// into a target. Returns an empty target for anything it cannot see
+	// through, which record() treats as a conflict.
+	resolveValue := func(value ast.Expr, info *types.Info) funcValueTarget {
+		switch v := value.(type) {
+		case *ast.FuncLit:
+			return funcValueTarget{lit: v}
+		case *ast.Ident:
+			if fn, ok := info.Uses[v].(*types.Func); ok {
+				if _, known := a.funcDecls[fn]; known {
+					return funcValueTarget{fn: fn}
+				}
+			}
+		case *ast.SelectorExpr:
+			// Package-qualified function reference, e.g.
+			// `newLoop: schedulersync.NewLoop`.
+			if fn, ok := info.Uses[v.Sel].(*types.Func); ok {
+				if _, known := a.funcDecls[fn]; known {
+					return funcValueTarget{fn: fn}
+				}
+			}
+		}
+		return funcValueTarget{}
+	}
+
+	isFuncTyped := func(t types.Type) bool {
+		if t == nil {
+			return false
+		}
+		_, ok := t.Underlying().(*types.Signature)
+		return ok
+	}
+
+	for _, ctx := range a.funcValueScopes {
+		ast.Inspect(ctx.node, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CompositeLit:
+				owner := namedTypeOf(ctx.info.TypeOf(node))
+				if owner == nil {
+					return true
+				}
+				for _, elt := range node.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					name, ok := kv.Key.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if !isFuncTyped(ctx.info.TypeOf(kv.Value)) {
+						continue
+					}
+					record(funcValueKey{owner: owner, field: name.Name},
+						resolveValue(kv.Value, ctx.info))
+				}
+			case *ast.AssignStmt:
+				if len(node.Lhs) != len(node.Rhs) {
+					return true
+				}
+				for i, lhs := range node.Lhs {
+					sel, ok := lhs.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+					if !isFuncTyped(ctx.info.TypeOf(node.Rhs[i])) {
+						continue
+					}
+					record(funcValueKey{
+						owner: namedTypeOf(ctx.info.TypeOf(sel.X)),
+						field: sel.Sel.Name,
+					}, resolveValue(node.Rhs[i], ctx.info))
+				}
+			}
+			return true
+		})
+	}
+}
+
+// resolveFuncValueField answers "which body does `recv.field(...)` run?" for a
+// call whose callee resolution already failed. Returns an empty target when
+// the field is unknown or has more than one implementation.
+func (a *analyzer) resolveFuncValueField(sel *ast.SelectorExpr, info *types.Info) funcValueTarget {
+	owner := namedTypeOf(info.TypeOf(sel.X))
+	if owner == nil {
+		return funcValueTarget{}
+	}
+	return a.funcValueTargets[funcValueKey{owner: owner, field: sel.Sel.Name}]
+}
+
+// markLitParamTainted is markParamTainted for a function literal. Kept as a
+// parallel map rather than folded into taintedParam because a *ast.FuncLit has
+// no *types.Func to key on.
+func (a *analyzer) markLitParamTainted(lit *ast.FuncLit, idx int) {
+	m := a.taintedLitParam[lit]
+	if m == nil {
+		m = map[int]bool{}
+		a.taintedLitParam[lit] = m
+	}
+	if !m[idx] {
+		m[idx] = true
+		a.changed = true
+	}
+}
+
+// propagateIntoFuncValue pushes argument taint into a resolved target's
+// parameters and records the resolution for the audit trail. Reports whether
+// it handled the call.
+func (a *analyzer) propagateIntoFuncValue(
+	call *ast.CallExpr,
+	sel *ast.SelectorExpr,
+	ctx funcCtx,
+	isTainted func(ast.Expr) bool,
+) bool {
+	target := a.resolveFuncValueField(sel, ctx.info)
+	if target.empty() {
+		return false
+	}
+	for i, arg := range call.Args {
+		if !isTainted(arg) {
+			continue
+		}
+		switch {
+		case target.fn != nil:
+			a.markParamTainted(target.fn, i)
+		case target.lit != nil:
+			a.markLitParamTainted(target.lit, i)
+		}
+	}
+	pos := a.fset.Position(call.Pos())
+	ownerName := "?"
+	if owner := namedTypeOf(ctx.info.TypeOf(sel.X)); owner != nil {
+		ownerName = owner.Obj().Name()
+	}
+	a.funcValueResolved = append(a.funcValueResolved, FuncValueResolvedCallSite{
+		File:   a.relFile(pos),
+		Line:   pos.Line,
+		Field:  ownerName + "." + sel.Sel.Name,
+		Target: a.display(target),
+	})
+	return true
+}

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -13,62 +13,87 @@ import (
 // structure, while the code that ACTS on that value was never exercised. Proving
 // a fact is available is not proving anything is done with it.
 
-// TestGateFailsOnEveryEnforcedCategory drives GateFailures directly, so deleting
-// any enforced category is caught. Previously each category was reported by its
-// own loop inside the gate test, and a unit test could only show the value
-// arrived in IncompleteRoleSurface -- deleting the loop that reported it left
-// every test green.
-func TestGateFailsOnEveryEnforcedCategory(t *testing.T) {
+// TestAdvisoryReportCoversEveryCategory is the successor to the enforcement test,
+// under the advisory posture.
+//
+// Nothing gates any more, so "deleting the enforcement is undetected" is no longer
+// the risk. The risk that remains is a whole CATEGORY of reporting silently
+// vanishing -- which, for a tool whose only output is its report, is the same
+// failure wearing different clothes: a category with nothing to say and a category
+// that is no longer printed look identical to the reader.
+//
+// Driving AdvisoryReport directly is what makes that assertable. When each
+// category was printed by its own loop in the surface test, a unit test could
+// prove the value reached the data structure while the loop that printed it was
+// deletable with everything still green.
+func TestAdvisoryReportCoversEveryCategory(t *testing.T) {
 	var selectOnly PrivilegeSet
 	selectOnly.add(PrivSelect)
 
+	criticalFinding := Finding{
+		Severity: Critical, Role: RoleCoordinator, Table: "some_table", Privilege: PrivUpdate,
+		Summary: "synthetic critical",
+	}
+	knownOpen := Finding{
+		Severity: Critical, Role: RoleCoordinator, Table: "sync_dispatch_outbox", Privilege: PrivInsert,
+		Summary: "synthetic known-open",
+	}
+	advisoryFinding := Finding{
+		Severity: Advisory, Role: RoleDomain, Table: "other_table", Privilege: PrivSelect,
+		Summary: "synthetic advisory",
+	}
+
 	report := &RoleReport{
+		Stats:       []string{"synthetic stats line"},
+		Findings:    []Finding{criticalFinding, knownOpen, advisoryFinding},
+		SharedPairs: []string{"shared_table SELECT (evidence on: coordinator+domain)"},
 		Incomplete: []IncompleteRoleSurface{{
-			Role: RoleCoordinator,
-			UndeclaredByEvidence: []PostureGapWithoutEvidence{
-				{Table: "nobody_touches_it", Privilege: PrivUpdate},
-			},
-			DynamicSQL: []DynamicSite{
-				{File: "internal/brand/new.go", Line: 3, Reason: "not a constant"},
-			},
-			UnparsedLocks: []UnparsedLockSite{
-				{File: "internal/x/y.go", Line: 9, Statement: "LOCK a, b"},
-			},
-			FuncValueConflicts: []FuncValueConflictSite{
-				{File: "cmd/x/deps.go", Line: 7, Field: "sources.newThing", Reason: "two implementations"},
-			},
+			Role:                 RoleCoordinator,
+			UndeclaredByEvidence: []PostureGapWithoutEvidence{{Table: "nobody_touches_it", Privilege: PrivUpdate}},
+			DynamicSQL:           []DynamicSite{{File: "internal/brand/new.go", Line: 3, Reason: "not a constant"}},
+			UnparsedLocks:        []UnparsedLockSite{{File: "internal/x/y.go", Line: 9, Statement: "LOCK \"a.b\""}},
+			FuncValueConflicts:   []FuncValueConflictSite{{File: "cmd/x/deps.go", Line: 7, Field: "sources.newThing", Reason: "two implementations"}},
+			WiringHops:           []UnresolvedCallSite{{File: "internal/x/y.go", Line: 11, Callee: "", Reason: "function value"}},
+			NameSeedOverrides:    []NameSeedOverride{{File: "cmd/x/deps.go", Line: 5, Name: "domainPool", Function: "build", ObservedRoles: []string{"coordinator"}}},
 		}},
 	}
 
-	failures := strings.Join(GateFailures(report), "\n")
-	for _, want := range []string{
-		"UNACKNOWLEDGED BLIND SPOT",
-		"UNACKNOWLEDGED DYNAMIC SQL",
-		"UNPARSED LOCK",
-		"UNRESOLVED FUNCTION-VALUE CALL",
-	} {
-		if !strings.Contains(failures, want) {
-			t.Errorf("GateFailures did not report %s -- that category is collected but no longer "+
-				"enforced, which is the exact state where the gate looks green over unanalyzed "+
-				"surface:\n%s", want, failures)
+	seen := map[AdvisoryCategory]int{}
+	for _, line := range AdvisoryReport(report) {
+		seen[line.Category]++
+	}
+	for _, category := range AllAdvisoryCategories {
+		if seen[category] == 0 {
+			t.Errorf("AdvisoryReport emitted nothing for category %s, but the input contains one. "+
+				"A category that stops being reported is indistinguishable from a category with "+
+				"nothing to say, and this report is the tool's ONLY output", category)
 		}
 	}
 
-	// And a clean report must produce NO failures, or the gate is unconditional and
-	// its green means nothing either. The acknowledgement lists are emptied for
-	// this half: with the REAL lists, an empty report correctly reports every
-	// acknowledgement as stale, which is the self-cleaning property working rather
-	// than a failure.
-	realBlind := acknowledgedBlindSpots
-	realDynamic := acknowledgedDynamicSQL
-	t.Cleanup(func() {
-		acknowledgedBlindSpots = realBlind
-		acknowledgedDynamicSQL = realDynamic
-	})
-	acknowledgedBlindSpots = nil
-	acknowledgedDynamicSQL = nil
-	if extra := GateFailures(&RoleReport{}); len(extra) != 0 {
-		t.Errorf("an empty report with no acknowledgements must produce no gate failures, got %v", extra)
+	// WIRING-HOP specifically: it was collected and never reported for three
+	// review rounds. Its line must name the count, because "taint stopped in N
+	// places" is the number that tells a reader how much of the surface is unseen.
+	var wiringLine string
+	for _, line := range AdvisoryReport(report) {
+		if line.Category == CategoryWiringHop {
+			wiringLine = line.Text
+		}
+	}
+	if !strings.Contains(wiringLine, "taint STOPPED") {
+		t.Errorf("the wiring-hop line must say what a hop MEANS -- that SQL beyond it is invisible: %q",
+			wiringLine)
+	}
+
+	// A ticketed known-open critical must be distinguishable from an untriaged
+	// one, or the report flattens "someone is fixing this" into "unreviewed".
+	var sawKnownOpen bool
+	for _, line := range AdvisoryReport(report) {
+		if line.Category == CategoryKnownOpen {
+			sawKnownOpen = true
+		}
+	}
+	if !sawKnownOpen {
+		t.Error("a ticketed known-open critical must be reported under its own category")
 	}
 }
 
@@ -104,11 +129,19 @@ func TestAcknowledgementsRequireAReason(t *testing.T) {
 			len(unreasoned))
 	}
 
-	// And it must reach the gate, not just the partition function.
-	failures := strings.Join(GateFailures(&RoleReport{Incomplete: []IncompleteRoleSurface{surface}}), "\n")
-	if !strings.Contains(failures, "has no reason recorded") ||
-		!strings.Contains(failures, "has no reasoning recorded") {
-		t.Errorf("reasonless acknowledgements must fail the gate:\n%s", failures)
+	// And it must reach the REPORT, not just the partition function. Under the
+	// advisory posture this no longer fails anything, but a reasonless
+	// acknowledgement that is never printed is an unexplained suppression nobody
+	// can review.
+	var reported string
+	for _, line := range AdvisoryReport(&RoleReport{Incomplete: []IncompleteRoleSurface{surface}}) {
+		if line.Category == CategoryAcknowledgement {
+			reported += line.Text + "\n"
+		}
+	}
+	if !strings.Contains(reported, "has no reason recorded") ||
+		!strings.Contains(reported, "has no reasoning recorded") {
+		t.Errorf("reasonless acknowledgements must appear in the advisory report:\n%s", reported)
 	}
 }
 
@@ -123,24 +156,7 @@ func TestAcknowledgementsRequireAReason(t *testing.T) {
 // produced. The fixture below is a self-contained module (its own local package
 // named pgxpool, so isPgxPoolPtr matches) and needs no network.
 func TestBuildPoolParamRolesMarksPartialEvidenceIncomplete(t *testing.T) {
-	dir := t.TempDir()
-	write := func(rel, content string) {
-		full := filepath.Join(dir, rel)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	write("go.mod", "module fixture\n\ngo 1.25\n")
-	write("pgxpool/pgxpool.go", "package pgxpool\n\ntype Pool struct{}\n")
-	// `build` is spelled for the DOMAIN role. One call site passes a recognised
-	// coordinator root; the other passes an expression this pass cannot classify
-	// (a struct field with a non-seed name). The observed set is therefore a LOWER
-	// BOUND -- and must not suppress the domain seed.
-	write("main.go", `package main
+	dir := writeFixtureModule(t, `package main
 
 import "fixture/pgxpool"
 
@@ -149,10 +165,16 @@ type pools struct {
 	Other       *pgxpool.Pool
 }
 
-func build(domainPool *pgxpool.Pool) {}
+// build executes REAL SQL through its domain-spelled parameter. The table is the
+// observable consequence: an earlier version of this test had an empty body and
+// asserted only on audit metadata, so it could not tell whether the SQL survived
+// in the domain surface -- which is the entire property under test.
+func build(domainPool *pgxpool.Pool) {
+	_ = domainPool.Exec(nil, "SELECT id FROM public.fixture_partial")
+}
 
-func wireOne(p *pools)   { build(p.Coordinator) }
-func wireTwo(p *pools)   { build(p.Other) }
+func wireOne(p *pools) { build(p.Coordinator) }
+func wireTwo(p *pools) { build(p.Other) }
 
 func main() { wireOne(nil); wireTwo(nil) }
 `)
@@ -161,23 +183,77 @@ func main() { wireOne(nil); wireTwo(nil) }
 	if err != nil {
 		t.Fatalf("DeriveForRole: %v", err)
 	}
-	// The observable consequence: no override is emitted, because the evidence is
-	// incomplete. If partial evidence were allowed to outrank spelling, the domain
-	// seed would be suppressed here and any SQL beyond `build` would vanish from
-	// the domain surface -- a false ABSENCE.
+	// wireTwo passes an argument this pass cannot classify, so the observed role
+	// set is a LOWER BOUND. It must not suppress the domain seed -- if it did, the
+	// SQL would vanish from the domain surface entirely: a false ABSENCE.
+	if surface := derived.Tables["fixture_partial"]; surface == nil || !surface.Privileges.Has(PrivSelect) {
+		t.Error("the domain surface LOST fixture_partial. Partial call-site evidence suppressed the " +
+			"domain seed, so real SQL disappeared -- the false absence this mechanism exists to avoid")
+	}
 	if len(derived.NameSeedOverrides) != 0 {
-		t.Errorf("partial call-site evidence must NOT override the parameter name; got overrides %+v. "+
-			"One call site passes an unclassifiable argument, so the observed role set is a lower "+
-			"bound, and suppressing the domain seed on it makes real SQL disappear",
-			derived.NameSeedOverrides)
+		t.Errorf("partial evidence must not be reported as an override: %+v", derived.NameSeedOverrides)
 	}
 }
 
 // TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence is the control:
-// with EVERY call site classified and none of them this role, the override must
-// fire. Without this half, the test above would pass for a build that simply
-// never overrides anything.
+// with EVERY call site classified and none of them this role, the override fires
+// and the SQL leaves this role's surface. Without this half the companion test
+// passes for a build that simply never overrides anything.
+//
+// It asserts on the TABLE, not on the override record, for the same reason: a
+// regression that records an override while still treating the expression as
+// tainted would keep an audit-metadata assertion green while attributing real SQL
+// to the wrong role.
 func TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence(t *testing.T) {
+	dir := writeFixtureModule(t, `package main
+
+import "fixture/pgxpool"
+
+type pools struct {
+	Coordinator *pgxpool.Pool
+}
+
+func build(domainPool *pgxpool.Pool) {
+	_ = domainPool.Exec(nil, "SELECT id FROM public.fixture_control")
+}
+
+func wireOne(p *pools) { build(p.Coordinator) }
+func wireTwo(p *pools) { build(p.Coordinator) }
+
+func main() { wireOne(nil); wireTwo(nil) }
+`)
+
+	domain, err := DeriveForRole(dir, RoleDomain)
+	if err != nil {
+		t.Fatalf("DeriveForRole(domain): %v", err)
+	}
+	if surface := domain.Tables["fixture_control"]; surface != nil && surface.Privileges.Has(PrivSelect) {
+		t.Error("every call site passes the COORDINATOR pool, so this SQL must not appear in the " +
+			"DOMAIN surface -- the parameter's spelling is the only thing suggesting otherwise, and " +
+			"call-site evidence is supposed to outrank it")
+	}
+	if len(domain.NameSeedOverrides) == 0 {
+		t.Error("the override must be REPORTED, not silent: a naming convention lied, and a reader " +
+			"seeing a smaller surface deserves to know why")
+	}
+
+	// And it must land on the coordinator, or the override moved the SQL nowhere.
+	coordinator, err := DeriveForRole(dir, RoleCoordinator)
+	if err != nil {
+		t.Fatalf("DeriveForRole(coordinator): %v", err)
+	}
+	if surface := coordinator.Tables["fixture_control"]; surface == nil || !surface.Privileges.Has(PrivSelect) {
+		t.Error("the SQL must appear in the COORDINATOR surface: that is where the pool actually " +
+			"comes from, and an override that removes SQL from one role without adding it to the " +
+			"other has lost it")
+	}
+}
+
+// writeFixtureModule builds a self-contained module with its own local pgxpool
+// package (so isPgxPoolPtr matches) and no external dependencies, so these tests
+// exercise the real package loader without network access.
+func writeFixtureModule(t *testing.T, mainGo string) string {
+	t.Helper()
 	dir := t.TempDir()
 	write := func(rel, content string) {
 		full := filepath.Join(dir, rel)
@@ -189,61 +265,12 @@ func TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence(t *testing.
 		}
 	}
 	write("go.mod", "module fixture\n\ngo 1.25\n")
-	write("pgxpool/pgxpool.go", "package pgxpool\n\ntype Pool struct{}\n")
-	// Both call sites pass the recognised coordinator root, and `build` executes
-	// SQL through its domain-spelled parameter.
-	write("main.go", `package main
+	write("pgxpool/pgxpool.go", `package pgxpool
 
-import (
-	"context"
+type Pool struct{}
 
-	"fixture/pgxpool"
-)
-
-type pools struct {
-	Coordinator *pgxpool.Pool
-}
-
-func (p *pgxpool.Pool) placeholder() {}
-
-func build(ctx context.Context, domainPool *pgxpool.Pool) {}
-
-func wireOne(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
-func wireTwo(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
-
-func main() { wireOne(nil, nil); wireTwo(nil, nil) }
+func (p *Pool) Exec(ctx interface{}, sql string, args ...interface{}) error { return nil }
 `)
-
-	// The method-on-imported-type line above is illegal Go; drop it.
-	write("main.go", `package main
-
-import (
-	"context"
-
-	"fixture/pgxpool"
-)
-
-type pools struct {
-	Coordinator *pgxpool.Pool
-}
-
-func build(ctx context.Context, domainPool *pgxpool.Pool) {
-	_ = domainPool
-}
-
-func wireOne(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
-func wireTwo(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
-
-func main() { wireOne(nil, nil); wireTwo(nil, nil) }
-`)
-
-	derived, err := DeriveForRole(dir, RoleDomain)
-	if err != nil {
-		t.Fatalf("DeriveForRole: %v", err)
-	}
-	if len(derived.NameSeedOverrides) == 0 {
-		t.Error("with every call site classified and none of them domain, the domain-spelled parameter " +
-			"must be overridden -- otherwise the collector never overrides anything and the companion " +
-			"test proves nothing")
-	}
+	write("main.go", mainGo)
+	return dir
 }

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -1,0 +1,249 @@
+package domaingrants
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for the three assertions codex found could not fail.
+//
+// Each had the same underlying shape: the test proved a value reached some data
+// structure, while the code that ACTS on that value was never exercised. Proving
+// a fact is available is not proving anything is done with it.
+
+// TestGateFailsOnEveryEnforcedCategory drives GateFailures directly, so deleting
+// any enforced category is caught. Previously each category was reported by its
+// own loop inside the gate test, and a unit test could only show the value
+// arrived in IncompleteRoleSurface -- deleting the loop that reported it left
+// every test green.
+func TestGateFailsOnEveryEnforcedCategory(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	report := &RoleReport{
+		Incomplete: []IncompleteRoleSurface{{
+			Role: RoleCoordinator,
+			UndeclaredByEvidence: []PostureGapWithoutEvidence{
+				{Table: "nobody_touches_it", Privilege: PrivUpdate},
+			},
+			DynamicSQL: []DynamicSite{
+				{File: "internal/brand/new.go", Line: 3, Reason: "not a constant"},
+			},
+			UnparsedLocks: []UnparsedLockSite{
+				{File: "internal/x/y.go", Line: 9, Statement: "LOCK a, b"},
+			},
+			FuncValueConflicts: []FuncValueConflictSite{
+				{File: "cmd/x/deps.go", Line: 7, Field: "sources.newThing", Reason: "two implementations"},
+			},
+		}},
+	}
+
+	failures := strings.Join(GateFailures(report), "\n")
+	for _, want := range []string{
+		"UNACKNOWLEDGED BLIND SPOT",
+		"UNACKNOWLEDGED DYNAMIC SQL",
+		"UNPARSED LOCK",
+		"UNRESOLVED FUNCTION-VALUE CALL",
+	} {
+		if !strings.Contains(failures, want) {
+			t.Errorf("GateFailures did not report %s -- that category is collected but no longer "+
+				"enforced, which is the exact state where the gate looks green over unanalyzed "+
+				"surface:\n%s", want, failures)
+		}
+	}
+
+	// And a clean report must produce NO failures, or the gate is unconditional and
+	// its green means nothing either. The acknowledgement lists are emptied for
+	// this half: with the REAL lists, an empty report correctly reports every
+	// acknowledgement as stale, which is the self-cleaning property working rather
+	// than a failure.
+	realBlind := acknowledgedBlindSpots
+	realDynamic := acknowledgedDynamicSQL
+	t.Cleanup(func() {
+		acknowledgedBlindSpots = realBlind
+		acknowledgedDynamicSQL = realDynamic
+	})
+	acknowledgedBlindSpots = nil
+	acknowledgedDynamicSQL = nil
+	if extra := GateFailures(&RoleReport{}); len(extra) != 0 {
+		t.Errorf("an empty report with no acknowledgements must produce no gate failures, got %v", extra)
+	}
+}
+
+// TestAcknowledgementsRequireAReason makes the mandatory-reason check
+// falsifiable. It could not fail before, because every real acknowledgement
+// already carries a reason -- so the check had no input that would exercise it.
+func TestAcknowledgementsRequireAReason(t *testing.T) {
+	realBlind := acknowledgedBlindSpots
+	realDynamic := acknowledgedDynamicSQL
+	t.Cleanup(func() {
+		acknowledgedBlindSpots = realBlind
+		acknowledgedDynamicSQL = realDynamic
+	})
+
+	acknowledgedBlindSpots = []AcknowledgedBlindSpot{
+		{Role: RoleDomain, Table: "t", Privilege: PrivSelect, Why: ""},
+	}
+	acknowledgedDynamicSQL = []AcknowledgedDynamicSQL{
+		{File: "internal/x/y.go", Why: "   "},
+	}
+
+	surface := IncompleteRoleSurface{
+		Role:                 RoleDomain,
+		UndeclaredByEvidence: []PostureGapWithoutEvidence{{Table: "t", Privilege: PrivSelect}},
+		DynamicSQL:           []DynamicSite{{File: "internal/x/y.go", Line: 1, Reason: "dynamic"}},
+	}
+
+	if _, _, unreasoned := PartitionBlindSpots([]IncompleteRoleSurface{surface}); len(unreasoned) != 1 {
+		t.Errorf("a blind-spot acknowledgement with no reason must be reported, got %d", len(unreasoned))
+	}
+	if _, _, unreasoned := PartitionDynamicSQL([]IncompleteRoleSurface{surface}); len(unreasoned) != 1 {
+		t.Errorf("a dynamic-SQL acknowledgement with a whitespace-only reason must be reported, got %d",
+			len(unreasoned))
+	}
+
+	// And it must reach the gate, not just the partition function.
+	failures := strings.Join(GateFailures(&RoleReport{Incomplete: []IncompleteRoleSurface{surface}}), "\n")
+	if !strings.Contains(failures, "has no reason recorded") ||
+		!strings.Contains(failures, "has no reasoning recorded") {
+		t.Errorf("reasonless acknowledgements must fail the gate:\n%s", failures)
+	}
+}
+
+// TestBuildPoolParamRolesMarksPartialEvidenceIncomplete exercises
+// buildPoolParamRoles through a REAL package load, on the exact shape codex
+// found: a parameter spelled for one role, reached by one recognised call from
+// the other role AND one call the pass cannot classify.
+//
+// The existing H1 tests injected poolParamRoles directly and never ran the
+// collector, which is precisely why this defect was invisible to them -- they
+// tested the consumer against a hand-built state the producer would not have
+// produced. The fixture below is a self-contained module (its own local package
+// named pgxpool, so isPgxPoolPtr matches) and needs no network.
+func TestBuildPoolParamRolesMarksPartialEvidenceIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("go.mod", "module fixture\n\ngo 1.25\n")
+	write("pgxpool/pgxpool.go", "package pgxpool\n\ntype Pool struct{}\n")
+	// `build` is spelled for the DOMAIN role. One call site passes a recognised
+	// coordinator root; the other passes an expression this pass cannot classify
+	// (a struct field with a non-seed name). The observed set is therefore a LOWER
+	// BOUND -- and must not suppress the domain seed.
+	write("main.go", `package main
+
+import "fixture/pgxpool"
+
+type pools struct {
+	Coordinator *pgxpool.Pool
+	Other       *pgxpool.Pool
+}
+
+func build(domainPool *pgxpool.Pool) {}
+
+func wireOne(p *pools)   { build(p.Coordinator) }
+func wireTwo(p *pools)   { build(p.Other) }
+
+func main() { wireOne(nil); wireTwo(nil) }
+`)
+
+	derived, err := DeriveForRole(dir, RoleDomain)
+	if err != nil {
+		t.Fatalf("DeriveForRole: %v", err)
+	}
+	// The observable consequence: no override is emitted, because the evidence is
+	// incomplete. If partial evidence were allowed to outrank spelling, the domain
+	// seed would be suppressed here and any SQL beyond `build` would vanish from
+	// the domain surface -- a false ABSENCE.
+	if len(derived.NameSeedOverrides) != 0 {
+		t.Errorf("partial call-site evidence must NOT override the parameter name; got overrides %+v. "+
+			"One call site passes an unclassifiable argument, so the observed role set is a lower "+
+			"bound, and suppressing the domain seed on it makes real SQL disappear",
+			derived.NameSeedOverrides)
+	}
+}
+
+// TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence is the control:
+// with EVERY call site classified and none of them this role, the override must
+// fire. Without this half, the test above would pass for a build that simply
+// never overrides anything.
+func TestBuildPoolParamRolesOverridesOnCompleteContradictingEvidence(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module fixture\n\ngo 1.25\n")
+	write("pgxpool/pgxpool.go", "package pgxpool\n\ntype Pool struct{}\n")
+	// Both call sites pass the recognised coordinator root, and `build` executes
+	// SQL through its domain-spelled parameter.
+	write("main.go", `package main
+
+import (
+	"context"
+
+	"fixture/pgxpool"
+)
+
+type pools struct {
+	Coordinator *pgxpool.Pool
+}
+
+func (p *pgxpool.Pool) placeholder() {}
+
+func build(ctx context.Context, domainPool *pgxpool.Pool) {}
+
+func wireOne(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
+func wireTwo(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
+
+func main() { wireOne(nil, nil); wireTwo(nil, nil) }
+`)
+
+	// The method-on-imported-type line above is illegal Go; drop it.
+	write("main.go", `package main
+
+import (
+	"context"
+
+	"fixture/pgxpool"
+)
+
+type pools struct {
+	Coordinator *pgxpool.Pool
+}
+
+func build(ctx context.Context, domainPool *pgxpool.Pool) {
+	_ = domainPool
+}
+
+func wireOne(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
+func wireTwo(ctx context.Context, p *pools) { build(ctx, p.Coordinator) }
+
+func main() { wireOne(nil, nil); wireTwo(nil, nil) }
+`)
+
+	derived, err := DeriveForRole(dir, RoleDomain)
+	if err != nil {
+		t.Fatalf("DeriveForRole: %v", err)
+	}
+	if len(derived.NameSeedOverrides) == 0 {
+		t.Error("with every call site classified and none of them domain, the domain-spelled parameter " +
+			"must be overridden -- otherwise the collector never overrides anything and the companion " +
+			"test proves nothing")
+	}
+}

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -55,6 +55,7 @@ func TestAdvisoryReportCoversEveryCategory(t *testing.T) {
 			FuncValueConflicts:   []FuncValueConflictSite{{File: "cmd/x/deps.go", Line: 7, Field: "sources.newThing", Reason: "two implementations"}},
 			WiringHops:           []UnresolvedCallSite{{File: "internal/x/y.go", Line: 11, Callee: "", Reason: "function value"}},
 			NameSeedOverrides:    []NameSeedOverride{{File: "cmd/x/deps.go", Line: 5, Name: "domainPool", Function: "build", ObservedRoles: []string{"coordinator"}}},
+			UnresolvedTx:         []UnresolvedTxSite{{File: "internal/x/y.go", Line: 13, Function: "Repo.Step"}},
 		}},
 	}
 

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -98,6 +98,71 @@ func TestAdvisoryReportCoversEveryCategory(t *testing.T) {
 	}
 }
 
+// TestKnownOpenLifecycleIsFullyReported covers the whole known-open lifecycle,
+// not just the accepted set.
+//
+// An earlier version of AdvisoryReport called PartitionKnownOpen and used only its
+// `accepted` result, discarding stale and unticketed, and labelled accepted entries
+// with a generic "[ticketed, known open]" naming neither ticket nor reason. So the
+// documented claim -- "expiry is suspended but the properties are still REPORTED"
+// -- was false for two of the three, and an entry with an empty ticket was
+// presented as ticketed. Same stale-claim defect as the doc comments, but in
+// BEHAVIOUR: prose can be re-read, a dropped code path cannot.
+func TestKnownOpenLifecycleIsFullyReported(t *testing.T) {
+	real := knownOpenCriticals
+	t.Cleanup(func() { knownOpenCriticals = real })
+
+	// One entry that reproduces (accepted, with a ticket and reason), one that no
+	// longer reproduces (stale), and one with no ticket at all.
+	knownOpenCriticals = []KnownOpenCritical{
+		{Role: RoleCoordinator, Table: "reproduces", Privilege: PrivInsert,
+			Ticket: "CHAOS-1111", Why: "the documented reason"},
+		{Role: RoleCoordinator, Table: "vanished", Privilege: PrivUpdate,
+			Ticket: "CHAOS-2222", Why: "was real once"},
+		{Role: RoleDomain, Table: "untracked", Privilege: PrivDelete,
+			Ticket: "", Why: "nobody owns this"},
+	}
+
+	report := &RoleReport{Findings: []Finding{
+		{Severity: Critical, Role: RoleCoordinator, Table: "reproduces", Privilege: PrivInsert,
+			Summary: "synthetic reproducing critical"},
+		{Severity: Critical, Role: RoleDomain, Table: "untracked", Privilege: PrivDelete,
+			Summary: "synthetic untracked critical"},
+	}}
+
+	var knownOpen string
+	for _, line := range AdvisoryReport(report) {
+		if line.Category == CategoryKnownOpen {
+			knownOpen += line.Text + "\n"
+		}
+	}
+
+	// Accepted: ticket AND reason must both be visible. "[ticketed]" with neither
+	// tells a reader nothing they can act on.
+	if !strings.Contains(knownOpen, "CHAOS-1111") {
+		t.Errorf("an accepted entry must name its TICKET, or nothing connects it to the fix:\n%s", knownOpen)
+	}
+	if !strings.Contains(knownOpen, "the documented reason") {
+		t.Errorf("an accepted entry must carry its recorded reason:\n%s", knownOpen)
+	}
+
+	// Stale: reported, and the report must say what suspension MEANS for it.
+	if !strings.Contains(knownOpen, "STALE") || !strings.Contains(knownOpen, "vanished") {
+		t.Errorf("an entry that no longer reproduces must be reported as stale -- under gating it "+
+			"would have failed and forced its own deletion:\n%s", knownOpen)
+	}
+	if !strings.Contains(knownOpen, "indefinitely") {
+		t.Errorf("the stale line must state the consequence of suspended expiry, not merely the fact "+
+			"of staleness:\n%s", knownOpen)
+	}
+
+	// Unticketed: must never be presented as ticketed.
+	if !strings.Contains(knownOpen, "NO TICKET") || !strings.Contains(knownOpen, "untracked") {
+		t.Errorf("an entry with no ticket must be reported as untracked, not labelled ticketed:\n%s",
+			knownOpen)
+	}
+}
+
 // TestAcknowledgementsRequireAReason makes the mandatory-reason check
 // falsifiable. It could not fail before, because every real acknowledgement
 // already carries a reason -- so the check had no input that would exercise it.

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -156,9 +156,49 @@ func TestKnownOpenLifecycleIsFullyReported(t *testing.T) {
 			"of staleness:\n%s", knownOpen)
 	}
 
-	// Unticketed: must never be presented as ticketed.
-	if !strings.Contains(knownOpen, "NO TICKET") || !strings.Contains(knownOpen, "untracked") {
-		t.Errorf("an entry with no ticket must be reported as untracked, not labelled ticketed:\n%s",
+	// Unticketed: must never be presented as ticketed, and the assertion must be
+	// specific to the DEDICATED unticketed loop.
+	//
+	// An earlier version checked only for "NO TICKET" and "untracked", both of which
+	// the ACCEPTED path also emits (it prints "NO TICKET RECORDED" for a blank ticket
+	// and includes the finding summary). So deleting the dedicated loop entirely left
+	// this test green -- the exact regression it claims to prevent. Asserting text
+	// unique to that loop is what makes it falsifiable.
+	if !strings.Contains(knownOpen, "nothing tracks its fix") {
+		t.Errorf("the DEDICATED unticketed line must appear; matching only on \"NO TICKET\" is "+
+			"satisfied by the accepted path's blank-ticket label, so it cannot detect that loop's "+
+			"removal:\n%s", knownOpen)
+	}
+	if !strings.Contains(knownOpen, "untracked") {
+		t.Errorf("the unticketed entry must be named:\n%s", knownOpen)
+	}
+}
+
+// TestUnticketedEntryWithNoMatchingFindingIsStillReported isolates the dedicated
+// unticketed loop from the accepted path completely: with no finding to match, the
+// accepted path cannot fire at all, so anything reported here comes only from the
+// lifecycle loops.
+func TestUnticketedEntryWithNoMatchingFindingIsStillReported(t *testing.T) {
+	real := knownOpenCriticals
+	t.Cleanup(func() { knownOpenCriticals = real })
+	knownOpenCriticals = []KnownOpenCritical{
+		{Role: RoleDomain, Table: "orphan", Privilege: PrivDelete, Ticket: "", Why: "no owner"},
+	}
+
+	// No findings at all.
+	var knownOpen string
+	for _, line := range AdvisoryReport(&RoleReport{}) {
+		if line.Category == CategoryKnownOpen {
+			knownOpen += line.Text + "\n"
+		}
+	}
+	if !strings.Contains(knownOpen, "nothing tracks its fix") || !strings.Contains(knownOpen, "orphan") {
+		t.Errorf("an unticketed entry must be reported even with no matching finding -- otherwise the "+
+			"only thing exercising that loop is a path that also emits similar text:\n%s", knownOpen)
+	}
+	// It is also stale (nothing reproduces it), and both facts must be said.
+	if !strings.Contains(knownOpen, "STALE") {
+		t.Errorf("an entry with no matching finding is also stale and must be reported as such:\n%s",
 			knownOpen)
 	}
 }

--- a/internal/domaingrants/groundtruth.go
+++ b/internal/domaingrants/groundtruth.go
@@ -45,6 +45,69 @@ var grantStatementTableRE = regexp.MustCompile(
 // B role split it genuinely IS data — the readiness query binds it through
 // unnest rather than embedding VALUES rows, so there is no SQL text left to
 // parse there.
+// LoadGroundTruthForRole reads one role's declared posture, and -- for the
+// domain role only -- also the independent GRANT statement list, so the two can
+// be cross-checked against each other.
+//
+// The asymmetry is real and load-bearing, not an omission. The DOMAIN role has
+// TWO hand-maintained artefacts (runtimeGrantStatements in migrate.go and
+// DomainPosture in domain_authorization.go), which is precisely why they
+// repeatedly drifted from the code while agreeing with each other. The
+// COORDINATOR role has ONE: migrate.go's coordinatorGrantStatements is
+// parameterized on options.CoordinatorGrants, and the only production caller
+// (cmd/dev-health-worker-migrate's coordinatorGrants(), main.go:198) builds that
+// by mechanically projecting CoordinatorPosture() field-for-field. So there is
+// no second coordinator list to disagree with, and a list-vs-list finding is
+// structurally impossible for it. Grants is left nil for such a role rather than
+// synthesized, so CompareRoles skips a comparison it cannot meaningfully make
+// instead of comparing the posture against a restatement of itself and reporting
+// a vacuous agreement.
+func LoadGroundTruthForRole(role PoolRole) (*GroundTruth, error) {
+	switch role {
+	case RoleDomain:
+		return LoadGroundTruth()
+	case RoleCoordinator:
+		gt := &GroundTruth{
+			RequiredTablePrivileges: map[string]PrivilegeSet{},
+			ColumnScopedTables:      map[string]bool{},
+		}
+		if err := gt.loadPosture(postgresstore.CoordinatorPosture(), "CoordinatorPosture"); err != nil {
+			return nil, err
+		}
+		return gt, nil
+	default:
+		return nil, fmt.Errorf("domaingrants: no ground truth defined for pool role %q", role)
+	}
+}
+
+// loadPosture reads a RolePosture declaration into the comparable per-table
+// privilege sets. Shared by both roles so a change to how a posture row maps to
+// privileges cannot apply to one role and be missed for the other.
+func (gt *GroundTruth) loadPosture(posture postgresstore.RolePosture, name string) error {
+	for _, table := range posture.RequiredTables {
+		var set PrivilegeSet
+		set.add(PrivSelect) // SELECT is implied by every posture row
+		if table.AllowInsert {
+			set.add(PrivInsert)
+		}
+		if table.AllowUpdate {
+			set.add(PrivUpdate)
+		}
+		if table.AllowDelete {
+			set.add(PrivDelete)
+		}
+		gt.RequiredTablePrivileges[strings.ToLower(table.TableName)] = set
+	}
+	if len(gt.RequiredTablePrivileges) == 0 {
+		return fmt.Errorf("domaingrants: %s() declared zero required tables, "+
+			"which cannot be right for a role the runtime asserts a posture for", name)
+	}
+	for _, column := range posture.ColumnScoped {
+		gt.ColumnScopedTables[strings.ToLower(column.TableName)] = true
+	}
+	return nil
+}
+
 func LoadGroundTruth() (*GroundTruth, error) {
 	gt := &GroundTruth{
 		Grants:                  map[string]PrivilegeSet{},
@@ -76,29 +139,8 @@ func LoadGroundTruth() (*GroundTruth, error) {
 			"the extraction regex has drifted from migrate.go's actual statement shape", riverstore.GrantCheckDomainRole)
 	}
 
-	posture := postgresstore.DomainPosture()
-	for _, table := range posture.RequiredTables {
-		var set PrivilegeSet
-		set.add(PrivSelect) // SELECT is implied by every posture row
-		if table.AllowInsert {
-			set.add(PrivInsert)
-		}
-		if table.AllowUpdate {
-			set.add(PrivUpdate)
-		}
-		if table.AllowDelete {
-			set.add(PrivDelete)
-		}
-		gt.RequiredTablePrivileges[strings.ToLower(table.TableName)] = set
+	if err := gt.loadPosture(postgresstore.DomainPosture(), "DomainPosture"); err != nil {
+		return nil, err
 	}
-	if len(gt.RequiredTablePrivileges) == 0 {
-		return nil, fmt.Errorf("domaingrants: DomainPosture() declared zero required tables, " +
-			"which cannot be right for a role the runtime asserts a posture for")
-	}
-
-	for _, column := range posture.ColumnScoped {
-		gt.ColumnScopedTables[strings.ToLower(column.TableName)] = true
-	}
-
 	return gt, nil
 }

--- a/internal/domaingrants/lock_chain_test.go
+++ b/internal/domaingrants/lock_chain_test.go
@@ -3,7 +3,6 @@ package domaingrants
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -176,8 +175,17 @@ func main() { run(nil) }
 	if !surfaced {
 		t.Error("the unparsed LOCK did not reach IncompleteRoleSurface, so the gate cannot see it")
 	}
-	if failures := strings.Join(GateFailures(report), "\n"); !strings.Contains(failures, "UNPARSED LOCK") {
-		t.Errorf("an unparsed LOCK must FAIL the gate -- its target may never enter the derived "+
-			"surface at all, so an absence is not a safe default:\n%s", failures)
+	// It must reach the advisory report under its own category. The report is the
+	// tool's only output now, so a refusal that is computed and not printed is
+	// indistinguishable from a statement that parsed cleanly.
+	var reported string
+	for _, line := range AdvisoryReport(report) {
+		if line.Category == CategoryUnparsedLock {
+			reported += line.Text + "\n"
+		}
+	}
+	if reported == "" {
+		t.Error("an unparsed LOCK must be REPORTED: its target may never enter the derived surface " +
+			"at all, so an absence is not a safe default and silence here is a lie by omission")
 	}
 }

--- a/internal/domaingrants/lock_chain_test.go
+++ b/internal/domaingrants/lock_chain_test.go
@@ -1,0 +1,183 @@
+package domaingrants
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Coverage for the unparsed-LOCK REPORTING CHAIN.
+//
+// Clause mutation of the re-derived lock model killed 19 of 25, and five of the
+// six survivors were one cluster: `parseLockStatements` reporting a refusal was
+// tested, but every link AFTER it was not. ParseStatement propagating the refusal,
+// the analyzer recording it, and the gate surfacing it could each be deleted with
+// every test still green -- so "an unparsed LOCK fails the gate" was a claim about
+// four functions of which one was exercised.
+//
+// The real tree contains no unparsed LOCK (both production strings parse), so the
+// whole-repo gate cannot reach this path at all. These tests build the state
+// deliberately, ending with an end-to-end run over a temporary module.
+
+// TestParseStatementPropagatesUnparsedLocks covers the link from the parser to
+// StatementResult. Killing this required no fixture beyond a bad statement, and
+// its absence meant the refusal could be computed and then dropped one frame later.
+func TestParseStatementPropagatesUnparsedLocks(t *testing.T) {
+	t.Parallel()
+
+	// A shape the parser refuses outright.
+	result := ParseStatement("LOCK TABLE")
+	if len(result.UnparsedLocks) == 0 {
+		t.Error("ParseStatement dropped the parser's refusal: a LOCK that could not be read must " +
+			"reach StatementResult, or nothing downstream can report it")
+	}
+
+	// A mode word the parser does not know is rejected by the PARSER.
+	result = ParseStatement("LOCK TABLE public.t IN NONSENSE MODE")
+	if len(result.UnparsedLocks) == 0 {
+		t.Error("a lock mode built from unknown words must be recorded as unparsed")
+	}
+
+	// A DIFFERENT refusal path, and the one mutation testing found untested: the
+	// statement parses cleanly -- every mode word is one the parser accepts -- but
+	// the resulting COMBINATION is not a real PostgreSQL mode. `IN UPDATE MODE`
+	// uses only legal mode words, so it reaches lockRequirementForMode, which
+	// refuses it. Without this case the parser's word check masked the refusal
+	// path entirely, and deleting that recording changed nothing.
+	result = ParseStatement("LOCK TABLE public.t IN UPDATE MODE")
+	if len(result.UnparsedLocks) == 0 {
+		t.Error("a syntactically parseable but semantically unrecognised mode must be recorded as " +
+			"unparsed; returning a guessed privilege set is how the previous version passed " +
+			"silently for a role that happened to hold UPDATE")
+	}
+	if _, recorded := result.LockRequirements["t"]; recorded {
+		t.Error("an unrecognised mode must produce NO requirement at all -- a guess that happens " +
+			"to be satisfied is indistinguishable from knowledge")
+	}
+}
+
+// TestParseLockStatementAcceptsNowaitWithoutModeClause covers `LOCK TABLE t
+// NOWAIT`. The grammar test only exercised NOWAIT after an explicit mode, which
+// is a different branch: with no IN clause the parser must still accept NOWAIT
+// and keep the defaulted mode.
+func TestParseLockStatementAcceptsNowaitWithoutModeClause(t *testing.T) {
+	t.Parallel()
+
+	statements, unparsed := parseLockStatements("LOCK TABLE public.t NOWAIT")
+	if len(unparsed) != 0 {
+		t.Fatalf("`LOCK TABLE t NOWAIT` must parse, got unparsed %v", unparsed)
+	}
+	if len(statements) != 1 {
+		t.Fatalf("expected one statement, got %d", len(statements))
+	}
+	if statements[0].Mode != lockDefaultMode {
+		t.Errorf("mode = %q, want the default %q -- NOWAIT is not a mode clause",
+			statements[0].Mode, lockDefaultMode)
+	}
+}
+
+// TestParseLockStatementIgnoresLockAwayFromStatementStart covers the anchoring.
+// The earlier cases (`SKIP LOCKED`, `lock_key`) were rejected by the word-boundary
+// check alone, so removing the statement-start anchor changed nothing and the
+// mutation survived. A whole-word LOCK inside a string literal is the case that
+// actually needs the anchor -- and it matters because an unparsed LOCK now FAILS
+// the gate, so a false positive here is a false gate failure.
+func TestParseLockStatementIgnoresLockAwayFromStatementStart(t *testing.T) {
+	t.Parallel()
+
+	for _, sql := range []string{
+		"SELECT 'LOCK TABLE public.t' AS example FROM public.other",
+		"INSERT INTO public.audit (note) VALUES ('LOCK public.a, public.b')",
+	} {
+		statements, unparsed := parseLockStatements(sql)
+		if len(statements) != 0 || len(unparsed) != 0 {
+			t.Errorf("%q: LOCK appears mid-statement (inside a literal), so it must not be read as a "+
+				"LOCK statement -- a false positive here is a false GATE FAILURE. got %d parsed, %v unparsed",
+				sql, len(statements), unparsed)
+		}
+	}
+
+	// Control: the same text AT a statement start must still be read, so the
+	// anchor is not simply rejecting everything.
+	if statements, _ := parseLockStatements("BEGIN; LOCK TABLE public.t IN SHARE MODE"); len(statements) != 1 {
+		t.Errorf("a LOCK following `;` is statement-initial and must parse, got %d", len(statements))
+	}
+}
+
+// TestUnparsedLockReachesTheGateEndToEnd is the link the other tests cannot
+// reach: analyzer recording, and incompleteFor surfacing it. Both survived
+// mutation because no test drove a real derivation containing an unparsed LOCK --
+// and the production tree has none, so the whole-repo gate never exercises it.
+func TestUnparsedLockReachesTheGateEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module fixture\n\ngo 1.25\n")
+	write("pgxpool/pgxpool.go", `package pgxpool
+
+type Pool struct{}
+
+func (p *Pool) Exec(ctx interface{}, sql string, args ...interface{}) error { return nil }
+`)
+	// A LOCK with a mode this analyzer does not recognise, executed on the domain
+	// pool. The seed name is what puts it in the domain surface.
+	write("main.go", `package main
+
+import "fixture/pgxpool"
+
+type pools struct {
+	Domain *pgxpool.Pool
+}
+
+func run(p *pools) {
+	domainPool := p.Domain
+	_ = domainPool.Exec(nil, "LOCK TABLE public.t IN NONSENSE MODE")
+}
+
+func main() { run(nil) }
+`)
+
+	derived, err := DeriveForRole(dir, RoleDomain)
+	if err != nil {
+		t.Fatalf("DeriveForRole: %v", err)
+	}
+	if len(derived.UnparsedLocks) == 0 {
+		t.Fatal("the analyzer did not record the unparsed LOCK: the parser's refusal was computed " +
+			"and then dropped, so nothing downstream can report it")
+	}
+
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: derived,
+			Truth: truthWith(map[string]PrivilegeSet{"t": selectOnly})},
+		{Role: RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator, Tables: map[string]*TableSurface{}},
+			Truth:   truthWith(map[string]PrivilegeSet{"t": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	surfaced := false
+	for _, surface := range report.Incomplete {
+		if len(surface.UnparsedLocks) > 0 {
+			surfaced = true
+		}
+	}
+	if !surfaced {
+		t.Error("the unparsed LOCK did not reach IncompleteRoleSurface, so the gate cannot see it")
+	}
+	if failures := strings.Join(GateFailures(report), "\n"); !strings.Contains(failures, "UNPARSED LOCK") {
+		t.Errorf("an unparsed LOCK must FAIL the gate -- its target may never enter the derived "+
+			"surface at all, so an absence is not a safe default:\n%s", failures)
+	}
+}

--- a/internal/domaingrants/lockparse.go
+++ b/internal/domaingrants/lockparse.go
@@ -1,0 +1,246 @@
+package domaingrants
+
+import (
+	"strings"
+)
+
+// A real parser for PostgreSQL's LOCK statement, replacing a regex that
+// recognised exactly ONE of its nine accepted shapes.
+//
+// The grammar (all forms below verified accepted by PostgreSQL 18.4):
+//
+//	LOCK [ TABLE ] [ ONLY ] name [ * ] [, [ONLY] name [*] ...] [ IN <mode> MODE ] [ NOWAIT ]
+//
+// The regex required the TABLE keyword, a single target, and an explicit mode.
+// So every one of these derived NOTHING -- no table, no privilege, no diagnostic:
+//
+//	LOCK public.t IN SHARE ROW EXCLUSIVE MODE          -- TABLE omitted
+//	LOCK TABLE public.a, public.b IN ... MODE          -- multiple targets
+//	LOCK TABLE public.t                                -- mode omitted (= ACCESS EXCLUSIVE)
+//	LOCK TABLE public.t *                              -- descendant marker
+//
+// `LOCK public.a, public.b` in coordinator-only code would derive neither table
+// nor privilege, CI would pass, and production would return 42501. Silently
+// ignoring input it does not recognise is the worst possible shape for a tool
+// whose entire job is to fail closed, so an unrecognised LOCK is now a RECORDED
+// FACT that fails the gate rather than an absence.
+
+// lockStatement is one successfully parsed LOCK.
+type lockStatement struct {
+	// Targets are the raw (possibly schema-qualified) names, in source order.
+	Targets []string
+	// Mode is the normalized mode, defaulted when the statement omits it.
+	Mode string
+}
+
+// lockModeWords are the tokens that may appear inside a mode name. Parsing stops
+// at MODE, so this only has to bound the scan.
+var lockModeWords = map[string]bool{
+	"ACCESS": true, "SHARE": true, "ROW": true, "EXCLUSIVE": true, "UPDATE": true,
+}
+
+// parseLockStatements finds every statement-initial LOCK in clean and returns the
+// ones it fully understood plus the verbatim text of the ones it did not.
+//
+// Statement-initial means preceded (ignoring whitespace) by nothing or by `;`.
+// That anchoring keeps the word LOCK inside a string literal or an identifier
+// from being read as a statement -- important now that an unparsed LOCK FAILS the
+// gate, because a false positive here would be a false failure.
+func parseLockStatements(clean string) (statements []lockStatement, unparsed []string) {
+	upper := strings.ToUpper(clean)
+	for index := 0; index < len(upper); {
+		found := strings.Index(upper[index:], "LOCK")
+		if found < 0 {
+			break
+		}
+		at := index + found
+		index = at + 4
+
+		if !isStatementStart(upper, at) || !isWordEnd(upper, at+4) {
+			continue
+		}
+		statement, rest, ok := parseOneLock(clean[at+4:])
+		if !ok {
+			unparsed = append(unparsed, statementText(clean[at:]))
+			// Skip past this statement so its tail is not re-scanned.
+			if end := strings.IndexByte(clean[at:], ';'); end >= 0 {
+				index = at + end
+			}
+			continue
+		}
+		statements = append(statements, statement)
+		index = len(clean) - len(rest)
+	}
+	return statements, unparsed
+}
+
+// isStatementStart reports whether position at begins a statement: only
+// whitespace back to either the start of the text or a semicolon.
+func isStatementStart(upper string, at int) bool {
+	for i := at - 1; i >= 0; i-- {
+		switch upper[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case ';':
+			return true
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isWordEnd(upper string, at int) bool {
+	if at >= len(upper) {
+		return true
+	}
+	c := upper[at]
+	return !(c == '_' || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+}
+
+// statementText returns the LOCK statement's text for reporting, bounded so a
+// diagnostic stays readable.
+func statementText(from string) string {
+	text := from
+	if end := strings.IndexByte(text, ';'); end >= 0 {
+		text = text[:end]
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	const maxLen = 120
+	if len(text) > maxLen {
+		text = text[:maxLen] + "..."
+	}
+	return text
+}
+
+// parseOneLock parses the remainder after the LOCK keyword.
+func parseOneLock(after string) (lockStatement, string, bool) {
+	rest := after
+	tok, rest, ok := nextToken(rest)
+	if !ok {
+		return lockStatement{}, after, false
+	}
+	if strings.EqualFold(tok, "TABLE") {
+		tok, rest, ok = nextToken(rest)
+		if !ok {
+			return lockStatement{}, after, false
+		}
+	}
+
+	statement := lockStatement{Mode: lockDefaultMode}
+	for {
+		if strings.EqualFold(tok, "ONLY") {
+			if tok, rest, ok = nextToken(rest); !ok {
+				return lockStatement{}, after, false
+			}
+		}
+		if !isNameToken(tok) {
+			return lockStatement{}, after, false
+		}
+		statement.Targets = append(statement.Targets, tok)
+
+		// Optional descendant marker, then either another target or the end of
+		// the target list.
+		peek, peekRest, havePeek := nextToken(rest)
+		if havePeek && peek == "*" {
+			rest = peekRest
+			peek, peekRest, havePeek = nextToken(rest)
+		}
+		if havePeek && peek == "," {
+			if tok, rest, ok = nextToken(peekRest); !ok {
+				return lockStatement{}, after, false
+			}
+			continue
+		}
+		if !havePeek {
+			return statement, rest, true // no mode clause: default stands
+		}
+		tok, rest = peek, peekRest
+		break
+	}
+
+	if !strings.EqualFold(tok, "IN") {
+		// Only NOWAIT or a statement terminator may follow the target list.
+		if strings.EqualFold(tok, "NOWAIT") || tok == ";" {
+			return statement, rest, true
+		}
+		return lockStatement{}, after, false
+	}
+
+	var modeWords []string
+	for {
+		tok, rest, ok = nextToken(rest)
+		if !ok {
+			return lockStatement{}, after, false
+		}
+		if strings.EqualFold(tok, "MODE") {
+			break
+		}
+		if !lockModeWords[strings.ToUpper(tok)] {
+			// An unrecognised word inside the mode clause. Refuse the whole
+			// statement rather than guess a mode -- see lockRequirementForMode.
+			return lockStatement{}, after, false
+		}
+		modeWords = append(modeWords, strings.ToUpper(tok))
+	}
+	if len(modeWords) == 0 {
+		return lockStatement{}, after, false
+	}
+	statement.Mode = normalizeLockMode(strings.Join(modeWords, " "))
+
+	if peek, peekRest, havePeek := nextToken(rest); havePeek {
+		if strings.EqualFold(peek, "NOWAIT") {
+			rest = peekRest
+		} else if peek != ";" {
+			return lockStatement{}, after, false
+		}
+	}
+	return statement, rest, true
+}
+
+// nextToken returns the next SQL token: a punctuation character, a quoted
+// identifier, or a run of identifier characters (dots included, so a qualified
+// name arrives whole).
+func nextToken(s string) (string, string, bool) {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	if i >= len(s) {
+		return "", "", false
+	}
+	switch s[i] {
+	case ',', '*', ';':
+		return string(s[i]), s[i+1:], true
+	case '"':
+		end := strings.IndexByte(s[i+1:], '"')
+		if end < 0 {
+			return "", "", false
+		}
+		return s[i+1 : i+1+end], s[i+2+end:], true
+	}
+	start := i
+	for i < len(s) && (isIdentChar(s[i]) || s[i] == '.') {
+		i++
+	}
+	if i == start {
+		return string(s[start]), s[start+1:], true
+	}
+	return s[start:i], s[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return c == '_' || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isNameToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for i := 0; i < len(tok); i++ {
+		if !isIdentChar(tok[i]) && tok[i] != '.' {
+			return false
+		}
+	}
+	return isIdentChar(tok[0]) || tok[0] == '"'
+}

--- a/internal/domaingrants/lockparse.go
+++ b/internal/domaingrants/lockparse.go
@@ -33,6 +33,24 @@ type lockStatement struct {
 	Mode string
 }
 
+// quotedTargetRefusal explains why a quoted lock target is refused rather than
+// resolved. It is a REFUSAL, not a skip, and that distinction is the point.
+//
+// PostgreSQL's quoting rules make a quoted identifier opaque: `"private.outbox"`
+// is ONE relation whose name contains a dot, and `"Outbox"` is a DIFFERENT
+// relation from `outbox`. Downstream, splitSchemaQualified reads embedded dots as
+// a schema separator and table keys are lowercased -- so a quoted target would be
+// re-interpreted as schema `private` (then dropped as out-of-scope, silently) or
+// folded into `outbox`. A posture covering the misidentified table then passes
+// while the real target holds no privileges.
+//
+// The mis-parse is not the defect; the SILENT SKIP is. This analyzer cannot
+// represent a quoted identifier faithfully, so it says so instead of guessing,
+// and the statement lands in UnparsedLocks where a reader can see it.
+const quotedTargetRefusal = "quoted lock target cannot be resolved faithfully " +
+	"(quoting makes dots and case significant, which this analyzer's schema-splitting " +
+	"and lower-casing would silently reinterpret)"
+
 // lockModeWords are the tokens that may appear inside a mode name. Parsing stops
 // at MODE, so this only has to bound the scan.
 var lockModeWords = map[string]bool{
@@ -137,6 +155,10 @@ func parseOneLock(after string) (lockStatement, string, bool) {
 		if !isNameToken(tok) {
 			return lockStatement{}, after, false
 		}
+		if strings.HasPrefix(tok, quotedTokenPrefix) {
+			// Refused, not skipped -- see quotedTargetRefusal.
+			return lockStatement{}, after, false
+		}
 		statement.Targets = append(statement.Targets, tok)
 
 		// Optional descendant marker, then either another target or the end of
@@ -201,6 +223,10 @@ func parseOneLock(after string) (lockStatement, string, bool) {
 // nextToken returns the next SQL token: a punctuation character, a quoted
 // identifier, or a run of identifier characters (dots included, so a qualified
 // name arrives whole).
+// quotedTokenPrefix marks a token that arrived double-quoted. A byte that cannot
+// appear in an unquoted SQL identifier, so it cannot collide with a real name.
+const quotedTokenPrefix = "\x00quoted:"
+
 func nextToken(s string) (string, string, bool) {
 	i := 0
 	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
@@ -217,7 +243,9 @@ func nextToken(s string) (string, string, bool) {
 		if end < 0 {
 			return "", "", false
 		}
-		return s[i+1 : i+1+end], s[i+2+end:], true
+		// The caller needs to know this was quoted; signal it with a sentinel
+		// prefix that cannot occur in an unquoted identifier.
+		return quotedTokenPrefix + s[i+1:i+1+end], s[i+2+end:], true
 	}
 	start := i
 	for i < len(s) && (isIdentChar(s[i]) || s[i] == '.') {
@@ -234,6 +262,9 @@ func isIdentChar(c byte) bool {
 }
 
 func isNameToken(tok string) bool {
+	if strings.HasPrefix(tok, quotedTokenPrefix) {
+		return len(tok) > len(quotedTokenPrefix)
+	}
 	if tok == "" {
 		return false
 	}

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -303,29 +303,50 @@ func TestFuncValueTargetsResolveTheKnownWiringHops(t *testing.T) {
 		t.Fatalf("DeriveForRole(coordinator): %v", err)
 	}
 
-	wantFields := []string{
-		"schedulerRuntimeSources.newRepository",
-		"schedulerRuntimeSources.newOccurrences",
-		"schedulerRuntimeSources.newFixedLoop",
-		"reconcilerDependencySources.buildRelay",
-		"reconcilerDependencySources.buildSyncMutation",
+	// Assert the MECHANISM and the TARGET, not a count and not merely that some
+	// table showed up.
+	//
+	// Why that distinction is load-bearing: taint ALSO re-seeds on the naming
+	// convention (a parameter literally named `coordinatorPool` is a seed root), so
+	// a table can become visible EITHER through this hop resolution OR because
+	// someone renamed a parameter. Those are not equivalent -- the convention is a
+	// comment enforced by nothing, and these three scheduler hops are the proof:
+	// they carried the coordinator pool with their parameter named `pool` and
+	// nothing caught it. A test asserting a table's presence, or a total count of
+	// resolved hops, would keep passing after such a rename while the mechanism it
+	// exists to pin had silently stopped working.
+	wantTargets := map[string]string{
+		"schedulerRuntimeSources.newRepository":         "func literal",
+		"schedulerRuntimeSources.newOccurrences":        "func literal",
+		"schedulerRuntimeSources.newFixedLoop":          "buildFixedScheduleLoop",
+		"reconcilerDependencySources.buildRelay":        "buildReconcilerRelay",
+		"reconcilerDependencySources.buildSyncMutation": "buildSyncMutationPipeline",
 	}
 	got := map[string]string{}
 	for _, resolved := range derived.FuncValueResolved {
 		got[resolved.Field] = resolved.Target
 	}
-	for _, field := range wantFields {
+	for field, wantTarget := range wantTargets {
 		target, ok := got[field]
 		if !ok {
-			t.Errorf("function-typed field %s no longer resolves to a single implementation; "+
-				"taint stops there and everything it builds becomes invisible to this role's surface", field)
+			t.Errorf("function-typed field %s no longer resolves through func-value resolution; "+
+				"taint stops there and everything it builds becomes invisible to this role's surface. "+
+				"NOTE: the affected tables may still appear via the coordinatorPool naming convention, "+
+				"which is exactly why this test asserts the mechanism and not the tables", field)
+			continue
+		}
+		if !strings.Contains(target, wantTarget) {
+			t.Errorf("function-typed field %s resolved to %q, want something containing %q -- "+
+				"it builds something else now, so what this hop proves has changed", field, target, wantTarget)
 			continue
 		}
 		t.Logf("%s -> %s", field, target)
 	}
 
-	// And the surface those hops unlock must actually be present. These are the
-	// tables that were missing before the hop was closed.
+	// Corroboration only: the surface those hops unlock is present. Deliberately
+	// secondary to the assertions above -- after a `pool` -> `coordinatorPool`
+	// rename anywhere in the scheduler wiring this block becomes satisfiable by the
+	// naming convention alone, and stops being evidence about the hop.
 	for _, table := range []string{
 		"scheduled_jobs",
 		"scheduled_sync_occurrences",
@@ -333,8 +354,80 @@ func TestFuncValueTargetsResolveTheKnownWiringHops(t *testing.T) {
 		"sync_configurations",
 	} {
 		if surface := derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
-			t.Errorf("coordinator surface lost %q: the scheduler wiring hop that reaches it "+
-				"is no longer resolved", table)
+			t.Errorf("coordinator surface lost %q entirely -- neither the wiring hop nor the "+
+				"naming convention reaches it now", table)
+		}
+	}
+}
+
+// TestLockTableRequiresAnyWritePrivilege pins the LOCK TABLE rule per role.
+//
+// This test exists because mutation testing found the rule was NOT covered:
+// deleting the whole check left the repo-wide gate green, since every table this
+// repo LOCKs already holds a write privilege for some other reason. A rule that
+// cannot fail is not a rule, and this one has already shipped a production 42501
+// (CHAOS-3113: workerctl's route rollback runs LOCK worker_job_outbox IN SHARE
+// ROW EXCLUSIVE MODE while the domain role holds only SELECT+INSERT).
+//
+// Postgres wants at least ONE of INSERT/UPDATE/DELETE for a LOCK mode stricter
+// than ROW EXCLUSIVE -- any one, not a specific one. That is a DIFFERENT shape
+// from `SELECT ... FOR UPDATE`, which requires UPDATE specifically and is
+// modelled as an ordinary UPDATE requirement. Both halves are asserted so the
+// asymmetry cannot be "simplified" into a single rule later.
+func TestLockTableRequiresAnyWritePrivilege(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+	var selectInsert PrivilegeSet
+	selectInsert.add(PrivSelect)
+	selectInsert.add(PrivInsert)
+
+	lockSurface := func(role PoolRole) *DerivedSurface {
+		s := &TableSurface{Table: "outbox"}
+		s.Privileges.add(PrivSelect)
+		s.Evidence = append(s.Evidence, Evidence{
+			File: "internal/jobroute/control.go", Line: 197, Privilege: PrivSelect,
+			Statement: "LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE", TxGroup: "tx",
+		})
+		s.RequiresAnyWriteLock = true
+		s.WriteLockEvidence = append(s.WriteLockEvidence, Evidence{
+			File: "internal/jobroute/control.go", Line: 197,
+			Statement: "LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE",
+		})
+		return &DerivedSurface{Role: role, Tables: map[string]*TableSurface{"outbox": s}}
+	}
+
+	// SELECT-only posture: the LOCK is denied at runtime. Must be CRITICAL.
+	report, err := CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+		{Role: RoleCoordinator, Derived: lockSurface(RoleCoordinator),
+			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(findingSummaries(report, Critical), "\n")
+	if !strings.Contains(joined, "LOCK TABLE") {
+		t.Fatalf("a LOCK TABLE against a SELECT-only posture was not reported CRITICAL -- that is the "+
+			"CHAOS-3113 defect shape exactly, and it must fail closed:\n%s", joined)
+	}
+
+	// SELECT+INSERT posture: any ONE write privilege satisfies Postgres, so there
+	// must be no finding. This half is what stops the rule degenerating into
+	// "report every table that is ever LOCKed".
+	report, err = CompareRoles([]RoleInput{
+		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+		{Role: RoleCoordinator, Derived: lockSurface(RoleCoordinator),
+			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectInsert})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range report.Findings {
+		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+			t.Errorf("INSERT alone should satisfy the LOCK requirement (Postgres accepts any one of "+
+				"INSERT/UPDATE/DELETE), but it was still reported: %s", f.Summary)
 		}
 	}
 }

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -34,8 +34,8 @@ import (
 //
 // Promoting this to a gate requires the blind-spot closure argument: a partition
 // of everything the analysis can fail to see, with each cell either failing the
-// check or documented as safe to accept PER SITE (not per file). That is tracked
-// separately as a design task.
+// check or documented as safe to accept PER SITE (not per file). Tracked as
+// CHAOS-3164.
 //
 // The only failures here are TOOL-BROKEN conditions -- the analysis could not run
 // at all. Those are not findings about the code under analysis, and reporting

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -116,6 +116,15 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 			"justification lives", entry.Role, entry.Table, entry.Privilege)
 	}
 	for _, surface := range report.Incomplete {
+		for _, lock := range surface.UnparsedLocks {
+			t.Errorf("UNPARSED LOCK (role %s): %s:%d %q -- this analyzer could not fully understand a "+
+				"LOCK statement, so the privilege it demands was NOT derived and its target may not "+
+				"appear in the surface at all. PostgreSQL accepts an optional TABLE keyword, multiple "+
+				"comma-separated targets, ONLY, a trailing *, an omitted mode (defaulting to ACCESS "+
+				"EXCLUSIVE) and NOWAIT; extend parseLockStatements to cover this shape rather than "+
+				"letting it pass as an absence",
+				surface.Role, lock.File, lock.Line, lock.Statement)
+		}
 		for _, conflict := range surface.FuncValueConflicts {
 			t.Errorf("UNRESOLVED FUNCTION-VALUE CALL (role %s): %s:%d %s -- %s. Pool-tainted arguments "+
 				"cross this call and NOTHING beyond it was analyzed. Fail-closed resolution is correct, "+
@@ -511,16 +520,18 @@ func TestLockTableRequirementIsModeAware(t *testing.T) {
 	var selectDelete PrivilegeSet
 	selectDelete.add(PrivSelect)
 	selectDelete.add(PrivDelete)
+	var updateOnly PrivilegeSet
+	updateOnly.add(PrivUpdate)
 
 	lockSurface := func(role PoolRole, mode string) *DerivedSurface {
-		requirement, needsMore := lockRequirementForMode(mode)
+		requirement, recognized := lockRequirementForMode(mode)
 		s := &TableSurface{Table: "outbox"}
 		s.Privileges.add(PrivSelect)
 		s.Evidence = append(s.Evidence, Evidence{
 			File: "internal/jobroute/control.go", Line: 197, Privilege: PrivSelect,
 			Statement: "LOCK TABLE public.outbox IN " + mode + " MODE", TxGroup: "tx",
 		})
-		if needsMore {
+		if recognized {
 			held := requirement
 			s.LockRequirement = &held
 			s.WriteLockEvidence = append(s.WriteLockEvidence, Evidence{
@@ -538,8 +549,10 @@ func TestLockTableRequirementIsModeAware(t *testing.T) {
 		postureName string
 		wantFinding bool
 	}{
-		// ACCESS SHARE: SELECT is enough.
+		// ACCESS SHARE: SELECT is enough -- and so is UPDATE ALONE, because the
+		// demand is a disjunction rather than a conjunction with SELECT.
 		{"ACCESS SHARE", selectOnly, "SELECT", false},
+		{"ACCESS SHARE", updateOnly, "UPDATE only (no SELECT)", false},
 
 		// ROW SHARE and ROW EXCLUSIVE: SELECT alone is NOT enough (the docs say
 		// ROW SHARE needs only SELECT; measurement says otherwise), and INSERT IS.
@@ -561,8 +574,9 @@ func TestLockTableRequirementIsModeAware(t *testing.T) {
 		{"SHARE ROW EXCLUSIVE", selectDelete, "SELECT+DELETE", false},
 		{"ACCESS EXCLUSIVE", selectUpdate, "SELECT+UPDATE", false},
 
-		// An unrecognized mode must fail CLOSED, not open.
-		{"SOME FUTURE", selectInsert, "SELECT+INSERT", true},
+		// A lock-only path authorized by UPDATE alone needs NO SELECT. If the
+		// model required SELECT as well, this would report a finding.
+		{"SHARE ROW EXCLUSIVE", updateOnly, "UPDATE only (no SELECT)", false},
 	}
 
 	for _, tc := range cases {
@@ -579,7 +593,7 @@ func TestLockTableRequirementIsModeAware(t *testing.T) {
 		}
 		found := false
 		for _, f := range report.Findings {
-			if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+			if f.Severity == Critical && strings.Contains(f.Summary, "LOCK IN") {
 				found = true
 			}
 		}
@@ -628,7 +642,7 @@ func TestLockTableSharedEvidenceIsDowngraded(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, f := range report.Findings {
-		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK IN") {
 			t.Errorf("a LOCK whose every site is shared between roles was reported CRITICAL, which "+
 				"tells maintainers to widen both postures on evidence that cannot attribute either: %s", f.Summary)
 		}

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -57,6 +57,19 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 		t.Log(line)
 	}
 
+	// Name-seed overrides: places where call-site evidence overruled a parameter's
+	// spelling. Reported because it means a naming convention LIED, and the reader
+	// should know that rather than assume the surface shrank on its own. This was
+	// collected but never printed or gated, so the "the override is reported"
+	// property did not actually exist.
+	for _, in := range inputs {
+		for _, override := range in.Derived.NameSeedOverrides {
+			t.Logf("NAME-SEED OVERRIDE (role %s): %s:%d parameter %q in %s is spelled for this role but "+
+				"its call sites pass %v -- call-site evidence wins, and the parameter name is misleading",
+				in.Role, override.File, override.Line, override.Name, override.Function, override.ObservedRoles)
+		}
+	}
+
 	// The derived shared set, printed so it is reviewable. It makes the dual-grant
 	// question checkable rather than purely asserted, but it is NOT authoritative
 	// on its own and does not replace the role-partition manifest's whitelist --
@@ -93,45 +106,19 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 	// Incompleteness must GATE, not merely print. A printout nobody is required to
 	// act on is indistinguishable from having checked.
 	//
+	// The enforcement lives in GateFailures rather than in loops here, because
+	// loops here were untestable: a unit test could prove a conflict reached
+	// IncompleteRoleSurface while deleting the loop that reported it left every
+	// test green.
+	//
 	// Deliberately NOT gated on the raw wiring-hop count: most hops are ordinary
 	// interface dispatch that reaches no SQL, so a count threshold would be noise
 	// that gets raised rather than investigated. What IS gated is the set with a
-	// real consequence -- a posture privilege nothing in the analysis justifies,
-	// and a tainted call through a field the resolver refused.
-	unacknowledged, staleAcks, unreasoned := PartitionBlindSpots(report.Incomplete)
-	for _, entry := range unacknowledged {
-		t.Errorf("UNACKNOWLEDGED BLIND SPOT: %s -- this role's posture authorizes a privilege that NO "+
-			"role has a derived call site for. Either it is an over-declaration (remove the row) or it "+
-			"sits inside a blind spot (add it to acknowledgedBlindSpots with the reason and where the "+
-			"justification lives). Leaving it unlisted is how a wrong posture row survives review", entry)
-	}
-	for _, entry := range staleAcks {
-		t.Errorf("STALE acknowledged blind spot: %s/%s %s no longer appears as an evidence-free posture "+
-			"row -- the evidence arrived or the row was removed, so this entry now suppresses nothing. "+
-			"DELETE it, or the gate stops failing if the blind spot returns",
-			entry.Role, entry.Table, entry.Privilege)
-	}
-	for _, entry := range unreasoned {
-		t.Errorf("acknowledged blind spot %s/%s %s has no reason recorded; every entry must say where the "+
-			"justification lives", entry.Role, entry.Table, entry.Privilege)
-	}
-	for _, surface := range report.Incomplete {
-		for _, lock := range surface.UnparsedLocks {
-			t.Errorf("UNPARSED LOCK (role %s): %s:%d %q -- this analyzer could not fully understand a "+
-				"LOCK statement, so the privilege it demands was NOT derived and its target may not "+
-				"appear in the surface at all. PostgreSQL accepts an optional TABLE keyword, multiple "+
-				"comma-separated targets, ONLY, a trailing *, an omitted mode (defaulting to ACCESS "+
-				"EXCLUSIVE) and NOWAIT; extend parseLockStatements to cover this shape rather than "+
-				"letting it pass as an absence",
-				surface.Role, lock.File, lock.Line, lock.Statement)
-		}
-		for _, conflict := range surface.FuncValueConflicts {
-			t.Errorf("UNRESOLVED FUNCTION-VALUE CALL (role %s): %s:%d %s -- %s. Pool-tainted arguments "+
-				"cross this call and NOTHING beyond it was analyzed. Fail-closed resolution is correct, "+
-				"but it must not be silent: give the field a single implementation, or narrow the type so "+
-				"the resolver can see it",
-				surface.Role, conflict.File, conflict.Line, conflict.Field, conflict.Reason)
-		}
+	// real consequence -- a posture privilege nothing justifies, a tainted call
+	// through a field the resolver refused, a LOCK the parser could not read, and
+	// a non-constant SQL site nobody has traced.
+	for _, failure := range GateFailures(report) {
+		t.Error(failure)
 	}
 
 	var critical, advisory []Finding
@@ -808,12 +795,22 @@ func TestTransactionStraddleIsCritical(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	joined := strings.Join(findingSummaries(report, Critical), "\n")
-	if !strings.Contains(joined, "TRANSACTION STRADDLES THE ROLE PARTITION") {
-		t.Fatalf("straddling transaction was not reported CRITICAL:\n%s", joined)
+	// ADVISORY by decision, never Critical: co-residency is INFERRED at both
+	// precisions. A "txorigin" group means the pgx.Tx traced to one Begin() source
+	// POSITION -- buildTxOrigins does no control-flow analysis, so mutually
+	// exclusive branches after that Begin carry the same origin and would be
+	// reported as one transaction. This finding can only widen a posture, so it
+	// must not block on an inference.
+	if criticals := strings.Join(findingSummaries(report, Critical), "\n"); strings.Contains(criticals, "STRADDLE") {
+		t.Fatalf("a straddle must never be CRITICAL -- co-residency is inferred, and a blocking "+
+			"finding here would tell maintainers to dual-grant on a guess:\n%s", criticals)
 	}
-	if !strings.Contains(joined, "PROVABLY share one transaction") {
-		t.Errorf("straddle finding did not distinguish a traced tx origin from the coarse fallback: %s", joined)
+	joined := strings.Join(findingSummaries(report, Advisory), "\n")
+	if !strings.Contains(joined, "POSSIBLE TRANSACTION STRADDLE") {
+		t.Fatalf("straddling transaction was not reported at all:\n%s", joined)
+	}
+	if !strings.Contains(joined, "NOT proof that these statements co-execute") {
+		t.Errorf("the traced-origin finding must state what the tracing does and does not prove: %s", joined)
 	}
 }
 

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -57,11 +57,12 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 		t.Log(line)
 	}
 
-	// The derived dual-grant set, printed so it is reviewable. This replaces the
-	// hand-maintained shared-table whitelist the role-partition manifest used to
-	// carry: a table needed by two roles is now a computed property of the
-	// evidence rather than a list someone must remember to update.
-	t.Logf("derived shared (dual-grant) pairs -- proven call sites on more than one pool, so legitimately in more than one posture (%d):", len(report.SharedPairs))
+	// The derived shared set, printed so it is reviewable. It makes the dual-grant
+	// question checkable rather than purely asserted, but it is NOT authoritative
+	// on its own and does not replace the role-partition manifest's whitelist --
+	// see RoleReport.SharedPairs for the three reasons (pair-level vs table-level,
+	// dual-constructed-type artifacts, and inherited blind spots).
+	t.Logf("derived shared pairs -- proven call sites on more than one pool (%d). Reviewable signal, not authoritative; see RoleReport.SharedPairs:", len(report.SharedPairs))
 	for _, pair := range report.SharedPairs {
 		t.Logf("    %s", pair)
 	}

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -1,7 +1,6 @@
 package domaingrants
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -10,36 +9,47 @@ import (
 	"testing"
 )
 
-// TestRoleGrantSurfacesMatchQuerySurfaces is the CI gate for the COORDINATOR
-// half of CHAOS-3033's grant derivation, and the role-attribution half for both
-// roles.
+// TestReportCoordinatorGrantSurface is a REPORT, not a gate, and the name says so
+// deliberately.
 //
-// It derives, separately per pool, which (table, privilege) pairs the code
-// reachable through that pool actually needs, and checks each against that
-// role's own declared posture -- DomainPosture() and CoordinatorPosture() in
-// internal/storage/postgres/domain_authorization.go.
+// # Why advisory
 //
-// Why a second gate rather than an extension of
-// TestDomainGrantSurfaceMatchesQuerySurface: that test's job is the DOMAIN
-// role's two-hand-maintained-lists problem (runtimeGrantStatements vs
-// DomainPosture, which agreed with each other and drifted from the code). The
-// coordinator has only one list, so its whole failure surface is different, and
-// the interesting new property -- attribution BETWEEN roles -- is not a property
-// of either role alone. Both gates run; neither replaces the other.
+// Three adversarial review rounds each found new places where THE ANALYSIS CANNOT
+// SEE SOMETHING AND THE CHECK PASSES ANYWAY: unresolved callees, unresolved
+// interface dispatch, function-valued fields with no single target, dynamic SQL,
+// unparsed statements, non-convergence, unrecognised lock forms, quoted
+// identifiers. Each was fixed where it was found and reappeared elsewhere -- one
+// defect with many addresses, discovered one review at a time.
 //
-// Read the CRITICAL/ADVISORY split in roles.go's header before acting on output.
-// The short version: a CRITICAL means real code on that pool executes something
-// the posture forbids. An ADVISORY means this tool cannot attribute the pair per
-// role, and a hand derivation from the construction site is more precise --
-// notably NOT a licence to widen a posture.
-func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
+// An advisory tool that is sometimes wrong is useful: it puts derived evidence in
+// front of a reviewer who can weigh it. A GATE that passes when the analysis is
+// blind is worse than no gate, because it LICENSES the hand-written rows it was
+// built to check -- which is how this epic produced green tickets over dormant
+// code in the first place.
+//
+// So: this test PRINTS everything and FAILS on nothing about the surface. A
+// passing run here is NOT evidence that the coordinator posture is correct.
+// TestDomainGrantSurfaceMatchesQuerySurface continues to gate the domain role as
+// it always has.
+//
+// Promoting this to a gate requires the blind-spot closure argument: a partition
+// of everything the analysis can fail to see, with each cell either failing the
+// check or documented as safe to accept PER SITE (not per file). That is tracked
+// separately as a design task.
+//
+// The only failures here are TOOL-BROKEN conditions -- the analysis could not run
+// at all. Those are not findings about the code under analysis, and reporting
+// nothing because the tool crashed would be the same silence this whole checker
+// exists to avoid.
+func TestReportCoordinatorGrantSurface(t *testing.T) {
 	root := findModuleRoot(t)
 
 	inputs := make([]RoleInput, 0, len(AllPoolRoles))
 	for _, role := range AllPoolRoles {
 		derived, err := DeriveForRole(root, role)
 		if err != nil {
-			t.Fatalf("DeriveForRole(%s): %v", role, err)
+			t.Fatalf("DeriveForRole(%s): %v -- the analysis could not run, so this report says "+
+				"nothing about the posture either way", role, err)
 		}
 		truth, err := LoadGroundTruthForRole(role)
 		if err != nil {
@@ -53,124 +63,20 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 		t.Fatalf("CompareRoles: %v", err)
 	}
 
-	for _, line := range report.Stats {
-		t.Log(line)
+	byCategory := map[AdvisoryCategory][]string{}
+	for _, line := range AdvisoryReport(report) {
+		byCategory[line.Category] = append(byCategory[line.Category], line.Text)
 	}
-
-	// Name-seed overrides: places where call-site evidence overruled a parameter's
-	// spelling. Reported because it means a naming convention LIED, and the reader
-	// should know that rather than assume the surface shrank on its own. This was
-	// collected but never printed or gated, so the "the override is reported"
-	// property did not actually exist.
-	for _, in := range inputs {
-		for _, override := range in.Derived.NameSeedOverrides {
-			t.Logf("NAME-SEED OVERRIDE (role %s): %s:%d parameter %q in %s is spelled for this role but "+
-				"its call sites pass %v -- call-site evidence wins, and the parameter name is misleading",
-				in.Role, override.File, override.Line, override.Name, override.Function, override.ObservedRoles)
+	for _, category := range AllAdvisoryCategories {
+		entries := byCategory[category]
+		t.Logf("=== %s (%d) ===", category, len(entries))
+		for _, entry := range entries {
+			t.Logf("    %s", entry)
 		}
 	}
-
-	// The derived shared set, printed so it is reviewable. It makes the dual-grant
-	// question checkable rather than purely asserted, but it is NOT authoritative
-	// on its own and does not replace the role-partition manifest's whitelist --
-	// see RoleReport.SharedPairs for the three reasons (pair-level vs table-level,
-	// dual-constructed-type artifacts, and inherited blind spots).
-	t.Logf("derived shared pairs -- proven call sites on more than one pool (%d). Reviewable signal, not authoritative; see RoleReport.SharedPairs:", len(report.SharedPairs))
-	for _, pair := range report.SharedPairs {
-		t.Logf("    %s", pair)
-	}
-
-	// Enumerated incompleteness. This block is the reason the gate can be
-	// trusted: it states what was NOT verified, so a table this tool cannot see
-	// never looks the same as a table it checked and approved.
-	for _, gap := range report.Incomplete {
-		t.Logf("INCOMPLETENESS for role %s -- the gate proves NOTHING about the following, and silence here is not confirmation:", gap.Role)
-		t.Logf("    posture (table, privilege) pairs with no derived call site (%d):", len(gap.UndeclaredByEvidence))
-		for _, pair := range gap.UndeclaredByEvidence {
-			t.Logf("        %s", pair.String())
-		}
-		t.Logf("    in-module wiring hops where taint stopped (%d, first 25 shown):", len(gap.WiringHops))
-		for _, hop := range firstNHops(gap.WiringHops, 25) {
-			callee := hop.Callee
-			if callee == "" {
-				callee = "<function value>"
-			}
-			t.Logf("        %s:%d callee=%s", hop.File, hop.Line, callee)
-		}
-		t.Logf("    non-constant SQL sites (%d):", len(gap.DynamicSQL))
-		for _, site := range gap.DynamicSQL {
-			t.Logf("        %s:%d %s", site.File, site.Line, site.Reason)
-		}
-	}
-
-	// Incompleteness must GATE, not merely print. A printout nobody is required to
-	// act on is indistinguishable from having checked.
-	//
-	// The enforcement lives in GateFailures rather than in loops here, because
-	// loops here were untestable: a unit test could prove a conflict reached
-	// IncompleteRoleSurface while deleting the loop that reported it left every
-	// test green.
-	//
-	// Deliberately NOT gated on the raw wiring-hop count: most hops are ordinary
-	// interface dispatch that reaches no SQL, so a count threshold would be noise
-	// that gets raised rather than investigated. What IS gated is the set with a
-	// real consequence -- a posture privilege nothing justifies, a tainted call
-	// through a field the resolver refused, a LOCK the parser could not read, and
-	// a non-constant SQL site nobody has traced.
-	for _, failure := range GateFailures(report) {
-		t.Error(failure)
-	}
-
-	var critical, advisory []Finding
-	for _, f := range report.Findings {
-		if f.Severity == Critical {
-			critical = append(critical, f)
-		} else {
-			advisory = append(advisory, f)
-		}
-	}
-	for _, f := range advisory {
-		t.Logf("[ADVISORY] %s", f.Summary)
-	}
-
-	blocking, accepted, stale, unticketed := PartitionKnownOpen(critical)
-	for _, f := range accepted {
-		t.Logf("[KNOWN-OPEN CRITICAL, ticketed] %s", f.Summary)
-	}
-	// A stale entry means the defect was fixed and the allowlist is now carrying
-	// a blind spot for nothing. Failing here is what stops this list from
-	// becoming permanent suppression.
-	for _, entry := range stale {
-		t.Errorf("STALE known-open entry: %s/%s %s (%s) no longer reproduces. "+
-			"The fix has landed -- DELETE this entry from knownOpenCriticals. "+
-			"Leaving it there means the gate would not fail if the defect came back",
-			entry.Role, entry.Table, entry.Privilege, entry.Ticket)
-	}
-	for _, entry := range unticketed {
-		t.Errorf("known-open entry %s/%s %s has no ticket; every accepted-open finding must name one",
-			entry.Role, entry.Table, entry.Privilege)
-	}
-	if len(blocking) == 0 {
-		return
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "\n%d CRITICAL role-grant disagreement(s) between a derived per-pool query surface and that role's declared posture:\n\n", len(blocking))
-	for i, f := range blocking {
-		fmt.Fprintf(&b, "%d) [%s] %s\n", i+1, f.Role, f.Summary)
-		for _, e := range f.Evidence {
-			fmt.Fprintf(&b, "     evidence: %s:%d  %s\n", e.File, e.Line, e.Statement)
-		}
-	}
-	fmt.Fprintf(&b, "\nFix: add the row to the OWNING role's posture in "+
-		"internal/storage/postgres/domain_authorization.go (domainPosture or coordinatorPosture). "+
-		"The coordinator's GRANT statements are projected from CoordinatorPosture() by "+
-		"cmd/dev-health-worker-migrate, so the posture is the only edit for that role; the domain role "+
-		"additionally needs the matching runtimeGrantStatements entry in internal/storage/river/migrate.go "+
-		"in the SAME commit, or CheckDomainAuthorization fails closed for every domain worker.\n\n"+
-		"Before widening anything, check whether the finding names SHARED evidence sites: those are an "+
-		"artifact of this tool's (type, field) taint granularity, not a missing grant. See roles.go's header.\n")
-	t.Fatal(b.String())
+	t.Log("ADVISORY ONLY: nothing above fails this test. A passing run is NOT evidence that the " +
+		"coordinator posture is correct -- see this test's doc comment for why, and what would be " +
+		"required to promote it to a gate.")
 }
 
 // TestPoolRoleSeedsMatchLiveWiringSites is the anti-vacuity guard for the whole

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -72,8 +72,10 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 	// never looks the same as a table it checked and approved.
 	for _, gap := range report.Incomplete {
 		t.Logf("INCOMPLETENESS for role %s -- the gate proves NOTHING about the following, and silence here is not confirmation:", gap.Role)
-		t.Logf("    posture tables with no derived call site (%d): %s",
-			len(gap.UndeclaredByEvidence), strings.Join(gap.UndeclaredByEvidence, ", "))
+		t.Logf("    posture (table, privilege) pairs with no derived call site (%d):", len(gap.UndeclaredByEvidence))
+		for _, pair := range gap.UndeclaredByEvidence {
+			t.Logf("        %s", pair.String())
+		}
 		t.Logf("    in-module wiring hops where taint stopped (%d, first 25 shown):", len(gap.WiringHops))
 		for _, hop := range firstNHops(gap.WiringHops, 25) {
 			callee := hop.Callee
@@ -85,6 +87,41 @@ func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
 		t.Logf("    non-constant SQL sites (%d):", len(gap.DynamicSQL))
 		for _, site := range gap.DynamicSQL {
 			t.Logf("        %s:%d %s", site.File, site.Line, site.Reason)
+		}
+	}
+
+	// Incompleteness must GATE, not merely print. A printout nobody is required to
+	// act on is indistinguishable from having checked.
+	//
+	// Deliberately NOT gated on the raw wiring-hop count: most hops are ordinary
+	// interface dispatch that reaches no SQL, so a count threshold would be noise
+	// that gets raised rather than investigated. What IS gated is the set with a
+	// real consequence -- a posture privilege nothing in the analysis justifies,
+	// and a tainted call through a field the resolver refused.
+	unacknowledged, staleAcks, unreasoned := PartitionBlindSpots(report.Incomplete)
+	for _, entry := range unacknowledged {
+		t.Errorf("UNACKNOWLEDGED BLIND SPOT: %s -- this role's posture authorizes a privilege that NO "+
+			"role has a derived call site for. Either it is an over-declaration (remove the row) or it "+
+			"sits inside a blind spot (add it to acknowledgedBlindSpots with the reason and where the "+
+			"justification lives). Leaving it unlisted is how a wrong posture row survives review", entry)
+	}
+	for _, entry := range staleAcks {
+		t.Errorf("STALE acknowledged blind spot: %s/%s %s no longer appears as an evidence-free posture "+
+			"row -- the evidence arrived or the row was removed, so this entry now suppresses nothing. "+
+			"DELETE it, or the gate stops failing if the blind spot returns",
+			entry.Role, entry.Table, entry.Privilege)
+	}
+	for _, entry := range unreasoned {
+		t.Errorf("acknowledged blind spot %s/%s %s has no reason recorded; every entry must say where the "+
+			"justification lives", entry.Role, entry.Table, entry.Privilege)
+	}
+	for _, surface := range report.Incomplete {
+		for _, conflict := range surface.FuncValueConflicts {
+			t.Errorf("UNRESOLVED FUNCTION-VALUE CALL (role %s): %s:%d %s -- %s. Pool-tainted arguments "+
+				"cross this call and NOTHING beyond it was analyzed. Fail-closed resolution is correct, "+
+				"but it must not be silent: give the field a single implementation, or narrow the type so "+
+				"the resolver can see it",
+				surface.Role, conflict.File, conflict.Line, conflict.Field, conflict.Reason)
 		}
 	}
 
@@ -289,6 +326,86 @@ func TestBarrierStopsTaintFromTheOtherRolesPool(t *testing.T) {
 	}
 }
 
+// TestCallSiteEvidenceOutranksParameterSpelling pins the fix for the attribution
+// INVERSION: a parameter spelled like one role's pool but only ever passed
+// another role's pool must NOT be seeded by its name.
+//
+// Why this is the worst failure mode in the package: it does not merely lose
+// surface, it MISDIRECTS it. `build(domainPool *pgxpool.Pool)` called only with
+// the coordinator pool would be seeded by the domain run from its spelling while
+// the coordinator run's barrier discards it, so downstream SQL looks
+// domain-EXCLUSIVE -- and role-exclusive evidence is exactly what this gate
+// escalates to CRITICAL. It would confidently tell a maintainer to grant the
+// privilege to the wrong role, and every "is it granted somewhere" check would
+// still pass.
+func TestCallSiteEvidenceOutranksParameterSpelling(t *testing.T) {
+	poolType := fakePoolType()
+
+	// `func build(domainPool *pgxpool.Pool)` -- one pool-typed parameter, spelled
+	// for the DOMAIN role.
+	param := ast.NewIdent("domainPool")
+	funcType := &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{{
+		Names: []*ast.Ident{param},
+		Type:  ast.NewIdent("ignored"),
+	}}}}
+	decl := &ast.FuncDecl{Name: ast.NewIdent("build"), Type: funcType, Body: &ast.BlockStmt{}}
+	use := ast.NewIdent("domainPool")
+	info := &types.Info{Types: map[ast.Expr]types.TypeAndValue{use: {Type: poolType}}}
+	ctx := funcCtx{decl: decl, info: info}
+	fn := types.NewFunc(token.NoPos, nil, "build", nil)
+
+	domainSeeds, domainBarrier := seedsFor(RoleDomain)
+
+	// Case 1: call sites pass ONLY the coordinator pool. The domain run must
+	// refuse the name-based seed.
+	contradicted := &analyzer{
+		seeds: domainSeeds, barrier: domainBarrier,
+		poolParamRoles: map[*types.Func]map[int]map[PoolRole]bool{
+			fn: {0: {RoleCoordinator: true}},
+		},
+	}
+	if !contradicted.nameSeedContradicted(use, ctx, fn) {
+		t.Error("a parameter named domainPool that is only ever passed the coordinator pool was still " +
+			"treated as a domain seed -- this is the attribution inversion, and it directs the grant " +
+			"to the wrong role")
+	}
+
+	// Case 2: call sites pass the domain pool too. The name agrees with the
+	// evidence, so it must still seed -- otherwise the fix would delete real
+	// surface rather than correcting a lie.
+	agreeing := &analyzer{
+		seeds: domainSeeds, barrier: domainBarrier,
+		poolParamRoles: map[*types.Func]map[int]map[PoolRole]bool{
+			fn: {0: {RoleDomain: true, RoleCoordinator: true}},
+		},
+	}
+	if agreeing.nameSeedContradicted(use, ctx, fn) {
+		t.Error("call sites DO pass the domain pool, so the domain seed must stand")
+	}
+
+	// Case 3: no resolvable call site. The convention is the only signal left and
+	// dropping it would lose real surface, so the name still applies.
+	noEvidence := &analyzer{
+		seeds: domainSeeds, barrier: domainBarrier,
+		poolParamRoles: map[*types.Func]map[int]map[PoolRole]bool{},
+	}
+	if noEvidence.nameSeedContradicted(use, ctx, fn) {
+		t.Error("with no call-site evidence the name must still seed; suppressing it would trade a " +
+			"false attribution for a false absence")
+	}
+
+	// Case 4: a LOCAL of the same name has no call sites to consult, so the
+	// override must not fire on it (paramIndex < 0).
+	localCtx := funcCtx{
+		decl: &ast.FuncDecl{Name: ast.NewIdent("other"),
+			Type: &ast.FuncType{Params: &ast.FieldList{}}, Body: &ast.BlockStmt{}},
+		info: info,
+	}
+	if contradicted.nameSeedContradicted(use, localCtx, fn) {
+		t.Error("a local variable is not a parameter and has no call sites; the override must not fire")
+	}
+}
+
 // TestFuncValueTargetsResolveTheKnownWiringHops pins the function-value
 // resolution to the specific hops it was built for. Without it the entire
 // scheduler and fixed-engine surface is invisible to the coordinator
@@ -361,75 +478,164 @@ func TestFuncValueTargetsResolveTheKnownWiringHops(t *testing.T) {
 	}
 }
 
-// TestLockTableRequiresAnyWritePrivilege pins the LOCK TABLE rule per role.
+// TestLockTableRequirementIsModeAware pins the LOCK TABLE rule per role, per
+// MODE, against the mapping measured on PostgreSQL 18.4 (see LockRequirement in
+// sql.go for the full table and the probe it came from).
 //
-// This test exists because mutation testing found the rule was NOT covered:
-// deleting the whole check left the repo-wide gate green, since every table this
-// repo LOCKs already holds a write privilege for some other reason. A rule that
-// cannot fail is not a rule, and this one has already shipped a production 42501
-// (CHAOS-3113: workerctl's route rollback runs LOCK worker_job_outbox IN SHARE
-// ROW EXCLUSIVE MODE while the domain role holds only SELECT+INSERT).
+// History worth keeping, because it is two different mistakes:
 //
-// Postgres wants at least ONE of INSERT/UPDATE/DELETE for a LOCK mode stricter
-// than ROW EXCLUSIVE -- any one, not a specific one. That is a DIFFERENT shape
-// from `SELECT ... FOR UPDATE`, which requires UPDATE specifically and is
-// modelled as an ordinary UPDATE requirement. Both halves are asserted so the
-// asymmetry cannot be "simplified" into a single rule later.
-func TestLockTableRequiresAnyWritePrivilege(t *testing.T) {
+//   - Mutation testing found the rule was UNCOVERED: deleting the whole check
+//     left the repo-wide gate green, since every table this repo LOCKs already
+//     holds a satisfying privilege for some other reason.
+//   - The first version of this test then pinned the rule as "any one of
+//     INSERT/UPDATE/DELETE, for every mode", asserting that INSERT alone
+//     SATISFIES a SHARE ROW EXCLUSIVE lock. Measurement says it does not. That
+//     assertion made a wrong rule authoritative, which is worse than the
+//     uncovered rule was -- and it is the CHAOS-3113 defect family exactly
+//     (workerctl's route rollback LOCKs worker_job_outbox IN SHARE ROW EXCLUSIVE
+//     MODE while the domain role holds only SELECT+INSERT).
+//
+// Three distinct rules live in this area and none may be collapsed into another:
+// ACCESS SHARE (SELECT suffices), ROW SHARE / ROW EXCLUSIVE (any of I/U/D), and
+// everything stricter (U/D only). `SELECT ... FOR UPDATE` is a fourth shape,
+// requiring UPDATE specifically, handled as an ordinary privilege elsewhere.
+func TestLockTableRequirementIsModeAware(t *testing.T) {
 	var selectOnly PrivilegeSet
 	selectOnly.add(PrivSelect)
 	var selectInsert PrivilegeSet
 	selectInsert.add(PrivSelect)
 	selectInsert.add(PrivInsert)
+	var selectUpdate PrivilegeSet
+	selectUpdate.add(PrivSelect)
+	selectUpdate.add(PrivUpdate)
+	var selectDelete PrivilegeSet
+	selectDelete.add(PrivSelect)
+	selectDelete.add(PrivDelete)
 
-	lockSurface := func(role PoolRole) *DerivedSurface {
+	lockSurface := func(role PoolRole, mode string) *DerivedSurface {
+		requirement, needsMore := lockRequirementForMode(mode)
 		s := &TableSurface{Table: "outbox"}
 		s.Privileges.add(PrivSelect)
 		s.Evidence = append(s.Evidence, Evidence{
 			File: "internal/jobroute/control.go", Line: 197, Privilege: PrivSelect,
-			Statement: "LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE", TxGroup: "tx",
+			Statement: "LOCK TABLE public.outbox IN " + mode + " MODE", TxGroup: "tx",
 		})
-		s.RequiresAnyWriteLock = true
+		if needsMore {
+			held := requirement
+			s.LockRequirement = &held
+			s.WriteLockEvidence = append(s.WriteLockEvidence, Evidence{
+				File: "internal/jobroute/control.go", Line: 197,
+				Statement: "LOCK TABLE public.outbox IN " + mode + " MODE",
+			})
+		}
+		return &DerivedSurface{Role: role, Tables: map[string]*TableSurface{"outbox": s}}
+	}
+
+	// One row per (mode, posture) cell of the measured table.
+	cases := []struct {
+		mode        string
+		posture     PrivilegeSet
+		postureName string
+		wantFinding bool
+	}{
+		// ACCESS SHARE: SELECT is enough.
+		{"ACCESS SHARE", selectOnly, "SELECT", false},
+
+		// ROW SHARE and ROW EXCLUSIVE: SELECT alone is NOT enough (the docs say
+		// ROW SHARE needs only SELECT; measurement says otherwise), and INSERT IS.
+		{"ROW SHARE", selectOnly, "SELECT", true},
+		{"ROW SHARE", selectInsert, "SELECT+INSERT", false},
+		{"ROW EXCLUSIVE", selectOnly, "SELECT", true},
+		{"ROW EXCLUSIVE", selectInsert, "SELECT+INSERT", false},
+
+		// Stricter modes: INSERT does NOT satisfy them. This is the row the
+		// previous version of this test got backwards.
+		{"SHARE UPDATE EXCLUSIVE", selectInsert, "SELECT+INSERT", true},
+		{"SHARE", selectInsert, "SELECT+INSERT", true},
+		{"SHARE ROW EXCLUSIVE", selectInsert, "SELECT+INSERT", true},
+		{"EXCLUSIVE", selectInsert, "SELECT+INSERT", true},
+		{"ACCESS EXCLUSIVE", selectInsert, "SELECT+INSERT", true},
+
+		// UPDATE or DELETE satisfies the strictest mode.
+		{"SHARE ROW EXCLUSIVE", selectUpdate, "SELECT+UPDATE", false},
+		{"SHARE ROW EXCLUSIVE", selectDelete, "SELECT+DELETE", false},
+		{"ACCESS EXCLUSIVE", selectUpdate, "SELECT+UPDATE", false},
+
+		// An unrecognized mode must fail CLOSED, not open.
+		{"SOME FUTURE", selectInsert, "SELECT+INSERT", true},
+	}
+
+	for _, tc := range cases {
+		// Only the coordinator locks, so its LOCK evidence is role-exclusive and
+		// the shared-evidence downgrade does not apply.
+		report, err := CompareRoles([]RoleInput{
+			{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+				Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
+			{Role: RoleCoordinator, Derived: lockSurface(RoleCoordinator, tc.mode),
+				Truth: truthWith(map[string]PrivilegeSet{"outbox": tc.posture})},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, f := range report.Findings {
+			if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
+				found = true
+			}
+		}
+		if found != tc.wantFinding {
+			verb := "did not report"
+			if found {
+				verb = "reported"
+			}
+			t.Errorf("LOCK IN %s MODE with posture %s: %s a CRITICAL, want wantFinding=%v. "+
+				"The measured PostgreSQL 18.4 mapping is in LockRequirement's doc comment; if this "+
+				"disagrees, re-run the probe rather than adjusting the expectation",
+				tc.mode, tc.postureName, verb, tc.wantFinding)
+		}
+	}
+}
+
+// TestLockTableSharedEvidenceIsDowngraded is the H3 half for the lock path: the
+// shared-evidence downgrade must apply here too. A repository type constructed
+// from both pools has its locking method attributed to both, so a blocking
+// "grant the coordinator too" would be the same over-widening the per-privilege
+// path already refuses.
+func TestLockTableSharedEvidenceIsDowngraded(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// The SAME file:line locks the table for BOTH roles.
+	shared := func(role PoolRole) *DerivedSurface {
+		requirement, _ := lockRequirementForMode("SHARE ROW EXCLUSIVE")
+		held := requirement
+		s := &TableSurface{Table: "outbox", LockRequirement: &held}
+		s.Privileges.add(PrivSelect)
 		s.WriteLockEvidence = append(s.WriteLockEvidence, Evidence{
-			File: "internal/jobroute/control.go", Line: 197,
+			File: "internal/shared/repo.go", Line: 42,
 			Statement: "LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE",
 		})
 		return &DerivedSurface{Role: role, Tables: map[string]*TableSurface{"outbox": s}}
 	}
 
-	// SELECT-only posture: the LOCK is denied at runtime. Must be CRITICAL.
 	report, err := CompareRoles([]RoleInput{
-		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
-			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
-		{Role: RoleCoordinator, Derived: lockSurface(RoleCoordinator),
+		{Role: RoleDomain, Derived: shared(RoleDomain),
 			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	joined := strings.Join(findingSummaries(report, Critical), "\n")
-	if !strings.Contains(joined, "LOCK TABLE") {
-		t.Fatalf("a LOCK TABLE against a SELECT-only posture was not reported CRITICAL -- that is the "+
-			"CHAOS-3113 defect shape exactly, and it must fail closed:\n%s", joined)
-	}
-
-	// SELECT+INSERT posture: any ONE write privilege satisfies Postgres, so there
-	// must be no finding. This half is what stops the rule degenerating into
-	// "report every table that is ever LOCKed".
-	report, err = CompareRoles([]RoleInput{
-		{Role: RoleDomain, Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
-			Truth: truthWith(map[string]PrivilegeSet{"unrelated": selectOnly})},
-		{Role: RoleCoordinator, Derived: lockSurface(RoleCoordinator),
-			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectInsert})},
+		{Role: RoleCoordinator, Derived: shared(RoleCoordinator),
+			Truth: truthWith(map[string]PrivilegeSet{"outbox": selectOnly})},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, f := range report.Findings {
 		if f.Severity == Critical && strings.Contains(f.Summary, "LOCK TABLE") {
-			t.Errorf("INSERT alone should satisfy the LOCK requirement (Postgres accepts any one of "+
-				"INSERT/UPDATE/DELETE), but it was still reported: %s", f.Summary)
+			t.Errorf("a LOCK whose every site is shared between roles was reported CRITICAL, which "+
+				"tells maintainers to widen both postures on evidence that cannot attribute either: %s", f.Summary)
 		}
+	}
+	joined := strings.Join(findingSummaries(report, Advisory), "\n")
+	if !strings.Contains(joined, "SHARED with another role") {
+		t.Errorf("expected the lock path to emit the shared-evidence ADVISORY, got:\n%s", joined)
 	}
 }
 
@@ -646,9 +852,13 @@ func TestIncompletenessNamesUndeclaredPostureTables(t *testing.T) {
 			Role: RoleCoordinator,
 			Derived: &DerivedSurface{Role: RoleCoordinator, Tables: map[string]*TableSurface{},
 				Unresolved: []UnresolvedCallSite{
-					// KEPT: an unnamed function value -- the shape that hid the
-					// whole scheduler surface before funcvalue.go.
-					{File: "cmd/x/dependencies.go", Line: 42, Callee: "", Reason: "function-typed field"},
+					// KEPT: a call through a function-typed field. The callee is the
+					// BARE FIELD NAME, which is what handleCall actually records for
+					// this shape (calleeDisplay = fn.Sel.Name) -- an earlier version
+					// of this test used Callee:"" instead, a state selector calls
+					// never produce, so it exercised a path the analyzer cannot
+					// reach and let the real one regress.
+					{File: "cmd/x/dependencies.go", Line: 42, Callee: "newRepository", Reason: "function-typed field"},
 					// KEPT: in-module interface dispatch with no unique implementer.
 					{File: "internal/x/y.go", Line: 7,
 						Callee: "(github.com/full-chaos/dev-health-ops/internal/x.Thing).Do",
@@ -663,7 +873,7 @@ func TestIncompletenessNamesUndeclaredPostureTables(t *testing.T) {
 					{File: "../../pkg/mod/pgx/conn.go", Line: 1, Callee: "", Reason: "third party"},
 					// DROPPED: duplicate of the first site; the fixed point can
 					// reach one site by several paths.
-					{File: "cmd/x/dependencies.go", Line: 42, Callee: "", Reason: "function-typed field"},
+					{File: "cmd/x/dependencies.go", Line: 42, Callee: "newRepository", Reason: "function-typed field"},
 				}},
 			Truth: truthWith(map[string]PrivilegeSet{"never_seen": selectOnly}),
 		},
@@ -680,18 +890,32 @@ func TestIncompletenessNamesUndeclaredPostureTables(t *testing.T) {
 	if coordinator == nil {
 		t.Fatal("no incompleteness record for the coordinator role")
 	}
-	if len(coordinator.UndeclaredByEvidence) != 1 || coordinator.UndeclaredByEvidence[0] != "never_seen" {
-		t.Errorf("posture table with no derived evidence not enumerated: %v", coordinator.UndeclaredByEvidence)
+	// Pair-granular, and the "nobody has evidence" case must be marked as such --
+	// that is the variant which used to vanish from every output.
+	if len(coordinator.UndeclaredByEvidence) != 1 {
+		t.Fatalf("posture pair with no derived evidence not enumerated: %v", coordinator.UndeclaredByEvidence)
+	}
+	gap := coordinator.UndeclaredByEvidence[0]
+	if gap.Table != "never_seen" || gap.Privilege != PrivSelect {
+		t.Errorf("gap = %+v, want never_seen SELECT", gap)
+	}
+	if len(gap.OtherRolesWithEvidence) != 0 {
+		t.Errorf("no role has evidence for never_seen, so OtherRolesWithEvidence must be empty: %+v", gap)
+	}
+	if !strings.Contains(gap.String(), "NO role has evidence") {
+		t.Errorf("the louder case must say so in its rendering: %q", gap.String())
 	}
 	// Exactly the two signal-bearing hops, deduplicated, with both third-party
 	// kinds filtered out.
 	if len(coordinator.WiringHops) != 2 {
-		t.Fatalf("expected 2 signal hops (unnamed function value + in-module interface dispatch), "+
+		t.Fatalf("expected 2 signal hops (function-typed field call + in-module interface dispatch), "+
 			"with third-party sinks, out-of-module files and the duplicate site filtered: %v",
 			coordinator.WiringHops)
 	}
-	if coordinator.WiringHops[0].File != "cmd/x/dependencies.go" || coordinator.WiringHops[0].Callee != "" {
-		t.Errorf("first hop should be the unnamed function value: %+v", coordinator.WiringHops[0])
+	if coordinator.WiringHops[0].File != "cmd/x/dependencies.go" ||
+		coordinator.WiringHops[0].Callee != "newRepository" {
+		t.Errorf("first hop should be the function-typed field call, kept because a BARE callee name "+
+			"cannot be a third-party method: %+v", coordinator.WiringHops[0])
 	}
 	if !strings.Contains(coordinator.WiringHops[1].Callee, "internal/x.Thing") {
 		t.Errorf("second hop should be the in-module interface dispatch: %+v", coordinator.WiringHops[1])

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -63,6 +63,14 @@ func TestReportCoordinatorGrantSurface(t *testing.T) {
 		t.Fatalf("CompareRoles: %v", err)
 	}
 
+	// The disclaimer goes FIRST as well as last. With -v this output can run to
+	// hundreds of lines, and a note only at the bottom is a note most readers never
+	// reach -- while `go test` without -v prints nothing but "ok", which is the
+	// single most misreadable outcome this check can produce.
+	t.Log("### ADVISORY REPORT -- THIS TEST GATES NOTHING. Everything below is reported, not " +
+		"asserted. A passing run is NOT evidence that CoordinatorPosture() is correct. See this " +
+		"test's doc comment, and CHAOS-3164 for what promoting it to a gate requires. ###")
+
 	byCategory := map[AdvisoryCategory][]string{}
 	for _, line := range AdvisoryReport(report) {
 		byCategory[line.Category] = append(byCategory[line.Category], line.Text)

--- a/internal/domaingrants/role_surface_test.go
+++ b/internal/domaingrants/role_surface_test.go
@@ -1,0 +1,665 @@
+package domaingrants
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestRoleGrantSurfacesMatchQuerySurfaces is the CI gate for the COORDINATOR
+// half of CHAOS-3033's grant derivation, and the role-attribution half for both
+// roles.
+//
+// It derives, separately per pool, which (table, privilege) pairs the code
+// reachable through that pool actually needs, and checks each against that
+// role's own declared posture -- DomainPosture() and CoordinatorPosture() in
+// internal/storage/postgres/domain_authorization.go.
+//
+// Why a second gate rather than an extension of
+// TestDomainGrantSurfaceMatchesQuerySurface: that test's job is the DOMAIN
+// role's two-hand-maintained-lists problem (runtimeGrantStatements vs
+// DomainPosture, which agreed with each other and drifted from the code). The
+// coordinator has only one list, so its whole failure surface is different, and
+// the interesting new property -- attribution BETWEEN roles -- is not a property
+// of either role alone. Both gates run; neither replaces the other.
+//
+// Read the CRITICAL/ADVISORY split in roles.go's header before acting on output.
+// The short version: a CRITICAL means real code on that pool executes something
+// the posture forbids. An ADVISORY means this tool cannot attribute the pair per
+// role, and a hand derivation from the construction site is more precise --
+// notably NOT a licence to widen a posture.
+func TestRoleGrantSurfacesMatchQuerySurfaces(t *testing.T) {
+	root := findModuleRoot(t)
+
+	inputs := make([]RoleInput, 0, len(AllPoolRoles))
+	for _, role := range AllPoolRoles {
+		derived, err := DeriveForRole(root, role)
+		if err != nil {
+			t.Fatalf("DeriveForRole(%s): %v", role, err)
+		}
+		truth, err := LoadGroundTruthForRole(role)
+		if err != nil {
+			t.Fatalf("LoadGroundTruthForRole(%s): %v", role, err)
+		}
+		inputs = append(inputs, RoleInput{Role: role, Derived: derived, Truth: truth})
+	}
+
+	report, err := CompareRoles(inputs)
+	if err != nil {
+		t.Fatalf("CompareRoles: %v", err)
+	}
+
+	for _, line := range report.Stats {
+		t.Log(line)
+	}
+
+	// The derived dual-grant set, printed so it is reviewable. This replaces the
+	// hand-maintained shared-table whitelist the role-partition manifest used to
+	// carry: a table needed by two roles is now a computed property of the
+	// evidence rather than a list someone must remember to update.
+	t.Logf("derived shared (dual-grant) pairs -- proven call sites on more than one pool, so legitimately in more than one posture (%d):", len(report.SharedPairs))
+	for _, pair := range report.SharedPairs {
+		t.Logf("    %s", pair)
+	}
+
+	// Enumerated incompleteness. This block is the reason the gate can be
+	// trusted: it states what was NOT verified, so a table this tool cannot see
+	// never looks the same as a table it checked and approved.
+	for _, gap := range report.Incomplete {
+		t.Logf("INCOMPLETENESS for role %s -- the gate proves NOTHING about the following, and silence here is not confirmation:", gap.Role)
+		t.Logf("    posture tables with no derived call site (%d): %s",
+			len(gap.UndeclaredByEvidence), strings.Join(gap.UndeclaredByEvidence, ", "))
+		t.Logf("    in-module wiring hops where taint stopped (%d, first 25 shown):", len(gap.WiringHops))
+		for _, hop := range firstNHops(gap.WiringHops, 25) {
+			callee := hop.Callee
+			if callee == "" {
+				callee = "<function value>"
+			}
+			t.Logf("        %s:%d callee=%s", hop.File, hop.Line, callee)
+		}
+		t.Logf("    non-constant SQL sites (%d):", len(gap.DynamicSQL))
+		for _, site := range gap.DynamicSQL {
+			t.Logf("        %s:%d %s", site.File, site.Line, site.Reason)
+		}
+	}
+
+	var critical, advisory []Finding
+	for _, f := range report.Findings {
+		if f.Severity == Critical {
+			critical = append(critical, f)
+		} else {
+			advisory = append(advisory, f)
+		}
+	}
+	for _, f := range advisory {
+		t.Logf("[ADVISORY] %s", f.Summary)
+	}
+
+	blocking, accepted, stale, unticketed := PartitionKnownOpen(critical)
+	for _, f := range accepted {
+		t.Logf("[KNOWN-OPEN CRITICAL, ticketed] %s", f.Summary)
+	}
+	// A stale entry means the defect was fixed and the allowlist is now carrying
+	// a blind spot for nothing. Failing here is what stops this list from
+	// becoming permanent suppression.
+	for _, entry := range stale {
+		t.Errorf("STALE known-open entry: %s/%s %s (%s) no longer reproduces. "+
+			"The fix has landed -- DELETE this entry from knownOpenCriticals. "+
+			"Leaving it there means the gate would not fail if the defect came back",
+			entry.Role, entry.Table, entry.Privilege, entry.Ticket)
+	}
+	for _, entry := range unticketed {
+		t.Errorf("known-open entry %s/%s %s has no ticket; every accepted-open finding must name one",
+			entry.Role, entry.Table, entry.Privilege)
+	}
+	if len(blocking) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n%d CRITICAL role-grant disagreement(s) between a derived per-pool query surface and that role's declared posture:\n\n", len(blocking))
+	for i, f := range blocking {
+		fmt.Fprintf(&b, "%d) [%s] %s\n", i+1, f.Role, f.Summary)
+		for _, e := range f.Evidence {
+			fmt.Fprintf(&b, "     evidence: %s:%d  %s\n", e.File, e.Line, e.Statement)
+		}
+	}
+	fmt.Fprintf(&b, "\nFix: add the row to the OWNING role's posture in "+
+		"internal/storage/postgres/domain_authorization.go (domainPosture or coordinatorPosture). "+
+		"The coordinator's GRANT statements are projected from CoordinatorPosture() by "+
+		"cmd/dev-health-worker-migrate, so the posture is the only edit for that role; the domain role "+
+		"additionally needs the matching runtimeGrantStatements entry in internal/storage/river/migrate.go "+
+		"in the SAME commit, or CheckDomainAuthorization fails closed for every domain worker.\n\n"+
+		"Before widening anything, check whether the finding names SHARED evidence sites: those are an "+
+		"artifact of this tool's (type, field) taint granularity, not a missing grant. See roles.go's header.\n")
+	t.Fatal(b.String())
+}
+
+// TestPoolRoleSeedsMatchLiveWiringSites is the anti-vacuity guard for the whole
+// per-role derivation. Every seed name is a bet that the wiring code still spells
+// the pool that way. If a rename made a role's seed set match nothing, that
+// role's surface would derive as EMPTY and every check against it would pass
+// vacuously -- the gate would go green precisely because it had stopped looking.
+//
+// So: assert each role derives a non-trivial surface AND that its seed sites
+// land in the binaries that are supposed to own that pool.
+func TestPoolRoleSeedsMatchLiveWiringSites(t *testing.T) {
+	root := findModuleRoot(t)
+
+	// Binaries each role's pool must be wired in. The coordinator set is the
+	// CHAOS-3114 partition: reconciler, scheduler, workerctl and nothing else.
+	expectedSeedOwners := map[PoolRole][]string{
+		RoleDomain: {
+			"cmd/dev-health-worker/",
+			"cmd/dev-health-stream-runner/",
+			"cmd/dev-health-workerctl/",
+			"cmd/dev-health-reconciler/",
+		},
+		RoleCoordinator: {
+			"cmd/dev-health-reconciler/",
+			"cmd/dev-health-scheduler/",
+			"cmd/dev-health-workerctl/",
+		},
+	}
+
+	for _, role := range AllPoolRoles {
+		derived, err := DeriveForRole(root, role)
+		if err != nil {
+			t.Fatalf("DeriveForRole(%s): %v", role, err)
+		}
+		if len(derived.SeedSites) == 0 {
+			t.Fatalf("role %s derived ZERO seed sites: its seed names in poolRoleSeeds no longer match any "+
+				"wiring site, so its surface is empty and every check against it passes vacuously", role)
+		}
+		if len(derived.Tables) == 0 {
+			t.Fatalf("role %s derived ZERO tables from %d seed sites", role, len(derived.SeedSites))
+		}
+		for _, prefix := range expectedSeedOwners[role] {
+			found := false
+			for _, site := range derived.SeedSites {
+				if strings.HasPrefix(site.File, prefix) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("role %s has no seed site under %s, but that binary is supposed to wire this pool -- "+
+					"either the wiring was removed or it was renamed out of poolRoleSeeds' reach", role, prefix)
+			}
+		}
+	}
+}
+
+// TestSeedsForBuildsTheOtherRolesAsBarrier pins the barrier's composition: it
+// must be exactly the union of every OTHER role's seed names, and it must not be
+// empty. An empty barrier silently turns a per-role derivation back into a
+// union-of-all-pools derivation wearing one role's name.
+func TestSeedsForBuildsTheOtherRolesAsBarrier(t *testing.T) {
+	for _, role := range AllPoolRoles {
+		seeds, barrier := seedsFor(role)
+		if len(barrier.fields) == 0 && len(barrier.getters) == 0 && len(barrier.idents) == 0 {
+			t.Fatalf("role %s got an EMPTY barrier: the other role's pool roots would fall through "+
+				"exprTainted's permissive rules into this role's surface", role)
+		}
+		for name := range seeds.fields {
+			if barrier.fields[name] {
+				t.Errorf("role %s: %q is both a seed and a barrier field", role, name)
+			}
+		}
+		for other, otherSeeds := range poolRoleSeeds {
+			if other == role {
+				continue
+			}
+			for name := range otherSeeds.fields {
+				if !barrier.fields[name] {
+					t.Errorf("role %s barrier is missing role %s's field seed %q", role, other, name)
+				}
+			}
+			for name := range otherSeeds.getters {
+				if !barrier.getters[name] {
+					t.Errorf("role %s barrier is missing role %s's getter seed %q", role, other, name)
+				}
+			}
+			for name := range otherSeeds.idents {
+				if !barrier.idents[name] {
+					t.Errorf("role %s barrier is missing role %s's ident seed %q", role, other, name)
+				}
+			}
+		}
+	}
+}
+
+// fakePoolType builds a *types.Type that isPgxPoolPtr accepts, so the barrier
+// can be exercised without loading the real driver.
+func fakePoolType() types.Type {
+	pkg := types.NewPackage("github.com/jackc/pgx/v5/pgxpool", "pgxpool")
+	named := types.NewNamed(
+		types.NewTypeName(token.NoPos, pkg, "Pool", nil),
+		types.NewStruct(nil, nil),
+		nil,
+	)
+	return types.NewPointer(named)
+}
+
+// TestBarrierStopsTaintFromTheOtherRolesPool is the behavioural test for the
+// barrier, and it is deliberately independent of whether the barrier currently
+// changes this repo's derived surface (measured: it does not, because no
+// multi-pool struct today reaches a SQL sink through the wrong field). It fails
+// if the barrier is removed or moved AFTER exprTainted's permissive
+// fall-throughs.
+//
+// The shape it models is the real hazard: `pools.Domain` selected off a receiver
+// that is already tainted because a SIBLING field holds the coordinator pool.
+// exprTainted's "anything selected off a tainted base is tainted" rule would
+// return true for it, and the barrier is the only thing that says otherwise.
+func TestBarrierStopsTaintFromTheOtherRolesPool(t *testing.T) {
+	poolType := fakePoolType()
+
+	// `pools.Domain`, where `pools` is a local the caller has already tainted.
+	base := ast.NewIdent("pools")
+	selector := &ast.SelectorExpr{X: base, Sel: ast.NewIdent("Domain")}
+	info := &types.Info{Types: map[ast.Expr]types.TypeAndValue{
+		selector: {Type: poolType},
+		base:     {Type: types.Typ[types.Int]}, // irrelevant, must merely exist
+	}}
+	locals := map[string]bool{"pools": true}
+
+	seeds, barrier := seedsFor(RoleCoordinator)
+	coordinator := &analyzer{seeds: seeds, barrier: barrier}
+	if coordinator.exprTainted(selector, info, locals) {
+		t.Error("coordinator run treated `pools.Domain` as coordinator-tainted: the barrier is not " +
+			"stopping the other role's pool root, so this role's surface silently includes the other's")
+	}
+	if !coordinator.isBarrierExpr(selector, info) {
+		t.Error("isBarrierExpr did not recognize `pools.Domain` as the domain role's root")
+	}
+
+	// Control: the SAME expression must still be tainted in a DOMAIN run, so the
+	// test proves the barrier is role-directed rather than just always false.
+	domainSeeds, domainBarrier := seedsFor(RoleDomain)
+	domain := &analyzer{seeds: domainSeeds, barrier: domainBarrier}
+	if !domain.exprTainted(selector, info, locals) {
+		t.Error("domain run did NOT treat `pools.Domain` as tainted -- the seed lookup itself is broken, " +
+			"which would empty the domain surface")
+	}
+}
+
+// TestFuncValueTargetsResolveTheKnownWiringHops pins the function-value
+// resolution to the specific hops it was built for. Without it the entire
+// scheduler and fixed-engine surface is invisible to the coordinator
+// derivation -- 8 of CoordinatorPosture()'s tables -- and the gate would pass
+// while checking nothing about them.
+//
+// Pinning the CALL SITES rather than a count is deliberate: a count keeps
+// passing when one hop stops resolving and an unrelated one starts.
+func TestFuncValueTargetsResolveTheKnownWiringHops(t *testing.T) {
+	root := findModuleRoot(t)
+	derived, err := DeriveForRole(root, RoleCoordinator)
+	if err != nil {
+		t.Fatalf("DeriveForRole(coordinator): %v", err)
+	}
+
+	wantFields := []string{
+		"schedulerRuntimeSources.newRepository",
+		"schedulerRuntimeSources.newOccurrences",
+		"schedulerRuntimeSources.newFixedLoop",
+		"reconcilerDependencySources.buildRelay",
+		"reconcilerDependencySources.buildSyncMutation",
+	}
+	got := map[string]string{}
+	for _, resolved := range derived.FuncValueResolved {
+		got[resolved.Field] = resolved.Target
+	}
+	for _, field := range wantFields {
+		target, ok := got[field]
+		if !ok {
+			t.Errorf("function-typed field %s no longer resolves to a single implementation; "+
+				"taint stops there and everything it builds becomes invisible to this role's surface", field)
+			continue
+		}
+		t.Logf("%s -> %s", field, target)
+	}
+
+	// And the surface those hops unlock must actually be present. These are the
+	// tables that were missing before the hop was closed.
+	for _, table := range []string{
+		"scheduled_jobs",
+		"scheduled_sync_occurrences",
+		"fixed_schedule_occurrences",
+		"sync_configurations",
+	} {
+		if surface := derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
+			t.Errorf("coordinator surface lost %q: the scheduler wiring hop that reaches it "+
+				"is no longer resolved", table)
+		}
+	}
+}
+
+// TestCompareRolesRefusesASingleRole pins the refusal rather than the happy
+// path: a one-role run cannot check attribution at all, and returning a clean
+// report for it would be the exact "green gate that checked nothing" failure this
+// package exists to prevent.
+func TestCompareRolesRefusesASingleRole(t *testing.T) {
+	truth := &GroundTruth{
+		RequiredTablePrivileges: map[string]PrivilegeSet{"t": {}},
+		ColumnScopedTables:      map[string]bool{},
+	}
+	_, err := CompareRoles([]RoleInput{{
+		Role:    RoleDomain,
+		Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+		Truth:   truth,
+	}})
+	if err == nil {
+		t.Fatal("CompareRoles accepted a single role: attribution is unverifiable with one role, " +
+			"and a nil error here reads as 'attribution checked and clean'")
+	}
+}
+
+// --- Synthetic-surface unit tests for the comparison logic itself. ---
+//
+// These build DerivedSurface/GroundTruth values by hand so each rule can be
+// killed independently. The whole-repo gate above cannot do that: it passes
+// today, so it cannot demonstrate that any individual rule still bites.
+
+func surfaceWith(role PoolRole, table string, p Privilege, file string, line int, txGroup string) *DerivedSurface {
+	s := &TableSurface{Table: table}
+	s.Privileges.add(p)
+	s.Evidence = append(s.Evidence, Evidence{File: file, Line: line, Privilege: p, TxGroup: txGroup, Statement: "SELECT 1"})
+	return &DerivedSurface{Role: role, Tables: map[string]*TableSurface{table: s}}
+}
+
+func truthWith(tables map[string]PrivilegeSet) *GroundTruth {
+	return &GroundTruth{RequiredTablePrivileges: tables, ColumnScopedTables: map[string]bool{}}
+}
+
+func findingSummaries(report *RoleReport, severity Severity) []string {
+	var out []string
+	for _, f := range report.Findings {
+		if f.Severity == severity {
+			out = append(out, f.Summary)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestRoleExclusiveEvidenceIsCritical: a pair proven ONLY through this role's
+// pool and absent from its posture is a real 42501.
+func TestRoleExclusiveEvidenceIsCritical(t *testing.T) {
+	var domainSet PrivilegeSet
+	domainSet.add(PrivSelect)
+
+	report, err := CompareRoles([]RoleInput{
+		{
+			Role:    RoleDomain,
+			Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth:   truthWith(map[string]PrivilegeSet{"other_table": domainSet}),
+		},
+		{
+			Role:    RoleCoordinator,
+			Derived: surfaceWith(RoleCoordinator, "outbox", PrivInsert, "internal/mat.go", 87, "tx"),
+			Truth:   truthWith(map[string]PrivilegeSet{"outbox": domainSet}), // SELECT only
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	criticals := findingSummaries(report, Critical)
+	if len(criticals) != 1 || !strings.Contains(criticals[0], "needs INSERT") {
+		t.Fatalf("expected one CRITICAL naming the missing INSERT, got %v", criticals)
+	}
+	if !strings.Contains(criticals[0], "ONLY through the coordinator pool") {
+		t.Errorf("CRITICAL did not state the evidence was role-exclusive: %s", criticals[0])
+	}
+}
+
+// TestSharedEvidenceIsAdvisoryNotCritical is the remaining_metric_* case: when
+// every proving site is shared with the other role, the pair comes from a type
+// fed by both pools and this tool cannot attribute it. Reporting it CRITICAL
+// would push a posture WIDER than the hand derivation, which is how a
+// least-privilege split degrades.
+func TestSharedEvidenceIsAdvisoryNotCritical(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// The SAME file:line proves UPDATE for both roles -- a dual-constructed type.
+	const file, line = "internal/jobs/metrics/remaining/postgres.go", 418
+	report, err := CompareRoles([]RoleInput{
+		{
+			Role:    RoleDomain,
+			Derived: surfaceWith(RoleDomain, "metric_runs", PrivUpdate, file, line, "tx"),
+			Truth:   truthWith(map[string]PrivilegeSet{"metric_runs": selectOnly}),
+		},
+		{
+			Role:    RoleCoordinator,
+			Derived: surfaceWith(RoleCoordinator, "metric_runs", PrivUpdate, file, line, "tx"),
+			Truth:   truthWith(map[string]PrivilegeSet{"metric_runs": selectOnly}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if criticals := findingSummaries(report, Critical); len(criticals) != 0 {
+		t.Fatalf("shared-evidence pair reported CRITICAL, which would license widening a posture "+
+			"beyond what the code proves: %v", criticals)
+	}
+	advisories := findingSummaries(report, Advisory)
+	joined := strings.Join(advisories, "\n")
+	if !strings.Contains(joined, "SHARED with another role") {
+		t.Fatalf("expected an ADVISORY explaining the shared-evidence limitation, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "DO NOT widen") {
+		t.Errorf("ADVISORY did not warn against widening the posture: %s", joined)
+	}
+	if len(report.SharedPairs) != 1 {
+		t.Errorf("expected the pair in the DERIVED shared set, got %v", report.SharedPairs)
+	}
+}
+
+// TestTransactionStraddleIsCritical is the veto check: one transaction, tables
+// on opposite sides of the partition. It cannot be satisfied by routing, because
+// a transaction runs on exactly one pool.
+func TestTransactionStraddleIsCritical(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	// One traced transaction on the coordinator pool touching two tables, only
+	// one of which the coordinator declares. The other belongs to domain.
+	coordinatorSurface := surfaceWith(RoleCoordinator, "coord_table", PrivSelect,
+		"internal/mat.go", 10, "txorigin:internal/mat.go:5")
+	domainOwned := &TableSurface{Table: "domain_table"}
+	domainOwned.Privileges.add(PrivSelect)
+	domainOwned.Evidence = append(domainOwned.Evidence, Evidence{
+		File: "internal/mat.go", Line: 11, Privilege: PrivSelect,
+		TxGroup: "txorigin:internal/mat.go:5", Statement: "SELECT 1",
+	})
+	coordinatorSurface.Tables["domain_table"] = domainOwned
+
+	report, err := CompareRoles([]RoleInput{
+		{
+			Role:    RoleDomain,
+			Derived: &DerivedSurface{Role: RoleDomain, Tables: map[string]*TableSurface{}},
+			Truth:   truthWith(map[string]PrivilegeSet{"domain_table": selectOnly}),
+		},
+		{
+			Role:    RoleCoordinator,
+			Derived: coordinatorSurface,
+			Truth:   truthWith(map[string]PrivilegeSet{"coord_table": selectOnly}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(findingSummaries(report, Critical), "\n")
+	if !strings.Contains(joined, "TRANSACTION STRADDLES THE ROLE PARTITION") {
+		t.Fatalf("straddling transaction was not reported CRITICAL:\n%s", joined)
+	}
+	if !strings.Contains(joined, "PROVABLY share one transaction") {
+		t.Errorf("straddle finding did not distinguish a traced tx origin from the coarse fallback: %s", joined)
+	}
+}
+
+// TestMisattributionCandidateIsReported covers the leak DIRECTION the static
+// analysis cannot prove: a posture row this role has no evidence for while the
+// other role does. Advisory by design (see roles.go's header), but it must never
+// be silent -- a privilege granted to the wrong role passes every "granted
+// somewhere" check.
+func TestMisattributionCandidateIsReported(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	report, err := CompareRoles([]RoleInput{
+		{
+			Role:    RoleDomain,
+			Derived: surfaceWith(RoleDomain, "only_domain_touches_it", PrivSelect, "internal/d.go", 1, "tx"),
+			Truth:   truthWith(map[string]PrivilegeSet{"only_domain_touches_it": selectOnly}),
+		},
+		{
+			Role:    RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator, Tables: map[string]*TableSurface{}},
+			// Coordinator declares it but has no call site for it.
+			Truth: truthWith(map[string]PrivilegeSet{"only_domain_touches_it": selectOnly}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(findingSummaries(report, Advisory), "\n")
+	if !strings.Contains(joined, "POSSIBLE MISATTRIBUTION") {
+		t.Fatalf("a posture row with no evidence for its own role, held by another role, was not "+
+			"flagged as a misattribution candidate:\n%s", joined)
+	}
+}
+
+// TestIncompletenessNamesUndeclaredPostureTables pins the silence-is-not-
+// confirmation property: a posture table the derivation never saw must appear in
+// the enumerated incompleteness, not vanish.
+func TestIncompletenessNamesUndeclaredPostureTables(t *testing.T) {
+	var selectOnly PrivilegeSet
+	selectOnly.add(PrivSelect)
+
+	report, err := CompareRoles([]RoleInput{
+		{
+			Role:    RoleDomain,
+			Derived: surfaceWith(RoleDomain, "seen", PrivSelect, "internal/d.go", 1, "tx"),
+			Truth:   truthWith(map[string]PrivilegeSet{"seen": selectOnly}),
+		},
+		{
+			Role: RoleCoordinator,
+			Derived: &DerivedSurface{Role: RoleCoordinator, Tables: map[string]*TableSurface{},
+				Unresolved: []UnresolvedCallSite{
+					// KEPT: an unnamed function value -- the shape that hid the
+					// whole scheduler surface before funcvalue.go.
+					{File: "cmd/x/dependencies.go", Line: 42, Callee: "", Reason: "function-typed field"},
+					// KEPT: in-module interface dispatch with no unique implementer.
+					{File: "internal/x/y.go", Line: 7,
+						Callee: "(github.com/full-chaos/dev-health-ops/internal/x.Thing).Do",
+						Reason: "multiple implementers"},
+					// DROPPED: a third-party sink. A tainted argument reaching
+					// pgx.Tx.Exec IS the SQL site, already extracted -- calling it
+					// "taint stopped here" is backwards and it would bury the
+					// hops above.
+					{File: "internal/x/y.go", Line: 8,
+						Callee: "(github.com/jackc/pgx/v5.Tx).Exec", Reason: "third party"},
+					// DROPPED: outside this module.
+					{File: "../../pkg/mod/pgx/conn.go", Line: 1, Callee: "", Reason: "third party"},
+					// DROPPED: duplicate of the first site; the fixed point can
+					// reach one site by several paths.
+					{File: "cmd/x/dependencies.go", Line: 42, Callee: "", Reason: "function-typed field"},
+				}},
+			Truth: truthWith(map[string]PrivilegeSet{"never_seen": selectOnly}),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var coordinator *IncompleteRoleSurface
+	for i := range report.Incomplete {
+		if report.Incomplete[i].Role == RoleCoordinator {
+			coordinator = &report.Incomplete[i]
+		}
+	}
+	if coordinator == nil {
+		t.Fatal("no incompleteness record for the coordinator role")
+	}
+	if len(coordinator.UndeclaredByEvidence) != 1 || coordinator.UndeclaredByEvidence[0] != "never_seen" {
+		t.Errorf("posture table with no derived evidence not enumerated: %v", coordinator.UndeclaredByEvidence)
+	}
+	// Exactly the two signal-bearing hops, deduplicated, with both third-party
+	// kinds filtered out.
+	if len(coordinator.WiringHops) != 2 {
+		t.Fatalf("expected 2 signal hops (unnamed function value + in-module interface dispatch), "+
+			"with third-party sinks, out-of-module files and the duplicate site filtered: %v",
+			coordinator.WiringHops)
+	}
+	if coordinator.WiringHops[0].File != "cmd/x/dependencies.go" || coordinator.WiringHops[0].Callee != "" {
+		t.Errorf("first hop should be the unnamed function value: %+v", coordinator.WiringHops[0])
+	}
+	if !strings.Contains(coordinator.WiringHops[1].Callee, "internal/x.Thing") {
+		t.Errorf("second hop should be the in-module interface dispatch: %+v", coordinator.WiringHops[1])
+	}
+}
+
+// firstNHops caps the printed hop list. The COUNT is the load-bearing number --
+// it is what tells a reader how much of the surface is unverified -- so the cap
+// applies only to the detail lines, never to the count above them.
+func firstNHops(hops []UnresolvedCallSite, n int) []UnresolvedCallSite {
+	if len(hops) <= n {
+		return hops
+	}
+	return hops[:n]
+}
+
+// TestKnownOpenAllowlistFailsOnStaleAndUnticketedEntries keeps the known-open
+// list from becoming a suppression list. Both failure modes are pinned: an entry
+// whose defect no longer reproduces, and a CRITICAL that is not on the list.
+func TestKnownOpenAllowlistFailsOnStaleAndUnticketedEntries(t *testing.T) {
+	// The real list against NO findings: every entry must be reported stale,
+	// because "the gate found nothing" means those defects are gone and the
+	// entries are now blind spots for nothing.
+	blocking, accepted, stale, _ := PartitionKnownOpen(nil)
+	if len(blocking) != 0 || len(accepted) != 0 {
+		t.Fatalf("no findings should mean no blocking and no accepted, got %d/%d", len(blocking), len(accepted))
+	}
+	if len(stale) != len(knownOpenCriticals) {
+		t.Fatalf("expected all %d known-open entries reported stale against an empty finding set, got %d",
+			len(knownOpenCriticals), len(stale))
+	}
+
+	// A CRITICAL for a DIFFERENT privilege on an allowlisted table must still
+	// block. Matching by table alone would silently absorb new defects on any
+	// table that ever had one.
+	blocking, _, _, _ = PartitionKnownOpen([]Finding{{
+		Severity: Critical, Role: RoleCoordinator,
+		Table: "sync_dispatch_outbox", Privilege: PrivDelete,
+		Summary: "synthetic DELETE finding",
+	}})
+	if len(blocking) != 1 {
+		t.Fatalf("a DELETE finding on an INSERT-allowlisted table must still block the gate, got %d blocking",
+			len(blocking))
+	}
+
+	// Same table and privilege but the OTHER role must also still block:
+	// attribution is the whole point, so the role is part of the identity.
+	blocking, _, _, _ = PartitionKnownOpen([]Finding{{
+		Severity: Critical, Role: RoleDomain,
+		Table: "sync_dispatch_outbox", Privilege: PrivInsert,
+		Summary: "synthetic domain finding",
+	}})
+	if len(blocking) != 1 {
+		t.Fatalf("the same (table, privilege) for a DIFFERENT role must still block, got %d blocking", len(blocking))
+	}
+
+	for _, entry := range knownOpenCriticals {
+		if strings.TrimSpace(entry.Ticket) == "" {
+			t.Errorf("known-open entry %s/%s %s has no ticket", entry.Role, entry.Table, entry.Privilege)
+		}
+		if strings.TrimSpace(entry.Why) == "" {
+			t.Errorf("known-open entry %s/%s %s has no justification", entry.Role, entry.Table, entry.Privilege)
+		}
+	}
+}

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -53,16 +53,26 @@ import (
 // ticket, and is being fixed by a lane that does not own this checker.
 //
 // This is not a suppression list and must not be used as one. It exists because
-// the gate's first run found a genuine latent 42501 whose fix is a posture edit
-// in another lane, and a gate that cannot be landed until someone else's commit
-// merges never gets landed at all. The three properties that keep it honest:
+// the checker's first run found a genuine latent 42501 whose fix is a posture edit
+// in another lane.
 //
-//  1. It matches EXACTLY one (role, table, privilege). Any other CRITICAL fails
-//     the gate, including a different privilege on the same table.
-//  2. An entry that STOPS reproducing fails the gate too ("stale entry, delete
-//     it"). So it cannot outlive the fix, which is what turns allowlists into
-//     permanent blindness.
-//  3. Every entry names a ticket. An entry without one fails the gate.
+// # ENFORCEMENT IS SUSPENDED under the advisory posture
+//
+// The coordinator check REPORTS and gates nothing (see AdvisoryReport), so none of
+// the three properties below currently FAIL anything -- they are reported instead.
+// That suspension is a consequence of the advisory decision, and it is written
+// here deliberately rather than left to be inferred from the absence of a
+// consumer: a comment claiming enforcement that no longer happens is worse than no
+// comment, because a reader trusts it. RESTORING these three is part of promoting
+// the check to a gate, tracked in CHAOS-3164.
+//
+// The three properties, all currently REPORTED rather than enforced:
+//
+//  1. An entry matches EXACTLY one (role, table, privilege), so a different
+//     privilege on the same table is not absorbed by it.
+//  2. An entry that STOPS reproducing is flagged stale, so it cannot outlive the
+//     fix -- which is what turns allowlists into permanent blindness.
+//  3. Every entry names a ticket.
 //
 // Emptying this list is the goal state, not a special case.
 type KnownOpenCritical struct {
@@ -96,10 +106,14 @@ func (k KnownOpenCritical) matches(f Finding) bool {
 }
 
 // PartitionKnownOpen splits criticals into the ones already accepted-and-ticketed
-// and the ones that must fail the gate, and separately reports allowlist entries
-// that no longer reproduce. A stale entry is itself a failure: it means the fix
-// landed and the gate is now carrying a blind spot for a defect that no longer
-// exists, which is exactly how a list like this rots into permanent suppression.
+// and the ones that would block, and separately reports allowlist entries that no
+// longer reproduce.
+//
+// Under the advisory posture NOTHING here fails; the four results are reported by
+// AdvisoryReport. A stale entry still MATTERS -- it means the fix landed and the
+// list is now carrying an exemption for a defect that no longer exists, which is
+// how a list like this rots into permanent suppression -- but saying so is
+// currently all this does. Enforcement returns with CHAOS-3164.
 func PartitionKnownOpen(criticals []Finding) (blocking []Finding, accepted []Finding, stale []KnownOpenCritical, unticketed []KnownOpenCritical) {
 	seen := make([]bool, len(knownOpenCriticals))
 	for _, f := range criticals {
@@ -131,15 +145,21 @@ func PartitionKnownOpen(criticals []Finding) (blocking []Finding, accepted []Fin
 // AcknowledgedBlindSpot is one posture-declared (role, table, privilege) that
 // this derivation cannot see, reviewed and accepted with a reason.
 //
-// It is the mechanism that makes enumerated incompleteness a GATE rather than a
-// printout. Before it, the gate reported dozens of stopped wiring hops and
-// several evidence-free posture rows and still passed -- exactly the "silence
-// reads as confirmation" failure the enumeration exists to prevent, since a
-// printout nobody must act on is indistinguishable from having checked.
+// It records which evidence-free posture rows a human has actually looked at, and
+// why each is safe to accept. Same three properties as knownOpenCriticals: exact
+// tuple match, a mandatory reason, and a stale entry flagged so the list cannot
+// outlive the blind spot it excuses.
 //
-// Same three properties as knownOpenCriticals, for the same reason: exact tuple
-// match, a mandatory reason, and a STALE entry fails the gate so the list cannot
-// outlive the blind spot. An unacknowledged evidence-free posture row fails.
+// ENFORCEMENT IS SUSPENDED under the advisory posture -- an unacknowledged row is
+// REPORTED, not failed. The distinction still earns its keep as documentation:
+// an acknowledged row carries a traceable reason, an unacknowledged one is a row
+// nobody has examined, and the report says which is which. Enforcement returns
+// with CHAOS-3164.
+//
+// Known limitation carried into that ticket: acknowledgements here are keyed by
+// (role, table, privilege), but the DYNAMIC-SQL equivalent is keyed by FILE, so a
+// new dynamic statement in an already-acknowledged file is accepted without
+// review. Per-site acceptance is part of the partition work.
 type AcknowledgedBlindSpot struct {
 	Role      PoolRole
 	Table     string
@@ -316,6 +336,7 @@ const (
 	CategoryFuncValue        AdvisoryCategory = "UNRESOLVED-FUNCTION-VALUE"
 	CategoryWiringHop        AdvisoryCategory = "WIRING-HOP"
 	CategoryNameSeedOverride AdvisoryCategory = "NAME-SEED-OVERRIDE"
+	CategoryUnresolvedTx     AdvisoryCategory = "UNRESOLVED-TX-ORIGIN"
 	CategoryAcknowledgement  AdvisoryCategory = "ACKNOWLEDGEMENT"
 	CategoryStats            AdvisoryCategory = "STATS"
 )
@@ -324,7 +345,8 @@ const (
 var AllAdvisoryCategories = []AdvisoryCategory{
 	CategoryStats, CategoryCritical, CategoryKnownOpen, CategoryAdvisory,
 	CategorySharedPair, CategoryNoEvidence, CategoryDynamicSQL, CategoryUnparsedLock,
-	CategoryFuncValue, CategoryWiringHop, CategoryNameSeedOverride, CategoryAcknowledgement,
+	CategoryFuncValue, CategoryWiringHop, CategoryNameSeedOverride, CategoryUnresolvedTx,
+	CategoryAcknowledgement,
 }
 
 // AdvisoryLine is one reportable statement, tagged with its category.
@@ -419,6 +441,14 @@ func AdvisoryReport(report *RoleReport) []AdvisoryLine {
 					"invisible to this analysis. First: %s",
 				surface.Role, len(surface.WiringHops), describeHops(surface.WiringHops, 5)))
 		}
+		if len(surface.UnresolvedTx) > 0 {
+			add(CategoryUnresolvedTx, fmt.Sprintf(
+				"role %s: %d SQL site(s) run through a pgx.Tx parameter whose Begin() could NOT be "+
+					"traced to a single origin, so their transaction grouping fell back to the coarse "+
+					"function-scoped fallback -- any transaction-shaped reading of these is incomplete, "+
+					"not a clean no-conflict signal. First: %s",
+				surface.Role, len(surface.UnresolvedTx), describeTxSites(surface.UnresolvedTx, 5)))
+		}
 		for _, override := range surface.NameSeedOverrides {
 			add(CategoryNameSeedOverride, fmt.Sprintf(
 				"role %s: %s:%d parameter %q in %s is spelled for this role but its call sites pass %v "+
@@ -463,6 +493,18 @@ func AdvisoryReport(report *RoleReport) []AdvisoryLine {
 	}
 
 	return lines
+}
+
+func describeTxSites(sites []UnresolvedTxSite, n int) string {
+	var parts []string
+	for i, site := range sites {
+		if i >= n {
+			parts = append(parts, "...")
+			break
+		}
+		parts = append(parts, fmt.Sprintf("%s:%d in %s", site.File, site.Line, site.Function))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func describeHops(hops []UnresolvedCallSite, n int) string {
@@ -528,6 +570,11 @@ type IncompleteRoleSurface struct {
 	// spelling. Carried here so the advisory report has ONE source for everything
 	// it prints.
 	NameSeedOverrides []NameSeedOverride
+	// UnresolvedTx are SQL sites issued through a pgx.Tx PARAMETER whose origin
+	// could not be traced to a single Begin(). Their TxGroup fell back to the
+	// coarse function-scoped grouping, so any transaction-shaped observation
+	// involving them is incomplete rather than a clean "no conflict" signal.
+	UnresolvedTx []UnresolvedTxSite
 	// UndeclaredByEvidence are the (table, privilege) PAIRS this role's posture
 	// declares that this role's derivation found no call site for. Each is either
 	// a legitimate over-declaration or a path inside a blind spot -- this tool
@@ -1166,6 +1213,7 @@ func incompleteFor(in RoleInput, byRole map[PoolRole]RoleInput) IncompleteRoleSu
 	}
 	out.UnparsedLocks = in.Derived.UnparsedLocks
 	out.NameSeedOverrides = in.Derived.NameSeedOverrides
+	out.UnresolvedTx = in.Derived.UnresolvedTx
 
 	// PAIR-granular, and computed against THIS role's own derivation. A
 	// table-level check would miss the case that matters most: SELECT still

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -1,0 +1,553 @@
+package domaingrants
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file is the multi-role half of the checker: Option B of CHAOS-3033 split
+// one domain role into domain + coordinator, and a two-role posture has a
+// failure mode one role does not -- a privilege granted to the WRONG role. Every
+// check that asks "is this granted somewhere" passes while least-privilege is
+// silently gone. So the comparison has to be per-role, and it has to say
+// something about the other role too.
+//
+// What this file can and cannot prove, stated up front because overstating it
+// would license exactly the hand-written rows the gate exists to adjudicate:
+//
+//   - PROVABLE, and reported CRITICAL: real code on role R's pool executes a
+//     statement R's posture does not authorize. Under-approximation cuts the
+//     other way here -- if the analyzer sees the call site, the call site is
+//     real.
+//   - PROVABLE, and reported CRITICAL: a (table, privilege) with evidence on
+//     BOTH pools that is missing from EITHER posture. This is the derived
+//     dual-grant check, and it replaces a hand-maintained shared-table
+//     whitelist with a computed property of the evidence.
+//   - NOT PROVABLE HERE, reported ADVISORY: "role B must not hold X." The
+//     derivation is a sound-but-INCOMPLETE under-approximation, so "B has no
+//     evidence for X" never implies "B does not need X" -- it may simply be a
+//     path this analyzer cannot see (see IncompleteRoleSurface). Asserting the
+//     negative direction statically would fire on every blind-spot table.
+//     The negative direction is proven at RUNTIME instead, by the union of each
+//     role calling CheckRolePosture against its own manifest: that query's
+//     "everything outside my own manifest is illegal for me to hold" catch-all
+//     inspects the CALLING role, so checking every role covers both leak
+//     directions. See CheckRolePosture's doc comment in
+//     internal/storage/postgres/domain_authorization.go.
+//
+// The one over-approximation that DOES bite, and why a finding here can be
+// wrong in the widening direction: taint is tracked per (type, field), not per
+// construction site. A repository type constructed from BOTH pools has its
+// whole method surface attributed to both roles. internal/jobs/metrics/remaining
+// is the live instance -- PostgresStore.pool is fed the coordinator pool by the
+// scheduler's fixed producers, so CancelRun/CompletePartition/FinalizeRun get
+// attributed to the coordinator even though only the domain worker calls them.
+// That is why a pair whose every evidence site is SHARED with the other role is
+// reported ADVISORY, never CRITICAL: for those, a careful hand derivation is
+// strictly more precise than this tool, and coordinatorPosture()'s
+// remaining_metric_runs/{true,false,false} is correctly NARROWER than what this
+// tool derives. Do not widen a posture on a shared-evidence finding.
+
+// KnownOpenCritical is one CRITICAL finding that is ACCEPTED AS REAL, has a
+// ticket, and is being fixed by a lane that does not own this checker.
+//
+// This is not a suppression list and must not be used as one. It exists because
+// the gate's first run found a genuine latent 42501 whose fix is a posture edit
+// in another lane, and a gate that cannot be landed until someone else's commit
+// merges never gets landed at all. The three properties that keep it honest:
+//
+//  1. It matches EXACTLY one (role, table, privilege). Any other CRITICAL fails
+//     the gate, including a different privilege on the same table.
+//  2. An entry that STOPS reproducing fails the gate too ("stale entry, delete
+//     it"). So it cannot outlive the fix, which is what turns allowlists into
+//     permanent blindness.
+//  3. Every entry names a ticket. An entry without one fails the gate.
+//
+// Emptying this list is the goal state, not a special case.
+type KnownOpenCritical struct {
+	Role      PoolRole
+	Table     string
+	Privilege Privilege
+	Ticket    string
+	Why       string
+}
+
+// knownOpenCriticals is the accepted-and-ticketed set. See KnownOpenCritical.
+var knownOpenCriticals = []KnownOpenCritical{
+	{
+		Role:      RoleCoordinator,
+		Table:     "sync_dispatch_outbox",
+		Privilege: PrivInsert,
+		Ticket:    "CHAOS-3079",
+		Why: "syncreconciler.Materializer.Step runs on the coordinator pool " +
+			"(cmd/dev-health-reconciler/dependencies.go:208 NewMaterializer(coordinatorPool)) and executes four " +
+			"INSERT INTO public.sync_dispatch_outbox (materializer.go:125/235/345/450), but coordinatorPosture() " +
+			"declares {\"sync_dispatch_outbox\", false, true, false} -- allow_insert=false. Latent only because " +
+			"checkedInReconcilerActivation.syncMutation is false today; a 42501 the moment that flag flips. " +
+			"This gate's first run found it, independently confirming the CUT-06 lane's hand-derived row. " +
+			"The fix is a coordinatorPosture edit, which belongs to the posture lane, not to this checker.",
+	},
+}
+
+// matches reports whether f is this known-open entry.
+func (k KnownOpenCritical) matches(f Finding) bool {
+	return f.Role == k.Role && f.Table == k.Table && f.Privilege == k.Privilege
+}
+
+// PartitionKnownOpen splits criticals into the ones already accepted-and-ticketed
+// and the ones that must fail the gate, and separately reports allowlist entries
+// that no longer reproduce. A stale entry is itself a failure: it means the fix
+// landed and the gate is now carrying a blind spot for a defect that no longer
+// exists, which is exactly how a list like this rots into permanent suppression.
+func PartitionKnownOpen(criticals []Finding) (blocking []Finding, accepted []Finding, stale []KnownOpenCritical, unticketed []KnownOpenCritical) {
+	seen := make([]bool, len(knownOpenCriticals))
+	for _, f := range criticals {
+		matchedAny := false
+		for i, known := range knownOpenCriticals {
+			if known.matches(f) {
+				seen[i] = true
+				matchedAny = true
+				break
+			}
+		}
+		if matchedAny {
+			accepted = append(accepted, f)
+			continue
+		}
+		blocking = append(blocking, f)
+	}
+	for i, known := range knownOpenCriticals {
+		if strings.TrimSpace(known.Ticket) == "" {
+			unticketed = append(unticketed, known)
+		}
+		if !seen[i] {
+			stale = append(stale, known)
+		}
+	}
+	return blocking, accepted, stale, unticketed
+}
+
+// RoleInput is one role's derived surface paired with the posture it is
+// checked against.
+type RoleInput struct {
+	Role    PoolRole
+	Derived *DerivedSurface
+	Truth   *GroundTruth
+}
+
+// IncompleteRoleSurface is the enumerated, first-class statement of what this
+// role's derivation could NOT see. It exists because silence must never read as
+// confirmation: a gate that reports nothing about a table it cannot analyze
+// looks identical to a gate that verified it, and that is what licenses
+// hand-written rows.
+type IncompleteRoleSurface struct {
+	Role PoolRole
+	// WiringHops are calls that received a pool-tainted argument but whose
+	// callee could not be resolved, restricted to this module's own code (the
+	// pgx-internal ones are noise). Taint stops here, so everything downstream
+	// is invisible.
+	WiringHops []UnresolvedCallSite
+	// DynamicSQL are SQL-shaped calls whose statement text is not a
+	// compile-time constant, so no table could be extracted.
+	DynamicSQL []DynamicSite
+	// UndeclaredByEvidence are tables this role's posture declares that the
+	// derivation found NO call site for. Each is either a legitimate
+	// over-declaration or a path inside a blind spot -- this tool cannot tell
+	// which, and says so rather than guessing.
+	UndeclaredByEvidence []string
+}
+
+// RoleReport is the multi-role comparison result.
+type RoleReport struct {
+	Findings   []Finding
+	Incomplete []IncompleteRoleSurface
+	// SharedPairs are the (table, privilege) pairs with proven call sites on
+	// more than one pool -- the DERIVED dual-grant set. Every one of these
+	// legitimately appears in more than one posture and must not be read as a
+	// leak.
+	SharedPairs []string
+	Stats       []string
+}
+
+// HasCritical reports whether any finding is Critical -- the CI-gate signal.
+func (r *RoleReport) HasCritical() bool {
+	for _, f := range r.Findings {
+		if f.Severity == Critical {
+			return true
+		}
+	}
+	return false
+}
+
+// pairKey identifies one (table, privilege) requirement.
+type pairKey struct {
+	table string
+	priv  Privilege
+}
+
+// evidenceSites returns the distinct "file:line" sites proving pair for a
+// surface, so two roles' evidence can be compared for exclusivity.
+func evidenceSites(surface *TableSurface, p Privilege) map[string]bool {
+	out := map[string]bool{}
+	if surface == nil {
+		return out
+	}
+	for _, e := range surface.Evidence {
+		if e.Privilege == p {
+			out[fmt.Sprintf("%s:%d", e.File, e.Line)] = true
+		}
+	}
+	return out
+}
+
+// CompareRoles cross-checks every role's derived surface against its own
+// posture, and cross-checks the roles against each other. See this file's
+// header for exactly which of those comparisons are proofs and which are
+// advisories.
+func CompareRoles(inputs []RoleInput) (*RoleReport, error) {
+	if len(inputs) < 2 {
+		return nil, fmt.Errorf("domaingrants: CompareRoles needs every role's surface, got %d; "+
+			"a single-role run cannot check attribution at all and must not be mistaken for one that did", len(inputs))
+	}
+	report := &RoleReport{}
+
+	byRole := map[PoolRole]RoleInput{}
+	for _, in := range inputs {
+		if in.Derived == nil || in.Truth == nil {
+			return nil, fmt.Errorf("domaingrants: role %q has a nil surface or posture", in.Role)
+		}
+		byRole[in.Role] = in
+	}
+
+	// Which roles have PROVEN evidence for each pair. This is the derived
+	// shared/exclusive classification everything below keys off.
+	rolesForPair := map[pairKey]map[PoolRole]bool{}
+	for _, in := range inputs {
+		for table, surface := range in.Derived.Tables {
+			for p := Privilege(0); p < numPrivileges; p++ {
+				if !surface.Privileges.Has(p) {
+					continue
+				}
+				key := pairKey{table: table, priv: p}
+				if rolesForPair[key] == nil {
+					rolesForPair[key] = map[PoolRole]bool{}
+				}
+				rolesForPair[key][in.Role] = true
+			}
+		}
+	}
+
+	for _, in := range inputs {
+		report.Stats = append(report.Stats, fmt.Sprintf(
+			"role %s: %d tables derived, %d posture tables, %d dynamic SQL sites, %d unresolved call sites, %d devirtualized, %d function-value hops resolved",
+			in.Role, len(in.Derived.Tables), len(in.Truth.RequiredTablePrivileges),
+			len(in.Derived.Dynamic), len(in.Derived.Unresolved),
+			len(in.Derived.Devirtualized), len(in.Derived.FuncValueResolved),
+		))
+		report.Findings = append(report.Findings, compareOneRole(in, byRole, rolesForPair)...)
+		report.Incomplete = append(report.Incomplete, incompleteFor(in))
+	}
+
+	report.Findings = append(report.Findings, transactionStraddleFindings(inputs, byRole)...)
+
+	for key, roles := range rolesForPair {
+		if len(roles) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(roles))
+		for role := range roles {
+			names = append(names, string(role))
+		}
+		sort.Strings(names)
+		report.SharedPairs = append(report.SharedPairs,
+			fmt.Sprintf("%s %s (evidence on: %s)", key.table, key.priv, strings.Join(names, "+")))
+	}
+	sort.Strings(report.SharedPairs)
+
+	sort.SliceStable(report.Findings, func(i, j int) bool {
+		if report.Findings[i].Severity != report.Findings[j].Severity {
+			return report.Findings[i].Severity < report.Findings[j].Severity
+		}
+		if report.Findings[i].Table != report.Findings[j].Table {
+			return report.Findings[i].Table < report.Findings[j].Table
+		}
+		return report.Findings[i].Privilege < report.Findings[j].Privilege
+	})
+	return report, nil
+}
+
+// compareOneRole is the per-role half: does this role's posture authorize what
+// this role's code actually executes?
+func compareOneRole(
+	in RoleInput,
+	byRole map[PoolRole]RoleInput,
+	rolesForPair map[pairKey]map[PoolRole]bool,
+) []Finding {
+	var findings []Finding
+
+	for _, table := range in.Derived.SortedTables() {
+		surface := in.Derived.Tables[table]
+		required := in.Truth.RequiredTablePrivileges[table]
+		columnScoped := in.Truth.ColumnScopedTables[table]
+
+		for p := Privilege(0); p < numPrivileges; p++ {
+			if !surface.Privileges.Has(p) {
+				continue
+			}
+			key := pairKey{table: table, priv: p}
+			if columnScoped {
+				if !required.Has(p) {
+					findings = append(findings, Finding{
+						Severity: Advisory, Table: table, Privilege: p, Role: in.Role,
+						Summary: fmt.Sprintf(
+							"role %s, table %q: derived surface requires %s and the table is column-scoped in this role's posture -- verify the column-level grant covers it (this tool does not model column grants)",
+							in.Role, table, p),
+						Evidence: evidenceFor(surface, p),
+					})
+				}
+				continue
+			}
+			if required.Has(p) {
+				continue
+			}
+
+			// The discriminator: is there at least one evidence site for this
+			// pair that ONLY this role has? If yes, this role's own pool
+			// provably executes it and the posture is wrong. If every site is
+			// shared with another role, the pair is reached through a type fed
+			// by more than one pool, and per-role attribution is beyond this
+			// tool's (type, field) granularity -- advisory, because a hand
+			// derivation is strictly more precise there. See the file header.
+			mine := evidenceSites(surface, p)
+			exclusive := map[string]bool{}
+			for site := range mine {
+				shared := false
+				for role, other := range byRole {
+					if role == in.Role {
+						continue
+					}
+					if evidenceSites(other.Derived.Tables[table], p)[site] {
+						shared = true
+						break
+					}
+				}
+				if !shared {
+					exclusive[site] = true
+				}
+			}
+			if len(exclusive) == 0 && len(rolesForPair[key]) > 1 {
+				findings = append(findings, Finding{
+					Severity: Advisory, Table: table, Privilege: p, Role: in.Role,
+					Summary: fmt.Sprintf(
+						"role %s, table %q: %s is derived but every proving call site is SHARED with another role's derivation, so it comes from a repository type constructed from more than one pool -- this tool's (type, field) taint granularity cannot attribute it per role. DO NOT widen %s's posture on this finding alone; a hand derivation from the construction site is more precise here",
+						in.Role, table, p, in.Role),
+					Evidence: evidenceFor(surface, p),
+				})
+				continue
+			}
+			sites := make([]string, 0, len(exclusive))
+			for site := range exclusive {
+				sites = append(sites, site)
+			}
+			sort.Strings(sites)
+			findings = append(findings, Finding{
+				Severity: Critical, Table: table, Privilege: p, Role: in.Role,
+				Summary: fmt.Sprintf(
+					"role %s, table %q needs %s, proven by %d call site(s) reachable ONLY through the %s pool (%s), but this role's posture does not authorize it -- a 42501 the moment that path runs",
+					in.Role, table, p, len(exclusive), in.Role, strings.Join(firstN(sites, 3), ", ")),
+				Evidence: evidenceFor(surface, p),
+			})
+		}
+
+		if surface.RequiresAnyWriteLock && !columnScoped {
+			// Postgres wants at least ONE of INSERT/UPDATE/DELETE for a LOCK
+			// TABLE mode stricter than ROW EXCLUSIVE -- any one, not a specific
+			// one. Deliberately a different shape from the FOR UPDATE / FOR
+			// SHARE row-lock clauses, which require UPDATE specifically and are
+			// modelled as an ordinary UPDATE requirement above. Both forms are
+			// modelled; do not collapse them.
+			if !required.Has(PrivInsert) && !required.Has(PrivUpdate) && !required.Has(PrivDelete) {
+				findings = append(findings, Finding{
+					Severity: Critical, Table: table, Role: in.Role,
+					Summary: fmt.Sprintf(
+						"role %s, table %q: LOCK TABLE in an exclusive-ish mode requires at least one of INSERT/UPDATE/DELETE, but this role's posture grants none of them",
+						in.Role, table),
+					Evidence: surface.WriteLockEvidence,
+				})
+			}
+		}
+	}
+
+	// Possible MISATTRIBUTION: this role's posture declares a pair it has no
+	// evidence for, while another role does have evidence. Advisory, not
+	// critical: see the file header for why the negative direction is not
+	// statically provable.
+	for table, privs := range in.Truth.RequiredTablePrivileges {
+		for p := Privilege(0); p < numPrivileges; p++ {
+			if !privs.Has(p) {
+				continue
+			}
+			surface := in.Derived.Tables[table]
+			if surface != nil && surface.Privileges.Has(p) {
+				continue
+			}
+			var others []string
+			for role, other := range byRole {
+				if role == in.Role {
+					continue
+				}
+				if s := other.Derived.Tables[table]; s != nil && s.Privileges.Has(p) {
+					others = append(others, string(role))
+				}
+			}
+			if len(others) == 0 {
+				continue
+			}
+			sort.Strings(others)
+			findings = append(findings, Finding{
+				Severity: Advisory, Table: table, Privilege: p, Role: in.Role,
+				Summary: fmt.Sprintf(
+					"role %s, table %q: posture authorizes %s but only role(s) %s have proven call sites for it -- POSSIBLE MISATTRIBUTION (granted to the wrong role, which every \"is it granted somewhere\" check passes) OR a path inside this role's enumerated blind spot. Resolve from the construction site, not from this list",
+					in.Role, table, p, strings.Join(others, "+")),
+			})
+		}
+	}
+	return findings
+}
+
+// transactionStraddleFindings implements the transaction-span veto: a single
+// transaction cannot span two connection pools, so every table a transaction
+// touches must be authorized for the ONE role whose pool runs it. A transaction
+// whose tables land on opposite sides of the partition either forces them into
+// the same role or needs restructuring -- and it fails as a runtime 42501, which
+// is what this check exists to catch first.
+//
+// TxGroup precision matters here and is not uniform: a "txorigin:" group was
+// traced to a single unambiguous Begin() across function boundaries, while a
+// package-qualified group is the coarse same-function-body fallback. Straddles
+// found in a coarse group are still reported, flagged as such, because a
+// possible straddle is worth a human's attention and the alternative is
+// silence.
+func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInput) []Finding {
+	var findings []Finding
+	for _, in := range inputs {
+		groups := map[string]map[string]bool{}
+		for table, surface := range in.Derived.Tables {
+			for _, e := range surface.Evidence {
+				if e.TxGroup == "" {
+					continue
+				}
+				if groups[e.TxGroup] == nil {
+					groups[e.TxGroup] = map[string]bool{}
+				}
+				groups[e.TxGroup][table] = true
+			}
+		}
+		for _, group := range sortedKeys(boolMapKeys(groups)) {
+			tables := sortedKeys(groups[group])
+			if len(tables) < 2 {
+				continue
+			}
+			var mine, elsewhere []string
+			for _, table := range tables {
+				if _, declared := in.Truth.RequiredTablePrivileges[table]; declared ||
+					in.Truth.ColumnScopedTables[table] {
+					mine = append(mine, table)
+					continue
+				}
+				// Not in this role's posture at all. Is it in another's? That is
+				// the straddle: one transaction, tables on both sides.
+				var holders []string
+				for role, other := range byRole {
+					if role == in.Role {
+						continue
+					}
+					if _, declared := other.Truth.RequiredTablePrivileges[table]; declared ||
+						other.Truth.ColumnScopedTables[table] {
+						holders = append(holders, string(role))
+					}
+				}
+				if len(holders) > 0 {
+					sort.Strings(holders)
+					elsewhere = append(elsewhere, fmt.Sprintf("%s (declared for %s)", table, strings.Join(holders, "+")))
+				} else {
+					elsewhere = append(elsewhere, table+" (declared for NO role)")
+				}
+			}
+			if len(elsewhere) == 0 {
+				continue
+			}
+			precision := "COARSE same-function-body grouping, so co-residency in one transaction is likely but not proven"
+			if strings.HasPrefix(group, "txorigin:") {
+				precision = "traced to a single unambiguous Begin() call site, so these statements PROVABLY share one transaction"
+			}
+			findings = append(findings, Finding{
+				Severity: Critical, Table: strings.Join(tables, ", "), Role: in.Role,
+				Summary: fmt.Sprintf(
+					"TRANSACTION STRADDLES THE ROLE PARTITION: transaction %s runs on the %s pool and touches %s, but %s not authorized for %s (%s). A transaction cannot span two pools -- either grant these to %s too (dual-grant) or restructure the transaction. This surfaces as a 42501 at runtime, not as a routing error",
+					group, in.Role, strings.Join(tables, "+"),
+					strings.Join(elsewhere, "; "), in.Role, precision, in.Role),
+			})
+		}
+	}
+	return findings
+}
+
+// incompleteFor enumerates what this role's derivation could not see.
+//
+// The filter matters as much as the list. Unresolved-callee records are dominated
+// by two kinds that are NOT blind spots and would bury the ones that are:
+//
+//   - third-party callees (pgx's Tx.Exec/Row.Scan, valkey's Do). A tainted
+//     argument reaching pgx.Tx.Exec is the SQL sink itself -- already extracted
+//     by recordSQLSite. Reporting it as "taint stopped here" is backwards.
+//   - files outside this module (the driver's own source, loaded as a dependency).
+//
+// What survives is what actually hides code: a call through a function-typed
+// value the resolver could not pin down, and in-module interface dispatch with
+// no unique implementer. Those are the shapes that hid the whole scheduler
+// surface before funcvalue.go, so those are the ones worth a human's eyes.
+// Deduplicated by site, because the fixed point can reach one site by several
+// paths and a repeated line adds no information.
+func incompleteFor(in RoleInput) IncompleteRoleSurface {
+	out := IncompleteRoleSurface{Role: in.Role}
+	seen := map[string]bool{}
+	for _, u := range in.Derived.Unresolved {
+		if strings.HasPrefix(u.File, "..") || strings.Contains(u.File, "/pkg/mod/") {
+			continue
+		}
+		// Keep only unnamed function values and this module's own unresolved
+		// interface dispatch; everything else is a third-party sink, not a gap.
+		inModule := strings.HasPrefix(u.Callee, "github.com/full-chaos/dev-health-ops") ||
+			strings.HasPrefix(u.Callee, "(github.com/full-chaos/dev-health-ops")
+		if u.Callee != "" && !inModule {
+			continue
+		}
+		site := fmt.Sprintf("%s:%d", u.File, u.Line)
+		if seen[site] {
+			continue
+		}
+		seen[site] = true
+		out.WiringHops = append(out.WiringHops, u)
+	}
+	out.DynamicSQL = in.Derived.Dynamic
+	for table := range in.Truth.RequiredTablePrivileges {
+		if surface := in.Derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
+			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, table)
+		}
+	}
+	for table := range in.Truth.ColumnScopedTables {
+		if surface := in.Derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
+			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, table+" (column-scoped)")
+		}
+	}
+	sort.Strings(out.UndeclaredByEvidence)
+	sort.SliceStable(out.WiringHops, func(i, j int) bool {
+		if out.WiringHops[i].File != out.WiringHops[j].File {
+			return out.WiringHops[i].File < out.WiringHops[j].File
+		}
+		return out.WiringHops[i].Line < out.WiringHops[j].Line
+	})
+	return out
+}

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -255,6 +255,10 @@ type IncompleteRoleSurface struct {
 	// value). These FAIL the gate: pool-tainted arguments cross them and nothing
 	// beyond was analyzed, so they are unanalyzed surface, not a known limit.
 	FuncValueConflicts []FuncValueConflictSite
+	// UnparsedLocks are LOCK statements the parser could not understand. These
+	// FAIL the gate for the same reason: the demand is real and its target may not
+	// even appear in the derived surface.
+	UnparsedLocks []UnparsedLockSite
 	// UndeclaredByEvidence are the (table, privilege) PAIRS this role's posture
 	// declares that this role's derivation found no call site for. Each is either
 	// a legitimate over-declaration or a path inside a blind spot -- this tool
@@ -632,15 +636,11 @@ func compareOneRole(
 					attribution = "but every LOCK site is SHARED with another role's derivation, so the locking method is reached through a type constructed from more than one pool"
 					remedy = fmt.Sprintf("this tool's (type, field) taint granularity cannot attribute it per role -- DO NOT widen %s's posture on this finding alone", in.Role)
 				}
-				unknown := ""
-				if requirement.Unknown {
-					unknown = " (mode UNRECOGNIZED by this analyzer, so it is assumed to be the strictest tier -- verify it by hand)"
-				}
 				findings = append(findings, Finding{
 					Severity: severity, Table: table, Role: in.Role,
 					Summary: fmt.Sprintf(
-						"role %s, table %q: LOCK TABLE IN %s MODE requires at least one of %s%s, and this role's posture grants none of them; %s -- %s",
-						in.Role, table, requirement.Mode, privilegeSetNames(requirement.Satisfying), unknown, attribution, remedy),
+						"role %s, table %q: LOCK IN %s MODE requires at least ONE of %s -- a disjunction, NOT a conjunction with SELECT -- and this role's posture grants none of them; %s -- %s",
+						in.Role, table, requirement.Mode, privilegeSetNames(requirement.Satisfying), attribution, remedy),
 					Evidence: surface.WriteLockEvidence,
 				})
 			}
@@ -873,6 +873,7 @@ func incompleteFor(in RoleInput, byRole map[PoolRole]RoleInput) IncompleteRoleSu
 		}
 		out.FuncValueConflicts = append(out.FuncValueConflicts, conflict)
 	}
+	out.UnparsedLocks = in.Derived.UnparsedLocks
 
 	// PAIR-granular, and computed against THIS role's own derivation. A
 	// table-level check would miss the case that matters most: SELECT still

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -770,19 +770,22 @@ func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInp
 			traced := strings.HasPrefix(group, "txorigin:")
 			groupSites := txGroupSites(in.Derived, group)
 			var otherGroupSites []map[string]bool
-			othersHaveGroup := false
 			for role, other := range byRole {
 				if role == in.Role {
 					continue
 				}
-				sites := txGroupSites(other.Derived, group)
-				if len(sites) > 0 {
-					othersHaveGroup = true
-				}
-				otherGroupSites = append(otherGroupSites, sites)
+				otherGroupSites = append(otherGroupSites, txGroupSites(other.Derived, group))
 			}
+			// One exclusive site is necessary AND sufficient here. A group key only
+			// exists because this role's own evidence produced it, so groupSites is
+			// never empty; therefore "no other role has this group" already implies
+			// every site is exclusive. An earlier version also OR'd in an explicit
+			// !othersHaveGroup clause, which mutation testing showed to be dead --
+			// unreachable rather than merely untested. Removed instead of left in
+			// place, because a dead clause reads as a second safeguard that is
+			// actually doing nothing.
 			exclusive := exclusiveTo(groupSites, otherGroupSites)
-			attributed := len(exclusive) > 0 || !othersHaveGroup
+			attributed := len(exclusive) > 0
 
 			severity := Critical
 			var caveat string

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -128,6 +128,105 @@ func PartitionKnownOpen(criticals []Finding) (blocking []Finding, accepted []Fin
 	return blocking, accepted, stale, unticketed
 }
 
+// AcknowledgedBlindSpot is one posture-declared (role, table, privilege) that
+// this derivation cannot see, reviewed and accepted with a reason.
+//
+// It is the mechanism that makes enumerated incompleteness a GATE rather than a
+// printout. Before it, the gate reported dozens of stopped wiring hops and
+// several evidence-free posture rows and still passed -- exactly the "silence
+// reads as confirmation" failure the enumeration exists to prevent, since a
+// printout nobody must act on is indistinguishable from having checked.
+//
+// Same three properties as knownOpenCriticals, for the same reason: exact tuple
+// match, a mandatory reason, and a STALE entry fails the gate so the list cannot
+// outlive the blind spot. An unacknowledged evidence-free posture row fails.
+type AcknowledgedBlindSpot struct {
+	Role      PoolRole
+	Table     string
+	Privilege Privilege
+	Why       string
+}
+
+// acknowledgedBlindSpots is the reviewed set. Every entry is a posture row whose
+// justification lives OUTSIDE this tool's reach; each says where.
+var acknowledgedBlindSpots = []AcknowledgedBlindSpot{
+	{
+		Role: RoleDomain, Table: "integration_credentials", Privilege: PrivSelect,
+		Why: "providerfoundation/repository_postgres.go:36 builds its query by runtime string " +
+			"concatenation, so the SQL text is not a compile-time constant and no table can be " +
+			"extracted. The grant is correct -- verified by hand in grant-surface-derivation.md -- " +
+			"and it is the one dynamic-SQL site in the domain surface.",
+	},
+	{
+		Role: RoleCoordinator, Table: "organizations", Privilege: PrivSelect,
+		Why: "the coordinator side is scheduler/fixed/organizations.go's PostgresOrganizationLister, " +
+			"which holds no pool: it receives a pgx.Tx PARAMETER through an OrganizationLister " +
+			"interface, so taint does not reach it from a pool root. The role-partition manifest " +
+			"records organizations as a verified dual-grant.",
+	},
+	{
+		Role: RoleCoordinator, Table: "work_graph_execution_requests", Privilege: PrivSelect,
+		Why: "added to coordinatorPosture by CHAOS-3114 for the fixed engine's work-graph producer. " +
+			"The SQL lives in internal/jobs/workgraph, reached through a producer interface the " +
+			"unique-implementer heuristic cannot resolve (see the Producer.Produce wiring hop).",
+	},
+	{
+		Role: RoleCoordinator, Table: "work_graph_execution_requests", Privilege: PrivInsert,
+		Why: "same producer path as the SELECT above; workgraph/publisher.go:37 does the INSERT.",
+	},
+}
+
+func (a AcknowledgedBlindSpot) matches(role PoolRole, gap PostureGapWithoutEvidence) bool {
+	return a.Role == role && a.Table == gap.Table && a.Privilege == gap.Privilege && !gap.ColumnScoped
+}
+
+// PartitionBlindSpots splits every role's evidence-free posture rows into the
+// acknowledged and the unacknowledged, and reports acknowledgements that no
+// longer correspond to a real gap.
+//
+// Unacknowledged rows FAIL the gate: each is a posture privilege nothing in the
+// analysis justifies, and leaving it unreported is how a wrong row survives.
+// Stale acknowledgements fail too -- the evidence arrived (or the row was
+// removed), so the entry is now suppressing nothing and must go.
+func PartitionBlindSpots(incomplete []IncompleteRoleSurface) (unacknowledged []string, stale []AcknowledgedBlindSpot, unreasoned []AcknowledgedBlindSpot) {
+	seen := make([]bool, len(acknowledgedBlindSpots))
+	for _, surface := range incomplete {
+		for _, gap := range surface.UndeclaredByEvidence {
+			matched := false
+			for i, ack := range acknowledgedBlindSpots {
+				if ack.matches(surface.Role, gap) {
+					seen[i] = true
+					matched = true
+					break
+				}
+			}
+			if matched {
+				continue
+			}
+			// A pair another role DOES have evidence for is already reported as a
+			// misattribution ADVISORY with its own explanation; requiring a second
+			// acknowledgement for it would be duplicate bookkeeping. The dangerous
+			// case -- nobody has evidence -- is what must be acknowledged or fail.
+			if len(gap.OtherRolesWithEvidence) > 0 || gap.ColumnScoped ||
+				gap.ImpliedSelect || gap.JustifiedByLock != "" {
+				continue
+			}
+			unacknowledged = append(unacknowledged,
+				fmt.Sprintf("%s: %s", surface.Role, gap.String()))
+		}
+	}
+	for i, ack := range acknowledgedBlindSpots {
+		if strings.TrimSpace(ack.Why) == "" {
+			unreasoned = append(unreasoned, ack)
+		}
+		if !seen[i] {
+			stale = append(stale, ack)
+		}
+	}
+	sort.Strings(unacknowledged)
+	return unacknowledged, stale, unreasoned
+}
+
 // RoleInput is one role's derived surface paired with the posture it is
 // checked against.
 type RoleInput struct {
@@ -151,11 +250,64 @@ type IncompleteRoleSurface struct {
 	// DynamicSQL are SQL-shaped calls whose statement text is not a
 	// compile-time constant, so no table could be extracted.
 	DynamicSQL []DynamicSite
-	// UndeclaredByEvidence are tables this role's posture declares that the
-	// derivation found NO call site for. Each is either a legitimate
-	// over-declaration or a path inside a blind spot -- this tool cannot tell
-	// which, and says so rather than guessing.
-	UndeclaredByEvidence []string
+	// FuncValueConflicts are tainted calls through a function-typed field the
+	// resolver deliberately refused (two implementations, or an unresolvable
+	// value). These FAIL the gate: pool-tainted arguments cross them and nothing
+	// beyond was analyzed, so they are unanalyzed surface, not a known limit.
+	FuncValueConflicts []FuncValueConflictSite
+	// UndeclaredByEvidence are the (table, privilege) PAIRS this role's posture
+	// declares that this role's derivation found no call site for. Each is either
+	// a legitimate over-declaration or a path inside a blind spot -- this tool
+	// cannot tell which, and says so rather than guessing.
+	//
+	// Pair granularity is load-bearing, not tidiness. A table-level list hides
+	// the case that matters most: if SELECT stays visible while the UPDATE path
+	// becomes unreachable, the table is nonempty, so a table-level list omits it
+	// entirely and the (table, UPDATE) gap disappears from every output.
+	UndeclaredByEvidence []PostureGapWithoutEvidence
+}
+
+// PostureGapWithoutEvidence is one posture-declared privilege with no derived
+// call site for its own role.
+type PostureGapWithoutEvidence struct {
+	Table     string
+	Privilege Privilege
+	// ColumnScoped marks a column-scoped declaration rather than a table row.
+	ColumnScoped bool
+	// ImpliedSelect marks a SELECT that loadPosture synthesized onto a posture row
+	// rather than the posture declaring it, on a table that HAS other derived
+	// evidence. An artifact of the representation, not a blind spot.
+	ImpliedSelect bool
+	// JustifiedByLock names the LOCK mode that already demands this privilege, if
+	// any. A lock's demand is a disjunction, so the per-privilege loop cannot
+	// record it as evidence even though the lock fully justifies the row.
+	JustifiedByLock string
+	// OtherRolesWithEvidence names roles that DO have a proven call site for this
+	// pair. Non-empty means "possible misattribution" (the privilege may belong
+	// to that role instead). EMPTY is the more dangerous case and the one that
+	// used to vanish: nothing anywhere justifies the row, so either it is an
+	// over-declaration or it sits inside a blind spot -- and either way no other
+	// output mentions it.
+	OtherRolesWithEvidence []string
+}
+
+func (g PostureGapWithoutEvidence) String() string {
+	suffix := ""
+	if g.ColumnScoped {
+		suffix = " (column-scoped)"
+	}
+	if g.ImpliedSelect {
+		suffix += " (SELECT implied by the posture model; table has other evidence)"
+	}
+	if g.JustifiedByLock != "" {
+		suffix += " (justified by LOCK IN " + g.JustifiedByLock + " MODE)"
+	}
+	if len(g.OtherRolesWithEvidence) > 0 {
+		suffix += " [evidence exists for: " + strings.Join(g.OtherRolesWithEvidence, "+") + "]"
+	} else {
+		suffix += " [NO role has evidence]"
+	}
+	return g.Table + " " + g.Privilege.String() + suffix
 }
 
 // RoleReport is the multi-role comparison result.
@@ -216,6 +368,87 @@ func evidenceSites(surface *TableSurface, p Privilege) map[string]bool {
 	return out
 }
 
+// lockEvidenceSites returns the distinct "file:line" LOCK TABLE sites for a
+// surface, so two roles' lock evidence can be compared for exclusivity exactly
+// the way per-privilege evidence is.
+func lockEvidenceSites(surface *TableSurface) map[string]bool {
+	out := map[string]bool{}
+	if surface == nil {
+		return out
+	}
+	for _, e := range surface.WriteLockEvidence {
+		out[fmt.Sprintf("%s:%d", e.File, e.Line)] = true
+	}
+	return out
+}
+
+// rolesWithEvidence names the roles OTHER than exclude that have a proven call
+// site for (table, p), sorted.
+func rolesWithEvidence(byRole map[PoolRole]RoleInput, exclude PoolRole, table string, p Privilege) []string {
+	var out []string
+	for role, other := range byRole {
+		if role == exclude {
+			continue
+		}
+		if surface := other.Derived.Tables[table]; surface != nil && surface.Privileges.Has(p) {
+			out = append(out, string(role))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// txGroupSites returns the distinct "file:line" sites contributing evidence to
+// one transaction group in a role's surface, so two roles' claim on the same
+// group can be compared for exclusivity.
+func txGroupSites(derived *DerivedSurface, group string) map[string]bool {
+	out := map[string]bool{}
+	if derived == nil {
+		return out
+	}
+	for _, surface := range derived.Tables {
+		for _, e := range surface.Evidence {
+			if e.TxGroup == group {
+				out[fmt.Sprintf("%s:%d", e.File, e.Line)] = true
+			}
+		}
+	}
+	return out
+}
+
+// exclusiveTo returns the sorted subset of mine that appears in NONE of the
+// other roles' site sets. Shared by the per-privilege and LOCK paths so both get
+// the same shared-evidence downgrade -- a second copy would let one path drift
+// into emitting blocking findings the other correctly downgrades.
+func exclusiveTo(mine map[string]bool, others []map[string]bool) []string {
+	var exclusive []string
+	for site := range mine {
+		shared := false
+		for _, otherSites := range others {
+			if otherSites[site] {
+				shared = true
+				break
+			}
+		}
+		if !shared {
+			exclusive = append(exclusive, site)
+		}
+	}
+	sort.Strings(exclusive)
+	return exclusive
+}
+
+// privilegeSetNames renders a disjunction of privileges for a message.
+func privilegeSetNames(set PrivilegeSet) string {
+	var names []string
+	for p := Privilege(0); p < numPrivileges; p++ {
+		if set.Has(p) {
+			names = append(names, p.String())
+		}
+	}
+	return strings.Join(names, "/")
+}
+
 // CompareRoles cross-checks every role's derived surface against its own
 // posture, and cross-checks the roles against each other. See this file's
 // header for exactly which of those comparisons are proofs and which are
@@ -261,7 +494,7 @@ func CompareRoles(inputs []RoleInput) (*RoleReport, error) {
 			len(in.Derived.Devirtualized), len(in.Derived.FuncValueResolved),
 		))
 		report.Findings = append(report.Findings, compareOneRole(in, byRole, rolesForPair)...)
-		report.Incomplete = append(report.Incomplete, incompleteFor(in))
+		report.Incomplete = append(report.Incomplete, incompleteFor(in, byRole))
 	}
 
 	report.Findings = append(report.Findings, transactionStraddleFindings(inputs, byRole)...)
@@ -334,23 +567,14 @@ func compareOneRole(
 			// by more than one pool, and per-role attribution is beyond this
 			// tool's (type, field) granularity -- advisory, because a hand
 			// derivation is strictly more precise there. See the file header.
-			mine := evidenceSites(surface, p)
-			exclusive := map[string]bool{}
-			for site := range mine {
-				shared := false
-				for role, other := range byRole {
-					if role == in.Role {
-						continue
-					}
-					if evidenceSites(other.Derived.Tables[table], p)[site] {
-						shared = true
-						break
-					}
+			others := make([]map[string]bool, 0, len(byRole))
+			for role, other := range byRole {
+				if role == in.Role {
+					continue
 				}
-				if !shared {
-					exclusive[site] = true
-				}
+				others = append(others, evidenceSites(other.Derived.Tables[table], p))
 			}
+			exclusive := exclusiveTo(evidenceSites(surface, p), others)
 			if len(exclusive) == 0 && len(rolesForPair[key]) > 1 {
 				findings = append(findings, Finding{
 					Severity: Advisory, Table: table, Privilege: p, Role: in.Role,
@@ -361,33 +585,62 @@ func compareOneRole(
 				})
 				continue
 			}
-			sites := make([]string, 0, len(exclusive))
-			for site := range exclusive {
-				sites = append(sites, site)
-			}
-			sort.Strings(sites)
 			findings = append(findings, Finding{
 				Severity: Critical, Table: table, Privilege: p, Role: in.Role,
 				Summary: fmt.Sprintf(
 					"role %s, table %q needs %s, proven by %d call site(s) reachable ONLY through the %s pool (%s), but this role's posture does not authorize it -- a 42501 the moment that path runs",
-					in.Role, table, p, len(exclusive), in.Role, strings.Join(firstN(sites, 3), ", ")),
+					in.Role, table, p, len(exclusive), in.Role, strings.Join(firstN(exclusive, 3), ", ")),
 				Evidence: evidenceFor(surface, p),
 			})
 		}
 
-		if surface.RequiresAnyWriteLock && !columnScoped {
-			// Postgres wants at least ONE of INSERT/UPDATE/DELETE for a LOCK
-			// TABLE mode stricter than ROW EXCLUSIVE -- any one, not a specific
-			// one. Deliberately a different shape from the FOR UPDATE / FOR
-			// SHARE row-lock clauses, which require UPDATE specifically and are
-			// modelled as an ordinary UPDATE requirement above. Both forms are
-			// modelled; do not collapse them.
-			if !required.Has(PrivInsert) && !required.Has(PrivUpdate) && !required.Has(PrivDelete) {
+		// LOCK TABLE. Postgres's demand is a DISJUNCTION over a mode-specific set
+		// (see LockRequirement in sql.go for the measured mapping), so this cannot
+		// be folded into the per-privilege loop above -- and it is a different
+		// shape again from the FOR UPDATE / FOR SHARE row-lock clauses, which
+		// require UPDATE specifically and ARE handled above as ordinary UPDATE
+		// requirements. Three distinct rules; do not collapse them.
+		if surface.LockRequirement != nil && !columnScoped {
+			requirement := *surface.LockRequirement
+			if !lockSatisfiedBy(requirement, required) {
+				// Route through the SAME shared-evidence downgrade the
+				// per-privilege path uses. Without this the lock path could emit a
+				// blocking "grant the coordinator too" for a table whose locking
+				// method only the other role actually invokes -- exactly the
+				// over-widening the downgrade exists to prevent, and the lock path
+				// has no more attribution precision than any other.
+				var otherLockSites []map[string]bool
+				othersLock := false
+				for role, other := range byRole {
+					if role == in.Role {
+						continue
+					}
+					sites := lockEvidenceSites(other.Derived.Tables[table])
+					if len(sites) > 0 {
+						othersLock = true
+					}
+					otherLockSites = append(otherLockSites, sites)
+				}
+				exclusive := exclusiveTo(lockEvidenceSites(surface), otherLockSites)
+
+				severity := Critical
+				attribution := fmt.Sprintf("proven at %d LOCK site(s) reachable ONLY through the %s pool (%s)",
+					len(exclusive), in.Role, strings.Join(firstN(exclusive, 3), ", "))
+				remedy := "a 42501 the moment that path runs"
+				if len(exclusive) == 0 && othersLock {
+					severity = Advisory
+					attribution = "but every LOCK site is SHARED with another role's derivation, so the locking method is reached through a type constructed from more than one pool"
+					remedy = fmt.Sprintf("this tool's (type, field) taint granularity cannot attribute it per role -- DO NOT widen %s's posture on this finding alone", in.Role)
+				}
+				unknown := ""
+				if requirement.Unknown {
+					unknown = " (mode UNRECOGNIZED by this analyzer, so it is assumed to be the strictest tier -- verify it by hand)"
+				}
 				findings = append(findings, Finding{
-					Severity: Critical, Table: table, Role: in.Role,
+					Severity: severity, Table: table, Role: in.Role,
 					Summary: fmt.Sprintf(
-						"role %s, table %q: LOCK TABLE in an exclusive-ish mode requires at least one of INSERT/UPDATE/DELETE, but this role's posture grants none of them",
-						in.Role, table),
+						"role %s, table %q: LOCK TABLE IN %s MODE requires at least one of %s%s, and this role's posture grants none of them; %s -- %s",
+						in.Role, table, requirement.Mode, privilegeSetNames(requirement.Satisfying), unknown, attribution, remedy),
 					Evidence: surface.WriteLockEvidence,
 				})
 			}
@@ -417,6 +670,10 @@ func compareOneRole(
 				}
 			}
 			if len(others) == 0 {
+				// Nobody has evidence for this pair. NOT discarded: it is carried
+				// by IncompleteRoleSurface.UndeclaredByEvidence with
+				// OtherRolesWithEvidence empty, which is the louder of the two
+				// cases and used to vanish from every output.
 				continue
 			}
 			sort.Strings(others)
@@ -493,16 +750,66 @@ func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInp
 			if len(elsewhere) == 0 {
 				continue
 			}
-			precision := "COARSE same-function-body grouping, so co-residency in one transaction is likely but not proven"
-			if strings.HasPrefix(group, "txorigin:") {
-				precision = "traced to a single unambiguous Begin() call site, so these statements PROVABLY share one transaction"
+
+			// A straddle is only BLOCKING when both of its premises are proven:
+			// that the statements really share one transaction, and that this
+			// transaction really runs on THIS role's pool.
+			//
+			//  - co-residency: a "txorigin:" group was traced to one unambiguous
+			//    Begin(); anything else is the coarse same-function-body fallback,
+			//    which this package's own doc comment calls unproven.
+			//  - attribution: the group's evidence must include at least one site
+			//    the other role does not also have. Otherwise the group is reached
+			//    through a type constructed from more than one pool, and the
+			//    (type, field) taint granularity cannot say whose transaction it
+			//    is -- the same limit the per-privilege and LOCK paths downgrade for.
+			//
+			// Emitting CRITICAL without both would tell maintainers to dual-grant on
+			// the strength of a guess, which is precisely the over-widening this
+			// checker refuses to do by hand.
+			traced := strings.HasPrefix(group, "txorigin:")
+			groupSites := txGroupSites(in.Derived, group)
+			var otherGroupSites []map[string]bool
+			othersHaveGroup := false
+			for role, other := range byRole {
+				if role == in.Role {
+					continue
+				}
+				sites := txGroupSites(other.Derived, group)
+				if len(sites) > 0 {
+					othersHaveGroup = true
+				}
+				otherGroupSites = append(otherGroupSites, sites)
+			}
+			exclusive := exclusiveTo(groupSites, otherGroupSites)
+			attributed := len(exclusive) > 0 || !othersHaveGroup
+
+			severity := Critical
+			var caveat string
+			switch {
+			case !traced && !attributed:
+				severity = Advisory
+				caveat = "DOWNGRADED: co-residency is only the COARSE same-function-body grouping (not proven), AND every evidence site is shared with another role so this tool cannot say whose pool runs it"
+			case !traced:
+				severity = Advisory
+				caveat = "DOWNGRADED: co-residency is only the COARSE same-function-body grouping, so these statements are not proven to share one transaction"
+			case !attributed:
+				severity = Advisory
+				caveat = fmt.Sprintf("DOWNGRADED: the transaction is traced to one Begin(), but every evidence site is SHARED with another role, so attributing it to %s is beyond this tool's (type, field) granularity", in.Role)
+			default:
+				caveat = "traced to a single unambiguous Begin() call site, so these statements PROVABLY share one transaction, and at least one evidence site is reachable only through this role's pool"
+			}
+			remedy := "A transaction cannot span two pools -- either grant these to " + string(in.Role) +
+				" too (dual-grant) or restructure the transaction. This surfaces as a 42501 at runtime, not as a routing error"
+			if severity == Advisory {
+				remedy = "Resolve from the construction site before changing any posture; do NOT dual-grant on this finding alone"
 			}
 			findings = append(findings, Finding{
-				Severity: Critical, Table: strings.Join(tables, ", "), Role: in.Role,
+				Severity: severity, Table: strings.Join(tables, ", "), Role: in.Role,
 				Summary: fmt.Sprintf(
-					"TRANSACTION STRADDLES THE ROLE PARTITION: transaction %s runs on the %s pool and touches %s, but %s not authorized for %s (%s). A transaction cannot span two pools -- either grant these to %s too (dual-grant) or restructure the transaction. This surfaces as a 42501 at runtime, not as a routing error",
+					"TRANSACTION STRADDLES THE ROLE PARTITION: transaction %s runs on the %s pool and touches %s, but %s not authorized for %s (%s). %s",
 					group, in.Role, strings.Join(tables, "+"),
-					strings.Join(elsewhere, "; "), in.Role, precision, in.Role),
+					strings.Join(elsewhere, "; "), in.Role, caveat, remedy),
 			})
 		}
 	}
@@ -525,7 +832,7 @@ func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInp
 // surface before funcvalue.go, so those are the ones worth a human's eyes.
 // Deduplicated by site, because the fixed point can reach one site by several
 // paths and a repeated line adds no information.
-func incompleteFor(in RoleInput) IncompleteRoleSurface {
+func incompleteFor(in RoleInput, byRole map[PoolRole]RoleInput) IncompleteRoleSurface {
 	out := IncompleteRoleSurface{Role: in.Role}
 	seen := map[string]bool{}
 	for _, u := range in.Derived.Unresolved {
@@ -536,7 +843,13 @@ func incompleteFor(in RoleInput) IncompleteRoleSurface {
 		// interface dispatch; everything else is a third-party sink, not a gap.
 		inModule := strings.HasPrefix(u.Callee, "github.com/full-chaos/dev-health-ops") ||
 			strings.HasPrefix(u.Callee, "(github.com/full-chaos/dev-health-ops")
-		if u.Callee != "" && !inModule {
+		// A BARE name (no package path, no receiver parens) is a call through a
+		// function-typed field or local -- in-module by construction, and the exact
+		// shape that hid the scheduler surface. An earlier version of this filter
+		// kept only empty or module-qualified callees, which dropped those records
+		// because their callee is just the field name.
+		bareName := u.Callee != "" && !strings.ContainsAny(u.Callee, ".(")
+		if u.Callee != "" && !inModule && !bareName {
 			continue
 		}
 		site := fmt.Sprintf("%s:%d", u.File, u.Line)
@@ -547,17 +860,66 @@ func incompleteFor(in RoleInput) IncompleteRoleSurface {
 		out.WiringHops = append(out.WiringHops, u)
 	}
 	out.DynamicSQL = in.Derived.Dynamic
-	for table := range in.Truth.RequiredTablePrivileges {
-		if surface := in.Derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
-			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, table)
+	for _, conflict := range in.Derived.FuncValueConflicts {
+		// In-module only. Third-party function-typed fields (encoding/json's
+		// scanner.step, pgx's QueuedQuery.Fn) are refused for the same mechanical
+		// reason but say nothing about this repo's wiring, and gating on them would
+		// drown the signal this check exists for.
+		if strings.HasPrefix(conflict.File, "..") || strings.Contains(conflict.File, "/pkg/mod/") {
+			continue
+		}
+		out.FuncValueConflicts = append(out.FuncValueConflicts, conflict)
+	}
+
+	// PAIR-granular, and computed against THIS role's own derivation. A
+	// table-level check would miss the case that matters most: SELECT still
+	// visible while the UPDATE path became unreachable leaves the table nonempty,
+	// so the (table, UPDATE) gap would appear in no output at all.
+	for table, privs := range in.Truth.RequiredTablePrivileges {
+		for p := Privilege(0); p < numPrivileges; p++ {
+			if !privs.Has(p) {
+				continue
+			}
+			surface := in.Derived.Tables[table]
+			if surface != nil && surface.Privileges.Has(p) {
+				continue
+			}
+			gap := PostureGapWithoutEvidence{
+				Table: table, Privilege: p,
+				OtherRolesWithEvidence: rolesWithEvidence(byRole, in.Role, table, p),
+			}
+			// SELECT is SYNTHESIZED onto every posture row by loadPosture, not
+			// declared, so a table the code only writes will always lack derived
+			// SELECT evidence. That is the model implying a privilege, not a blind
+			// spot, and gating it would demand acknowledgements for an artifact of
+			// our own representation. A table with NO evidence at all still counts.
+			if p == PrivSelect && surface != nil && !surface.Privileges.Empty() {
+				gap.ImpliedSelect = true
+			}
+			// A privilege that SATISFIES a derived LOCK requirement is justified by
+			// that lock, even though the per-privilege loop cannot record it (the
+			// lock's demand is a disjunction). coordinator worker_job_outbox UPDATE
+			// is exactly this: it exists for jobroute's SHARE ROW EXCLUSIVE lock.
+			if surface != nil && surface.LockRequirement != nil &&
+				surface.LockRequirement.Satisfying.Has(p) {
+				gap.JustifiedByLock = surface.LockRequirement.Mode
+			}
+			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, gap)
 		}
 	}
 	for table := range in.Truth.ColumnScopedTables {
 		if surface := in.Derived.Tables[table]; surface == nil || surface.Privileges.Empty() {
-			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, table+" (column-scoped)")
+			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, PostureGapWithoutEvidence{
+				Table: table, ColumnScoped: true,
+			})
 		}
 	}
-	sort.Strings(out.UndeclaredByEvidence)
+	sort.Slice(out.UndeclaredByEvidence, func(i, j int) bool {
+		if out.UndeclaredByEvidence[i].Table != out.UndeclaredByEvidence[j].Table {
+			return out.UndeclaredByEvidence[i].Table < out.UndeclaredByEvidence[j].Table
+		}
+		return out.UndeclaredByEvidence[i].Privilege < out.UndeclaredByEvidence[j].Privilege
+	})
 	sort.SliceStable(out.WiringHops, func(i, j int) bool {
 		if out.WiringHops[i].File != out.WiringHops[j].File {
 			return out.WiringHops[i].File < out.WiringHops[j].File

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -299,76 +299,196 @@ func PartitionBlindSpots(incomplete []IncompleteRoleSurface) (unacknowledged []s
 	return unacknowledged, stale, unreasoned
 }
 
-// GateFailures returns every reason this report must FAIL the gate, as ready-to-
-// print messages. Empty means the enforced properties all hold.
+// AdvisoryCategory names one kind of line the report can contain. Enumerated so a
+// test can assert the report still covers every one -- a category silently
+// dropped from the output is indistinguishable from a category with nothing to
+// say, which is the failure mode this whole checker exists to avoid.
+type AdvisoryCategory string
+
+const (
+	CategoryCritical         AdvisoryCategory = "CRITICAL"
+	CategoryKnownOpen        AdvisoryCategory = "KNOWN-OPEN"
+	CategoryAdvisory         AdvisoryCategory = "ADVISORY"
+	CategorySharedPair       AdvisoryCategory = "SHARED-PAIR"
+	CategoryNoEvidence       AdvisoryCategory = "POSTURE-ROW-WITHOUT-EVIDENCE"
+	CategoryDynamicSQL       AdvisoryCategory = "DYNAMIC-SQL"
+	CategoryUnparsedLock     AdvisoryCategory = "UNPARSED-LOCK"
+	CategoryFuncValue        AdvisoryCategory = "UNRESOLVED-FUNCTION-VALUE"
+	CategoryWiringHop        AdvisoryCategory = "WIRING-HOP"
+	CategoryNameSeedOverride AdvisoryCategory = "NAME-SEED-OVERRIDE"
+	CategoryAcknowledgement  AdvisoryCategory = "ACKNOWLEDGEMENT"
+	CategoryStats            AdvisoryCategory = "STATS"
+)
+
+// AllAdvisoryCategories is every category the report must be able to emit.
+var AllAdvisoryCategories = []AdvisoryCategory{
+	CategoryStats, CategoryCritical, CategoryKnownOpen, CategoryAdvisory,
+	CategorySharedPair, CategoryNoEvidence, CategoryDynamicSQL, CategoryUnparsedLock,
+	CategoryFuncValue, CategoryWiringHop, CategoryNameSeedOverride, CategoryAcknowledgement,
+}
+
+// AdvisoryLine is one reportable statement, tagged with its category.
+type AdvisoryLine struct {
+	Category AdvisoryCategory
+	Text     string
+}
+
+// AdvisoryReport returns everything this checker has to say about a report.
 //
-// It exists as a function rather than a sequence of t.Errorf loops in the test
-// because those loops were untestable: a unit test could prove a conflict reached
-// IncompleteRoleSurface, but deleting the loop that reported it left every test
-// green. The enforcement and the thing being enforced have to be reachable from
-// one assertion, or "it is gated" is a claim about test source rather than about
-// behaviour.
-func GateFailures(report *RoleReport) []string {
-	var failures []string
+// # This is a REPORT, not a gate, and that is a deliberate decision
+//
+// The coordinator surface is advisory because the blind-spot partition does not
+// exist yet. Three review rounds each found new places where THE ANALYSIS CANNOT
+// SEE SOMETHING AND THE CHECK PASSES ANYWAY -- unresolved callees, unresolved
+// interface dispatch, function-valued fields with no single target, dynamic SQL,
+// unparsed statements, non-convergence, unrecognised lock forms, quoted
+// identifiers. Each was fixed where it was found, and reappeared somewhere else.
+// That is one defect with many addresses, and the addresses were being discovered
+// one review at a time.
+//
+// An advisory tool that is sometimes wrong is useful: it puts derived evidence in
+// front of a reviewer who can weigh it. A GATE that passes when the analysis is
+// blind is worse than no gate, because it LICENSES the hand-written rows it was
+// built to check -- which is exactly how this epic produced green tickets over
+// dormant code in the first place.
+//
+// Promoting this to a gate requires the closure argument: a partition of
+// everything the analysis can fail to see, with each cell either failing the
+// check or documented as safe to accept PER SITE. Until that exists, a passing
+// coordinator check is not evidence and must not be read as any.
+//
+// Returning tagged lines from ONE function is also what makes the reporting
+// assertable. When each category was printed by its own loop in the test, a unit
+// test could prove a value reached the data structure while the loop that
+// reported it could be deleted with everything still green.
+func AdvisoryReport(report *RoleReport) []AdvisoryLine {
+	var lines []AdvisoryLine
+	add := func(category AdvisoryCategory, text string) {
+		lines = append(lines, AdvisoryLine{Category: category, Text: text})
+	}
 
-	unacknowledged, staleAcks, unreasoned := PartitionBlindSpots(report.Incomplete)
-	for _, entry := range unacknowledged {
-		failures = append(failures, "UNACKNOWLEDGED BLIND SPOT: "+entry+
-			" -- this role's posture authorizes a privilege that NO role has a derived call site for. "+
-			"Either it is an over-declaration (remove the row) or it sits inside a blind spot (add it to "+
-			"acknowledgedBlindSpots with the reason and where the justification lives). Leaving it "+
-			"unlisted is how a wrong posture row survives review")
-	}
-	for _, entry := range staleAcks {
-		failures = append(failures, fmt.Sprintf(
-			"STALE acknowledged blind spot: %s/%s %s no longer appears as an evidence-free posture row -- "+
-				"the evidence arrived or the row was removed, so this entry now suppresses nothing. DELETE "+
-				"it, or the gate stops failing if the blind spot returns",
-			entry.Role, entry.Table, entry.Privilege))
-	}
-	for _, entry := range unreasoned {
-		failures = append(failures, fmt.Sprintf(
-			"acknowledged blind spot %s/%s %s has no reason recorded; every entry must say where the "+
-				"justification lives", entry.Role, entry.Table, entry.Privilege))
+	for _, stat := range report.Stats {
+		add(CategoryStats, stat)
 	}
 
-	unackDynamic, staleDynamic, unreasonedDynamic := PartitionDynamicSQL(report.Incomplete)
-	for _, entry := range unackDynamic {
-		failures = append(failures, "UNACKNOWLEDGED DYNAMIC SQL: "+entry+
-			" -- this statement's text is not a compile-time constant, so NO table or privilege was "+
-			"derived from it. Hand-trace which tables it can reach and add it to acknowledgedDynamicSQL "+
-			"with that reasoning, or make the SQL constant. Leaving it unlisted means a write to an "+
-			"unlisted table is invisible to every check here")
+	critical, advisory := splitBySeverity(report.Findings)
+	_, accepted, _, _ := PartitionKnownOpen(critical)
+	acceptedSet := map[string]bool{}
+	for _, f := range accepted {
+		acceptedSet[f.Summary] = true
 	}
-	for _, entry := range staleDynamic {
-		failures = append(failures, "STALE acknowledged dynamic SQL: "+entry.File+
-			" no longer has a dynamic site -- the SQL became constant or the file moved, so DELETE this "+
-			"entry rather than letting it excuse a future one")
+	for _, f := range critical {
+		if acceptedSet[f.Summary] {
+			add(CategoryKnownOpen, "[ticketed, known open] "+f.Summary)
+			continue
+		}
+		add(CategoryCritical, f.Summary)
 	}
-	for _, entry := range unreasonedDynamic {
-		failures = append(failures, "acknowledged dynamic SQL "+entry.File+" has no reasoning recorded")
+	for _, f := range advisory {
+		add(CategoryAdvisory, f.Summary)
+	}
+	for _, pair := range report.SharedPairs {
+		add(CategorySharedPair, pair)
 	}
 
 	for _, surface := range report.Incomplete {
+		for _, gap := range surface.UndeclaredByEvidence {
+			add(CategoryNoEvidence, fmt.Sprintf("role %s: %s", surface.Role, gap.String()))
+		}
+		for _, site := range surface.DynamicSQL {
+			add(CategoryDynamicSQL, fmt.Sprintf(
+				"role %s: %s:%d %s -- no table or privilege could be derived from this statement",
+				surface.Role, site.File, site.Line, site.Reason))
+		}
 		for _, lock := range surface.UnparsedLocks {
-			failures = append(failures, fmt.Sprintf(
-				"UNPARSED LOCK (role %s): %s:%d %q -- this analyzer could not fully understand a LOCK "+
-					"statement, so the privilege it demands was NOT derived and its target may not appear "+
-					"in the surface at all. PostgreSQL accepts an optional TABLE keyword, multiple "+
-					"comma-separated targets, ONLY, a trailing *, an omitted mode (defaulting to ACCESS "+
-					"EXCLUSIVE) and NOWAIT; extend parseLockStatements rather than letting it pass as an absence",
+			add(CategoryUnparsedLock, fmt.Sprintf(
+				"role %s: %s:%d %q -- the privilege this LOCK demands was NOT derived, and its target "+
+					"may not appear in the surface at all",
 				surface.Role, lock.File, lock.Line, lock.Statement))
 		}
 		for _, conflict := range surface.FuncValueConflicts {
-			failures = append(failures, fmt.Sprintf(
-				"UNRESOLVED FUNCTION-VALUE CALL (role %s): %s:%d %s -- %s. Pool-tainted arguments cross "+
-					"this call and NOTHING beyond it was analyzed. Fail-closed resolution is correct, but "+
-					"it must not be silent: give the field a single implementation, or narrow the type so "+
-					"the resolver can see it",
+			add(CategoryFuncValue, fmt.Sprintf(
+				"role %s: %s:%d %s -- %s. Pool-tainted arguments cross this call and NOTHING beyond "+
+					"it was analyzed",
 				surface.Role, conflict.File, conflict.Line, conflict.Field, conflict.Reason))
 		}
+		if len(surface.WiringHops) > 0 {
+			add(CategoryWiringHop, fmt.Sprintf(
+				"role %s: %d in-module call site(s) where pool taint STOPPED -- any SQL beyond them is "+
+					"invisible to this analysis. First: %s",
+				surface.Role, len(surface.WiringHops), describeHops(surface.WiringHops, 5)))
+		}
+		for _, override := range surface.NameSeedOverrides {
+			add(CategoryNameSeedOverride, fmt.Sprintf(
+				"role %s: %s:%d parameter %q in %s is spelled for this role but its call sites pass %v "+
+					"-- call-site evidence wins, and the parameter name is misleading",
+				surface.Role, override.File, override.Line, override.Name, override.Function,
+				override.ObservedRoles))
+		}
 	}
-	return failures
+
+	// Acknowledgement bookkeeping. Under the advisory posture these no longer
+	// fail anything, but they must still be SAID: an acknowledgement that has
+	// stopped corresponding to a real gap is suppressing nothing and should be
+	// deleted, and a gap nobody has acknowledged is one nobody has looked at.
+	unacknowledged, staleAcks, unreasoned := PartitionBlindSpots(report.Incomplete)
+	for _, entry := range unacknowledged {
+		add(CategoryAcknowledgement, "UNACKNOWLEDGED posture row without evidence: "+entry+
+			" -- either an over-declaration (remove the row) or a blind spot (add it to "+
+			"acknowledgedBlindSpots with the reason and where the justification lives)")
+	}
+	for _, entry := range staleAcks {
+		add(CategoryAcknowledgement, fmt.Sprintf(
+			"STALE acknowledged blind spot: %s/%s %s no longer appears as an evidence-free posture "+
+				"row -- delete it, or it will silently excuse a future one",
+			entry.Role, entry.Table, entry.Privilege))
+	}
+	for _, entry := range unreasoned {
+		add(CategoryAcknowledgement, fmt.Sprintf(
+			"acknowledged blind spot %s/%s %s has no reason recorded",
+			entry.Role, entry.Table, entry.Privilege))
+	}
+	unackDynamic, staleDynamic, unreasonedDynamic := PartitionDynamicSQL(report.Incomplete)
+	for _, entry := range unackDynamic {
+		add(CategoryAcknowledgement, "UNACKNOWLEDGED dynamic SQL: "+entry+
+			" -- hand-trace which tables it can reach and record that, or make the SQL constant")
+	}
+	for _, entry := range staleDynamic {
+		add(CategoryAcknowledgement, "STALE acknowledged dynamic SQL: "+entry.File+
+			" no longer has a dynamic site -- delete it")
+	}
+	for _, entry := range unreasonedDynamic {
+		add(CategoryAcknowledgement, "acknowledged dynamic SQL "+entry.File+" has no reasoning recorded")
+	}
+
+	return lines
+}
+
+func describeHops(hops []UnresolvedCallSite, n int) string {
+	var parts []string
+	for i, hop := range hops {
+		if i >= n {
+			parts = append(parts, "...")
+			break
+		}
+		callee := hop.Callee
+		if callee == "" {
+			callee = "<function value>"
+		}
+		parts = append(parts, fmt.Sprintf("%s:%d %s", hop.File, hop.Line, callee))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func splitBySeverity(findings []Finding) (critical, advisory []Finding) {
+	for _, f := range findings {
+		if f.Severity == Critical {
+			critical = append(critical, f)
+		} else {
+			advisory = append(advisory, f)
+		}
+	}
+	return critical, advisory
 }
 
 // RoleInput is one role's derived surface paired with the posture it is
@@ -399,10 +519,14 @@ type IncompleteRoleSurface struct {
 	// value). These FAIL the gate: pool-tainted arguments cross them and nothing
 	// beyond was analyzed, so they are unanalyzed surface, not a known limit.
 	FuncValueConflicts []FuncValueConflictSite
-	// UnparsedLocks are LOCK statements the parser could not understand. These
-	// FAIL the gate for the same reason: the demand is real and its target may not
-	// even appear in the derived surface.
+	// UnparsedLocks are LOCK statements the parser could not understand or could
+	// not represent faithfully (including quoted targets). The demand is real and
+	// its target may not even appear in the derived surface.
 	UnparsedLocks []UnparsedLockSite
+	// NameSeedOverrides are places call-site evidence overruled a parameter's
+	// spelling. Carried here so the advisory report has ONE source for everything
+	// it prints.
+	NameSeedOverrides []NameSeedOverride
 	// UndeclaredByEvidence are the (table, privilege) PAIRS this role's posture
 	// declares that this role's derivation found no call site for. Each is either
 	// a legitimate over-declaration or a path inside a blind spot -- this tool
@@ -1040,6 +1164,7 @@ func incompleteFor(in RoleInput, byRole map[PoolRole]RoleInput) IncompleteRoleSu
 		out.FuncValueConflicts = append(out.FuncValueConflicts, conflict)
 	}
 	out.UnparsedLocks = in.Derived.UnparsedLocks
+	out.NameSeedOverrides = in.Derived.NameSeedOverrides
 
 	// PAIR-granular, and computed against THIS role's own derivation. A
 	// table-level check would miss the case that matters most: SELECT still

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -147,6 +147,78 @@ type AcknowledgedBlindSpot struct {
 	Why       string
 }
 
+// AcknowledgedDynamicSQL is one SQL-execution site whose statement text is not a
+// compile-time constant, reviewed and accepted.
+//
+// These must be gated, not merely logged. PartitionBlindSpots only inspects
+// privileges ALREADY in a posture, so a runtime-built query that starts writing a
+// table absent from every posture produces no derived pair AND no posture-gap
+// tuple -- nothing anywhere reports it, and the gate stays green until a 42501.
+// The set is small and slow-changing, so acknowledging each one by site is
+// tractable; a NEW dynamic-SQL site fails until someone looks at it.
+type AcknowledgedDynamicSQL struct {
+	File string
+	Why  string
+}
+
+// acknowledgedDynamicSQL is the reviewed set, keyed by file because line numbers
+// move for unrelated reasons and a churning acknowledgement gets ignored.
+var acknowledgedDynamicSQL = []AcknowledgedDynamicSQL{
+	{
+		File: "internal/providerfoundation/repository_postgres.go",
+		Why: "builds its integration_credentials query by runtime string concatenation " +
+			"(`query := literal; if ... { query += ... }`). Hand-traced in " +
+			"grant-surface-derivation.md: the reachable variants read integration_credentials " +
+			"only, which the domain posture already grants SELECT on.",
+	},
+	{
+		File: "internal/scheduler/sync/transaction.go",
+		Why: "assembles the handoff statement from named constants chosen by ownership policy. " +
+			"Both variants target scheduled_jobs/scheduled_sync_occurrences/sync_configurations, " +
+			"which the coordinator posture already declares (and which the non-dynamic sites in " +
+			"the same package independently prove).",
+	},
+	{
+		File: "internal/syncroute/control.go",
+		Why: "builds a route-record read whose column list varies. Its table, " +
+			"sync_dispatch_transport_routes, is proven by the constant-SQL sites in the same " +
+			"controller, so the dynamic variant adds no new table.",
+	},
+}
+
+// PartitionDynamicSQL splits dynamic-SQL sites into acknowledged and not, and
+// reports acknowledgements that no longer correspond to a real site. Same
+// self-cleaning discipline as the other two lists.
+func PartitionDynamicSQL(incomplete []IncompleteRoleSurface) (unacknowledged []string, stale []AcknowledgedDynamicSQL, unreasoned []AcknowledgedDynamicSQL) {
+	seen := make([]bool, len(acknowledgedDynamicSQL))
+	for _, surface := range incomplete {
+		for _, site := range surface.DynamicSQL {
+			matched := false
+			for i, ack := range acknowledgedDynamicSQL {
+				if ack.File == site.File {
+					seen[i] = true
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				unacknowledged = append(unacknowledged,
+					fmt.Sprintf("%s: %s:%d %s", surface.Role, site.File, site.Line, site.Reason))
+			}
+		}
+	}
+	for i, ack := range acknowledgedDynamicSQL {
+		if strings.TrimSpace(ack.Why) == "" {
+			unreasoned = append(unreasoned, ack)
+		}
+		if !seen[i] {
+			stale = append(stale, ack)
+		}
+	}
+	sort.Strings(unacknowledged)
+	return unacknowledged, stale, unreasoned
+}
+
 // acknowledgedBlindSpots is the reviewed set. Every entry is a posture row whose
 // justification lives OUTSIDE this tool's reach; each says where.
 var acknowledgedBlindSpots = []AcknowledgedBlindSpot{
@@ -225,6 +297,78 @@ func PartitionBlindSpots(incomplete []IncompleteRoleSurface) (unacknowledged []s
 	}
 	sort.Strings(unacknowledged)
 	return unacknowledged, stale, unreasoned
+}
+
+// GateFailures returns every reason this report must FAIL the gate, as ready-to-
+// print messages. Empty means the enforced properties all hold.
+//
+// It exists as a function rather than a sequence of t.Errorf loops in the test
+// because those loops were untestable: a unit test could prove a conflict reached
+// IncompleteRoleSurface, but deleting the loop that reported it left every test
+// green. The enforcement and the thing being enforced have to be reachable from
+// one assertion, or "it is gated" is a claim about test source rather than about
+// behaviour.
+func GateFailures(report *RoleReport) []string {
+	var failures []string
+
+	unacknowledged, staleAcks, unreasoned := PartitionBlindSpots(report.Incomplete)
+	for _, entry := range unacknowledged {
+		failures = append(failures, "UNACKNOWLEDGED BLIND SPOT: "+entry+
+			" -- this role's posture authorizes a privilege that NO role has a derived call site for. "+
+			"Either it is an over-declaration (remove the row) or it sits inside a blind spot (add it to "+
+			"acknowledgedBlindSpots with the reason and where the justification lives). Leaving it "+
+			"unlisted is how a wrong posture row survives review")
+	}
+	for _, entry := range staleAcks {
+		failures = append(failures, fmt.Sprintf(
+			"STALE acknowledged blind spot: %s/%s %s no longer appears as an evidence-free posture row -- "+
+				"the evidence arrived or the row was removed, so this entry now suppresses nothing. DELETE "+
+				"it, or the gate stops failing if the blind spot returns",
+			entry.Role, entry.Table, entry.Privilege))
+	}
+	for _, entry := range unreasoned {
+		failures = append(failures, fmt.Sprintf(
+			"acknowledged blind spot %s/%s %s has no reason recorded; every entry must say where the "+
+				"justification lives", entry.Role, entry.Table, entry.Privilege))
+	}
+
+	unackDynamic, staleDynamic, unreasonedDynamic := PartitionDynamicSQL(report.Incomplete)
+	for _, entry := range unackDynamic {
+		failures = append(failures, "UNACKNOWLEDGED DYNAMIC SQL: "+entry+
+			" -- this statement's text is not a compile-time constant, so NO table or privilege was "+
+			"derived from it. Hand-trace which tables it can reach and add it to acknowledgedDynamicSQL "+
+			"with that reasoning, or make the SQL constant. Leaving it unlisted means a write to an "+
+			"unlisted table is invisible to every check here")
+	}
+	for _, entry := range staleDynamic {
+		failures = append(failures, "STALE acknowledged dynamic SQL: "+entry.File+
+			" no longer has a dynamic site -- the SQL became constant or the file moved, so DELETE this "+
+			"entry rather than letting it excuse a future one")
+	}
+	for _, entry := range unreasonedDynamic {
+		failures = append(failures, "acknowledged dynamic SQL "+entry.File+" has no reasoning recorded")
+	}
+
+	for _, surface := range report.Incomplete {
+		for _, lock := range surface.UnparsedLocks {
+			failures = append(failures, fmt.Sprintf(
+				"UNPARSED LOCK (role %s): %s:%d %q -- this analyzer could not fully understand a LOCK "+
+					"statement, so the privilege it demands was NOT derived and its target may not appear "+
+					"in the surface at all. PostgreSQL accepts an optional TABLE keyword, multiple "+
+					"comma-separated targets, ONLY, a trailing *, an omitted mode (defaulting to ACCESS "+
+					"EXCLUSIVE) and NOWAIT; extend parseLockStatements rather than letting it pass as an absence",
+				surface.Role, lock.File, lock.Line, lock.Statement))
+		}
+		for _, conflict := range surface.FuncValueConflicts {
+			failures = append(failures, fmt.Sprintf(
+				"UNRESOLVED FUNCTION-VALUE CALL (role %s): %s:%d %s -- %s. Pool-tainted arguments cross "+
+					"this call and NOTHING beyond it was analyzed. Fail-closed resolution is correct, but "+
+					"it must not be silent: give the field a single implementation, or narrow the type so "+
+					"the resolver can see it",
+				surface.Role, conflict.File, conflict.Line, conflict.Field, conflict.Reason))
+		}
+	}
+	return failures
 }
 
 // RoleInput is one role's derived surface paired with the posture it is
@@ -767,6 +911,29 @@ func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInp
 			// Emitting CRITICAL without both would tell maintainers to dual-grant on
 			// the strength of a guess, which is precisely the over-widening this
 			// checker refuses to do by hand.
+			// DECISION: a straddle is never BLOCKING, because co-residency is
+			// inferred rather than proven at either precision.
+			//
+			// A "txorigin:" group means every statement's pgx.Tx traced back to the
+			// same Begin() SOURCE POSITION. That is a fact about where the handle
+			// came from, not about what executes: buildTxOrigins does no
+			// control-flow analysis, so two MUTUALLY EXCLUSIVE branches after one
+			// Begin -- an if/else, an early return, a switch -- carry the same
+			// origin and are reported as one transaction touching both sides of the
+			// partition. Calling that "proven" was wrong, and a premise labelled
+			// proven is worse than one labelled inferred because nobody re-checks it.
+			//
+			// Downgrading rather than doing the path analysis, for the same reason
+			// the remaining_metric_* over-approximation is advisory: this finding
+			// can only push a posture WIDER (dual-grant these tables), and an
+			// over-grant emitted on an inference is exactly what the two-role split
+			// exists to prevent. The blocking signal is not lost -- a table genuinely
+			// missing from the executing role's posture still produces its own
+			// per-privilege CRITICAL when its evidence is role-exclusive. What is
+			// lost is only the transaction FRAMING, which is a review aid.
+			//
+			// The traced/coarse distinction is still reported, because it tells a
+			// reader how much weight the grouping carries.
 			traced := strings.HasPrefix(group, "txorigin:")
 			groupSites := txGroupSites(in.Derived, group)
 			var otherGroupSites []map[string]bool
@@ -787,32 +954,31 @@ func transactionStraddleFindings(inputs []RoleInput, byRole map[PoolRole]RoleInp
 			exclusive := exclusiveTo(groupSites, otherGroupSites)
 			attributed := len(exclusive) > 0
 
-			severity := Critical
-			var caveat string
-			switch {
-			case !traced && !attributed:
-				severity = Advisory
-				caveat = "DOWNGRADED: co-residency is only the COARSE same-function-body grouping (not proven), AND every evidence site is shared with another role so this tool cannot say whose pool runs it"
-			case !traced:
-				severity = Advisory
-				caveat = "DOWNGRADED: co-residency is only the COARSE same-function-body grouping, so these statements are not proven to share one transaction"
-			case !attributed:
-				severity = Advisory
-				caveat = fmt.Sprintf("DOWNGRADED: the transaction is traced to one Begin(), but every evidence site is SHARED with another role, so attributing it to %s is beyond this tool's (type, field) granularity", in.Role)
-			default:
-				caveat = "traced to a single unambiguous Begin() call site, so these statements PROVABLY share one transaction, and at least one evidence site is reachable only through this role's pool"
+			// ALWAYS Advisory. The two axes below describe how much the grouping is
+			// worth, not whether it blocks.
+			var coResidency string
+			if traced {
+				coResidency = "every statement's pgx.Tx traced to the same Begin() SOURCE POSITION -- " +
+					"which is where the handle came from, NOT proof that these statements co-execute: " +
+					"mutually exclusive branches after one Begin share this origin"
+			} else {
+				coResidency = "grouped only by the COARSE same-function-body fallback, so co-residency is a guess"
 			}
-			remedy := "A transaction cannot span two pools -- either grant these to " + string(in.Role) +
-				" too (dual-grant) or restructure the transaction. This surfaces as a 42501 at runtime, not as a routing error"
-			if severity == Advisory {
-				remedy = "Resolve from the construction site before changing any posture; do NOT dual-grant on this finding alone"
+			attribution := "at least one evidence site is reachable only through this role's pool"
+			if !attributed {
+				attribution = fmt.Sprintf("every evidence site is SHARED with another role, so attributing "+
+					"the transaction to %s is beyond this tool's (type, field) granularity", in.Role)
 			}
 			findings = append(findings, Finding{
-				Severity: severity, Table: strings.Join(tables, ", "), Role: in.Role,
+				Severity: Advisory, Table: strings.Join(tables, ", "), Role: in.Role,
 				Summary: fmt.Sprintf(
-					"TRANSACTION STRADDLES THE ROLE PARTITION: transaction %s runs on the %s pool and touches %s, but %s not authorized for %s (%s). %s",
+					"POSSIBLE TRANSACTION STRADDLE (advisory -- co-residency is inferred, never proven): group %s "+
+						"appears to run on the %s pool and touch %s, but %s not authorized for %s. Co-residency: %s. "+
+						"Attribution: %s. A transaction cannot span two pools, so IF these really do co-execute the "+
+						"options are dual-grant or restructure -- but confirm from the source before changing any "+
+						"posture, because this finding can only widen one",
 					group, in.Role, strings.Join(tables, "+"),
-					strings.Join(elsewhere, "; "), in.Role, caveat, remedy),
+					strings.Join(elsewhere, "; "), in.Role, coResidency, attribution),
 			})
 		}
 	}
@@ -900,13 +1066,28 @@ func incompleteFor(in RoleInput, byRole map[PoolRole]RoleInput) IncompleteRoleSu
 			if p == PrivSelect && surface != nil && !surface.Privileges.Empty() {
 				gap.ImpliedSelect = true
 			}
-			// A privilege that SATISFIES a derived LOCK requirement is justified by
-			// that lock, even though the per-privilege loop cannot record it (the
-			// lock's demand is a disjunction). coordinator worker_job_outbox UPDATE
-			// is exactly this: it exists for jobroute's SHARE ROW EXCLUSIVE lock.
+			// A privilege that SATISFIES a derived LOCK is justified by that lock,
+			// even though the per-privilege loop cannot record it (the demand is a
+			// disjunction). coordinator worker_job_outbox UPDATE is exactly this: it
+			// exists for jobroute's SHARE ROW EXCLUSIVE lock.
+			//
+			// But ONLY when it is the SOLE satisfying privilege the posture holds. A
+			// disjunction needs exactly one member; if the posture grants two, one of
+			// them is redundant. Excusing every satisfying privilege -- as an earlier
+			// version did -- meant a posture holding both UPDATE and DELETE had BOTH
+			// evidence-free gaps waved through, preserving a redundant over-grant
+			// that nothing else would ever report.
 			if surface != nil && surface.LockRequirement != nil &&
 				surface.LockRequirement.Satisfying.Has(p) {
-				gap.JustifiedByLock = surface.LockRequirement.Mode
+				held := 0
+				for q := Privilege(0); q < numPrivileges; q++ {
+					if surface.LockRequirement.Satisfying.Has(q) && privs.Has(q) {
+						held++
+					}
+				}
+				if held == 1 {
+					gap.JustifiedByLock = surface.LockRequirement.Mode
+				}
 			}
 			out.UndeclaredByEvidence = append(out.UndeclaredByEvidence, gap)
 		}

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -354,8 +354,9 @@ type AdvisoryLine struct {
 //
 // Promoting this to a gate requires the closure argument: a partition of
 // everything the analysis can fail to see, with each cell either failing the
-// check or documented as safe to accept PER SITE. Until that exists, a passing
-// coordinator check is not evidence and must not be read as any.
+// check or documented as safe to accept PER SITE. Tracked as CHAOS-3164. Until
+// that exists, a passing coordinator check is not evidence and must not be read
+// as any.
 //
 // Returning tagged lines from ONE function is also what makes the reporting
 // assertable. When each category was printed by its own loop in the test, a unit

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -17,13 +17,13 @@ import (
 // would license exactly the hand-written rows the gate exists to adjudicate:
 //
 //   - PROVABLE, and reported CRITICAL: real code on role R's pool executes a
-//     statement R's posture does not authorize. Under-approximation cuts the
-//     other way here -- if the analyzer sees the call site, the call site is
-//     real.
-//   - PROVABLE, and reported CRITICAL: a (table, privilege) with evidence on
-//     BOTH pools that is missing from EITHER posture. This is the derived
-//     dual-grant check, and it replaces a hand-maintained shared-table
-//     whitelist with a computed property of the evidence.
+//     statement R's posture does not authorize, where at least one proving call
+//     site is reachable ONLY through R's pool. Under-approximation cuts the safe
+//     way here -- if the analyzer sees the call site, the call site is real.
+//   - NOT PROVABLE, reported ADVISORY: a (table, privilege) missing from a
+//     posture whose every proving site is SHARED with another role. See the
+//     granularity note below -- this is the one place a finding can be wrong in
+//     the WIDENING direction, so it must not be a CRITICAL.
 //   - NOT PROVABLE HERE, reported ADVISORY: "role B must not hold X." The
 //     derivation is a sound-but-INCOMPLETE under-approximation, so "B has no
 //     evidence for X" never implies "B does not need X" -- it may simply be a
@@ -162,10 +162,25 @@ type IncompleteRoleSurface struct {
 type RoleReport struct {
 	Findings   []Finding
 	Incomplete []IncompleteRoleSurface
-	// SharedPairs are the (table, privilege) pairs with proven call sites on
-	// more than one pool -- the DERIVED dual-grant set. Every one of these
-	// legitimately appears in more than one posture and must not be read as a
-	// leak.
+	// SharedPairs are the (table, privilege) pairs with proven call sites on more
+	// than one pool. It is a REVIEWABLE SIGNAL, deliberately not a drop-in
+	// replacement for the role-partition manifest's hand-maintained dual-grant
+	// whitelist, and three differences matter before anyone treats it as one:
+	//
+	//  1. It is PAIR-level, the whitelist is TABLE-level. A table granted to both
+	//     roles with DIFFERENT privileges (sync_dispatch_transport_routes: domain
+	//     SELECT, coordinator UPDATE) is a shared TABLE but has no shared PAIR, so
+	//     it does not appear here.
+	//  2. It cannot distinguish a genuine dual-grant from a dual-constructed-type
+	//     artifact. remaining_metric_runs/partitions appear here only because
+	//     PostgresStore.pool is fed both pools, not because both roles run every
+	//     statement -- see the granularity note in this file's header.
+	//  3. It inherits the derivation's blind spots. `organizations` is a real
+	//     dual-grant that does NOT appear here, because the coordinator side has no
+	//     derived evidence (it is in IncompleteRoleSurface instead).
+	//
+	// So: useful for review, and it makes the shared set visible and checkable
+	// rather than purely asserted. Not authoritative on its own.
 	SharedPairs []string
 	Stats       []string
 }

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -395,17 +395,48 @@ func AdvisoryReport(report *RoleReport) []AdvisoryLine {
 	}
 
 	critical, advisory := splitBySeverity(report.Findings)
-	_, accepted, _, _ := PartitionKnownOpen(critical)
-	acceptedSet := map[string]bool{}
+	_, accepted, staleKnownOpen, unticketed := PartitionKnownOpen(critical)
+
+	// The ENTIRE lifecycle must be reported, not just the accepted set. An earlier
+	// version discarded stale and unticketed and labelled accepted entries with a
+	// generic "[ticketed, known open]" that named neither ticket nor reason -- so
+	// the claim "expiry is suspended but still reported" was false for two of the
+	// three properties, and an entry with an EMPTY ticket was presented as ticketed.
+	// That is the same stale-claim defect as the doc comments, in behaviour rather
+	// than prose, and it is worse: prose can be re-read, a dropped code path cannot.
+	acceptedByTicket := map[string]KnownOpenCritical{}
 	for _, f := range accepted {
-		acceptedSet[f.Summary] = true
+		for _, known := range knownOpenCriticals {
+			if known.matches(f) {
+				acceptedByTicket[f.Summary] = known
+				break
+			}
+		}
 	}
 	for _, f := range critical {
-		if acceptedSet[f.Summary] {
-			add(CategoryKnownOpen, "[ticketed, known open] "+f.Summary)
+		if known, isAccepted := acceptedByTicket[f.Summary]; isAccepted {
+			ticket := known.Ticket
+			if strings.TrimSpace(ticket) == "" {
+				ticket = "NO TICKET RECORDED -- this entry names no owner and cannot be tracked"
+			}
+			add(CategoryKnownOpen, fmt.Sprintf("[%s] %s\n        accepted because: %s",
+				ticket, f.Summary, known.Why))
 			continue
 		}
 		add(CategoryCritical, f.Summary)
+	}
+	for _, entry := range staleKnownOpen {
+		add(CategoryKnownOpen, fmt.Sprintf(
+			"STALE: %s/%s %s (%s) no longer reproduces. Under gating this would have FAILED and forced "+
+				"its own deletion; expiry is suspended, so it will sit here indefinitely until someone "+
+				"removes it. If the defect regresses it would be silently re-accepted under this same "+
+				"entry rather than reported as new",
+			entry.Role, entry.Table, entry.Privilege, entry.Ticket))
+	}
+	for _, entry := range unticketed {
+		add(CategoryKnownOpen, fmt.Sprintf(
+			"NO TICKET: %s/%s %s is accepted as known-open but names no ticket, so nothing tracks its fix",
+			entry.Role, entry.Table, entry.Privilege))
 	}
 	for _, f := range advisory {
 		add(CategoryAdvisory, f.Summary)

--- a/internal/domaingrants/sql.go
+++ b/internal/domaingrants/sql.go
@@ -84,17 +84,125 @@ type StatementResult struct {
 	// NOT to attribute to a public-schema table (e.g. the River schema) --
 	// kept for diagnostics, never compared against required_table_privileges.
 	NonPublicTables map[string]bool
-	// RequiresAnyWriteLock lists tables LOCK TABLE'd in a mode stricter than
-	// ROW EXCLUSIVE (e.g. SHARE ROW EXCLUSIVE), which per Postgres docs
-	// requires at least one of INSERT/UPDATE/DELETE/TRUNCATE -- NOT
-	// specifically UPDATE. This is intentionally NOT folded into
-	// PrivilegeSet.PrivUpdate: doing so produced a real false positive
-	// (internal/jobroute/control.go's `LOCK TABLE worker_job_outbox IN
-	// SHARE ROW EXCLUSIVE MODE` is already satisfied by the existing
-	// SELECT+INSERT grant; Postgres never requires UPDATE specifically
-	// here). The comparator checks this against the granted set directly
-	// (any of I/U/D satisfies it) instead of comparing a single privilege.
-	RequiresAnyWriteLock map[string]bool
+	// LockRequirements maps a table to the privilege demand its strictest
+	// explicit LOCK TABLE places on it. Absent means no LOCK, or only ACCESS
+	// SHARE (which SELECT alone satisfies). See LockRequirement.
+	LockRequirements map[string]LockRequirement
+}
+
+// LockRequirement is the privilege demand one LOCK TABLE mode places on its
+// target: any ONE privilege in Satisfying permits the lock.
+//
+// This is NOT foldable into PrivilegeSet, because Postgres's demand here is a
+// disjunction ("any one of these") while every PrivilegeSet entry is an
+// independent requirement. Folding UPDATE in produced a real false positive on
+// jobroute's SELECT+INSERT grant when the mode was ROW EXCLUSIVE.
+type LockRequirement struct {
+	// Mode is the normalized lock mode, e.g. "SHARE ROW EXCLUSIVE".
+	Mode string
+	// Satisfying holds the privileges any one of which permits this mode.
+	Satisfying PrivilegeSet
+	// rank orders modes by strictness so the strictest LOCK on a table wins
+	// when a statement (or several) locks it more than once.
+	rank int
+	// Unknown marks a mode string this analyzer does not recognize. Such a mode
+	// is treated as the STRICTEST tier and reported, so a future PostgreSQL lock
+	// mode fails closed rather than silently requiring nothing.
+	Unknown bool
+}
+
+// Lock-mode strictness tiers, MEASURED against PostgreSQL 18.4
+// (server_version_num 180004) rather than read off the documentation, because
+// the documentation is wrong about one of them.
+//
+// Measured one grant set per candidate privilege, one query per lock mode, WITH
+// the two controls that isolate each denial to the lock clause. Without the
+// controls a DENIED cell is a denial plus a guess about its cause; C2 is the row
+// that makes the attribution real, because it is the identical statement with
+// only the lock clause removed.
+//
+//	STATEMENT                    SELECT  +INSERT  +UPDATE  +DELETE
+//	C1 empty tx (control)        ok      ok       ok       ok
+//	C2 read, NO lock (control)   ok      ok       ok       ok
+//	ACCESS SHARE                 ok      ok       ok       ok
+//	ROW SHARE                    DENIED  ok       ok       ok
+//	ROW EXCLUSIVE                DENIED  ok       ok       ok
+//	SHARE UPDATE EXCLUSIVE       DENIED  DENIED   ok       ok
+//	SHARE                        DENIED  DENIED   ok       ok
+//	SHARE ROW EXCLUSIVE          DENIED  DENIED   ok       ok
+//	EXCLUSIVE                    DENIED  DENIED   ok       ok
+//	ACCESS EXCLUSIVE             DENIED  DENIED   ok       ok
+//
+// (TRUNCATE and MAINTAIN were also measured and behave like UPDATE/DELETE.)
+//
+// Two things that table settles, both of which a from-memory reading gets wrong:
+//
+//   - INSERT satisfies ROW SHARE and ROW EXCLUSIVE, and NOTHING stricter. The
+//     earlier model here was a single boolean satisfied by any of I/U/D, so a
+//     posture holding only SELECT+INSERT passed a SHARE ROW EXCLUSIVE lock and
+//     returned 42501 at runtime. That is the CHAOS-3113 defect family exactly.
+//   - ROW SHARE requires a write privilege. The PostgreSQL LOCK documentation
+//     states ROW SHARE needs only SELECT; on 18.4 it does not. Measured, not
+//     assumed -- which is the whole reason this table exists.
+//
+// TRUNCATE and MAINTAIN also satisfy the stricter tiers, but rolePostureQuery
+// asserts both are ABSENT for every runtime role, so they can never be the thing
+// that satisfies a lock here. They are deliberately omitted from Satisfying: a
+// role that held one would already have failed its posture check for a different
+// and louder reason.
+const (
+	lockRankSelectOnly     = iota // ACCESS SHARE
+	lockRankAnyWrite              // ROW SHARE, ROW EXCLUSIVE
+	lockRankUpdateOrDelete        // everything stricter
+)
+
+func lockSatisfyingSet(rank int) PrivilegeSet {
+	var set PrivilegeSet
+	switch rank {
+	case lockRankAnyWrite:
+		set.add(PrivInsert)
+		set.add(PrivUpdate)
+		set.add(PrivDelete)
+	case lockRankUpdateOrDelete:
+		set.add(PrivUpdate)
+		set.add(PrivDelete)
+	}
+	return set
+}
+
+// lockRequirementForMode maps a LOCK TABLE mode to its privilege demand, per the
+// measured table above. The second result is false when SELECT alone suffices
+// (ACCESS SHARE), meaning there is nothing extra to record.
+//
+// An UNRECOGNIZED mode is deliberately treated as the strictest tier and flagged
+// Unknown. This replaced two successively-wrong predicates: first a substring
+// test for "EXCLUSIVE" (which failed open on bare SHARE and ROW SHARE, neither of
+// which contains that word), then a "not ACCESS SHARE" test (which failed open on
+// INSERT-only postures under strict modes). Both failed OPEN, which is the
+// under-attribution this package exists to catch -- so the unknown case now fails
+// closed and says so.
+func lockRequirementForMode(mode string) (LockRequirement, bool) {
+	normalized := strings.TrimSpace(strings.ToUpper(mode))
+	normalized = lockModeWhitespaceRE.ReplaceAllString(normalized, " ")
+	switch normalized {
+	case "ACCESS SHARE":
+		return LockRequirement{}, false
+	case "ROW SHARE", "ROW EXCLUSIVE":
+		return LockRequirement{
+			Mode: normalized, Satisfying: lockSatisfyingSet(lockRankAnyWrite), rank: lockRankAnyWrite,
+		}, true
+	case "SHARE UPDATE EXCLUSIVE", "SHARE", "SHARE ROW EXCLUSIVE", "EXCLUSIVE", "ACCESS EXCLUSIVE":
+		return LockRequirement{
+			Mode: normalized, Satisfying: lockSatisfyingSet(lockRankUpdateOrDelete), rank: lockRankUpdateOrDelete,
+		}, true
+	default:
+		return LockRequirement{
+			Mode:       normalized,
+			Satisfying: lockSatisfyingSet(lockRankUpdateOrDelete),
+			rank:       lockRankUpdateOrDelete,
+			Unknown:    true,
+		}, true
+	}
 }
 
 var (
@@ -272,31 +380,6 @@ func findFromJoinWithAliases(sql string, ctes map[string]bool, nonPublic map[str
 // internal/providersync/repository_postgres.go's claimUnitSQL, which joins
 // integrations/integration_sources/integration_datasets read-only alongside
 // a `FOR UPDATE OF unit` lock on sync_run_units.
-// lockModeRequiresWritePrivilege reports whether an explicit LOCK TABLE in the
-// given mode needs a write privilege on the target, per the PostgreSQL LOCK
-// documentation: ACCESS SHARE requires only SELECT, ROW EXCLUSIVE requires
-// INSERT/UPDATE/DELETE/TRUNCATE, and every other mode requires
-// UPDATE/DELETE/TRUNCATE. So the predicate is simply "not ACCESS SHARE".
-//
-// This replaced a substring test for "EXCLUSIVE", which failed open on exactly
-// the modes hardest to reason about: bare SHARE MODE and ROW SHARE MODE both
-// require a write privilege and contain no "EXCLUSIVE", so a LOCK in either
-// mode passed the grant-surface gate unflagged. That is the under-attribution
-// this package exists to catch, and the FOR UPDATE branch above states the
-// standard — a false negative is worse than a false positive here.
-//
-// Known remaining imprecision, deliberately not modelled: ROW EXCLUSIVE is
-// satisfied by INSERT alone, while stricter modes are not. RequiresAnyWriteLock
-// is one boolean, so a table holding only INSERT and locked in a stricter mode
-// is not reported. Every LOCK TABLE in this repository is SHARE ROW EXCLUSIVE,
-// so distinguishing the two would add a second field for no present caller;
-// recording the gap here is better than implying precision that is absent.
-func lockModeRequiresWritePrivilege(mode string) bool {
-	normalized := strings.TrimSpace(strings.ToUpper(mode))
-	normalized = lockModeWhitespaceRE.ReplaceAllString(normalized, " ")
-	return normalized != "ACCESS SHARE"
-}
-
 func resolveForUpdateOf(clean string, selectTables []string, aliasToTable map[string]string, add func(string, Privilege)) {
 	m := forUpdateOfRE.FindStringSubmatch(clean)
 	if m == nil {
@@ -340,9 +423,9 @@ func ParseStatement(sql string) StatementResult {
 	clean := stripComments(sql)
 	ctes := cteNames(clean)
 	result := StatementResult{
-		Tables:               map[string]PrivilegeSet{},
-		NonPublicTables:      map[string]bool{},
-		RequiresAnyWriteLock: map[string]bool{},
+		Tables:           map[string]PrivilegeSet{},
+		NonPublicTables:  map[string]bool{},
+		LockRequirements: map[string]LockRequirement{},
 	}
 
 	add := func(table string, p Privilege) {
@@ -388,10 +471,11 @@ func ParseStatement(sql string) StatementResult {
 	// false positive here.
 	resolveForUpdateOf(clean, selectTables, aliasToTable, add)
 
-	// LOCK TABLE ... IN <mode> MODE: SELECT is always required; every mode
-	// except ACCESS SHARE additionally requires at least one of
-	// INSERT/UPDATE/DELETE/TRUNCATE (see RequiresAnyWriteLock's doc
-	// comment for why this is not simply added as PrivUpdate).
+	// LOCK TABLE ... IN <mode> MODE: SELECT is always required, and every mode
+	// except ACCESS SHARE additionally requires ONE OF a mode-specific set --
+	// see lockRequirementForMode for the measured mapping and why the demand is
+	// a disjunction rather than a PrivilegeSet entry. When a table is locked
+	// more than once, the STRICTEST mode wins.
 	for _, m := range lockTableRE.FindAllStringSubmatch(clean, -1) {
 		table, inScope := splitSchemaQualified(m[1])
 		table = strings.ToLower(table)
@@ -399,9 +483,14 @@ func ParseStatement(sql string) StatementResult {
 			continue
 		}
 		add(table, PrivSelect)
-		if lockModeRequiresWritePrivilege(m[2]) {
-			result.RequiresAnyWriteLock[table] = true
+		requirement, needsMore := lockRequirementForMode(m[2])
+		if !needsMore {
+			continue
 		}
+		if existing, ok := result.LockRequirements[table]; ok && existing.rank >= requirement.rank {
+			continue
+		}
+		result.LockRequirements[table] = requirement
 	}
 
 	return result

--- a/internal/domaingrants/sql.go
+++ b/internal/domaingrants/sql.go
@@ -88,121 +88,131 @@ type StatementResult struct {
 	// explicit LOCK TABLE places on it. Absent means no LOCK, or only ACCESS
 	// SHARE (which SELECT alone satisfies). See LockRequirement.
 	LockRequirements map[string]LockRequirement
+	// UnparsedLocks is the verbatim text of every LOCK statement this parser
+	// could not fully understand, including any with an unrecognised mode. These
+	// are REPORTED and FAIL the gate: an unparsed LOCK may demand a privilege on
+	// a table that never appears in the derived surface at all, so swallowing it
+	// is a silent hole rather than a known limitation.
+	UnparsedLocks []string
 }
 
-// LockRequirement is the privilege demand one LOCK TABLE mode places on its
-// target: any ONE privilege in Satisfying permits the lock.
+// LockRequirement is the privilege demand one LOCK mode places on its target:
+// any ONE privilege in Satisfying permits the lock.
 //
-// This is NOT foldable into PrivilegeSet, because Postgres's demand here is a
-// disjunction ("any one of these") while every PrivilegeSet entry is an
-// independent requirement. Folding UPDATE in produced a real false positive on
-// jobroute's SELECT+INSERT grant when the mode was ROW EXCLUSIVE.
+// It is a DISJUNCTION, and that is the whole shape. It is not "SELECT and a
+// write privilege", and it is not foldable into PrivilegeSet, where every member
+// is an independent requirement.
 type LockRequirement struct {
 	// Mode is the normalized lock mode, e.g. "SHARE ROW EXCLUSIVE".
 	Mode string
 	// Satisfying holds the privileges any one of which permits this mode.
 	Satisfying PrivilegeSet
-	// rank orders modes by strictness so the strictest LOCK on a table wins
-	// when a statement (or several) locks it more than once.
+	// rank orders modes by strictness so the strictest LOCK on a table wins when
+	// a table is locked more than once.
 	rank int
-	// Unknown marks a mode string this analyzer does not recognize. Such a mode
-	// is treated as the STRICTEST tier and reported, so a future PostgreSQL lock
-	// mode fails closed rather than silently requiring nothing.
-	Unknown bool
 }
 
-// Lock-mode strictness tiers, MEASURED against PostgreSQL 18.4
-// (server_version_num 180004) rather than read off the documentation, because
-// the documentation is wrong about one of them.
+// The lock model, DERIVED FROM THE BACKEND'S OWN ACL CHECK rather than
+// reconstructed from prose. Three previous attempts each got a different part
+// wrong (a substring test that failed open on bare SHARE; a boolean satisfied by
+// any write privilege, which passed SELECT+INSERT against SHARE ROW EXCLUSIVE;
+// and a conjunction with SELECT that over-granted every lock-only path), so this
+// stops paraphrasing the documentation and encodes the structure of
+// LockTableAclCheck (src/backend/commands/lockcmds.c) directly:
 //
-// Measured one grant set per candidate privilege, one query per lock mode, WITH
-// the two controls that isolate each denial to the lock clause. Without the
-// controls a DENIED cell is a denial plus a guess about its cause; C2 is the row
-// that makes the attribution real, because it is the identical statement with
-// only the lock clause removed.
+//	aclmask =  (mode == AccessShareLock)      ? ACL_SELECT
+//	        : ((mode <= RowExclusiveLock)     ? ACL_INSERT : 0)
+//	aclmask |= ACL_UPDATE | ACL_DELETE | ACL_TRUNCATE | ACL_MAINTAIN
+//	pg_class_aclcheck(rel, user, aclmask)     // ANY bit suffices
 //
-//	STATEMENT                    SELECT  +INSERT  +UPDATE  +DELETE
-//	C1 empty tx (control)        ok      ok       ok       ok
-//	C2 read, NO lock (control)   ok      ok       ok       ok
-//	ACCESS SHARE                 ok      ok       ok       ok
-//	ROW SHARE                    DENIED  ok       ok       ok
-//	ROW EXCLUSIVE                DENIED  ok       ok       ok
-//	SHARE UPDATE EXCLUSIVE       DENIED  DENIED   ok       ok
-//	SHARE                        DENIED  DENIED   ok       ok
-//	SHARE ROW EXCLUSIVE          DENIED  DENIED   ok       ok
-//	EXCLUSIVE                    DENIED  DENIED   ok       ok
-//	ACCESS EXCLUSIVE             DENIED  DENIED   ok       ok
+// One OR-mask per mode, tested with pg_class_aclcheck, which succeeds if the
+// role holds ANY bit in it. Measured on PostgreSQL 18.4 (server_version_num
+// 180004) with each privilege granted ALONE and the LOCK executed as the only
+// statement in its transaction:
 //
-// (TRUNCATE and MAINTAIN were also measured and behave like UPDATE/DELETE.)
+//	MODE (lock only)        NONE    SELECT  INSERT  UPDATE  DELETE  TRUNCATE  MAINTAIN  REFERENCES  TRIGGER
+//	ACCESS SHARE            DENIED  ok      ok      ok      ok      ok        ok        DENIED      DENIED
+//	ROW SHARE               DENIED  DENIED  ok      ok      ok      ok        ok        DENIED      DENIED
+//	ROW EXCLUSIVE           DENIED  DENIED  ok      ok      ok      ok        ok        DENIED      DENIED
+//	SHARE UPDATE EXCLUSIVE  DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
+//	SHARE                   DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
+//	SHARE ROW EXCLUSIVE     DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
+//	EXCLUSIVE               DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
+//	ACCESS EXCLUSIVE        DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
+//	<mode omitted>          DENIED  DENIED  DENIED  ok      ok      ok        ok        DENIED      DENIED
 //
-// Two things that table settles, both of which a from-memory reading gets wrong:
+// Two confounds in the PREVIOUS measurement, both of which made the model
+// unfalsifiable in exactly the direction it was wrong, and both avoided here:
 //
-//   - INSERT satisfies ROW SHARE and ROW EXCLUSIVE, and NOTHING stricter. The
-//     earlier model here was a single boolean satisfied by any of I/U/D, so a
-//     posture holding only SELECT+INSERT passed a SHARE ROW EXCLUSIVE lock and
-//     returned 42501 at runtime. That is the CHAOS-3113 defect family exactly.
-//   - ROW SHARE requires a write privilege. The PostgreSQL LOCK documentation
-//     states ROW SHARE needs only SELECT; on 18.4 it does not. Measured, not
-//     assumed -- which is the whole reason this table exists.
+//   - every grant set began with SELECT, so a conjunction and a disjunction
+//     containing SELECT are indistinguishable. The tiers came out right and the
+//     OPERATOR came out wrong: a lock-only path authorized by UPDATE alone was
+//     reported as also needing SELECT, which over-grants -- the exact failure the
+//     two-role split exists to prevent.
+//   - the probe appended a read after the LOCK, so no grant set without SELECT
+//     could ever reach the lock's own check.
 //
-// TRUNCATE and MAINTAIN also satisfy the stricter tiers, but rolePostureQuery
-// asserts both are ABSENT for every runtime role, so they can never be the thing
-// that satisfies a lock here. They are deliberately omitted from Satisfying: a
-// role that held one would already have failed its posture check for a different
-// and louder reason.
+// Correction to a claim previously recorded here: the PostgreSQL documentation is
+// NOT wrong about ROW SHARE. It says the INSERT-class applies to "ROW EXCLUSIVE or
+// a less-conflicting mode", which INCLUDES ROW SHARE, matching the measurement
+// above. The earlier note asserting otherwise was a misreading, and a wrong "the
+// docs are wrong" note is worse than the original confusion because it teaches the
+// next reader to distrust the correct source.
+//
+// TRUNCATE and MAINTAIN are in the real mask but omitted from Satisfying:
+// rolePostureQuery asserts both ABSENT for every runtime role, so neither can ever
+// be the privilege that satisfies a lock here. A role holding one would already
+// have failed its posture check for a louder reason.
 const (
-	lockRankSelectOnly     = iota // ACCESS SHARE
-	lockRankAnyWrite              // ROW SHARE, ROW EXCLUSIVE
-	lockRankUpdateOrDelete        // everything stricter
+	lockRankSelectOrAny    = iota // ACCESS SHARE
+	lockRankInsertOrWrite         // ROW SHARE, ROW EXCLUSIVE
+	lockRankUpdateOrDelete        // everything stricter, and an omitted mode
 )
+
+// lockDefaultMode is what PostgreSQL uses when the mode is omitted entirely
+// (`LOCK TABLE t;`). Measured above: it behaves as ACCESS EXCLUSIVE.
+const lockDefaultMode = "ACCESS EXCLUSIVE"
 
 func lockSatisfyingSet(rank int) PrivilegeSet {
 	var set PrivilegeSet
-	switch rank {
-	case lockRankAnyWrite:
+	// The UPDATE/DELETE bits are unconditional in the backend's mask.
+	set.add(PrivUpdate)
+	set.add(PrivDelete)
+	if rank <= lockRankInsertOrWrite {
 		set.add(PrivInsert)
-		set.add(PrivUpdate)
-		set.add(PrivDelete)
-	case lockRankUpdateOrDelete:
-		set.add(PrivUpdate)
-		set.add(PrivDelete)
+	}
+	if rank == lockRankSelectOrAny {
+		set.add(PrivSelect)
 	}
 	return set
 }
 
-// lockRequirementForMode maps a LOCK TABLE mode to its privilege demand, per the
-// measured table above. The second result is false when SELECT alone suffices
-// (ACCESS SHARE), meaning there is nothing extra to record.
+// lockRequirementForMode maps a lock mode to its privilege disjunction. The
+// second result is FALSE for an unrecognized mode -- the caller must then record
+// the statement as unparsed and fail the gate rather than guess.
 //
-// An UNRECOGNIZED mode is deliberately treated as the strictest tier and flagged
-// Unknown. This replaced two successively-wrong predicates: first a substring
-// test for "EXCLUSIVE" (which failed open on bare SHARE and ROW SHARE, neither of
-// which contains that word), then a "not ACCESS SHARE" test (which failed open on
-// INSERT-only postures under strict modes). Both failed OPEN, which is the
-// under-attribution this package exists to catch -- so the unknown case now fails
-// closed and says so.
+// An earlier version returned a guessed strict set for unknown modes and called
+// that fail-closed. It was not: the comparator only reported the mode when the
+// GUESSED set was unsatisfied, so a role already holding UPDATE passed silently
+// with no manual-verification finding. A guess that happens to be satisfied is
+// indistinguishable from knowledge. Unknown input is now a reported fact.
 func lockRequirementForMode(mode string) (LockRequirement, bool) {
-	normalized := strings.TrimSpace(strings.ToUpper(mode))
-	normalized = lockModeWhitespaceRE.ReplaceAllString(normalized, " ")
+	normalized := normalizeLockMode(mode)
 	switch normalized {
 	case "ACCESS SHARE":
-		return LockRequirement{}, false
+		return LockRequirement{Mode: normalized, Satisfying: lockSatisfyingSet(lockRankSelectOrAny), rank: lockRankSelectOrAny}, true
 	case "ROW SHARE", "ROW EXCLUSIVE":
-		return LockRequirement{
-			Mode: normalized, Satisfying: lockSatisfyingSet(lockRankAnyWrite), rank: lockRankAnyWrite,
-		}, true
+		return LockRequirement{Mode: normalized, Satisfying: lockSatisfyingSet(lockRankInsertOrWrite), rank: lockRankInsertOrWrite}, true
 	case "SHARE UPDATE EXCLUSIVE", "SHARE", "SHARE ROW EXCLUSIVE", "EXCLUSIVE", "ACCESS EXCLUSIVE":
-		return LockRequirement{
-			Mode: normalized, Satisfying: lockSatisfyingSet(lockRankUpdateOrDelete), rank: lockRankUpdateOrDelete,
-		}, true
+		return LockRequirement{Mode: normalized, Satisfying: lockSatisfyingSet(lockRankUpdateOrDelete), rank: lockRankUpdateOrDelete}, true
 	default:
-		return LockRequirement{
-			Mode:       normalized,
-			Satisfying: lockSatisfyingSet(lockRankUpdateOrDelete),
-			rank:       lockRankUpdateOrDelete,
-			Unknown:    true,
-		}, true
+		return LockRequirement{}, false
 	}
+}
+
+func normalizeLockMode(mode string) string {
+	normalized := strings.TrimSpace(strings.ToUpper(mode))
+	return lockModeWhitespaceRE.ReplaceAllString(normalized, " ")
 }
 
 var (
@@ -223,7 +233,6 @@ var (
 	updateSetRE  = regexp.MustCompile(`(?i)\bUPDATE\s+((?:[a-zA-Z_][a-zA-Z0-9_]*\.)?[a-zA-Z_][a-zA-Z0-9_]*)\s+(?:AS\s+[a-zA-Z_][a-zA-Z0-9_]*\s+)?SET\b`)
 	deleteFromRE = regexp.MustCompile(`(?i)\bDELETE\s+FROM\s+(?:ONLY\s+)?((?:[a-zA-Z_][a-zA-Z0-9_]*\.)?[a-zA-Z_][a-zA-Z0-9_]*)`)
 	fromJoinRE   = regexp.MustCompile(`(?i)\b(?:FROM|JOIN)\s+((?:[a-zA-Z_][a-zA-Z0-9_]*\.)?[a-zA-Z_][a-zA-Z0-9_]*)`)
-	lockTableRE  = regexp.MustCompile(`(?i)\bLOCK\s+TABLE\s+(?:ONLY\s+)?((?:[a-zA-Z_][a-zA-Z0-9_]*\.)?[a-zA-Z_][a-zA-Z0-9_]*)\s+IN\s+([A-Z ]+?)\s+MODE\b`)
 	// lockModeWhitespaceRE normalizes the captured mode so "SHARE   ROW
 	// EXCLUSIVE" compares equal to "SHARE ROW EXCLUSIVE".
 	lockModeWhitespaceRE = regexp.MustCompile(`\s+`)
@@ -471,26 +480,37 @@ func ParseStatement(sql string) StatementResult {
 	// false positive here.
 	resolveForUpdateOf(clean, selectTables, aliasToTable, add)
 
-	// LOCK TABLE ... IN <mode> MODE: SELECT is always required, and every mode
-	// except ACCESS SHARE additionally requires ONE OF a mode-specific set --
-	// see lockRequirementForMode for the measured mapping and why the demand is
-	// a disjunction rather than a PrivilegeSet entry. When a table is locked
-	// more than once, the STRICTEST mode wins.
-	for _, m := range lockTableRE.FindAllStringSubmatch(clean, -1) {
-		table, inScope := splitSchemaQualified(m[1])
-		table = strings.ToLower(table)
-		if !inScope || ctes[table] {
+	// LOCK: a DISJUNCTION over a mode-specific set, and nothing else.
+	//
+	// Note what is NOT here: SELECT is not added. The backend's check is a single
+	// OR-mask (see the model above), so a lock-only path authorized by UPDATE
+	// alone does not need SELECT, and asserting one over-grants -- precisely the
+	// failure the two-role split exists to prevent. An earlier version added
+	// PrivSelect for every LOCK, which no mode test could catch because every
+	// fixture already granted SELECT.
+	//
+	// When a table is locked more than once, the STRICTEST mode wins.
+	statements, unparsed := parseLockStatements(clean)
+	result.UnparsedLocks = append(result.UnparsedLocks, unparsed...)
+	for _, statement := range statements {
+		requirement, known := lockRequirementForMode(statement.Mode)
+		if !known {
+			// Unrecognised mode: record the fact, never a guessed requirement.
+			result.UnparsedLocks = append(result.UnparsedLocks,
+				"unrecognised lock mode "+statement.Mode+" on "+strings.Join(statement.Targets, ", "))
 			continue
 		}
-		add(table, PrivSelect)
-		requirement, needsMore := lockRequirementForMode(m[2])
-		if !needsMore {
-			continue
+		for _, target := range statement.Targets {
+			table, inScope := splitSchemaQualified(target)
+			table = strings.ToLower(table)
+			if !inScope || ctes[table] {
+				continue
+			}
+			if existing, ok := result.LockRequirements[table]; ok && existing.rank >= requirement.rank {
+				continue
+			}
+			result.LockRequirements[table] = requirement
 		}
-		if existing, ok := result.LockRequirements[table]; ok && existing.rank >= requirement.rank {
-			continue
-		}
-		result.LockRequirements[table] = requirement
 	}
 
 	return result

--- a/internal/domaingrants/sql_test.go
+++ b/internal/domaingrants/sql_test.go
@@ -104,20 +104,42 @@ func TestParseStatement_NonPublicSchemaExcluded(t *testing.T) {
 	}
 }
 
-func TestParseStatement_LockTableExclusiveModeRequiresAnyWriteNotSpecificallyUpdate(t *testing.T) {
-	// Postgres requires SELECT plus at least one of INSERT/UPDATE/DELETE
-	// for a mode stricter than ROW EXCLUSIVE -- NOT specifically UPDATE.
-	// internal/jobroute/control.go's `LOCK TABLE worker_job_outbox IN SHARE
-	// ROW EXCLUSIVE MODE` is already satisfied by an existing INSERT grant;
-	// asserting PrivUpdate here would be a false positive (see
-	// RequiresAnyWriteLock's doc comment).
+func TestParseStatement_LockTableRecordsADisjunctionNotAPrivilege(t *testing.T) {
+	// A LOCK's demand is a DISJUNCTION over a mode-specific set, so it must not
+	// be recorded as a PrivilegeSet entry: asserting PrivUpdate directly would be
+	// a false positive for ROW EXCLUSIVE, which INSERT alone satisfies.
 	res := ParseStatement(`LOCK TABLE public.sync_dispatch_outbox IN SHARE ROW EXCLUSIVE MODE`)
 	has(t, res, "sync_dispatch_outbox", PrivSelect)
 	if res.Tables["sync_dispatch_outbox"].Has(PrivUpdate) {
 		t.Errorf("LOCK TABLE must not directly assert PrivUpdate: %+v", res.Tables["sync_dispatch_outbox"])
 	}
-	if !res.RequiresAnyWriteLock["sync_dispatch_outbox"] {
-		t.Errorf("expected sync_dispatch_outbox in RequiresAnyWriteLock, got %+v", res.RequiresAnyWriteLock)
+	requirement, ok := res.LockRequirements["sync_dispatch_outbox"]
+	if !ok {
+		t.Fatalf("expected a LockRequirement for sync_dispatch_outbox, got %+v", res.LockRequirements)
+	}
+	if requirement.Mode != "SHARE ROW EXCLUSIVE" {
+		t.Errorf("Mode = %q, want SHARE ROW EXCLUSIVE", requirement.Mode)
+	}
+	// Measured on PostgreSQL 18.4: INSERT does NOT satisfy this mode.
+	if requirement.Satisfying.Has(PrivInsert) {
+		t.Errorf("SHARE ROW EXCLUSIVE must not accept INSERT: %+v", requirement.Satisfying)
+	}
+	if !requirement.Satisfying.Has(PrivUpdate) || !requirement.Satisfying.Has(PrivDelete) {
+		t.Errorf("SHARE ROW EXCLUSIVE must accept UPDATE or DELETE: %+v", requirement.Satisfying)
+	}
+}
+
+// TestParseStatement_LockTableStrictestModeWins covers a table locked twice: the
+// weaker mode must never mask the stronger one's requirement.
+func TestParseStatement_LockTableStrictestModeWins(t *testing.T) {
+	res := ParseStatement(`LOCK TABLE public.t IN ROW EXCLUSIVE MODE;
+		LOCK TABLE public.t IN ACCESS EXCLUSIVE MODE`)
+	requirement := res.LockRequirements["t"]
+	if requirement.Mode != "ACCESS EXCLUSIVE" {
+		t.Errorf("Mode = %q, want the strictest (ACCESS EXCLUSIVE)", requirement.Mode)
+	}
+	if requirement.Satisfying.Has(PrivInsert) {
+		t.Error("the weaker ROW EXCLUSIVE lock masked the stricter one's requirement")
 	}
 }
 
@@ -178,53 +200,98 @@ SELECT 1 /* JOIN public.also_fake */ FROM public.real_table`
 	has(t, res, "real_table", PrivSelect)
 }
 
-// TestLockModeRequiresWritePrivilege pins the PostgreSQL LOCK privilege rule
-// this detector previously got wrong. It matched a substring "EXCLUSIVE", which
-// silently missed SHARE and ROW SHARE — both of which require a write privilege
-// — so a LOCK in either mode passed the grant-surface gate unflagged.
-func TestLockModeRequiresWritePrivilege(t *testing.T) {
+// TestLockRequirementForMode pins the mode-to-privilege mapping MEASURED against
+// PostgreSQL 18.4 (the table in LockRequirement's doc comment). Two predecessors
+// of this rule both failed OPEN: a substring test for "EXCLUSIVE" (missing bare
+// SHARE and ROW SHARE), then a "not ACCESS SHARE" boolean satisfied by any of
+// INSERT/UPDATE/DELETE (missing that INSERT satisfies nothing above ROW
+// EXCLUSIVE).
+func TestLockRequirementForMode(t *testing.T) {
 	t.Parallel()
 
-	// Only ACCESS SHARE is satisfied by SELECT alone.
+	// ACCESS SHARE: SELECT alone suffices, so there is no extra demand at all.
 	for _, mode := range []string{"ACCESS SHARE", "access share", "  ACCESS   SHARE  "} {
-		if lockModeRequiresWritePrivilege(mode) {
-			t.Errorf("lockModeRequiresWritePrivilege(%q) = true, want false", mode)
+		if _, needsMore := lockRequirementForMode(mode); needsMore {
+			t.Errorf("lockRequirementForMode(%q) reported an extra demand, want none", mode)
 		}
 	}
-	// Every other mode needs at least one write privilege. SHARE and ROW SHARE
-	// are the two the old substring test failed open on.
-	for _, mode := range []string{
-		"ROW SHARE",
-		"SHARE",
-		"ROW EXCLUSIVE",
-		"SHARE UPDATE EXCLUSIVE",
-		"SHARE ROW EXCLUSIVE",
-		"EXCLUSIVE",
-		"ACCESS EXCLUSIVE",
-	} {
-		if !lockModeRequiresWritePrivilege(mode) {
-			t.Errorf("lockModeRequiresWritePrivilege(%q) = false, want true", mode)
+
+	// ROW SHARE and ROW EXCLUSIVE: any of INSERT/UPDATE/DELETE. Note ROW SHARE --
+	// the PostgreSQL docs say it needs only SELECT; on 18.4 it does not.
+	for _, mode := range []string{"ROW SHARE", "ROW EXCLUSIVE"} {
+		requirement, needsMore := lockRequirementForMode(mode)
+		if !needsMore {
+			t.Fatalf("lockRequirementForMode(%q) reported no demand, want any-write", mode)
 		}
+		for _, p := range []Privilege{PrivInsert, PrivUpdate, PrivDelete} {
+			if !requirement.Satisfying.Has(p) {
+				t.Errorf("%s must accept %s", mode, p)
+			}
+		}
+	}
+
+	// Everything stricter: UPDATE or DELETE only -- INSERT must NOT satisfy.
+	for _, mode := range []string{
+		"SHARE UPDATE EXCLUSIVE", "SHARE", "SHARE ROW EXCLUSIVE", "EXCLUSIVE", "ACCESS EXCLUSIVE",
+	} {
+		requirement, needsMore := lockRequirementForMode(mode)
+		if !needsMore {
+			t.Fatalf("lockRequirementForMode(%q) reported no demand", mode)
+		}
+		if requirement.Satisfying.Has(PrivInsert) {
+			t.Errorf("%s must NOT accept INSERT -- measured DENIED on 18.4", mode)
+		}
+		if !requirement.Satisfying.Has(PrivUpdate) || !requirement.Satisfying.Has(PrivDelete) {
+			t.Errorf("%s must accept UPDATE and DELETE", mode)
+		}
+	}
+
+	// An unknown mode must fail CLOSED: strictest tier, and flagged so a human
+	// verifies it rather than the tool trusting a guess.
+	requirement, needsMore := lockRequirementForMode("SOME FUTURE MODE")
+	if !needsMore || !requirement.Unknown {
+		t.Errorf("an unrecognized mode must fail closed and be flagged Unknown, got %+v", requirement)
+	}
+	if requirement.Satisfying.Has(PrivInsert) {
+		t.Error("an unrecognized mode must be treated as the strictest tier")
 	}
 }
 
-// TestAnalyzeFlagsBareShareLockAsRequiringWrite exercises the same rule through
-// the real statement analyzer rather than the helper alone.
-func TestAnalyzeFlagsBareShareLockAsRequiringWrite(t *testing.T) {
+// TestAnalyzeRecordsLockRequirementPerMode exercises the same rule through the
+// real statement analyzer rather than the helper alone, including the two modes
+// the original substring test failed open on.
+func TestAnalyzeRecordsLockRequirementPerMode(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range []struct {
-		name string
-		sql  string
-		want bool
+		name           string
+		sql            string
+		wantDemand     bool
+		insertSuffices bool
 	}{
-		{name: "bare share", sql: "LOCK TABLE public.worker_job_outbox IN SHARE MODE", want: true},
-		{name: "row share", sql: "LOCK TABLE public.worker_job_outbox IN ROW SHARE MODE", want: true},
-		{name: "access share", sql: "LOCK TABLE public.worker_job_outbox IN ACCESS SHARE MODE", want: false},
+		{name: "bare share", sql: "LOCK TABLE public.worker_job_outbox IN SHARE MODE",
+			wantDemand: true, insertSuffices: false},
+		{name: "row share", sql: "LOCK TABLE public.worker_job_outbox IN ROW SHARE MODE",
+			wantDemand: true, insertSuffices: true},
+		{name: "row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN ROW EXCLUSIVE MODE",
+			wantDemand: true, insertSuffices: true},
+		{name: "share row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN SHARE ROW EXCLUSIVE MODE",
+			wantDemand: true, insertSuffices: false},
+		{name: "access share", sql: "LOCK TABLE public.worker_job_outbox IN ACCESS SHARE MODE",
+			wantDemand: false},
 	} {
 		result := ParseStatement(testCase.sql)
-		if got := result.RequiresAnyWriteLock["worker_job_outbox"]; got != testCase.want {
-			t.Errorf("%s: RequiresAnyWriteLock = %v, want %v", testCase.name, got, testCase.want)
+		requirement, got := result.LockRequirements["worker_job_outbox"]
+		if got != testCase.wantDemand {
+			t.Errorf("%s: recorded a LockRequirement = %v, want %v", testCase.name, got, testCase.wantDemand)
+			continue
+		}
+		if !got {
+			continue
+		}
+		if requirement.Satisfying.Has(PrivInsert) != testCase.insertSuffices {
+			t.Errorf("%s: INSERT satisfies = %v, want %v", testCase.name,
+				requirement.Satisfying.Has(PrivInsert), testCase.insertSuffices)
 		}
 	}
 }

--- a/internal/domaingrants/sql_test.go
+++ b/internal/domaingrants/sql_test.go
@@ -244,6 +244,24 @@ func TestLockRequirementForMode(t *testing.T) {
 		if !requirement.Satisfying.Has(PrivUpdate) || !requirement.Satisfying.Has(PrivDelete) {
 			t.Errorf("%s must accept UPDATE and DELETE", mode)
 		}
+		// Dropping a mode from the recognized list still lands it in the strictest
+		// tier via the fail-closed default, so the privilege SET would not change --
+		// only the message, which would start calling a known mode unrecognized.
+		// Asserting the flag catches that degradation; without it the mutation is
+		// merely equivalent rather than caught.
+		if requirement.Unknown {
+			t.Errorf("%s is a known PostgreSQL lock mode and must not be flagged Unknown: it has "+
+				"fallen through to the fail-closed default, which still denies correctly but reports "+
+				"the mode as unrecognized", mode)
+		}
+	}
+
+	// Same for the any-write tier, where falling through to the default WOULD
+	// change behaviour -- INSERT would stop satisfying.
+	for _, mode := range []string{"ROW SHARE", "ROW EXCLUSIVE"} {
+		if requirement, _ := lockRequirementForMode(mode); requirement.Unknown {
+			t.Errorf("%s must be recognized, not treated as an unknown strict mode", mode)
+		}
 	}
 
 	// An unknown mode must fail CLOSED: strictest tier, and flagged so a human

--- a/internal/domaingrants/sql_test.go
+++ b/internal/domaingrants/sql_test.go
@@ -109,9 +109,13 @@ func TestParseStatement_LockTableRecordsADisjunctionNotAPrivilege(t *testing.T) 
 	// be recorded as a PrivilegeSet entry: asserting PrivUpdate directly would be
 	// a false positive for ROW EXCLUSIVE, which INSERT alone satisfies.
 	res := ParseStatement(`LOCK TABLE public.sync_dispatch_outbox IN SHARE ROW EXCLUSIVE MODE`)
-	has(t, res, "sync_dispatch_outbox", PrivSelect)
-	if res.Tables["sync_dispatch_outbox"].Has(PrivUpdate) {
-		t.Errorf("LOCK TABLE must not directly assert PrivUpdate: %+v", res.Tables["sync_dispatch_outbox"])
+	// A lock-only statement asserts NO per-privilege requirement at all -- not
+	// UPDATE (the demand is a disjunction, not a specific privilege) and not
+	// SELECT (the backend's check is one OR-mask; requiring SELECT alongside it
+	// over-grants every lock-only path).
+	if !res.Tables["sync_dispatch_outbox"].Empty() {
+		t.Errorf("a lock-only statement must assert no standalone privilege: %+v",
+			res.Tables["sync_dispatch_outbox"])
 	}
 	requirement, ok := res.LockRequirements["sync_dispatch_outbox"]
 	if !ok {
@@ -200,116 +204,192 @@ SELECT 1 /* JOIN public.also_fake */ FROM public.real_table`
 	has(t, res, "real_table", PrivSelect)
 }
 
-// TestLockRequirementForMode pins the mode-to-privilege mapping MEASURED against
-// PostgreSQL 18.4 (the table in LockRequirement's doc comment). Two predecessors
-// of this rule both failed OPEN: a substring test for "EXCLUSIVE" (missing bare
-// SHARE and ROW SHARE), then a "not ACCESS SHARE" boolean satisfied by any of
-// INSERT/UPDATE/DELETE (missing that INSERT satisfies nothing above ROW
-// EXCLUSIVE).
+// TestLockRequirementForMode pins the mode-to-privilege DISJUNCTION derived from
+// LockTableAclCheck's OR-mask and measured on PostgreSQL 18.4 -- see the table in
+// sql.go. Every privilege is tested ALONE, because the previous version of this
+// test granted SELECT in every fixture, which made a conjunction and a
+// disjunction indistinguishable and let a wrong OPERATOR ship with correct tiers.
 func TestLockRequirementForMode(t *testing.T) {
 	t.Parallel()
 
-	// ACCESS SHARE: SELECT alone suffices, so there is no extra demand at all.
-	for _, mode := range []string{"ACCESS SHARE", "access share", "  ACCESS   SHARE  "} {
-		if _, needsMore := lockRequirementForMode(mode); needsMore {
-			t.Errorf("lockRequirementForMode(%q) reported an extra demand, want none", mode)
-		}
+	// mode -> the privileges that must EACH, on their own, satisfy it.
+	satisfiesAlone := map[string][]Privilege{
+		"ACCESS SHARE":           {PrivSelect, PrivInsert, PrivUpdate, PrivDelete},
+		"ROW SHARE":              {PrivInsert, PrivUpdate, PrivDelete},
+		"ROW EXCLUSIVE":          {PrivInsert, PrivUpdate, PrivDelete},
+		"SHARE UPDATE EXCLUSIVE": {PrivUpdate, PrivDelete},
+		"SHARE":                  {PrivUpdate, PrivDelete},
+		"SHARE ROW EXCLUSIVE":    {PrivUpdate, PrivDelete},
+		"EXCLUSIVE":              {PrivUpdate, PrivDelete},
+		"ACCESS EXCLUSIVE":       {PrivUpdate, PrivDelete},
 	}
-
-	// ROW SHARE and ROW EXCLUSIVE: any of INSERT/UPDATE/DELETE. Note ROW SHARE --
-	// the PostgreSQL docs say it needs only SELECT; on 18.4 it does not.
-	for _, mode := range []string{"ROW SHARE", "ROW EXCLUSIVE"} {
-		requirement, needsMore := lockRequirementForMode(mode)
-		if !needsMore {
-			t.Fatalf("lockRequirementForMode(%q) reported no demand, want any-write", mode)
+	for mode, expected := range satisfiesAlone {
+		requirement, known := lockRequirementForMode(mode)
+		if !known {
+			t.Fatalf("%s must be a recognized mode", mode)
 		}
-		for _, p := range []Privilege{PrivInsert, PrivUpdate, PrivDelete} {
-			if !requirement.Satisfying.Has(p) {
-				t.Errorf("%s must accept %s", mode, p)
+		want := map[Privilege]bool{}
+		for _, p := range expected {
+			want[p] = true
+			// Each one ALONE must satisfy: this is what distinguishes the
+			// disjunction from a conjunction with SELECT.
+			var alone PrivilegeSet
+			alone.add(p)
+			if !lockSatisfiedBy(requirement, alone) {
+				t.Errorf("%s: %s ALONE must satisfy the lock (measured ok on 18.4)", mode, p)
+			}
+		}
+		for p := Privilege(0); p < numPrivileges; p++ {
+			if !want[p] && lockSatisfiedBy(requirement, singleton(p)) {
+				t.Errorf("%s: %s ALONE must NOT satisfy the lock (measured DENIED on 18.4)", mode, p)
 			}
 		}
 	}
 
-	// Everything stricter: UPDATE or DELETE only -- INSERT must NOT satisfy.
-	for _, mode := range []string{
-		"SHARE UPDATE EXCLUSIVE", "SHARE", "SHARE ROW EXCLUSIVE", "EXCLUSIVE", "ACCESS EXCLUSIVE",
-	} {
-		requirement, needsMore := lockRequirementForMode(mode)
-		if !needsMore {
-			t.Fatalf("lockRequirementForMode(%q) reported no demand", mode)
-		}
-		if requirement.Satisfying.Has(PrivInsert) {
-			t.Errorf("%s must NOT accept INSERT -- measured DENIED on 18.4", mode)
-		}
-		if !requirement.Satisfying.Has(PrivUpdate) || !requirement.Satisfying.Has(PrivDelete) {
-			t.Errorf("%s must accept UPDATE and DELETE", mode)
-		}
-		// Dropping a mode from the recognized list still lands it in the strictest
-		// tier via the fail-closed default, so the privilege SET would not change --
-		// only the message, which would start calling a known mode unrecognized.
-		// Asserting the flag catches that degradation; without it the mutation is
-		// merely equivalent rather than caught.
-		if requirement.Unknown {
-			t.Errorf("%s is a known PostgreSQL lock mode and must not be flagged Unknown: it has "+
-				"fallen through to the fail-closed default, which still denies correctly but reports "+
-				"the mode as unrecognized", mode)
-		}
+	// The whole point of the correction: a lock-only path is NOT required to hold
+	// SELECT. If SELECT were a separate requirement, UPDATE alone would fail here.
+	strict, _ := lockRequirementForMode("SHARE ROW EXCLUSIVE")
+	if !lockSatisfiedBy(strict, singleton(PrivUpdate)) {
+		t.Error("UPDATE alone must satisfy SHARE ROW EXCLUSIVE: modelling the demand as " +
+			"'SELECT AND a write privilege' over-grants every lock-only path, which is the failure " +
+			"the two-role split exists to prevent")
 	}
 
-	// Same for the any-write tier, where falling through to the default WOULD
-	// change behaviour -- INSERT would stop satisfying.
-	for _, mode := range []string{"ROW SHARE", "ROW EXCLUSIVE"} {
-		if requirement, _ := lockRequirementForMode(mode); requirement.Unknown {
-			t.Errorf("%s must be recognized, not treated as an unknown strict mode", mode)
-		}
-	}
-
-	// An unknown mode must fail CLOSED: strictest tier, and flagged so a human
-	// verifies it rather than the tool trusting a guess.
-	requirement, needsMore := lockRequirementForMode("SOME FUTURE MODE")
-	if !needsMore || !requirement.Unknown {
-		t.Errorf("an unrecognized mode must fail closed and be flagged Unknown, got %+v", requirement)
-	}
-	if requirement.Satisfying.Has(PrivInsert) {
-		t.Error("an unrecognized mode must be treated as the strictest tier")
+	// An unknown mode is NOT a guess. It is refused, so the caller records it as
+	// an unparsed statement and the gate fails. The previous version returned a
+	// guessed strict set and called that fail-closed; it was not, because a role
+	// already holding UPDATE satisfied the guess and nothing was ever reported.
+	if _, known := lockRequirementForMode("SOME FUTURE MODE"); known {
+		t.Error("an unrecognized mode must be REFUSED, not given a guessed privilege set: a guess " +
+			"that happens to be satisfied is indistinguishable from knowledge")
 	}
 }
 
-// TestAnalyzeRecordsLockRequirementPerMode exercises the same rule through the
-// real statement analyzer rather than the helper alone, including the two modes
-// the original substring test failed open on.
+func singleton(p Privilege) PrivilegeSet {
+	var set PrivilegeSet
+	set.add(p)
+	return set
+}
+
+// TestParseLockStatementGrammar covers every shape PostgreSQL accepts, all nine
+// of which were verified against a live 18.4 server. The previous regex
+// recognised only the first, and silently derived NOTHING for the rest -- no
+// table, no privilege, no diagnostic.
+func TestParseLockStatementGrammar(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		sql     string
+		targets []string
+		mode    string
+	}{
+		{"LOCK TABLE public.t IN SHARE ROW EXCLUSIVE MODE", []string{"public.t"}, "SHARE ROW EXCLUSIVE"},
+		{"LOCK public.t IN SHARE ROW EXCLUSIVE MODE", []string{"public.t"}, "SHARE ROW EXCLUSIVE"},
+		{"LOCK TABLE public.t", []string{"public.t"}, "ACCESS EXCLUSIVE"},
+		{"LOCK public.t", []string{"public.t"}, "ACCESS EXCLUSIVE"},
+		{"LOCK TABLE public.a, public.b IN SHARE MODE", []string{"public.a", "public.b"}, "SHARE"},
+		{"LOCK TABLE ONLY public.t IN EXCLUSIVE MODE", []string{"public.t"}, "EXCLUSIVE"},
+		{"LOCK TABLE public.t * IN SHARE MODE", []string{"public.t"}, "SHARE"},
+		{"LOCK TABLE public.t IN SHARE MODE NOWAIT", []string{"public.t"}, "SHARE"},
+		{"LOCK   TABLE   public.t   IN   SHARE   ROW   EXCLUSIVE   MODE", []string{"public.t"}, "SHARE ROW EXCLUSIVE"},
+	} {
+		statements, unparsed := parseLockStatements(tc.sql)
+		if len(unparsed) != 0 {
+			t.Errorf("%q reported unparsed: %v", tc.sql, unparsed)
+			continue
+		}
+		if len(statements) != 1 {
+			t.Errorf("%q produced %d statements, want 1", tc.sql, len(statements))
+			continue
+		}
+		if statements[0].Mode != tc.mode {
+			t.Errorf("%q mode = %q, want %q", tc.sql, statements[0].Mode, tc.mode)
+		}
+		if len(statements[0].Targets) != len(tc.targets) {
+			t.Errorf("%q targets = %v, want %v", tc.sql, statements[0].Targets, tc.targets)
+			continue
+		}
+		for i, want := range tc.targets {
+			if statements[0].Targets[i] != want {
+				t.Errorf("%q target %d = %q, want %q", tc.sql, i, statements[0].Targets[i], want)
+			}
+		}
+	}
+}
+
+// TestParseLockStatementReportsWhatItCannotParse is the fail-closed half. A LOCK
+// the parser does not understand must be REPORTED, never dropped.
+func TestParseLockStatementReportsWhatItCannotParse(t *testing.T) {
+	t.Parallel()
+
+	for _, sql := range []string{
+		"LOCK TABLE public.t IN NONSENSE MODE",
+		"LOCK TABLE public.t IN SHARE",
+		"LOCK TABLE",
+	} {
+		statements, unparsed := parseLockStatements(sql)
+		if len(unparsed) == 0 {
+			t.Errorf("%q was silently ignored (%d statements parsed); an unparseable LOCK must be "+
+				"reported so the gate fails rather than treating it as an absence", sql, len(statements))
+		}
+	}
+
+	// And the word LOCK inside another statement must NOT be read as one, since a
+	// false positive here is now a false GATE FAILURE.
+	for _, sql := range []string{
+		"SELECT id FROM public.t FOR UPDATE SKIP LOCKED",
+		"SELECT lock_key FROM public.t",
+	} {
+		if _, unparsed := parseLockStatements(sql); len(unparsed) != 0 {
+			t.Errorf("%q must not be read as a LOCK statement: %v", sql, unparsed)
+		}
+	}
+}
+
+// TestAnalyzeRecordsLockRequirementPerMode exercises the rule through the real
+// statement analyzer, and pins that a LOCK does NOT add a SELECT requirement.
 func TestAnalyzeRecordsLockRequirementPerMode(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range []struct {
 		name           string
 		sql            string
-		wantDemand     bool
 		insertSuffices bool
+		selectSuffices bool
 	}{
-		{name: "bare share", sql: "LOCK TABLE public.worker_job_outbox IN SHARE MODE",
-			wantDemand: true, insertSuffices: false},
-		{name: "row share", sql: "LOCK TABLE public.worker_job_outbox IN ROW SHARE MODE",
-			wantDemand: true, insertSuffices: true},
-		{name: "row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN ROW EXCLUSIVE MODE",
-			wantDemand: true, insertSuffices: true},
-		{name: "share row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN SHARE ROW EXCLUSIVE MODE",
-			wantDemand: true, insertSuffices: false},
 		{name: "access share", sql: "LOCK TABLE public.worker_job_outbox IN ACCESS SHARE MODE",
-			wantDemand: false},
+			insertSuffices: true, selectSuffices: true},
+		{name: "row share", sql: "LOCK TABLE public.worker_job_outbox IN ROW SHARE MODE",
+			insertSuffices: true, selectSuffices: false},
+		{name: "row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN ROW EXCLUSIVE MODE",
+			insertSuffices: true, selectSuffices: false},
+		{name: "bare share", sql: "LOCK TABLE public.worker_job_outbox IN SHARE MODE",
+			insertSuffices: false, selectSuffices: false},
+		{name: "share row exclusive", sql: "LOCK TABLE public.worker_job_outbox IN SHARE ROW EXCLUSIVE MODE",
+			insertSuffices: false, selectSuffices: false},
+		{name: "mode omitted defaults to access exclusive", sql: "LOCK TABLE public.worker_job_outbox",
+			insertSuffices: false, selectSuffices: false},
 	} {
 		result := ParseStatement(testCase.sql)
 		requirement, got := result.LockRequirements["worker_job_outbox"]
-		if got != testCase.wantDemand {
-			t.Errorf("%s: recorded a LockRequirement = %v, want %v", testCase.name, got, testCase.wantDemand)
-			continue
-		}
 		if !got {
+			t.Errorf("%s: no LockRequirement recorded", testCase.name)
 			continue
 		}
 		if requirement.Satisfying.Has(PrivInsert) != testCase.insertSuffices {
 			t.Errorf("%s: INSERT satisfies = %v, want %v", testCase.name,
 				requirement.Satisfying.Has(PrivInsert), testCase.insertSuffices)
+		}
+		if requirement.Satisfying.Has(PrivSelect) != testCase.selectSuffices {
+			t.Errorf("%s: SELECT satisfies = %v, want %v", testCase.name,
+				requirement.Satisfying.Has(PrivSelect), testCase.selectSuffices)
+		}
+		// A lock-only statement must NOT assert a standalone SELECT requirement.
+		// The backend's check is one OR-mask; requiring SELECT alongside it
+		// over-grants every lock-only path.
+		if result.Tables["worker_job_outbox"].Has(PrivSelect) {
+			t.Errorf("%s: a LOCK must not add a separate SELECT requirement -- the demand is a "+
+				"disjunction, so a path authorized by UPDATE alone needs no SELECT", testCase.name)
 		}
 	}
 }


### PR DESCRIPTION
## What this is

The Postgres grant-surface checker for the Celery→Go cutover, **converted from a gate to an advisory report** for the coordinator role. The domain role stays gated.

## Why advisory, and why that is the conservative choice

Three adversarial review rounds found the same defect at five different addresses: **the analysis cannot see something and the gate passes anyway.** That is not a bug to patch site-by-site — a gate that passes while blind *licenses* the hand-written rows it was built to check, which is the same mechanism that let nineteen cutover tickets be closed against dormant code.

So the coordinator surface now **reports and gates nothing**. `TestDomainGrantSurfaceMatchesQuerySurface` still gates the domain role, and that gate is proven to bite rather than assumed to: **5/5 mutations killed**, including the one that matters most now that `main()` has two modes — the domain path still exits nonzero on `CRITICAL`. A regression there would silently un-gate the role that *is* still gated.

Promotion back to gating is tracked as **CHAOS-3164**: a blind-spot closure argument that partitions every way the analysis can be blind, dispositions each cell, accepts **per-site** rather than per-file, and adds a test per cell. `knownOpenCriticals` expiry enforcement is **suspended** under advisory; restoring it is part of promotion, not an assumption.

## What review found, and what it cost

Four rounds. Rounds 4 and 5 landed on the same HIGH, and both times the author's first fix was to the wrong half:

- **Round 4** — the report was invisible in CI. Everything goes through `t.Log`, and `ci/check_go.sh` runs `go test` without `-v`, which discards a passing package's logs. Printing the banner first helps a reader who sees output and does nothing for a run that sees none. **A report whose only channel is suppressed output is not a report.**
- **Round 5** — the first fix added a command and left the wiring as shared infra for someone else. A manually invoked command is not delivery through the path that motivated the finding. Now wired as a `grant-advisory` verb in `ci/check_go.sh`, in both `fast` and `all`, run last, and verified to publish through CI's own path. Chosen over editing `.github/workflows/go.yml` because the workflow already calls the script — smallest conflict surface while other lanes touch shared infra.
- **A second finding sat inside a test written to close this exact class.** `AdvisoryReport` called `PartitionKnownOpen` and used only `accepted`, dropping stale and unticketed and labelling accepted entries with neither ticket nor reason — so "suspended but still reported" was false for two of three categories. Prose can be re-read; a dropped code path cannot. Round 5 then found that the *fix's* test could not falsify its own branch, matching a string the accepted path also emits: reached, not exercised.

Codex's final verdict is `approve`, zero findings, and it independently confirmed the direction that mattered most: **findings exit zero while analysis and build failures propagate nonzero.** An advisory that swallows its own crash is indistinguishable from a clean run.

## Findings the analysis surfaced

- `sync_dispatch_outbox` INSERT on the coordinator → `42501` when `syncMutation` is flipped (**CHAOS-3146**).
- `WIRING-HOP`, collected for three rounds and surfaced for the first time.
- `UNRESOLVED-TX-ORIGIN` — sites whose `Begin()` could not be traced, so grouping silently fell back to the coarse path. **Two live sites on this tree.** A list of the analysis's own blindness is exactly what must never be collected and dropped.

The lock model was also re-derived from `LockTableAclCheck`'s mask structure: PostgreSQL's lock ACL is one OR-mask, not `SELECT AND write`, so `UPDATE` alone satisfies even `ACCESS SHARE`.

## Scope

`CoordinatorPosture()` is untouched — `domain_authorization.go` does not appear in the diff. **`ci/check_go.sh` is the only shared file** (one function, one verb, two dispatch lines); no other in-flight branch or worktree touches it.

Deliberately **not** in scope: **CHAOS-3166**, deriving the domain grant statements from `DomainPosture()` the way the coordinator side already derives them. That is a change to the production grant path and does not belong in a gate conversion.

## Gate

`ci/local_validate.sh` green against this base, run bare under `env -i`: all nine stages, 9056 passed / 62 skipped.

Refs CHAOS-3144, CHAOS-3164, CHAOS-3146, CHAOS-3166
