### PR TITLE
CHAOS-3174: activate PostgreSQL-gated tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
           DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
           # No OTLP collector runs in CI; with OTEL on, the exporter retries to
           # localhost:4317 with backoff on every span/metric, flooding logs and
@@ -116,12 +117,24 @@ jobs:
           # 4 vCPUs, so this matches `-n auto` there while staying predictable on
           # larger runners. Override PYTEST_XDIST_WORKERS to tune.
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible --deselect=tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
           ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
+
+      - name: Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)
+        continue-on-error: true
+        env:
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+        run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
+
+      - name: Run quarantined PostgreSQL planner test (CHAOS-3180)
+        continue-on-error: true
+        env:
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+        run: pytest -q tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
 
       - name: Run PostgreSQL 0066 migration tests
         env:
@@ -206,16 +219,29 @@ jobs:
           DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
           COVERAGE_THRESHOLD: "70"
-          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           OTEL_ENABLED: "false"
           PYTEST_XDIST_WORKERS: "4"
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible --deselect=tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
           ./ci/run_tests.sh ci 2>&1 | tee test-results/logs/ci-3.12.log
+
+      - name: Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)
+        continue-on-error: true
+        env:
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+        run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
+
+      - name: Run quarantined PostgreSQL planner test (CHAOS-3180)
+        continue-on-error: true
+        env:
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+        run: pytest -q tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
 
       - name: Upload junit test reports
         if: always()

--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -75,7 +75,55 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
         if step.get("name") == "Run parallel unit test contract"
     )
     assert unit_step["env"]["PYTEST_ADDOPTS"] == (
-        "--ignore=tests/test_0066_celery_river_cutover_postgres.py"
+        "--ignore=tests/test_0066_celery_river_cutover_postgres.py "
+        "--deselect=tests/test_dispatch_outbox.py::"
+        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible "
+        "--deselect=tests/test_sync_planner.py::"
+        "test_postgres_missing_tier_limits_stays_inside_planner_savepoint"
+    )
+    assert unit_step["env"][_POSTGRES_TEST_URI_ENV] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+    assert "./ci/run_tests.sh unit" in unit_step["run"]
+
+    coverage_step = next(
+        step
+        for step in workflow["jobs"]["coverage"]["steps"]
+        if step.get("name") == "Run coverage-gated test contract"
+    )
+    assert coverage_step["env"][_POSTGRES_TEST_URI_ENV] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+    assert coverage_step["env"]["PYTEST_ADDOPTS"] == unit_step["env"]["PYTEST_ADDOPTS"]
+    assert "./ci/run_tests.sh ci" in coverage_step["run"]
+
+    quarantine_step = next(
+        step
+        for step in workflow["jobs"]["test-matrix"]["steps"]
+        if step.get("name")
+        == "Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)"
+    )
+    assert quarantine_step["continue-on-error"] is True
+    assert quarantine_step["env"][_POSTGRES_TEST_URI_ENV] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+    assert quarantine_step["run"] == (
+        "pytest -q tests/test_dispatch_outbox.py::"
+        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible"
+    )
+
+    planner_quarantine_step = next(
+        step
+        for step in workflow["jobs"]["test-matrix"]["steps"]
+        if step.get("name") == "Run quarantined PostgreSQL planner test (CHAOS-3180)"
+    )
+    assert planner_quarantine_step["continue-on-error"] is True
+    assert planner_quarantine_step["env"][_POSTGRES_TEST_URI_ENV] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+    assert planner_quarantine_step["run"] == (
+        "pytest -q tests/test_sync_planner.py::"
+        "test_postgres_missing_tier_limits_stays_inside_planner_savepoint"
     )
 
     coverage_step = next(
@@ -108,6 +156,27 @@ def test_missing_postgres_test_uri_fails_in_ci(
     postgres_tests = importlib.import_module(
         "tests.test_0066_celery_river_cutover_postgres"
     )
+    monkeypatch.delenv(_POSTGRES_TEST_URI_ENV, raising=False)
+    monkeypatch.setenv("CI", "true")
+
+    with pytest.raises(pytest.fail.Exception, match=_POSTGRES_TEST_URI_ENV):
+        postgres_tests._require_postgres_test_uri()
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    (
+        "tests.test_dispatch_outbox",
+        "tests.test_sync_reconciler",
+        "tests.test_sync_planner",
+        "tests.test_service_credentials_cli",
+    ),
+)
+def test_known_postgres_tests_fail_in_ci_without_uri(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> None:
+    postgres_tests = importlib.import_module(module_name)
     monkeypatch.delenv(_POSTGRES_TEST_URI_ENV, raising=False)
     monkeypatch.setenv("CI", "true")
 

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -14,6 +14,7 @@ from sqlalchemy import create_engine, event, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from dev_health_ops.db import normalize_sync_postgres_uri
 from dev_health_ops.models import (
     Base,
     Integration,
@@ -41,6 +42,27 @@ from dev_health_ops.sync.dispatch_outbox import (
     observe_due_outbox_rows,
     upsert_outbox_wakeup,
 )
+
+_POSTGRES_TEST_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+
+def _require_postgres_test_uri() -> None:
+    if os.getenv(_POSTGRES_TEST_URI_ENV):
+        return
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        pytest.fail(f"{_POSTGRES_TEST_URI_ENV} must be configured for PostgreSQL tests")
+    pytest.skip(f"requires {_POSTGRES_TEST_URI_ENV}")
+
+
+@pytest.fixture(scope="module")
+def require_postgres_test_uri() -> None:
+    _require_postgres_test_uri()
+
+
+def _postgres_engine():
+    return create_engine(
+        normalize_sync_postgres_uri(os.environ[_POSTGRES_TEST_URI_ENV])
+    )
 
 
 @pytest.fixture
@@ -894,12 +916,9 @@ def test_backoff_seconds_sequence_is_capped():
     ]
 
 
-@pytest.mark.skipif(
-    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
-    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
-)
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = _postgres_engine()
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None
@@ -988,12 +1007,9 @@ def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible()
         engine.dispose()
 
 
-@pytest.mark.skipif(
-    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
-    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
-)
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_real_postgres_route_change_fences_claim_from_another_session():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = _postgres_engine()
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None
@@ -1078,12 +1094,9 @@ def test_real_postgres_route_change_fences_claim_from_another_session():
         engine.dispose()
 
 
-@pytest.mark.skipif(
-    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
-    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
-)
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_real_postgres_publish_lock_blocks_route_change_until_commit():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = _postgres_engine()
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None

--- a/tests/test_service_credentials_cli.py
+++ b/tests/test_service_credentials_cli.py
@@ -6,19 +6,82 @@ import os
 import subprocess
 import sys
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import make_url
 
 from dev_health_ops import cli, service_credentials
+from dev_health_ops.db import normalize_sync_postgres_uri
+from dev_health_ops.models import Base
 from dev_health_ops.models.internal_service_credential import InternalServiceCredential
+from dev_health_ops.models.users import User
+
+_POSTGRES_TEST_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+
+def _require_postgres_test_uri() -> None:
+    if os.getenv(_POSTGRES_TEST_URI_ENV):
+        return
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        pytest.fail(f"{_POSTGRES_TEST_URI_ENV} must be configured for PostgreSQL tests")
+    pytest.skip(f"requires {_POSTGRES_TEST_URI_ENV}")
+
+
+@pytest.fixture(scope="module")
+def require_postgres_test_uri() -> None:
+    _require_postgres_test_uri()
 
 
 def _postgres_test_uri() -> str:
-    uri = os.getenv("DEV_HEALTH_POSTGRES_TEST_URI")
-    if uri is None:
-        pytest.skip("DEV_HEALTH_POSTGRES_TEST_URI is not configured")
-    return uri
+    _require_postgres_test_uri()
+    return os.environ[_POSTGRES_TEST_URI_ENV]
+
+
+@contextmanager
+def _postgres_credential_database(postgres_uri: str) -> Iterator[str]:
+    configured_url = make_url(postgres_uri)
+    database_name = f"test_service_credentials_{uuid.uuid4().hex}"
+    admin_url = configured_url.set(
+        drivername="postgresql+psycopg2", database="postgres"
+    )
+    admin_engine = sa.create_engine(admin_url, isolation_level="AUTOCOMMIT")
+    engine = None
+    try:
+        with admin_engine.connect() as connection:
+            connection.exec_driver_sql(f'CREATE DATABASE "{database_name}"')
+        test_url = configured_url.set(database=database_name)
+        engine = sa.create_engine(
+            normalize_sync_postgres_uri(test_url.render_as_string(hide_password=False))
+        )
+        Base.metadata.create_all(
+            engine,
+            tables=[
+                Base.metadata.tables[User.__tablename__],
+                Base.metadata.tables["internal_service_credentials"],
+            ],
+        )
+        yield test_url.render_as_string(hide_password=False)
+    finally:
+        if engine is not None:
+            engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.exec_driver_sql(f'DROP DATABASE IF EXISTS "{database_name}"')
+        admin_engine.dispose()
 
 
 def _run_service_credentials_cli(
@@ -241,18 +304,20 @@ async def test_rotate_rejects_past_expiry_without_mutating_existing_credential(
     assert session.commits == 0
 
 
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_service_credential_create_emits_only_token_and_db_flag_is_honored() -> None:
     postgres_uri = _postgres_test_uri()
-    created = _run_service_credentials_cli(
-        postgres_uri, "create", "--scope", "entitlements:read"
-    )
-    assert created.returncode == 0, created.stderr
-    token_lines = created.stdout.splitlines()
-    assert len(token_lines) == 1
-    assert token_lines[0].startswith("svc_acr_")
-    assert token_lines[0] not in created.stderr
+    with _postgres_credential_database(postgres_uri) as test_uri:
+        created = _run_service_credentials_cli(
+            test_uri, "create", "--scope", "entitlements:read"
+        )
+        assert created.returncode == 0, created.stderr
+        token_lines = created.stdout.splitlines()
+        assert len(token_lines) == 1
+        assert token_lines[0].startswith("svc_acr_")
+        assert token_lines[0] not in created.stderr
 
-    listed = _run_service_credentials_cli(postgres_uri, "list")
-    assert listed.returncode == 0, listed.stderr
-    assert token_lines[0] not in listed.stdout
-    assert isinstance(json.loads(listed.stdout), list)
+        listed = _run_service_credentials_cli(test_uri, "list")
+        assert listed.returncode == 0, listed.stderr
+        assert token_lines[0] not in listed.stdout
+        assert isinstance(json.loads(listed.stdout), list)

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
+from dev_health_ops.db import normalize_sync_postgres_uri
 from dev_health_ops.models import (
     Base,
     Integration,
@@ -23,6 +24,7 @@ from dev_health_ops.models import (
     SyncWatermark,
 )
 from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.settings import IntegrationCredential
 from dev_health_ops.models.users import Organization
 from dev_health_ops.sync import planner
 from dev_health_ops.sync.dispatch_outbox import (
@@ -32,7 +34,21 @@ from dev_health_ops.sync.dispatch_outbox import (
 from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
 from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
+_POSTGRES_TEST_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
 ORG_ID = "planner-org"
+
+
+def _require_postgres_test_uri() -> None:
+    if os.getenv(_POSTGRES_TEST_URI_ENV):
+        return
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        pytest.fail(f"{_POSTGRES_TEST_URI_ENV} must be configured for PostgreSQL tests")
+    pytest.skip(f"requires {_POSTGRES_TEST_URI_ENV}")
+
+
+@pytest.fixture(scope="module")
+def require_postgres_test_uri() -> None:
+    _require_postgres_test_uri()
 
 
 @pytest.fixture
@@ -722,10 +738,7 @@ def test_plan_sync_run_succeeds_when_tier_limits_unavailable(db_session, monkeyp
     )
 
 
-@pytest.mark.skipif(
-    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
-    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
-)
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_postgres_missing_tier_limits_stays_inside_planner_savepoint():
     """CHAOS-2580: a pre-migration Postgres tier_limits miss must not poison planning.
 
@@ -736,7 +749,7 @@ def test_postgres_missing_tier_limits_stays_inside_planner_savepoint():
     """
     from tests._helpers import tables_of
 
-    uri = os.environ["DEV_HEALTH_POSTGRES_TEST_URI"]
+    uri = normalize_sync_postgres_uri(os.environ[_POSTGRES_TEST_URI_ENV])
     schema = f"chaos_2580_{uuid.uuid4().hex}"
     engine = create_engine(uri)
     connection = engine.connect()
@@ -749,6 +762,7 @@ def test_postgres_missing_tier_limits_stays_inside_planner_savepoint():
             tables=tables_of(
                 Organization,
                 OrgLicense,
+                IntegrationCredential,
                 Integration,
                 IntegrationSource,
                 IntegrationDataset,

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -11,6 +11,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
+from dev_health_ops.db import normalize_sync_postgres_uri
 from dev_health_ops.models import (
     BackfillJob,
     Base,
@@ -35,6 +36,21 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_STATUS_PENDING,
     upsert_outbox_wakeup,
 )
+
+_POSTGRES_TEST_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+
+def _require_postgres_test_uri() -> None:
+    if os.getenv(_POSTGRES_TEST_URI_ENV):
+        return
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        pytest.fail(f"{_POSTGRES_TEST_URI_ENV} must be configured for PostgreSQL tests")
+    pytest.skip(f"requires {_POSTGRES_TEST_URI_ENV}")
+
+
+@pytest.fixture(scope="module")
+def require_postgres_test_uri() -> None:
+    _require_postgres_test_uri()
 
 
 @pytest.fixture
@@ -233,16 +249,15 @@ def test_reconciler_parity_logging_failure_does_not_change_claims(
     assert dispatches == [((str(run.id),), "sync")]
 
 
-@pytest.mark.skipif(
-    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
-    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
-)
+@pytest.mark.usefixtures("require_postgres_test_uri")
 def test_parity_capture_recovery_clears_real_postgres_statement_failure():
     from dev_health_ops.workers.sync_reconciler import (
         _recover_sync_dispatch_parity_capture_transaction,
     )
 
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(
+        normalize_sync_postgres_uri(os.environ[_POSTGRES_TEST_URI_ENV])
+    )
     try:
         with Session(engine) as session:
             with pytest.raises(DBAPIError):


### PR DESCRIPTION
## Summary
- pass the PostgreSQL test URI into both GitHub Actions test contracts and fail loudly if it is absent in CI
- normalize synchronous test engines and isolate the service-credential CLI database fixture
- pin workflow shape in a static guard; two real PostgreSQL failures execute in visible tracked quarantine steps

## PostgreSQL outcomes
- PASS: two-session outbox route fence
- PASS: outbox publish lock
- PASS: reconciler transaction recovery
- PASS: service-credential CLI create/list
- FAIL, quarantined: CHAOS-3179 legacy dispatch compatibility is rejected by the 0049 claim-route constraint
- FAIL, quarantined: CHAOS-3180 tier-limit fallback leaves the PostgreSQL transaction aborted

## CI evidence
[Run 30236280021 / test-matrix (3.12)](https://github.com/full-chaos/dev-health-ops/actions/runs/30236280021/job/89884604468) executed the four passing PostgreSQL tests in the unit contract and then ran both tracked quarantine steps. The unit result was `9091 passed, 58 skipped`; the last successful `main` baseline was `9078 passed, 64 skipped` ([run 30230488894](https://github.com/full-chaos/dev-health-ops/actions/runs/30230488894/job/89868332058)): **six fewer skips**.

Follow-up commit `23478b4c0` also wires the merge-queue/main coverage contract with the PostgreSQL URI, matching deselections, and visible quarantines, so it cannot fail solely because the URI is absent.

## Validation
- `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=chaos3174_postgres_coverage bash ci/local_validate.sh` — passed (`9089 passed, 65 skipped`)
- workflow guard — `9 passed`
- Fresh GitHub Actions checks for `23478b4c0` are pending.

LANE-CHAOS-3174-POSTGRES-ACTIVATION