### PR TITLE
docs: record lane operational lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,18 @@ CLICKHOUSE_URI=… dev-hops metrics daily
 - GraphQL schema export `api/graphql/export_schema.py` is consumed by web CI for drift detection.
 - **Lefthook** (`make install` once — `core.hooksPath` is shared across worktrees): `commit-msg` strips agent attribution; `pre-commit` ruff format+fix then `mypy` gate; `pre-push` `ruff format --check` + `ruff check` + `mypy`. Fix code, don't add ignores/config exclusions.
 
+## Landing the plane
+
+- **Push early and incrementally.** “Work is not done until `git push` succeeds” is not only end-of-run cleanup. One CHAOS-3033 lane ran 57 minutes, compacted with “commit, push, PR” still in its plan, and delivered code that was never pushed. Push after the first commit; an unpushed worktree is one crash from nothing.
+- **Split landing from long autonomous work.** Commit, push, and PR is short, mechanical, and high-certainty. Exploratory porting is long and compaction-prone. Dispatch landing as its own short task.
+- **Give long-running lanes a durable brief and a todo pointer.** Write the brief to `<project>/.remember/lanes/<lane-id>/BRIEF.md`. The `dev-health` root is not a git repository, so this does not pollute `git status --porcelain`; unlike `/tmp`, it does not evaporate. Forty review artifacts were lost in `/tmp` (CHAOS-3169). The todo list is load-bearing because the harness re-injects it after compaction: its first item must be “re-read BRIEF.md” and its last must be “land per BRIEF.md”. Require the lane to quote a `MARKER` line from the brief in its final report; otherwise “I re-read it” is unverified. Briefs are operational scaffolding for one run. Decisions and plans still belong in Linear, never only in `.remember/`.
+- **Do not let worker lanes delegate to sub-agents.** One port lane blocked on a delegated result and was killed after 30 minutes of inactivity without producing anything. Two sibling lanes completed the same task without delegating. A “30 minutes of inactivity” timeout is itself a fallback masquerade: an outstanding call made the lane look alive until the clock showed it was dead.
+- **A cited constructor is not proof of capability.** The constructor must be reachable with only its own switch enabled. A port satisfied the `file:line` acceptance bar while `cmd/dev-health-worker/provider_sync.go` returned an empty worker family because its config switch was missing from the activation condition. Registry ownership did not make the binary construct it. Strengthen the bar: cite the constructor and prove reachability with a table-driven test that enables only each pair's switch.
+
+## PR and CI conventions
+
+- The `governance` check requires `TEST-EVIDENCE` and `RISK-NOTES` markers in the PR body when a change touches `src/dev_health_ops/workers/provider_unit_route.py`. This is a PR-body requirement, not a code requirement. Missing markers cost two lanes a CI round.
+
 ## Pre-push validation gate (REQUIRED for every ops change)
 
 Before pushing ANY change to `dev-health-ops`, run the standing local gate from the

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -24,6 +24,68 @@ same reasoning that produced the bugs. Treat an adversarial pass over the
 diff as a required step of this recipe, not a nice-to-have, and read the
 checklist below BEFORE writing the handler, not after a review flags it.
 
+**Tenant-isolation precondition:** every port must carry `org_id` through the
+row type, production construction, a mismatch-rejecting validation, the
+ClickHouse INSERT, and the readback predicate. Ship a cross-tenant test that
+is proven to FAIL when `org_id` is removed from the predicate. This is not
+defensive polish: a Critical cross-tenant leak was found on `github/cicd`, and
+making this a precondition let the next three ports ship it first-pass.
+
+**PR governance precondition:** when a change touches
+`src/dev_health_ops/workers/provider_unit_route.py`, the PR body must contain
+the `TEST-EVIDENCE` and `RISK-NOTES` markers required by the `governance`
+check. These are PR-body markers, not code markers; two lanes lost a CI round
+by omitting them.
+
+**Session audit precondition:** audits found a real defect in every port
+produced in this session, merged and unmerged alike, all with green CI. The
+preconditions below come from actual shipped or nearly-shipped defects; they
+are not style guidance.
+
+**Further port preconditions:**
+
+1. **A cited constructor is not proof of capability.** It must be reachable
+   with only its own switch enabled. `github/security` shipped a correct case
+   in `cmd/dev-health-worker/provider_sync.go:127`, but an upstream activation
+   gate returned an empty worker family because that switch was missing from
+   the gate condition. The registry said Go owned it; the binary could not
+   construct it. Add the switch to the activation condition and extend the
+   table-driven `TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch`
+   test, including `providerSyncRouteEnabled`, so only that pair's switch
+   enabled constructs a worker family. Remove the switch and prove the test
+   fails.
+2. **The cross-tenant test must be a true collision, not a one-sided check.**
+   A row under only the foreign tenant proves only that a foreign row is not
+   returned. Insert the SAME natural key under TWO `org_id` values with
+   distinguishable content; assert a tenant-scoped `SELECT ... FINAL` returns
+   exactly one row containing the claim tenant's content; assert `EffectExact`
+   in BOTH directions. Use
+   `internal/providersync/github_commit_stats_effects_integration_test.go` as
+   the example. This defect shipped twice on the same PR; both variants pass
+   an `org_id` predicate mutation proof and read the same in a PR summary.
+3. **Never both capped and successful.** If pagination reaches a cap, fail the
+   unit and do not advance the watermark. Otherwise the dropped records are
+   deterministic and every later run skips them. The rule is explicit at
+   `internal/providersync/github_prs_route.go:203`, but
+   `launchdarkly/feature-flags` and `github/cicd` currently truncate silently,
+   return success, and advance state at their 5,000-flag and 1,000-run caps.
+   Tracked as CHAOS-3192, CHAOS-3196, and CHAOS-3188.
+4. **An empty result must be distinguishable from a broken fetch.** A producer
+   that reports SUCCESS on an empty inventory passes seam tests while the
+   capability is absent. Emit an explicit status distinguishing `complete`,
+   `empty`, and `no_commit_at_bound`, as the `github/files` route does, and
+   assert it in a test. Also persist the computed `FetchEvidence.CapReached`
+   into the unit `Result`; `internal/providersync/native_rest.go:30` defines
+   the evidence, but `resultWithEvidence` currently returns it only inside
+   `FetchResult` at line 837. Truncation must remain queryable. CHAOS-3197.
+5. **A fail-open that also advances state is permanent data loss.** Swallowing
+   an error into an empty batch is survivable only if the unit remains
+   retryable. Trace the downstream consequence through
+   `internal/jobs/providerunit/`, `sync/sync_units.py`, and
+   `sync/watermarks.py` before allowing any error to be swallowed. CHAOS-3189
+   was live Python data loss found only by asking what state followed a
+   "successful" empty result.
+
 ## Defect classes to check for explicitly in every pair
 
 These are not hypothetical. Every one below was found by an adversarial


### PR DESCRIPTION
## Summary
- Add six evidence-first operational lessons to the tracked agent briefing.
- Add tenant-isolation and PR governance preconditions to the provider sync porting recipe.

## Canonical location
The workspace-level AGENTS.md is outside the ops repository and is not tracked by it. ops/AGENTS.md is the versioned, discoverable agent briefing. The provider recipe is the versioned port-specific checklist, so its preconditions are recorded there too.

## Verification
- python scripts/validate_docs_v2_publication.py
- python -m mkdocs build --strict --config-file mkdocs.yml
- python scripts/check_built_site_links.py --site-dir .build/docs
- python scripts/check_docs_candidate_search.py --site-dir .build/docs --queries .github/documentation-program/phase-10/search-acceptance.json
- python scripts/check_docs_candidate_accessibility.py --site-dir .build/docs --css docs/stylesheets/extra.css
- python scripts/check_docs_candidate_facts.py
- git diff --check

Docs only. No customer docs under docs/ changed.

MARKER: LANE-AGENTS-MD-LESSONS