### PR TITLE
fix(ask-dev): restore platform provider fallback (CHAOS-3242)

### DIFF
--- a/docs/admin/troubleshooting/provider-connections.md
+++ b/docs/admin/troubleshooting/provider-connections.md
@@ -91,14 +91,18 @@ Unknown events and malformed authority must fail closed.
 ## Ask Dev model readiness
 
 Ask Dev uses a separate multi-turn model contract; a provider that works for
-categorization or explanation can still be unavailable for Ask Dev. The V1
-certified surfaces are the platform OpenAI-compatible connection, a workspace
-BYO OpenAI-compatible connection, and the scripted OpenAI-compatible service
-used only by deterministic release acceptance. The scripted service is not a
-customer-selectable provider family and cannot be enabled through organization
-settings. Other provider families return `model_not_supported`; no model or tool
-work starts, and an admitted submission is closed as a safe failed run for audit
-and idempotent retry.
+categorization or explanation can still be unavailable for Ask Dev. Ask Dev
+certifies the connection by source and readiness, not by family label alone.
+The V1 certified surfaces are the platform OpenAI-compatible connection, a
+workspace BYO OpenAI-compatible connection, and the scripted OpenAI-compatible
+service used only by deterministic release acceptance. The scripted service is
+not a customer-selectable provider family and cannot be enabled through
+organization settings. A platform-managed Ask Dev connection may use a local
+OpenAI-compatible endpoint, including LM Studio, Ollama, or vLLM, when that
+endpoint is configured as the platform connection and has a passing readiness
+result for the exact provider/model fingerprint. Other provider families return
+`model_not_supported`; no model or tool work starts, and an admitted submission
+is closed as a safe failed run for audit and idempotent retry.
 
 Re-run readiness after changing provider, model, endpoint, credentials, or the
 capability-test version. The stored result contains only a derived fingerprint,
@@ -109,7 +113,9 @@ and tool contract; it never retrieves tenant evidence. A changed provider,
 model, base URL, or readiness-test version produces `stale_readiness` until the
 test is rerun.
 
-Workspace BYO is evaluated first. If it is unusable, Ask Dev fails closed unless
-the workspace explicitly permits platform fallback. Global disable and
-provider/model deny rules always win. Usage created by both readiness checks and
-live calls is attributed to the `ask_dev` use case.
+Workspace BYO is evaluated first. If it is unusable, Ask Dev falls back to the
+platform connection by default for configured orgs; an explicit organization
+fail_closed choice opts out of that fallback. Global disable and provider/model
+deny rules always win. Usage created by both readiness checks and live calls is
+attributed to the `ask_dev` use case and remains source-tagged so
+platform-managed and BYO accounting stay separate.

--- a/docs/operate/configure/environment-and-secrets.md
+++ b/docs/operate/configure/environment-and-secrets.md
@@ -90,15 +90,25 @@ A configuration rollout is complete only after all required processes use the sa
 
 Ask Dev reuses the existing source-bound LLM credential bundles: workspace BYO
 key and base URL stay together, and platform key and base URL stay together.
-Never combine a platform key with a workspace endpoint. OpenAI-compatible BYO
-base URLs pass the existing public-HTTPS and SSRF validation before they can be
-certified.
+Treat the source label separately from the provider family label. A connection
+may be `platform` or `byo` regardless of whether the endpoint family is
+OpenAI-compatible, local, Ollama, LM Studio, or another supported server.
+
+Never combine a platform key with a workspace endpoint or a workspace key with a
+platform endpoint. OpenAI-compatible BYO base URLs pass the existing
+public-HTTPS and SSRF validation before they can be certified.
 
 Enabling Ask Dev is not sufficient to admit model traffic. Admission also
 requires a current readiness result for the exact provider/model fingerprint.
-Global LLM disable, the Ask Dev emergency disable, and provider/model deny rules
-must remain available during rollout. Workspace-to-platform fallback is an
-explicit policy choice; absence of that choice is fail-closed.
+The platform connection may use an OpenAI-compatible endpoint, including a local
+one, but Ask Dev only admits that connection after readiness succeeds for that
+exact fingerprint. Global LLM disable, the Ask Dev emergency disable, and
+provider/model deny rules must remain available during rollout.
+
+Workspace-to-platform fallback defaults to platform after a configured org BYO
+is evaluated; an explicit organization fail_closed choice opts out of that
+fallback. Source-tagged accounting keeps platform-managed usage and BYO usage
+separate.
 
 Organization policy is stored through the dedicated Ask Dev administrator API,
 not environment variables or the generic settings endpoint. A malformed stored

--- a/src/dev_health_ops/api/dev/org_policy.py
+++ b/src/dev_health_ops/api/dev/org_policy.py
@@ -56,7 +56,7 @@ def platform_operator_cost_limit_microusd() -> int:
 @dataclass(frozen=True, slots=True)
 class AskDevOrgPolicy:
     retention_days: Literal[0, 30] = 30
-    fallback_policy: Literal["fail_closed", "platform"] = "fail_closed"
+    fallback_policy: Literal["fail_closed", "platform"] = "platform"
     emergency_disabled: bool = False
     platform_monthly_request_limit: int = PLATFORM_MONTHLY_REQUEST_LIMIT_DEFAULT
     platform_monthly_cost_limit_microusd: int = (
@@ -94,9 +94,12 @@ async def load_ask_dev_org_policy(settings: SettingsService) -> AskDevOrgPolicy:
     operator_cost_limit = platform_operator_cost_limit_microusd()
 
     retention_days: Literal[0, 30] = 0 if retention == "0" else 30
-    fallback_policy: Literal["fail_closed", "platform"] = (
-        "platform" if fallback in {"platform", "true"} else "fail_closed"
-    )
+    fallback_policy: Literal["fail_closed", "platform"]
+    if fallback is None or fallback in {"platform", "true"}:
+        fallback_policy = "platform"
+    else:
+        # Explicit fail_closed and malformed stored values both remain closed.
+        fallback_policy = "fail_closed"
     # Unknown values are treated as disabled rather than silently reopening a
     # tenant surface after a corrupt or partial administrative write.
     disabled = emergency_disabled not in {None, "", "false", "0"}

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -20,6 +20,7 @@ from dev_health_ops.llm.agent.openai_compatible import (
     OpenAICompatibleAgentProvider,
 )
 from dev_health_ops.llm.agent.policy import (
+    CERTIFIED_PLATFORM_AGENT_PROVIDERS,
     AgentFallbackPolicy,
     AgentProviderCandidate,
     AgentProviderPolicy,
@@ -29,7 +30,12 @@ from dev_health_ops.llm.agent.policy import (
 from dev_health_ops.llm.agent.readiness import SettingsAgentReadinessStore
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.budget import attach_agent_budget_guard
-from dev_health_ops.llm.credentials import LLMCredentials
+from dev_health_ops.llm.credentials import LLMCredentials, resolve_llm_credentials
+from dev_health_ops.llm.errors import LLMAuthError
+from dev_health_ops.llm.providers import (
+    resolve_model_name,
+    resolve_provider_name,
+)
 from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
 from dev_health_ops.models.settings import SettingCategory
 
@@ -244,22 +250,29 @@ async def _provider_candidates(
     )
 
     acceptance = _acceptance_openai_configuration()
-    platform_provider_name = os.getenv("LLM_PROVIDER", "").strip().lower()
+    try:
+        platform_provider_name = resolve_provider_name("auto", org_id=None)
+    except LLMAuthError:
+        platform_provider_name = ""
     if acceptance is not None:
         platform_model = ACCEPTANCE_OPENAI_MODEL
         platform_credentials = LLMCredentials(
             api_key=acceptance.api_key, base_url=acceptance.base_url
         )
     else:
-        platform_model = (
-            os.getenv("LLM_MODEL", "").strip() or os.getenv("OPENAI_MODEL", "").strip()
-        )
-        if platform_provider_name in {"", "openai"} and not platform_model:
-            platform_model = DEFAULT_MODEL_BY_PROVIDER["openai"]
-        platform_credentials = LLMCredentials(
-            api_key=(os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY") or ""),
-            base_url=(os.getenv("LLM_BASE_URL") or os.getenv("OPENAI_BASE_URL") or ""),
-        )
+        if platform_provider_name == "none":
+            platform_model = ""
+            platform_credentials = LLMCredentials()
+        else:
+            platform_model = (
+                resolve_model_name(platform_provider_name or "openai") or ""
+            )
+            try:
+                platform_credentials = resolve_llm_credentials(
+                    platform_provider_name or "openai", org_id=None
+                )
+            except LLMAuthError:
+                platform_credentials = LLMCredentials()
     platform = _candidate(
         provider_name=platform_provider_name,
         model=platform_model,
@@ -346,16 +359,10 @@ def _candidate(
     ):
         return None
     provider_name = provider_name or "openai"
-    if provider_name != "openai":
-        return AgentProviderCandidate(
-            provider=provider_name,
-            model=model,
-            credentials=credentials,
-            source=source,
-            readiness_current=False,
-        )
     candidate_type = (
-        _AcceptanceOpenAICandidate if acceptance else AgentProviderCandidate
+        _AcceptanceOpenAICandidate
+        if acceptance and provider_name == "openai"
+        else AgentProviderCandidate
     )
     candidate = candidate_type(
         provider=provider_name,
@@ -401,12 +408,12 @@ def _readiness_fingerprint(candidate: AgentProviderCandidate) -> str:
 
 
 def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
-    if candidate.provider != "openai":
+    if candidate.provider not in CERTIFIED_PLATFORM_AGENT_PROVIDERS:
         raise DevRuntimeUnavailable(
             "model_not_supported", "The configured Ask Dev model is not supported."
         )
     return OpenAICompatibleAgentProvider(
-        api_key=candidate.credentials.api_key,
+        api_key=candidate.credentials.api_key or "platform-openai-compatible",
         model=candidate.model,
         base_url=candidate.credentials.base_url or None,
         disclosure_key=(

--- a/src/dev_health_ops/llm/agent/policy.py
+++ b/src/dev_health_ops/llm/agent/policy.py
@@ -1,15 +1,23 @@
-"""Fail-closed Ask Dev provider policy, separate from completion fallback."""
+"""Source-bound Ask Dev provider policy, separate from completion fallback."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from urllib.parse import urlsplit
 
 from dev_health_ops.llm.credentials import LLMCredentials, validate_llm_base_url
 
 from .errors import AgentProviderError, AgentProviderErrorCode
 
-CERTIFIED_AGENT_PROVIDERS = frozenset({"openai"})
+CERTIFIED_BYO_AGENT_PROVIDERS = frozenset({"openai"})
+CERTIFIED_PLATFORM_AGENT_PROVIDERS = frozenset(
+    {"openai", "local", "ollama", "lmstudio"}
+)
+CERTIFIED_AGENT_PROVIDERS = (
+    CERTIFIED_BYO_AGENT_PROVIDERS | CERTIFIED_PLATFORM_AGENT_PROVIDERS
+)
+_LOCAL_PLATFORM_PROVIDERS = frozenset({"local", "ollama", "lmstudio"})
 
 
 class AgentProviderSource(str, Enum):
@@ -31,16 +39,58 @@ class AgentProviderCandidate:
     readiness_current: bool = False
 
     @property
+    def certified(self) -> bool:
+        certified = (
+            CERTIFIED_PLATFORM_AGENT_PROVIDERS
+            if self.source is AgentProviderSource.PLATFORM
+            else CERTIFIED_BYO_AGENT_PROVIDERS
+        )
+        return self.provider in certified
+
+    @property
     def usable(self) -> bool:
-        valid_url, _ = validate_llm_base_url(self.credentials.base_url)
-        credentials_present = bool(self.credentials.api_key)
+        if self.source is AgentProviderSource.PLATFORM:
+            valid_url = _operator_base_url_is_sane(self.credentials.base_url)
+            credentials_present = bool(
+                self.credentials.api_key
+                or (
+                    self.credentials.base_url
+                    and self.provider in CERTIFIED_PLATFORM_AGENT_PROVIDERS
+                )
+            )
+            if self.provider in _LOCAL_PLATFORM_PROVIDERS:
+                credentials_present = bool(self.credentials.base_url)
+        else:
+            valid_url, _ = validate_llm_base_url(self.credentials.base_url)
+            credentials_present = bool(self.credentials.api_key)
         return (
-            self.provider in CERTIFIED_AGENT_PROVIDERS
+            self.certified
             and bool(self.model)
             and credentials_present
             and valid_url
             and self.readiness_current
         )
+
+
+def _operator_base_url_is_sane(base_url: str | None) -> bool:
+    if not base_url:
+        return True
+    if any(ord(char) <= 0x20 or ord(char) == 0x7F for char in base_url):
+        return False
+    try:
+        parsed = urlsplit(base_url)
+        host = parsed.hostname
+        _ = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.username is None
+        and parsed.password is None
+        and host is not None
+        and not parsed.query
+        and not parsed.fragment
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,7 +108,7 @@ def resolve_agent_provider_selection(
     byo: AgentProviderCandidate | None,
     platform: AgentProviderCandidate | None,
 ) -> AgentProviderCandidate:
-    """Resolve a certified candidate without implicit cross-source fallback."""
+    """Resolve a certified candidate under the configured source fallback policy."""
     if not policy.ask_dev_enabled or policy.llm_globally_disabled:
         raise AgentProviderError(AgentProviderErrorCode.DISABLED)
 
@@ -76,7 +126,7 @@ def resolve_agent_provider_selection(
         if policy.fallback is not AgentFallbackPolicy.ALLOW_PLATFORM:
             code = (
                 AgentProviderErrorCode.MODEL_NOT_SUPPORTED
-                if byo.provider not in CERTIFIED_AGENT_PROVIDERS
+                if not byo.certified
                 or byo.provider in policy.denied_providers
                 or byo.model in policy.denied_models
                 else AgentProviderErrorCode.PROVIDER_NOT_CONFIGURED
@@ -86,7 +136,7 @@ def resolve_agent_provider_selection(
     if allowed(platform):
         return platform  # type: ignore[return-value]
     if platform is not None and (
-        platform.provider not in CERTIFIED_AGENT_PROVIDERS
+        not platform.certified
         or platform.provider in policy.denied_providers
         or platform.model in policy.denied_models
     ):

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -229,6 +229,7 @@ async def test_operator_maxima_do_not_raise_the_unconfigured_org_defaults(
     body = response.json()
     assert body["settings"]["platform_monthly_request_limit"] == 1000
     assert body["settings"]["platform_monthly_cost_limit_microusd"] == 100_000_000
+    assert body["settings"]["fallback_policy"] == "platform"
     assert body["platform_allowance_bounds"]["request_maximum"] == 5000
     assert body["platform_allowance_bounds"]["cost_maximum_microusd"] == 500_000_000
 

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -401,7 +401,7 @@ async def test_acceptance_openai_rejects_non_allowlisted_or_ambiguous_targets(
 
 
 @pytest.mark.asyncio
-async def test_normal_platform_base_url_still_rejects_loopback(
+async def test_operator_platform_base_url_accepts_loopback(
     monkeypatch: pytest.MonkeyPatch,
     settings_session: AsyncSession,
 ) -> None:
@@ -409,9 +409,15 @@ async def test_normal_platform_base_url_still_rejects_loopback(
     monkeypatch.setenv("LLM_MODEL", "customer-model")
     monkeypatch.setenv("LLM_API_KEY", "customer-key")
     monkeypatch.setenv("LLM_BASE_URL", "http://127.0.0.1:8001/v1")
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await resolve_certification_provider(settings_session, org_id=_ORG_ID)
-    assert exc_info.value.code == "provider_not_configured"
+    resolution = await resolve_certification_provider(settings_session, org_id=_ORG_ID)
+    provider = cast(OpenAICompatibleAgentProvider, resolution.provider)
+    try:
+        assert resolution.family == "openai"
+        assert resolution.source is AgentProviderSource.PLATFORM
+        assert resolution.model == "customer-model"
+        assert provider.base_url == "http://127.0.0.1:8001/v1"
+    finally:
+        await provider.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -14,7 +14,8 @@ from dev_health_ops.api.dev.production_runtime import ProductionProviderResoluti
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
 from dev_health_ops.api.dev.tool_registry import ToolExecutionContext
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
-from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
+from dev_health_ops.llm.credentials import LLMCredentials
 
 
 class FakeProvider:
@@ -39,10 +40,32 @@ class FakeSettingsService:
         return self.values.get(key, default)
 
 
-def _fingerprint(base_url: str = "", model: str = "certified-model") -> str:
+def _fingerprint(
+    base_url: str = "", model: str = "certified-model", provider: str = "openai"
+) -> str:
     return hashlib.sha256(
-        "\0".join(("platform", "openai", model, base_url, READINESS_VERSION)).encode()
+        "\0".join(("platform", provider, model, base_url, READINESS_VERSION)).encode()
     ).hexdigest()[:24]
+
+
+def test_readiness_fingerprint_changes_when_source_changes() -> None:
+    credentials = LLMCredentials(base_url="https://models.example.com/v1")
+    platform = AgentProviderCandidate(
+        provider="openai",
+        model="certified-model",
+        credentials=credentials,
+        source=AgentProviderSource.PLATFORM,
+    )
+    byo = AgentProviderCandidate(
+        provider="openai",
+        model="certified-model",
+        credentials=credentials,
+        source=AgentProviderSource.BYO,
+    )
+
+    assert production_runtime._readiness_fingerprint(
+        platform
+    ) != production_runtime._readiness_fingerprint(byo)
 
 
 @pytest.mark.asyncio
@@ -95,6 +118,106 @@ async def test_provider_resolution_requires_current_certification(
     )
     with pytest.raises(DevRuntimeUnavailable) as exc_info:
         await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_platform_local_provider_uses_only_operator_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    candidates: list[Any] = []
+
+    def provider(candidate):
+        candidates.append(candidate)
+        return FakeProvider()
+
+    monkeypatch.setattr(production_runtime, "_provider", provider)
+    attached: list[dict[str, Any]] = []
+
+    def attach(value, **kwargs):
+        attached.append(kwargs)
+        return value
+
+    monkeypatch.setattr(production_runtime, "attach_agent_budget_guard", attach)
+    monkeypatch.setenv("LLM_PROVIDER", "local")
+    monkeypatch.setenv("LLM_MODEL", "google/gemma-4-e4b")
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "google/gemma-4-e4b")
+    monkeypatch.setenv("LOCAL_LLM_BASE_URL", "http://host.docker.internal:1234/v1")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_LLM_API_KEY", raising=False)
+    FakeSettingsService.values = {
+        "ask_dev_agent_readiness": json.dumps(
+            {
+                "fingerprint": _fingerprint(
+                    provider="local",
+                    model="google/gemma-4-e4b",
+                    base_url="http://host.docker.internal:1234/v1",
+                ),
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        # A complete organization BYO bundle remains database-owned and does
+        # not overwrite the independently resolved platform candidate.
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+    }
+
+    resolved = await production_runtime.resolve_production_provider(
+        cast(Any, object()), org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.family == "local"
+    assert resolved.model == "google/gemma-4-e4b"
+    assert len(candidates) == 1
+    assert candidates[0].credentials.api_key == ""
+    assert candidates[0].credentials.base_url == "http://host.docker.internal:1234/v1"
+    assert attached == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_fail_closed_prevents_platform_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "local")
+    monkeypatch.setenv("LOCAL_LLM_MODEL", "local-agent-model")
+    monkeypatch.setenv("LOCAL_LLM_BASE_URL", "http://host.docker.internal:1234/v1")
+    FakeSettingsService.values = {
+        "ask_dev_agent_readiness": json.dumps(
+            {
+                "fingerprint": _fingerprint(
+                    provider="local",
+                    model="local-agent-model",
+                    base_url="http://host.docker.internal:1234/v1",
+                ),
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+        "ask_dev_platform_fallback": "fail_closed",
+    }
+
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(
+            cast(Any, object()), org_id="org_01"
+        )
+
     assert exc_info.value.code == "provider_not_configured"
 
 

--- a/tests/llm/agent/test_contracts_and_policy.py
+++ b/tests/llm/agent/test_contracts_and_policy.py
@@ -98,6 +98,72 @@ def test_uncertified_candidate_is_not_usable() -> None:
     assert caught.value.code is AgentProviderErrorCode.PROVIDER_NOT_CONFIGURED
 
 
+@pytest.mark.parametrize("provider", ["local", "ollama", "lmstudio"])
+def test_platform_openai_compatible_alias_is_source_aware(provider: str) -> None:
+    platform = AgentProviderCandidate(
+        provider=provider,
+        model="local-agent-model",
+        credentials=LLMCredentials(base_url="http://host.docker.internal:1234/v1"),
+        source=AgentProviderSource.PLATFORM,
+        readiness_current=True,
+    )
+    assert platform.usable is True
+
+    byo = AgentProviderCandidate(
+        provider=provider,
+        model="local-agent-model",
+        credentials=LLMCredentials(
+            api_key="org-key", base_url="https://models.example.com/v1"
+        ),
+        source=AgentProviderSource.BYO,
+        readiness_current=True,
+    )
+    assert byo.certified is False
+    assert byo.usable is False
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://user:secret@host.docker.internal:1234/v1",
+        "http://host.docker.internal:1234/v1?token=secret",
+        "file:///tmp/model.sock",
+    ],
+)
+def test_platform_operator_url_rejects_credential_and_non_http_shapes(
+    base_url: str,
+) -> None:
+    platform = AgentProviderCandidate(
+        provider="local",
+        model="local-agent-model",
+        credentials=LLMCredentials(base_url=base_url),
+        source=AgentProviderSource.PLATFORM,
+        readiness_current=True,
+    )
+    assert platform.usable is False
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1:1234/v1",
+        "https://user:secret@models.example.com/v1",
+        "file:///tmp/model.sock",
+    ],
+)
+def test_byo_certified_candidate_rejects_unsafe_base_url(base_url: str) -> None:
+    byo = AgentProviderCandidate(
+        provider="openai",
+        model="agent-model",
+        credentials=LLMCredentials(api_key="org-key", base_url=base_url),
+        source=AgentProviderSource.BYO,
+        readiness_current=True,
+    )
+
+    assert byo.certified is True
+    assert byo.usable is False
+
+
 def test_internal_scripted_adapter_is_not_a_product_provider_family() -> None:
     with pytest.raises(AgentProviderError) as caught:
         resolve_agent_provider_selection(


### PR DESCRIPTION
## Summary

- Resolve the Ask Dev platform provider exclusively from operator environment configuration while keeping organization BYO settings database-owned and source-bound.
- Restore platform fallback as the default after an unusable BYO candidate, with explicit organization `fail_closed` remaining available.
- Certify platform `openai`, `local`, `ollama`, and `lmstudio` labels through the OpenAI-compatible agent contract, including operator-controlled local/private HTTP endpoints.
- Preserve strict public-HTTPS/SSRF validation and the organization budget guard for BYO connections only.
- Update governed customer documentation for provider source, readiness, fallback, and accounting behavior.

## Verification

- `55 passed` across focused Ask Dev runtime, policy, admin, and Compose-contract tests.
- Full local validation: `9501 passed, 69 skipped`; Ruff, full mypy, Go format/vet/test/build, River compatibility, isolated ClickHouse migrations, and live ClickHouse execution passed.
- Strict documentation publication, MkDocs build, source/built links, search acceptance, accessibility, and canonical facts passed.
- Disposable Compose acceptance: `2 passed` for permanent-window continuity/grounded answers and independent platform validation/member denial; the stack was removed afterward.
- Independent review approved with no concrete contract defect found.

## Validation limit

The local model endpoint was not listening on port 1234 during verification, so its specific model could not be readiness-certified. The exact environment contract and no-key local endpoint path are covered by regression tests.

SCREENSHOT-WAIVER: Backend provider resolution, policy, tests, and customer documentation only; no rendered UI behavior changed.

Closes CHAOS-3242

Linear: https://linear.app/fullchaos/issue/CHAOS-3242/ask-dev-restore-platform-provider-resolution-and-fallback-contract
