### PR TITLE
test: extract scheduler readiness flake fix from #1318

### DIFF
--- a/internal/scheduler/sync/loop_test.go
+++ b/internal/scheduler/sync/loop_test.go
@@ -83,13 +83,16 @@ func openLoopReadiness(t *testing.T, registry *health.Registry) {
 	}
 }
 
-func waitForLoopReadiness(t *testing.T, registry *health.Registry, wantReady bool) health.Readiness {
+func waitForLoopReadiness(t *testing.T, loop *Loop, registry *health.Registry, wantReady bool) health.Readiness {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	var status health.Readiness
 	for time.Now().Before(deadline) {
 		status = registry.Readiness(context.Background())
-		if status.Ready == wantReady {
+		loop.mu.Lock()
+		up := loop.up
+		loop.mu.Unlock()
+		if status.Ready == wantReady && up == wantReady {
 			return status
 		}
 		time.Sleep(time.Millisecond)
@@ -224,7 +227,8 @@ func TestLoopFailureBacksOffClosesReadinessAndRecovers(t *testing.T) {
 	clock.mu.Unlock()
 	ticker.ticks <- firstTick
 	<-failed
-	if status := waitForLoopReadiness(t, registry, false); !strings.Contains(strings.Join(status.Failed, ","), "scheduler_loop") {
+	status := waitForLoopReadiness(t, loop, registry, false)
+	if status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "scheduler_loop") {
 		t.Fatalf("failed readiness = %#v", status)
 	}
 	var failedMetrics bytes.Buffer
@@ -247,7 +251,7 @@ func TestLoopFailureBacksOffClosesReadinessAndRecovers(t *testing.T) {
 	clock.mu.Unlock()
 	ticker.ticks <- retryTick
 	<-recovered
-	waitForLoopReadiness(t, registry, true)
+	waitForLoopReadiness(t, loop, registry, true)
 	if err := loop.Shutdown(context.Background()); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Close both independent readiness-transition races in `TestLoopFailureBacksOffClosesReadinessAndRecovers`. The fix remains test-only and reuses one condition-based, one-second bounded wait helper; it does not add a blanket sleep.

- Initial-failure readiness closure at `:213`: the callback signals `failed` before `Loop.step()` returns the error and `Loop.run` executes `loop.setFailed()`. The assertion previously read readiness before that asynchronous transition completed.
- Recovery readiness opening at `:236`: the callback signals `recovered` before `Loop.step()` commits `loop.lastOK, loop.up = now.UTC(), true` and `loop.ready.Store(true)`. The existing assertion now waits for the real recovered state.

## Evidence

- PR #1318 `go-quality` failed at `:236` with `recovered readiness = health.Readiness{Ready:false, Failed:[]{"scheduler_loop"}}`.
- PR #1315 `go-quality` failed at `:213` with `failed readiness = health.Readiness{Ready:true, Failed:[]}`. PR #1315 is documentation-only, so this confirms a scheduler-test flake rather than a behavior regression.

## Validation

- `go clean -testcache && go test -race -count=20 ./internal/scheduler/sync` — passed; the flake did not reproduce in this run.
- `bash ci/check_go.sh all` — passed.

This PR changes only `internal/scheduler/sync/loop_test.go`; it contains no production code, CI configuration, or linter configuration changes.