### PR TITLE
CHAOS-3172: port github/cicd sync unit to Go

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -431,6 +431,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		LaunchDarklyFeatureFlags: cfg.WorkerLaunchDarklyFeatureFlagsEnabled,
 		GithubRepoMetadata:       cfg.WorkerGithubRepoMetadataEnabled,
 		GithubPRs:                cfg.WorkerGithubPRsEnabled,
+		GithubCICD:               cfg.WorkerGithubCICDEnabled,
 	}
 }
 
@@ -450,6 +451,7 @@ func providerRouteSwitchesReady(
 		{"launchdarkly", "feature-flags", cfg.WorkerLaunchDarklyFeatureFlagsEnabled},
 		{"github", "repo-metadata", cfg.WorkerGithubRepoMetadataEnabled},
 		{"github", "prs", cfg.WorkerGithubPRsEnabled},
+		{"github", "cicd", cfg.WorkerGithubCICDEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -181,9 +181,9 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Three route-ready pairs can reach this closure today
-			// (launchdarkly/feature-flags, github/repo-metadata,
-			// github/prs — see CompleteRouteSwitches.Descriptor), and each
+			// Four route-ready pairs can reach this closure today
+			// (launchdarkly/feature-flags, github/repo-metadata, github/prs,
+			// github/cicd — see CompleteRouteSwitches.Descriptor), and each
 			// has its own CompleteRouteHandler and effect sink. session.Claim
 			// is already known here — providerunit.Handler.Work only calls
 			// BuildExecutor after its own descriptor gate passed for THIS
@@ -225,6 +225,13 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubPullRequestRouteHandler{}
 				sink, readback = ghPRSink, ghPRSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "cicd":
+				ghCICDSink := providersync.GitHubCICDClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubCICDRouteHandler{}
+				sink, readback = ghCICDSink, ghCICDSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
@@ -300,7 +307,8 @@ func buildProviderSyncWorker(
 	// a worker with nothing registered.
 	if cfg.Profile != "sync" ||
 		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled &&
-			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled) {
+			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled &&
+			!cfg.WorkerGithubCICDEnabled) {
 		return workerFamily{}, nil
 	}
 	if registry == nil || observer == nil || logger == nil ||

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -224,10 +224,11 @@ func disjointHandlerSets(left, right map[string]struct{}) bool {
 func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
 	t.Parallel()
 	for name, want := range map[string]providersync.CompleteRouteSwitches{
-		"none":       {},
-		"github":     {GithubRepoMetadata: true},
-		"github_prs": {GithubPRs: true},
-		"both":       {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
+		"none":        {},
+		"github":      {GithubRepoMetadata: true},
+		"github_prs":  {GithubPRs: true},
+		"github_cicd": {GithubCICD: true},
+		"both":        {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -268,6 +269,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 			cfg:  config.Config{WorkerGithubPRsEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubPRs: true},
 		},
+		"github_cicd": {
+			cfg:  config.Config{WorkerGithubCICDEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubCICD: true},
+		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
 			want: providersync.CompleteRouteSwitches{LinearWorkItems: true},
@@ -287,5 +292,30 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 				t.Fatalf("workerRouteSwitches = %+v, want %+v", got, probe.want)
 			}
 		})
+	}
+}
+
+func TestBuildProviderSyncHandlerConstructsGitHubCICDCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(
+		nil,
+		providersync.CompleteRouteSwitches{GithubCICD: true},
+		nil, nil, nil, nil, nil, slog.Default(),
+	)
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("provider sync handler is not constructed")
+	}
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "github", Dataset: "cicd",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.GitHubCICDRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.GitHubCICDClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
 	}
 }

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -44,11 +44,13 @@
       "processor_flags": {
         "sync_cicd": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "cicd",
-      "route_destinations": [],
-      "route_ready": false,
+      "route_destinations": [
+        "ci_pipeline_runs"
+      ],
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -114,6 +114,8 @@ type Config struct {
 	// Its Python counterpart is ProviderUnitRouteSwitches.github_prs, read
 	// from the same WORKER_GITHUB_PRS_ENABLED name.
 	WorkerGithubPRsEnabled bool
+	// WorkerGithubCICDEnabled gates the isolated (github, cicd) route.
+	WorkerGithubCICDEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -193,6 +195,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_PRS_ENABLED",
 			target: &cfg.WorkerGithubPRsEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_CICD_ENABLED",
+			target: &cfg.WorkerGithubCICDEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -138,7 +138,8 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 	if cfg.WorkerLinearWorkItemsEnabled || cfg.WorkerJiraWorkItemsEnabled ||
 		cfg.WorkerJiraIncidentsEnabled ||
 		cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
-		cfg.WorkerGithubRepoMetadataEnabled || cfg.WorkerGithubPRsEnabled {
+		cfg.WorkerGithubRepoMetadataEnabled || cfg.WorkerGithubPRsEnabled ||
+		cfg.WorkerGithubCICDEnabled {
 		t.Fatal("provider route switches must default off")
 	}
 }
@@ -166,6 +167,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true",
 		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "true",
 		"WORKER_GITHUB_PRS_ENABLED":                 "true",
+		"WORKER_GITHUB_CICD_ENABLED":                "true",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +196,8 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 	if !cfg.WorkerLinearWorkItemsEnabled || !cfg.WorkerJiraWorkItemsEnabled ||
 		!cfg.WorkerJiraIncidentsEnabled ||
 		!cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
-		!cfg.WorkerGithubRepoMetadataEnabled || !cfg.WorkerGithubPRsEnabled {
+		!cfg.WorkerGithubRepoMetadataEnabled || !cfg.WorkerGithubPRsEnabled ||
+		!cfg.WorkerGithubCICDEnabled {
 		t.Fatal("expected independent provider route opt-ins")
 	}
 

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -63,6 +63,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //   - github/repo-metadata: CHAOS-3123, fixture-level field parity against the
 //     Python collector (TestGitHubRepositoryRouteEmitsOneBoundedReposEffect).
 //     Canary staging and live-traffic parity are waived for this program.
+//   - github/cicd: CHAOS-3172, differential row parity against the live Python
+//     normalizer and builder plus readback-fenced ClickHouse effects.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -79,6 +81,7 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 var routeReadyPairs = map[string]struct{}{
 	"launchdarkly/feature-flags": {},
 	"github/repo-metadata":       {},
+	"github/cicd":                {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -101,9 +104,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 	all := CompleteRouteSwitches{
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
-		GithubPRs: true,
+		GithubPRs: true, GithubCICD: true,
 	}
-	if reflect.TypeOf(all).NumField() != 6 {
+	if reflect.TypeOf(all).NumField() != 7 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -212,6 +215,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"launchdarkly/feature-flags": LaunchDarklyRouteHandler{},
 		"github/repo-metadata":       GitHubRepositoryRouteHandler{},
 		"github/prs":                 GitHubPullRequestRouteHandler{},
+		"github/cicd":                GitHubCICDRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -34,6 +34,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"launchdarkly/feature-flags": ExecutorNativeGo,
 	"github/repo-metadata":       ExecutorNativeGo,
 	"github/prs":                 ExecutorNativeGo,
+	"github/cicd":                ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -129,6 +130,8 @@ type CompleteRouteSwitches struct {
 	// left for github/pr-reviews, which needs its own GraphQL fetch — see
 	// deploy/go-workers/provider-sync-porting-recipe.md.
 	GithubPRs bool
+	// GithubCICD gates the isolated ci_pipeline_runs writer only.
+	GithubCICD bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -219,6 +222,10 @@ func (switches CompleteRouteSwitches) Descriptor(
 		// is a no-op today and a one-line flip later, not new plumbing.
 		descriptor.Destinations = []string{"git_pull_requests"}
 		descriptor.RouteEnabled = switches.GithubPRs
+	case provider == "github" && dataset == "cicd":
+		descriptor.Destinations = []string{"ci_pipeline_runs"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubCICD
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_cicd_effects_clickhouse.go
+++ b/internal/providersync/github_cicd_effects_clickhouse.go
@@ -1,0 +1,194 @@
+package providersync
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubCICDClickHouseEffects persists the ci_pipeline_runs effect emitted by
+// GitHubCICDRouteHandler and uses a FINAL point lookup to fence recovery.
+type GitHubCICDClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubCICDClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "cicd" ||
+		effect.Destination != "ci_pipeline_runs" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[ciPipelineRunRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO ci_pipeline_runs (
+  org_id, repo_id, run_id, status, queued_at, started_at, finished_at, retry_count, last_synced
+)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.OrgID, row.RepoID, row.RunID, row.Status, row.QueuedAt, row.StartedAt,
+			row.FinishedAt, row.RetryCount, row.LastSynced,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubCICDClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "cicd" ||
+		effect.Destination != "ci_pipeline_runs" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[ciPipelineRunRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectPipelineRun(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink GitHubCICDClickHouseEffects) inspectPipelineRun(
+	ctx context.Context,
+	expected ciPipelineRunRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT org_id, run_id, status, queued_at, started_at, finished_at, retry_count, last_synced
+FROM ci_pipeline_runs FINAL
+WHERE org_id = ? AND repo_id = ? AND run_id = ?`, expected.OrgID, expected.RepoID, expected.RunID)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var version ciPipelineRunVersion
+	for rows.Next() {
+		if err := rows.Scan(
+			&version.Row.OrgID, &version.Row.RunID, &version.Row.Status, &version.Row.QueuedAt,
+			&version.Row.StartedAt, &version.Row.FinishedAt, &version.Row.RetryCount,
+			&version.LastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		version.Found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return comparePipelineRunVersion(expected, version), nil
+}
+
+type ciPipelineRunVersion struct {
+	Row        ciPipelineRunRow
+	LastSynced time.Time
+	Found      bool
+}
+
+func comparePipelineRunVersion(
+	expected ciPipelineRunRow,
+	actual ciPipelineRunVersion,
+) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if actual.Row.RunID != expected.RunID {
+		return EffectConflict
+	}
+	if actual.Row.OrgID != expected.OrgID {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.Status, expected.Status) {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.QueuedAt, expected.QueuedAt) {
+		return EffectConflict
+	}
+	if !actual.Row.StartedAt.UTC().Equal(expected.StartedAt.UTC()) {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.FinishedAt, expected.FinishedAt) {
+		return EffectConflict
+	}
+	if actual.Row.RetryCount != expected.RetryCount {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitHubCICDClickHouseEffects{}
+var _ EffectReadback = GitHubCICDClickHouseEffects{}

--- a/internal/providersync/github_cicd_effects_integration_test.go
+++ b/internal/providersync/github_cicd_effects_integration_test.go
@@ -27,35 +27,9 @@ CREATE TABLE ci_pipeline_runs (
 ORDER BY (org_id, repo_id, run_id)`
 
 func TestGitHubCICDReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	instance, err := containers.StartClickHouse(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer closeCancel()
-		if err := instance.Close(closeContext); err != nil {
-			t.Errorf("terminate ClickHouse: %v", err)
-		}
-	})
-	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	if err := conn.Exec(ctx, ciPipelineRunsDDL); err != nil {
-		t.Fatal(err)
-	}
+	ctx, sink := newGitHubCICDIntegrationSink(t)
 	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
 	claim := nativeTestClaim("github", "cicd")
-	sink := GitHubCICDClickHouseEffects{
-		Conn: conn,
-		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
-			return nil
-		}),
-	}
 	current := ciPipelineRunRow{
 		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", RunID: "101",
 		StartedAt: now.Add(-time.Minute), RetryCount: 2, LastSynced: now,
@@ -82,6 +56,70 @@ func TestGitHubCICDReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T
 	inspection, err = sink.InspectEffect(ctx, claim, effect)
 	if err != nil || inspection != EffectExact {
 		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitHubCICDReadbackExcludesSameRunFromOtherTenant(t *testing.T) {
+	ctx, sink := newGitHubCICDIntegrationSink(t)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim := nativeTestClaim("github", "cicd")
+	row := ciPipelineRunRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", RunID: "101",
+		StartedAt: now.Add(-time.Minute), RetryCount: 2, LastSynced: now,
+	}
+	otherClaim := claim
+	otherClaim.OrgID = "other-org"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	otherRow.RetryCount = 3
+	if err := sink.WriteEffect(ctx, otherClaim, ciPipelineRunEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+
+	effect := ciPipelineRunEffect(t, row)
+	inspection, err := sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("tenant-scoped inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newGitHubCICDIntegrationSink(
+	t *testing.T,
+) (context.Context, GitHubCICDClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, ciPipelineRunsDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitHubCICDClickHouseEffects{
+		Conn: conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return nil
+		}),
 	}
 }
 

--- a/internal/providersync/github_cicd_effects_integration_test.go
+++ b/internal/providersync/github_cicd_effects_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const ciPipelineRunsDDL = `
+CREATE TABLE ci_pipeline_runs (
+  org_id String,
+  repo_id UUID,
+  run_id String,
+  status Nullable(String),
+  queued_at Nullable(DateTime64(3, 'UTC')),
+  started_at DateTime64(3, 'UTC'),
+  finished_at Nullable(DateTime64(3, 'UTC')),
+  retry_count UInt32 DEFAULT 0,
+  last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, run_id)`
+
+func TestGitHubCICDReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, ciPipelineRunsDDL); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim := nativeTestClaim("github", "cicd")
+	sink := GitHubCICDClickHouseEffects{
+		Conn: conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return nil
+		}),
+	}
+	current := ciPipelineRunRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", RunID: "101",
+		StartedAt: now.Add(-time.Minute), RetryCount: 2, LastSynced: now,
+	}
+	effect := ciPipelineRunEffect(t, current)
+
+	inspection, err := sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty table inspection=%s error=%v", inspection, err)
+	}
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previous.RetryCount = 1
+	if err := sink.WriteEffect(ctx, claim, ciPipelineRunEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+}
+
+func ciPipelineRunEffect(t *testing.T, row ciPipelineRunRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(
+		"ci_pipeline_runs", EffectReadbackRequired, []ciPipelineRunRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/github_cicd_generic_oracle_test.go
+++ b/internal/providersync/github_cicd_generic_oracle_test.go
@@ -1,0 +1,73 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var oracleCICDGoOnlyFields = map[string]string{
+	"last_synced": "stamped from normalizedAt by the Go complete-route handler after Python's build_ci_pipeline_run boundary",
+	"org_id":      "carried from the Go claim to keep ClickHouse writes tenant-scoped",
+}
+
+var oracleCICDNormalizedAt = time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+
+func buildCICDRowForOracle(t *testing.T, input map[string]any) ciPipelineRunRow {
+	t.Helper()
+	rawRun, ok := input["raw_run"]
+	if !ok {
+		t.Fatalf("oracle case missing raw_run: %v", input)
+	}
+	encoded, err := json.Marshal(rawRun)
+	if err != nil {
+		t.Fatalf("marshal raw_run: %v", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var workflow gitHubWorkflowRunPayload
+	if err := decoder.Decode(&workflow); err != nil {
+		t.Fatalf("unmarshal workflow run: %v", err)
+	}
+	row, ok := normalizeGitHubWorkflowRun(
+		nativeTestClaim("github", "cicd"), input["repo_id"].(string), workflow, oracleCICDNormalizedAt,
+	)
+	if !ok {
+		t.Fatal("oracle workflow run did not produce a row")
+	}
+	return row
+}
+
+func oracleCICDCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "completed_run_with_retries",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_run": map[string]any{
+					"id": 101, "conclusion": "success", "status": "completed",
+					"created_at":     "2026-07-22T10:00:00Z",
+					"run_started_at": "2026-07-22T10:01:00Z",
+					"updated_at":     "2026-07-22T10:05:00Z", "run_attempt": 3,
+				},
+			},
+		},
+		{
+			ID: "queued_run_falls_back_to_created_at",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_run": map[string]any{
+					"id": "102", "status": "queued", "created_at": "2026-07-22T11:00:00Z",
+					"run_started_at": nil, "updated_at": nil, "run_attempt": "not-a-number",
+				},
+			},
+		},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForCICDRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/cicd/row", oracleCICDCases(), buildCICDRowForOracle, oracleCICDGoOnlyFields,
+	)
+}

--- a/internal/providersync/github_cicd_route.go
+++ b/internal/providersync/github_cicd_route.go
@@ -1,0 +1,192 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const defaultGitHubCICDMaxRuns = 1_000
+
+// ciPipelineRunRow is the frozen ci_pipeline_runs projection written by the
+// github/cicd sync unit. Its fields and JSON names mirror Python's
+// build_ci_pipeline_run -> ClickHouseStore.insert_ci_pipeline_runs boundary.
+type ciPipelineRunRow struct {
+	OrgID      string     `json:"org_id"`
+	RepoID     string     `json:"repo_id"`
+	RunID      string     `json:"run_id"`
+	Status     *string    `json:"status"`
+	QueuedAt   *time.Time `json:"queued_at"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at"`
+	RetryCount uint32     `json:"retry_count"`
+	LastSynced time.Time  `json:"last_synced"`
+}
+
+type gitHubWorkflowRunsPayload struct {
+	Runs []gitHubWorkflowRunPayload `json:"workflow_runs"`
+}
+
+type gitHubWorkflowRunPayload struct {
+	ID           json.Number `json:"id"`
+	Conclusion   any         `json:"conclusion"`
+	Status       any         `json:"status"`
+	CreatedAt    *string     `json:"created_at"`
+	RunStartedAt *string     `json:"run_started_at"`
+	UpdatedAt    *string     `json:"updated_at"`
+	RunAttempt   any         `json:"run_attempt"`
+}
+
+// GitHubCICDRouteHandler mirrors _fetch_github_workflow_runs_async followed
+// by its caller's _filter_after(..., until, "started_at") in github.py. It
+// owns exactly ci_pipeline_runs; tests, deployments, and PR datasets remain
+// distinct Python/Go units.
+type GitHubCICDRouteHandler struct{ MaxRuns int }
+
+func (handler GitHubCICDRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "cicd" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+	var repoPayload gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repoPayload); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repoPayload.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	maxRuns := handler.MaxRuns
+	if maxRuns == 0 {
+		maxRuns = defaultGitHubCICDMaxRuns
+	}
+	if maxRuns < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	pages := (maxRuns + nativePerPage - 1) / nativePerPage
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx, client, providerfoundation.GitHubPageOptions{
+			Path:    root + "/actions/runs",
+			Query:   url.Values{"per_page": {"100"}},
+			DataKey: "workflow_runs", MaxPages: pages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	items := page.Items
+	if len(items) > maxRuns {
+		items = items[:maxRuns]
+	}
+	rows := make([]ciPipelineRunRow, 0, len(items))
+	for _, raw := range items {
+		var workflow gitHubWorkflowRunPayload
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.UseNumber()
+		if decoder.Decode(&workflow) != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, include := normalizeGitHubWorkflowRun(claim, repoID, workflow, normalizedAt)
+		if !include || ciPipelineRunOutsideWindow(row.StartedAt, claim) {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues("ci_pipeline_runs", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	watermark := claim.BeforeAt
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result: map[string]any{
+			"pipeline_runs_synced": len(rows),
+			"repo":                 repoPayload.FullName,
+		},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: page.Pages + 1, Pages: page.Pages, Records: len(rows),
+			CapReached: page.CapReached,
+		},
+	}, nil
+}
+
+func normalizeGitHubWorkflowRun(
+	claim Claim,
+	repoID string,
+	workflow gitHubWorkflowRunPayload,
+	normalizedAt time.Time,
+) (ciPipelineRunRow, bool) {
+	queuedAt := parseGitHubWorkflowTime(workflow.CreatedAt)
+	startedAt := parseGitHubWorkflowTime(workflow.RunStartedAt)
+	if startedAt == nil {
+		startedAt = queuedAt
+	}
+	if startedAt == nil {
+		return ciPipelineRunRow{}, false
+	}
+	status := workflowRunStatus(workflow.Conclusion, workflow.Status)
+	return ciPipelineRunRow{
+		OrgID: claim.OrgID, RepoID: repoID, RunID: stringValue(workflow.ID), Status: status,
+		QueuedAt: queuedAt, StartedAt: *startedAt,
+		FinishedAt: parseGitHubWorkflowTime(workflow.UpdatedAt),
+		RetryCount: workflowRetryCount(workflow.RunAttempt), LastSynced: normalizedAt,
+	}, true
+}
+
+func parseGitHubWorkflowTime(value *string) *time.Time {
+	return parseGitHubPullTime(value)
+}
+
+func workflowRunStatus(conclusion, status any) *string {
+	value := stringValue(conclusion)
+	if value == "" {
+		value = stringValue(status)
+	}
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func workflowRetryCount(value any) uint32 {
+	attempt, err := json.Number(stringValue(value)).Int64()
+	if err != nil || attempt < 2 {
+		return 0
+	}
+	return uint32(attempt - 1)
+}
+
+func ciPipelineRunOutsideWindow(startedAt time.Time, claim Claim) bool {
+	return (claim.SinceAt != nil && startedAt.Before(claim.SinceAt.UTC())) ||
+		(claim.BeforeAt != nil && startedAt.After(claim.BeforeAt.UTC()))
+}
+
+func (row ciPipelineRunRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.RepoID == "" ||
+		len(row.RepoID) != 36 || row.RunID == "" ||
+		row.StartedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubCICDRouteHandler{}

--- a/internal/providersync/github_cicd_route_test.go
+++ b/internal/providersync/github_cicd_route_test.go
@@ -1,0 +1,180 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const gitHubCICDWorkflowRunsFixture = `{
+  "workflow_runs": [
+    {
+      "id": 101,
+      "conclusion": "success",
+      "status": "completed",
+      "created_at": "2026-07-22T10:00:00Z",
+      "run_started_at": "2026-07-22T10:01:00Z",
+      "updated_at": "2026-07-22T10:05:00Z",
+      "run_attempt": 3
+    },
+    {
+      "id": 102,
+      "status": "queued",
+      "created_at": "2026-07-22T11:00:00Z",
+      "run_started_at": null,
+      "updated_at": null,
+      "run_attempt": "not-a-number"
+    },
+    {
+      "id": 103,
+      "status": "completed",
+      "created_at": "2026-06-20T10:00:00Z",
+      "run_started_at": "2026-06-20T10:01:00Z",
+      "updated_at": "2026-06-20T10:05:00Z",
+      "run_attempt": 1
+    },
+    {
+      "id": 104,
+      "status": "completed",
+      "created_at": "2026-08-01T10:00:00Z",
+      "run_started_at": "2026-08-01T10:01:00Z",
+      "updated_at": "2026-08-01T10:05:00Z",
+      "run_attempt": 1
+    }
+  ]
+}`
+
+type gitHubCICDDoer struct {
+	t        *testing.T
+	requests []string
+}
+
+func (doer *gitHubCICDDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request.URL.Path)
+	body := gitHubCICDWorkflowRunsFixture
+	if request.URL.Path == "/repos/acme/api" {
+		body = gitHubRepositoryFixture
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestGitHubCICDRouteEmitsOnlyWindowedPipelineRuns(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubCICDDoer{t: t}
+	client := gitHubRepositoryClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "cicd")
+
+	batch, err := (GitHubCICDRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "cicd")
+	if !ok {
+		t.Fatal("github/cicd has no canonical descriptor")
+	}
+	if err := batch.validate(descriptor); err != nil {
+		t.Fatalf("batch does not satisfy the canonical destination manifest: %v", err)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v want claim.BeforeAt=%v", batch.Watermark, claim.BeforeAt)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "ci_pipeline_runs" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if got, want := doer.requests, []string{"/repos/acme/api", "/repos/acme/api/actions/runs"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("requests=%v want=%v", got, want)
+	}
+
+	var first, second ciPipelineRunRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(batch.Effects[0].Rows[1], &second); err != nil {
+		t.Fatal(err)
+	}
+	if first.OrgID != claim.OrgID || first.RunID != "101" || first.Status == nil || *first.Status != "success" ||
+		first.RetryCount != 2 || first.QueuedAt == nil || first.StartedAt.IsZero() ||
+		first.FinishedAt == nil {
+		t.Fatalf("first row=%+v", first)
+	}
+	if second.OrgID != claim.OrgID || second.RunID != "102" || second.Status == nil || *second.Status != "queued" ||
+		second.RetryCount != 0 || second.QueuedAt == nil ||
+		!second.StartedAt.Equal(*second.QueuedAt) || second.FinishedAt != nil {
+		t.Fatalf("second row=%+v", second)
+	}
+}
+
+func TestPipelineRunReadbackRejectsEachPersistedFieldMismatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	status := "success"
+	queuedAt := now.Add(-2 * time.Minute)
+	finishedAt := now.Add(-time.Minute)
+	expected := ciPipelineRunRow{
+		OrgID: "org-1", RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", RunID: "101",
+		Status: &status, QueuedAt: &queuedAt, StartedAt: now.Add(-90 * time.Second),
+		FinishedAt: &finishedAt, RetryCount: 2, LastSynced: now,
+	}
+	matching := ciPipelineRunVersion{Row: expected, LastSynced: now, Found: true}
+	if got := comparePipelineRunVersion(expected, matching); got != EffectExact {
+		t.Fatalf("matching version=%s", got)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*ciPipelineRunVersion)
+	}{
+		{"org ID", func(actual *ciPipelineRunVersion) { actual.Row.OrgID = "other-org" }},
+		{"run ID", func(actual *ciPipelineRunVersion) { actual.Row.RunID = "other" }},
+		{"status", func(actual *ciPipelineRunVersion) { value := "failure"; actual.Row.Status = &value }},
+		{"queued at", func(actual *ciPipelineRunVersion) { value := queuedAt.Add(time.Second); actual.Row.QueuedAt = &value }},
+		{"started at", func(actual *ciPipelineRunVersion) { actual.Row.StartedAt = expected.StartedAt.Add(time.Second) }},
+		{"finished at", func(actual *ciPipelineRunVersion) {
+			value := finishedAt.Add(time.Second)
+			actual.Row.FinishedAt = &value
+		}},
+		{"retry count", func(actual *ciPipelineRunVersion) { actual.Row.RetryCount++ }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := matching
+			test.mutate(&actual)
+			if got := comparePipelineRunVersion(expected, actual); got != EffectConflict {
+				t.Fatalf("inspection=%s", got)
+			}
+		})
+	}
+}
+
+func TestWorkflowRetryCountClampsPreFirstAttempts(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		input any
+		want  uint32
+	}{
+		{json.Number("0"), 0},
+		{json.Number("1"), 0},
+		{json.Number("2"), 1},
+		{json.Number("3"), 2},
+		{"invalid", 0},
+	} {
+		if got := workflowRetryCount(test.input); got != test.want {
+			t.Fatalf("workflowRetryCount(%v)=%d want=%d", test.input, got, test.want)
+		}
+	}
+}

--- a/internal/providersync/testdata/field_reflection.py
+++ b/internal/providersync/testdata/field_reflection.py
@@ -97,3 +97,26 @@ def dict_literal_keys(
             "not silently returning an empty/stale set"
         )
     return frozenset(keys)
+
+
+def class_annotated_field_names(source: str, class_name: str) -> frozenset[str]:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        fields = {
+            statement.target.id
+            for statement in node.body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and not statement.target.id.startswith("_")
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Name)
+            and statement.value.func.id == "mapped_column"
+        }
+        if fields:
+            return frozenset(fields)
+        break
+    raise ValueError(
+        f"class_annotated_field_names: no annotated public fields found for {class_name!r}"
+    )

--- a/internal/providersync/testdata/oracle_pairs/github_cicd_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_cicd_row.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
+_BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(_MODEL_SOURCE.read_text(), "CiPipelineRun")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    code_client = load_live_module(_CODE_CLIENT_SOURCE)
+    workflow_run = code_client._workflow_run_from_item(case["raw_run"])
+    base_git = load_live_module(_BASE_GIT_SOURCE)
+    run = base_git.build_ci_pipeline_run(
+        repo_id=case["repo_id"],
+        run_id=workflow_run.run_id,
+        status=workflow_run.status,
+        queued_at=workflow_run.queued_at,
+        started_at=workflow_run.started_at,
+        finished_at=workflow_run.finished_at,
+        retry_count=workflow_run.retry_count,
+    )
+    return {key: value for key, value in vars(run).items() if not key.startswith("_")}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/cicd/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "last_synced": (
+                "stamped by ClickHouseStore.insert_ci_pipeline_runs at persistence time, "
+                "not by build_ci_pipeline_run"
+            )
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -131,7 +131,11 @@ def _target_base_git() -> None:
     _install_module(
         "dev_health_ops.models.git",
         {
-            "CiPipelineRun": object,
+            "CiPipelineRun": type(
+                "CiPipelineRun",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            ),
             "Deployment": object,
             "GitBlame": object,
             "GitCommitStat": object,

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -130,6 +130,7 @@ class ProviderUnitRouteSwitches:
     # config.Config.WorkerGithubPRsEnabled, read from the same
     # WORKER_GITHUB_PRS_ENABLED environment name.
     github_prs: bool = False
+    github_cicd: bool = False
 
     @classmethod
     def from_environment(
@@ -145,6 +146,7 @@ class ProviderUnitRouteSwitches:
             ),
             github_repo_metadata=_flag(source, "WORKER_GITHUB_REPO_METADATA_ENABLED"),
             github_prs=_flag(source, "WORKER_GITHUB_PRS_ENABLED"),
+            github_cicd=_flag(source, "WORKER_GITHUB_CICD_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -195,6 +195,38 @@ def test_github_prs_switch_does_not_open_pr_reviews_or_pr_comments() -> None:
         assert not switches.routes_to_river("github", dataset)
 
 
+def test_github_cicd_defaults_to_false() -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true"}
+    )
+    assert switches.github_cicd is False
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._TRUE))
+def test_github_cicd_parses_true_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_CICD_ENABLED": value}
+    )
+    assert switches.github_cicd is True
+    assert switches.routes_to_river("github", "cicd")
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._FALSE))
+def test_github_cicd_parses_false_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_CICD_ENABLED": value}
+    )
+    assert switches.github_cicd is False
+    assert not switches.routes_to_river("github", "cicd")
+
+
+def test_github_cicd_invalid_value_fails_closed() -> None:
+    with pytest.raises(ProviderUnitRouteError):
+        ProviderUnitRouteSwitches.from_environment(
+            {"WORKER_GITHUB_CICD_ENABLED": "sometimes"}
+        )
+
+
 # ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.


### PR DESCRIPTION
## Summary
- Ports the isolated GitHub CI/CD pipeline-run sync unit to Go and enables the matching Python and Go route switches.
- Writes and reads `ci_pipeline_runs` with `org_id`; this fixes the Critical cross-tenant readback/write isolation gap found in review.
- Adds live Python producer parity, production construction, ClickHouse integration, and route/matrix coverage.

## Route-ready decision
`github/cicd` remains `route_ready: true`. Evidence:
- Live-producer parity: `internal/providersync/github_cicd_generic_oracle_test.go:69-72` executes the Python workflow normalizer and `build_ci_pipeline_run`; `bash ci/check_go.sh all` executed `live-python-oracles` with `-count=1`.
- Production construction: `cmd/dev-health-worker/provider_sync.go:228-234` constructs `GitHubCICDRouteHandler` and `GitHubCICDClickHouseEffects`; `:308-312` constructs the worker when its switch is enabled.
- ClickHouse proofs: `internal/providersync/github_cicd_effects_integration_test.go:29-59` verifies winning ReplacingMergeTree readback; `:62-90` inserts the same `(repo_id, run_id)` for two orgs and proves an org-A readback excludes org B.

## Tenant-predicate proof
- With the `org_id = ?` predicate temporarily removed and a cold test cache, `TestGitHubCICDReadbackExcludesSameRunFromOtherTenant` failed: `foreign-only inspection=conflict`.
- After restoration and another `go clean -testcache`, the same real ClickHouse test passed.

## Validation
- `bash ci/check_go.sh all` — exit 0; live Python oracles executed.
- Six-defect acceptance gate (`TestGenericOracleRediscoversRowConstructionDefects`, `TestGenericOracleRediscoversWindowGuardDefect`, `TestGenericComparatorRediscoversReadbackDefects`) — exit 0 after the comparator change.
- `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=<unique> bash ci/local_validate.sh` — exit 0.
- Tagged ClickHouse integration tests — exit 0.

## Mutation evidence
Historical cold-cache proofs for this unit killed: inverted since-window guard and before-window guard at `TestGitHubCICDRouteEmitsOnlyWindowedPipelineRuns`; retry-boundary mutation at `TestWorkflowRetryCountClampsPreFirstAttempts`. The tenant predicate now has a fresh cold-cache remove/restore fail/pass proof above.

## NOT PINNED / residual risk
- The shared mutation harness is absent on this branch, so there is no fresh post-`org_id` comparator mutation proof beyond the real-query predicate proof.
- Python silently caps workflow-run pagination at 1000 records; D16 requires this port to mirror Python. Follow-up: CHAOS-3175.
- No live provider API/canary traffic parity is included; parity is at the live Python producer and ClickHouse boundary.