### PR TITLE
fix(licensing): seed Platform Admin feature override catalog

### DIFF
--- a/deploy/helm/dev-health/templates/migrate-job.yaml
+++ b/deploy/helm/dev-health/templates/migrate-job.yaml
@@ -88,7 +88,12 @@ spec:
               if [ -n "$POSTGRES_URI" ] || [ -n "$DATABASE_URI" ]
               || [ "${MIGRATION_DATABASE_URI+x}" = x ]
               || [ "${MIGRATION_DATABASE_URI_FILE+x}" = x ];
-              then dev-hops migrate postgres; fi
+              then dev-hops migrate postgres
+              && if [ -n "$POSTGRES_URI" ] || [ -n "$DATABASE_URI" ];
+              then dev-hops admin features seed;
+              elif [ "${MIGRATION_DATABASE_URI+x}" = x ];
+              then dev-hops --db "$MIGRATION_DATABASE_URI" admin features seed;
+              else dev-hops --db "$(cat "$MIGRATION_DATABASE_URI_FILE")" admin features seed; fi; fi
               && dev-hops migrate clickhouse
           envFrom:
             - configMapRef:

--- a/tests/api/admin/test_feature_flag_crud.py
+++ b/tests/api/admin/test_feature_flag_crud.py
@@ -22,11 +22,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.licensing import seed_feature_flags_async
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.licensing import FeatureFlag
+from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride
+from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
-_TABLES = tables_of(FeatureFlag)
+_TABLES = tables_of(User, Organization, FeatureFlag, OrgFeatureOverride)
 
 # Import the actual module (not the re-exported router object)
 _features_router_module = importlib.import_module(
@@ -294,3 +296,45 @@ async def test_superuser_list_includes_canonical_ask_dev_migration_rows(
         },
     ]
     assert len({row["id"] for row in rows}) == 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_seed_returns_overrideable_ask_dev_feature_ids(session_maker):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    current_user = AuthenticatedUser(
+        user_id=str(user_id),
+        email="admin@example.com",
+        org_id=str(org_id),
+        role="owner",
+        is_superuser=True,
+    )
+
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Organization(
+                    id=org_id,
+                    slug="test-org",
+                    name="Test Org",
+                    tier="community",
+                ),
+                User(id=user_id, email="admin@example.com", is_active=True),
+            ]
+        )
+        await seed_feature_flags_async(session)
+
+    app = _make_app(session_maker, current_user)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        catalog = await client.get("/api/v1/admin/feature-flags")
+        assert catalog.status_code == 200
+        feature_ids = {row["key"]: row["id"] for row in catalog.json()}
+
+        for key in ("ask_dev", "ask_dev_contextual_entrypoints"):
+            response = await client.post(
+                f"/api/v1/admin/orgs/{org_id}/feature-overrides",
+                json={"feature_id": feature_ids[key], "is_enabled": True},
+            )
+            assert response.status_code == 201
+            assert response.json()["feature_key"] == key

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -610,6 +610,7 @@ def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:
     assert "helm.sh/hook: pre-install,pre-upgrade" in template
     assert "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded" in template
     assert "dev-hops migrate clickhouse" in template
+    assert "dev-hops admin features seed" in template
     assert "unset MIGRATION_DATABASE_URI" in template
     assert "MIGRATION_DATABASE_URI_FILE+x" in template
 


### PR DESCRIPTION
## Summary

- run the existing canonical feature catalog seeder from the Helm migration hook after PostgreSQL migrations
- ensure `ask_dev` and `ask_dev_contextual_entrypoints` receive normal persisted feature IDs in deployed environments
- prove the returned IDs work with the existing organization feature-override POST path

## Why

The Platform Admin entitlement display reads the canonical in-code feature registry, while the override selector reads persisted `feature_flags` rows. Compose/local setup seeds that catalog, but the Helm migration hook did not, allowing production to display both Ask Dev features without offering them in the override selector.

This uses the same standard seeder and existing override flow as every other feature; it adds no Ask Dev-specific IDs or UI behavior.

## Validation

- `bash ci/local_validate.sh`
  - 9,533 passed, 69 skipped
  - Ruff, mypy, Go, River compatibility, ClickHouse migrations, and live argMax proof passed
- focused admin/catalog regression proves both Ask Dev IDs can be fetched and used to create overrides

SCREENSHOT-WAIVER: deployment/catalog reconciliation only; no rendered UI changes.

Closes [CHAOS-3248](https://linear.app/fullchaos/issue/CHAOS-3248/ask-dev-missing-from-feature-override-selector).
