### PR TITLE
fix(workers): package job contracts in runtime images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,6 +94,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git wget \
 COPY --from=builder /install /usr/local
 COPY --from=go-migrator-builder /out/dev-health-worker-migrate /usr/local/bin/dev-health-worker-migrate
 
+# Fail the image build if the installed distribution cannot load the exact job
+# contract artifacts used by Python worker routing.
+RUN python -c "from dev_health_ops.workers.job_contracts.registry import load_migration_jobs, load_registry; load_registry(); load_migration_jobs()"
+
 RUN useradd --uid 10001 --create-home --shell /bin/bash appuser
 
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,14 @@ include-package-data = true
   "**/*.txt",
 ]
 
+[tool.setuptools.data-files]
+"contracts/jobs/v1" = [
+  "contracts/jobs/v1/*.json",
+  "contracts/jobs/v1/*.md",
+]
+"contracts/jobs/v1/examples" = ["contracts/jobs/v1/examples/*.json"]
+"contracts/jobs/v1/schemas" = ["contracts/jobs/v1/schemas/*.json"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py310"

--- a/src/dev_health_ops/workers/job_contracts/registry.py
+++ b/src/dev_health_ops/workers/job_contracts/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import sysconfig
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -132,9 +133,12 @@ class MigrationJob:
 
 
 def default_contract_root() -> Path:
-    """Find the repository contract tree from a source checkout."""
+    """Find the job contract tree in a checkout or installed distribution."""
 
-    return Path(__file__).resolve().parents[4] / "contracts" / "jobs" / "v1"
+    checkout_root = Path(__file__).resolve().parents[4] / "contracts" / "jobs" / "v1"
+    if checkout_root.is_dir():
+        return checkout_root
+    return Path(sysconfig.get_path("data")) / "contracts" / "jobs" / "v1"
 
 
 def load_registry(root: Path | None = None) -> Registry:

--- a/tests/workers/job_contracts/test_codec.py
+++ b/tests/workers/job_contracts/test_codec.py
@@ -48,6 +48,7 @@ from dev_health_ops.workers.job_contracts import (
     encode_envelope,
     load_registry,
 )
+from dev_health_ops.workers.job_contracts import registry as contract_registry
 
 
 @pytest.mark.parametrize(
@@ -275,3 +276,21 @@ def test_default_contract_root_points_to_regular_artifacts() -> None:
     root = default_contract_root()
     assert isinstance(root, Path)
     assert (root / "registry.json").is_file()
+
+
+def test_default_contract_root_uses_installed_data_scheme(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    installed_module = (
+        tmp_path
+        / "lib/python3.14/site-packages/dev_health_ops/workers/job_contracts/registry.py"
+    )
+    data_root = tmp_path / "installation-data"
+    monkeypatch.setattr(contract_registry, "__file__", str(installed_module))
+    monkeypatch.setattr(
+        contract_registry.sysconfig,
+        "get_path",
+        lambda name: str(data_root) if name == "data" else None,
+    )
+
+    assert default_contract_root() == data_root / "contracts/jobs/v1"

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
+import tomllib
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _PROFILES = _REPO_ROOT / "deploy" / "go-workers" / "profiles.json"
 _APP_DOCKERFILE = _REPO_ROOT / "docker" / "Dockerfile"
 _GO_WORKER_DOCKERFILE = _REPO_ROOT / "docker" / "go-worker.Dockerfile"
@@ -480,6 +482,34 @@ def test_reconciler_image_packages_both_runtime_contract_roots() -> None:
         + "/runtime/reconciler/app/contracts/sync-dispatch/v1;"
         in dockerfile
     )
+
+
+def test_python_image_packages_and_validates_job_contracts() -> None:
+    project = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    data_files = project["tool"]["setuptools"]["data-files"]
+    patterns = {
+        pattern
+        for destination, destination_patterns in data_files.items()
+        if destination == "contracts/jobs/v1"
+        or destination.startswith("contracts/jobs/v1/")
+        for pattern in destination_patterns
+    }
+    packaged = {
+        path.relative_to(_REPO_ROOT)
+        for pattern in patterns
+        for path in _REPO_ROOT.glob(pattern)
+    }
+    expected = {
+        path.relative_to(_REPO_ROOT)
+        for path in (_REPO_ROOT / "contracts/jobs/v1").rglob("*")
+        if path.is_file() and path.suffix in {".json", ".md"}
+    }
+    assert packaged == expected
+
+    dockerfile = _APP_DOCKERFILE.read_text(encoding="utf-8")
+    runtime = dockerfile.split("FROM python:3.14-slim AS runtime", maxsplit=1)[1]
+    runtime = runtime.split("FROM runtime AS api", maxsplit=1)[0]
+    assert "load_registry(); load_migration_jobs()" in runtime
 
 
 def test_scheduler_image_packages_runtime_policy_inputs() -> None:


### PR DESCRIPTION
## Summary

- package the canonical `contracts/jobs/v1` tree into Python distributions
- resolve job contracts from the source checkout or the installed Python data scheme
- make runtime image builds load both the registry and migration state before publication
- pin the complete packaged artifact inventory and installed-path fallback in tests

## Root cause

Production Celery workers ran the installed wheel from `/usr/local/lib/python3.14/site-packages`, so the source-checkout-only path calculation looked for `migration-state.json` under `/usr/local/lib/python3.14/contracts/jobs/v1`. The runtime image did not contain that tree. Local Compose masked the defect by mounting the repository at `/app`.

At baseline `6724fb3`, both a production-style image probe and a clean wheel install reproduced `ContractDecodeError: contract artifact must be a regular file`.

## Verification

- rebuilt runtime image resolves `/usr/local/contracts/jobs/v1` and loads all 24 registry and migration entries
- direct wheel install: green from an unrelated working directory
- sdist -> wheel -> clean install: green from an unrelated working directory
- focused tests: `80 passed`
- `bash ci/local_validate.sh`: `GATE PASSED`
  - ruff format/check
  - mypy
  - Go format/vet/test and live Python oracle
  - River compatibility harness
  - isolated ClickHouse migration and live `argMax` proof
  - full unit suite: `9535 passed, 68 skipped`

SCREENSHOT-WAIVER: backend distribution and runtime-image packaging only; no rendered UI changes.