### PR TITLE
feat: port GitHub commit stats provider sync to Go

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -436,6 +436,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		GithubDeployments:        cfg.WorkerGithubDeploymentsEnabled,
 		GithubSecurity:           cfg.WorkerGithubSecurityEnabled,
 		GithubFiles:              cfg.WorkerGithubFilesEnabled,
+		GithubCommitStats:        cfg.WorkerGithubCommitStatsEnabled,
 	}
 }
 
@@ -460,6 +461,7 @@ func providerRouteSwitchesReady(
 		{"github", "deployments", cfg.WorkerGithubDeploymentsEnabled},
 		{"github", "security", cfg.WorkerGithubSecurityEnabled},
 		{"github", "files", cfg.WorkerGithubFilesEnabled},
+		{"github", "commit-stats", cfg.WorkerGithubCommitStatsEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -192,9 +192,9 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Seven route-ready pairs can reach this closure today:
+			// Eight route-ready pairs can reach this closure today:
 			// launchdarkly/feature-flags plus github/repo-metadata, cicd,
-			// commits, deployments, security, and files. Each
+			// commits, deployments, security, files, and commit-stats. Each
 			// has its own CompleteRouteHandler and effect sink. session.Claim
 			// is already known here — providerunit.Handler.Work only calls
 			// BuildExecutor after its own descriptor gate passed for THIS
@@ -271,6 +271,13 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubFilesRouteHandler{}
 				sink, readback = ghFilesSink, ghFilesSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "commit-stats":
+				ghCommitStatsSink := providersync.GitHubCommitStatsClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubCommitStatsRouteHandler{}
+				sink, readback = ghCommitStatsSink, ghCommitStatsSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
@@ -455,7 +462,8 @@ func providerSyncWorkerEnabled(cfg config.Config) bool {
 	return cfg.WorkerLaunchDarklyFeatureFlagsEnabled || cfg.WorkerGithubRepoMetadataEnabled ||
 		cfg.WorkerGithubPRsEnabled || cfg.WorkerGithubCICDEnabled ||
 		cfg.WorkerGithubCommitsEnabled || cfg.WorkerGithubDeploymentsEnabled ||
-		cfg.WorkerGithubSecurityEnabled || cfg.WorkerGithubFilesEnabled
+		cfg.WorkerGithubSecurityEnabled || cfg.WorkerGithubFilesEnabled ||
+		cfg.WorkerGithubCommitStatsEnabled
 }
 
 func providerSyncRiverConfig(

--- a/cmd/dev-health-worker/provider_sync_reachability_integration_test.go
+++ b/cmd/dev-health-worker/provider_sync_reachability_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestBuildProviderSyncWorkerConstructsRealDependenciesForEveryRouteReadySwitch(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	clickhouse, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clickhouse.Close(context.Background()) })
+	valkey, err := containers.StartValkey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = valkey.Close(context.Background()) })
+	registry, err := jobruntime.Load(filepath.Join("contracts", "jobs", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{Profiles: []string{"sync"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, enable := range map[string]func(*config.Config){
+		"launchdarkly_feature_flags": func(cfg *config.Config) { cfg.WorkerLaunchDarklyFeatureFlagsEnabled = true },
+		"github_repo_metadata":       func(cfg *config.Config) { cfg.WorkerGithubRepoMetadataEnabled = true },
+		"github_prs":                 func(cfg *config.Config) { cfg.WorkerGithubPRsEnabled = true },
+		"github_cicd":                func(cfg *config.Config) { cfg.WorkerGithubCICDEnabled = true },
+		"github_commits":             func(cfg *config.Config) { cfg.WorkerGithubCommitsEnabled = true },
+		"github_deployments":         func(cfg *config.Config) { cfg.WorkerGithubDeploymentsEnabled = true },
+		"github_security":            func(cfg *config.Config) { cfg.WorkerGithubSecurityEnabled = true },
+		"github_files":               func(cfg *config.Config) { cfg.WorkerGithubFilesEnabled = true },
+		"github_commit_stats":        func(cfg *config.Config) { cfg.WorkerGithubCommitStatsEnabled = true },
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := config.Config{
+				Profile:               "sync",
+				RiverDatabaseSchema:   "river",
+				SettingsEncryptionKey: secrets.NewValue("test-encryption-key"),
+				ClickHouseURI:         secrets.NewValue(clickhouse.URI),
+				ValkeyURI:             secrets.NewValue(valkey.URI),
+			}
+			enable(&cfg)
+			family, err := buildProviderSyncWorker(
+				ctx, cfg, reportBuilderDatabase(t), registry, collector, slog.Default(),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if family.component == nil || len(family.handlers) != 1 || len(family.queues) != 1 {
+				t.Fatalf("provider sync family=%#v", family)
+			}
+			if err := family.component.Shutdown(ctx); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -290,6 +290,12 @@ func TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch(t *testing.T)
 			},
 		},
 		{
+			name: "github prs",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubPRsEnabled: true,
+			},
+		},
+		{
 			name: "github commits",
 			cfg: config.Config{
 				Profile: "sync", WorkerGithubCommitsEnabled: true,
@@ -311,6 +317,12 @@ func TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch(t *testing.T)
 			name: "github files",
 			cfg: config.Config{
 				Profile: "sync", WorkerGithubFilesEnabled: true,
+			},
+		},
+		{
+			name: "github commit stats",
+			cfg: config.Config{
+				Profile: "sync", WorkerGithubCommitStatsEnabled: true,
 			},
 		},
 	} {
@@ -372,6 +384,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 			cfg:  config.Config{WorkerGithubFilesEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubFiles: true},
 		},
+		"github_commit_stats": {
+			cfg:  config.Config{WorkerGithubCommitStatsEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubCommitStats: true},
+		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
 			want: providersync.CompleteRouteSwitches{LinearWorkItems: true},
@@ -391,6 +407,31 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 				t.Fatalf("workerRouteSwitches = %+v, want %+v", got, probe.want)
 			}
 		})
+	}
+}
+
+func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(
+		nil,
+		providersync.CompleteRouteSwitches{GithubCommitStats: true},
+		nil, nil, nil, nil, nil, slog.Default(),
+	)
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("provider sync handler is not constructed")
+	}
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "github", Dataset: "commit-stats",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.GitHubCommitStatsRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.GitHubCommitStatsClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
 	}
 }
 
@@ -501,6 +542,7 @@ func TestProviderSyncWorkerEnabledForEveryRouteReadySwitch(t *testing.T) {
 		"github_deployments":   {WorkerGithubDeploymentsEnabled: true},
 		"github_security":      {WorkerGithubSecurityEnabled: true},
 		"github_files":         {WorkerGithubFilesEnabled: true},
+		"github_commit_stats":  {WorkerGithubCommitStatsEnabled: true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if !providerSyncWorkerEnabled(cfg) {

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -69,11 +69,13 @@
         "sync_commit_stats": true,
         "sync_git": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "commit-stats",
-      "route_destinations": [],
-      "route_ready": false,
+      "route_destinations": [
+        "git_commit_stats"
+      ],
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -124,6 +124,8 @@ type Config struct {
 	WorkerGithubSecurityEnabled bool
 	// WorkerGithubFilesEnabled gates the isolated (github, files) route.
 	WorkerGithubFilesEnabled bool
+	// WorkerGithubCommitStatsEnabled gates the isolated (github, commit-stats) route.
+	WorkerGithubCommitStatsEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -223,6 +225,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_FILES_ENABLED",
 			target: &cfg.WorkerGithubFilesEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_COMMIT_STATS_ENABLED",
+			target: &cfg.WorkerGithubCommitStatsEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -141,7 +141,7 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 		cfg.WorkerGithubRepoMetadataEnabled || cfg.WorkerGithubPRsEnabled ||
 		cfg.WorkerGithubCICDEnabled || cfg.WorkerGithubCommitsEnabled ||
 		cfg.WorkerGithubDeploymentsEnabled || cfg.WorkerGithubSecurityEnabled ||
-		cfg.WorkerGithubFilesEnabled {
+		cfg.WorkerGithubFilesEnabled || cfg.WorkerGithubCommitStatsEnabled {
 		t.Fatal("provider route switches must default off")
 	}
 }
@@ -174,6 +174,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_GITHUB_DEPLOYMENTS_ENABLED":         "true",
 		"WORKER_GITHUB_SECURITY_ENABLED":            "true",
 		"WORKER_GITHUB_FILES_ENABLED":               "true",
+		"WORKER_GITHUB_COMMIT_STATS_ENABLED":        "true",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -205,7 +206,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		!cfg.WorkerGithubRepoMetadataEnabled || !cfg.WorkerGithubPRsEnabled ||
 		!cfg.WorkerGithubCICDEnabled || !cfg.WorkerGithubCommitsEnabled ||
 		!cfg.WorkerGithubDeploymentsEnabled || !cfg.WorkerGithubSecurityEnabled ||
-		!cfg.WorkerGithubFilesEnabled {
+		!cfg.WorkerGithubFilesEnabled || !cfg.WorkerGithubCommitStatsEnabled {
 		t.Fatal("expected independent provider route opt-ins")
 	}
 
@@ -228,6 +229,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "sometimes",
 		"WORKER_GITHUB_PRS_ENABLED":                 "sometimes",
 		"WORKER_GITHUB_COMMITS_ENABLED":             "sometimes",
+		"WORKER_GITHUB_COMMIT_STATS_ENABLED":        "sometimes",
 	} {
 		if _, err := Load(workerSpec(map[string]string{key: value})); err == nil {
 			t.Fatalf("expected %s=%q to fail", key, value)

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -73,6 +73,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //     production source mappings plus FINAL tenant-fenced ClickHouse effects.
 //   - github/files: live traversal/row parity against backfill_file_records plus
 //     tenant-qualified FINAL readback.
+//   - github/commit-stats: CHAOS-3033, live producer oracle parity plus
+//     tenant-scoped FINAL readback and production-worker construction.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -94,6 +96,7 @@ var routeReadyPairs = map[string]struct{}{
 	"github/deployments":         {},
 	"github/security":            {},
 	"github/files":               {},
+	"github/commit-stats":        {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -118,8 +121,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
 		GithubPRs: true, GithubCICD: true, GithubCommits: true,
 		GithubDeployments: true, GithubSecurity: true, GithubFiles: true,
+		GithubCommitStats: true,
 	}
-	if reflect.TypeOf(all).NumField() != 11 {
+	if reflect.TypeOf(all).NumField() != 12 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -233,6 +237,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"github/deployments":         GitHubDeploymentsRouteHandler{},
 		"github/security":            GitHubSecurityRouteHandler{},
 		"github/files":               GitHubFilesRouteHandler{},
+		"github/commit-stats":        GitHubCommitStatsRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -39,6 +39,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"github/deployments":         ExecutorNativeGo,
 	"github/security":            ExecutorNativeGo,
 	"github/files":               ExecutorNativeGo,
+	"github/commit-stats":        ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -142,6 +143,8 @@ type CompleteRouteSwitches struct {
 	GithubSecurity bool
 	// GithubFiles gates the isolated git_files writer only.
 	GithubFiles bool
+	// GithubCommitStats gates the isolated git_commit_stats writer only.
+	GithubCommitStats bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -252,6 +255,10 @@ func (switches CompleteRouteSwitches) Descriptor(
 		descriptor.Destinations = []string{"git_files"}
 		descriptor.RouteReady = true
 		descriptor.RouteEnabled = switches.GithubFiles
+	case provider == "github" && dataset == "commit-stats":
+		descriptor.Destinations = []string{"git_commit_stats"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubCommitStats
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_commit_stats_effects_clickhouse.go
+++ b/internal/providersync/github_commit_stats_effects_clickhouse.go
@@ -1,0 +1,174 @@
+package providersync
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubCommitStatsClickHouseEffects writes git_commit_stats rows and reads
+// the winning ReplacingMergeTree version through a tenant-scoped FINAL lookup.
+type GitHubCommitStatsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubCommitStatsClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "commit-stats" ||
+		effect.Destination != "git_commit_stats" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[commitStatsRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_commit_stats (
+  repo_id, commit_hash, file_path, additions, deletions, old_file_mode,
+  new_file_mode, last_synced, org_id
+)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.RepoID, row.CommitHash, row.FilePath, row.Additions, row.Deletions,
+			row.OldFileMode, row.NewFileMode, row.LastSynced, row.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubCommitStatsClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "commit-stats" ||
+		effect.Destination != "git_commit_stats" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[commitStatsRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectCommitStats(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink GitHubCommitStatsClickHouseEffects) inspectCommitStats(
+	ctx context.Context,
+	expected commitStatsRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT org_id, commit_hash, file_path, additions, deletions, old_file_mode,
+       new_file_mode, last_synced
+FROM git_commit_stats FINAL
+WHERE org_id = ? AND repo_id = ? AND commit_hash = ? AND file_path = ?`,
+		expected.OrgID, expected.RepoID, expected.CommitHash, expected.FilePath)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var version commitStatsVersion
+	for rows.Next() {
+		if err := rows.Scan(
+			&version.Row.OrgID, &version.Row.CommitHash, &version.Row.FilePath,
+			&version.Row.Additions, &version.Row.Deletions, &version.Row.OldFileMode,
+			&version.Row.NewFileMode, &version.LastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		version.Found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareCommitStatsVersion(expected, version), nil
+}
+
+type commitStatsVersion struct {
+	Row        commitStatsRow
+	LastSynced time.Time
+	Found      bool
+}
+
+func compareCommitStatsVersion(expected commitStatsRow, actual commitStatsVersion) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) ||
+		actual.Row.OrgID != expected.OrgID || actual.Row.CommitHash != expected.CommitHash ||
+		actual.Row.FilePath != expected.FilePath || actual.Row.Additions != expected.Additions ||
+		actual.Row.Deletions != expected.Deletions || actual.Row.OldFileMode != expected.OldFileMode ||
+		actual.Row.NewFileMode != expected.NewFileMode {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitHubCommitStatsClickHouseEffects{}
+var _ EffectReadback = GitHubCommitStatsClickHouseEffects{}

--- a/internal/providersync/github_commit_stats_effects_integration_test.go
+++ b/internal/providersync/github_commit_stats_effects_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const gitCommitStatsDDL = `
+CREATE TABLE git_commit_stats (
+  repo_id UUID,
+  commit_hash String,
+  file_path String,
+  additions Int32,
+  deletions Int32,
+  old_file_mode String,
+  new_file_mode String,
+  last_synced DateTime64(3, 'UTC'),
+  org_id String
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, commit_hash, file_path)`
+
+func TestGitHubCommitStatsReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, sink := newGitHubCommitStatsIntegrationSink(t)
+	claim := nativeTestClaim("github", "commit-stats")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	current := commitStatsRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		CommitHash: "abc123", FilePath: "src/main.go", Additions: 4, Deletions: 2,
+		OldFileMode: "unknown", NewFileMode: "unknown", LastSynced: now,
+	}
+	effect := commitStatsEffect(t, current)
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty inspection=%s error=%v", inspection, err)
+	}
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previous.Additions = 1
+	if err := sink.WriteEffect(ctx, claim, commitStatsEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitHubCommitStatsReadbackSelectsOwningTenantFromNaturalKeyCollision(t *testing.T) {
+	ctx, sink := newGitHubCommitStatsIntegrationSink(t)
+	claim := nativeTestClaim("github", "commit-stats")
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	row := commitStatsRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		CommitHash: "abc123", FilePath: "src/main.go", Additions: 4, Deletions: 2,
+		OldFileMode: "unknown", NewFileMode: "unknown", LastSynced: now,
+	}
+	otherClaim := claim
+	otherClaim.OrgID = claim.OrgID + "-foreign"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	otherRow.Additions = 9
+	if err := sink.WriteEffect(ctx, claim, commitStatsEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, commitStatsEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	var count uint64
+	var minOrgID, maxOrgID string
+	var minAdditions, maxAdditions int32
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count(), min(org_id), max(org_id), min(additions), max(additions)
+FROM git_commit_stats FINAL
+WHERE org_id = ? AND repo_id = ? AND commit_hash = ? AND file_path = ?`,
+		row.OrgID, row.RepoID, row.CommitHash, row.FilePath,
+	).Scan(&count, &minOrgID, &maxOrgID, &minAdditions, &maxAdditions); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || minOrgID != row.OrgID || maxOrgID != row.OrgID ||
+		minAdditions != row.Additions || maxAdditions != row.Additions {
+		t.Fatalf(
+			"tenant-scoped readback returned count=%d orgs=(%q,%q) additions=(%d,%d), want only %+v",
+			count, minOrgID, maxOrgID, minAdditions, maxAdditions, row,
+		)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, commitStatsEffect(t, row)); err != nil || inspection != EffectExact {
+		t.Fatalf("tenant-scoped inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, otherClaim, commitStatsEffect(t, otherRow)); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newGitHubCommitStatsIntegrationSink(
+	t *testing.T,
+) (context.Context, GitHubCommitStatsClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitCommitStatsDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitHubCommitStatsClickHouseEffects{
+		Conn: conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return nil
+		}),
+	}
+}
+
+func commitStatsEffect(t *testing.T, row commitStatsRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(
+		"git_commit_stats", EffectReadbackRequired, []commitStatsRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/github_commit_stats_generic_oracle_test.go
+++ b/internal/providersync/github_commit_stats_generic_oracle_test.go
@@ -1,0 +1,40 @@
+package providersync
+
+import "testing"
+
+var oracleCommitStatsGoOnlyFields = map[string]string{
+	"org_id": "carried from the Go claim to scope ClickHouse's tenant-partitioned replacing key",
+}
+
+func buildCommitStatsRowForOracle(t *testing.T, input map[string]any) commitStatsRow {
+	t.Helper()
+	file, ok := input["raw_file"].(map[string]any)
+	if !ok {
+		t.Fatalf("oracle case missing raw_file: %v", input)
+	}
+	filename, _ := file["filename"].(string)
+	additions, _ := file["additions"].(float64)
+	deletions, _ := file["deletions"].(float64)
+	return commitStatsRow{
+		OrgID: "org-1", RepoID: input["repo_id"].(string),
+		CommitHash: input["commit_hash"].(string), FilePath: filename,
+		Additions: int32(additions), Deletions: int32(deletions),
+		OldFileMode: "unknown", NewFileMode: "unknown", LastSynced: oracleCICDNormalizedAt,
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForCommitStatsRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/commit-stats/row",
+		[]oracleCase{{
+			ID: "commit_file_stat_defaults_modes_at_sink",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "commit_hash": "abc123",
+				"raw_file": map[string]any{"filename": "src/main.go", "additions": float64(4), "deletions": float64(2)},
+			},
+		}},
+		buildCommitStatsRowForOracle,
+		oracleCommitStatsGoOnlyFields,
+	)
+}

--- a/internal/providersync/github_commit_stats_route.go
+++ b/internal/providersync/github_commit_stats_route.go
@@ -1,0 +1,221 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	defaultGitHubCommitStatsMaxCommits = 300
+	defaultGitHubCommitStatsSampleSize = 50
+)
+
+// commitStatsRow is the git_commit_stats projection emitted by github's
+// commit-stats unit. Python's _github_commit_stat_to_model leaves file modes
+// unset; its ClickHouse sink supplies the same "unknown" defaults represented
+// directly here. org_id is carried from the claim because migration 027 makes
+// it part of the table's replacing key.
+type commitStatsRow struct {
+	OrgID       string    `json:"org_id"`
+	RepoID      string    `json:"repo_id"`
+	CommitHash  string    `json:"commit_hash"`
+	FilePath    string    `json:"file_path"`
+	Additions   int32     `json:"additions"`
+	Deletions   int32     `json:"deletions"`
+	OldFileMode string    `json:"old_file_mode"`
+	NewFileMode string    `json:"new_file_mode"`
+	LastSynced  time.Time `json:"last_synced"`
+}
+
+type gitHubCommitListPayload struct {
+	SHA    string `json:"sha"`
+	Commit struct {
+		Author struct {
+			Date *string `json:"date"`
+		} `json:"author"`
+		Committer struct {
+			Date *string `json:"date"`
+		} `json:"committer"`
+	} `json:"commit"`
+}
+
+type gitHubCommitDetailPayload struct {
+	Files []gitHubCommitFilePayload `json:"files"`
+}
+
+type gitHubCommitFilePayload struct {
+	Filename  string `json:"filename"`
+	Additions int32  `json:"additions"`
+	Deletions int32  `json:"deletions"`
+}
+
+// GitHubCommitStatsRouteHandler mirrors _fetch_github_commits_async followed
+// by _sync_github_commit_stats: it lists commits with the Python window
+// parameters, then makes one sequential detail request per retained commit.
+// MaxCommits is the upstream sync cap; a zero value uses Python's configured
+// hard ceiling, while an incremental window that exceeds either cap is skipped
+// rather than written partially.
+type GitHubCommitStatsRouteHandler struct{ MaxCommits int }
+
+func (handler GitHubCommitStatsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "commit-stats" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+	var repoPayload gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repoPayload); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repoPayload.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+
+	maxCommits := handler.MaxCommits
+	if maxCommits == 0 {
+		maxCommits = defaultGitHubCommitStatsMaxCommits
+	}
+	if maxCommits < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	fetchLimit := maxCommits + 1
+	pages := (fetchLimit + nativePerPage - 1) / nativePerPage
+	query := url.Values{"per_page": {"100"}}
+	if claim.SinceAt != nil {
+		query.Set("since", claim.SinceAt.UTC().Format(time.RFC3339Nano))
+	}
+	if claim.BeforeAt != nil {
+		query.Set("until", claim.BeforeAt.UTC().Format(time.RFC3339Nano))
+	}
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx,
+		client,
+		providerfoundation.GitHubPageOptions{
+			Path: root + "/commits", Query: query, MaxPages: pages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	windowTruncated := len(page.Items) >= fetchLimit
+	if windowTruncated {
+		page.Items = page.Items[:maxCommits]
+	}
+	if claim.SinceAt != nil && (windowTruncated || len(page.Items) > defaultGitHubCommitStatsMaxCommits) {
+		return handler.completeBatch(claim, repoPayload.FullName, nil, page.Pages, page.Pages+1, true)
+	}
+
+	statsLimit := defaultGitHubCommitStatsSampleSize
+	if claim.SinceAt != nil {
+		statsLimit = len(page.Items)
+	}
+	if statsLimit > maxCommits {
+		statsLimit = maxCommits
+	}
+	if statsLimit > defaultGitHubCommitStatsMaxCommits {
+		statsLimit = defaultGitHubCommitStatsMaxCommits
+	}
+	rows := make([]commitStatsRow, 0)
+	detailRequests := 0
+	for _, raw := range page.Items[:min(statsLimit, len(page.Items))] {
+		var commit gitHubCommitListPayload
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.UseNumber()
+		if decoder.Decode(&commit) != nil || commit.SHA == "" {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		if commitStatsBeforeSince(commit, claim.SinceAt) {
+			continue
+		}
+		var detail gitHubCommitDetailPayload
+		if err := fetchObject(ctx, client, root+"/commits/"+url.PathEscape(commit.SHA), &detail); err != nil {
+			if isRateLimited(err) {
+				return CompleteRouteBatch{}, err
+			}
+			continue
+		}
+		detailRequests++
+		for _, file := range detail.Files {
+			if file.Filename == "" {
+				continue
+			}
+			rows = append(rows, commitStatsRow{
+				OrgID: claim.OrgID, RepoID: repoID, CommitHash: commit.SHA,
+				FilePath: file.Filename, Additions: file.Additions, Deletions: file.Deletions,
+				OldFileMode: "unknown", NewFileMode: "unknown", LastSynced: normalizedAt,
+			})
+		}
+	}
+	return handler.completeBatch(claim, repoPayload.FullName, rows, page.Pages, page.Pages+1+detailRequests, page.CapReached)
+}
+
+func (handler GitHubCommitStatsRouteHandler) completeBatch(
+	claim Claim,
+	fullName string,
+	rows []commitStatsRow,
+	pages int,
+	requests int,
+	capReached bool,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("git_commit_stats", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Watermark: claim.BeforeAt,
+		Result: map[string]any{
+			"commit_stats_synced": len(rows),
+			"repo":                fullName,
+		},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages, Records: len(rows), CapReached: capReached,
+		},
+	}, nil
+}
+
+func commitStatsBeforeSince(commit gitHubCommitListPayload, since *time.Time) bool {
+	if since == nil {
+		return false
+	}
+	when := parseGitHubPullTime(commit.Commit.Committer.Date)
+	if when == nil {
+		when = parseGitHubPullTime(commit.Commit.Author.Date)
+	}
+	return when != nil && when.Before(since.UTC())
+}
+
+func isRateLimited(err error) bool {
+	var providerErr *providerfoundation.ProviderError
+	return errors.As(err, &providerErr) && providerErr.Class == providerfoundation.ErrorRateLimited
+}
+
+func (row commitStatsRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || len(row.RepoID) != 36 ||
+		row.CommitHash == "" || row.FilePath == "" || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubCommitStatsRouteHandler{}

--- a/internal/providersync/github_commit_stats_route_test.go
+++ b/internal/providersync/github_commit_stats_route_test.go
@@ -1,0 +1,125 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const gitHubCommitStatsListFixture = `[
+  {"sha":"first","commit":{"committer":{"date":"2026-07-22T10:00:00Z"}}},
+  {"sha":"second","commit":{"author":{"date":"2026-07-22T09:00:00Z"}}}
+]`
+
+type gitHubCommitStatsDoer struct {
+	t        *testing.T
+	requests []string
+}
+
+func (doer *gitHubCommitStatsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request.URL.RequestURI())
+	body := ""
+	switch request.URL.Path {
+	case "/repos/acme/api":
+		body = gitHubRepositoryFixture
+	case "/repos/acme/api/commits":
+		body = gitHubCommitStatsListFixture
+	case "/repos/acme/api/commits/first":
+		body = `{"files":[{"filename":"src/main.go","additions":4,"deletions":2},{"filename":"","additions":8,"deletions":3}]}`
+	case "/repos/acme/api/commits/second":
+		body = `{"files":[{"filename":"README.md","additions":1,"deletions":0}]}`
+	default:
+		doer.t.Fatalf("unexpected request %s", request.URL.RequestURI())
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestGitHubCommitStatsRouteListsThenFetchesEachCommitDetail(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubCommitStatsDoer{t: t}
+	client := gitHubRepositoryClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "commit-stats")
+
+	batch, err := (GitHubCommitStatsRouteHandler{MaxCommits: 3}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "git_commit_stats" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 4 || batch.Evidence.Pages != 1 || batch.Evidence.Records != 2 {
+		t.Fatalf("evidence=%+v", batch.Evidence)
+	}
+	wantRequests := []string{
+		"/repos/acme/api",
+		"/repos/acme/api/commits?per_page=100&since=2026-07-01T00%3A00%3A00Z&until=2026-07-31T23%3A59%3A59Z",
+		"/repos/acme/api/commits/first",
+		"/repos/acme/api/commits/second",
+	}
+	if len(doer.requests) != len(wantRequests) {
+		t.Fatalf("requests=%v want=%v", doer.requests, wantRequests)
+	}
+	for index := range wantRequests {
+		if doer.requests[index] != wantRequests[index] {
+			t.Fatalf("request[%d]=%q want %q", index, doer.requests[index], wantRequests[index])
+		}
+	}
+	var first commitStatsRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.OrgID != claim.OrgID || first.CommitHash != "first" || first.FilePath != "src/main.go" ||
+		first.Additions != 4 || first.Deletions != 2 || first.OldFileMode != "unknown" ||
+		first.NewFileMode != "unknown" || !first.LastSynced.Equal(now) {
+		t.Fatalf("row=%+v", first)
+	}
+}
+
+func TestGitHubCommitStatsRouteSkipsIncrementalWindowThatExceedsCap(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubCommitStatsDoer{t: t}
+	client := gitHubRepositoryClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "commit-stats")
+	since := now.Add(-24 * time.Hour)
+	claim.SinceAt = &since
+
+	batch, err := (GitHubCommitStatsRouteHandler{MaxCommits: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 || len(doer.requests) != 2 {
+		t.Fatalf("effects=%+v requests=%v", batch.Effects, doer.requests)
+	}
+}
+
+func TestCommitStatsRowRejectsTenantMismatch(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "commit-stats")
+	row := commitStatsRow{
+		OrgID: "other-org", RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		CommitHash: "abc123", FilePath: "src/main.go", OldFileMode: "unknown",
+		NewFileMode: "unknown", LastSynced: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	}
+	if err := row.validate(claim); err == nil {
+		t.Fatal("tenant-mismatched row passed validation")
+	}
+}

--- a/internal/providersync/testdata/oracle_pairs/github_commit-stats_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_commit-stats_row.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
+_PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(_MODEL_SOURCE.read_text(), "GitCommitStat")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    code_client = load_live_module(_CODE_CLIENT_SOURCE)
+    processor = load_live_module(_PROCESSOR_SOURCE)
+    file_stat = code_client._commit_stat_from_file(
+        case["commit_hash"], case["raw_file"]
+    )
+    stat = processor._github_commit_stat_to_model(file_stat, case["repo_id"])
+    return {key: value for key, value in vars(stat).items() if not key.startswith("_")}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/commit-stats/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "old_file_mode": "ClickHouseStore.insert_git_commit_stats supplies unknown when Python leaves the model field unset",
+            "new_file_mode": "ClickHouseStore.insert_git_commit_stats supplies unknown when Python leaves the model field unset",
+            "last_synced": "ClickHouseStore.insert_git_commit_stats stamps persistence time after the producer boundary",
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -277,6 +277,11 @@ def _target_github_code_client() -> None:
 _GITHUB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/github.py")
 
 
+class _OracleGitCommitStat:
+    def __init__(self, **values: Any) -> None:
+        self.__dict__.update(values)
+
+
 def _target_github_processor() -> None:
     """Stub processors/github.py's heavy, unrelated imports (CHAOS-3162).
 
@@ -340,7 +345,7 @@ def _target_github_processor() -> None:
                 (),
                 {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
             ),
-            "GitCommitStat": object,
+            "GitCommitStat": _OracleGitCommitStat,
             "GitPullRequest": object,
             "GitPullRequestReview": object,
             "Repo": object,

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -135,6 +135,7 @@ class ProviderUnitRouteSwitches:
     github_deployments: bool = False
     github_security: bool = False
     github_files: bool = False
+    github_commit_stats: bool = False
 
     @classmethod
     def from_environment(
@@ -155,6 +156,7 @@ class ProviderUnitRouteSwitches:
             github_deployments=_flag(source, "WORKER_GITHUB_DEPLOYMENTS_ENABLED"),
             github_security=_flag(source, "WORKER_GITHUB_SECURITY_ENABLED"),
             github_files=_flag(source, "WORKER_GITHUB_FILES_ENABLED"),
+            github_commit_stats=_flag(source, "WORKER_GITHUB_COMMIT_STATS_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -247,6 +247,24 @@ def test_github_files_switch_is_the_second_required_key() -> None:
     ).routes_to_river("github", "files")
 
 
+def test_github_commit_stats_switch_routes_only_when_enabled() -> None:
+    off = ProviderUnitRouteSwitches.from_environment({})
+    on = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_COMMIT_STATS_ENABLED": "true"}
+    )
+    assert off.github_commit_stats is False
+    assert not off.routes_to_river("github", "commit-stats")
+    assert on.github_commit_stats is True
+    assert on.routes_to_river("github", "commit-stats")
+
+
+def test_github_commit_stats_invalid_switch_fails_closed() -> None:
+    with pytest.raises(ProviderUnitRouteError):
+        ProviderUnitRouteSwitches.from_environment(
+            {"WORKER_GITHUB_COMMIT_STATS_ENABLED": "sometimes"}
+        )
+
+
 # ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.


### PR DESCRIPTION
## Summary
- ports GitHub commit-stats ingestion, ClickHouse effects, worker switch, and executor routing to Go
- adds live Python↔Go oracle coverage plus tenant-scoped FINAL readback proofs
- registers the route-ready capability and verifies construction through the production worker

## Route readiness
`route_ready: true`

- Live producer parity: `TestGenericOracleMatchesLivePythonForCommitStatsRowConstruction` executes the real Python producer chain through `github_commit-stats_row.py`.
- Production construction: `cmd/dev-health-worker/provider_sync.go:235-241` constructs the commit-stats handler and ClickHouse sink; `provider_sync.go:411-415` activates the worker family.
- ClickHouse winning-version: `TestGitHubCommitStatsReadbackResolvesWinningReplacingMergeTreeVersion` executes a `FINAL` readback.
- Tenant isolation: `TestGitHubCommitStatsReadbackSelectsOwningTenantFromNaturalKeyCollision` writes the same natural key for two orgs with distinguishable content and proves both scoped readbacks.
- Reachability: `TestBuildProviderSyncWorkerConstructsForEveryRouteReadySwitch` constructs the production worker family with only `WorkerGithubCommitStatsEnabled`.

## TEST-EVIDENCE
- cold-cache mutation proof: removing `org_id = ?` from the production readback predicate fails the collision test; restoration passes.
- cold-cache mutation proof: removing `WorkerGithubCommitStatsEnabled` from the activation gate fails the activation test; restoration passes.
- `bash ci/check_go.sh all` passed, including an executed `live-python-oracles` stage.
- isolated `ci/local_validate.sh` passed with a unique scratch ClickHouse database.
- six-defect generic-oracle acceptance gate passed.

## RISK-NOTES
- D16 is preserved: the route keeps Python’s sequential N+1 per-commit detail fetch strategy.
- NOT-PINNED: dataset-specific multi-page pagination behavior has no explicit route test.
- NOT-PINNED: there is no explicit dataset test distinguishing a normal empty inventory from a broken non-rate-limited detail fetch; the route currently continues past such fetch errors to mirror Python.

Linear: CHAOS-3187