### PR TITLE
CHAOS-3178: port GitHub security sync to Go

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -434,6 +434,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		GithubCICD:               cfg.WorkerGithubCICDEnabled,
 		GithubCommits:            cfg.WorkerGithubCommitsEnabled,
 		GithubDeployments:        cfg.WorkerGithubDeploymentsEnabled,
+		GithubSecurity:           cfg.WorkerGithubSecurityEnabled,
 	}
 }
 
@@ -456,6 +457,7 @@ func providerRouteSwitchesReady(
 		{"github", "cicd", cfg.WorkerGithubCICDEnabled},
 		{"github", "commits", cfg.WorkerGithubCommitsEnabled},
 		{"github", "deployments", cfg.WorkerGithubDeploymentsEnabled},
+		{"github", "security", cfg.WorkerGithubSecurityEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -111,6 +111,17 @@ type providerSyncRepository interface {
 	providersync.EffectLedger
 }
 
+type providerSyncWorkerConstructor func(
+	context.Context,
+	config.Config,
+	workerDatabase,
+	*jobruntime.Registry,
+	jobruntime.Observer,
+	*slog.Logger,
+) (workerFamily, error)
+
+var constructProviderSyncWorker providerSyncWorkerConstructor = constructProviderSyncWorkerWithDependencies
+
 // buildProviderSyncHandler constructs the provider-unit handler and the one
 // providerfoundation.Metrics instance its executor is wired to reference.
 //
@@ -181,9 +192,9 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Four route-ready pairs can reach this closure today
+			// Five route-ready pairs can reach this closure today
 			// (launchdarkly/feature-flags, github/repo-metadata, github/prs,
-			// github/cicd — see CompleteRouteSwitches.Descriptor), and each
+			// github/cicd, github/security — see CompleteRouteSwitches.Descriptor), and each
 			// has its own CompleteRouteHandler and effect sink. session.Claim
 			// is already known here — providerunit.Handler.Work only calls
 			// BuildExecutor after its own descriptor gate passed for THIS
@@ -246,6 +257,13 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubDeploymentsRouteHandler{}
 				sink, readback = ghDeploymentsSink, ghDeploymentsSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "security":
+				ghSecuritySink := providersync.GitHubSecurityClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubSecurityRouteHandler{}
+				sink, readback = ghSecuritySink, ghSecuritySink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
@@ -323,9 +341,20 @@ func buildProviderSyncWorker(
 		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled &&
 			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled &&
 			!cfg.WorkerGithubCICDEnabled && !cfg.WorkerGithubCommitsEnabled &&
-			!cfg.WorkerGithubDeploymentsEnabled) {
+			!cfg.WorkerGithubDeploymentsEnabled && !cfg.WorkerGithubSecurityEnabled) {
 		return workerFamily{}, nil
 	}
+	return constructProviderSyncWorker(ctx, cfg, database, registry, observer, logger)
+}
+
+func constructProviderSyncWorkerWithDependencies(
+	ctx context.Context,
+	cfg config.Config,
+	database workerDatabase,
+	registry *jobruntime.Registry,
+	observer jobruntime.Observer,
+	logger *slog.Logger,
+) (workerFamily, error) {
 	if registry == nil || observer == nil || logger == nil ||
 		!cfg.SettingsEncryptionKey.Configured() {
 		return workerFamily{}, errWorkerDependencyUnavailable

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -224,11 +224,12 @@ func disjointHandlerSets(left, right map[string]struct{}) bool {
 func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
 	t.Parallel()
 	for name, want := range map[string]providersync.CompleteRouteSwitches{
-		"none":        {},
-		"github":      {GithubRepoMetadata: true},
-		"github_prs":  {GithubPRs: true},
-		"github_cicd": {GithubCICD: true},
-		"both":        {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
+		"none":            {},
+		"github":          {GithubRepoMetadata: true},
+		"github_prs":      {GithubPRs: true},
+		"github_cicd":     {GithubCICD: true},
+		"github_security": {GithubSecurity: true},
+		"both":            {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -240,6 +241,82 @@ func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
 			}
 			if handler.Switches != want {
 				t.Fatalf("handler.Switches = %+v, want %+v", handler.Switches, want)
+			}
+		})
+	}
+}
+
+func TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch(t *testing.T) {
+	originalConstructor := constructProviderSyncWorker
+	t.Cleanup(func() {
+		constructProviderSyncWorker = originalConstructor
+	})
+
+	constructProviderSyncWorker = func(
+		_ context.Context,
+		_ config.Config,
+		_ workerDatabase,
+		_ *jobruntime.Registry,
+		_ jobruntime.Observer,
+		_ *slog.Logger,
+	) (workerFamily, error) {
+		return workerFamily{
+			queues: []jobruntime.QueueBudget{{
+				Queue: providerUnitQueue, MaxWorkers: providerUnitQueueWorkers,
+			}},
+		}, nil
+	}
+
+	for _, test := range []struct {
+		name string
+		cfg  config.Config
+	}{
+		{
+			name: "launchdarkly feature flags",
+			cfg: config.Config{
+				Profile: "sync", WorkerLaunchDarklyFeatureFlagsEnabled: true,
+			},
+		},
+		{
+			name: "github repo metadata",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubRepoMetadataEnabled: true,
+			},
+		},
+		{
+			name: "github cicd",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubCICDEnabled: true,
+			},
+		},
+		{
+			name: "github commits",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubCommitsEnabled: true,
+			},
+		},
+		{
+			name: "github deployments",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubDeploymentsEnabled: true,
+			},
+		},
+		{
+			name: "github security",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubSecurityEnabled: true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			family, err := buildProviderSyncWorker(
+				context.Background(), test.cfg, nil, nil, nil, nil,
+			)
+			if err != nil {
+				t.Fatalf("buildProviderSyncWorker() error = %v", err)
+			}
+			if len(family.queues) == 0 {
+				t.Fatal("buildProviderSyncWorker returned an empty worker family")
 			}
 		})
 	}
@@ -280,6 +357,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 		"github_deployments": {
 			cfg:  config.Config{WorkerGithubDeploymentsEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubDeployments: true},
+		},
+		"github_security": {
+			cfg:  config.Config{WorkerGithubSecurityEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubSecurity: true},
 		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
@@ -363,6 +444,23 @@ func TestBuildProviderSyncHandlerConstructsGitHubDeploymentsCapability(t *testin
 		t.Fatalf("executor handler=%T", executor.Handler)
 	}
 	if _, ok := executor.Committer.Sink.(providersync.GitHubDeploymentsClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+}
+
+func TestBuildProviderSyncHandlerConstructsGitHubSecurityCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubSecurity: true}, nil, nil, nil, nil, nil, slog.Default())
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("provider sync handler is not constructed")
+	}
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{Claim: providersync.Claim{Unit: providersync.Unit{Provider: "github", Dataset: "security"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.GitHubSecurityRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.GitHubSecurityClickHouseEffects); !ok {
 		t.Fatalf("executor sink=%T", executor.Committer.Sink)
 	}
 }

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -253,11 +253,13 @@
       "processor_flags": {
         "sync_security": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "security",
-      "route_destinations": [],
-      "route_ready": false,
+      "route_destinations": [
+        "security_alerts"
+      ],
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	WorkerGithubCommitsEnabled bool
 	// WorkerGithubDeploymentsEnabled gates the isolated (github, deployments) route.
 	WorkerGithubDeploymentsEnabled bool
+	// WorkerGithubSecurityEnabled gates the isolated (github, security) route.
+	WorkerGithubSecurityEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -211,6 +213,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_DEPLOYMENTS_ENABLED",
 			target: &cfg.WorkerGithubDeploymentsEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_SECURITY_ENABLED",
+			target: &cfg.WorkerGithubSecurityEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)
@@ -477,6 +483,7 @@ func (c Config) SafeAttrs() []slog.Attr {
 		slog.Bool("worker_github_repo_metadata_enabled", c.WorkerGithubRepoMetadataEnabled),
 		slog.Bool("worker_github_prs_enabled", c.WorkerGithubPRsEnabled),
 		slog.Bool("worker_github_commits_enabled", c.WorkerGithubCommitsEnabled),
+		slog.Bool("worker_github_security_enabled", c.WorkerGithubSecurityEnabled),
 		slog.Bool("clickhouse_configured", c.ClickHouseURI.Configured()),
 		slog.Bool("valkey_configured", c.ValkeyURI.Configured()),
 		slog.Bool("settings_encryption_key_configured", c.SettingsEncryptionKey.Configured()),

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -69,6 +69,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //     tenant-scoped FINAL readback.
 //   - github/deployments: CHAOS-3176, differential row parity against the live
 //     Python normalizer and builder plus tenant-scoped FINAL readback.
+//   - github/security: CHAOS-3178, differential row parity against the live
+//     production source mappings plus FINAL tenant-fenced ClickHouse effects.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -88,6 +90,7 @@ var routeReadyPairs = map[string]struct{}{
 	"github/cicd":                {},
 	"github/commits":             {},
 	"github/deployments":         {},
+	"github/security":            {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -111,9 +114,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
 		GithubPRs: true, GithubCICD: true, GithubCommits: true,
-		GithubDeployments: true,
+		GithubDeployments: true, GithubSecurity: true,
 	}
-	if reflect.TypeOf(all).NumField() != 9 {
+	if reflect.TypeOf(all).NumField() != 10 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -225,6 +228,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"github/cicd":                GitHubCICDRouteHandler{},
 		"github/commits":             GitHubCommitsRouteHandler{},
 		"github/deployments":         GitHubDeploymentsRouteHandler{},
+		"github/security":            GitHubSecurityRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -37,6 +37,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"github/cicd":                ExecutorNativeGo,
 	"github/commits":             ExecutorNativeGo,
 	"github/deployments":         ExecutorNativeGo,
+	"github/security":            ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -136,6 +137,8 @@ type CompleteRouteSwitches struct {
 	GithubCICD        bool
 	GithubCommits     bool
 	GithubDeployments bool
+	// GithubSecurity gates the isolated tenant-scoped security_alerts writer.
+	GithubSecurity bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -238,6 +241,10 @@ func (switches CompleteRouteSwitches) Descriptor(
 		descriptor.Destinations = []string{"deployments"}
 		descriptor.RouteReady = true
 		descriptor.RouteEnabled = switches.GithubDeployments
+	case provider == "github" && dataset == "security":
+		descriptor.Destinations = []string{"security_alerts"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubSecurity
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_security_effects_clickhouse.go
+++ b/internal/providersync/github_security_effects_clickhouse.go
@@ -1,0 +1,134 @@
+package providersync
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubSecurityClickHouseEffects writes and tenant-fences security_alerts.
+type GitHubSecurityClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubSecurityClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "security" || effect.Destination != "security_alerts" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[securityAlertRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO security_alerts (org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(row.OrgID, row.RepoID, row.AlertID, row.Source, row.Severity, row.State, row.PackageName, row.CVEID, row.URL, row.Title, row.Description, row.CreatedAt, row.FixedAt, row.DismissedAt, row.LastSynced); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubSecurityClickHouseEffects) InspectEffect(ctx context.Context, claim Claim, effect EffectBatch) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "security" || effect.Destination != "security_alerts" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[securityAlertRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectSecurityAlert(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink GitHubSecurityClickHouseEffects) inspectSecurityAlert(ctx context.Context, expected securityAlertRow) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `SELECT org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced FROM security_alerts FINAL WHERE org_id = ? AND repo_id = ? AND alert_id = ?`, expected.OrgID, expected.RepoID, expected.AlertID)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual securityAlertRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(&actual.OrgID, &actual.RepoID, &actual.AlertID, &actual.Source, &actual.Severity, &actual.State, &actual.PackageName, &actual.CVEID, &actual.URL, &actual.Title, &actual.Description, &actual.CreatedAt, &actual.FixedAt, &actual.DismissedAt, &actual.LastSynced); err != nil {
+			return EffectConflict, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareSecurityAlertVersion(expected, actual, found), nil
+}
+
+func compareSecurityAlertVersion(expected, actual securityAlertRow, found bool) EffectInspection {
+	if !found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if actual.OrgID != expected.OrgID || actual.RepoID != expected.RepoID || actual.AlertID != expected.AlertID || actual.Source != expected.Source || !stringPointersEqual(actual.Severity, expected.Severity) || !stringPointersEqual(actual.State, expected.State) || !stringPointersEqual(actual.PackageName, expected.PackageName) || !stringPointersEqual(actual.CVEID, expected.CVEID) || !stringPointersEqual(actual.URL, expected.URL) || !stringPointersEqual(actual.Title, expected.Title) || !stringPointersEqual(actual.Description, expected.Description) || !actual.CreatedAt.UTC().Equal(expected.CreatedAt.UTC()) || !timePointersEqual(actual.FixedAt, expected.FixedAt) || !timePointersEqual(actual.DismissedAt, expected.DismissedAt) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitHubSecurityClickHouseEffects{}
+var _ EffectReadback = GitHubSecurityClickHouseEffects{}

--- a/internal/providersync/github_security_effects_integration_test.go
+++ b/internal/providersync/github_security_effects_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const securityAlertsDDL = `
+CREATE TABLE security_alerts (
+  org_id String, repo_id UUID, alert_id String, source String,
+  severity Nullable(String), state Nullable(String), package_name Nullable(String),
+  cve_id Nullable(String), url Nullable(String), title Nullable(String),
+  description Nullable(String), created_at DateTime64(3, 'UTC'),
+  fixed_at Nullable(DateTime64(3, 'UTC')), dismissed_at Nullable(DateTime64(3, 'UTC')),
+  last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced) ORDER BY (org_id, repo_id, alert_id)`
+
+func TestGitHubSecurityReadbackExcludesSameNaturalKeyFromOtherTenant(t *testing.T) {
+	ctx, sink := newGitHubSecurityIntegrationSink(t)
+	claim := nativeTestClaim("github", "security")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	row := securityAlertRow{OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", AlertID: "dependabot:1", Source: "dependabot", CreatedAt: now, LastSynced: now}
+	otherClaim, otherRow := claim, row
+	otherClaim.OrgID, otherRow.OrgID = "other-org", "other-org"
+	if err := sink.WriteEffect(ctx, otherClaim, securityAlertEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, securityAlertEffect(t, row))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign row inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, securityAlertEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, securityAlertEffect(t, row))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("tenant row inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newGitHubSecurityIntegrationSink(t *testing.T) (context.Context, GitHubSecurityClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, securityAlertsDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitHubSecurityClickHouseEffects{Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })}
+}
+
+func securityAlertEffect(t *testing.T, row securityAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, []securityAlertRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/github_security_generic_oracle_test.go
+++ b/internal/providersync/github_security_generic_oracle_test.go
@@ -1,0 +1,47 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var oracleSecurityGoOnlyFields = map[string]string{
+	"org_id":      "stamped from the Go claim for tenant-scoped persistence",
+	"repo_id":     "provided by the Go route after repository identity resolution",
+	"last_synced": "stamped from normalizedAt by the Go route",
+}
+
+var oracleSecurityNormalizedAt = time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+
+func buildSecurityRowForOracle(t *testing.T, input map[string]any) securityAlertRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["raw_alert"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var item gitHubSecurityPayload
+	if err := decoder.Decode(&item); err != nil {
+		t.Fatal(err)
+	}
+	row, ok := normalizeGitHubSecurityAlert(nativeTestClaim("github", "security"), input["repo_id"].(string), input["source"].(string), item, oracleSecurityNormalizedAt)
+	if !ok {
+		t.Fatal("security oracle item did not produce a row")
+	}
+	return row
+}
+
+func oracleSecurityCases() []oracleCase {
+	return []oracleCase{
+		{ID: "dependabot", Input: map[string]any{"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "source": "dependabot", "raw_alert": map[string]any{"number": 1, "state": "open", "html_url": "https://example.invalid/a", "created_at": "2026-07-22T10:00:00Z", "security_advisory": map[string]any{"severity": "high", "cve_id": "CVE-2026-0001", "summary": "summary", "description": "description"}, "dependency": map[string]any{"package": map[string]any{"name": "widget"}}}}},
+		{ID: "code-scanning", Input: map[string]any{"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "source": "code_scanning", "raw_alert": map[string]any{"number": 2, "state": "dismissed", "html_url": "https://example.invalid/b", "created_at": "2026-07-22T11:00:00Z", "dismissed_at": "2026-07-22T12:00:00Z", "rule": map[string]any{"severity": "critical", "description": "rule"}, "most_recent_instance": map[string]any{"message": map[string]any{"text": "message"}}}}},
+		{ID: "advisory", Input: map[string]any{"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "source": "advisory", "raw_alert": map[string]any{"ghsa_id": "GHSA-demo", "state": "published", "severity": "medium", "cve_id": "CVE-2026-0002", "html_url": "https://example.invalid/c", "summary": "summary", "description": "description", "created_at": "2026-07-22T12:00:00Z"}}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForSecurityRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/security/row", oracleSecurityCases(), buildSecurityRowForOracle, oracleSecurityGoOnlyFields)
+}

--- a/internal/providersync/github_security_route.go
+++ b/internal/providersync/github_security_route.go
@@ -1,0 +1,195 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const defaultGitHubSecurityMaxAlerts = 1_000
+
+// securityAlertRow mirrors the SecurityAlert construction in
+// _fetch_github_security_alerts_async and its ClickHouse persistence boundary.
+type securityAlertRow struct {
+	OrgID       string     `json:"org_id"`
+	RepoID      string     `json:"repo_id"`
+	AlertID     string     `json:"alert_id"`
+	Source      string     `json:"source"`
+	Severity    *string    `json:"severity"`
+	State       *string    `json:"state"`
+	PackageName *string    `json:"package_name"`
+	CVEID       *string    `json:"cve_id"`
+	URL         *string    `json:"url"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	FixedAt     *time.Time `json:"fixed_at"`
+	DismissedAt *time.Time `json:"dismissed_at"`
+	LastSynced  time.Time  `json:"last_synced"`
+}
+
+type gitHubSecurityPayload struct {
+	Number             json.Number    `json:"number"`
+	GHSAID             any            `json:"ghsa_id"`
+	State              any            `json:"state"`
+	HTMLURL            any            `json:"html_url"`
+	CreatedAt          *string        `json:"created_at"`
+	FixedAt            *string        `json:"fixed_at"`
+	DismissedAt        *string        `json:"dismissed_at"`
+	SecurityAdvisory   map[string]any `json:"security_advisory"`
+	Dependency         map[string]any `json:"dependency"`
+	Rule               map[string]any `json:"rule"`
+	MostRecentInstance map[string]any `json:"most_recent_instance"`
+	Severity           any            `json:"severity"`
+	CVEID              any            `json:"cve_id"`
+	Summary            any            `json:"summary"`
+	Description        any            `json:"description"`
+}
+
+// GitHubSecurityRouteHandler owns exactly security_alerts. It mirrors the
+// three best-effort Python sources: Dependabot, code scanning, and advisories.
+type GitHubSecurityRouteHandler struct{ MaxAlerts int }
+
+func (handler GitHubSecurityRouteHandler) Collect(ctx context.Context, claim Claim, _ providerfoundation.Credential, client *providerfoundation.HTTPClient, normalizedAt time.Time) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "security" || client == nil || client.Provider != "github" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	root := providerRelativePath(client, "repos", owner, repository)
+	var repo gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repo); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repo.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	maxAlerts := handler.MaxAlerts
+	if maxAlerts == 0 {
+		maxAlerts = defaultGitHubSecurityMaxAlerts
+	}
+	if maxAlerts < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	pages := (maxAlerts + nativePerPage - 1) / nativePerPage
+	rows := make([]securityAlertRow, 0)
+	requests := 1
+	for _, source := range []struct {
+		name, path string
+		query      url.Values
+	}{
+		{"dependabot", root + "/dependabot/alerts", url.Values{"state": {"open"}, "per_page": {"100"}}},
+		{"code_scanning", root + "/code-scanning/alerts", url.Values{"state": {"open"}, "per_page": {"100"}}},
+		{"advisory", root + "/security-advisories", url.Values{"per_page": {"100"}}},
+	} {
+		items, fetched, ok := fetchGitHubSecurityPage(ctx, client, source.path, source.query, pages)
+		requests += fetched
+		if !ok {
+			continue
+		}
+		if len(items) > maxAlerts {
+			items = items[:maxAlerts]
+		}
+		for _, item := range items {
+			row, include := normalizeGitHubSecurityAlert(claim, repoID, source.name, item, normalizedAt)
+			if !include || securityAlertOutsideWindow(row.CreatedAt, claim) {
+				continue
+			}
+			rows = append(rows, row)
+		}
+	}
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{Effects: []EffectBatch{effect}, Result: map[string]any{"security_alerts_synced": len(rows), "repo": repo.FullName}, Watermark: claim.BeforeAt, Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests, Pages: requests - 1, Records: len(rows)}}, nil
+}
+
+func fetchGitHubSecurityPage(ctx context.Context, client *providerfoundation.HTTPClient, path string, query url.Values, maxPages int) ([]gitHubSecurityPayload, int, bool) {
+	page, err := providerfoundation.CollectGitHubLinkPages(ctx, client, providerfoundation.GitHubPageOptions{Path: path, Query: query, MaxPages: maxPages})
+	if err != nil {
+		return nil, 0, false
+	}
+	items := make([]gitHubSecurityPayload, 0, len(page.Items))
+	for _, raw := range page.Items {
+		var item gitHubSecurityPayload
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.UseNumber()
+		if decoder.Decode(&item) != nil {
+			return nil, page.Pages, false
+		}
+		items = append(items, item)
+	}
+	return items, page.Pages, true
+}
+
+func normalizeGitHubSecurityAlert(claim Claim, repoID, source string, item gitHubSecurityPayload, normalizedAt time.Time) (securityAlertRow, bool) {
+	createdAt := parseGitHubPullTime(item.CreatedAt)
+	if createdAt == nil {
+		return securityAlertRow{}, false
+	}
+	row := securityAlertRow{OrgID: claim.OrgID, RepoID: repoID, Source: source, CreatedAt: *createdAt, LastSynced: normalizedAt, URL: securityOptionalString(item.HTMLURL), FixedAt: parseGitHubPullTime(item.FixedAt), DismissedAt: parseGitHubPullTime(item.DismissedAt)}
+	switch source {
+	case "dependabot":
+		advisory, dependency := item.SecurityAdvisory, item.Dependency
+		packageData := mapValue(dependency, "package")
+		row.AlertID = "dependabot:" + stringValue(item.Number)
+		row.Severity, row.State = securityOptionalString(mapGet(advisory, "severity")), securityOptionalString(item.State)
+		row.PackageName, row.CVEID = securityOptionalString(mapGet(packageData, "name")), securityOptionalString(mapGet(advisory, "cve_id"))
+		row.Title, row.Description = securityOptionalString(mapGet(advisory, "summary")), securityOptionalString(mapGet(advisory, "description"))
+	case "code_scanning":
+		rule, instance := item.Rule, item.MostRecentInstance
+		message := mapValue(instance, "message")
+		row.AlertID = "code_scanning:" + stringValue(item.Number)
+		row.Severity, row.State = securityOptionalString(mapGet(rule, "severity")), securityOptionalString(item.State)
+		row.Title, row.Description = securityOptionalString(mapGet(rule, "description")), securityOptionalString(mapGet(message, "text"))
+	case "advisory":
+		row.AlertID = "advisory:" + stringValue(item.GHSAID)
+		row.Severity, row.State, row.CVEID = securityOptionalString(item.Severity), securityOptionalString(item.State), securityOptionalString(item.CVEID)
+		row.Title, row.Description = securityOptionalString(item.Summary), securityOptionalString(item.Description)
+	default:
+		return securityAlertRow{}, false
+	}
+	if row.AlertID == "dependabot:" || row.AlertID == "code_scanning:" || row.AlertID == "advisory:" {
+		return securityAlertRow{}, false
+	}
+	return row, true
+}
+
+func mapValue(value map[string]any, key string) map[string]any {
+	if nested, ok := value[key].(map[string]any); ok {
+		return nested
+	}
+	return map[string]any{}
+}
+
+func mapGet(value map[string]any, key string) any { return value[key] }
+
+func securityOptionalString(value any) *string {
+	text := strings.TrimSpace(stringValue(value))
+	if text == "" {
+		return nil
+	}
+	return &text
+}
+
+func securityAlertOutsideWindow(createdAt time.Time, claim Claim) bool {
+	return (claim.SinceAt != nil && createdAt.Before(claim.SinceAt.UTC())) || (claim.BeforeAt != nil && createdAt.After(claim.BeforeAt.UTC()))
+}
+
+func (row securityAlertRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.RepoID == "" || len(row.RepoID) != 36 || row.AlertID == "" || row.Source == "" || row.CreatedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubSecurityRouteHandler{}

--- a/internal/providersync/github_security_route_test.go
+++ b/internal/providersync/github_security_route_test.go
@@ -1,0 +1,81 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitHubSecurityDoer struct{ requests []string }
+
+func (doer *gitHubSecurityDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.requests = append(doer.requests, request.URL.Path)
+	body := gitHubRepositoryFixture
+	switch request.URL.Path {
+	case "/repos/acme/api/dependabot/alerts":
+		body = `[{"number":1,"state":"open","html_url":"https://example.invalid/a","created_at":"2026-07-22T10:00:00Z","security_advisory":{"severity":"high","cve_id":"CVE-2026-0001","summary":"dependency issue","description":"dependency description"},"dependency":{"package":{"name":"widget"}}}]`
+	case "/repos/acme/api/code-scanning/alerts":
+		body = `[{"number":2,"state":"open","html_url":"https://example.invalid/b","created_at":"2026-07-22T11:00:00Z","dismissed_at":"2026-07-22T12:00:00Z","rule":{"severity":"critical","description":"rule description"},"most_recent_instance":{"message":{"text":"instance message"}}}]`
+	case "/repos/acme/api/security-advisories":
+		body = `[{"ghsa_id":"GHSA-demo","state":"published","severity":"medium","cve_id":"CVE-2026-0002","html_url":"https://example.invalid/c","summary":"advisory summary","description":"advisory description","created_at":"2026-07-22T12:00:00Z"}]`
+	}
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+}
+
+func TestGitHubSecurityRouteEmitsEachPythonSource(t *testing.T) {
+	t.Parallel()
+	// Given
+	doer := &gitHubSecurityDoer{}
+	claim := nativeTestClaim("github", "security")
+	client := gitHubRepositoryClient(t, doer, "https://api.github.com")
+
+	// When
+	batch, err := (GitHubSecurityRouteHandler{}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC))
+
+	// Then
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "security_alerts" || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	rows := make([]securityAlertRow, 0, 3)
+	for _, raw := range batch.Effects[0].Rows {
+		var row securityAlertRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, row)
+	}
+	byID := make(map[string]securityAlertRow, len(rows))
+	for _, row := range rows {
+		byID[row.AlertID] = row
+	}
+	dependabot := byID["dependabot:1"]
+	if dependabot.OrgID != claim.OrgID || dependabot.PackageName == nil || *dependabot.PackageName != "widget" {
+		t.Fatalf("dependabot=%+v", dependabot)
+	}
+	codeScanning := byID["code_scanning:2"]
+	if codeScanning.FixedAt != nil || codeScanning.DismissedAt == nil {
+		t.Fatalf("code scanning=%+v", codeScanning)
+	}
+	advisory := byID["advisory:GHSA-demo"]
+	if advisory.State == nil || *advisory.State != "published" {
+		t.Fatalf("advisory=%+v", advisory)
+	}
+}
+
+func TestSecurityAlertValidationRejectsCrossTenantRow(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "security")
+	row := securityAlertRow{OrgID: "other-org", RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", AlertID: "dependabot:1", Source: "dependabot", CreatedAt: time.Now().UTC(), LastSynced: time.Now().UTC()}
+	if err := row.validate(claim); err == nil {
+		t.Fatal("cross-tenant row passed validation")
+	}
+}

--- a/internal/providersync/testdata/oracle_pairs/github_security_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_security_row.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(_MODEL_SOURCE.read_text(), "SecurityAlert")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    client = load_live_module(_CODE_CLIENT_SOURCE)
+    source = case["source"]
+    item = case["raw_alert"]
+    builders = {
+        "dependabot": client._dependabot_alert_from_item,
+        "code_scanning": client._code_scanning_alert_from_item,
+        "advisory": client._security_advisory_from_item,
+    }
+    row = builders[source](item)
+    return vars(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/security/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "repo_id": "attached by processors/github.py after the code-client mapping boundary",
+            "last_synced": "stamped by the persistence boundary, not the code-client mapping",
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -197,7 +197,14 @@ def _target_github_code_client() -> None:
     _install_module("httpx", {"Response": object, "AsyncBaseTransport": object})
     _install_module(
         "dev_health_ops.connectors.models",
-        {"FileBlame": object, "SecurityAlertData": object},
+        {
+            "FileBlame": object,
+            "SecurityAlertData": type(
+                "SecurityAlertData",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            ),
+        },
     )
     _install_module(
         "dev_health_ops.exceptions",

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -133,6 +133,7 @@ class ProviderUnitRouteSwitches:
     github_cicd: bool = False
     github_commits: bool = False
     github_deployments: bool = False
+    github_security: bool = False
 
     @classmethod
     def from_environment(
@@ -151,6 +152,7 @@ class ProviderUnitRouteSwitches:
             github_cicd=_flag(source, "WORKER_GITHUB_CICD_ENABLED"),
             github_commits=_flag(source, "WORKER_GITHUB_COMMITS_ENABLED"),
             github_deployments=_flag(source, "WORKER_GITHUB_DEPLOYMENTS_ENABLED"),
+            github_security=_flag(source, "WORKER_GITHUB_SECURITY_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -227,6 +227,16 @@ def test_github_cicd_invalid_value_fails_closed() -> None:
         )
 
 
+def test_github_security_switch_is_the_second_required_key() -> None:
+    assert ProviderUnitRouteSwitches.is_route_ready("github", "security")
+    assert not ProviderUnitRouteSwitches.from_environment({}).routes_to_river(
+        "github", "security"
+    )
+    assert ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_SECURITY_ENABLED": "true"}
+    ).routes_to_river("github", "security")
+
+
 # ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.


### PR DESCRIPTION
## Summary
- Port GitHub security sync for Dependabot, code-scanning, and advisory alerts.
- Add tenant-fenced ClickHouse FINAL readback and production worker construction.
- Add live Python↔Go row parity and cross-tenant integration coverage.
- Close the provider-sync activation gap with a table-driven construction test for every currently route-ready switch.

## Verification
- `bash ci/check_go.sh all`
- `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=<unique> bash ci/local_validate.sh`
- Cold-cache defect proof: removing `WorkerGithubSecurityEnabled` from the construction gate fails the security-only activation case; restoring it passes.
- Cold-cache tenant proofs: removing the `org_id` readback predicate fails the cross-tenant integration test; removing the row tenant-match validation fails its unit test.

## Route readiness
`github/security` is route-ready: executed live-producer oracle parity, a production worker construction test, FINAL readback proof, and pinned `org_id` tenant isolation.

## TEST-EVIDENCE
The Python route entry has executed live-producer oracle parity, local stub-path coverage, tenant-isolation integration coverage, and the full local validation gate.

## RISK-NOTES
This change preserves the existing route decision and only proves construction for enabled route-ready switches; no provider payloads or secrets are introduced.