### PR TITLE
fix(llm): support platform OpenAI-compatible endpoints

### DIFF
--- a/docs/admin/troubleshooting/provider-connections.md
+++ b/docs/admin/troubleshooting/provider-connections.md
@@ -104,6 +104,13 @@ result for the exact provider/model fingerprint. Other provider families return
 `model_not_supported`; no model or tool work starts, and an admitted submission
 is closed as a safe failed run for audit and idempotent retry.
 
+For local LM Studio, use either the `local` bundle with `LOCAL_LLM_BASE_URL` and
+`LOCAL_LLM_MODEL`, or the `lmstudio` bundle with `LMSTUDIO_BASE_URL` and
+`LMSTUDIO_MODEL`. For Ollama, use `OLLAMA_BASE_URL` and `OLLAMA_MODEL`; add
+`OLLAMA_API_KEY` for an authenticated cloud-compatible endpoint. The generic
+`LLM_API_KEY` alias remains supported. Environment-configured local and cloud
+endpoints are platform connections and do not require workspace BYO setup.
+
 Re-run readiness after changing provider, model, endpoint, credentials, or the
 capability-test version. The stored result contains only a derived fingerprint,
 test version, timestamp, outcome, and safe error code. It never contains the
@@ -112,6 +119,13 @@ The organization-administrator readiness action uses a fixed synthetic nonce
 and tool contract; it never retrieves tenant evidence. A changed provider,
 model, base URL, or readiness-test version produces `stale_readiness` until the
 test is rerun.
+
+Readiness permits both native OpenAI `tool_calls` and the provider-neutral JSON
+tool-decision envelope. It uses the runtime's 30-second provider-call timeout and
+then requires a strict structured final response after the synthetic tool result.
+The administrator state distinguishes rejected authentication/configuration,
+timeout, temporary endpoint unavailability, and a response that does not satisfy
+the Ask Dev agent-capability contract. Raw provider responses are never returned.
 
 Workspace BYO is evaluated first. If it is unusable, Ask Dev falls back to the
 platform connection by default for configured orgs; an explicit organization

--- a/docs/operate/configure/environment-and-secrets.md
+++ b/docs/operate/configure/environment-and-secrets.md
@@ -105,6 +105,30 @@ one, but Ask Dev only admits that connection after readiness succeeds for that
 exact fingerprint. Global LLM disable, the Ask Dev emergency disable, and
 provider/model deny rules must remain available during rollout.
 
+Supported platform OpenAI-compatible bundles include:
+
+```dotenv
+# Generic/local OpenAI-compatible server (for example LM Studio or vLLM)
+LLM_PROVIDER=local
+LOCAL_LLM_BASE_URL=http://host.docker.internal:1234/v1
+LOCAL_LLM_MODEL=your-model-id
+
+# LM Studio provider aliases
+LLM_PROVIDER=lmstudio
+LMSTUDIO_BASE_URL=http://host.docker.internal:1234/v1
+LMSTUDIO_MODEL=your-model-id
+
+# Local Ollama or authenticated Ollama Cloud-compatible endpoint
+LLM_PROVIDER=ollama
+OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
+OLLAMA_MODEL=your-model-id
+OLLAMA_API_KEY=optional-cloud-key
+```
+
+`OLLAMA_API_KEY` is the provider-specific platform alias; `LLM_API_KEY` remains
+supported. Omit the key for an unauthenticated local host. These environment
+bundles are platform configuration, never organization BYO settings.
+
 Workspace-to-platform fallback defaults to platform after a configured org BYO
 is evaluated; an explicit organization fail_closed choice opts out of that
 fallback. Source-tagged accounting keeps platform-managed usage and BYO usage
@@ -133,3 +157,10 @@ disabled, provider not configured, model not supported, provider unavailable,
 invalid response, timeout, or cancelled. Inspect provider logs through the
 approved secret-redacting path; do not copy raw provider bodies into settings or
 support records.
+
+The readiness provider-call timeout is 30 seconds, matching the Ask Dev runtime
+contract. The synthetic exchange accepts either an OpenAI-native `tool_calls`
+decision or the normalized JSON decision envelope, then verifies tool-result
+continuation and a strict final response. A timeout, authentication failure,
+temporarily unavailable endpoint, and invalid agent response remain distinct
+safe administrative outcomes.

--- a/scripts/acceptance/prepare_ask_dev_acceptance.py
+++ b/scripts/acceptance/prepare_ask_dev_acceptance.py
@@ -19,7 +19,7 @@ _REQUIRED_FEATURES = (
     "ask_dev",
     "ask_dev_contextual_entrypoints",
 )
-_EXPECTED_MODEL = "ask-dev-scripted-v1"
+_DEFAULT_EXPECTED_MODEL = "ask-dev-scripted-v1"
 
 
 class AcceptanceFailure(RuntimeError):
@@ -75,7 +75,13 @@ def _require(condition: bool, message: str) -> None:
         raise AcceptanceFailure(message)
 
 
-def prepare(api: AcceptanceApi, *, email: str, password: str) -> str:
+def prepare(
+    api: AcceptanceApi,
+    *,
+    email: str,
+    password: str,
+    expected_model: str = _DEFAULT_EXPECTED_MODEL,
+) -> str:
     login = api.request(
         "POST",
         "/api/v1/auth/login",
@@ -152,7 +158,7 @@ def prepare(api: AcceptanceApi, *, email: str, password: str) -> str:
         "full_page_available": True,
         "provider_source": "platform",
         "readiness": "ready",
-        "effective_model_label": _EXPECTED_MODEL,
+        "effective_model_label": expected_model,
     }
     for field, expected in expected_readiness.items():
         _require(
@@ -175,7 +181,7 @@ def prepare(api: AcceptanceApi, *, email: str, password: str) -> str:
         "evidence_resolver": True,
         "provider_source": "platform",
         "readiness": "ready",
-        "effective_model_label": _EXPECTED_MODEL,
+        "effective_model_label": expected_model,
     }
     for field, expected in expected_capabilities.items():
         _require(
@@ -194,8 +200,19 @@ def main() -> int:
     )
     email = os.getenv("TEST_SUPERUSER_EMAIL", "admin@devhealth.example")
     password = os.getenv("TEST_SUPERUSER_PASSWORD", "devhealth123")
+    expected_model = os.getenv(
+        "ASK_DEV_ACCEPTANCE_EXPECTED_MODEL", _DEFAULT_EXPECTED_MODEL
+    ).strip()
+    if not expected_model:
+        print("ASK_DEV_ACCEPTANCE_EXPECTED_MODEL must not be empty", file=sys.stderr)
+        return 64
     try:
-        org_id = prepare(api, email=email, password=password)
+        org_id = prepare(
+            api,
+            email=email,
+            password=password,
+            expected_model=expected_model,
+        )
     except AcceptanceFailure as exc:
         print(f"Ask Dev acceptance preparation failed: {exc}", file=sys.stderr)
         return 1

--- a/scripts/acceptance/run_ask_dev_provider_profile.sh
+++ b/scripts/acceptance/run_ask_dev_provider_profile.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: run_ask_dev_provider_profile.sh --profile lmstudio-local|ollama-local|ollama-cloud
+
+Optional environment:
+  ASK_DEV_PROVIDER_MODEL      Exact loaded/cloud model identifier.
+  ASK_DEV_PROVIDER_BASE_URL   OpenAI-compatible /v1 base URL as seen by Compose.
+  ASK_DEV_ACCEPTANCE_PYTHON   Python with this checkout installed (default: .venv).
+  OLLAMA_API_KEY              Required only for ollama-cloud; supply from a secret.
+EOF
+}
+
+if [[ "${1:-}" != "--profile" || -z "${2:-}" || "$#" -ne 2 ]]; then
+  usage
+  exit 64
+fi
+
+profile="$2"
+case "${profile}" in
+  lmstudio-local)
+    provider="local"
+    model="${ASK_DEV_PROVIDER_MODEL:-google/gemma-4-e4b}"
+    base_url="${ASK_DEV_PROVIDER_BASE_URL:-http://host.docker.internal:1234/v1}"
+    local_base_url="${base_url}"
+    local_model="${model}"
+    ollama_base_url=""
+    ollama_model=""
+    ollama_api_key=""
+    ;;
+  ollama-local)
+    provider="ollama"
+    model="${ASK_DEV_PROVIDER_MODEL:-}"
+    base_url="${ASK_DEV_PROVIDER_BASE_URL:-http://host.docker.internal:11434/v1}"
+    local_base_url=""
+    local_model=""
+    ollama_base_url="${base_url}"
+    ollama_model="${model}"
+    ollama_api_key=""
+    ;;
+  ollama-cloud)
+    provider="ollama"
+    model="${ASK_DEV_PROVIDER_MODEL:-}"
+    base_url="${ASK_DEV_PROVIDER_BASE_URL:-https://ollama.com/v1}"
+    local_base_url=""
+    local_model=""
+    ollama_base_url="${base_url}"
+    ollama_model="${model}"
+    ollama_api_key="${OLLAMA_API_KEY:-}"
+    if [[ -z "${ollama_api_key}" ]]; then
+      echo "OLLAMA_API_KEY is required for the opt-in ollama-cloud profile" >&2
+      exit 64
+    fi
+    ;;
+  *)
+    usage
+    exit 64
+    ;;
+esac
+
+if [[ -z "${model}" ]]; then
+  echo "ASK_DEV_PROVIDER_MODEL is required for ${profile}" >&2
+  exit 64
+fi
+if [[ "${base_url}" != */v1 && "${base_url}" != */v1/ ]]; then
+  echo "ASK_DEV_PROVIDER_BASE_URL must identify an OpenAI-compatible /v1 endpoint" >&2
+  exit 64
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ops_root="$(cd -- "${script_dir}/../.." && pwd)"
+python_bin="${ASK_DEV_ACCEPTANCE_PYTHON:-${ops_root}/.venv/bin/python}"
+if [[ ! -x "${python_bin}" ]]; then
+  echo "ASK_DEV_ACCEPTANCE_PYTHON must identify an executable project Python" >&2
+  exit 64
+fi
+compose_file="${ops_root}/compose.yml"
+profile_compose_file="${ops_root}/tests/acceptance/compose.ask-dev-provider-profile.yml"
+project_name="dev-health-ask-dev-${profile}"
+fixture_org_id="0a155cab-8833-42ac-a4ef-0d121725a7b0"
+
+export ASK_DEV_PROFILE_PROVIDER="${provider}"
+export ASK_DEV_PROFILE_MODEL="${model}"
+export ASK_DEV_PROFILE_BASE_URL="${base_url}"
+export ASK_DEV_PROFILE_LOCAL_BASE_URL="${local_base_url}"
+export ASK_DEV_PROFILE_LOCAL_MODEL="${local_model}"
+export ASK_DEV_PROFILE_OLLAMA_BASE_URL="${ollama_base_url}"
+export ASK_DEV_PROFILE_OLLAMA_MODEL="${ollama_model}"
+export ASK_DEV_PROFILE_OLLAMA_API_KEY="${ollama_api_key}"
+export BUGSINK_SECRET_KEY="${BUGSINK_SECRET_KEY:-ask-dev-provider-profile-unused}"
+
+compose=(
+  docker compose
+  --project-name "${project_name}"
+  --project-directory "${ops_root}"
+  -f "${compose_file}"
+  -f "${profile_compose_file}"
+)
+
+report_failure() {
+  status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    echo "Ask Dev ${profile} acceptance failed; retained containers and recent API logs follow." >&2
+    "${compose[@]}" ps >&2 || true
+    "${compose[@]}" logs --tail=200 api >&2 || true
+  fi
+  exit "${status}"
+}
+trap report_failure EXIT
+
+"${compose[@]}" config --quiet
+"${compose[@]}" down --volumes --remove-orphans
+"${compose[@]}" up -d --build --wait \
+  postgres pgbouncer clickhouse valkey migrate api
+
+"${compose[@]}" exec -T api dev-hops fixtures generate \
+  --sink clickhouse://ch:ch@clickhouse:8123/default \
+  --org "${fixture_org_id}" \
+  --repo-name meridian/web-app \
+  --repo-count 1 \
+  --days 28 \
+  --commits-per-day 2 \
+  --pr-count 10 \
+  --team-count 3 \
+  --seed 3200 \
+  --with-metrics \
+  --with-work-graph
+
+ASK_DEV_LIVE_ACCEPTANCE=1 \
+ASK_DEV_ACCEPTANCE_API_URL=http://127.0.0.1:18081 \
+ASK_DEV_ACCEPTANCE_EXPECTED_MODEL="${model}" \
+TEST_SUPERUSER_EMAIL=admin@devhealth.example \
+TEST_SUPERUSER_PASSWORD=devhealth123 \
+PYTHONPATH="${ops_root}/src:${ops_root}" \
+  "${python_bin}" \
+  "${ops_root}/scripts/acceptance/prepare_ask_dev_acceptance.py"
+
+ASK_DEV_LIVE_ACCEPTANCE=1 \
+ASK_DEV_ACCEPTANCE_API_URL=http://127.0.0.1:18081 \
+ASK_DEV_ACCEPTANCE_EXPECTED_PROVIDER="${provider}" \
+ASK_DEV_ACCEPTANCE_EXPECTED_MODEL="${model}" \
+TEST_SUPERUSER_EMAIL=admin@devhealth.example \
+TEST_SUPERUSER_PASSWORD=devhealth123 \
+PYTHONPATH="${ops_root}/src:${ops_root}" \
+  "${python_bin}" \
+  "${ops_root}/scripts/acceptance/smoke_ask_dev_provider_profile.py"
+
+"${compose[@]}" down --volumes --remove-orphans
+trap - EXIT
+echo "Ask Dev ${profile} provider-profile acceptance completed successfully."

--- a/scripts/acceptance/smoke_ask_dev_provider_profile.py
+++ b/scripts/acceptance/smoke_ask_dev_provider_profile.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Exercise a live platform provider through the public Ask Dev REST/SSE API."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from dev_health_ops.api.dev.contracts import (
+    DevStreamEvent,
+    StreamEventType,
+    validate_stream,
+)
+from scripts.acceptance.prepare_ask_dev_acceptance import (
+    AcceptanceApi,
+    AcceptanceFailure,
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AcceptanceFailure(message)
+
+
+def _authenticate(api: AcceptanceApi, *, email: str, password: str) -> str:
+    login = api.request(
+        "POST",
+        "/api/v1/auth/login",
+        {"email": email, "password": password},
+    )
+    _require(isinstance(login, dict), "login response was not an object")
+    token = login.get("access_token")
+    user = login.get("user")
+    _require(isinstance(token, str) and bool(token), "login returned no access token")
+    _require(isinstance(user, dict), "login returned no user")
+    org_id = user.get("org_id")
+    _require(isinstance(org_id, str) and bool(org_id), "login returned no org_id")
+    api.token = token
+    return org_id
+
+
+def _scope(org_id: str) -> dict[str, Any]:
+    now = datetime.now(UTC).replace(microsecond=0)
+    current_start = now - timedelta(days=28)
+    comparison_start = current_start - timedelta(days=28)
+
+    def time_range(start: datetime, end: datetime) -> dict[str, str]:
+        return {
+            "start": start.isoformat().replace("+00:00", "Z"),
+            "end": end.isoformat().replace("+00:00", "Z"),
+            "timezone": "UTC",
+        }
+
+    return {
+        "schema_version": "dev_scope.v1",
+        "organization_id": org_id,
+        "direct_scope": "organization",
+        "repositories": [],
+        "entity_refs": [],
+        "team_ids": [],
+        "time_range": time_range(current_start, now),
+        "comparison_range": time_range(comparison_start, current_start),
+        "surface_context": {
+            "route_id": "diagnose_overview",
+            "entity_refs": [],
+            "filter_fingerprint": "provider_profile_acceptance",
+        },
+    }
+
+
+def _sse_request(
+    api: AcceptanceApi, path: str, payload: dict[str, Any]
+) -> list[DevStreamEvent]:
+    _require(api.token is not None, "SSE request requires authentication")
+    request = Request(
+        f"{api.base_url}{path}",
+        data=json.dumps(payload, separators=(",", ":")).encode(),
+        headers={
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {api.token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=180) as response:  # noqa: S310
+            content_type = response.headers.get_content_type()
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise AcceptanceFailure(
+            f"POST {path} returned HTTP {exc.code}: {detail}"
+        ) from exc
+    except URLError as exc:
+        raise AcceptanceFailure(f"POST {path} failed: {exc.reason}") from exc
+
+    _require(content_type == "text/event-stream", f"unexpected SSE type {content_type}")
+    events: list[DevStreamEvent] = []
+    for frame in body.split("\n\n"):
+        if not frame.strip():
+            continue
+        event_name: str | None = None
+        data_lines: list[str] = []
+        for line in frame.splitlines():
+            if line.startswith("event: "):
+                event_name = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                data_lines.append(line.removeprefix("data: "))
+        _require(event_name is not None, "SSE frame omitted event name")
+        _require(bool(data_lines), f"SSE {event_name} frame omitted data")
+        try:
+            raw = json.loads("\n".join(data_lines))
+            event = DevStreamEvent.model_validate(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise AcceptanceFailure(f"invalid SSE {event_name} frame: {exc}") from exc
+        _require(
+            event.event.value == event_name, "SSE event name disagreed with payload"
+        )
+        events.append(event)
+    try:
+        validate_stream(events)
+    except ValueError as exc:
+        raise AcceptanceFailure(f"invalid bounded Ask Dev stream: {exc}") from exc
+    return events
+
+
+def smoke(
+    api: AcceptanceApi,
+    *,
+    email: str,
+    password: str,
+    expected_provider: str,
+) -> tuple[str, str]:
+    org_id = _authenticate(api, email=email, password=password)
+    scope = _scope(org_id)
+    conversation = api.request(
+        "POST",
+        "/api/v1/dev/conversations",
+        {
+            "current_scope": scope,
+            "retention_days": 30,
+            "title": "Live provider acceptance",
+        },
+    )
+    _require(isinstance(conversation, dict), "conversation response was not an object")
+    conversation_id = conversation.get("conversation_id")
+    _require(
+        isinstance(conversation_id, str) and bool(conversation_id),
+        "conversation response returned no conversation_id",
+    )
+    request_id = str(uuid.uuid4())
+    events = _sse_request(
+        api,
+        f"/api/v1/dev/conversations/{conversation_id}/messages",
+        {
+            "schema_version": "dev_message_request.v1",
+            "request_id": request_id,
+            "client_message_id": str(uuid.uuid4()),
+            "conversation_id": conversation_id,
+            "question": (
+                "For this acceptance request, call only query_metric.v1 for "
+                "items_completed with comparison enabled and limit 5. Make exactly one tool call. "
+                "After that metric result is present, do not call another tool; return "
+                "a grounded final answer summarizing what changed in completed work."
+            ),
+            "question_class": "observed_change",
+            "scope": scope,
+            "requested_metric_ids": ["items_completed"],
+        },
+    )
+    completed = next(
+        (event for event in events if event.event is StreamEventType.ANSWER_COMPLETED),
+        None,
+    )
+    if completed is None or completed.answer is None:
+        failed = next(
+            (event for event in events if event.event is StreamEventType.ERROR), None
+        )
+        detail = "no answer completed"
+        if failed is not None and failed.error is not None:
+            detail = (
+                f"Ask Dev run failed with {failed.error.code}: "
+                f"{failed.error.safe_message}"
+            )
+        raise AcceptanceFailure(detail)
+    answer = completed.answer
+    _require(
+        answer.model.provider_source == "platform", "answer did not use platform LLM"
+    )
+    _require(
+        answer.model.provider_family == expected_provider,
+        (
+            f"answer provider was {answer.model.provider_family!r}, expected "
+            f"{expected_provider!r}"
+        ),
+    )
+    _require(bool(answer.direct_summary.strip()), "answer summary was empty")
+    _require(answer.status.value != "error", "Ask Dev returned an error answer")
+    _require(events[-1].terminal_kind == "answer", "stream did not terminate as answer")
+    return conversation_id, answer.answer_id
+
+
+def main() -> int:
+    if os.getenv("ASK_DEV_LIVE_ACCEPTANCE") != "1":
+        print("ASK_DEV_LIVE_ACCEPTANCE=1 is required", file=sys.stderr)
+        return 64
+    expected_provider = os.getenv("ASK_DEV_ACCEPTANCE_EXPECTED_PROVIDER", "").strip()
+    expected_model = os.getenv("ASK_DEV_ACCEPTANCE_EXPECTED_MODEL", "").strip()
+    if not expected_provider or not expected_model:
+        print(
+            "ASK_DEV_ACCEPTANCE_EXPECTED_PROVIDER and "
+            "ASK_DEV_ACCEPTANCE_EXPECTED_MODEL are required",
+            file=sys.stderr,
+        )
+        return 64
+    api = AcceptanceApi(
+        os.getenv("ASK_DEV_ACCEPTANCE_API_URL", "http://127.0.0.1:8000")
+    )
+    email = os.getenv("TEST_SUPERUSER_EMAIL", "admin@devhealth.example")
+    password = os.getenv("TEST_SUPERUSER_PASSWORD", "devhealth123")
+    try:
+        conversation_id, answer_id = smoke(
+            api,
+            email=email,
+            password=password,
+            expected_provider=expected_provider,
+        )
+    except AcceptanceFailure as exc:
+        print(f"Ask Dev live provider smoke failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "Ask Dev live provider smoke completed "
+        f"(provider={expected_provider}, model={expected_model}, "
+        f"conversation={conversation_id}, answer={answer_id})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -292,6 +292,24 @@ def _checked_at(value: str | None) -> datetime | None:
     return parsed
 
 
+def _failed_readiness_state(safe_error_code: str | None) -> tuple[ReadinessState, str]:
+    if safe_error_code == "provider_not_configured":
+        return (
+            "missing_credentials",
+            "Ask Dev could not authenticate with the configured model endpoint.",
+        )
+    if safe_error_code == "timeout":
+        return "degraded", "The configured Ask Dev model timed out during readiness."
+    if safe_error_code == "invalid_response":
+        return (
+            "unsupported_model",
+            "The configured model did not satisfy the Ask Dev agent capability contract.",
+        )
+    if safe_error_code == "provider_unavailable":
+        return "degraded", "The configured Ask Dev model endpoint is unavailable."
+    return "degraded", "The configured Ask Dev model failed readiness."
+
+
 async def _admin_response(
     session: AsyncSession,
     *,
@@ -341,8 +359,9 @@ async def _admin_response(
                 and readiness_record.readiness_version == READINESS_VERSION
                 and readiness_record.outcome is AgentReadinessOutcome.FAILED
             ):
-                readiness = "degraded"
-                failure_reason = "The configured Ask Dev model failed certification."
+                readiness, failure_reason = _failed_readiness_state(
+                    readiness_record.safe_error_code
+                )
             else:
                 readiness = "stale_readiness"
                 failure_reason = (

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -399,6 +399,7 @@ class DevOrchestrator:
         model_fingerprint: str | None = None
         prompt_checksum: str | None = None
         resolution: DevScopeResolution | None = None
+        provider_continuation: tuple[AgentMessage, ...] = ()
         terminal_written = False
         repair_count = 0
         retry_count = 0
@@ -542,6 +543,7 @@ class DevOrchestrator:
                 messages = (
                     AgentMessage(AgentMessageRole.SYSTEM, composed.system_text),
                     AgentMessage(AgentMessageRole.USER, composed.user_text),
+                    *provider_continuation,
                 )
                 tools = self._provider_tools()
                 while True:
@@ -658,6 +660,18 @@ class DevOrchestrator:
                         )
                     tool_results.append(execution.result)
                     tool_bytes_total = next_total
+                    provider_continuation += (
+                        AgentMessage(
+                            AgentMessageRole.ASSISTANT,
+                            "",
+                            tool_request=decision,
+                        ),
+                        AgentMessage(
+                            AgentMessageRole.TOOL,
+                            execution.result.model_dump_json(),
+                            tool_call_id=decision.call_id,
+                        ),
+                    )
                     await self._recorder.record_tool(
                         ordinal=len(tool_results) - 1,
                         request=tool_request,
@@ -682,12 +696,36 @@ class DevOrchestrator:
                         tool_results=tuple(tool_results),
                     )
                     candidate = dict(decision.value)
+                    canonical_data = self._canonical_answer_data(tuple(tool_results))
+                    if canonical_data is None:
+                        return await finish(
+                            RunState.FAILED,
+                            error=error(
+                                "answer_validation_failed",
+                                "The answer failed grounding validation.",
+                            ),
+                        )
+                    canonical_metrics, canonical_evidence = canonical_data
+                    now = datetime.now(UTC)
                     candidate.update(
                         {
                             "schema_version": "dev_answer.v1",
                             "answer_id": answer_id,
                             "conversation_id": conversation_id,
+                            "generated_at": now,
                             "resolved_scope": resolution.model_dump(mode="json"),
+                            "as_of": now,
+                            "metrics": [
+                                item.model_dump(mode="json")
+                                for item in canonical_metrics
+                            ],
+                            "evidence": [
+                                item.model_dump(mode="json")
+                                for item in canonical_evidence
+                            ],
+                            "coverage": self._coverage_from_tool_results(
+                                tuple(tool_results), now
+                            ).model_dump(mode="json"),
                             "versions": self._versions.model_dump(mode="json"),
                             "model": model.model_dump(mode="json"),
                         }
@@ -889,11 +927,48 @@ class DevOrchestrator:
             AgentToolDefinition(
                 tool_id=str(item["tool_id"]),
                 description=str(item["description"]),
-                input_schema=DevToolRequest.model_json_schema(mode="validation"),
+                input_schema=self._provider_tool_input_schema(
+                    ToolID(str(item["tool_id"])), int(item["max_items"])
+                ),
             )
             for item in tools
             if isinstance(item, Mapping)
         )
+
+    @staticmethod
+    def _provider_tool_input_schema(tool_id: ToolID, max_items: int) -> dict[str, Any]:
+        """Expose only model-owned arguments accepted by the exact tool contract."""
+
+        properties: dict[str, Any] = {
+            "limit": {"type": "integer", "enum": list(range(1, max_items + 1))}
+        }
+        if tool_id is ToolID.QUERY_METRIC:
+            properties = {
+                "metric_id": {"type": "string"},
+                "include_comparison": {"type": "boolean"},
+                **properties,
+            }
+        elif tool_id in {ToolID.RESOLVE_SCOPE, ToolID.SEARCH_EVIDENCE}:
+            properties = {"query": {"type": "string"}, **properties}
+        elif tool_id is ToolID.GET_EVIDENCE:
+            properties = {
+                "evidence_ref_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                **properties,
+            }
+        elif tool_id in {ToolID.STATUS_SNAPSHOT, ToolID.CHANGE_SUMMARY}:
+            properties = {
+                "include_comparison": {"type": "boolean"},
+                **properties,
+            }
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": properties,
+            "required": sorted(properties),
+        }
 
     def _budget_answer(
         self,
@@ -906,30 +981,12 @@ class DevOrchestrator:
     ) -> DevAnswer | None:
         """Return only canonical retrieved data when a later model call is blocked."""
 
-        evidence: dict[str, DevEvidenceRef] = {}
-        metrics: dict[str, DevMetricRef] = {}
-        for result in tool_results:
-            for evidence_item in result.evidence:
-                current_evidence = evidence.setdefault(
-                    evidence_item.evidence_ref_id, evidence_item
-                )
-                if current_evidence != evidence_item:
-                    return None
-            for metric_item in result.metrics:
-                current_metric = metrics.setdefault(
-                    metric_item.metric_ref_id, metric_item
-                )
-                if current_metric != metric_item:
-                    return None
-        if not evidence and not metrics:
+        canonical_data = self._canonical_answer_data(tool_results)
+        if canonical_data is None:
             return None
-        canonical_evidence = list(evidence.values())[: self._limits.evidence_refs]
-        allowed_evidence_ids = {item.evidence_ref_id for item in canonical_evidence}
-        canonical_metrics = [
-            item
-            for item in metrics.values()
-            if set(item.evidence_ref_ids) <= allowed_evidence_ids
-        ][: self._limits.metrics]
+        canonical_metrics, canonical_evidence = canonical_data
+        if not canonical_evidence and not canonical_metrics:
+            return None
         now = datetime.now(UTC)
         degraded = any(
             result.status in {"unavailable", "error"} for result in tool_results
@@ -967,6 +1024,58 @@ class DevOrchestrator:
                 provider_family=self._provider_family,
                 model_fingerprint=model_fingerprint,
             ),
+        )
+
+    def _canonical_answer_data(
+        self, tool_results: tuple[DevToolResult, ...]
+    ) -> tuple[list[DevMetricRef], list[DevEvidenceRef]] | None:
+        evidence: dict[str, DevEvidenceRef] = {}
+        metrics: dict[str, DevMetricRef] = {}
+        for result in tool_results:
+            for evidence_item in result.evidence:
+                current_evidence = evidence.setdefault(
+                    evidence_item.evidence_ref_id, evidence_item
+                )
+                if current_evidence != evidence_item:
+                    return None
+            for metric_item in result.metrics:
+                current_metric = metrics.setdefault(
+                    metric_item.metric_ref_id, metric_item
+                )
+                if current_metric != metric_item:
+                    return None
+        canonical_evidence = list(evidence.values())[: self._limits.evidence_refs]
+        allowed_evidence_ids = {item.evidence_ref_id for item in canonical_evidence}
+        canonical_metrics = [
+            item
+            for item in metrics.values()
+            if set(item.evidence_ref_ids) <= allowed_evidence_ids
+        ][: self._limits.metrics]
+        return canonical_metrics, canonical_evidence
+
+    @staticmethod
+    def _coverage_from_tool_results(
+        tool_results: tuple[DevToolResult, ...], as_of: datetime
+    ) -> DevCoverage:
+        available = [
+            result for result in tool_results if result.status in {"success", "partial"}
+        ]
+        unavailable = [
+            result.tool_id.value
+            for result in tool_results
+            if result.status in {"unavailable", "error"}
+        ]
+        stale = [
+            result.tool_id.value
+            for result in tool_results
+            if any(item.freshness == "stale" for item in result.data_health)
+        ]
+        return DevCoverage(
+            required_source_count=len(tool_results),
+            available_source_count=len(available),
+            unavailable_required_sources=sorted(set(unavailable)),
+            stale_required_sources=sorted(set(stale)),
+            as_of=as_of,
         )
 
     @staticmethod

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -33,8 +33,37 @@ from .errors import (
     safe_agent_provider_error,
 )
 
-READINESS_VERSION = "ask-dev-agent-v1"
+READINESS_VERSION = "ask-dev-agent-v2"
 PLATFORM_PRICE_BOOK_VERSION = "openai-2026-07-29"
+
+_DECISION_FIELDS = frozenset(
+    {
+        "kind",
+        "tool_id",
+        "arguments",
+        "call_id",
+        "value",
+        "prompt",
+        "candidates",
+        "code",
+        "message",
+    }
+)
+
+_STRUCTURAL_SCHEMA_KEYS = frozenset(
+    {
+        "$defs",
+        "$ref",
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "items",
+        "anyOf",
+        "enum",
+        "const",
+    }
+)
 
 # Server-owned conservative prices in microUSD per million tokens. Cached input
 # is intentionally charged at the full input rate because the normalized usage
@@ -68,7 +97,7 @@ def _estimated_cost_microusd(
 
 
 class OpenAICompatibleAgentProvider:
-    """Normalize a native tool-capable OpenAI-compatible endpoint."""
+    """Normalize native and JSON tool decisions from OpenAI-compatible endpoints."""
 
     def __init__(
         self,
@@ -132,23 +161,31 @@ class OpenAICompatibleAgentProvider:
             )
         started = time.monotonic()
         create_completion = cast(Any, self._client.chat.completions.create)
-        provider_task = asyncio.create_task(
-            create_completion(
-                model=self.model,
-                messages=[self._message_payload(item) for item in messages],
-                tools=[self._tool_payload(item) for item in tools] or None,
-                tool_choice="auto" if tools else None,
-                response_format={
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": "ask_dev_decision",
-                        "strict": True,
-                        "schema": dict(response_schema),
-                    },
-                },
-                max_completion_tokens=max_output_tokens,
-            )
+        allow_final_answer = not tools or any(
+            message.role is AgentMessageRole.TOOL for message in messages
         )
+        completion_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": [self._message_payload(item) for item in messages],
+            "tools": [self._tool_payload(item) for item in tools] or None,
+            "tool_choice": "auto" if tools else None,
+            "temperature": 0,
+            "max_completion_tokens": max_output_tokens,
+        }
+        if allow_final_answer:
+            completion_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ask_dev_decision",
+                    "strict": True,
+                    "schema": self._decision_response_schema(
+                        self._answer_draft_schema(response_schema),
+                        tools,
+                        allow_final_answer=True,
+                    ),
+                },
+            }
+        provider_task = asyncio.create_task(create_completion(**completion_kwargs))
         cancel_task = asyncio.create_task(signal.wait()) if signal is not None else None
         try:
             waiters = {provider_task}
@@ -176,7 +213,9 @@ class OpenAICompatibleAgentProvider:
                 await asyncio.gather(cancel_task, return_exceptions=True)
 
         try:
-            decision = self._normalize_response(response)
+            decision = self._normalize_response(
+                response, allowed_tool_ids=frozenset(item.tool_id for item in tools)
+            )
         except (
             AttributeError,
             IndexError,
@@ -245,42 +284,307 @@ class OpenAICompatibleAgentProvider:
             "function": {
                 "name": tool.tool_id,
                 "description": tool.description,
-                "parameters": dict(tool.input_schema),
+                "parameters": OpenAICompatibleAgentProvider._structural_schema(
+                    tool.input_schema
+                ),
                 "strict": True,
             },
         }
 
     @staticmethod
-    def _normalize_response(response: Any) -> Any:
+    def _decision_response_schema(
+        response_schema: Mapping[str, Any],
+        tools: Sequence[AgentToolDefinition],
+        *,
+        allow_final_answer: bool = True,
+    ) -> dict[str, Any]:
+        """Describe every decision in OpenAI's supported root-object subset."""
+
+        final_value_schema = OpenAICompatibleAgentProvider._structural_schema(
+            response_schema
+        )
+        definitions: dict[str, Any] = {}
+        OpenAICompatibleAgentProvider._merge_definitions(
+            definitions, final_value_schema.pop("$defs", None)
+        )
+        argument_schemas: list[dict[str, Any]] = []
+        for tool in tools:
+            arguments_schema = OpenAICompatibleAgentProvider._structural_schema(
+                tool.input_schema
+            )
+            OpenAICompatibleAgentProvider._merge_definitions(
+                definitions, arguments_schema.pop("$defs", None)
+            )
+            argument_schemas.append(arguments_schema)
+
+        nullable_arguments: dict[str, Any]
+        if argument_schemas:
+            nullable_arguments = {"anyOf": [*argument_schemas, {"type": "null"}]}
+        else:
+            nullable_arguments = {"type": "null"}
+
+        schema: dict[str, Any] = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(_DECISION_FIELDS),
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        *(["tool_request"] if tools else []),
+                        *(["final_answer"] if allow_final_answer else []),
+                        "disambiguation",
+                        "refusal",
+                    ],
+                },
+                "tool_id": {
+                    "type": ["string", "null"],
+                    "enum": [*(tool.tool_id for tool in tools), None],
+                },
+                "arguments": nullable_arguments,
+                "call_id": {
+                    "anyOf": [
+                        {"type": "string", "minLength": 1, "maxLength": 256},
+                        {"type": "null"},
+                    ]
+                },
+                "value": (
+                    {"anyOf": [final_value_schema, {"type": "null"}]}
+                    if allow_final_answer
+                    else {"type": "null"}
+                ),
+                "prompt": {"type": ["string", "null"]},
+                "candidates": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "null"},
+                    ]
+                },
+                "code": {"type": ["string", "null"]},
+                "message": {"type": ["string", "null"]},
+            },
+        }
+        if definitions:
+            schema["$defs"] = definitions
+        return OpenAICompatibleAgentProvider._structural_schema(schema)
+
+    @staticmethod
+    def _structural_schema(schema: Mapping[str, Any]) -> dict[str, Any]:
+        """Project runtime-validated JSON Schema into provider grammar syntax."""
+
+        def project(node: Any) -> Any:
+            if isinstance(node, list):
+                return [project(item) for item in node]
+            if not isinstance(node, Mapping):
+                return node
+            result: dict[str, Any] = {}
+            for key, value in node.items():
+                if key not in _STRUCTURAL_SCHEMA_KEYS:
+                    continue
+                if key in {"$defs", "properties"} and isinstance(value, Mapping):
+                    result[key] = {
+                        str(name): project(definition)
+                        for name, definition in value.items()
+                    }
+                else:
+                    result[key] = project(value)
+            properties = result.get("properties")
+            if isinstance(properties, Mapping):
+                result["additionalProperties"] = False
+                result["required"] = sorted(str(name) for name in properties)
+            return result
+
+        return cast(dict[str, Any], project(schema))
+
+    @staticmethod
+    def _answer_draft_schema(schema: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Remove server-owned/defaulted DevAnswer fields from provider grammar."""
+
+        properties = schema.get("properties")
+        if not isinstance(properties, Mapping):
+            return schema
+        draft_fields = {
+            "status",
+            "direct_summary",
+        }
+        if not draft_fields.issubset(properties):
+            return schema
+
+        selected_properties = {
+            field: properties[field] for field in sorted(draft_fields)
+        }
+        definitions = schema.get("$defs")
+        selected_definitions: dict[str, Any] = {}
+        pending: list[Any] = list(selected_properties.values())
+        while pending:
+            node = pending.pop()
+            if isinstance(node, Mapping):
+                reference = node.get("$ref")
+                if isinstance(reference, str) and reference.startswith("#/$defs/"):
+                    name = reference.removeprefix("#/$defs/")
+                    if (
+                        name not in selected_definitions
+                        and isinstance(definitions, Mapping)
+                        and name in definitions
+                    ):
+                        definition = definitions[name]
+                        selected_definitions[name] = definition
+                        pending.append(definition)
+                pending.extend(node.values())
+            elif isinstance(node, list):
+                pending.extend(node)
+
+        draft: dict[str, Any] = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": selected_properties,
+            "required": sorted(draft_fields),
+        }
+        if selected_definitions:
+            draft["$defs"] = selected_definitions
+        return draft
+
+    @staticmethod
+    def _merge_definitions(target: dict[str, Any], incoming: object | None) -> None:
+        if incoming is None:
+            return
+        if not isinstance(incoming, Mapping):
+            raise ValueError("JSON schema definitions must be an object")
+        for name, definition in incoming.items():
+            existing = target.get(str(name))
+            if existing is not None and existing != definition:
+                raise ValueError("conflicting JSON schema definitions")
+            target[str(name)] = definition
+
+    @staticmethod
+    def _normalize_response(response: Any, *, allowed_tool_ids: frozenset[str]) -> Any:
         message = response.choices[0].message
         tool_calls = getattr(message, "tool_calls", None) or []
         if len(tool_calls) > 1:
             raise ValueError("only one tool decision is allowed")
         if tool_calls:
             call = tool_calls[0]
+            tool_id = str(call.function.name)
+            if tool_id not in allowed_tool_ids:
+                raise ValueError("tool decision is not registered")
+            arguments = json.loads(call.function.arguments)
+            if not isinstance(arguments, dict):
+                raise ValueError("tool arguments must be an object")
+            call_id = str(call.id)
+            if not call_id:
+                raise ValueError("tool decision requires a call ID")
             return AgentToolRequest(
-                tool_id=str(call.function.name),
-                arguments=json.loads(call.function.arguments),
-                call_id=str(call.id),
+                tool_id=tool_id,
+                arguments=arguments,
+                call_id=call_id,
             )
         payload = json.loads(str(message.content or ""))
+        if not isinstance(payload, dict):
+            raise ValueError("agent decision must be an object")
         kind = payload.get("kind")
+        if kind == "tool_request":
+            return OpenAICompatibleAgentProvider._json_tool_request(
+                payload, allowed_tool_ids=allowed_tool_ids
+            )
         if kind == "final_answer":
+            OpenAICompatibleAgentProvider._validate_envelope_fields(
+                payload,
+                compact_fields={"kind", "value"},
+            )
             value = payload.get("value")
             if not isinstance(value, dict):
                 raise ValueError("final answer must be an object")
+            legacy_tool = OpenAICompatibleAgentProvider._legacy_json_tool_request(
+                value, allowed_tool_ids=allowed_tool_ids
+            )
+            if legacy_tool is not None:
+                return legacy_tool
             return AgentFinalAnswer(value=value)
         if kind == "disambiguation":
-            candidates = payload.get("candidates") or []
+            OpenAICompatibleAgentProvider._validate_envelope_fields(
+                payload,
+                compact_fields={"kind", "prompt", "candidates"},
+            )
+            candidates = payload.get("candidates")
+            if not isinstance(payload.get("prompt"), str) or not isinstance(
+                candidates, list
+            ):
+                raise ValueError("invalid disambiguation decision")
+            if not all(isinstance(item, str) for item in candidates):
+                raise ValueError("invalid disambiguation candidates")
             return AgentDisambiguation(
                 prompt=str(payload["prompt"]),
                 candidates=tuple(str(item) for item in candidates),
             )
         if kind == "refusal":
+            OpenAICompatibleAgentProvider._validate_envelope_fields(
+                payload,
+                compact_fields={"kind", "code", "message"},
+            )
+            if not isinstance(payload.get("code"), str) or not isinstance(
+                payload.get("message"), str
+            ):
+                raise ValueError("invalid refusal decision")
             return AgentRefusal(
                 code=str(payload["code"]), message=str(payload["message"])
             )
         raise ValueError("unknown agent decision")
+
+    @staticmethod
+    def _json_tool_request(
+        payload: Mapping[str, Any], *, allowed_tool_ids: frozenset[str]
+    ) -> AgentToolRequest:
+        OpenAICompatibleAgentProvider._validate_envelope_fields(
+            payload,
+            compact_fields={"kind", "tool_id", "arguments", "call_id"},
+        )
+        tool_id = payload.get("tool_id")
+        arguments = payload.get("arguments")
+        call_id = payload.get("call_id")
+        if not isinstance(tool_id, str) or tool_id not in allowed_tool_ids:
+            raise ValueError("tool decision is not registered")
+        if not isinstance(arguments, dict):
+            raise ValueError("tool arguments must be an object")
+        if not isinstance(call_id, str) or not call_id:
+            raise ValueError("tool decision requires a call ID")
+        return AgentToolRequest(tool_id, arguments, call_id)
+
+    @staticmethod
+    def _validate_envelope_fields(
+        payload: Mapping[str, Any],
+        *,
+        compact_fields: set[str],
+    ) -> None:
+        fields = set(payload)
+        if fields == compact_fields:
+            return
+        if fields != _DECISION_FIELDS:
+            raise ValueError("invalid agent decision fields")
+
+    @staticmethod
+    def _legacy_json_tool_request(
+        value: Mapping[str, Any], *, allowed_tool_ids: frozenset[str]
+    ) -> AgentToolRequest | None:
+        """Normalize the exact LM Studio envelope produced by the old bad schema."""
+
+        if set(value) != {"tool_call"}:
+            return None
+        tool_call = value.get("tool_call")
+        if not isinstance(tool_call, dict) or set(tool_call) != {"name", "args"}:
+            raise ValueError("invalid JSON tool decision")
+        tool_id = tool_call.get("name")
+        arguments = tool_call.get("args")
+        if not isinstance(tool_id, str) or tool_id not in allowed_tool_ids:
+            raise ValueError("tool decision is not registered")
+        if not isinstance(arguments, dict):
+            raise ValueError("tool arguments must be an object")
+        canonical = json.dumps(
+            {"tool_id": tool_id, "arguments": arguments},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        call_id = "json-call-" + hashlib.sha256(canonical.encode()).hexdigest()[:16]
+        return AgentToolRequest(tool_id, arguments, call_id)
 
     async def aclose(self) -> None:
         close = getattr(self._client, "close", None)

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -31,6 +31,7 @@ from .errors import (
 )
 
 READINESS_SETTING_KEY = "ask_dev_agent_readiness"
+READINESS_MAX_OUTPUT_TOKENS = 512
 
 
 class AgentReadinessOutcome(str, Enum):
@@ -116,7 +117,7 @@ class AgentReadinessService:
         provider_name: str,
         model: str,
         fingerprint: str,
-        timeout_seconds: float = 10,
+        timeout_seconds: float = 30,
         signal: CancellationSignal | None = None,
     ) -> AgentReadinessRecord:
         usage = AgentUsage()
@@ -134,11 +135,8 @@ class AgentReadinessService:
             response_schema: Mapping[str, object] = {
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["kind", "value"],
-                "properties": {
-                    "kind": {"const": "final_answer"},
-                    "value": {"type": "object"},
-                },
+                "required": ["nonce"],
+                "properties": {"nonce": {"const": "ready-v1"}},
             }
             first = await provider.decide(
                 [
@@ -150,7 +148,7 @@ class AgentReadinessService:
                 [tool],
                 response_schema,
                 timeout_seconds,
-                128,
+                READINESS_MAX_OUTPUT_TOKENS,
                 signal,
             )
             usage = _add_usage(usage, first.usage)
@@ -176,15 +174,24 @@ class AgentReadinessService:
                         '{"nonce":"ready-v1"}',
                         tool_call_id=first.decision.call_id,
                     ),
+                    AgentMessage(
+                        AgentMessageRole.USER,
+                        (
+                            "Return a final_answer now with value exactly "
+                            '{"nonce":"ready-v1"}. Do not request another tool.'
+                        ),
+                    ),
                 ],
-                [tool],
+                [],
                 response_schema,
                 timeout_seconds,
-                128,
+                READINESS_MAX_OUTPUT_TOKENS,
                 signal,
             )
             usage = _add_usage(usage, second.usage)
             if not isinstance(second.decision, AgentFinalAnswer):
+                raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+            if second.decision.value != {"nonce": "ready-v1"}:
                 raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
             record = AgentReadinessRecord(
                 fingerprint=fingerprint,

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -43,6 +43,19 @@ def _tool_results_from_messages(payload: dict[str, Any]) -> list[dict[str, Any]]
     return []
 
 
+def _requested_tool_names_from_messages(payload: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for message in payload.get("messages") or []:
+        if message.get("role") != "assistant":
+            continue
+        for call in message.get("tool_calls") or []:
+            function = call.get("function") or {}
+            name = function.get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
 def _acceptance_answer(tool_results: list[dict[str, Any]]) -> dict[str, Any]:
     now = datetime.now(UTC).isoformat()
     available_tool_ids = {
@@ -207,6 +220,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
         self.server.requests.append(payload)
         tool_names = [item["function"]["name"] for item in payload.get("tools") or []]
         tool_results = _tool_results_from_messages(payload)
+        requested_tool_names = _requested_tool_names_from_messages(payload)
         result_tool_ids = {str(result.get("tool_id") or "") for result in tool_results}
         if not tool_results:
             arguments: dict[str, Any]
@@ -295,7 +309,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
         else:
             value = (
                 {"nonce": "ready-v1"}
-                if "readiness_echo" in tool_names
+                if "readiness_echo" in requested_tool_names
                 else _acceptance_answer(tool_results)
             )
             message = {

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -37,7 +37,7 @@ _API_KEY_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     "gemini": ("LLM_API_KEY", "GEMINI_API_KEY"),
     "qwen": ("LLM_API_KEY", "QWEN_API_KEY", "DASHSCOPE_API_KEY"),
     "local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
-    "ollama": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "ollama": ("OLLAMA_API_KEY", "LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "lmstudio": ("LMSTUDIO_API_KEY", "LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -44,3 +44,61 @@ The provider has no published host port. It exists only in the
 `ask-dev-acceptance` profile on the internal `ask-dev-acceptance` network. A
 successful run removes the dedicated acceptance project and volumes; a failed
 run retains them and prints recent Ops, provider, and Web logs for diagnosis.
+
+## Live provider profiles
+
+Live provider smokes supplement the deterministic oracle above; they never
+replace it as the release gate. Each profile starts a disposable Ops stack,
+generates the same seeded organization data, enables Ask Dev through the public
+admin API, and invokes the real administrator readiness action. Readiness proves
+the OpenAI-compatible structured-output turn and its tool-result continuation.
+The smoke then creates a conversation and requires a bounded, contract-valid
+`answer.completed` event from the real `/api/v1/dev/**` REST/SSE surface with
+`provider_source=platform`. A selected profile fails on missing configuration,
+provider errors, invalid output, or an error terminal; it never turns those
+conditions into a skip.
+
+For the current local LM Studio profile, LM Studio is listening on the host at
+`127.0.0.1:1234` with `google/gemma-4-e4b` loaded. The launcher maps the host
+endpoint to Compose and deliberately selects the platform `local` environment
+bundle used by normal deployments:
+
+```console
+scripts/acceptance/run_ask_dev_provider_profile.sh --profile lmstudio-local
+```
+
+Override either exact value only when intentionally validating another loaded
+model or endpoint:
+
+```console
+ASK_DEV_PROVIDER_MODEL=my/model \
+ASK_DEV_PROVIDER_BASE_URL=http://host.docker.internal:1234/v1 \
+  scripts/acceptance/run_ask_dev_provider_profile.sh --profile lmstudio-local
+```
+
+For a local Ollama daemon, provide the exact installed model. Ollama's documented
+OpenAI-compatible default is `http://localhost:11434/v1`; the Compose profile
+uses the equivalent host bridge address:
+
+```console
+ASK_DEV_PROVIDER_MODEL=qwen3:8b \
+  scripts/acceptance/run_ask_dev_provider_profile.sh --profile ollama-local
+```
+
+Ollama Cloud is opt-in and requires both an exact cloud model and an
+`OLLAMA_API_KEY` injected by the operator's shell credential store or CI secret.
+Do not put the key in a command-line argument or checked-in environment file.
+The profile uses the OpenAI-compatible `https://ollama.com/v1` endpoint unless
+`ASK_DEV_PROVIDER_BASE_URL` explicitly overrides it:
+
+```console
+export OLLAMA_API_KEY
+ASK_DEV_PROVIDER_MODEL=gpt-oss:120b-cloud \
+  scripts/acceptance/run_ask_dev_provider_profile.sh --profile ollama-cloud
+```
+
+Local Ollama and Ollama Cloud use the `OLLAMA_*` platform aliases; LM Studio's
+validated `local` profile uses `LOCAL_LLM_*`. The overlay also sets the generic
+`LLM_MODEL` and `LLM_BASE_URL` to the same values and clears unrelated provider
+aliases, so the smoke proves the documented source-bound environment resolution
+instead of inheriting a developer's unrelated `.env` provider.

--- a/tests/acceptance/compose.ask-dev-provider-profile.yml
+++ b/tests/acceptance/compose.ask-dev-provider-profile.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    ports: !reset []
+
+  pgbouncer:
+    ports: !reset []
+
+  clickhouse:
+    ports: !reset []
+
+  valkey:
+    ports: !reset []
+
+  migrate:
+    environment:
+      DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER: "1"
+
+  api:
+    ports: !override
+      - "127.0.0.1:18081:8000"
+    environment:
+      ENVIRONMENT: acceptance
+      ASK_DEV_LIVE_ACCEPTANCE: "0"
+      JWT_SECRET_KEY: ask-dev-provider-profile-jwt-secret-key-v1
+      LLM_PROVIDER: ${ASK_DEV_PROFILE_PROVIDER:?select a provider profile through the launcher}
+      LLM_MODEL: ${ASK_DEV_PROFILE_MODEL:?select a model through the launcher}
+      LLM_BASE_URL: ${ASK_DEV_PROFILE_BASE_URL:?select a base URL through the launcher}
+      LLM_API_KEY: ""
+      LOCAL_LLM_BASE_URL: ${ASK_DEV_PROFILE_LOCAL_BASE_URL:-}
+      LOCAL_LLM_MODEL: ${ASK_DEV_PROFILE_LOCAL_MODEL:-}
+      LOCAL_LLM_API_KEY: ""
+      OLLAMA_BASE_URL: ${ASK_DEV_PROFILE_OLLAMA_BASE_URL:-}
+      OLLAMA_MODEL: ${ASK_DEV_PROFILE_OLLAMA_MODEL:-}
+      OLLAMA_API_KEY: ${ASK_DEV_PROFILE_OLLAMA_API_KEY:-}
+      LMSTUDIO_BASE_URL: ""
+      LMSTUDIO_MODEL: ""
+      LMSTUDIO_API_KEY: ""
+      OPENAI_BASE_URL: ""
+      OPENAI_API_KEY: ""
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -156,8 +156,14 @@ def test_readiness_bootstrap_uses_public_http_contracts() -> None:
 class _FakeAcceptanceApi:
     token: str | None = None
 
-    def __init__(self, *, disabled_key: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        disabled_key: str | None = None,
+        model: str = "ask-dev-scripted-v1",
+    ) -> None:
         self.disabled_key = disabled_key
+        self.model = model
         self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
 
     def request(
@@ -198,7 +204,7 @@ class _FakeAcceptanceApi:
                 "full_page_available": True,
                 "provider_source": "platform",
                 "readiness": "ready",
-                "effective_model_label": "ask-dev-scripted-v1",
+                "effective_model_label": self.model,
                 "readiness_checked_at": "2026-07-29T00:00:00+00:00",
             }
         if path == "/api/v1/dev/capabilities":
@@ -211,7 +217,7 @@ class _FakeAcceptanceApi:
                 "evidence_resolver": True,
                 "provider_source": "platform",
                 "readiness": "ready",
-                "effective_model_label": "ask-dev-scripted-v1",
+                "effective_model_label": self.model,
             }
         raise AssertionError(f"unexpected request: {method} {path}")
 
@@ -237,3 +243,14 @@ def test_readiness_bootstrap_fails_closed_on_global_kill_switch() -> None:
     api = _FakeAcceptanceApi(disabled_key="ask_dev")
     with pytest.raises(AcceptanceFailure, match="globally disabled: ask_dev"):
         prepare(api, email="admin@devhealth.example", password="devhealth123")  # type: ignore[arg-type]
+
+
+def test_readiness_bootstrap_accepts_an_exact_live_profile_model() -> None:
+    api = _FakeAcceptanceApi(model="google/gemma-4-e4b")
+    org_id = prepare(
+        api,  # type: ignore[arg-type]
+        email="admin@devhealth.example",
+        password="devhealth123",
+        expected_model="google/gemma-4-e4b",
+    )
+    assert org_id == "0a155cab-8833-42ac-a4ef-0d121725a7b0"

--- a/tests/acceptance/test_ask_dev_provider_profiles.py
+++ b/tests/acceptance/test_ask_dev_provider_profiles.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_OVERLAY = _ROOT / "tests" / "acceptance" / "compose.ask-dev-provider-profile.yml"
+_LAUNCHER = _ROOT / "scripts" / "acceptance" / "run_ask_dev_provider_profile.sh"
+_SMOKE = _ROOT / "scripts" / "acceptance" / "smoke_ask_dev_provider_profile.py"
+
+
+class _ComposeLoader(yaml.SafeLoader):
+    pass
+
+
+_ComposeLoader.add_constructor(
+    "!reset", lambda loader, node: loader.construct_sequence(node)
+)
+_ComposeLoader.add_constructor(
+    "!override", lambda loader, node: loader.construct_sequence(node)
+)
+
+
+def _load_overlay() -> dict[str, Any]:
+    return yaml.load(_OVERLAY.read_text(encoding="utf-8"), Loader=_ComposeLoader)
+
+
+def test_provider_profile_overlay_passes_source_bound_platform_bundles() -> None:
+    api = _load_overlay()["services"]["api"]
+    environment = api["environment"]
+    assert environment["ASK_DEV_LIVE_ACCEPTANCE"] == "0"
+    assert environment["LLM_PROVIDER"].startswith("${ASK_DEV_PROFILE_PROVIDER:?")
+    assert environment["LLM_MODEL"].startswith("${ASK_DEV_PROFILE_MODEL:?")
+    assert environment["LLM_BASE_URL"].startswith("${ASK_DEV_PROFILE_BASE_URL:?")
+    assert environment["LOCAL_LLM_BASE_URL"] == ("${ASK_DEV_PROFILE_LOCAL_BASE_URL:-}")
+    assert environment["LOCAL_LLM_MODEL"] == "${ASK_DEV_PROFILE_LOCAL_MODEL:-}"
+    assert environment["OLLAMA_BASE_URL"] == ("${ASK_DEV_PROFILE_OLLAMA_BASE_URL:-}")
+    assert environment["OLLAMA_MODEL"] == "${ASK_DEV_PROFILE_OLLAMA_MODEL:-}"
+    assert environment["OLLAMA_API_KEY"] == ("${ASK_DEV_PROFILE_OLLAMA_API_KEY:-}")
+    assert environment["LMSTUDIO_BASE_URL"] == ""
+    assert environment["OPENAI_API_KEY"] == ""
+    assert api["extra_hosts"] == ["host.docker.internal:host-gateway"]
+    assert api["ports"] == ["127.0.0.1:18081:8000"]
+
+
+def test_launcher_has_three_explicit_non_skipping_profiles() -> None:
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    assert "lmstudio-local)" in launcher
+    assert "ollama-local)" in launcher
+    assert "ollama-cloud)" in launcher
+    assert 'provider="local"' in launcher
+    assert 'model="${ASK_DEV_PROVIDER_MODEL:-google/gemma-4-e4b}"' in launcher
+    assert "http://host.docker.internal:1234/v1" in launcher
+    assert "http://host.docker.internal:11434/v1" in launcher
+    assert "https://ollama.com/v1" in launcher
+    assert "OLLAMA_API_KEY is required" in launcher
+    assert "ASK_DEV_PROVIDER_MODEL is required" in launcher
+    assert "prepare_ask_dev_acceptance.py" in launcher
+    assert "smoke_ask_dev_provider_profile.py" in launcher
+    assert "ASK_DEV_ACCEPTANCE_EXPECTED_MODEL" in launcher
+    assert "skip" not in launcher.lower()
+
+
+def test_selected_cloud_profile_fails_before_compose_without_secret() -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), "--profile", "ollama-cloud"],
+        cwd=_ROOT,
+        env={"PATH": "/usr/bin:/bin", "ASK_DEV_PROVIDER_MODEL": "cloud-model"},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 64
+    assert "OLLAMA_API_KEY is required" in result.stderr
+
+
+def test_selected_ollama_local_profile_fails_before_compose_without_model() -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), "--profile", "ollama-local"],
+        cwd=_ROOT,
+        env={"PATH": "/usr/bin:/bin"},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 64
+    assert "ASK_DEV_PROVIDER_MODEL is required" in result.stderr
+
+
+def test_live_smoke_uses_public_conversation_and_bounded_sse_contract() -> None:
+    smoke = _SMOKE.read_text(encoding="utf-8")
+    assert "/api/v1/dev/conversations" in smoke
+    assert "text/event-stream" in smoke
+    assert "DevStreamEvent.model_validate" in smoke
+    assert "validate_stream(events)" in smoke
+    assert "StreamEventType.ANSWER_COMPLETED" in smoke
+    assert 'answer.model.provider_source == "platform"' in smoke
+    assert "answer.model.provider_family == expected_provider" in smoke
+    assert 'answer.status.value != "error"' in smoke

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -81,7 +81,7 @@ class FakeReadinessProvider:
                 model_fingerprint="model",
             )
         return AgentDecisionResult(
-            decision=AgentFinalAnswer(value={}),
+            decision=AgentFinalAnswer(value={"nonce": "ready-v1"}),
             usage=AgentUsage(input_tokens=4, output_tokens=1),
             latency_ms=1,
             provider_fingerprint="provider",
@@ -214,6 +214,30 @@ async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context)
         "conversation",
     ):
         assert forbidden not in serialized
+
+
+@pytest.mark.parametrize(
+    ("safe_error_code", "state", "message"),
+    [
+        (
+            "provider_not_configured",
+            "missing_credentials",
+            "could not authenticate",
+        ),
+        ("timeout", "degraded", "timed out"),
+        ("invalid_response", "unsupported_model", "capability contract"),
+        ("provider_unavailable", "degraded", "endpoint is unavailable"),
+    ],
+)
+def test_failed_readiness_exposes_only_specific_safe_remediation(
+    safe_error_code: str, state: str, message: str
+) -> None:
+    readiness, reason = ask_dev_admin._failed_readiness_state(safe_error_code)
+
+    assert readiness == state
+    assert message in reason
+    assert "api_key" not in reason
+    assert "base_url" not in reason
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -80,6 +80,28 @@ def _fingerprint(script_id: str) -> str:
     return hashlib.sha256(script_id.encode()).hexdigest()[:24]
 
 
+def test_provider_tool_schema_exposes_only_registered_model_arguments() -> None:
+    metric = DevOrchestrator._provider_tool_input_schema(ToolID.QUERY_METRIC, 12)
+    evidence = DevOrchestrator._provider_tool_input_schema(ToolID.SEARCH_EVIDENCE, 25)
+
+    assert set(metric["properties"]) == {
+        "metric_id",
+        "include_comparison",
+        "limit",
+    }
+    assert metric["properties"]["limit"]["enum"] == list(range(1, 13))
+    assert set(evidence["properties"]) == {"query", "limit"}
+    for server_owned in {
+        "schema_version",
+        "run_id",
+        "tool_call_id",
+        "tool_id",
+        "scope",
+    }:
+        assert server_owned not in metric["properties"]
+        assert server_owned not in evidence["properties"]
+
+
 def _answer(*, script_id: str, invalid_schema: bool = False) -> dict:
     payload = deepcopy(positive_fixtures()["dev_answer.v1"])
     payload["model"] = {

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev.contracts import DevAnswer
 from dev_health_ops.llm.agent.contracts import (
     AgentFinalAnswer,
     AgentMessage,
@@ -42,13 +43,24 @@ class Client:
         self.closed = True
 
 
-def response(*, content: str | None = None, tool_call: Any = None) -> Any:
+def response(
+    *,
+    content: str | None = None,
+    tool_call: Any = None,
+    tool_calls: list[Any] | None = None,
+) -> Any:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
                     content=content,
-                    tool_calls=[tool_call] if tool_call else [],
+                    tool_calls=(
+                        tool_calls
+                        if tool_calls is not None
+                        else [tool_call]
+                        if tool_call
+                        else []
+                    ),
                 )
             )
         ],
@@ -89,7 +101,359 @@ async def test_normalizes_native_tool_decision_and_usage() -> None:
     assert result.usage.cached_input_tokens == 3
     sent = client.chat.completions.calls[0]
     assert sent["tools"][0]["function"]["name"] == "lookup"
-    assert sent["response_format"]["json_schema"]["strict"] is True
+    assert sent["temperature"] == 0
+    assert "response_format" not in sent
+
+
+@pytest.mark.asyncio
+async def test_normalizes_json_tool_decision_for_openai_compatible_fallback() -> None:
+    client = Client(
+        [
+            response(
+                content=json.dumps(
+                    {
+                        "kind": "tool_request",
+                        "tool_id": "lookup",
+                        "arguments": {"id": "WU-1"},
+                        "call_id": "json-call-1",
+                    }
+                )
+            )
+        ]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [
+            AgentToolDefinition(
+                "lookup",
+                "Lookup a work unit",
+                {"type": "object", "properties": {"id": {"type": "string"}}},
+            )
+        ],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    assert result.decision == AgentToolRequest("lookup", {"id": "WU-1"}, "json-call-1")
+
+
+@pytest.mark.asyncio
+async def test_normalizes_strict_root_object_json_tool_decision() -> None:
+    client = Client(
+        [
+            response(
+                content=json.dumps(
+                    {
+                        "kind": "tool_request",
+                        "tool_id": "lookup",
+                        "arguments": {"id": "WU-1"},
+                        "call_id": "json-call-1",
+                        "value": None,
+                        "prompt": None,
+                        "candidates": None,
+                        "code": None,
+                        "message": None,
+                    }
+                )
+            )
+        ]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [
+            AgentToolDefinition(
+                "lookup",
+                "Lookup a work unit",
+                {"type": "object", "properties": {"id": {"type": "string"}}},
+            )
+        ],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    assert result.decision == AgentToolRequest("lookup", {"id": "WU-1"}, "json-call-1")
+
+
+@pytest.mark.asyncio
+async def test_ignores_inactive_strict_fields_populated_by_lmstudio() -> None:
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client(
+            [
+                response(
+                    content=json.dumps(
+                        {
+                            "kind": "tool_request",
+                            "tool_id": "lookup",
+                            "arguments": {"id": "WU-1"},
+                            "call_id": "json-call-1",
+                            "value": None,
+                            "prompt": None,
+                            "candidates": [],
+                            "code": 'call:lookup{id:"WU-1"}',
+                            "message": "",
+                        }
+                    )
+                )
+            ]
+        ),
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [
+            AgentToolDefinition(
+                "lookup",
+                "Lookup a work unit",
+                {"type": "object", "properties": {"id": {"type": "string"}}},
+            )
+        ],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    assert result.decision == AgentToolRequest("lookup", {"id": "WU-1"}, "json-call-1")
+
+
+@pytest.mark.asyncio
+async def test_normalizes_observed_lmstudio_tool_envelope_without_leaking_content() -> (
+    None
+):
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client(
+            [
+                response(
+                    content=json.dumps(
+                        {
+                            "kind": "final_answer",
+                            "value": {
+                                "tool_call": {
+                                    "name": "readiness_echo",
+                                    "args": {"nonce": "ready-v1"},
+                                }
+                            },
+                        }
+                    )
+                )
+            ]
+        ),
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "Call readiness_echo")],
+        [
+            AgentToolDefinition(
+                "readiness_echo",
+                "Return the supplied nonce",
+                {"type": "object", "properties": {"nonce": {"type": "string"}}},
+            )
+        ],
+        {"type": "object"},
+        1,
+        128,
+    )
+
+    assert isinstance(result.decision, AgentToolRequest)
+    assert result.decision.tool_id == "readiness_echo"
+    assert result.decision.arguments == {"nonce": "ready-v1"}
+    assert result.decision.call_id.startswith("json-call-")
+
+
+@pytest.mark.asyncio
+async def test_unknown_json_tool_decision_fails_closed() -> None:
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client(
+            [
+                response(
+                    content=json.dumps(
+                        {
+                            "kind": "tool_request",
+                            "tool_id": "not_registered",
+                            "arguments": {},
+                            "call_id": "json-call-1",
+                        }
+                    )
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [
+                AgentToolDefinition(
+                    "lookup", "Lookup", {"type": "object", "properties": {}}
+                )
+            ],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "kind": "tool_request",
+            "tool_id": "lookup",
+            "arguments": {},
+            "call_id": "json-call-1",
+            "unexpected": True,
+        },
+        {"kind": "tool_request", "tool_id": "lookup", "arguments": {}},
+        {"kind": "not-a-decision"},
+    ],
+)
+async def test_malformed_json_decisions_fail_closed(payload: dict[str, object]) -> None:
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(content=json.dumps(payload))]),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_multiple_native_tool_calls_fail_closed() -> None:
+    first = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    second = SimpleNamespace(
+        id="call-2", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(tool_calls=[first, second])]),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+
+
+def test_decision_schema_hoists_final_and_tool_definitions_for_root_refs() -> None:
+    schema = OpenAICompatibleAgentProvider._decision_response_schema(
+        {
+            "$defs": {"Answer": {"type": "object"}},
+            "$ref": "#/$defs/Answer",
+        },
+        [
+            AgentToolDefinition(
+                "lookup",
+                "Lookup",
+                {
+                    "$defs": {"Arguments": {"type": "object"}},
+                    "$ref": "#/$defs/Arguments",
+                },
+            )
+        ],
+    )
+
+    assert schema["$defs"] == {
+        "Answer": {"type": "object"},
+        "Arguments": {"type": "object"},
+    }
+    assert "$defs" not in schema["properties"]["value"]["anyOf"][0]
+    assert "$defs" not in schema["properties"]["arguments"]["anyOf"][0]
+
+
+def test_structural_schema_preserves_shape_and_removes_runtime_constraints() -> None:
+    schema = OpenAICompatibleAgentProvider._structural_schema(
+        {
+            "type": "object",
+            "title": "Answer",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "pattern": "^[a-z]+$",
+                },
+                "nested": {"$ref": "#/$defs/Nested"},
+            },
+            "required": ["id"],
+            "$defs": {
+                "Nested": {
+                    "type": "object",
+                    "properties": {"at": {"type": "string", "format": "date-time"}},
+                    "default": {},
+                }
+            },
+        }
+    )
+
+    assert set(schema["properties"]) == {"id", "nested"}
+    assert schema["required"] == ["id", "nested"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["nested"] == {"$ref": "#/$defs/Nested"}
+    assert schema["$defs"]["Nested"] == {
+        "type": "object",
+        "properties": {"at": {"type": "string"}},
+        "required": ["at"],
+        "additionalProperties": False,
+    }
+    rendered = json.dumps(schema)
+    assert "minLength" not in rendered
+    assert "maxLength" not in rendered
+    assert "pattern" not in rendered
+    assert "format" not in rendered
+    assert "default" not in rendered
+    assert "title" not in rendered
+
+
+def test_answer_draft_schema_keeps_grounding_and_drops_server_owned_fields() -> None:
+    draft = OpenAICompatibleAgentProvider._answer_draft_schema(
+        DevAnswer.model_json_schema(mode="validation")
+    )
+
+    assert set(draft["properties"]) == {
+        "status",
+        "direct_summary",
+    }
+    assert set(draft["required"]) == set(draft["properties"])
+    assert set(draft["$defs"]) == {"AnswerStatus"}
+    assert "DevScopeResolution" not in draft["$defs"]
+    assert "DevContractVersions" not in draft["$defs"]
+    assert "DevModelMetadata" not in draft["$defs"]
 
 
 @pytest.mark.asyncio
@@ -131,6 +495,9 @@ async def test_normalizes_structured_final_answer() -> None:
         256,
     )
     assert result.decision == AgentFinalAnswer({"answer": 42})
+    sent_schema = client.chat.completions.calls[0]["response_format"]["json_schema"]
+    assert "final_answer" in sent_schema["schema"]["properties"]["kind"]["enum"]
+    assert "tool_request" not in sent_schema["schema"]["properties"]["kind"]["enum"]
 
 
 def test_translates_normalized_tool_continuation_to_openai_wire_shape() -> None:
@@ -146,6 +513,49 @@ def test_translates_normalized_tool_continuation_to_openai_wire_shape() -> None:
         "arguments": '{"id":"WU-1"}',
     }
     assert tool["tool_call_id"] == "call-1"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_continuation_allows_tools_and_strict_final_answer() -> None:
+    client = Client(
+        [response(content=json.dumps({"kind": "final_answer", "value": {"ok": True}}))]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+    request = AgentToolRequest("lookup", {"id": "WU-1"}, "call-1")
+
+    result = await provider.decide(
+        [
+            AgentMessage(AgentMessageRole.USER, "question"),
+            AgentMessage(AgentMessageRole.ASSISTANT, "", tool_request=request),
+            AgentMessage(
+                AgentMessageRole.TOOL,
+                '{"result":1}',
+                tool_call_id="call-1",
+            ),
+        ],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {
+            "type": "object",
+            "properties": {"ok": {"type": "boolean"}},
+            "required": ["ok"],
+        },
+        1,
+        256,
+    )
+
+    assert result.decision == AgentFinalAnswer({"ok": True})
+    schema = client.chat.completions.calls[0]["response_format"]["json_schema"][
+        "schema"
+    ]
+    assert schema["properties"]["kind"]["enum"] == [
+        "tool_request",
+        "final_answer",
+        "disambiguation",
+        "refusal",
+    ]
+    assert schema["properties"]["value"]["anyOf"][0]["required"] == ["ok"]
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_readiness.py
+++ b/tests/llm/agent/test_readiness.py
@@ -8,6 +8,7 @@ from dev_health_ops.llm.agent.contracts import (
     AgentUsage,
 )
 from dev_health_ops.llm.agent.readiness import (
+    READINESS_MAX_OUTPUT_TOKENS,
     AgentReadinessOutcome,
     AgentReadinessRecord,
     AgentReadinessService,
@@ -25,9 +26,27 @@ class Store:
         self.record = record
 
 
+class CapturingScriptedProvider(ScriptedAgentProvider):
+    def __init__(self, steps: list[ScriptedStep]):
+        super().__init__(steps)
+        self.calls: list[dict[str, object]] = []
+
+    async def decide(self, *args, **kwargs):
+        self.calls.append(
+            {
+                "response_schema": args[2],
+                "tool_count": len(args[1]),
+                "last_message": args[0][-1].content,
+                "timeout_seconds": args[3],
+                "max_output_tokens": args[4],
+            }
+        )
+        return await super().decide(*args, **kwargs)
+
+
 @pytest.mark.asyncio
 async def test_certification_proves_tool_continuation_and_final_answer() -> None:
-    provider = ScriptedAgentProvider(
+    provider = CapturingScriptedProvider(
         [
             ScriptedStep(
                 AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-1"),
@@ -49,6 +68,22 @@ async def test_certification_proves_tool_continuation_and_final_answer() -> None
         fingerprint=provider.provider_fingerprint,
         readiness_version=provider.capabilities.readiness_version,
     )
+    assert [call["timeout_seconds"] for call in provider.calls] == [30, 30]
+    assert [call["tool_count"] for call in provider.calls] == [1, 0]
+    assert provider.calls[1]["last_message"] == (
+        'Return a final_answer now with value exactly {"nonce":"ready-v1"}. '
+        "Do not request another tool."
+    )
+    assert [call["max_output_tokens"] for call in provider.calls] == [
+        READINESS_MAX_OUTPUT_TOKENS,
+        READINESS_MAX_OUTPUT_TOKENS,
+    ]
+    assert provider.calls[0]["response_schema"] == {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["nonce"],
+        "properties": {"nonce": {"const": "ready-v1"}},
+    }
 
 
 @pytest.mark.asyncio
@@ -61,6 +96,29 @@ async def test_failed_certification_persists_only_safe_error_code() -> None:
         model="scripted-v1",
         fingerprint=provider.provider_fingerprint,
     )
+    assert record.outcome is AgentReadinessOutcome.FAILED
+    assert record.safe_error_code == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_repeated_tool_request_on_final_answer_turn_fails_closed() -> None:
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-1")
+            ),
+            ScriptedStep(
+                AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-2")
+            ),
+        ]
+    )
+    record = await AgentReadinessService(Store()).certify(
+        provider,
+        provider_name="scripted",
+        model="scripted-v1",
+        fingerprint=provider.provider_fingerprint,
+    )
+
     assert record.outcome is AgentReadinessOutcome.FAILED
     assert record.safe_error_code == "invalid_response"
 

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -292,6 +292,22 @@ def test_resolve_llm_credentials_is_source_bound_for_org():
     assert anthropic_creds.base_url != "https://api.openai.com/v1"
 
 
+def test_ollama_cloud_uses_provider_specific_platform_api_key_alias():
+    with patch.dict(
+        os.environ,
+        {
+            "OLLAMA_API_KEY": "ollama-platform-key",
+            "OLLAMA_BASE_URL": "https://ollama.com/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org({}):
+            resolved = creds.resolve_llm_credentials("ollama", org_id=None)
+
+    assert resolved.api_key == "ollama-platform-key"
+    assert resolved.base_url == "https://ollama.com/v1"
+
+
 def test_org_byo_model_is_source_bound_not_platform_env():
     """Review finding (CHAOS-2550): when org BYO wins, the model must come from
     the org (or provider default), NOT a platform env model var. Otherwise an


### PR DESCRIPTION
## Summary

- make Ask Dev resolve its platform OpenAI-compatible provider from platform environment settings, independently of organization BYO LLM settings
- support LM Studio, local Ollama, and Ollama Cloud endpoint and credential profiles, including the `OLLAMA_API_KEY` platform secret alias
- support native OpenAI tool calls and strict JSON decisions, retaining the complete tool-call continuation and failing closed on ambiguous or malformed output
- keep grounding server-owned: the model supplies the answer status and summary while canonical metrics, evidence, coverage, scope, versions, and model metadata come from executed tools and runtime state
- add strict readiness certification plus disposable real-HTTP provider-profile acceptance coverage and operator documentation

## Validation

- `bash ci/local_validate.sh` — full gate passed, including 9,531 tests, Ruff, mypy, Go checks, River compatibility, scratch ClickHouse migrations, and live `argMax` proof
- focused Ask Dev provider/readiness/orchestrator/admin/acceptance suite: 89 passed
- strict docs publication, MkDocs build, built-site links, and candidate-search acceptance passed
- LM Studio local profile completed forced readiness and two consecutive real `/api/v1/dev/**` SSE answer smokes using `google/gemma-4-e4b`
- Ollama local and Ollama Cloud profiles are structurally covered but were not live-run because no Ollama host/model or cloud credential was available

SCREENSHOT-WAIVER: backend, configuration, acceptance-harness, and documentation changes only; no rendered UI changes.

Linear: https://linear.app/fullchaos/issue/CHAOS-3244/make-ask-dev-work-with-platform-lm-studio-and-ollama-localcloud

Closes CHAOS-3244
