### PR TITLE
CHAOS-3033: port github/files sync unit to Go

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -435,6 +435,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		GithubCommits:            cfg.WorkerGithubCommitsEnabled,
 		GithubDeployments:        cfg.WorkerGithubDeploymentsEnabled,
 		GithubSecurity:           cfg.WorkerGithubSecurityEnabled,
+		GithubFiles:              cfg.WorkerGithubFilesEnabled,
 	}
 }
 
@@ -458,6 +459,7 @@ func providerRouteSwitchesReady(
 		{"github", "commits", cfg.WorkerGithubCommitsEnabled},
 		{"github", "deployments", cfg.WorkerGithubDeploymentsEnabled},
 		{"github", "security", cfg.WorkerGithubSecurityEnabled},
+		{"github", "files", cfg.WorkerGithubFilesEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -192,9 +192,9 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Five route-ready pairs can reach this closure today
-			// (launchdarkly/feature-flags, github/repo-metadata, github/prs,
-			// github/cicd, github/security — see CompleteRouteSwitches.Descriptor), and each
+			// Seven route-ready pairs can reach this closure today:
+			// launchdarkly/feature-flags plus github/repo-metadata, cicd,
+			// commits, deployments, security, and files. Each
 			// has its own CompleteRouteHandler and effect sink. session.Claim
 			// is already known here — providerunit.Handler.Work only calls
 			// BuildExecutor after its own descriptor gate passed for THIS
@@ -264,10 +264,17 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubSecurityRouteHandler{}
 				sink, readback = ghSecuritySink, ghSecuritySink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "files":
+				ghFilesSink := providersync.GitHubFilesClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubFilesRouteHandler{}
+				sink, readback = ghFilesSink, ghFilesSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
-				// reported RouteReady && RouteEnabled, and those three cases
+				// reported RouteReady && RouteEnabled, and the cases
 				// above are the only pairs CompleteRouteSwitches.Descriptor
 				// ever marks RouteReady. Fail closed rather than construct an
 				// executor with a nil Handler.
@@ -337,11 +344,7 @@ func buildProviderSyncWorker(
 	// (github, prs) in CHAOS-3122, and a process that dispatches github units
 	// while refusing to build the handler for them would strand every unit at
 	// a worker with nothing registered.
-	if cfg.Profile != "sync" ||
-		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled &&
-			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled &&
-			!cfg.WorkerGithubCICDEnabled && !cfg.WorkerGithubCommitsEnabled &&
-			!cfg.WorkerGithubDeploymentsEnabled && !cfg.WorkerGithubSecurityEnabled) {
+	if cfg.Profile != "sync" || !providerSyncWorkerEnabled(cfg) {
 		return workerFamily{}, nil
 	}
 	return constructProviderSyncWorker(ctx, cfg, database, registry, observer, logger)
@@ -446,6 +449,13 @@ func constructProviderSyncWorkerWithDependencies(
 		},
 		metricsSource: providerMetrics,
 	}, nil
+}
+
+func providerSyncWorkerEnabled(cfg config.Config) bool {
+	return cfg.WorkerLaunchDarklyFeatureFlagsEnabled || cfg.WorkerGithubRepoMetadataEnabled ||
+		cfg.WorkerGithubPRsEnabled || cfg.WorkerGithubCICDEnabled ||
+		cfg.WorkerGithubCommitsEnabled || cfg.WorkerGithubDeploymentsEnabled ||
+		cfg.WorkerGithubSecurityEnabled || cfg.WorkerGithubFilesEnabled
 }
 
 func providerSyncRiverConfig(

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -307,6 +307,12 @@ func TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch(t *testing.T)
 				Profile: "sync", WorkerGithubSecurityEnabled: true,
 			},
 		},
+		{
+			name: "github files",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubFilesEnabled: true,
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			family, err := buildProviderSyncWorker(
@@ -361,6 +367,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 		"github_security": {
 			cfg:  config.Config{WorkerGithubSecurityEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubSecurity: true},
+		},
+		"github_files": {
+			cfg:  config.Config{WorkerGithubFilesEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubFiles: true},
 		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
@@ -462,5 +472,40 @@ func TestBuildProviderSyncHandlerConstructsGitHubSecurityCapability(t *testing.T
 	}
 	if _, ok := executor.Committer.Sink.(providersync.GitHubSecurityClickHouseEffects); !ok {
 		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+}
+
+func TestBuildProviderSyncHandlerConstructsGitHubFilesCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubFiles: true}, nil, nil, nil, nil, nil, slog.Default())
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("provider sync handler is not constructed")
+	}
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{Claim: providersync.Claim{Unit: providersync.Unit{Provider: "github", Dataset: "files"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.GitHubFilesRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.GitHubFilesClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+}
+
+func TestProviderSyncWorkerEnabledForEveryRouteReadySwitch(t *testing.T) {
+	for name, cfg := range map[string]config.Config{
+		"launchdarkly":         {WorkerLaunchDarklyFeatureFlagsEnabled: true},
+		"github_repo_metadata": {WorkerGithubRepoMetadataEnabled: true},
+		"github_cicd":          {WorkerGithubCICDEnabled: true},
+		"github_commits":       {WorkerGithubCommitsEnabled: true},
+		"github_deployments":   {WorkerGithubDeploymentsEnabled: true},
+		"github_security":      {WorkerGithubSecurityEnabled: true},
+		"github_files":         {WorkerGithubFilesEnabled: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !providerSyncWorkerEnabled(cfg) {
+				t.Fatal("route-ready switch leaves the provider worker family dormant")
+			}
+		})
 	}
 }

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -141,11 +141,13 @@
         "sync_files": true,
         "sync_git": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "files",
-      "route_destinations": [],
-      "route_ready": false,
+      "route_destinations": [
+        "git_files"
+      ],
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -35,6 +35,11 @@ const RouteReconciliationCategory = "route_reconciliation_required"
 // first attempt because retrying a deterministic fault cannot change it.
 const RepositoryIdentityCategory = "repository_identity_ambiguous"
 
+// GitHubFilesInventoryFailureCategory marks an exhausted file-inventory sync;
+// unlike a successful empty repository, it says inventory completeness was
+// never established.
+const GitHubFilesInventoryFailureCategory = "github_files_inventory_failed"
+
 // deterministicTerminalCategory maps executor failures that no retry can clear
 // onto their own durable category. Anything not listed keeps the ordinary
 // bounded-retry path.
@@ -43,6 +48,13 @@ func deterministicTerminalCategory(err error) (string, bool) {
 		return RepositoryIdentityCategory, true
 	}
 	return "", false
+}
+
+func exhaustedFailureCategory(claim providersync.Claim) string {
+	if claim.Provider == "github" && claim.Dataset == "files" {
+		return GitHubFilesInventoryFailureCategory
+	}
+	return "provider_unit_exhausted"
 }
 
 // RouteFault describes a producer/consumer capability disagreement for
@@ -260,7 +272,7 @@ func (handler *Handler) Work(
 		// only adds the ability to gate the metric on true success; it does
 		// not change the existing best-effort, always-retryable behavior.
 		failErr := handler.Repository.Fail(
-			context.WithoutCancel(ctx), session.Claim, "provider_unit_exhausted",
+			context.WithoutCancel(ctx), session.Claim, exhaustedFailureCategory(session.Claim),
 			startedAt, completedAt,
 		)
 		if failErr == nil {

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -53,6 +54,70 @@ func TestEnabledProviderUnitExecutesCompleteRouteAndTerminalizes(t *testing.T) {
 	}
 	if _, ok := repository.result["go_provider_route"]; !ok {
 		t.Fatalf("terminal result=%#v", repository.result)
+	}
+}
+
+func TestProviderUnitKeepsWatermarkUnadvancedWhenGitHubFilesTraversalFails(t *testing.T) {
+	// Given
+	t.Setenv("REPO_UUID", "")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	repository := newMemoryUnitRepository(githubFilesUnit())
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			GithubFiles: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: githubFilesTraversalExecutor(now),
+	}
+
+	// When
+	err := handler.Work(context.Background(), providerExecution(repository.unit, now, 1))
+
+	// Then
+	if err == nil {
+		t.Fatal("Work() error = nil, want retryable traversal failure")
+	}
+	if repository.status != "dispatching" || repository.result != nil || repository.watermark != nil {
+		t.Fatalf(
+			"status=%s result=%#v watermark=%v, want retrying state without completed result or watermark",
+			repository.status, repository.result, repository.watermark,
+		)
+	}
+}
+
+func TestProviderUnitRecordsGitHubFilesTraversalFailureAfterRetriesExhaust(t *testing.T) {
+	// Given
+	t.Setenv("REPO_UUID", "")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	repository := newMemoryUnitRepository(githubFilesUnit())
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			GithubFiles: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: githubFilesTraversalExecutor(now),
+	}
+	execution := providerExecution(repository.unit, now, 5)
+	execution.Definition.MaxAttempts = 5
+
+	// When
+	err := handler.Work(context.Background(), execution)
+
+	// Then
+	if err == nil {
+		t.Fatal("Work() error = nil, want exhausted traversal failure")
+	}
+	if repository.status != "failed" || repository.lastFailCategory != GitHubFilesInventoryFailureCategory {
+		t.Fatalf(
+			"status=%s category=%s, want failed/%s",
+			repository.status, repository.lastFailCategory, GitHubFilesInventoryFailureCategory,
+		)
 	}
 }
 
@@ -214,6 +279,20 @@ func providerUnit() providersync.Unit {
 	}
 }
 
+func githubFilesUnit() providersync.Unit {
+	unit := providerUnit()
+	capability, ok := providersync.Capability("github", "files")
+	if !ok {
+		panic("github/files capability missing")
+	}
+	unit.SourceExternalID = "acme/api"
+	unit.SourceName = "acme/api"
+	unit.Provider = "github"
+	unit.Dataset = "files"
+	unit.CostClass = capability.CostClass
+	return unit
+}
+
 func successfulExecutor(
 	t *testing.T,
 	now time.Time,
@@ -245,7 +324,41 @@ func successfulExecutor(
 			},
 			Handler:           testCompleteRouteHandler{t: t, now: now},
 			Comparator:        providersync.ProductionContractComparator{},
-			Committer:         providersync.EffectCommitter{Ledger: &testEffectLedger{}, Sink: testEffectSink{}, Now: func() time.Time { return now }},
+			Committer:         providersync.EffectCommitter{Ledger: &testEffectLedger{}, Sink: testEffectSink{}, Readback: testEffectReadback{}, Now: func() time.Time { return now }},
+			HeartbeatInterval: 10 * time.Second,
+			Now:               func() time.Time { return now },
+		}, nil
+	}
+}
+
+func githubFilesTraversalExecutor(now time.Time) ExecutorFactory {
+	return func(
+		session *providersync.LeaseSession,
+	) (providersync.CompleteRouteExecutor, error) {
+		return providersync.CompleteRouteExecutor{
+			Credentials: providerfoundation.CredentialResolver{
+				Repository: githubCredentialRepository{unit: session.Claim.Unit},
+				Decryptor:  githubCredentialDecryptor{},
+			},
+			Doer: githubFilesTraversalDoer{},
+			Retry: providerfoundation.RetryPolicy{
+				MaxAttempts: 1, InitialWait: time.Nanosecond,
+				MaxWait: time.Nanosecond,
+			},
+			Budget: testBudgetStore{},
+			BudgetLimits: map[providersync.CostClass]int{
+				providersync.CostMedium: 1,
+			},
+			BudgetTTL: time.Minute,
+			Gate: func(
+				providersync.Claim,
+				*providerfoundation.HTTPClient,
+			) providerfoundation.BackoffGate {
+				return testBackoffGate{}
+			},
+			Handler:           providersync.GitHubFilesRouteHandler{},
+			Comparator:        providersync.ProductionContractComparator{},
+			Committer:         providersync.EffectCommitter{Ledger: &testEffectLedger{}, Sink: testEffectSink{}, Readback: testEffectReadback{}, Now: func() time.Time { return now }},
 			HeartbeatInterval: 10 * time.Second,
 			Now:               func() time.Time { return now },
 		}, nil
@@ -259,6 +372,7 @@ type memoryUnitRepository struct {
 	attempt          int
 	lastClaim        providersync.Claim
 	result           map[string]any
+	watermark        *time.Time
 	failures         int
 	lastFailCategory string
 	releaseErr       error
@@ -326,7 +440,7 @@ func (repository *memoryUnitRepository) Complete(
 	_ context.Context,
 	claim providersync.Claim,
 	result map[string]any,
-	_ *time.Time,
+	watermark *time.Time,
 	_ time.Time,
 	_ time.Time,
 ) error {
@@ -335,7 +449,7 @@ func (repository *memoryUnitRepository) Complete(
 	if repository.status != "running" || repository.lastClaim.Owner != claim.Owner {
 		return providersync.ErrLeaseLost
 	}
-	repository.status, repository.result = "success", result
+	repository.status, repository.result, repository.watermark = "success", result, watermark
 	return nil
 }
 
@@ -393,10 +507,52 @@ func (testCredentialDecryptor) Decrypt(secrets.Value) ([]byte, error) {
 	return []byte(`{"api_key":"test-token"}`), nil
 }
 
+type githubCredentialRepository struct{ unit providersync.Unit }
+
+func (repository githubCredentialRepository) ResolveEncrypted(
+	_ context.Context,
+	_ providerfoundation.TenantScope,
+) (providerfoundation.EncryptedCredential, error) {
+	return providerfoundation.EncryptedCredential{
+		ID: repository.unit.CredentialID, Provider: "github",
+		Name: "default", Active: true,
+		Ciphertext: secrets.NewValue("ciphertext"),
+	}, nil
+}
+
+type githubCredentialDecryptor struct{}
+
+func (githubCredentialDecryptor) Decrypt(secrets.Value) ([]byte, error) {
+	return []byte(`{"token":"test-token"}`), nil
+}
+
 type testDoer struct{}
 
 func (testDoer) Do(*http.Request) (*http.Response, error) {
 	return nil, errors.New("unexpected request")
+}
+
+type githubFilesTraversalDoer struct{}
+
+func (githubFilesTraversalDoer) Do(request *http.Request) (*http.Response, error) {
+	switch request.URL.Path {
+	case "/repos/acme/api":
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"full_name":"acme/api","default_branch":"main"}`)),
+			Request:    request,
+		}, nil
+	case "/repos/acme/api/branches/main":
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"message":"tree traversal unavailable"}`)),
+			Request:    request,
+		}, nil
+	default:
+		return nil, errors.New("unexpected request")
+	}
 }
 
 type testReservation struct{}
@@ -513,4 +669,14 @@ func (testEffectSink) WriteEffect(
 	providersync.EffectBatch,
 ) error {
 	return nil
+}
+
+type testEffectReadback struct{}
+
+func (testEffectReadback) InspectEffect(
+	context.Context,
+	providersync.Claim,
+	providersync.EffectBatch,
+) (providersync.EffectInspection, error) {
+	return providersync.EffectAbsent, nil
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -122,6 +122,8 @@ type Config struct {
 	WorkerGithubDeploymentsEnabled bool
 	// WorkerGithubSecurityEnabled gates the isolated (github, security) route.
 	WorkerGithubSecurityEnabled bool
+	// WorkerGithubFilesEnabled gates the isolated (github, files) route.
+	WorkerGithubFilesEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -217,6 +219,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_SECURITY_ENABLED",
 			target: &cfg.WorkerGithubSecurityEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_FILES_ENABLED",
+			target: &cfg.WorkerGithubFilesEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -139,7 +139,9 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 		cfg.WorkerJiraIncidentsEnabled ||
 		cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
 		cfg.WorkerGithubRepoMetadataEnabled || cfg.WorkerGithubPRsEnabled ||
-		cfg.WorkerGithubCICDEnabled || cfg.WorkerGithubCommitsEnabled {
+		cfg.WorkerGithubCICDEnabled || cfg.WorkerGithubCommitsEnabled ||
+		cfg.WorkerGithubDeploymentsEnabled || cfg.WorkerGithubSecurityEnabled ||
+		cfg.WorkerGithubFilesEnabled {
 		t.Fatal("provider route switches must default off")
 	}
 }
@@ -169,6 +171,9 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_GITHUB_PRS_ENABLED":                 "true",
 		"WORKER_GITHUB_CICD_ENABLED":                "true",
 		"WORKER_GITHUB_COMMITS_ENABLED":             "true",
+		"WORKER_GITHUB_DEPLOYMENTS_ENABLED":         "true",
+		"WORKER_GITHUB_SECURITY_ENABLED":            "true",
+		"WORKER_GITHUB_FILES_ENABLED":               "true",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +203,9 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		!cfg.WorkerJiraIncidentsEnabled ||
 		!cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
 		!cfg.WorkerGithubRepoMetadataEnabled || !cfg.WorkerGithubPRsEnabled ||
-		!cfg.WorkerGithubCICDEnabled || !cfg.WorkerGithubCommitsEnabled {
+		!cfg.WorkerGithubCICDEnabled || !cfg.WorkerGithubCommitsEnabled ||
+		!cfg.WorkerGithubDeploymentsEnabled || !cfg.WorkerGithubSecurityEnabled ||
+		!cfg.WorkerGithubFilesEnabled {
 		t.Fatal("expected independent provider route opt-ins")
 	}
 

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -71,6 +71,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //     Python normalizer and builder plus tenant-scoped FINAL readback.
 //   - github/security: CHAOS-3178, differential row parity against the live
 //     production source mappings plus FINAL tenant-fenced ClickHouse effects.
+//   - github/files: live traversal/row parity against backfill_file_records plus
+//     tenant-qualified FINAL readback.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -91,6 +93,7 @@ var routeReadyPairs = map[string]struct{}{
 	"github/commits":             {},
 	"github/deployments":         {},
 	"github/security":            {},
+	"github/files":               {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -114,9 +117,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
 		GithubPRs: true, GithubCICD: true, GithubCommits: true,
-		GithubDeployments: true, GithubSecurity: true,
+		GithubDeployments: true, GithubSecurity: true, GithubFiles: true,
 	}
-	if reflect.TypeOf(all).NumField() != 10 {
+	if reflect.TypeOf(all).NumField() != 11 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -229,6 +232,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"github/commits":             GitHubCommitsRouteHandler{},
 		"github/deployments":         GitHubDeploymentsRouteHandler{},
 		"github/security":            GitHubSecurityRouteHandler{},
+		"github/files":               GitHubFilesRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -38,6 +38,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"github/commits":             ExecutorNativeGo,
 	"github/deployments":         ExecutorNativeGo,
 	"github/security":            ExecutorNativeGo,
+	"github/files":               ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -139,6 +140,8 @@ type CompleteRouteSwitches struct {
 	GithubDeployments bool
 	// GithubSecurity gates the isolated tenant-scoped security_alerts writer.
 	GithubSecurity bool
+	// GithubFiles gates the isolated git_files writer only.
+	GithubFiles bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -245,6 +248,10 @@ func (switches CompleteRouteSwitches) Descriptor(
 		descriptor.Destinations = []string{"security_alerts"}
 		descriptor.RouteReady = true
 		descriptor.RouteEnabled = switches.GithubSecurity
+	case provider == "github" && dataset == "files":
+		descriptor.Destinations = []string{"git_files"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubFiles
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_files_effects_clickhouse.go
+++ b/internal/providersync/github_files_effects_clickhouse.go
@@ -1,0 +1,150 @@
+package providersync
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubFilesClickHouseEffects persists github/files rows and fences recovery
+// through the ReplacingMergeTree winning version for the tenant-qualified key.
+type GitHubFilesClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_files (repo_id, path, executable, contents, last_synced, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(row.RepoID, row.Path, row.Executable, row.Contents, row.LastSynced, row.OrgID); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubFilesClickHouseEffects) InspectEffect(ctx context.Context, claim Claim, effect EffectBatch) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectFile(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink GitHubFilesClickHouseEffects) inspectFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT repo_id, path, executable, contents, last_synced, org_id
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, expected.OrgID, expected.RepoID, expected.Path)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual gitFileVersion
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.Row.RepoID, &actual.Row.Path, &actual.Row.Executable, &actual.Row.Contents,
+			&actual.LastSynced, &actual.Row.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.Found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitFileVersion(expected, actual), nil
+}
+
+type gitFileVersion struct {
+	Row        gitFileRow
+	LastSynced time.Time
+	Found      bool
+}
+
+func compareGitFileVersion(expected gitFileRow, actual gitFileVersion) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) || actual.Row.RepoID != expected.RepoID ||
+		actual.Row.Path != expected.Path || actual.Row.Executable != expected.Executable ||
+		actual.Row.OrgID != expected.OrgID || !stringPointersEqual(actual.Row.Contents, expected.Contents) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitHubFilesClickHouseEffects{}
+var _ EffectReadback = GitHubFilesClickHouseEffects{}

--- a/internal/providersync/github_files_effects_integration_test.go
+++ b/internal/providersync/github_files_effects_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const gitFilesDDL = `
+CREATE TABLE git_files (
+  repo_id UUID,
+  path String,
+  executable Bool,
+  contents Nullable(String),
+  last_synced DateTime64(3, 'UTC'),
+  org_id String
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, path)`
+
+func TestGitHubFilesReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, sink := newGitHubFilesIntegrationSink(t)
+	claim := nativeTestClaim("github", "files")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	current := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	currentContent := "package main\n"
+	current.Contents = &currentContent
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previousContent := "package old"
+	previous.Contents = &previousContent
+	if err := sink.WriteEffect(ctx, claim, gitFileEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, gitFileEffect(t, current))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitFileEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, gitFileEffect(t, current))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitHubFilesReadbackReturnsClaimTenantForSameNaturalKey(t *testing.T) {
+	ctx, sink := newGitHubFilesIntegrationSink(t)
+	claim := nativeTestClaim("github", "files")
+	claim.OrgID = "org-a"
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	row := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	claimContent := "package orga\n"
+	row.Contents = &claimContent
+	otherClaim := claim
+	otherClaim.OrgID = "org-b"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	otherContent := "package orgb\n"
+	otherRow.Contents = &otherContent
+	if err := sink.WriteEffect(ctx, otherClaim, gitFileEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitFileEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	var count uint64
+	var minOrgID, maxOrgID, minContents, maxContents string
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count(), min(org_id), max(org_id), min(ifNull(contents, '')), max(ifNull(contents, ''))
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`,
+		row.OrgID, row.RepoID, row.Path,
+	).Scan(&count, &minOrgID, &maxOrgID, &minContents, &maxContents); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || minOrgID != row.OrgID || maxOrgID != row.OrgID ||
+		minContents != claimContent || maxContents != claimContent {
+		t.Fatalf(
+			"tenant-scoped readback returned count=%d orgs=(%q,%q) contents=(%q,%q), want only %+v",
+			count, minOrgID, maxOrgID, minContents, maxContents, row,
+		)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, gitFileEffect(t, row))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("claim tenant must win same-key readback, inspection=%s error=%v", inspection, err)
+	}
+	inspection, err = sink.InspectEffect(ctx, otherClaim, gitFileEffect(t, otherRow))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("other tenant must read its own same-key row, inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newGitHubFilesIntegrationSink(t *testing.T) (context.Context, GitHubFilesClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitFilesDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitHubFilesClickHouseEffects{Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })}
+}
+
+func gitFileEffect(t *testing.T, row gitFileRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, []gitFileRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/github_files_generic_oracle_test.go
+++ b/internal/providersync/github_files_generic_oracle_test.go
@@ -1,0 +1,51 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+)
+
+var oracleFilesGoOnlyFields = map[string]string{
+	"last_synced": "stamped from normalizedAt by the Go complete-route handler after Python's backfill_file_records boundary",
+	"org_id":      "carried from the Go claim to keep ClickHouse writes tenant-scoped",
+}
+
+func buildGitHubFileRowForOracle(t *testing.T, input map[string]any) gitFileRow {
+	t.Helper()
+	contents, _ := input["contents_by_path"].(map[string]any)
+	content, _ := contents[input["path"].(string)].(string)
+	return newGitHubFileRow(
+		nativeTestClaim("github", "files"), input["repo_id"].(string), input["path"].(string), content,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitHubFilesRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/files/row", []oracleCase{
+		{ID: "scannable_content", Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/main.go",
+			"contents_by_path": map[string]any{"src/main.go": "package main\n"},
+		}},
+		{ID: "path_only", Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "README.md",
+		}},
+	}, buildGitHubFileRowForOracle, oracleFilesGoOnlyFields)
+}
+
+func TestGitHubFilesOracleLoaderExecutesStubbedBaseGitProducer(t *testing.T) {
+	caseInput := map[string]any{
+		"repo_id":          "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		"path":             "src/main.go",
+		"contents_by_path": map[string]any{"src/main.go": "package main\n"},
+	}
+	divergences := oracleDivergences(
+		t,
+		"github/files/row",
+		[]oracleCase{{ID: "stubbed_base_git", Input: caseInput}},
+		func(t *testing.T, input map[string]any) any { return buildGitHubFileRowForOracle(t, input) },
+		oracleFilesGoOnlyFields,
+	)
+	if len(divergences) != 0 {
+		t.Fatalf("github/files oracle loader divergences=%v", divergences)
+	}
+}

--- a/internal/providersync/github_files_route.go
+++ b/internal/providersync/github_files_route.go
@@ -1,0 +1,327 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	gitHubFileContentMaxBytes = 1_000_000
+	gitHubFileContentMaxFiles = 2_000
+	gitHubFileContentBatch    = 50
+)
+
+// ErrGitHubFilesTraversalFailed marks an inventory traversal that could not
+// establish whether the repository is empty. Callers must retry it rather than
+// completing the sync with a zero-row effect.
+var ErrGitHubFilesTraversalFailed = errors.New("github files traversal failed")
+
+// gitFileRow is the git_files projection produced by github/files. The Python
+// producer constructs GitFile records in backfill_file_records and stamps the
+// sink-owned last_synced value at ClickHouse insertion; this route carries the
+// equivalent normalized timestamp explicitly for crash-safe readback.
+type gitFileRow struct {
+	RepoID     string    `json:"repo_id"`
+	Path       string    `json:"path"`
+	Executable bool      `json:"executable"`
+	Contents   *string   `json:"contents"`
+	LastSynced time.Time `json:"last_synced"`
+	OrgID      string    `json:"org_id"`
+}
+
+type gitHubBranchPayload struct {
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
+type gitHubTreePayload struct {
+	Tree []gitHubTreeEntry `json:"tree"`
+}
+
+type gitHubTreeEntry struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+	Size *int   `json:"size"`
+}
+
+// GitHubFilesRouteHandler mirrors github.py's files branch: resolve the branch
+// at the claim's upper bound, traverse its recursive tree, retain every blob
+// path, and fetch scanner-eligible, <=1MB blob text in 50-path GraphQL batches.
+// Python deliberately does not reject a truncated tree response, so this route
+// preserves that behavior rather than inventing a stricter policy.
+type GitHubFilesRouteHandler struct{}
+
+func (GitHubFilesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "files" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+	var repoPayload gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repoPayload); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repoPayload.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	branch := repoPayload.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+	treeRef, requests, err := gitHubFilesTreeRef(ctx, client, root, branch, claim.BeforeAt)
+	if err != nil {
+		if err := continueGitHubFilesTraversal(err, repoPayload.FullName); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		return gitHubFilesBatch(claim, repoPayload.FullName, nil, normalizedAt, requests, 0, false)
+	}
+	if treeRef == "" {
+		return gitHubFilesBatch(claim, repoPayload.FullName, nil, normalizedAt, requests, 0, false)
+	}
+	var tree gitHubTreePayload
+	if err := fetchObject(ctx, client, root+"/git/trees/"+url.PathEscape(treeRef)+"?recursive=true", &tree); err != nil {
+		if err := continueGitHubFilesTraversal(err, repoPayload.FullName); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		return gitHubFilesBatch(claim, repoPayload.FullName, nil, normalizedAt, requests, 0, false)
+	}
+	requests++
+	paths := make([]string, 0, len(tree.Tree))
+	sizes := make(map[string]*int, len(tree.Tree))
+	for _, entry := range tree.Tree {
+		if entry.Type != "blob" || entry.Path == "" {
+			continue
+		}
+		paths = append(paths, entry.Path)
+		sizes[entry.Path] = entry.Size
+	}
+	contents, contentRequests, err := fetchGitHubFileContents(ctx, client, owner, repository, treeRef, paths, sizes)
+	if err != nil {
+		if err := continueGitHubFilesTraversal(err, repoPayload.FullName); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		return gitHubFilesBatch(claim, repoPayload.FullName, nil, normalizedAt, requests+contentRequests, 0, false)
+	}
+	requests += contentRequests
+	rows := make([]gitFileRow, 0, len(paths))
+	for _, filePath := range paths {
+		row := newGitHubFileRow(claim, repoID, filePath, contents[filePath], normalizedAt)
+		if err := row.validate(claim); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	return gitHubFilesBatch(claim, repoPayload.FullName, rows, normalizedAt, requests, 1, false)
+}
+
+func continueGitHubFilesTraversal(err error, repository string) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr.Class == providerfoundation.ErrorRateLimited {
+		return err
+	}
+	slog.Warn("github files traversal failed", "repository", repository, "inventory_status", "failed", "error", err)
+	return fmt.Errorf("%w: %w", ErrGitHubFilesTraversalFailed, err)
+}
+
+func newGitHubFileRow(claim Claim, repoID, filePath, content string, normalizedAt time.Time) gitFileRow {
+	row := gitFileRow{RepoID: repoID, Path: filePath, LastSynced: normalizedAt, OrgID: claim.OrgID}
+	if content != "" {
+		row.Contents = &content
+	}
+	return row
+}
+
+func gitHubFilesTreeRef(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	root, branch string,
+	beforeAt *time.Time,
+) (string, int, error) {
+	if beforeAt != nil {
+		query := url.Values{"per_page": {"1"}, "sha": {branch}, "until": {beforeAt.UTC().Format(time.RFC3339Nano)}}
+		var commits []struct {
+			SHA string `json:"sha"`
+		}
+		if err := fetchObject(ctx, client, root+"/commits?"+query.Encode(), &commits); err != nil {
+			return "", 0, err
+		}
+		if len(commits) == 0 {
+			return "", 1, nil
+		}
+		return commits[0].SHA, 1, nil
+	}
+	var branchPayload gitHubBranchPayload
+	if err := fetchObject(ctx, client, root+"/branches/"+url.PathEscape(branch), &branchPayload); err != nil {
+		return "", 0, err
+	}
+	return branchPayload.Commit.SHA, 1, nil
+}
+
+func gitHubFilesBatch(
+	claim Claim,
+	fullName string,
+	rows []gitFileRow,
+	normalizedAt time.Time,
+	requests, pages int,
+	capReached bool,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	inventoryStatus := "complete"
+	if len(rows) == 0 {
+		inventoryStatus = "empty"
+		if pages == 0 {
+			inventoryStatus = "no_commit_at_bound"
+		}
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result: map[string]any{
+			"files_synced": len(rows), "inventory_status": inventoryStatus, "repo": fullName,
+		},
+		Watermark: claim.BeforeAt,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages, Records: len(rows), CapReached: capReached,
+		},
+	}, nil
+}
+
+func fetchGitHubFileContents(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	owner, repository, ref string,
+	paths []string,
+	sizes map[string]*int,
+) (map[string]string, int, error) {
+	scannable := make([]string, 0, min(len(paths), gitHubFileContentMaxFiles))
+	for _, filePath := range paths {
+		if !gitHubFileContentEligible(filePath, sizes[filePath]) {
+			continue
+		}
+		scannable = append(scannable, filePath)
+		if len(scannable) >= gitHubFileContentMaxFiles {
+			break
+		}
+	}
+	contents := make(map[string]string)
+	requests := 0
+	for start := 0; start < len(scannable); start += gitHubFileContentBatch {
+		end := min(start+gitHubFileContentBatch, len(scannable))
+		chunk := scannable[start:end]
+		body, err := json.Marshal(map[string]any{
+			"query":     gitHubBlobTextsQuery(ref, chunk),
+			"variables": map[string]string{"owner": owner, "repo": repository},
+		})
+		if err != nil {
+			return nil, requests, providerfoundation.ErrNormalizationInvalid
+		}
+		response, err := client.Do(ctx, "POST", gitHubGraphQLPath(client), bytes.NewReader(body))
+		if err != nil {
+			return nil, requests, err
+		}
+		requests++
+		var envelope struct {
+			Data struct {
+				Repository map[string]struct {
+					Text        *string `json:"text"`
+					IsBinary    bool    `json:"isBinary"`
+					IsTruncated bool    `json:"isTruncated"`
+				} `json:"repository"`
+			} `json:"data"`
+			Errors json.RawMessage `json:"errors"`
+		}
+		decodeErr := json.NewDecoder(response.Body).Decode(&envelope)
+		closeErr := response.Body.Close()
+		if decodeErr != nil || closeErr != nil || len(envelope.Errors) > 0 {
+			return nil, requests, providerfoundation.ErrNormalizationInvalid
+		}
+		for index, filePath := range chunk {
+			blob, ok := envelope.Data.Repository["f"+strconv.Itoa(index)]
+			if !ok || blob.IsBinary || blob.IsTruncated || blob.Text == nil {
+				continue
+			}
+			contents[filePath] = *blob.Text
+		}
+	}
+	return contents, requests, nil
+}
+
+func gitHubFileContentEligible(filePath string, size *int) bool {
+	if size != nil && *size > gitHubFileContentMaxBytes {
+		return false
+	}
+	for _, segment := range strings.Split(filePath, "/") {
+		switch segment {
+		case "migrations", "tests", "venv", ".venv", "node_modules", "dist", "build", ".next", "vendor":
+			return false
+		}
+	}
+	base := path.Base(filePath)
+	if base == "__init__.py" || strings.HasSuffix(base, ".min.js") || strings.HasSuffix(base, ".d.ts") ||
+		strings.HasSuffix(base, ".config.js") || strings.HasSuffix(base, ".config.ts") || strings.HasSuffix(base, ".config.mjs") {
+		return false
+	}
+	switch strings.ToLower(path.Ext(base)) {
+	case ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".go", ".rs", ".java", ".kt", ".kts", ".rb", ".php", ".c", ".h", ".cpp", ".cc", ".hpp", ".cs", ".swift", ".scala", ".m", ".mm", ".lua", ".vue":
+		return true
+	default:
+		return false
+	}
+}
+
+func gitHubBlobTextsQuery(ref string, paths []string) string {
+	fields := make([]string, 0, len(paths))
+	for index, filePath := range paths {
+		expression, _ := json.Marshal(ref + ":" + filePath)
+		fields = append(fields, "f"+strconv.Itoa(index)+": object(expression: "+string(expression)+") { ... on Blob { text isBinary isTruncated } }")
+	}
+	return "query($owner: String!, $repo: String!) {\n  repository(owner: $owner, name: $repo) {\n" + strings.Join(fields, "\n") + "\n  }\n}"
+}
+
+func gitHubGraphQLPath(client *providerfoundation.HTTPClient) string {
+	base := strings.TrimSuffix(client.BaseURL.EscapedPath(), "/")
+	if strings.HasSuffix(base, "/api/v3") {
+		return strings.TrimSuffix(base, "/api/v3") + "/api/graphql"
+	}
+	return base + "/graphql"
+}
+
+func (row gitFileRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || len(row.RepoID) != 36 || row.Path == "" || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubFilesRouteHandler{}

--- a/internal/providersync/github_files_route_test.go
+++ b/internal/providersync/github_files_route_test.go
@@ -1,0 +1,131 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitHubFilesDoer struct {
+	t             *testing.T
+	contentStatus int
+}
+
+func (doer gitHubFilesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	body := `{"full_name":"acme/api","default_branch":"main"}`
+	switch request.URL.Path {
+	case "/repos/acme/api":
+	case "/repos/acme/api/commits":
+		body = `[{"sha":"tree-sha"}]`
+	case "/repos/acme/api/git/trees/tree-sha":
+		body = `{"tree":[{"path":"README.md","type":"blob","size":20},{"path":"src/main.go","type":"blob","size":12},{"path":"dir","type":"tree"}]}`
+	case "/graphql":
+		if doer.contentStatus != 0 {
+			return &http.Response{
+				StatusCode: doer.contentStatus,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"message":"content fetch failed"}`)),
+				Request:    request,
+			}, nil
+		}
+		var requestBody struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			doer.t.Fatal(err)
+		}
+		if !strings.Contains(requestBody.Query, "tree-sha:src/main.go") {
+			doer.t.Fatalf("graphql query=%q", requestBody.Query)
+		}
+		body = `{"data":{"repository":{"f0":{"text":"package main\n","isBinary":false,"isTruncated":false}}}}`
+	default:
+		doer.t.Fatalf("unexpected request %s", request.URL.String())
+	}
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+}
+
+func TestGitHubFilesRouteTraversesTreeAndWritesNonEmptyInventory(t *testing.T) {
+	claim := nativeTestClaim("github", "files")
+	client := gitHubRepositoryClient(t, gitHubFilesDoer{t: t}, "https://api.github.com")
+	batch, err := (GitHubFilesRouteHandler{}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "git_files" || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var withContent gitFileRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[1], &withContent); err != nil {
+		t.Fatal(err)
+	}
+	if withContent.OrgID != claim.OrgID || withContent.Path != "src/main.go" || withContent.Contents == nil || *withContent.Contents != "package main\n" {
+		t.Fatalf("file row=%+v", withContent)
+	}
+}
+
+func TestGitHubFilesRouteReturnsTraversalFailureWhenContentFetchFails(t *testing.T) {
+	claim := nativeTestClaim("github", "files")
+	client := gitHubRepositoryClient(t, gitHubFilesDoer{
+		t: t, contentStatus: http.StatusInternalServerError,
+	}, "https://api.github.com")
+
+	_, err := (GitHubFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrGitHubFilesTraversalFailed) {
+		t.Fatalf("content fetch error=%v, want ErrGitHubFilesTraversalFailed", err)
+	}
+}
+
+func TestGitHubFilesRouteReraisesContentRateLimits(t *testing.T) {
+	claim := nativeTestClaim("github", "files")
+	client := gitHubRepositoryClient(t, gitHubFilesDoer{
+		t: t, contentStatus: http.StatusTooManyRequests,
+	}, "https://api.github.com")
+
+	_, err := (GitHubFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("rate limit error=%v, want ProviderError{Class: ErrorRateLimited}", err)
+	}
+}
+
+func TestGitHubFilesTraversalPropagatesContextCancellation(t *testing.T) {
+	err := continueGitHubFilesTraversal(context.Canceled, "acme/api")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error=%v, want context.Canceled", err)
+	}
+}
+
+func TestGitHubFileContentEligibilityMatchesScannerConfig(t *testing.T) {
+	large := gitHubFileContentMaxBytes + 1
+	for _, test := range []struct {
+		path string
+		size *int
+		want bool
+	}{
+		{path: "src/main.go", want: true},
+		{path: "tests/main.go", want: false},
+		{path: "migrations/001.go", want: false},
+		{path: "src/app.min.js", want: false},
+		{path: "src/types.d.ts", want: false},
+		{path: "README.md", want: false},
+		{path: "src/oversized.go", size: &large, want: false},
+	} {
+		if got := gitHubFileContentEligible(test.path, test.size); got != test.want {
+			t.Fatalf("eligible(%q)=%v want %v", test.path, got, test.want)
+		}
+	}
+}

--- a/internal/providersync/testdata/oracle_pairs/github_files_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_files_row.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.rows: list[Any] = []
+
+    async def insert_git_file_data(self, rows: list[Any]) -> None:
+        self.rows.extend(rows)
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(_MODEL_SOURCE.read_text(), "GitFile")
+
+
+async def _build_row_async(case: dict[str, Any]) -> dict[str, Any]:
+    base_git = load_live_module(_BASE_GIT_SOURCE)
+    sink = _Sink()
+    await base_git.backfill_file_records(
+        sink,
+        case["repo_id"],
+        [case["path"]],
+        "acme/api",
+        contents_by_path=case.get("contents_by_path"),
+    )
+    return dict(vars(sink.rows[0]))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return asyncio.run(_build_row_async(case))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/files/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "last_synced": "stamped by ClickHouseStore.insert_git_file_data, not backfill_file_records",
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -106,6 +106,29 @@ def _target_dataset_adapters() -> None:
     )
 
 
+class _OracleGitFile:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+class _OracleAsyncBatchCollector:
+    def __init__(self, callback: Callable[[list[Any]], Any]) -> None:
+        self._callback = callback
+        self._items: list[Any] = []
+
+    async def __aenter__(self) -> _OracleAsyncBatchCollector:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        await self._callback(self._items)
+
+    def add(self, item: Any) -> None:
+        self._items.append(item)
+
+    async def maybe_flush(self) -> None:
+        return None
+
+
 def _target_base_git() -> None:
     """Stub base_git.py's heavy, unrelated imports (CHAOS-3122).
 
@@ -144,7 +167,7 @@ def _target_base_git() -> None:
             ),
             "GitBlame": object,
             "GitCommitStat": object,
-            "GitFile": object,
+            "GitFile": _OracleGitFile,
             "GitPullRequest": type(
                 "GitPullRequest",
                 (),
@@ -153,7 +176,8 @@ def _target_base_git() -> None:
         },
     )
     _install_module(
-        "dev_health_ops.processors.fetch_utils", {"AsyncBatchCollector": object}
+        "dev_health_ops.processors.fetch_utils",
+        {"AsyncBatchCollector": _OracleAsyncBatchCollector},
     )
     # False keeps base_git.py's `elif CONNECTORS_AVAILABLE:` branch from firing,
     # so it never needs dev_health_ops.connectors.utils stubbed too.

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -134,6 +134,7 @@ class ProviderUnitRouteSwitches:
     github_commits: bool = False
     github_deployments: bool = False
     github_security: bool = False
+    github_files: bool = False
 
     @classmethod
     def from_environment(
@@ -153,6 +154,7 @@ class ProviderUnitRouteSwitches:
             github_commits=_flag(source, "WORKER_GITHUB_COMMITS_ENABLED"),
             github_deployments=_flag(source, "WORKER_GITHUB_DEPLOYMENTS_ENABLED"),
             github_security=_flag(source, "WORKER_GITHUB_SECURITY_ENABLED"),
+            github_files=_flag(source, "WORKER_GITHUB_FILES_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -237,6 +237,16 @@ def test_github_security_switch_is_the_second_required_key() -> None:
     ).routes_to_river("github", "security")
 
 
+def test_github_files_switch_is_the_second_required_key() -> None:
+    assert ProviderUnitRouteSwitches.is_route_ready("github", "files")
+    assert not ProviderUnitRouteSwitches.from_environment({}).routes_to_river(
+        "github", "files"
+    )
+    assert ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_FILES_ENABLED": "true"}
+    ).routes_to_river("github", "files")
+
+
 # ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.


### PR DESCRIPTION
## Summary
- Adds Go github/files tree traversal, bounded GraphQL content fetch, ClickHouse git_files effects, and tenant-scoped FINAL readback.
- Prevents a non-rate-limit traversal/content failure from completing the Go unit or advancing its watermark; cancellation and rate limits also propagate.
- Intentionally diverges from current Python behavior because Python has the same live silent-data-loss defect (CHAOS-3189); D16 cannot justify mirroring known permanent inventory loss. CHAOS-3188 records the policy decision and Python remediation.

## TEST-EVIDENCE
- Cold-cache two-tenant proof: SELECT FINAL with org_id in the readback predicate returned only the scoped tenant. The scoped-aggregate assertion fails if org_id is removed from the readback predicate; verified locally by mutation on 2026-07-27.
- Traversal-failure state test proves a non-rate-limit GitHub files failure leaves the unit dispatching, with no successful result and no watermark.
- Rate-limit content failures remain ProviderError rate-limited. Context cancellation is propagated.
- Cold-cache loader stub-path proof: TestGitHubFilesOracleLoaderExecutesStubbedBaseGitProducer passed.

## EMITTED STATE
- A genuine empty tree emits result inventory_status=empty; a no-commit-at-bound path emits inventory_status=no_commit_at_bound.
- An exhausted GitHub files unit records error_category=github_files_inventory_failed, never a successful empty inventory.

## NOT-PINNED
- Tree pagination and truncation remain Python-parity gaps tracked by CHAOS-3186.

## RISK-NOTES
- Python currently catches a non-rate-limit traversal/content exception and later records the unit successful and advances its watermark. This PR intentionally does not mirror that live bug; CHAOS-3189 is Urgent.

## Adversarial self-review
- No findings judged contrived.

Linear: CHAOS-3185 (contributes to CHAOS-3033).

## TRAVERSAL STATE-MUTATION EVIDENCE
- UNPROVEN locally: the original lane did not retain a recorded revert-and-rerun transcript for TestProviderUnitKeepsWatermarkUnadvancedWhenGitHubFilesTraversalFails, so this PR does not claim that mutation was executed.