### PR TITLE
fix(migrations): restore published revision 0070

### DIFF
--- a/src/dev_health_ops/alembic/versions/0070_seed_ask_dev_contextual_entrypoints_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0070_seed_ask_dev_contextual_entrypoints_feature_flag.py
@@ -1,0 +1,67 @@
+"""Seed the default-disabled Ask Dev contextual-entrypoints entitlement.
+
+Revision ID: 0070
+Revises: 0069
+Create Date: 2026-07-29 00:00:00
+
+The row is globally available so the canonical feature decision can act as an
+operator kill switch. ``ask_dev_contextual_entrypoints`` is registered as an
+explicit-enable feature, so every tier remains denied until an organization or
+license override grants it. The migration intentionally does not alter the
+base ``ask_dev`` entitlement.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0070"
+down_revision: str | None = "0069"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_FEATURE_KEY = "ask_dev_contextual_entrypoints"
+_FEATURE_NAME = "Ask Dev Contextual Entrypoints"
+_FEATURE_CATEGORY = "analytics"
+_FEATURE_MIN_TIER = "community"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO feature_flags
+                (id, key, name, category, min_tier, is_enabled, is_beta,
+                 is_deprecated, created_at, updated_at)
+            SELECT :id, :key, :name, :category, :min_tier,
+                   TRUE, FALSE, FALSE, :created_at, :updated_at
+            WHERE NOT EXISTS (
+                SELECT 1 FROM feature_flags WHERE key = :key
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": _FEATURE_KEY,
+            "name": _FEATURE_NAME,
+            "category": _FEATURE_CATEGORY,
+            "min_tier": _FEATURE_MIN_TIER,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    # Organization and license overrides may reference this row. Preserve the
+    # additive registration on rollback, matching the base Ask Dev entitlement.
+    pass

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -181,7 +181,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revision(migrated_to_0065.engine) == "0069"
+    assert _revision(migrated_to_0065.engine) == "0070"
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
     ]

--- a/tests/test_0070_ask_dev_contextual_entrypoints_migration.py
+++ b/tests/test_0070_ask_dev_contextual_entrypoints_migration.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def test_migration_0070_is_additive_idempotent_and_preserves_base_ask_dev() -> None:
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0070_seed_ask_dev_contextual_entrypoints_feature_flag"
+    )
+    assert migration.revision == "0070"
+    assert migration.down_revision == "0069"
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                sa.text(
+                    """
+                    CREATE TABLE feature_flags (
+                        id TEXT PRIMARY KEY,
+                        key TEXT NOT NULL UNIQUE,
+                        name TEXT NOT NULL,
+                        category TEXT NOT NULL,
+                        min_tier TEXT NOT NULL,
+                        is_enabled BOOLEAN NOT NULL,
+                        is_beta BOOLEAN NOT NULL,
+                        is_deprecated BOOLEAN NOT NULL,
+                        created_at DATETIME NOT NULL,
+                        updated_at DATETIME NOT NULL
+                    )
+                    """
+                )
+            )
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO feature_flags
+                        (id, key, name, category, min_tier, is_enabled,
+                         is_beta, is_deprecated, created_at, updated_at)
+                    VALUES
+                        (:id, 'ask_dev', 'Ask Dev', 'analytics', 'community',
+                         TRUE, FALSE, FALSE, :now, :now)
+                    """
+                ),
+                {"id": str(uuid.uuid4()), "now": datetime.now(UTC)},
+            )
+            context = MigrationContext.configure(conn)
+            with Operations.context(context):
+                migration.upgrade()
+                migration.upgrade()
+                rows = conn.execute(
+                    sa.text("SELECT key, is_enabled FROM feature_flags ORDER BY key")
+                ).all()
+                assert rows == [
+                    ("ask_dev", 1),
+                    ("ask_dev_contextual_entrypoints", 1),
+                ]
+                migration.downgrade()
+                remaining = conn.execute(
+                    sa.text("SELECT key FROM feature_flags ORDER BY key")
+                ).scalars()
+                assert list(remaining) == [
+                    "ask_dev",
+                    "ask_dev_contextual_entrypoints",
+                ]
+    finally:
+        engine.dispose()

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -165,7 +165,7 @@ class TestPostgresUpgrade:
         )
         current_head = ScriptDirectory.from_config(cfg).get_current_head()
 
-        assert current_head == "0069"
+        assert current_head == "0070"
         assert _database_has_revision(cfg, (current_head,), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:


### PR DESCRIPTION
## Summary

- publish Alembic revision `0070` independently of the larger Ask Dev Wave 3 branch
- preserve the exact additive, idempotent feature-flag seed already applied to affected databases
- advance migration-head assertions and add a regression covering repeated upgrade and no-op downgrade

## Why

A database reached revision `0070` from #1326, while `main` still ended at `0069`. Running a main-based image then failed before startup with `Can't locate revision identified by '0070'`. Alembic revision identifiers are durable database compatibility contracts, so this revision must be resolvable on `main` independently of the larger feature branch.

After this lands, #1326 must rebase and drop its duplicate copy of the migration.

## Validation

- `bash ci/local_validate.sh`
  - 9,408 passed, 67 skipped
  - Ruff, mypy, Go, River compatibility, isolated ClickHouse migration, and live argMax checks passed
- commit and pre-push hooks passed

Linear: [CHAOS-3233](https://linear.app/fullchaos/issue/CHAOS-3233/branch-only-alembic-revision-0070-breaks-main-after-migration)

SCREENSHOT-WAIVER: Backend migration compatibility only; no rendered UI change.