### PR TITLE
fix: defer unauthorized Celery-to-River cutover

### DIFF
--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -158,14 +158,14 @@ own compose file(s) for exactly which services exist and where.
 ### Bring-up order: the Python schema is a prerequisite, never a `depends_on`
 
 **`depends_on` ignores profiles.** A profiled service that declares
-`depends_on: migrate` pulls the *unprofiled* Python migrator into the plan, so
-`docker compose --profile go up -d` runs Alembic to **head** — and head is
-`0066_activate_river_worker_job_routes`, the cutover that retargets 23 of 24
-job kinds from Celery to River. Both Go runtimes sit downstream of
-`go-worker-migrate`, so that edge guaranteed precisely the ordering `0066`'s
-own docstring forbids: routes flip to River *before* any River consumer can
-start, and envelopes then accumulate in `worker_job_outbox` with nothing to
-execute them.
+`depends_on: migrate` pulls the *unprofiled* Python migrator into the plan. The
+application migrator now stops at `0065` unless
+`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`, but a deployment carrying that
+one-shot authorization would still run
+`0066_activate_river_worker_job_routes` before the downstream Go runtimes can
+start. That is precisely the ordering `0066`'s own docstring forbids: routes
+flip to River before any River consumer is available, and envelopes then
+accumulate in `worker_job_outbox` with nothing to execute them.
 
 `go-worker-migrate` therefore does **not** depend on `migrate`, and standing up
 the Go observation path cannot move real traffic as a side effect.
@@ -175,10 +175,9 @@ is the regression barrier.
 Bring the Python schema to the last pre-cutover revision yourself, first:
 
 ```bash
-# Explicit, separately authorized, and stops one revision short of the cutover.
-# `revision` is a positional on `upgrade`; omitting it means head, i.e. 0066.
+# Without the cutover opt-in, the application migrator stops at 0065.
 docker compose run --rm --entrypoint sh migrate -c \
-  'python -m dev_health_ops.cli migrate postgres upgrade 0065'
+  'python -m dev_health_ops.cli migrate postgres upgrade'
 
 # Confirm where you actually landed before going further.
 docker compose run --rm --entrypoint sh migrate -c \
@@ -386,8 +385,8 @@ line per unsatisfied requirement — `postgres.DiagnoseRolePosture`, wired at
 reconciler's own logs first; the query above is for when you need to trace
 it back to a specific migration yourself.
 
-**Before you reach for `alembic upgrade head` (or the `migrate` service, which
-always goes to head) to fix this: read every pending migration first, not
+**Before you reach for direct `alembic upgrade head` to fix this: read every
+pending migration first, not
 just the one that creates the table you need.** "Behind on migrations" and
 "the next migration is inert DDL" are not the same claim, and treating
 `migrate` as a safe, idempotent, always-correct-to-run step because it
@@ -398,31 +397,29 @@ database this was diagnosed against was `0065_add_fixed_schedule_occurrences.py`
 `0066_activate_river_worker_job_routes.py` — the CHAOS-3033 Celery-to-River
 cutover migration, which flips checked-in job kinds from `transport='celery'`
 to `transport='river'` and, per its own docstring, requires Go consumers to
-already be running for every affected queue before it commits. Running
-`migrate` to head on a database with no Go workers running yet would have
-silently stopped background processing for every one of those job kinds. If
-a targeted `alembic upgrade <revision>` stopping short of a cutover migration
-is what you need, use that instead of `head`, and confirm first that the
+already be running for every affected queue before it commits. Direct
+`alembic upgrade head` on a database with no Go workers running would silently
+stop background processing for every one of those job kinds. The application
+`migrate postgres` command instead leaves `0066` pending unless
+`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`. If a targeted direct Alembic upgrade
+stopping short of a cutover migration is what you need, use that instead of
+`head`, and confirm first that the
 `api`/`migrate` container actually has your target revision's file available
 (root compose mounts `./ops:/app`, so it does if you're on a branch with that
 migration file; it does not against an unmodified `origin/main` checkout).
 
-### Live landmine: a mounted `ops` checkout is one `migrate` run away from an unattended cutover
+### Live landmine: direct Alembic and authorized migration runs can still cut over
 
 Independent of everything else in this document: if the compose project
 running this stack mounts a working copy of this repository into its
 `migrate` service (as the coexistence overlays and CHAOS-3142's own
 repo-root wiring do, so a nested `migrate` target and other Go/Alembic
-artifacts on a feature branch are visible without a rebuild), then **any
-`docker compose up` that (re)starts `migrate`** — not just an explicit,
-reviewed cutover — **applies every pending Alembic migration on that
-checkout, including a cutover migration, unattended, the moment one exists
-in the pending set.** There is no confirmation step, no dry run, and no
-distinction in `migrate`'s own behavior between "add a column" and "flip 23
-job kinds from Celery to River." The migration itself is the only gate, and
-by the time it's pending in a checked-out branch, that gate is one ordinary
-`up` away from being crossed by whoever runs it next, for any reason,
-possibly without realizing a cutover migration is even in the pending set.
+artifacts on a feature branch are visible without a rebuild), direct Alembic
+still applies every pending revision. The application migrator prevents an
+unattended `0066` cutover by stopping at `0065` unless
+`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`; that one-shot authorization must
+therefore be scoped to the reviewed cutover run and removed afterward. There
+is no separate interactive confirmation once the authorization is present.
 This is a general operational hazard of mounting a live checkout into a
 migration-running service, not specific to CHAOS-3142 or to this migration —
 it deserves review as its own item, independent of the Go execution path

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1284,7 +1284,7 @@ Database schema migrations for PostgreSQL (Alembic) and ClickHouse.
 Run PostgreSQL (Alembic) schema migrations. Uses `POSTGRES_URI`.
 
 ```bash
-# Apply all pending migrations (upgrade to head)
+# Apply all ordinary pending migrations
 dev-hops migrate postgres
 dev-hops migrate postgres upgrade
 
@@ -1303,6 +1303,14 @@ dev-hops migrate postgres history
 # Show available heads
 dev-hops migrate postgres heads
 ```
+
+The Celery-to-River ownership cutover at PostgreSQL revision `0066` is deferred
+by default. An ordinary upgrade applies through revision `0065` and exits
+successfully, leaving `0066` pending. Set
+`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1` only on the explicitly authorized
+migration run after the River consumers are ready and Celery is drained. A
+database that has already applied `0066` continues upgrading normally when the
+one-shot variable is absent.
 
 **Backward-compatible aliases:** `dev-hops migrate upgrade`, `dev-hops migrate downgrade`, etc. still work and target PostgreSQL.
 

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -12,6 +12,7 @@ installed wheel exists.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import os
 import subprocess
@@ -28,6 +29,12 @@ logger = logging.getLogger(__name__)
 # Resolve the alembic directory from the *installed* package tree,
 # not from a hard-coded source path.
 _ALEMBIC_DIR = Path(__file__).resolve().parent / "alembic"
+_CELERY_RIVER_CUTOVER_ENV = "DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER"
+_CELERY_RIVER_CUTOVER_REVISION = "0066"
+_PRE_CELERY_RIVER_CUTOVER_REVISION = "0065"
+# tests/test_migrate_commands.py pins 0066 as the sole head. A later revision
+# must deliberately decide whether it is also deferred or needs a separate
+# Alembic branch that can advance without crossing this ownership cutover.
 
 
 def _get_migration_database_uri() -> str | None:
@@ -81,6 +88,80 @@ def _make_alembic_config(db_url: str | None = None):
 # ── individual commands ────────────────────────────────────────────
 
 
+async def _read_current_postgres_heads(cfg) -> tuple[str, ...]:
+    from alembic.runtime.migration import MigrationContext
+    from sqlalchemy import pool
+    from sqlalchemy.engine import Connection
+    from sqlalchemy.ext.asyncio import async_engine_from_config
+
+    connectable = async_engine_from_config(
+        cfg.get_section(cfg.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    try:
+        async with connectable.connect() as connection:
+
+            def current_heads(sync_connection: Connection) -> tuple[str, ...]:
+                context = MigrationContext.configure(sync_connection)
+                return tuple(context.get_current_heads())
+
+            return await connection.run_sync(current_heads)
+    finally:
+        await connectable.dispose()
+
+
+def _current_postgres_heads(cfg) -> tuple[str, ...]:
+    return asyncio.run(_read_current_postgres_heads(cfg))
+
+
+def _database_has_revision(
+    cfg, current_heads: tuple[str, ...], target_revision: str
+) -> bool:
+    """Return whether any current Alembic head descends from ``target_revision``."""
+    from alembic.script import ScriptDirectory
+
+    scripts = ScriptDirectory.from_config(cfg)
+    pending = list(current_heads)
+    visited: set[str] = set()
+    while pending:
+        revision = pending.pop()
+        if revision == target_revision:
+            return True
+        if revision in visited:
+            continue
+        visited.add(revision)
+        script = scripts.get_revision(revision)
+        if script is None or script.down_revision is None:
+            continue
+        if isinstance(script.down_revision, str):
+            pending.append(script.down_revision)
+        else:
+            pending.extend(script.down_revision)
+    return False
+
+
+def _effective_postgres_upgrade_revision(cfg, requested_revision: str) -> str:
+    """Keep an ordinary upgrade below the explicit Celery-to-River cutover."""
+    if requested_revision != "head":
+        return requested_revision
+    if os.getenv(_CELERY_RIVER_CUTOVER_ENV) == "1":
+        return requested_revision
+
+    current_heads = _current_postgres_heads(cfg)
+    if _database_has_revision(cfg, current_heads, _CELERY_RIVER_CUTOVER_REVISION):
+        # The cutover already ran in this database. Never turn an upgrade into a
+        # backwards target merely because a one-shot authorization is absent.
+        return requested_revision
+
+    logger.info(
+        "Deferring Celery-to-River cutover revision %s; set %s=1 to apply it",
+        _CELERY_RIVER_CUTOVER_REVISION,
+        _CELERY_RIVER_CUTOVER_ENV,
+    )
+    return _PRE_CELERY_RIVER_CUTOVER_REVISION
+
+
 def _run_upgrade(ns: argparse.Namespace) -> int:
     from alembic import command
 
@@ -94,7 +175,8 @@ def _run_upgrade(ns: argparse.Namespace) -> int:
             "MIGRATION_DATABASE_URI_FILE for a unified upgrade"
         )
     cfg = _make_alembic_config(explicit_db)
-    command.upgrade(cfg, ns.revision)
+    revision = _effective_postgres_upgrade_revision(cfg, ns.revision)
+    command.upgrade(cfg, revision)
     return _run_river_upgrade()
 
 

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import uuid
+from argparse import Namespace
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -146,6 +147,22 @@ def test_0066_real_postgres_refuses_without_opt_in_without_advancing_revision(
     assert _routes(migrated_to_0065.engine, migration) == before
 
 
+def test_application_migrator_defers_0066_without_opt_in(
+    migrated_to_0065: PostgresMigrationHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _migration()
+    before = _routes(migrated_to_0065.engine, migration)
+    monkeypatch.delenv(_CUTOVER_ENV, raising=False)
+
+    from dev_health_ops.migrate import _run_upgrade
+
+    assert _run_upgrade(Namespace(db=None, revision="head")) == 0
+
+    assert _revision(migrated_to_0065.engine) == "0065"
+    assert _routes(migrated_to_0065.engine, migration) == before
+
+
 def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     migrated_to_0065: PostgresMigrationHarness,
     monkeypatch: pytest.MonkeyPatch,
@@ -155,6 +172,15 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
 
     command.upgrade(_migration_config(), "head")
 
+    assert _revision(migrated_to_0065.engine) == "0066"
+    assert _routes(migrated_to_0065.engine, migration) == [
+        (kind, "river", False, 2) for kind in sorted(migration._KINDS)
+    ]
+
+    monkeypatch.delenv(_CUTOVER_ENV, raising=False)
+    from dev_health_ops.migrate import _run_upgrade
+
+    assert _run_upgrade(Namespace(db=None, revision="head")) == 0
     assert _revision(migrated_to_0065.engine) == "0066"
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -1004,13 +1004,10 @@ def test_go_profile_overlay_never_depends_on_python_migrate() -> None:
     """CHAOS-3142/CHAOS-3143: no `go-*` service may `depends_on` the Python
     `migrate` service.
 
-    `depends_on` pulls a service in regardless of profile, so such an edge makes
-    `docker compose --profile go up -d` run Alembic to *head* -- which is
-    0066_activate_river_worker_job_routes, the cutover that retargets 23 job
-    kinds from Celery to River. Both Go runtimes sit downstream of
-    go-worker-migrate, so the edge guaranteed precisely the ordering 0066's own
-    docstring forbids: routes flip to River before any River consumer can
-    start, and envelopes then pile up in worker_job_outbox with no executor.
+    `depends_on` pulls a service in regardless of profile. The application
+    migrator defers 0066 by default, but an environment carrying the explicit
+    cutover authorization would still flip routes before the downstream Go
+    runtimes can start, violating 0066's ordering contract.
 
     Standing up the Go observation path must never be able to move real traffic
     as a side effect, so the Python schema stays an explicitly authorized
@@ -1035,8 +1032,8 @@ def test_go_profile_overlay_never_depends_on_python_migrate() -> None:
         )
         assert "migrate" not in dependencies, (
             f"{name} must not depend on the Python `migrate` service: that edge runs "
-            "Alembic to head (0066, the Celery->River cutover) on a plain "
-            "`--profile go up`, before any Go consumer can start"
+            "the Python migration service on a plain `--profile go up`; an "
+            "authorized 0066 cutover would run before any Go consumer can start"
         )
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -9,9 +9,12 @@ import pytest
 
 from dev_health_ops.cli import _resolve_org, _should_resolve_org, build_parser
 from dev_health_ops.migrate import (
+    _database_has_revision,
+    _make_alembic_config,
     _run_clickhouse_repair,
     _run_clickhouse_status,
     _run_clickhouse_upgrade,
+    _run_upgrade,
 )
 
 # ---------------------------------------------------------------------------
@@ -146,6 +149,102 @@ class TestMigrateRouting:
     def test_upgrade_flat_accepts_revision(self):
         ns = self.parser.parse_args(["migrate", "upgrade", "abc123"])
         assert ns.revision == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# _run_upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresUpgrade:
+    def test_cutover_deferral_is_revisited_when_alembic_head_changes(self) -> None:
+        from alembic.script import ScriptDirectory
+
+        cfg = _make_alembic_config(
+            "postgresql+asyncpg://unused:unused@localhost:5432/unused"
+        )
+
+        assert ScriptDirectory.from_config(cfg).get_current_head() == "0066"
+
+    def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
+        cfg = _make_alembic_config(
+            "postgresql+asyncpg://unused:unused@localhost:5432/unused"
+        )
+
+        assert _database_has_revision(cfg, ("0066",), "0066")
+        assert not _database_has_revision(cfg, ("0065",), "0066")
+
+    @pytest.mark.parametrize("raw", [None, "", "0"])
+    def test_disabled_cutover_opt_in_defers_head_at_0065(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str | None
+    ) -> None:
+        if raw is None:
+            monkeypatch.delenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", raising=False)
+        else:
+            monkeypatch.setenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", raw)
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch(
+                "dev_health_ops.migrate._current_postgres_heads", return_value=("0051",)
+            ),
+            patch("dev_health_ops.migrate._database_has_revision", return_value=False),
+            patch("alembic.command.upgrade") as upgrade,
+            patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
+        ):
+            assert _run_upgrade(_ns(revision="head")) == 0
+
+        upgrade.assert_called_once_with(cfg, "0065")
+
+    def test_explicit_cutover_opt_in_keeps_head(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", "1")
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch("dev_health_ops.migrate._current_postgres_heads") as current_heads,
+            patch("alembic.command.upgrade") as upgrade,
+            patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
+        ):
+            assert _run_upgrade(_ns(revision="head")) == 0
+
+        current_heads.assert_not_called()
+        upgrade.assert_called_once_with(cfg, "head")
+
+    def test_unset_opt_in_does_not_move_an_applied_cutover_backwards(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", raising=False)
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch(
+                "dev_health_ops.migrate._current_postgres_heads", return_value=("0066",)
+            ),
+            patch("dev_health_ops.migrate._database_has_revision", return_value=True),
+            patch("alembic.command.upgrade") as upgrade,
+            patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
+        ):
+            assert _run_upgrade(_ns(revision="head")) == 0
+
+        upgrade.assert_called_once_with(cfg, "head")
+
+    def test_explicit_revision_keeps_direct_alembic_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", raising=False)
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch("dev_health_ops.migrate._current_postgres_heads") as current_heads,
+            patch("alembic.command.upgrade") as upgrade,
+            patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
+        ):
+            assert _run_upgrade(_ns(revision="0066")) == 0
+
+        current_heads.assert_not_called()
+        upgrade.assert_called_once_with(cfg, "0066")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make ordinary `dev-hops migrate postgres` runs stop successfully at revision `0065` when the Celery-to-River cutover is not authorized
- keep revision `0066` fail-closed for direct or explicitly targeted Alembic execution so an unperformed cutover is never stamped as applied
- preserve normal `head` upgrades when the one-shot authorization is exactly `1` or the database has already applied `0066`
- document the application migrator boundary and update the Go-worker deployment guidance

## Production failure

An ordinary production migration reached `0066_activate_river_worker_job_routes` with `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER` unset and raised its cutover guard. Revisions `0052` through `0065` are additive or preparatory; `0066` is the ownership transition that retargets the checked-in job routes from Celery to River.

The application migrator now resolves an ordinary `head` request to `0065` unless the cutover is authorized. The guard inside `0066` remains unchanged: silently returning from `upgrade()` would cause Alembic to stamp the cutover revision even though its route changes did not run.

## Verification

- `pytest -q tests/test_migrate_commands.py::TestPostgresUpgrade` — 8 passed
- real PostgreSQL migration integration suite — 4 passed
- neighboring migration suites — 17 passed
- `pytest -q tests/docs` — 112 passed
- source-link check and strict MkDocs build passed
- Ruff formatting/linting, `mypy`, and `git diff --check` passed
- pre-commit and pre-push hooks passed, including repository-wide mypy over 1,743 source files

SCREENSHOT-WAIVER: backend migration behavior and operator documentation only; no rendered web UI changes.
