### PR TITLE
feat(llm): CHAOS-3238 enforce organization budgets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,9 @@ TRIAL_DAYS=14
 # APP_BASE_URL="http://localhost:3000"         # Frontend URL (used in emails, OAuth callbacks)
 # JWT_SECRET_KEY="change-me-in-production"    # JWT signing secret
 # SETTINGS_ENCRYPTION_KEY="change-me-in-production"  # Settings encryption key
+# Upper bound an organization admin may assign to the shared BYO LLM monthly
+# budget, in integer micro-USD ($100 = 100000000 micro-USD).
+# BYO_LLM_MAX_BUDGET_MICRO_USD="100000000"
 EMAIL_PROVIDER="smtp"                        # smtp|resend|console
 EMAIL_FROM_ADDRESS="no-reply@example.com"
 EMAIL_API_KEY=""                              # Required when EMAIL_PROVIDER=resend

--- a/docs/admin/workspace/settings.md
+++ b/docs/admin/workspace/settings.md
@@ -50,3 +50,42 @@ and readiness tests are unavailable while impersonating. The supported API is
 
 Context Fabric Validation is a platform-administrator diagnostic surface. It is
 not granted by `ask_dev`, `byo_llm`, or organization-administrator status.
+
+## BYO LLM budget
+
+An organization administrator can set a calendar-month monetary ceiling for
+shared BYO LLM use. The ceiling is stored separately from the provider API key
+and applies to Ask Dev and other workflows that use the organization's BYO
+provider. Per-request token and concurrency limits remain active even when a
+provider does not return enough information for reliable monetary enforcement.
+
+For configured budgets, each provider network attempt first commits a
+maximum-cost reservation. Provider execution occurs after that transaction
+closes, and a separate transaction reconciles the reservation to reported
+usage. An internal OpenAI retry therefore receives its own admission decision
+and usage record before the second network request. Concurrent requests cannot
+spend the same remaining balance, and replayed request identities are rejected
+before another provider call is made. While a call is in flight,
+`used_micro_usd` includes its committed maximum-cost reservation and then falls
+to the reported actual cost after reconciliation.
+
+A cancellation explicitly confirmed before provider dispatch is voided at zero
+cost. Voided attempts do not contribute to `used_micro_usd` and do not change
+the budget status reason. If a process exits after admission without proving
+that dispatch did not occur or reporting terminal usage, the reservation stays
+at its maximum exposure for the current window. The service does not infer zero
+cost from a client timeout because the remote provider may still complete and
+bill the request.
+
+Budget values use integer micro-USD. `GET /api/v1/admin/llm-settings/budget`
+returns the used, limit, remaining, UTC reset timestamp, enforcement
+availability, and a safe reason code. Unknown pricing or missing token usage is
+shown as unavailable; it is never displayed as zero cost. Administrators can
+set `budget_limit_micro_usd` through the existing
+`PUT /api/v1/admin/llm-settings` request, up to the operator-provisioned maximum.
+Custom OpenAI-compatible endpoints and provider-batch calls remain unavailable
+for monetary enforcement until their complete billing dimensions are certified.
+They remain compatible when no monetary budget is configured. When a budget is
+configured, unknown pricing is rejected before provider execution, and missing
+usage on a completed attempt makes later calls fail closed until the next UTC
+budget window. Budget writes are unavailable while impersonating.

--- a/src/dev_health_ops/alembic/versions/0071_add_byo_llm_budget_reservations.py
+++ b/src/dev_health_ops/alembic/versions/0071_add_byo_llm_budget_reservations.py
@@ -1,0 +1,104 @@
+"""Add durable reservations and usage for organization BYO LLM budgets.
+
+Revision ID: 0071
+Revises: 0070
+Create Date: 2026-07-29 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0071"
+down_revision: str | None = "0070"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "byo_llm_budget_reservations",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=False),
+        sa.Column("reserved_micro_usd", sa.BigInteger(), nullable=False),
+        sa.Column("actual_micro_usd", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("pricing_version", sa.String(length=64), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("cached_input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reconciled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'succeeded', 'failed', 'cancelled', "
+            "'voided', 'usage_unavailable')",
+            name="ck_byo_llm_budget_reservation_status",
+        ),
+        sa.CheckConstraint(
+            "reserved_micro_usd >= 0",
+            name="ck_byo_llm_budget_reserved_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "actual_micro_usd IS NULL OR actual_micro_usd >= 0",
+            name="ck_byo_llm_budget_actual_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0",
+            name="ck_byo_llm_budget_input_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "cached_input_tokens IS NULL OR cached_input_tokens >= 0",
+            name="ck_byo_llm_budget_cached_input_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0",
+            name="ck_byo_llm_budget_output_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "cached_input_tokens IS NULL OR input_tokens IS NULL OR "
+            "cached_input_tokens <= input_tokens",
+            name="ck_byo_llm_budget_cached_within_input",
+        ),
+        sa.CheckConstraint(
+            "(status = 'reserved' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NULL) OR "
+            "(status = 'usage_unavailable' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NOT NULL) OR "
+            "(status = 'voided' AND actual_micro_usd = 0 "
+            "AND input_tokens = 0 AND cached_input_tokens = 0 "
+            "AND output_tokens = 0 AND reconciled_at IS NOT NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled') "
+            "AND actual_micro_usd IS NOT NULL AND input_tokens IS NOT NULL "
+            "AND cached_input_tokens IS NOT NULL AND output_tokens IS NOT NULL "
+            "AND reconciled_at IS NOT NULL)",
+            name="ck_byo_llm_budget_reconciliation_state",
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "org_id",
+            "window_start",
+            "idempotency_key",
+            name="uq_byo_llm_budget_reservation_attempt",
+        ),
+    )
+    op.create_index(
+        "ix_byo_llm_budget_org_window_status",
+        "byo_llm_budget_reservations",
+        ["org_id", "window_start", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_byo_llm_budget_org_window_status",
+        table_name="byo_llm_budget_reservations",
+    )
+    op.drop_table("byo_llm_budget_reservations")

--- a/src/dev_health_ops/api/admin/llm_settings.py
+++ b/src/dev_health_ops/api/admin/llm_settings.py
@@ -10,6 +10,7 @@ from dev_health_ops.api.admin.schemas import LLMSettingsResponse, LLMSettingsUps
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.api.services.licensing import byo_llm_flag_state, resolve_org_tier
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
+from dev_health_ops.llm.budget import set_budget_limit
 from dev_health_ops.llm.credentials import validate_llm_base_url
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import SettingCategory
@@ -184,6 +185,18 @@ async def upsert_llm_settings(
             SettingCategory.LLM.value,
             description="BYO LLM maximum concurrent categorizations for this organization",
         )
+    if payload.budget_limit_micro_usd is not None:
+        try:
+            await set_budget_limit(svc, payload.budget_limit_micro_usd)
+        except ValueError as exc:
+            raise LLMSettingsAccessError(
+                status_code=400,
+                detail={
+                    "error": "budget_limit_exceeds_maximum",
+                    "feature": "byo_llm",
+                    "message": str(exc),
+                },
+            ) from exc
     return await get_llm_settings_response(svc)
 
 

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -18,8 +18,9 @@ from dev_health_ops.api.admin.llm_settings import (
 from dev_health_ops.api.admin.llm_settings import (
     upsert_llm_settings as upsert_llm_settings_values,
 )
-from dev_health_ops.api.admin.middleware import get_admin_org_id
+from dev_health_ops.api.admin.middleware import get_admin_org_id, get_admin_user
 from dev_health_ops.api.admin.schemas import (
+    LLMBudgetResponse,
     LLMSettingsResponse,
     LLMSettingsStatusResponse,
     LLMSettingsUpsert,
@@ -29,12 +30,15 @@ from dev_health_ops.api.admin.schemas import (
     SettingsListResponse,
     SettingUpdate,
 )
+from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.db import require_clickhouse_uri
+from dev_health_ops.llm.budget import BUDGET_CATEGORY, get_budget_status
 from dev_health_ops.llm.credentials import (
     evaluate_org_llm_status,
     latest_recent_org_byo_base_url_fallback_at,
 )
+from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
 from dev_health_ops.metrics.schemas import LLMTokenSpendSummaryRecord
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.models.settings import SettingCategory
@@ -72,14 +76,14 @@ def _reject_llm_category(category: str) -> None:
     # be managed via the dedicated /llm-settings endpoints. The generic settings
     # routes would otherwise let any org admin write/read category='llm' rows
     # (bypassing the BYO-LLM tier gate and exposing the raw api_key).
-    if category == SettingCategory.LLM.value:
+    if category in {SettingCategory.LLM.value, BUDGET_CATEGORY}:
         raise HTTPException(
             status_code=403,
             detail={
                 "error": "use_llm_settings_endpoint",
                 "message": (
-                    "LLM settings must be managed via /admin/llm-settings "
-                    "(tier-gated, encrypted, masked)."
+                    "LLM settings and budgets must be managed via "
+                    "/admin/llm-settings (tier-gated, validated, and masked)."
                 ),
             },
         )
@@ -160,6 +164,30 @@ async def get_llm_settings_status(
 
 
 @router.get(
+    "/llm-settings/budget",
+    response_model=LLMBudgetResponse,
+)
+async def get_llm_settings_budget(
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> LLMBudgetResponse:
+    await _require_byo_llm_tier(session, org_id)
+    svc = SettingsService(session, org_id)
+    provider = await svc.get("provider", SettingCategory.LLM.value) or ""
+    model = await svc.get("model", SettingCategory.LLM.value) or (
+        DEFAULT_MODEL_BY_PROVIDER.get(provider, "")
+    )
+    base_url = await svc.get("base_url", SettingCategory.LLM.value)
+    status = await get_budget_status(
+        svc,
+        provider=provider,
+        model=model,
+        base_url=base_url,
+    )
+    return LLMBudgetResponse.model_validate(asdict(status))
+
+
+@router.get(
     "/llm-settings/spend",
     response_model=LLMSpendResponse,
 )
@@ -192,8 +220,17 @@ async def upsert_llm_settings(
     payload: LLMSettingsUpsert,
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
 ) -> LLMSettingsResponse:
     await _require_byo_llm_tier(session, org_id)
+    if payload.budget_limit_micro_usd is not None and current_user.impersonated_by:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "impersonated_write_forbidden",
+                "message": "BYO LLM budget changes are unavailable while impersonating",
+            },
+        )
     svc = SettingsService(session, org_id)
     try:
         return await upsert_llm_settings_values(svc, payload)

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -35,6 +35,24 @@ class SettingsListResponse(BaseModel):
     settings: list[SettingResponse]
 
 
+class LLMBudgetResponse(BaseModel):
+    used_micro_usd: int | None = None
+    limit_micro_usd: int | None = None
+    remaining_micro_usd: int | None = None
+    window: Literal["calendar_month_utc"] = "calendar_month_utc"
+    reset_at: datetime
+    enforcement_available: bool
+    reason: Literal[
+        "available",
+        "budget_not_configured",
+        "pricing_unavailable",
+        "usage_unavailable",
+        "budget_exhausted",
+    ]
+    maximum_limit_micro_usd: int
+    pricing_version: str | None = None
+
+
 class LLMSettingsResponse(BaseModel):
     provider: str | None = None
     model: str | None = None
@@ -63,6 +81,7 @@ class LLMSettingsUpsert(BaseModel):
     api_key: str | None = None
     base_url: str | None = None
     concurrency: int | None = Field(default=None, ge=1, le=32)
+    budget_limit_micro_usd: int | None = Field(default=None, ge=0)
 
 
 class LLMSpendRun(BaseModel):

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -35,6 +35,7 @@ from dev_health_ops.llm.agent.errors import (
     AgentProviderErrorCode,
     safe_agent_provider_error,
 )
+from dev_health_ops.llm.budget import budget_idempotency_scope
 
 from .answer_validator import (
     AnswerValidationContext,
@@ -555,12 +556,15 @@ class DevOrchestrator:
                             ),
                         )
                     try:
-                        decision_result = await self._decide_with_cancellation(
-                            messages=messages,
-                            tools=tools,
-                            timeout_seconds=provider_timeout,
-                            cancellation=cancellation,
-                        )
+                        with budget_idempotency_scope(
+                            f"ask-dev:{request.request_id}:{retry_count}:{len(tool_results)}"
+                        ):
+                            decision_result = await self._decide_with_cancellation(
+                                messages=messages,
+                                tools=tools,
+                                timeout_seconds=provider_timeout,
+                                cancellation=cancellation,
+                            )
                         break
                     except Exception as exc:
                         provider_error = safe_agent_provider_error(exc)
@@ -1014,6 +1018,8 @@ class DevOrchestrator:
             AgentProviderErrorCode.INVALID_RESPONSE: "internal_error",
             AgentProviderErrorCode.TIMEOUT: "provider_unavailable",
             AgentProviderErrorCode.CANCELLED: "cancelled",
+            AgentProviderErrorCode.BUDGET_EXHAUSTED: "cost_limit_reached",
+            AgentProviderErrorCode.BUDGET_UNAVAILABLE: "provider_unavailable",
         }
         return DevError(
             schema_version="dev_error.v1",

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -28,6 +28,7 @@ from dev_health_ops.llm.agent.policy import (
 )
 from dev_health_ops.llm.agent.readiness import SettingsAgentReadinessStore
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
+from dev_health_ops.llm.budget import attach_agent_budget_guard
 from dev_health_ops.llm.credentials import LLMCredentials
 from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
 from dev_health_ops.models.settings import SettingCategory
@@ -187,7 +188,13 @@ async def resolve_production_provider(
     readiness = await SettingsAgentReadinessStore(settings).load()
 
     byo, platform, policy = await _provider_candidates(settings, readiness=readiness)
-    return _resolve_provider_selection(byo=byo, platform=platform, policy=policy)
+    return _resolve_provider_selection(
+        byo=byo,
+        platform=platform,
+        policy=policy,
+        session=session,
+        org_id=org_id,
+    )
 
 
 async def resolve_certification_provider(
@@ -199,7 +206,13 @@ async def resolve_certification_provider(
     byo, platform, policy = await _provider_candidates(
         settings, readiness=None, certification=True
     )
-    return _resolve_provider_selection(byo=byo, platform=platform, policy=policy)
+    return _resolve_provider_selection(
+        byo=byo,
+        platform=platform,
+        policy=policy,
+        session=session,
+        org_id=org_id,
+    )
 
 
 async def _provider_candidates(
@@ -274,6 +287,8 @@ def _resolve_provider_selection(
     byo: AgentProviderCandidate | None,
     platform: AgentProviderCandidate | None,
     policy: AgentProviderPolicy,
+    session: AsyncSession,
+    org_id: str,
 ) -> ProductionProviderResolution:
     try:
         selected = resolve_agent_provider_selection(
@@ -293,6 +308,15 @@ def _resolve_provider_selection(
         raise DevRuntimeUnavailable(code, message) from None
 
     provider = _provider(selected)
+    if selected.source is AgentProviderSource.BYO:
+        provider = attach_agent_budget_guard(
+            provider,
+            session=session,
+            org_id=org_id,
+            provider=selected.provider,
+            model=selected.model,
+            base_url=selected.credentials.base_url or None,
+        )
     return ProductionProviderResolution(
         provider=provider,
         source=selected.source,

--- a/src/dev_health_ops/llm/agent/contracts.py
+++ b/src/dev_health_ops/llm/agent/contracts.py
@@ -64,6 +64,7 @@ class AgentUsage:
     input_tokens: int = 0
     output_tokens: int = 0
     estimated_cost_microusd: int | None = None
+    cached_input_tokens: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/llm/agent/errors.py
+++ b/src/dev_health_ops/llm/agent/errors.py
@@ -15,6 +15,8 @@ class AgentProviderErrorCode(str, Enum):
     INVALID_RESPONSE = "invalid_response"
     TIMEOUT = "timeout"
     CANCELLED = "cancelled"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    BUDGET_UNAVAILABLE = "budget_unavailable"
 
 
 _SAFE_MESSAGES = {
@@ -25,13 +27,22 @@ _SAFE_MESSAGES = {
     AgentProviderErrorCode.INVALID_RESPONSE: "The model provider returned an invalid response.",
     AgentProviderErrorCode.TIMEOUT: "The model provider timed out.",
     AgentProviderErrorCode.CANCELLED: "The model request was cancelled.",
+    AgentProviderErrorCode.BUDGET_EXHAUSTED: "The organization BYO LLM budget was reached.",
+    AgentProviderErrorCode.BUDGET_UNAVAILABLE: "BYO LLM budget accounting is temporarily unavailable.",
 }
 
 
 class AgentProviderError(RuntimeError):
-    def __init__(self, code: AgentProviderErrorCode, *, retryable: bool = False):
+    def __init__(
+        self,
+        code: AgentProviderErrorCode,
+        *,
+        retryable: bool = False,
+        provider_dispatched: bool = True,
+    ):
         self.code = code
         self.retryable = retryable
+        self.provider_dispatched = provider_dispatched
         super().__init__(_SAFE_MESSAGES[code])
 
 

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -126,7 +126,10 @@ class OpenAICompatibleAgentProvider:
         signal: CancellationSignal | None = None,
     ) -> AgentDecisionResult:
         if signal is not None and signal.is_cancelled():
-            raise AgentProviderError(AgentProviderErrorCode.CANCELLED)
+            raise AgentProviderError(
+                AgentProviderErrorCode.CANCELLED,
+                provider_dispatched=False,
+            )
         started = time.monotonic()
         create_completion = cast(Any, self._client.chat.completions.create)
         provider_task = asyncio.create_task(
@@ -185,11 +188,16 @@ class OpenAICompatibleAgentProvider:
         usage = getattr(response, "usage", None)
         input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
         output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        cached_tokens = getattr(prompt_details, "cached_tokens", None)
         return AgentDecisionResult(
             decision=decision,
             usage=AgentUsage(
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                cached_input_tokens=(
+                    int(cached_tokens) if cached_tokens is not None else None
+                ),
                 estimated_cost_microusd=_estimated_cost_microusd(
                     model=self.model,
                     input_tokens=input_tokens,

--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -1,0 +1,865 @@
+"""Durable organization monetary budgets for shared BYO LLM execution.
+
+Budget configuration is stored outside the encrypted ``llm`` credential
+category. PostgreSQL advisory locking serializes short reservation transactions
+across processes; provider network execution happens only after that reservation
+is committed and the transaction lock is released.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import uuid
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Any, Final, Literal, TypeVar
+from urllib.parse import urlsplit
+
+from sqlalchemy import inspect, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.configuration.generic import SettingsService
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.llm.errors import LLMError
+from dev_health_ops.llm.providers.base import CompletionResult, LLMProvider
+from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.llm_budget import BYOLLMBudgetReservation
+
+BUDGET_CATEGORY: Final = "llm_budget"
+BUDGET_LIMIT_KEY: Final = "limit_micro_usd"
+PRICING_VERSION: Final = "openai-public-2025-08-07.v1"
+BUDGET_WINDOW: Final = "calendar_month_utc"
+DEFAULT_OPERATOR_MAX_MICRO_USD: Final = 100_000_000
+LICENSE_LIMIT_KEY: Final = "byo_llm_budget_micro_usd"
+
+# Integer micro-USD per one million tokens.  Only exact, server-certified
+# provider/model pairs are present.  An absent pair is unavailable, never zero.
+# Source snapshot: https://developers.openai.com/api/docs/models/gpt-5-mini
+_PRICE_PER_MILLION: Final[dict[tuple[str, str], tuple[int, int, int]]] = {
+    # input, cached input, output
+    ("openai", "gpt-5-mini"): (250_000, 25_000, 2_000_000),
+}
+
+BudgetReason = Literal[
+    "available",
+    "budget_not_configured",
+    "pricing_unavailable",
+    "usage_unavailable",
+    "budget_exhausted",
+]
+
+_idempotency_key: ContextVar[str | None] = ContextVar(
+    "byo_llm_budget_idempotency_key", default=None
+)
+_attempt_request_key: ContextVar[str | None] = ContextVar(
+    "byo_llm_budget_attempt_request_key", default=None
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BYOBudgetStatus:
+    used_micro_usd: int | None
+    limit_micro_usd: int | None
+    remaining_micro_usd: int | None
+    window: str
+    reset_at: datetime
+    enforcement_available: bool
+    reason: BudgetReason
+    maximum_limit_micro_usd: int
+    pricing_version: str | None
+
+
+class BYOBudgetExceeded(LLMError):
+    """The configured organization BYO monetary ceiling denied admission."""
+
+
+class BYOBudgetAccountingError(LLMError):
+    """A budget reservation, pricing decision, or reconciliation could not complete."""
+
+
+_T = TypeVar("_T")
+_locks_guard = Lock()
+_org_locks: dict[str, asyncio.Lock] = {}
+
+
+def operator_maximum_micro_usd() -> int:
+    raw = os.getenv("BYO_LLM_MAX_BUDGET_MICRO_USD")
+    if raw is None:
+        return DEFAULT_OPERATOR_MAX_MICRO_USD
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return max(0, value)
+
+
+async def provisioned_maximum_micro_usd(settings: SettingsService) -> int:
+    """Resolve the lower of operator and optional licensed organization maxima."""
+
+    operator_maximum = operator_maximum_micro_usd()
+    try:
+        org_uuid = uuid.UUID(settings.org_id)
+    except (TypeError, ValueError):
+        return operator_maximum
+    bind = settings.session.get_bind()
+    if bind is not None and bind.dialect.name == "sqlite":
+        has_license_table = await settings.session.run_sync(_has_org_license_table)
+        if not has_license_table:
+            return operator_maximum
+    result = await settings.session.execute(
+        select(OrgLicense.limits_override).where(OrgLicense.org_id == org_uuid)
+    )
+    overrides = result.scalar_one_or_none()
+    if not isinstance(overrides, dict) or LICENSE_LIMIT_KEY not in overrides:
+        return operator_maximum
+    licensed_maximum = _nonnegative_int(str(overrides[LICENSE_LIMIT_KEY]))
+    if licensed_maximum is None:
+        return 0
+    return min(operator_maximum, licensed_maximum)
+
+
+def _org_lock(org_id: str) -> asyncio.Lock:
+    with _locks_guard:
+        lock = _org_locks.get(org_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _org_locks[org_id] = lock
+        return lock
+
+
+def _has_org_license_table(sync_session: Any) -> bool:
+    bind = sync_session.get_bind()
+    if bind is None:
+        return False
+    return inspect(bind).has_table(OrgLicense.__tablename__)
+
+
+@contextmanager
+def budget_idempotency_scope(key: str):
+    """Bind a stable caller-owned identity to one provider attempt."""
+
+    token = _idempotency_key.set(key)
+    try:
+        yield
+    finally:
+        _idempotency_key.reset(token)
+
+
+def _window(now: datetime) -> tuple[datetime, datetime]:
+    value = now.astimezone(UTC)
+    start = datetime(value.year, value.month, 1, tzinfo=UTC)
+    if value.month == 12:
+        reset = datetime(value.year + 1, 1, 1, tzinfo=UTC)
+    else:
+        reset = datetime(value.year, value.month + 1, 1, tzinfo=UTC)
+    return start, reset
+
+
+def _normalized_model(model: str) -> str:
+    value = model.strip().lower()
+    if value == "gpt-5-mini" or value.startswith("gpt-5-mini-"):
+        return "gpt-5-mini"
+    return value
+
+
+def _official_openai_endpoint(base_url: str | None) -> bool:
+    if not (base_url or "").strip():
+        return True
+    try:
+        parsed = urlsplit(str(base_url))
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and parsed.hostname == "api.openai.com"
+
+
+def reliable_price(
+    *, provider: str, model: str, base_url: str | None
+) -> tuple[int, int, int] | None:
+    normalized_provider = provider.strip().lower()
+    if normalized_provider != "openai" or not _official_openai_endpoint(base_url):
+        return None
+    return _PRICE_PER_MILLION.get((normalized_provider, _normalized_model(model)))
+
+
+def cost_micro_usd(
+    *,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    cached_input_tokens: int | None,
+) -> int | None:
+    price = reliable_price(provider=provider, model=model, base_url=base_url)
+    if price is None:
+        return None
+    if (
+        input_tokens < 0
+        or output_tokens < 0
+        or cached_input_tokens is None
+        or cached_input_tokens < 0
+        or cached_input_tokens > input_tokens
+    ):
+        return None
+    input_rate, cached_input_rate, output_rate = price
+    uncached_input_tokens = input_tokens - cached_input_tokens
+    numerator = (
+        uncached_input_tokens * input_rate
+        + cached_input_tokens * cached_input_rate
+        + output_tokens * output_rate
+    )
+    return math.ceil(numerator / 1_000_000)
+
+
+async def set_budget_limit(settings: SettingsService, limit_micro_usd: int) -> None:
+    maximum = await provisioned_maximum_micro_usd(settings)
+    if limit_micro_usd < 0 or limit_micro_usd > maximum:
+        raise ValueError(f"budget_limit_micro_usd must be between 0 and {maximum}")
+    async with _org_lock(settings.org_id):
+        await _acquire_advisory_lock(settings.session, settings.org_id)
+        await settings.set(
+            BUDGET_LIMIT_KEY,
+            str(limit_micro_usd),
+            BUDGET_CATEGORY,
+            description=(
+                "Organization BYO LLM monetary ceiling in integer micro-USD; "
+                "stored separately from provider credentials"
+            ),
+        )
+
+
+async def get_budget_status(
+    settings: SettingsService,
+    *,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    now: datetime | None = None,
+) -> BYOBudgetStatus:
+    effective_now = now or datetime.now(UTC)
+    window_start, reset_at = _window(effective_now)
+    maximum = await provisioned_maximum_micro_usd(settings)
+    raw_limit = await settings.get(BUDGET_LIMIT_KEY, BUDGET_CATEGORY)
+    parsed_limit = _nonnegative_int(raw_limit)
+    limit = min(parsed_limit, maximum) if parsed_limit is not None else None
+    if reliable_price(provider=provider, model=model, base_url=base_url) is None:
+        return BYOBudgetStatus(
+            used_micro_usd=None,
+            limit_micro_usd=limit,
+            remaining_micro_usd=None,
+            window=BUDGET_WINDOW,
+            reset_at=reset_at,
+            enforcement_available=False,
+            reason=(
+                "budget_not_configured" if limit is None else "pricing_unavailable"
+            ),
+            maximum_limit_micro_usd=maximum,
+            pricing_version=None,
+        )
+
+    try:
+        org_uuid = uuid.UUID(settings.org_id)
+    except (TypeError, ValueError):
+        org_uuid = None
+    reservations: list[BYOLLMBudgetReservation] = []
+    if org_uuid is not None:
+        result = await settings.session.execute(
+            select(BYOLLMBudgetReservation).where(
+                BYOLLMBudgetReservation.org_id == org_uuid,
+                BYOLLMBudgetReservation.window_start == window_start,
+            )
+        )
+        reservations = list(result.scalars().all())
+    if any(row.status == "usage_unavailable" for row in reservations):
+        return BYOBudgetStatus(
+            used_micro_usd=None,
+            limit_micro_usd=limit,
+            remaining_micro_usd=None,
+            window=BUDGET_WINDOW,
+            reset_at=reset_at,
+            enforcement_available=False,
+            reason="usage_unavailable",
+            maximum_limit_micro_usd=maximum,
+            pricing_version=PRICING_VERSION,
+        )
+    # A committed reservation is monetary exposure until reconciled, so it
+    # participates in admission immediately even while the provider is running.
+    used = sum(
+        row.actual_micro_usd
+        if row.actual_micro_usd is not None
+        else row.reserved_micro_usd
+        for row in reservations
+        if row.status != "voided"
+    )
+    if limit is None:
+        return BYOBudgetStatus(
+            used_micro_usd=used,
+            limit_micro_usd=None,
+            remaining_micro_usd=None,
+            window=BUDGET_WINDOW,
+            reset_at=reset_at,
+            enforcement_available=False,
+            reason="budget_not_configured",
+            maximum_limit_micro_usd=maximum,
+            pricing_version=PRICING_VERSION,
+        )
+    remaining = max(0, limit - used)
+    exhausted = remaining == 0
+    return BYOBudgetStatus(
+        used_micro_usd=used,
+        limit_micro_usd=limit,
+        remaining_micro_usd=remaining,
+        window=BUDGET_WINDOW,
+        reset_at=reset_at,
+        enforcement_available=True,
+        reason="budget_exhausted" if exhausted else "available",
+        maximum_limit_micro_usd=maximum,
+        pricing_version=PRICING_VERSION,
+    )
+
+
+async def guard_byo_call(
+    *,
+    session: AsyncSession,
+    org_id: str,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    idempotency_key: str,
+    maximum_input_tokens: int,
+    maximum_output_tokens: int,
+    invoke: Callable[[], Awaitable[_T]],
+    usage: Callable[[_T], tuple[int | None, int | None, int | None]],
+) -> tuple[_T, int | None]:
+    """Reserve, execute outside a transaction, then reconcile one BYO call."""
+
+    settings = SettingsService(session, org_id)
+    maximum_cost = cost_micro_usd(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        input_tokens=max(0, maximum_input_tokens),
+        output_tokens=max(0, maximum_output_tokens),
+        cached_input_tokens=0,
+    )
+    reservation: BYOLLMBudgetReservation | None = None
+    budget_configured = False
+    unpriced_without_budget = False
+    async with _org_lock(org_id):
+        try:
+            await _acquire_advisory_lock(session, org_id)
+            status = await get_budget_status(
+                settings, provider=provider, model=model, base_url=base_url
+            )
+            budget_configured = status.limit_micro_usd is not None
+            if maximum_cost is None:
+                await session.rollback()
+                if budget_configured:
+                    raise BYOBudgetAccountingError(
+                        "BYO LLM pricing is unavailable for the configured budget.",
+                        provider=provider,
+                        model=model,
+                    )
+                # Preserve pre-budget custom-provider behavior. The read
+                # transaction is closed before the network call below.
+                unpriced_without_budget = True
+            elif budget_configured and status.reason == "usage_unavailable":
+                await session.rollback()
+                raise BYOBudgetAccountingError(
+                    "BYO LLM usage is unavailable for the configured budget.",
+                    provider=provider,
+                    model=model,
+                )
+            elif budget_configured and (
+                status.remaining_micro_usd is None
+                or maximum_cost > status.remaining_micro_usd
+            ):
+                await session.rollback()
+                raise BYOBudgetExceeded(
+                    "Organization BYO LLM monetary budget is exhausted.",
+                    provider=provider,
+                    model=model,
+                )
+            elif maximum_cost is not None:
+                reservation = await _create_reservation(
+                    session,
+                    org_id=org_id,
+                    provider=provider,
+                    model=model,
+                    idempotency_key=idempotency_key,
+                    reserved_micro_usd=maximum_cost,
+                )
+                await session.commit()
+        except (BYOBudgetAccountingError, BYOBudgetExceeded):
+            if session.in_transaction():
+                await session.rollback()
+            raise
+        except Exception as accounting_exc:
+            await session.rollback()
+            raise BYOBudgetAccountingError(
+                "BYO LLM budget reservation is temporarily unavailable.",
+                provider=provider,
+                model=model,
+                original=accounting_exc,
+            ) from accounting_exc
+
+    if unpriced_without_budget:
+        return await invoke(), None
+    if reservation is None:
+        raise BYOBudgetAccountingError(
+            "BYO LLM budget reservation was not created.",
+            provider=provider,
+            model=model,
+        )
+
+    # The reservation is committed and both locks are released before invoking
+    # the provider. This line is the network transaction boundary.
+    try:
+        result = await invoke()
+    except BaseException as exc:
+        provider_dispatched = getattr(exc, "provider_dispatched", True)
+        reported = (
+            (0, 0, 0) if provider_dispatched is False else _usage_from_exception(exc)
+        )
+        if provider_dispatched is False:
+            outcome = "voided"
+        else:
+            outcome = (
+                "cancelled" if isinstance(exc, asyncio.CancelledError) else "failed"
+            )
+        try:
+            await _reconcile_reservation(
+                session,
+                reservation=reservation,
+                provider=provider,
+                model=model,
+                base_url=base_url,
+                outcome=outcome,
+                reported=reported,
+            )
+        except Exception as accounting_exc:
+            await session.rollback()
+            raise BYOBudgetAccountingError(
+                "BYO LLM budget accounting is temporarily unavailable.",
+                provider=provider,
+                model=model,
+                original=accounting_exc,
+            ) from accounting_exc
+        raise
+
+    try:
+        billed = await _reconcile_reservation(
+            session,
+            reservation=reservation,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            outcome="succeeded",
+            reported=usage(result),
+        )
+    except Exception as accounting_exc:
+        await session.rollback()
+        raise BYOBudgetAccountingError(
+            "BYO LLM budget accounting is temporarily unavailable.",
+            provider=provider,
+            model=model,
+            original=accounting_exc,
+        ) from accounting_exc
+    if billed is None and budget_configured:
+        raise BYOBudgetAccountingError(
+            "BYO LLM usage is unavailable for the configured budget.",
+            provider=provider,
+            model=model,
+        )
+    return result, billed
+
+
+async def _create_reservation(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    provider: str,
+    model: str,
+    idempotency_key: str,
+    reserved_micro_usd: int,
+) -> BYOLLMBudgetReservation:
+    window_start, _ = _window(datetime.now(UTC))
+    org_uuid = uuid.UUID(org_id)
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+    existing = await session.execute(
+        select(BYOLLMBudgetReservation.id).where(
+            BYOLLMBudgetReservation.org_id == org_uuid,
+            BYOLLMBudgetReservation.window_start == window_start,
+            BYOLLMBudgetReservation.idempotency_key == digest,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise BYOBudgetAccountingError(
+            "BYO LLM request has already been reserved.",
+            provider=provider,
+            model=model,
+        )
+    reservation = BYOLLMBudgetReservation(
+        org_id=org_uuid,
+        window_start=window_start,
+        idempotency_key=digest,
+        provider=provider,
+        model=model,
+        reserved_micro_usd=reserved_micro_usd,
+        status="reserved",
+        pricing_version=PRICING_VERSION,
+    )
+    session.add(reservation)
+    return reservation
+
+
+async def _reconcile_reservation(
+    session: AsyncSession,
+    *,
+    reservation: BYOLLMBudgetReservation,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    outcome: str,
+    reported: tuple[int | None, int | None, int | None],
+) -> int | None:
+    input_tokens, output_tokens, cached_input_tokens = reported
+    row = await session.get(BYOLLMBudgetReservation, reservation.id)
+    if row is None:
+        raise RuntimeError(
+            "BYO LLM budget reservation disappeared before reconciliation"
+        )
+    await session.refresh(row)
+    if row.status != "reserved":
+        raise RuntimeError(
+            "BYO LLM budget reservation is no longer owned by this attempt"
+        )
+    row.input_tokens = input_tokens
+    row.output_tokens = output_tokens
+    row.cached_input_tokens = cached_input_tokens
+    row.reconciled_at = datetime.now(UTC)
+    if outcome == "voided":
+        row.status = "voided"
+        row.input_tokens = 0
+        row.output_tokens = 0
+        row.cached_input_tokens = 0
+        row.actual_micro_usd = 0
+        await session.commit()
+        return 0
+    if input_tokens is None or output_tokens is None or cached_input_tokens is None:
+        row.status = "usage_unavailable"
+        row.actual_micro_usd = None
+        await session.commit()
+        return None
+    billed = cost_micro_usd(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+    )
+    if billed is None:
+        row.status = "usage_unavailable"
+        row.actual_micro_usd = None
+        await session.commit()
+        return None
+    row.status = outcome
+    row.actual_micro_usd = billed
+    await session.commit()
+    return billed
+
+
+def attach_llm_budget_guard(
+    provider_instance: LLMProvider,
+    *,
+    org_id: str,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    maximum_output_tokens: int = 4096,
+) -> LLMProvider:
+    """Decorate the shared provider instance without changing its concrete type."""
+
+    original = provider_instance.complete
+    attempt_setter = getattr(provider_instance, "set_attempt_executor", None)
+    if provider.strip().lower() == "openai" and callable(attempt_setter):
+
+        async def execute_attempt(
+            attempt_number: int,
+            maximum_input_tokens: int,
+            attempt_maximum_output_tokens: int,
+            invoke: Callable[[], Awaitable[Any]],
+        ) -> Any:
+            request_key = _attempt_request_key.get()
+            if request_key is None:
+                raise BYOBudgetAccountingError(
+                    "BYO LLM attempt is missing its request identity.",
+                    provider=provider,
+                    model=model,
+                )
+            async with get_postgres_session() as session:
+                result, _ = await guard_byo_call(
+                    session=session,
+                    org_id=org_id,
+                    provider=provider,
+                    model=model,
+                    base_url=base_url,
+                    idempotency_key=f"{request_key}:attempt:{attempt_number}",
+                    maximum_input_tokens=maximum_input_tokens,
+                    maximum_output_tokens=attempt_maximum_output_tokens,
+                    invoke=invoke,
+                    usage=_provider_response_usage,
+                )
+                return result
+
+        attempt_setter(execute_attempt)
+
+        async def complete(prompt: str) -> CompletionResult:
+            request_key = _idempotency_key.get() or f"shared:{uuid.uuid4()}"
+            token = _attempt_request_key.set(request_key)
+            try:
+                return await original(prompt)
+            finally:
+                _attempt_request_key.reset(token)
+
+    else:
+
+        async def complete(prompt: str) -> CompletionResult:
+            request_key = _idempotency_key.get() or f"shared:{uuid.uuid4()}"
+            async with get_postgres_session() as session:
+                result, _ = await guard_byo_call(
+                    session=session,
+                    org_id=org_id,
+                    provider=provider,
+                    model=model,
+                    base_url=base_url,
+                    idempotency_key=request_key,
+                    maximum_input_tokens=max(1, len(prompt.encode("utf-8"))),
+                    maximum_output_tokens=maximum_output_tokens,
+                    invoke=lambda: original(prompt),
+                    usage=lambda item: (
+                        item.input_tokens,
+                        item.output_tokens,
+                        item.cached_input_tokens,
+                    ),
+                )
+                return result
+
+    setattr(provider_instance, "complete", complete)
+    original_submit = getattr(provider_instance, "submit_batch", None)
+    if callable(original_submit):
+
+        async def submit_batch(items: Any) -> Any:
+            # The existing batch result contract does not retain cached-token
+            # detail and Batch API pricing differs from synchronous pricing.
+            # Configured budgets therefore fail closed before execution. An
+            # unbudgeted organization retains its existing batch behavior.
+            async with get_postgres_session() as session:
+                settings = SettingsService(session, org_id)
+                limit = _nonnegative_int(
+                    await settings.get(BUDGET_LIMIT_KEY, BUDGET_CATEGORY)
+                )
+                await session.rollback()
+            if limit is not None:
+                raise BYOBudgetAccountingError(
+                    "BYO LLM batch pricing is unavailable for the configured budget.",
+                    provider=provider,
+                    model=model,
+                )
+            return await original_submit(items)
+
+        setattr(provider_instance, "submit_batch", submit_batch)
+    return provider_instance
+
+
+def attach_agent_budget_guard(
+    provider_instance: Any,
+    *,
+    session: AsyncSession,
+    org_id: str,
+    provider: str,
+    model: str,
+    base_url: str | None,
+) -> Any:
+    """Decorate Ask Dev's provider-neutral decision seam with the shared guard."""
+
+    original = provider_instance.decide
+    call_number = 0
+    _ = session
+
+    async def decide(
+        messages: Sequence[Any],
+        tools: Sequence[Any],
+        response_schema: Mapping[str, Any],
+        timeout_seconds: float,
+        max_output_tokens: int,
+        signal: Any = None,
+    ) -> Any:
+        nonlocal call_number
+        call_number += 1
+        payload = json.dumps(
+            {
+                "messages": [str(item) for item in messages],
+                "tools": [str(item) for item in tools],
+                "response_schema": response_schema,
+            },
+            sort_keys=True,
+            default=str,
+        )
+        try:
+            async with get_postgres_session() as budget_session:
+                result, billed = await guard_byo_call(
+                    session=budget_session,
+                    org_id=org_id,
+                    provider=provider,
+                    model=model,
+                    base_url=base_url,
+                    idempotency_key=(
+                        _idempotency_key.get()
+                        or f"ask-dev:{id(provider_instance)}:{call_number}"
+                    ),
+                    maximum_input_tokens=max(1, len(payload.encode("utf-8"))),
+                    maximum_output_tokens=max_output_tokens,
+                    invoke=lambda: original(
+                        messages,
+                        tools,
+                        response_schema,
+                        timeout_seconds,
+                        max_output_tokens,
+                        signal,
+                    ),
+                    usage=_agent_usage,
+                )
+        except (BYOBudgetExceeded, BYOBudgetAccountingError) as exc:
+            from dev_health_ops.llm.agent.errors import (
+                AgentProviderError,
+                AgentProviderErrorCode,
+            )
+
+            code = (
+                AgentProviderErrorCode.BUDGET_EXHAUSTED
+                if isinstance(exc, BYOBudgetExceeded)
+                else AgentProviderErrorCode.BUDGET_UNAVAILABLE
+            )
+            raise AgentProviderError(code) from None
+        if billed is not None:
+            result = replace(
+                result,
+                usage=replace(result.usage, estimated_cost_microusd=billed),
+            )
+        return result
+
+    setattr(provider_instance, "decide", decide)
+    return provider_instance
+
+
+async def _acquire_advisory_lock(session: AsyncSession, org_id: str) -> None:
+    bind = session.get_bind()
+    if bind is None or bind.dialect.name != "postgresql":
+        return
+    digest = hashlib.sha256(f"byo-llm-budget:{org_id}".encode()).digest()
+    lock_key = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_key)"), {"lock_key": lock_key}
+    )
+
+
+def _usage_from_exception(
+    exc: BaseException,
+) -> tuple[int | None, int | None, int | None]:
+    usage = getattr(exc, "usage", None)
+    if usage is None:
+        return None, None, None
+    details = (
+        usage.get("prompt_tokens_details") or usage.get("input_tokens_details")
+        if isinstance(usage, dict)
+        else getattr(usage, "prompt_tokens_details", None)
+        or getattr(usage, "input_tokens_details", None)
+    )
+    return (
+        _usage_value(usage, "prompt_tokens", "input_tokens"),
+        _usage_value(usage, "completion_tokens", "output_tokens"),
+        _usage_value(details, "cached_tokens"),
+    )
+
+
+def _agent_usage(item: Any) -> tuple[int | None, int | None, int | None]:
+    usage = getattr(item, "usage", None)
+    if usage is None:
+        return None, None, None
+    input_tokens = _usage_value(usage, "input_tokens")
+    output_tokens = _usage_value(usage, "output_tokens")
+    cached_input_tokens = _usage_value(usage, "cached_input_tokens")
+    # The OpenAI-compatible adapter uses its contract's zero defaults when the
+    # provider omitted the usage object. A valid completion cannot consume no
+    # input and no output tokens, so preserve that state as unknown, not $0.
+    if input_tokens == 0 and output_tokens == 0:
+        return None, None, None
+    return input_tokens, output_tokens, cached_input_tokens
+
+
+def _provider_response_usage(
+    item: Any,
+) -> tuple[int | None, int | None, int | None]:
+    usage = getattr(item, "usage", None)
+    if usage is None:
+        return None, None, None
+    details = (
+        usage.get("input_tokens_details") or usage.get("prompt_tokens_details")
+        if isinstance(usage, dict)
+        else getattr(usage, "input_tokens_details", None)
+        or getattr(usage, "prompt_tokens_details", None)
+    )
+    return (
+        _usage_value(usage, "input_tokens", "prompt_tokens"),
+        _usage_value(usage, "output_tokens", "completion_tokens"),
+        _usage_value(details, "cached_tokens"),
+    )
+
+
+def _usage_value(usage: Any, *names: str) -> int | None:
+    for name in names:
+        value = (
+            usage.get(name) if isinstance(usage, dict) else getattr(usage, name, None)
+        )
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return None
+
+
+def _nonnegative_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+__all__ = [
+    "BUDGET_CATEGORY",
+    "BUDGET_LIMIT_KEY",
+    "BYOBudgetAccountingError",
+    "BYOBudgetExceeded",
+    "BYOBudgetStatus",
+    "attach_agent_budget_guard",
+    "attach_llm_budget_guard",
+    "budget_idempotency_scope",
+    "cost_micro_usd",
+    "get_budget_status",
+    "guard_byo_call",
+    "operator_maximum_micro_usd",
+    "provisioned_maximum_micro_usd",
+    "reliable_price",
+    "set_budget_limit",
+]

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -267,88 +267,119 @@ def get_provider(
         provider_name, org_id=org_id, api_key=api_key, base_url=base_url
     )
 
+    def _budgeted(instance: LLMProvider) -> LLMProvider:
+        if not org_id or not org_byo_provider_matches(provider_name, org_id=org_id):
+            return instance
+        from dev_health_ops.llm.budget import attach_llm_budget_guard
+
+        return attach_llm_budget_guard(
+            instance,
+            org_id=org_id,
+            provider=provider_name,
+            model=model_name or provider_name,
+            base_url=credentials.base_url or None,
+        )
+
     if provider_name == "mock":
         from .mock import MockProvider
 
-        return MockProvider()
+        return _budgeted(MockProvider())
 
     if provider_name == "openai":
         from .openai import OpenAIProvider
 
-        return OpenAIProvider(
-            api_key=credentials.api_key,
-            base_url=credentials.base_url or None,
-            model=model_name,
+        return _budgeted(
+            OpenAIProvider(
+                api_key=credentials.api_key,
+                base_url=credentials.base_url or None,
+                model=model_name,
+            )
         )
 
     if provider_name == "anthropic":
         from .anthropic import AnthropicProvider
 
-        return AnthropicProvider(
-            api_key=credentials.api_key,
-            base_url=credentials.base_url or None,
-            model=model_name,
+        return _budgeted(
+            AnthropicProvider(
+                api_key=credentials.api_key,
+                base_url=credentials.base_url or None,
+                model=model_name,
+            )
         )
 
     if provider_name == "gemini":
         from .gemini import GeminiProvider
 
-        return GeminiProvider(
-            api_key=credentials.api_key,
-            base_url=credentials.base_url or None,
-            model=model_name,
+        return _budgeted(
+            GeminiProvider(
+                api_key=credentials.api_key,
+                base_url=credentials.base_url or None,
+                model=model_name,
+            )
         )
 
     if provider_name == "local":
         from .local import LocalProvider
 
-        return LocalProvider(
-            api_key=credentials.api_key or None,
-            base_url=credentials.base_url or None,
-            model=model_name,
+        return _budgeted(
+            LocalProvider(
+                api_key=credentials.api_key or None,
+                base_url=credentials.base_url or None,
+                model=model_name,
+            )
         )
 
     if provider_name == "ollama":
         from .local import OllamaProvider
 
-        return OllamaProvider(base_url=credentials.base_url or None, model=model_name)
+        return _budgeted(
+            OllamaProvider(base_url=credentials.base_url or None, model=model_name)
+        )
 
     if provider_name == "lmstudio":
         if model_name and model_name.startswith("openai/gpt-oss"):
             from .local import LMStudioGPT5Provider
 
-            return LMStudioGPT5Provider(
-                api_key=credentials.api_key or None,
-                base_url=credentials.base_url or None,
-                model=model_name,
-                validate_model_on_startup=_lmstudio_validate_model_on_startup(),
+            return _budgeted(
+                LMStudioGPT5Provider(
+                    api_key=credentials.api_key or None,
+                    base_url=credentials.base_url or None,
+                    model=model_name,
+                    validate_model_on_startup=_lmstudio_validate_model_on_startup(),
+                )
             )
 
         from .local import LMStudioProvider
 
-        return LMStudioProvider(base_url=credentials.base_url or None, model=model_name)
+        return _budgeted(
+            LMStudioProvider(base_url=credentials.base_url or None, model=model_name)
+        )
 
     if provider_name == "qwen":
         from .qwen import QwenProvider
 
-        return QwenProvider(
-            api_key=credentials.api_key,
-            base_url=credentials.base_url or None,
-            model=model_name,
+        return _budgeted(
+            QwenProvider(
+                api_key=credentials.api_key,
+                base_url=credentials.base_url or None,
+                model=model_name,
+            )
         )
 
     if provider_name == "qwen-local":
         from .qwen import QwenLocalProvider
 
-        return QwenLocalProvider(
-            base_url=credentials.base_url or None, model=model_name
+        return _budgeted(
+            QwenLocalProvider(base_url=credentials.base_url or None, model=model_name)
         )
 
     if provider_name == "qwen-lmstudio":
         from .qwen import QwenLMStudioProvider
 
-        return QwenLMStudioProvider(
-            base_url=credentials.base_url or None, model=model_name
+        return _budgeted(
+            QwenLMStudioProvider(
+                base_url=credentials.base_url or None, model=model_name
+            )
         )
 
     raise ValueError(f"Unknown LLM provider: {provider_name}")

--- a/src/dev_health_ops/llm/providers/base.py
+++ b/src/dev_health_ops/llm/providers/base.py
@@ -10,6 +10,7 @@ class CompletionResult:
     input_tokens: int | None
     output_tokens: int | None
     model: str
+    cached_input_tokens: int | None = None
 
 
 @runtime_checkable

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -17,10 +17,12 @@ import asyncio
 import io
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
 from dev_health_ops.llm.errors import (
+    LLMError,
     LLMRateLimitError,
     classify_provider_error,
     is_retryable,
@@ -46,6 +48,10 @@ from .batch import (
 )
 
 logger = logging.getLogger(__name__)
+
+OpenAIAttemptExecutor = Callable[
+    [int, int, int, Callable[[], Awaitable[Any]]], Awaitable[Any]
+]
 
 CATEGORIZATION_RESPONSE_FORMAT = "investment_categorization"
 INVESTMENT_MIX_RESPONSE_FORMAT = "investment_mix_explanation"
@@ -462,6 +468,11 @@ class OpenAIProvider(LLMProviderBase):
     async def complete(self, prompt: str) -> CompletionResult:
         return await self._impl.complete(prompt)
 
+    def set_attempt_executor(self, executor: OpenAIAttemptExecutor) -> None:
+        """Install accounting around each actual synchronous API attempt."""
+
+        self._impl.set_attempt_executor(executor)
+
     def batch_capability(self, model: str | None = None) -> BatchCapability:
         return self._impl.batch_capability(model)
 
@@ -499,8 +510,42 @@ class _OpenAIProviderBase(LLMProviderBase):
     def __init__(self, cfg: OpenAIProviderConfig) -> None:
         self.cfg = cfg
         self._client: Any | None = None
+        self._attempt_executor: OpenAIAttemptExecutor | None = None
         if cfg.validate_model_on_startup:
             self._validate_model_on_startup()
+
+    def set_attempt_executor(self, executor: OpenAIAttemptExecutor) -> None:
+        self._attempt_executor = executor
+
+    async def _execute_attempt(
+        self,
+        *,
+        attempt_number: int,
+        request: dict[str, Any],
+        maximum_output_tokens: int,
+        invoke: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        if self._attempt_executor is None:
+            return await invoke()
+        # UTF-8 request bytes are a conservative upper bound for input tokens,
+        # including system instructions and structured-output schema overhead.
+        maximum_input_tokens = max(
+            1,
+            len(
+                json.dumps(
+                    request,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            ),
+        )
+        return await self._attempt_executor(
+            attempt_number,
+            maximum_input_tokens,
+            maximum_output_tokens,
+            invoke,
+        )
 
     def _get_client(self) -> Any:
         if self._client is None:
@@ -707,7 +752,11 @@ class _OpenAIProviderBase(LLMProviderBase):
         max_retries: int,
         api_name: str,
     ) -> bool:
-        llm_exc = classify_provider_error(exc, provider="openai", model=self.cfg.model)
+        llm_exc = (
+            exc
+            if isinstance(exc, LLMError)
+            else classify_provider_error(exc, provider="openai", model=self.cfg.model)
+        )
         if is_retryable(llm_exc) and retry_count < max_retries:
             delay = retry_delay(retry_count)
             if isinstance(llm_exc, LLMRateLimitError) and llm_exc.retry_after:
@@ -728,6 +777,14 @@ class _OpenAIProviderBase(LLMProviderBase):
     def _completion_result(
         self, text: str, usage: object | None = None
     ) -> CompletionResult:
+        if isinstance(usage, dict):
+            input_details = usage.get("input_tokens_details") or usage.get(
+                "prompt_tokens_details"
+            )
+        else:
+            input_details = getattr(usage, "input_tokens_details", None) or getattr(
+                usage, "prompt_tokens_details", None
+            )
         return CompletionResult(
             text=text,
             input_tokens=usage_token_count(usage, "input_tokens", "prompt_tokens"),
@@ -735,6 +792,7 @@ class _OpenAIProviderBase(LLMProviderBase):
                 usage, "output_tokens", "completion_tokens"
             ),
             model=self.cfg.model,
+            cached_input_tokens=usage_token_count(input_details, "cached_tokens"),
         )
 
     async def aclose(self) -> None:
@@ -804,7 +862,12 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                 if self._supports_temperature():
                     kwargs["temperature"] = self.cfg.temperature
 
-                response = await client.responses.create(**kwargs)
+                response = await self._execute_attempt(
+                    attempt_number=retry_count + 1,
+                    request=kwargs,
+                    maximum_output_tokens=token_budget,
+                    invoke=lambda: client.responses.create(**kwargs),
+                )
                 usage = getattr(response, "usage", None)
 
                 # Best-effort extraction
@@ -904,7 +967,12 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                 if self._supports_temperature():
                     kwargs["temperature"] = self.cfg.temperature
 
-                response = await client.chat.completions.create(**kwargs)
+                response = await self._execute_attempt(
+                    attempt_number=retry_count + 1,
+                    request=kwargs,
+                    maximum_output_tokens=max_tokens,
+                    invoke=lambda: client.chat.completions.create(**kwargs),
+                )
                 usage = getattr(response, "usage", None)
 
                 choice = response.choices[0]

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -75,6 +75,7 @@ from .licensing import (
     OrgFeatureOverride,
     OrgLicense,
 )
+from .llm_budget import BYOLLMBudgetReservation
 from .operational_deliveries import BillingNotification, WebhookDelivery
 from .org_invite import OrgInvite
 from .pagerduty_webhook_binding import PagerDutyWebhookBinding
@@ -160,6 +161,7 @@ __all__ = [
     "Base",
     "BillingAuditLog",
     "BillingNotification",
+    "BYOLLMBudgetReservation",
     "GitBlame",
     "GitBlameMixin",
     "GitCommit",

--- a/src/dev_health_ops/models/llm_budget.py
+++ b/src/dev_health_ops/models/llm_budget.py
@@ -1,0 +1,115 @@
+"""Durable reservations and reconciled usage for organization BYO LLM budgets."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .git import GUID, Base
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class BYOLLMBudgetReservation(Base):
+    """One provider attempt's committed maximum exposure and final usage."""
+
+    __tablename__ = "byo_llm_budget_reservations"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    reserved_micro_usd: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    actual_micro_usd: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[str] = mapped_column(String(24), nullable=False, default="reserved")
+    pricing_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cached_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "window_start",
+            "idempotency_key",
+            name="uq_byo_llm_budget_reservation_attempt",
+        ),
+        CheckConstraint(
+            "status IN ('reserved', 'succeeded', 'failed', 'cancelled', "
+            "'voided', 'usage_unavailable')",
+            name="ck_byo_llm_budget_reservation_status",
+        ),
+        CheckConstraint(
+            "reserved_micro_usd >= 0",
+            name="ck_byo_llm_budget_reserved_nonnegative",
+        ),
+        CheckConstraint(
+            "actual_micro_usd IS NULL OR actual_micro_usd >= 0",
+            name="ck_byo_llm_budget_actual_nonnegative",
+        ),
+        CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0",
+            name="ck_byo_llm_budget_input_nonnegative",
+        ),
+        CheckConstraint(
+            "cached_input_tokens IS NULL OR cached_input_tokens >= 0",
+            name="ck_byo_llm_budget_cached_input_nonnegative",
+        ),
+        CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0",
+            name="ck_byo_llm_budget_output_nonnegative",
+        ),
+        CheckConstraint(
+            "cached_input_tokens IS NULL OR input_tokens IS NULL OR "
+            "cached_input_tokens <= input_tokens",
+            name="ck_byo_llm_budget_cached_within_input",
+        ),
+        CheckConstraint(
+            "(status = 'reserved' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NULL) OR "
+            "(status = 'usage_unavailable' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NOT NULL) OR "
+            "(status = 'voided' AND actual_micro_usd = 0 "
+            "AND input_tokens = 0 AND cached_input_tokens = 0 "
+            "AND output_tokens = 0 AND reconciled_at IS NOT NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled') "
+            "AND actual_micro_usd IS NOT NULL AND input_tokens IS NOT NULL "
+            "AND cached_input_tokens IS NOT NULL AND output_tokens IS NOT NULL "
+            "AND reconciled_at IS NOT NULL)",
+            name="ck_byo_llm_budget_reconciliation_state",
+        ),
+        Index(
+            "ix_byo_llm_budget_org_window_status",
+            "org_id",
+            "window_start",
+            "status",
+        ),
+    )

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -26,6 +26,7 @@ from dev_health_ops.llm.credentials import (
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.llm_budget import BYOLLMBudgetReservation
 from dev_health_ops.models.settings import Setting, SettingCategory
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
@@ -43,6 +44,7 @@ _TABLES = tables_of(
     OrgFeatureOverride,
     Setting,
     AuditLog,
+    BYOLLMBudgetReservation,
 )
 
 
@@ -111,7 +113,13 @@ async def _seed_org(
     return {"org_id": str(org_id), "user_id": str(user_id)}
 
 
-def _make_app(session_maker, state: dict[str, str]) -> FastAPI:
+def _make_app(
+    session_maker,
+    state: dict[str, str],
+    *,
+    role: str = "owner",
+    impersonated_by: str | None = None,
+) -> FastAPI:
     app = FastAPI()
     app.include_router(admin_router_module.router)
 
@@ -119,8 +127,9 @@ def _make_app(session_maker, state: dict[str, str]) -> FastAPI:
         user_id=state["user_id"],
         email="admin@example.com",
         org_id=state["org_id"],
-        role="owner",
+        role=role,
         is_superuser=False,
+        impersonated_by=impersonated_by,
     )
 
     async def _session_override():
@@ -478,6 +487,145 @@ async def test_admin_llm_settings_rejects_excessive_concurrency(session_maker):
 
 
 @pytest.mark.asyncio
+async def test_admin_llm_budget_persists_separately_and_exposes_contract(
+    session_maker, monkeypatch
+):
+    monkeypatch.setenv("BYO_LLM_MAX_BUDGET_MICRO_USD", "5000000")
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        updated = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={
+                "provider": "openai",
+                "model": "gpt-5-mini",
+                "api_key": "sk-secret-value",
+                "budget_limit_micro_usd": 2000000,
+            },
+        )
+        budget = await ac.get("/api/v1/admin/llm-settings/budget")
+
+    assert updated.status_code == 200, updated.text
+    assert budget.status_code == 200, budget.text
+    body = budget.json()
+    assert body == {
+        "used_micro_usd": 0,
+        "limit_micro_usd": 2000000,
+        "remaining_micro_usd": 2000000,
+        "window": "calendar_month_utc",
+        "reset_at": body["reset_at"],
+        "enforcement_available": True,
+        "reason": "available",
+        "maximum_limit_micro_usd": 5000000,
+        "pricing_version": "openai-public-2025-08-07.v1",
+    }
+
+    async with session_maker() as session:
+        svc = SettingsService(session, state["org_id"])
+        credentials = await svc.list_by_category(SettingCategory.LLM.value)
+        monetary = await svc.list_by_category("llm_budget")
+    assert {row["key"] for row in credentials}.isdisjoint(
+        {row["key"] for row in monetary}
+    )
+    assert monetary[0]["value"] == "2000000"
+
+
+@pytest.mark.asyncio
+async def test_admin_llm_budget_rejects_above_operator_maximum(
+    session_maker, monkeypatch
+):
+    monkeypatch.setenv("BYO_LLM_MAX_BUDGET_MICRO_USD", "1000")
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={
+                "provider": "openai",
+                "model": "gpt-5-mini",
+                "api_key": "sk-secret-value",
+                "budget_limit_micro_usd": 1001,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"] == "budget_limit_exceeds_maximum"
+
+
+@pytest.mark.asyncio
+async def test_admin_llm_budget_rejects_above_licensed_maximum(
+    session_maker, monkeypatch
+):
+    monkeypatch.setenv("BYO_LLM_MAX_BUDGET_MICRO_USD", "5000")
+    state = await _seed_org(session_maker, "team")
+    async with session_maker() as session:
+        license_result = await session.execute(
+            select(OrgLicense).where(OrgLicense.org_id == uuid.UUID(state["org_id"]))
+        )
+        license_result.scalar_one().limits_override = {"byo_llm_budget_micro_usd": 750}
+        await session.commit()
+    app = _make_app(session_maker, state)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={
+                "provider": "openai",
+                "model": "gpt-5-mini",
+                "api_key": "sk-secret-value",
+                "budget_limit_micro_usd": 751,
+            },
+        )
+        budget = await ac.get("/api/v1/admin/llm-settings/budget")
+
+    assert response.status_code == 400
+    assert budget.status_code == 200
+    assert budget.json()["maximum_limit_micro_usd"] == 750
+
+
+@pytest.mark.asyncio
+async def test_llm_budget_rejects_non_admin(session_maker):
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state, role="member")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.get("/api/v1/admin/llm-settings/budget")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_llm_budget_blocks_impersonated_admin_write(session_maker):
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(
+        session_maker,
+        state,
+        impersonated_by=str(uuid.uuid4()),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={"provider": "openai", "budget_limit_micro_usd": 1000},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "impersonated_write_forbidden"
+
+
+@pytest.mark.asyncio
 async def test_admin_llm_settings_requires_team_or_enterprise(session_maker):
     state = await _seed_org(session_maker, "community")
     app = _make_app(session_maker, state)
@@ -494,7 +642,10 @@ async def test_admin_llm_settings_requires_team_or_enterprise(session_maker):
 
 
 @pytest.mark.asyncio
-async def test_generic_settings_routes_reject_llm_category(session_maker):
+@pytest.mark.parametrize("category", ["llm", "llm_budget"])
+async def test_generic_settings_routes_reject_llm_categories(
+    session_maker, category: str
+):
     # Review finding: the generic settings routes must NOT be a back door for
     # category='llm' (would bypass the BYO-LLM tier gate + forced encryption).
     state = await _seed_org(session_maker, "team")
@@ -502,21 +653,21 @@ async def test_generic_settings_routes_reject_llm_category(session_maker):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         put_resp = await ac.put(
-            "/api/v1/admin/settings/llm/api_key",
+            f"/api/v1/admin/settings/{category}/api_key",
             json={"value": "sk-leak", "encrypt": False},
         )
         assert put_resp.status_code == 403
         assert put_resp.json()["detail"]["error"] == "use_llm_settings_endpoint"
         post_resp = await ac.post(
             "/api/v1/admin/settings",
-            json={"key": "api_key", "value": "sk-leak", "category": "llm"},
+            json={"key": "api_key", "value": "sk-leak", "category": category},
         )
         assert post_resp.status_code == 403
-        get_resp = await ac.get("/api/v1/admin/settings/llm/api_key")
+        get_resp = await ac.get(f"/api/v1/admin/settings/{category}/api_key")
         assert get_resp.status_code == 403
-        del_resp = await ac.delete("/api/v1/admin/settings/llm/api_key")
+        del_resp = await ac.delete(f"/api/v1/admin/settings/{category}/api_key")
         assert del_resp.status_code == 403
-        list_resp = await ac.get("/api/v1/admin/settings/llm")
+        list_resp = await ac.get(f"/api/v1/admin/settings/{category}")
         assert list_resp.status_code == 403
 
 

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -99,6 +99,48 @@ async def test_provider_resolution_requires_current_certification(
 
 
 @pytest.mark.asyncio
+async def test_byo_provider_resolution_attaches_shared_budget_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    provider = FakeProvider()
+    monkeypatch.setattr(production_runtime, "_provider", lambda _candidate: provider)
+    attached: list[dict[str, Any]] = []
+
+    def attach(value, **kwargs):
+        attached.append(kwargs)
+        return value
+
+    monkeypatch.setattr(production_runtime, "attach_agent_budget_guard", attach)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    FakeSettingsService.values = {
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_certification_provider(
+        session, org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.BYO
+    assert resolved.provider is provider
+    assert attached == [
+        {
+            "session": session,
+            "org_id": "org_01",
+            "provider": "openai",
+            "model": "gpt-5-mini",
+            "base_url": "https://api.openai.com/v1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_production_runtime_wires_exactly_the_nine_registered_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -52,7 +52,11 @@ def response(*, content: str | None = None, tool_call: Any = None) -> Any:
                 )
             )
         ],
-        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7),
+        usage=SimpleNamespace(
+            prompt_tokens=11,
+            completion_tokens=7,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=3),
+        ),
     )
 
 
@@ -82,6 +86,7 @@ async def test_normalizes_native_tool_decision_and_usage() -> None:
     assert result.decision == AgentToolRequest("lookup", {"id": "WU-1"}, "call-1")
     assert (result.usage.input_tokens, result.usage.output_tokens) == (11, 7)
     assert result.usage.estimated_cost_microusd is None
+    assert result.usage.cached_input_tokens == 3
     sent = client.chat.completions.calls[0]
     assert sent["tools"][0]["function"]["name"] == "lookup"
     assert sent["response_format"]["json_schema"]["strict"] is True
@@ -176,6 +181,35 @@ async def test_timeout_is_enforced_by_adapter() -> None:
             256,
         )
     assert caught.value.code is AgentProviderErrorCode.TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_pre_dispatch_cancellation_is_explicitly_identified() -> None:
+    class CancelledSignal:
+        def is_cancelled(self) -> bool:
+            return True
+
+        async def wait(self) -> None:
+            return None
+
+    client = Client([])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+            CancelledSignal(),
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.CANCELLED
+    assert caught.value.provider_dispatched is False
+    assert client.chat.completions.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_byo_budget.py
+++ b/tests/llm/test_byo_budget.py
@@ -1,0 +1,744 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.budget import (
+    BYOBudgetAccountingError,
+    BYOBudgetExceeded,
+    attach_llm_budget_guard,
+    cost_micro_usd,
+    get_budget_status,
+    guard_byo_call,
+    set_budget_limit,
+)
+from dev_health_ops.llm.providers.openai import OpenAIProvider
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.llm_budget import BYOLLMBudgetReservation
+from dev_health_ops.models.settings import Setting
+from dev_health_ops.models.users import Organization
+from tests._helpers import tables_of
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'budget.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(Organization, Setting, BYOLLMBudgetReservation),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _configure(session_maker, org_id: str, limit: int) -> None:
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=uuid.UUID(org_id),
+                slug=f"budget-{org_id[:8]}",
+                name="Budget Test Organization",
+                tier="team",
+            )
+        )
+        await set_budget_limit(SettingsService(session, org_id), limit)
+        await session.commit()
+
+
+async def _seed_org_without_budget(session_maker, org_id: str) -> None:
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=uuid.UUID(org_id),
+                slug=f"budget-{org_id[:8]}",
+                name="Budget Test Organization",
+                tier="team",
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_known_price_is_integer_micro_usd_and_unknown_is_not_zero():
+    assert (
+        cost_micro_usd(
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cached_input_tokens=0,
+        )
+        == 2_250_000
+    )
+    assert (
+        cost_micro_usd(
+            provider="openai",
+            model="gpt-5-mini-2025-08-07",
+            base_url="https://api.openai.com/v1",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cached_input_tokens=1_000_000,
+        )
+        == 2_025_000
+    )
+    assert (
+        cost_micro_usd(
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+            input_tokens=10,
+            output_tokens=10,
+            cached_input_tokens=None,
+        )
+        is None
+    )
+    assert (
+        cost_micro_usd(
+            provider="openai",
+            model="customer-model",
+            base_url="https://gateway.example/v1",
+            input_tokens=10,
+            output_tokens=10,
+            cached_input_tokens=0,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_pricing_reports_unavailable_never_zero(session_maker):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    async with session_maker() as session:
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="private-model",
+            base_url="https://gateway.example/v1",
+        )
+    assert status.used_micro_usd is None
+    assert status.remaining_micro_usd is None
+    assert status.enforcement_available is False
+    assert status.reason == "pricing_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_configured_budget_rejects_unknown_pricing_before_provider_execution(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    calls = 0
+
+    async def invoke() -> tuple[int, int, int]:
+        nonlocal calls
+        calls += 1
+        return 1, 1, 0
+
+    async with session_maker() as session:
+        with pytest.raises(BYOBudgetAccountingError):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="private-model",
+                base_url="https://gateway.example/v1",
+                idempotency_key="unknown-price",
+                maximum_input_tokens=1,
+                maximum_output_tokens=1,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_budget_preserves_unknown_price_provider_execution(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    await _seed_org_without_budget(session_maker, org_id)
+
+    async with session_maker() as session:
+
+        async def invoke() -> tuple[int, int, int]:
+            assert session.in_transaction() is False
+            return 1, 1, 0
+
+        result, billed = await guard_byo_call(
+            session=session,
+            org_id=org_id,
+            provider="openai",
+            model="private-model",
+            base_url="https://gateway.example/v1",
+            idempotency_key="unconfigured-unknown-price",
+            maximum_input_tokens=1,
+            maximum_output_tokens=1,
+            invoke=invoke,
+            usage=lambda value: value,
+        )
+
+    assert result == (1, 1, 0)
+    assert billed is None
+
+
+@pytest.mark.asyncio
+async def test_configured_budget_rejects_unpriceable_batch_before_execution(
+    session_maker, monkeypatch
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    calls = 0
+
+    @asynccontextmanager
+    async def budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", budget_session
+    )
+
+    class BatchProvider:
+        async def complete(self, prompt: str):
+            raise AssertionError(f"unexpected synchronous call: {prompt}")
+
+        async def submit_batch(self, items):
+            nonlocal calls
+            calls += 1
+            return items
+
+    provider = attach_llm_budget_guard(
+        BatchProvider(),  # type: ignore[arg-type]
+        org_id=org_id,
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+    )
+    with pytest.raises(BYOBudgetAccountingError):
+        await provider.submit_batch([])  # type: ignore[attr-defined]
+
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_admission_records_usage_idempotently_and_rejects_exhaustion(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    one_call = cost_micro_usd(
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+        input_tokens=4,
+        output_tokens=2,
+        cached_input_tokens=0,
+    )
+    assert one_call is not None
+    await _configure(session_maker, org_id, one_call)
+
+    calls = 0
+
+    async def invoke() -> tuple[int, int, int]:
+        nonlocal calls
+        calls += 1
+        return 4, 2, 0
+
+    async with session_maker() as session:
+        await guard_byo_call(
+            session=session,
+            org_id=org_id,
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+            idempotency_key="call-1",
+            maximum_input_tokens=4,
+            maximum_output_tokens=2,
+            invoke=invoke,
+            usage=lambda value: value,
+        )
+
+    # A replay cannot execute the provider again because doing so would incur a
+    # second billable call under the same accounting identity.
+    async with session_maker() as session:
+        with pytest.raises(BYOBudgetAccountingError):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="call-1",
+                maximum_input_tokens=0,
+                maximum_output_tokens=0,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+    assert calls == 1
+    assert status.used_micro_usd == one_call
+    assert status.remaining_micro_usd == 0
+
+    async with session_maker() as session:
+        with pytest.raises(BYOBudgetExceeded):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="call-2",
+                maximum_input_tokens=4,
+                maximum_output_tokens=2,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_admissions_cannot_both_spend_one_call_budget(session_maker):
+    org_id = str(uuid.uuid4())
+    one_call = cost_micro_usd(
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+        input_tokens=4,
+        output_tokens=2,
+        cached_input_tokens=0,
+    )
+    assert one_call is not None
+    await _configure(session_maker, org_id, one_call)
+    entered = 0
+
+    async def attempt(key: str) -> str:
+        async with session_maker() as session:
+
+            async def invoke() -> tuple[int, int, int]:
+                nonlocal entered
+                entered += 1
+                await asyncio.sleep(0)
+                return 4, 2, 0
+
+            try:
+                await guard_byo_call(
+                    session=session,
+                    org_id=org_id,
+                    provider="openai",
+                    model="gpt-5-mini",
+                    base_url=None,
+                    idempotency_key=key,
+                    maximum_input_tokens=4,
+                    maximum_output_tokens=2,
+                    invoke=invoke,
+                    usage=lambda value: value,
+                )
+            except BYOBudgetExceeded:
+                return "rejected"
+            return "admitted"
+
+    outcomes = await asyncio.gather(attempt("one"), attempt("two"))
+    assert sorted(outcomes) == ["admitted", "rejected"]
+    assert entered == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_reported_usage_marks_window_unavailable(session_maker):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    async with session_maker() as session:
+        with pytest.raises(BYOBudgetAccountingError):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="missing-usage",
+                maximum_input_tokens=1,
+                maximum_output_tokens=1,
+                invoke=lambda: asyncio.sleep(0, result=(None, None, None)),
+                usage=lambda value: value,
+            )
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+    assert status.used_micro_usd is None
+    assert status.remaining_micro_usd is None
+    assert status.enforcement_available is False
+    assert status.reason == "usage_unavailable"
+
+    calls = 0
+
+    async def invoke() -> tuple[int, int, int]:
+        nonlocal calls
+        calls += 1
+        return 1, 1, 0
+
+    async with session_maker() as session:
+        with pytest.raises(BYOBudgetAccountingError):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="after-missing-usage",
+                maximum_input_tokens=1,
+                maximum_output_tokens=1,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_execution_occurs_after_reservation_transaction_commits(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+
+    async with session_maker() as session:
+
+        async def invoke() -> tuple[int, int, int]:
+            assert session.in_transaction() is False
+            async with session_maker() as observer:
+                rows = await observer.execute(select(BYOLLMBudgetReservation))
+                reservation = rows.scalar_one()
+                assert reservation.status == "reserved"
+                assert reservation.actual_micro_usd is None
+            return 4, 2, 0
+
+        await guard_byo_call(
+            session=session,
+            org_id=org_id,
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+            idempotency_key="transaction-boundary",
+            maximum_input_tokens=4,
+            maximum_output_tokens=2,
+            invoke=invoke,
+            usage=lambda value: value,
+        )
+
+    async with session_maker() as session:
+        rows = await session.execute(select(BYOLLMBudgetReservation))
+        reservation = rows.scalar_one()
+        assert reservation.status == "succeeded"
+        assert reservation.reserved_micro_usd == 5
+        assert reservation.actual_micro_usd == 5
+        assert reservation.reconciled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_window_resets_at_next_utc_month_and_old_usage_does_not_carry(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    async with session_maker() as session:
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+            now=datetime(2026, 12, 31, 23, 59, tzinfo=UTC),
+        )
+    assert status.used_micro_usd == 0
+    assert status.reset_at == datetime(2027, 1, 1, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_failed_call_counts_usage_when_provider_reports_it(session_maker):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+
+    class ReportedFailure(RuntimeError):
+        usage = {
+            "prompt_tokens": 4,
+            "completion_tokens": 2,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        }
+
+    async def invoke():
+        raise ReportedFailure("provider failed")
+
+    async with session_maker() as session:
+        with pytest.raises(ReportedFailure):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="failed-call",
+                maximum_input_tokens=4,
+                maximum_output_tokens=2,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+
+    async with session_maker() as session:
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+    assert status.used_micro_usd == 5
+
+
+@pytest.mark.asyncio
+async def test_pre_dispatch_cancellation_voids_reservation_without_poisoning_window(
+    session_maker,
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+
+    async def invoke():
+        raise AgentProviderError(
+            AgentProviderErrorCode.CANCELLED, provider_dispatched=False
+        )
+
+    async with session_maker() as session:
+        with pytest.raises(AgentProviderError):
+            await guard_byo_call(
+                session=session,
+                org_id=org_id,
+                provider="openai",
+                model="gpt-5-mini",
+                base_url=None,
+                idempotency_key="cancelled-before-dispatch",
+                maximum_input_tokens=4,
+                maximum_output_tokens=2,
+                invoke=invoke,
+                usage=lambda value: value,
+            )
+
+    async with session_maker() as session:
+        row = (await session.execute(select(BYOLLMBudgetReservation))).scalar_one()
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+
+    assert row.status == "voided"
+    assert row.actual_micro_usd == 0
+    assert (row.input_tokens, row.output_tokens, row.cached_input_tokens) == (0, 0, 0)
+    assert status.reason == "available"
+    assert status.used_micro_usd == 0
+    assert status.remaining_micro_usd == 50_000
+
+
+@pytest.mark.asyncio
+async def test_unreconciled_reservation_remains_counted_conservatively(session_maker):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 50_000)
+    async with session_maker() as session:
+        session.add(
+            BYOLLMBudgetReservation(
+                org_id=uuid.UUID(org_id),
+                window_start=datetime.now(UTC).replace(
+                    day=1, hour=0, minute=0, second=0, microsecond=0
+                ),
+                idempotency_key="orphaned",
+                provider="openai",
+                model="gpt-5-mini",
+                reserved_micro_usd=20_000,
+                status="reserved",
+                pricing_version="test",
+                created_at=datetime(2020, 1, 1, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+
+    assert status.used_micro_usd == 20_000
+    assert status.remaining_micro_usd == 30_000
+
+
+@pytest.mark.asyncio
+async def test_openai_retry_attempts_are_independently_admitted_and_accounted(
+    session_maker, monkeypatch
+):
+    org_id = str(uuid.uuid4())
+    one_attempt = cost_micro_usd(
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+        input_tokens=4,
+        output_tokens=4096,
+        cached_input_tokens=0,
+    )
+    assert one_attempt == 8193
+    budget_limit = 100_000
+    await _configure(session_maker, org_id, budget_limit)
+
+    @asynccontextmanager
+    async def budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", budget_session
+    )
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("dev_health_ops.llm.providers.openai.asyncio.sleep", no_sleep)
+
+    responses = [
+        SimpleNamespace(
+            output_text="",
+            output=[],
+            incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+            usage=SimpleNamespace(
+                input_tokens=4,
+                output_tokens=4096,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        ),
+        SimpleNamespace(
+            output_text='{"ok": true}',
+            output=[],
+            incomplete_details=None,
+            usage=SimpleNamespace(
+                input_tokens=4,
+                output_tokens=4096,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        ),
+    ]
+
+    class Responses:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        async def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return responses.pop(0)
+
+    client = SimpleNamespace(responses=Responses())
+    provider = OpenAIProvider(api_key="unused", model="gpt-5-mini")
+    provider._impl._client = client
+    guarded = attach_llm_budget_guard(
+        provider,
+        org_id=org_id,
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+    )
+
+    result = await guarded.complete("test")
+
+    async with session_maker() as session:
+        rows = list((await session.execute(select(BYOLLMBudgetReservation))).scalars())
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+
+    assert result.text == '{"ok": true}'
+    assert len(client.responses.calls) == 2
+    assert len(rows) == 2
+    assert all(row.status == "succeeded" for row in rows)
+    assert sum(row.actual_micro_usd or 0 for row in rows) == one_attempt * 2
+    assert status.used_micro_usd == one_attempt * 2
+    assert status.remaining_micro_usd == budget_limit - (one_attempt * 2)
+
+
+@pytest.mark.asyncio
+async def test_openai_retry_is_rejected_before_second_network_attempt(
+    session_maker, monkeypatch
+):
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 20_000)
+
+    @asynccontextmanager
+    async def budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", budget_session
+    )
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("dev_health_ops.llm.providers.openai.asyncio.sleep", no_sleep)
+
+    response = SimpleNamespace(
+        output_text="",
+        output=[],
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        usage=SimpleNamespace(
+            input_tokens=4,
+            output_tokens=4096,
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        ),
+    )
+
+    class Responses:
+        def __init__(self):
+            self.calls = 0
+
+        async def create(self, **_kwargs):
+            self.calls += 1
+            return response
+
+    client = SimpleNamespace(responses=Responses())
+    provider = OpenAIProvider(api_key="unused", model="gpt-5-mini")
+    provider._impl._client = client
+    guarded = attach_llm_budget_guard(
+        provider,
+        org_id=org_id,
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+    )
+
+    with pytest.raises(BYOBudgetExceeded):
+        await guarded.complete("test")
+
+    assert client.responses.calls == 1

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -181,7 +181,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revision(migrated_to_0065.engine) == "0070"
+    assert _revision(migrated_to_0065.engine) == "0071"
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
     ]

--- a/tests/test_byo_llm_budget_migration.py
+++ b/tests/test_byo_llm_budget_migration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+def _organizations_table(connection: sa.Connection) -> None:
+    metadata = sa.MetaData()
+    sa.Table(
+        "organizations",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.Text(), nullable=False),
+    )
+    metadata.create_all(connection)
+
+
+def test_0071_budget_reservation_upgrade_and_downgrade_are_rehearsable() -> None:
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0071_add_byo_llm_budget_reservations"
+    )
+    assert migration.revision == "0071"
+    assert migration.down_revision == "0070"
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _organizations_table(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                migration.upgrade()
+                inspector = sa.inspect(connection)
+                assert "byo_llm_budget_reservations" in inspector.get_table_names()
+                assert {
+                    "id",
+                    "org_id",
+                    "window_start",
+                    "idempotency_key",
+                    "provider",
+                    "model",
+                    "reserved_micro_usd",
+                    "actual_micro_usd",
+                    "status",
+                    "pricing_version",
+                    "input_tokens",
+                    "cached_input_tokens",
+                    "output_tokens",
+                    "created_at",
+                    "reconciled_at",
+                } == {
+                    column["name"]
+                    for column in inspector.get_columns("byo_llm_budget_reservations")
+                }
+                assert {
+                    index["name"]
+                    for index in inspector.get_indexes("byo_llm_budget_reservations")
+                } == {"ix_byo_llm_budget_org_window_status"}
+                assert "uq_byo_llm_budget_reservation_attempt" in {
+                    constraint["name"]
+                    for constraint in inspector.get_unique_constraints(
+                        "byo_llm_budget_reservations"
+                    )
+                }
+
+                migration.downgrade()
+                assert (
+                    "byo_llm_budget_reservations"
+                    not in sa.inspect(connection).get_table_names()
+                )
+                assert "organizations" in sa.inspect(connection).get_table_names()
+
+                migration.upgrade()
+                assert (
+                    "byo_llm_budget_reservations"
+                    in sa.inspect(connection).get_table_names()
+                )
+    finally:
+        engine.dispose()

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -61,6 +61,37 @@ def test_org_byo_provider_beats_platform_env_in_auto():
     assert provider._impl.cfg.base_url == "https://api.openai.com/v1"
 
 
+def test_org_byo_provider_factory_attaches_shared_budget_guard():
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "model": "gpt-5-mini",
+            "api_key": "sk-org",
+            "base_url": "https://api.openai.com/v1",
+        }
+    }
+    attached: list[dict[str, object]] = []
+
+    def attach(value, **kwargs):
+        attached.append(kwargs)
+        return value
+
+    with patch.dict(os.environ, {}, clear=True):
+        with _patch_org(org):
+            with patch("dev_health_ops.llm.budget.attach_llm_budget_guard", attach):
+                provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert attached == [
+        {
+            "org_id": "org-1",
+            "provider": "openai",
+            "model": "gpt-5-mini",
+            "base_url": "https://api.openai.com/v1",
+        }
+    ]
+
+
 def test_platform_env_used_when_org_absent():
     """Org with no BYO settings falls through to the platform/env default."""
     with patch.dict(

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -165,7 +165,7 @@ class TestPostgresUpgrade:
         )
         current_head = ScriptDirectory.from_config(cfg).get_current_head()
 
-        assert current_head == "0070"
+        assert current_head == "0071"
         assert _database_has_revision(cfg, (current_head,), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:


### PR DESCRIPTION
## Summary

- add a durable organization-wide monthly BYO LLM monetary budget in integer micro-USD
- reserve maximum exposure before each provider network attempt and reconcile reported usage afterward
- enforce independent accounting for OpenAI internal retries so a retry cannot bypass the hard cap
- add the organization-admin budget/status API under `/api/v1/admin/llm-settings`
- reject generic settings-route writes to the protected `llm_budget` category
- preserve an explicit zero-dollar hard stop and fail closed for unknown pricing or missing usage

## Contract

- `PUT /api/v1/admin/llm-settings` accepts optional `budget_limit_micro_usd`; omission preserves the current value and zero blocks new budgeted calls
- `GET /api/v1/admin/llm-settings/budget` returns used-or-reserved spend, limit, remaining capacity, UTC reset, enforcement state, provisioned maximum, and pricing version
- the effective maximum is the lower of the operator and licensed organization limits
- configured budgets reject unknown pricing before provider dispatch
- confirmed pre-dispatch cancellation is durably voided at zero cost
- missing post-dispatch usage blocks later budgeted calls rather than being treated as free
- every OpenAI retry attempt has its own admission, reservation, idempotency identity, and reconciliation

## Safety review

The adversarial pass reproduced and closed three High-severity defects before publication:

1. generic settings routes could bypass tier, impersonation, value, and maximum-limit checks
2. an internal OpenAI retry could be billed while only the final attempt was recorded
3. cancellation before provider dispatch could poison the organization budget for the rest of the month

Crash-orphaned reservations remain conservatively charged at maximum exposure because timeout or worker death cannot prove that the remote provider did not process and bill the request. A safe audited operator-reconciliation workflow is tracked separately in CHAOS-3240; reservations are never automatically freed on lease expiry.

## Validation

- `bash ci/local_validate.sh` — passed
- full Python suite — 9,493 passed, 69 skipped
- Go format, vet, tests, and live Python differential oracle — passed
- mypy and Ruff — passed
- River compatibility harness — passed
- ClickHouse scratch migration and argMax live-execution proof — passed
- post-merge focused BYO/API/runtime/OpenAI/migration suite — 68 passed
- migration rehearsal upgrade → downgrade → upgrade — passed

PostgreSQL-only cutover tests were skipped because `DEV_HEALTH_POSTGRES_TEST_URI` is not configured locally; CI supplies the authoritative PostgreSQL environment.

`SCREENSHOT-WAIVER: backend, persistence, API, and documentation change; the corresponding admin UX evidence is on full-chaos/dev-health-web#818.`

## Dependencies

- platform allowance foundation: full-chaos/dev-health-ops#1328 (merged)
- BYO organization budget UX: full-chaos/dev-health-web#818
- canonical issue: CHAOS-3238
