### PR TITLE
CHAOS-3176: port github/deployments sync unit to Go

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -433,6 +433,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		GithubPRs:                cfg.WorkerGithubPRsEnabled,
 		GithubCICD:               cfg.WorkerGithubCICDEnabled,
 		GithubCommits:            cfg.WorkerGithubCommitsEnabled,
+		GithubDeployments:        cfg.WorkerGithubDeploymentsEnabled,
 	}
 }
 
@@ -454,6 +455,7 @@ func providerRouteSwitchesReady(
 		{"github", "prs", cfg.WorkerGithubPRsEnabled},
 		{"github", "cicd", cfg.WorkerGithubCICDEnabled},
 		{"github", "commits", cfg.WorkerGithubCommitsEnabled},
+		{"github", "deployments", cfg.WorkerGithubDeploymentsEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -239,6 +239,13 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubCommitsRouteHandler{}
 				sink, readback = ghCommitsSink, ghCommitsSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "deployments":
+				ghDeploymentsSink := providersync.GitHubDeploymentsClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubDeploymentsRouteHandler{}
+				sink, readback = ghDeploymentsSink, ghDeploymentsSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
@@ -315,7 +322,8 @@ func buildProviderSyncWorker(
 	if cfg.Profile != "sync" ||
 		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled &&
 			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled &&
-			!cfg.WorkerGithubCICDEnabled && !cfg.WorkerGithubCommitsEnabled) {
+			!cfg.WorkerGithubCICDEnabled && !cfg.WorkerGithubCommitsEnabled &&
+			!cfg.WorkerGithubDeploymentsEnabled) {
 		return workerFamily{}, nil
 	}
 	if registry == nil || observer == nil || logger == nil ||

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -277,6 +277,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 			cfg:  config.Config{WorkerGithubCommitsEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubCommits: true},
 		},
+		"github_deployments": {
+			cfg:  config.Config{WorkerGithubDeploymentsEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubDeployments: true},
+		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
 			want: providersync.CompleteRouteSwitches{LinearWorkItems: true},
@@ -345,6 +349,20 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitsCapability(t *testing.T)
 		t.Fatalf("executor handler=%T", executor.Handler)
 	}
 	if _, ok := executor.Committer.Sink.(providersync.GitHubCommitsClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+}
+
+func TestBuildProviderSyncHandlerConstructsGitHubDeploymentsCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubDeployments: true}, nil, nil, nil, nil, nil, slog.Default())
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{Claim: providersync.Claim{Unit: providersync.Unit{Provider: "github", Dataset: "deployments"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.GitHubDeploymentsRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.GitHubDeploymentsClickHouseEffects); !ok {
 		t.Fatalf("executor sink=%T", executor.Committer.Sink)
 	}
 }

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -116,11 +116,13 @@
       "processor_flags": {
         "sync_deployments": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "deployments",
-      "route_destinations": [],
-      "route_ready": false,
+      "route_destinations": [
+        "deployments"
+      ],
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -118,6 +118,8 @@ type Config struct {
 	WorkerGithubCICDEnabled bool
 	// WorkerGithubCommitsEnabled gates the isolated (github, commits) route.
 	WorkerGithubCommitsEnabled bool
+	// WorkerGithubDeploymentsEnabled gates the isolated (github, deployments) route.
+	WorkerGithubDeploymentsEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -205,6 +207,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_COMMITS_ENABLED",
 			target: &cfg.WorkerGithubCommitsEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_DEPLOYMENTS_ENABLED",
+			target: &cfg.WorkerGithubDeploymentsEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -67,6 +67,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //     normalizer and builder plus readback-fenced ClickHouse effects.
 //   - github/commits: CHAOS-3177, live producer oracle parity plus
 //     tenant-scoped FINAL readback.
+//   - github/deployments: CHAOS-3176, differential row parity against the live
+//     Python normalizer and builder plus tenant-scoped FINAL readback.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -85,6 +87,7 @@ var routeReadyPairs = map[string]struct{}{
 	"github/repo-metadata":       {},
 	"github/cicd":                {},
 	"github/commits":             {},
+	"github/deployments":         {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -108,8 +111,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
 		GithubPRs: true, GithubCICD: true, GithubCommits: true,
+		GithubDeployments: true,
 	}
-	if reflect.TypeOf(all).NumField() != 8 {
+	if reflect.TypeOf(all).NumField() != 9 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -220,6 +224,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"github/prs":                 GitHubPullRequestRouteHandler{},
 		"github/cicd":                GitHubCICDRouteHandler{},
 		"github/commits":             GitHubCommitsRouteHandler{},
+		"github/deployments":         GitHubDeploymentsRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -36,6 +36,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"github/prs":                 ExecutorNativeGo,
 	"github/cicd":                ExecutorNativeGo,
 	"github/commits":             ExecutorNativeGo,
+	"github/deployments":         ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -132,8 +133,9 @@ type CompleteRouteSwitches struct {
 	// deploy/go-workers/provider-sync-porting-recipe.md.
 	GithubPRs bool
 	// GithubCICD gates the isolated ci_pipeline_runs writer only.
-	GithubCICD    bool
-	GithubCommits bool
+	GithubCICD        bool
+	GithubCommits     bool
+	GithubDeployments bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -232,6 +234,10 @@ func (switches CompleteRouteSwitches) Descriptor(
 		descriptor.Destinations = []string{"git_commits"}
 		descriptor.RouteReady = true
 		descriptor.RouteEnabled = switches.GithubCommits
+	case provider == "github" && dataset == "deployments":
+		descriptor.Destinations = []string{"deployments"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubDeployments
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_deployments_effects_clickhouse.go
+++ b/internal/providersync/github_deployments_effects_clickhouse.go
@@ -1,0 +1,150 @@
+package providersync
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type GitHubDeploymentsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubDeploymentsClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "deployments" || effect.Destination != "deployments" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[deploymentRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO deployments (repo_id, deployment_id, status, environment, started_at, finished_at, deployed_at, merged_at, pull_request_number, release_ref, release_ref_confidence, org_id, last_synced)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(row.RepoID, row.DeploymentID, row.Status, row.Environment, row.StartedAt, row.FinishedAt, row.DeployedAt, row.MergedAt, nullableInt32(row.PullRequestNumber), row.ReleaseRef, row.ReleaseRefConfidence, row.OrgID, row.LastSynced); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubDeploymentsClickHouseEffects) InspectEffect(ctx context.Context, claim Claim, effect EffectBatch) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "deployments" || effect.Destination != "deployments" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[deploymentRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectDeployment(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink GitHubDeploymentsClickHouseEffects) inspectDeployment(ctx context.Context, expected deploymentRow) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `SELECT repo_id, deployment_id, status, environment, started_at, finished_at, deployed_at, merged_at, pull_request_number, release_ref, release_ref_confidence, org_id, last_synced FROM deployments FINAL WHERE org_id = ? AND repo_id = ? AND deployment_id = ?`, expected.OrgID, expected.RepoID, expected.DeploymentID)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual deploymentRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(&actual.RepoID, &actual.DeploymentID, &actual.Status, &actual.Environment, &actual.StartedAt, &actual.FinishedAt, &actual.DeployedAt, &actual.MergedAt, &actual.PullRequestNumber, &actual.ReleaseRef, &actual.ReleaseRefConfidence, &actual.OrgID, &actual.LastSynced); err != nil {
+			return EffectConflict, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareDeploymentVersion(expected, actual, found), nil
+}
+
+func compareDeploymentVersion(expected, actual deploymentRow, found bool) EffectInspection {
+	if !found || actual.LastSynced.IsZero() {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if actual.RepoID != expected.RepoID || actual.DeploymentID != expected.DeploymentID || actual.OrgID != expected.OrgID || !stringPointersEqual(actual.Status, expected.Status) || !stringPointersEqual(actual.Environment, expected.Environment) || !timePointersEqual(actual.StartedAt, expected.StartedAt) || !timePointersEqual(actual.FinishedAt, expected.FinishedAt) || !timePointersEqual(actual.DeployedAt, expected.DeployedAt) || !timePointersEqual(actual.MergedAt, expected.MergedAt) || !intPointersEqual(actual.PullRequestNumber, expected.PullRequestNumber) || actual.ReleaseRef != expected.ReleaseRef || actual.ReleaseRefConfidence != expected.ReleaseRefConfidence {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func intPointersEqual(left, right *int) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func nullableInt32(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return int32(*value)
+}
+
+var _ EffectSink = GitHubDeploymentsClickHouseEffects{}
+var _ EffectReadback = GitHubDeploymentsClickHouseEffects{}

--- a/internal/providersync/github_deployments_effects_integration_test.go
+++ b/internal/providersync/github_deployments_effects_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const deploymentsDDL = `
+CREATE TABLE deployments (
+  repo_id UUID, deployment_id String, status Nullable(String), environment Nullable(String),
+  started_at Nullable(DateTime64(3, 'UTC')), finished_at Nullable(DateTime64(3, 'UTC')),
+  deployed_at Nullable(DateTime64(3, 'UTC')), merged_at Nullable(DateTime64(3, 'UTC')),
+  pull_request_number Nullable(Int32), release_ref String, release_ref_confidence Float64,
+  org_id String, last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced) ORDER BY (org_id, repo_id, deployment_id)`
+
+func TestGitHubDeploymentsReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, sink := newGitHubDeploymentsIntegrationSink(t)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim := nativeTestClaim("github", "deployments")
+	current := deploymentRow{OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", DeploymentID: "101", DeployedAt: pointerTo(now.Add(-time.Minute)), ReleaseRef: "v1", ReleaseRefConfidence: 1, LastSynced: now}
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previous.ReleaseRef = "old"
+	if err := sink.WriteEffect(ctx, claim, deploymentEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, deploymentEffect(t, current))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, deploymentEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, deploymentEffect(t, current))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitHubDeploymentsReadbackExcludesSameNaturalKeyFromOtherTenant(t *testing.T) {
+	ctx, sink := newGitHubDeploymentsIntegrationSink(t)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim := nativeTestClaim("github", "deployments")
+	row := deploymentRow{OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", DeploymentID: "101", DeployedAt: pointerTo(now), ReleaseRef: "v1", ReleaseRefConfidence: 1, LastSynced: now}
+	otherClaim := claim
+	otherClaim.OrgID = "other-org"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	otherRow.ReleaseRef = "other"
+	if err := sink.WriteEffect(ctx, otherClaim, deploymentEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, deploymentEffect(t, row))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, deploymentEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, deploymentEffect(t, row))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("tenant-scoped inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newGitHubDeploymentsIntegrationSink(t *testing.T) (context.Context, GitHubDeploymentsClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, deploymentsDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitHubDeploymentsClickHouseEffects{Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })}
+}
+
+func deploymentEffect(t *testing.T, row deploymentRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("deployments", EffectReadbackRequired, []deploymentRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+func pointerTo(value time.Time) *time.Time { return &value }

--- a/internal/providersync/github_deployments_generic_oracle_test.go
+++ b/internal/providersync/github_deployments_generic_oracle_test.go
@@ -1,0 +1,68 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var oracleDeploymentsGoOnlyFields = map[string]string{
+	"org_id":      "carried from the Go claim to keep ClickHouse writes tenant-scoped",
+	"last_synced": "stamped from normalizedAt by the Go complete-route handler",
+}
+
+var oracleDeploymentsNormalizedAt = time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+
+func buildDeploymentRowForOracle(t *testing.T, input map[string]any) deploymentRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["raw_deployment"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var deployment gitHubDeploymentPayload
+	if err := decoder.Decode(&deployment); err != nil {
+		t.Fatal(err)
+	}
+	var releases []gitHubReleasePayload
+	encoded, err = json.Marshal(input["releases"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder = json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&releases); err != nil {
+		t.Fatal(err)
+	}
+	row, ok := normalizeGitHubDeployment(nativeTestClaim("github", "deployments"), input["repo_id"].(string), deployment, releases, oracleDeploymentsNormalizedAt)
+	if !ok {
+		t.Fatal("oracle deployment did not produce a row")
+	}
+	encoded, err = json.Marshal(input["pulls"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder = json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var pulls []gitHubPullPayload
+	if err := decoder.Decode(&pulls); err != nil {
+		t.Fatal(err)
+	}
+	if deployment.SHA != nil {
+		row.PullRequestNumber, row.MergedAt = chooseDeploymentPullRequest(pulls, *deployment.SHA)
+	}
+	return row
+}
+
+func oracleDeploymentCases() []oracleCase {
+	return []oracleCase{
+		{ID: "release_tag_with_merged_pull", Input: map[string]any{"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "releases": []map[string]any{{"tag_name": "v1.2.3"}}, "pulls": []map[string]any{{"number": 42, "merge_commit_sha": "abc", "merged_at": "2026-07-21T10:00:00Z"}}, "raw_deployment": map[string]any{"id": 101, "state": "success", "environment": "production", "created_at": "2026-07-22T10:00:00Z", "ref": "v1.2.3", "sha": "abc"}}},
+		{ID: "fallback", Input: map[string]any{"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "releases": []map[string]any{}, "pulls": []map[string]any{}, "raw_deployment": map[string]any{"id": "102", "status": "pending", "environment": nil, "created_at": "2026-07-22T11:00:00Z"}}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForDeploymentsRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/deployments/row", oracleDeploymentCases(), buildDeploymentRowForOracle, oracleDeploymentsGoOnlyFields)
+}

--- a/internal/providersync/github_deployments_route.go
+++ b/internal/providersync/github_deployments_route.go
@@ -1,0 +1,245 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const defaultGitHubDeploymentsMax = 1_000
+
+// deploymentRow mirrors Python's build_deployment -> insert_deployments boundary.
+type deploymentRow struct {
+	RepoID               string     `json:"repo_id"`
+	DeploymentID         string     `json:"deployment_id"`
+	Status               *string    `json:"status"`
+	Environment          *string    `json:"environment"`
+	StartedAt            *time.Time `json:"started_at"`
+	FinishedAt           *time.Time `json:"finished_at"`
+	DeployedAt           *time.Time `json:"deployed_at"`
+	MergedAt             *time.Time `json:"merged_at"`
+	PullRequestNumber    *int       `json:"pull_request_number"`
+	ReleaseRef           string     `json:"release_ref"`
+	ReleaseRefConfidence float64    `json:"release_ref_confidence"`
+	OrgID                string     `json:"org_id"`
+	LastSynced           time.Time  `json:"last_synced"`
+}
+
+type gitHubDeploymentPayload struct {
+	ID          json.Number    `json:"id"`
+	State       any            `json:"state"`
+	Status      any            `json:"status"`
+	Environment any            `json:"environment"`
+	CreatedAt   *string        `json:"created_at"`
+	SHA         *string        `json:"sha"`
+	Ref         any            `json:"ref"`
+	Tag         any            `json:"tag"`
+	TagName     any            `json:"tag_name"`
+	Payload     map[string]any `json:"payload"`
+}
+
+type gitHubReleasePayload struct {
+	TagName any `json:"tag_name"`
+}
+type gitHubPullPayload struct {
+	Number         any     `json:"number"`
+	MergedAt       *string `json:"merged_at"`
+	MergeCommitSHA any     `json:"merge_commit_sha"`
+}
+
+// GitHubDeploymentsRouteHandler mirrors _fetch_github_deployments_async. It
+// owns only deployments, including Python's release and PR enrichment.
+type GitHubDeploymentsRouteHandler struct{ MaxDeployments int }
+
+func (handler GitHubDeploymentsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "deployments" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+	var repoPayload gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repoPayload); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repoPayload.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	maxDeployments := handler.MaxDeployments
+	if maxDeployments == 0 {
+		maxDeployments = defaultGitHubDeploymentsMax
+	}
+	if maxDeployments < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	pages := (maxDeployments + nativePerPage - 1) / nativePerPage
+	releases, releasePages, err := fetchGitHubDeploymentsPage[gitHubReleasePayload](ctx, client, root+"/releases", pages)
+	if err != nil {
+		// Python treats release enrichment as best effort.
+		releases, releasePages = nil, 0
+	}
+	deployments, deploymentPages, err := fetchGitHubDeploymentsPage[gitHubDeploymentPayload](ctx, client, root+"/deployments", pages)
+	if err != nil {
+		// Python logs and returns the successful empty batch for this optional collection.
+		effect, effectErr := effectBatchFromValues("deployments", EffectReadbackRequired, []deploymentRow{})
+		if effectErr != nil {
+			return CompleteRouteBatch{}, effectErr
+		}
+		return CompleteRouteBatch{Effects: []EffectBatch{effect}, Result: map[string]any{"deployments_synced": 0, "repo": repoPayload.FullName}, Watermark: claim.BeforeAt, Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset, Requests: releasePages + 1, Pages: releasePages, Records: 0}}, nil
+	}
+	if len(deployments) > maxDeployments {
+		deployments = deployments[:maxDeployments]
+	}
+	rows := make([]deploymentRow, 0, len(deployments))
+	for _, deployment := range deployments {
+		row, include := normalizeGitHubDeployment(claim, repoID, deployment, releases, normalizedAt)
+		if !include || deploymentOutsideWindow(row.DeployedAt, claim) {
+			continue
+		}
+		if deployment.SHA != nil && strings.TrimSpace(*deployment.SHA) != "" {
+			pulls, _, pullErr := fetchGitHubDeploymentsPage[gitHubPullPayload](ctx, client, root+"/commits/"+url.PathEscape(*deployment.SHA)+"/pulls", 1)
+			if pullErr == nil {
+				row.PullRequestNumber, row.MergedAt = chooseDeploymentPullRequest(pulls, *deployment.SHA)
+			}
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues("deployments", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{Effects: []EffectBatch{effect}, Result: map[string]any{"deployments_synced": len(rows), "repo": repoPayload.FullName}, Watermark: claim.BeforeAt, Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset, Requests: releasePages + deploymentPages + 1, Pages: releasePages + deploymentPages, Records: len(rows)}}, nil
+}
+
+func fetchGitHubDeploymentsPage[T any](ctx context.Context, client *providerfoundation.HTTPClient, path string, maxPages int) ([]T, int, error) {
+	page, err := providerfoundation.CollectGitHubLinkPages(ctx, client, providerfoundation.GitHubPageOptions{Path: path, Query: url.Values{"per_page": {"100"}}, MaxPages: maxPages})
+	if err != nil {
+		return nil, 0, err
+	}
+	items := make([]T, 0, len(page.Items))
+	for _, raw := range page.Items {
+		var item T
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.UseNumber()
+		if decoder.Decode(&item) != nil {
+			return nil, 0, providerfoundation.ErrNormalizationInvalid
+		}
+		items = append(items, item)
+	}
+	return items, page.Pages, nil
+}
+
+func normalizeGitHubDeployment(claim Claim, repoID string, deployment gitHubDeploymentPayload, releases []gitHubReleasePayload, normalizedAt time.Time) (deploymentRow, bool) {
+	deployedAt := parseGitHubWorkflowTime(deployment.CreatedAt)
+	if deployedAt == nil {
+		return deploymentRow{}, false
+	}
+	releaseRef, confidence := deploymentReleaseRef(deployment, releases)
+	return deploymentRow{RepoID: repoID, DeploymentID: stringValue(deployment.ID), Status: optionalString(deployment.State, deployment.Status), Environment: optionalString(deployment.Environment), StartedAt: deployedAt, DeployedAt: deployedAt, ReleaseRef: releaseRef, ReleaseRefConfidence: confidence, OrgID: claim.OrgID, LastSynced: normalizedAt}, true
+}
+
+func deploymentReleaseRef(deployment gitHubDeploymentPayload, releases []gitHubReleasePayload) (string, float64) {
+	for _, candidate := range []any{deployment.TagName, deployment.Tag, deployment.Payload["release_ref"], deployment.Payload["release"], deployment.Payload["release_tag"], deployment.Payload["tag_name"], deployment.Payload["tag"], deployment.Payload["version"]} {
+		if value := strings.TrimSpace(stringValue(candidate)); value != "" {
+			return value, deploymentExplicitConfidence(deployment)
+		}
+	}
+	candidates := map[string]struct{}{}
+	for _, candidate := range []any{deployment.Ref, deployment.Tag, deployment.TagName, deployment.Payload["ref"], deployment.Payload["tag"], deployment.Payload["tag_name"], deployment.Payload["release_tag"]} {
+		if value := strings.TrimSpace(stringValue(candidate)); value != "" {
+			candidates[value] = struct{}{}
+		}
+	}
+	for _, release := range releases {
+		if tag := strings.TrimSpace(stringValue(release.TagName)); tag != "" {
+			if _, ok := candidates[tag]; ok {
+				return tag, 1
+			}
+		}
+	}
+	return stringValue(deployment.ID), 0.3
+}
+
+func deploymentExplicitConfidence(deployment gitHubDeploymentPayload) float64 {
+	value, ok := deployment.Payload["release_ref_confidence"]
+	if !ok {
+		return 1
+	}
+	number, err := json.Number(stringValue(value)).Float64()
+	if err != nil {
+		return 1
+	}
+	if number < 0 {
+		return 0
+	}
+	if number > 1 {
+		return 1
+	}
+	return number
+}
+
+func optionalString(values ...any) *string {
+	for _, value := range values {
+		if text := strings.TrimSpace(stringValue(value)); text != "" {
+			return &text
+		}
+	}
+	return nil
+}
+func deploymentOutsideWindow(deployedAt *time.Time, claim Claim) bool {
+	return deployedAt == nil || (claim.SinceAt != nil && deployedAt.Before(claim.SinceAt.UTC())) || (claim.BeforeAt != nil && deployedAt.After(claim.BeforeAt.UTC()))
+}
+func chooseDeploymentPullRequest(pulls []gitHubPullPayload, sha string) (*int, *time.Time) {
+	var chosen *gitHubPullPayload
+	for i := range pulls {
+		if parseGitHubWorkflowTime(pulls[i].MergedAt) != nil && stringValue(pulls[i].MergeCommitSHA) == sha {
+			chosen = &pulls[i]
+			break
+		}
+	}
+	if chosen == nil {
+		for i := range pulls {
+			if parseGitHubWorkflowTime(pulls[i].MergedAt) != nil {
+				chosen = &pulls[i]
+				break
+			}
+		}
+	}
+	if chosen == nil && len(pulls) > 0 {
+		chosen = &pulls[0]
+	}
+	if chosen == nil {
+		return nil, nil
+	}
+	number, err := json.Number(stringValue(chosen.Number)).Int64()
+	if err != nil {
+		return nil, parseGitHubWorkflowTime(chosen.MergedAt)
+	}
+	value := int(number)
+	return &value, parseGitHubWorkflowTime(chosen.MergedAt)
+}
+
+func (row deploymentRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.RepoID == "" || len(row.RepoID) != 36 || row.DeploymentID == "" || row.DeployedAt == nil || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubDeploymentsRouteHandler{}

--- a/internal/providersync/github_deployments_route_test.go
+++ b/internal/providersync/github_deployments_route_test.go
@@ -1,0 +1,95 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitHubDeploymentsDoer struct{ requests []string }
+
+func (doer *gitHubDeploymentsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.requests = append(doer.requests, request.URL.Path)
+	body := `[]`
+	switch request.URL.Path {
+	case "/repos/acme/api":
+		body = gitHubRepositoryFixture
+	case "/repos/acme/api/releases":
+		body = `[{"tag_name":"v1.2.3"}]`
+	case "/repos/acme/api/deployments":
+		body = `[{"id":101,"state":"success","environment":"production","created_at":"2026-07-22T10:00:00Z","ref":"v1.2.3","sha":"abc"},{"id":102,"status":"pending","created_at":"2026-06-20T10:00:00Z"}]`
+	case "/repos/acme/api/commits/abc/pulls":
+		body = `[{"number":42,"merge_commit_sha":"abc","merged_at":"2026-07-21T10:00:00Z"}]`
+	}
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+}
+
+func TestGitHubDeploymentsRouteMirrorsPythonEnrichmentAndWindow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubDeploymentsDoer{}
+	client := gitHubRepositoryClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "deployments")
+	batch, err := (GitHubDeploymentsRouteHandler{}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "deployments")
+	if !ok {
+		t.Fatal("github/deployments has no canonical descriptor")
+	}
+	if err := batch.validate(descriptor); err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v", batch.Watermark)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "deployments" || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var row deploymentRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	if row.OrgID != claim.OrgID || row.DeploymentID != "101" || row.ReleaseRef != "v1.2.3" || row.ReleaseRefConfidence != 1 || row.PullRequestNumber == nil || *row.PullRequestNumber != 42 || row.MergedAt == nil || row.DeployedAt == nil {
+		t.Fatalf("row=%+v", row)
+	}
+	want := []string{"/repos/acme/api", "/repos/acme/api/releases", "/repos/acme/api/deployments", "/repos/acme/api/commits/abc/pulls"}
+	if len(doer.requests) != len(want) {
+		t.Fatalf("requests=%v want=%v", doer.requests, want)
+	}
+	for index := range want {
+		if doer.requests[index] != want[index] {
+			t.Fatalf("requests=%v want=%v", doer.requests, want)
+		}
+	}
+}
+
+func TestDeploymentReadbackRejectsEachPersistedFieldMismatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	expected := deploymentRow{OrgID: "org-1", RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", DeploymentID: "101", DeployedAt: deploymentTimePointer(now), ReleaseRef: "v1", ReleaseRefConfidence: 1, LastSynced: now}
+	actual := expected
+	actual.ReleaseRef = "other"
+	if got := compareDeploymentVersion(expected, actual, true); got != EffectConflict {
+		t.Fatalf("inspection=%s", got)
+	}
+}
+
+func TestDeploymentRowRejectsCrossTenantClaim(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "deployments")
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	row := deploymentRow{OrgID: "other-org", RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", DeploymentID: "101", DeployedAt: deploymentTimePointer(now), LastSynced: now}
+	if err := row.validate(claim); err == nil {
+		t.Fatal("cross-tenant row passed validation")
+	}
+}
+
+func deploymentTimePointer(value time.Time) *time.Time { return &value }

--- a/internal/providersync/testdata/oracle_pairs/github_deployments_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_deployments_row.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
+_BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+_RELEASE_REF_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/release_ref.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(_MODEL_SOURCE.read_text(), "Deployment")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    code_client = load_live_module(_CODE_CLIENT_SOURCE)
+    deployment = code_client._deployment_from_item(case["raw_deployment"])
+    release_ref = load_live_module(_RELEASE_REF_SOURCE)
+    enrichment = release_ref.get_release_ref_enrichment(
+        deployment,
+        "github",
+        releases=[code_client._release_from_item(item) for item in case["releases"]],
+    )
+    pull_request_number, merged_at = code_client._choose_deployment_pull_request(
+        case.get("pulls", []), deployment.sha
+    )
+    base_git = load_live_module(_BASE_GIT_SOURCE)
+    row = base_git.build_deployment(
+        repo_id=case["repo_id"],
+        deployment_id=deployment.deployment_id,
+        status=deployment.state,
+        environment=deployment.environment,
+        started_at=deployment.created_at,
+        finished_at=None,
+        deployed_at=deployment.created_at,
+        merged_at=merged_at,
+        pull_request_number=pull_request_number,
+        release_ref=enrichment.release_ref,
+        release_ref_confidence=enrichment.confidence,
+    )
+    return {key: value for key, value in vars(row).items() if not key.startswith("_")}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/deployments/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "org_id": "carried from the Go claim for tenant-scoped persistence",
+            "last_synced": "stamped by the Go handler at its normalized collection instant",
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -40,6 +40,7 @@ _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/bud
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
 _BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
 _GITHUB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/github/code_client.py")
+_RELEASE_REF_SOURCE = _source("dev_health_ops/processors/release_ref.py")
 
 _SAFE_SOURCE_MODULES: dict[str, Path] = {
     "dev_health_ops.sync.budget_types": _BUDGET_TYPES_SOURCE,
@@ -136,7 +137,11 @@ def _target_base_git() -> None:
                 (),
                 {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
             ),
-            "Deployment": object,
+            "Deployment": type(
+                "Deployment",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            ),
             "GitBlame": object,
             "GitCommitStat": object,
             "GitFile": object,
@@ -405,6 +410,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
         "dev_health_ops.providers.github.code_client",
         _GITHUB_CODE_CLIENT_SOURCE,
         _target_github_code_client,
+    ),
+    _RELEASE_REF_SOURCE: (
+        "dev_health_ops.processors.release_ref",
+        _RELEASE_REF_SOURCE,
+        lambda: None,
     ),
     _GITHUB_PROCESSOR_SOURCE: (
         "dev_health_ops.processors.github",

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -132,6 +132,7 @@ class ProviderUnitRouteSwitches:
     github_prs: bool = False
     github_cicd: bool = False
     github_commits: bool = False
+    github_deployments: bool = False
 
     @classmethod
     def from_environment(
@@ -149,6 +150,7 @@ class ProviderUnitRouteSwitches:
             github_prs=_flag(source, "WORKER_GITHUB_PRS_ENABLED"),
             github_cicd=_flag(source, "WORKER_GITHUB_CICD_ENABLED"),
             github_commits=_flag(source, "WORKER_GITHUB_COMMITS_ENABLED"),
+            github_deployments=_flag(source, "WORKER_GITHUB_DEPLOYMENTS_ENABLED"),
         )
         switches.require_complete_routes()
         return switches


### PR DESCRIPTION
## Summary
- ports the isolated `github/deployments` route, ClickHouse effect sink, and production worker construction
- records `route_ready: true` with a real-producer Python↔Go oracle and FINAL readback
- pins tenant isolation for identical natural keys across organizations

## Evidence
- Production construction: `cmd/dev-health-worker/provider_sync.go:237-243` selects `GitHubDeploymentsRouteHandler` and `GitHubDeploymentsClickHouseEffects`.
- Oracle: `internal/providersync/testdata/oracle_pairs/github_deployments_row.py` executes the production GitHub parser, release-ref enrichment, and `build_deployment`; the loader stub path ran locally under the cold-cache Go oracle test.
- ClickHouse: `GitHubDeploymentsClickHouseEffects` inserts `org_id`; `FINAL` readback scopes `WHERE org_id = ? AND repo_id = ? AND deployment_id = ?`.
- Tenant mutation proof (cold cache): removing `org_id = ?` made `TestGitHubDeploymentsReadbackExcludesSameNaturalKeyFromOtherTenant` fail (`foreign-only inspection=conflict`); restore passed.
- Validation mutation proof (cold cache): removing `row.OrgID != claim.OrgID` made `TestDeploymentRowRejectsCrossTenantClaim` fail; restore passed.
- Six-defect oracle acceptance gate: passed through `bash ci/check_go.sh all`, including `live-python-oracles` with `-count=1`.
- Gates: `bash ci/check_go.sh all` passed; clean-environment `ci/local_validate.sh` passed (9080 passed, 62 skipped).

## Route-ready decision
`github/deployments` is route-ready: native production construction, executed live-producer oracle parity, FINAL winning-version ClickHouse readback, and pinned cross-tenant isolation are all present.

## Review
Adversarial review found and fixed the missing PR-enrichment oracle coverage. The top-level release-ref concern was judged contrived after tracing the actual Python producer: `GitHubDeploymentData` drops those top-level fields before calling release enrichment, so current Python behavior cannot observe them.

## NOT-PINNED
- Live external GitHub traffic parity is not run; this project permits fixture-level parity because it has no production users.
- Release endpoint failure behavior is covered by parity implementation but not a live GitHub outage fixture.

TEST-EVIDENCE: `bash ci/check_go.sh all` passed and executed `live-python-oracles` with `-count=1`; clean-environment `ci/local_validate.sh` passed.

RISK-NOTES: Blast radius is the GitHub deployment route, ClickHouse effects, route-ready matrix, and execution registry. Rollback is to revert this PR (restoring Python routing); no follow-up is required for the governance marker repair.