### PR TITLE
CHAOS-3180: contain tier limit fallback in savepoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           # 4 vCPUs, so this matches `-n auto` there while staying predictable on
           # larger runners. Override PYTEST_XDIST_WORKERS to tune.
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible --deselect=tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
@@ -129,12 +129,6 @@ jobs:
         env:
           DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
         run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
-
-      - name: Run quarantined PostgreSQL planner test (CHAOS-3180)
-        continue-on-error: true
-        env:
-          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-        run: pytest -q tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
 
       - name: Run PostgreSQL 0066 migration tests
         env:
@@ -224,7 +218,7 @@ jobs:
           COVERAGE_THRESHOLD: "70"
           OTEL_ENABLED: "false"
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible --deselect=tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
@@ -236,12 +230,6 @@ jobs:
         env:
           DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
         run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
-
-      - name: Run quarantined PostgreSQL planner test (CHAOS-3180)
-        continue-on-error: true
-        env:
-          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-        run: pytest -q tests/test_sync_planner.py::test_postgres_missing_tier_limits_stays_inside_planner_savepoint
 
       - name: Upload junit test reports
         if: always()

--- a/src/dev_health_ops/api/services/licensing.py
+++ b/src/dev_health_ops/api/services/licensing.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import jwt
 from jwt.exceptions import InvalidTokenError
+from sqlalchemy.exc import SQLAlchemyError
 
 from dev_health_ops.licensing.feature_decisions import evaluate_org_feature_sync
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
@@ -367,17 +368,21 @@ class TierLimitService:
 
     def _get_db_tier_limits(self, tier: str) -> dict[str, int | float | None]:
         """Read tier limits from the tier_limits table."""
-        try:
+        if self.session.in_nested_transaction():
+            # Let the caller-owned SAVEPOINT roll back before the fallback
+            # consumes a missing-table error.
             rows = self.session.query(TierLimit).filter(TierLimit.tier == tier).all()
             return {str(row.limit_key): row.typed_value for row in rows}
-        except Exception:
+        try:
+            with self.session.begin_nested():
+                rows = (
+                    self.session.query(TierLimit).filter(TierLimit.tier == tier).all()
+                )
+        except SQLAlchemyError:
             # Table may not exist yet (pre-migration) — fall through to
-            # hardcoded defaults. Must NOT call session.rollback() here: this
-            # service is invoked from async callers via run_sync, and a sync
-            # rollback in that path breaks the greenlet context
-            # (sqlalchemy MissingGreenlet). Pre-migration planner transaction
-            # recovery is handled in the planner's own sync context.
+            # hardcoded defaults without rolling back the caller's transaction.
             return {}
+        return {str(row.limit_key): row.typed_value for row in rows}
 
     def _resolve_tier_limits(
         self, org_tier: LicenseTier

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -77,6 +77,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, text
+from sqlalchemy.exc import SQLAlchemyError
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -281,10 +282,11 @@ def _resolve_total_unit_cap(session: Session, org_id: str) -> int:
     try:
         from dev_health_ops.api.services.licensing import TierLimitService
 
-        tier_cap = TierLimitService(session).get_limit(
-            uuid.UUID(org_id), "max_sync_units"
-        )
-    except Exception:
+        with session.begin_nested():
+            tier_cap = TierLimitService(session).get_limit(
+                uuid.UUID(org_id), "max_sync_units"
+            )
+    except (SQLAlchemyError, ValueError):
         return default_cap
     if tier_cap is None:
         return default_cap

--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -77,9 +77,7 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
     assert unit_step["env"]["PYTEST_ADDOPTS"] == (
         "--ignore=tests/test_0066_celery_river_cutover_postgres.py "
         "--deselect=tests/test_dispatch_outbox.py::"
-        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible "
-        "--deselect=tests/test_sync_planner.py::"
-        "test_postgres_missing_tier_limits_stays_inside_planner_savepoint"
+        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible"
     )
     assert unit_step["env"][_POSTGRES_TEST_URI_ENV] == (
         "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
@@ -112,19 +110,11 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
         "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible"
     )
 
-    planner_quarantine_step = next(
-        step
-        for step in workflow["jobs"]["test-matrix"]["steps"]
-        if step.get("name") == "Run quarantined PostgreSQL planner test (CHAOS-3180)"
-    )
-    assert planner_quarantine_step["continue-on-error"] is True
-    assert planner_quarantine_step["env"][_POSTGRES_TEST_URI_ENV] == (
-        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
-    )
-    assert planner_quarantine_step["run"] == (
-        "pytest -q tests/test_sync_planner.py::"
-        "test_postgres_missing_tier_limits_stays_inside_planner_savepoint"
-    )
+    for job_name in ("test-matrix", "coverage"):
+        assert all(
+            step.get("name") != "Run quarantined PostgreSQL planner test (CHAOS-3180)"
+            for step in workflow["jobs"][job_name]["steps"]
+        )
 
     coverage_step = next(
         step


### PR DESCRIPTION
## Summary
- contain planner tier-limit resolution in a nested transaction
- let the tier-limit service propagate a missing-table query to its caller-owned savepoint, while preserving its standalone fallback
- include the credential table required by the PostgreSQL regression fixture

## Root cause
On PostgreSQL, a missing `tier_limits` query aborts the transaction. The service swallowed the query error before the planner could roll back a savepoint, so the following `sync_runs` insert failed with `InFailedSqlTransaction`. This affects the running Python planner.

## Evidence
- **RED:** activated `test_postgres_missing_tier_limits_stays_inside_planner_savepoint` failed on real PostgreSQL with `InFailedSqlTransaction` at the post-lookup `sync_runs` insert.
- **GREEN:** the same PostgreSQL test and both existing missing-tier-limit fallbacks pass after this change.
- CHAOS-3179 is separately diagnosed as test rot: the metadata-only fixture creates the route-coherence constraint but not migration 0049's trigger. Its Linear issue contains the migration-backed passing proof.

## Verification
- `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=pg_failures_3179_3180 bash ci/local_validate.sh`
- `bash ci/check_go.sh all`

Depends on PR #1316 to activate this PostgreSQL regression in CI.