### PR TITLE
fix(migrations): advance schema without River cutover

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,6 +208,7 @@ jobs:
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
           COVERAGE_THRESHOLD: "70"
+          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           OTEL_ENABLED: "false"
           PYTEST_XDIST_WORKERS: "4"
         run: |

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -159,9 +159,9 @@ own compose file(s) for exactly which services exist and where.
 
 **`depends_on` ignores profiles.** A profiled service that declares
 `depends_on: migrate` pulls the *unprofiled* Python migrator into the plan. The
-application migrator now stops at `0065` unless
-`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`, but a deployment carrying that
-one-shot authorization would still run
+application migrator advances ordinary schema on a separate branch and leaves
+`0066` pending unless `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`, but a
+deployment carrying that one-shot authorization would still run
 `0066_activate_river_worker_job_routes` before the downstream Go runtimes can
 start. That is precisely the ordering `0066`'s own docstring forbids: routes
 flip to River before any River consumer is available, and envelopes then
@@ -172,16 +172,17 @@ the Go observation path cannot move real traffic as a side effect.
 `tests/test_compose_config.py::test_go_profile_overlay_never_depends_on_python_migrate`
 is the regression barrier.
 
-Bring the Python schema to the last pre-cutover revision yourself, first:
+Bring the Python application schema current without activating the cutover,
+first:
 
 ```bash
-# Without the cutover opt-in, the application migrator stops at 0065.
+# Without the cutover opt-in, ordinary schema advances and 0066 remains pending.
 docker compose run --rm --entrypoint sh migrate -c \
   'python -m dev_health_ops.cli migrate postgres upgrade'
 
-# Confirm where you actually landed before going further.
+# Confirm the application schema is current before going further.
 docker compose run --rm --entrypoint sh migrate -c \
-  'python -m dev_health_ops.cli migrate postgres current'
+  'python -m dev_health_ops.cli migrate postgres status --check'
 
 # Only then start the Go path.
 docker compose --profile go up -d go-worker go-reconciler
@@ -400,10 +401,11 @@ to `transport='river'` and, per its own docstring, requires Go consumers to
 already be running for every affected queue before it commits. Direct
 `alembic upgrade head` on a database with no Go workers running would silently
 stop background processing for every one of those job kinds. The application
-`migrate postgres` command instead leaves `0066` pending unless
-`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`. If a targeted direct Alembic upgrade
-stopping short of a cutover migration is what you need, use that instead of
-`head`, and confirm first that the
+`migrate postgres` command advances the separate `application_schema` branch
+while leaving the sibling `0066` River activation pending unless
+`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`. Do not use direct
+`alembic upgrade head`: the graph intentionally has multiple heads. Use the
+application migrator, and confirm first that the
 `api`/`migrate` container actually has your target revision's file available
 (root compose mounts `./ops:/app`, so it does if you're on a branch with that
 migration file; it does not against an unmodified `origin/main` checkout).
@@ -415,11 +417,12 @@ running this stack mounts a working copy of this repository into its
 `migrate` service (as the coexistence overlays and CHAOS-3142's own
 repo-root wiring do, so a nested `migrate` target and other Go/Alembic
 artifacts on a feature branch are visible without a rebuild), direct Alembic
-still applies every pending revision. The application migrator prevents an
-unattended `0066` cutover by stopping at `0065` unless
-`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`; that one-shot authorization must
-therefore be scoped to the reviewed cutover run and removed afterward. There
-is no separate interactive confirmation once the authorization is present.
+still applies every explicitly targeted pending revision. The application
+migrator prevents an unattended `0066` cutover by targeting only the
+`application_schema` branch unless `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`;
+that one-shot authorization must therefore be scoped to the reviewed cutover
+run and removed afterward. There is no separate interactive confirmation once
+the authorization is present.
 This is a general operational hazard of mounting a live checkout into a
 migration-running service, not specific to CHAOS-3142 or to this migration —
 it deserves review as its own item, independent of the Go execution path

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1312,6 +1312,9 @@ dev-hops migrate postgres downgrade -1
 # Show current applied revision
 dev-hops migrate postgres current
 
+# Read-only application-schema check (exit 1 while required revisions are pending)
+dev-hops migrate postgres status --check
+
 # Show migration history
 dev-hops migrate postgres history
 
@@ -1319,13 +1322,22 @@ dev-hops migrate postgres history
 dev-hops migrate postgres heads
 ```
 
-The Celery-to-River ownership cutover at PostgreSQL revision `0066` is deferred
-by default. An ordinary upgrade applies through revision `0065` and exits
-successfully, leaving `0066` pending. Set
-`DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1` only on the explicitly authorized
-migration run after the River consumers are ready and Celery is drained. A
-database that has already applied `0066` continues upgrading normally when the
-one-shot variable is absent.
+The migration graph has two branches after revision `0065`:
+
+- `application_schema` contains ordinary application migrations and is always
+  advanced by `dev-hops migrate postgres`;
+- `river_cutover` contains revision `0066`, the Celery-to-River ownership
+  activation, and remains pending by default.
+
+Set `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1` only on the explicitly authorized
+migration run after the River consumers are ready and Celery is drained. With
+that opt-in, the migrator advances both heads. Without it, River support tables
+and route records may remain present but unused while application schema such
+as Ask Dev persistence continues to migrate normally.
+
+`migrate postgres status --check` is read-only. It requires the current
+`application_schema` head and, only when the cutover opt-in is present, the
+`river_cutover` head.
 
 **Backward-compatible aliases:** `dev-hops migrate upgrade`, `dev-hops migrate downgrade`, etc. still work and target PostgreSQL.
 

--- a/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
+++ b/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
@@ -53,7 +53,7 @@ from sqlalchemy.sql.selectable import TableClause
 
 revision: str = "0066"
 down_revision: str | None = "0065"
-branch_labels = None
+branch_labels = ("river_cutover",)
 depends_on = None
 
 _RIVER_TRANSPORT = "river"

--- a/src/dev_health_ops/alembic/versions/0067_seed_ask_dev_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0067_seed_ask_dev_feature_flag.py
@@ -1,7 +1,7 @@
 """Seed the default-disabled Ask Dev entitlement.
 
 Revision ID: 0067
-Revises: 0066
+Revises: 0065
 Create Date: 2026-07-28 00:00:00
 
 The row is globally available so the existing feature decision can act as an
@@ -21,8 +21,8 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0067"
-down_revision: str | None = "0066"
-branch_labels: str | Sequence[str] | None = None
+down_revision: str | None = "0065"
+branch_labels: str | Sequence[str] | None = ("application_schema",)
 depends_on: str | Sequence[str] | None = None
 
 __all__ = ["revision", "down_revision", "branch_labels", "depends_on"]

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -520,9 +520,11 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("migrate", "postgres", "upgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "postgres", "downgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "postgres", "current"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "postgres", "status"): frozenset({_REQ_POSTGRES}),
     ("migrate", "upgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "downgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "current"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "status"): frozenset({_REQ_POSTGRES}),
     # Bare ``migrate postgres`` / ``migrate clickhouse`` default to upgrade.
     ("migrate", "postgres"): frozenset({_REQ_POSTGRES}),
     ("migrate", "clickhouse"): frozenset({_REQ_CLICKHOUSE}),

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -31,11 +31,13 @@ logger = logging.getLogger(__name__)
 _ALEMBIC_DIR = Path(__file__).resolve().parent / "alembic"
 _CELERY_RIVER_CUTOVER_ENV = "DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER"
 _CELERY_RIVER_CUTOVER_REVISION = "0066"
-_PRE_CELERY_RIVER_CUTOVER_REVISION = "0065"
-# tests/test_migrate_commands.py pins the current head and requires it to descend
-# from 0066. Descendants are intentionally deferred with the cutover because an
-# ordinary pre-cutover upgrade remains capped at 0065. A separate Alembic branch
-# would be required for migrations that must advance without crossing 0066.
+_APPLICATION_SCHEMA_BRANCH = "application_schema"
+_APPLICATION_SCHEMA_MINIMUM_REVISION = "0071"
+
+# Revision 0066 changes worker execution ownership and remains an explicit
+# operator action. Application schema migrations branch from 0065 separately,
+# so a normal upgrade can keep Celery active while still applying every schema
+# required by the running API (including Ask Dev persistence).
 
 
 def _get_migration_database_uri() -> str | None:
@@ -142,25 +144,62 @@ def _database_has_revision(
     return False
 
 
+def _cutover_is_authorized() -> bool:
+    return os.getenv(_CELERY_RIVER_CUTOVER_ENV) == "1"
+
+
+def _application_schema_head(cfg) -> str:
+    """Return the installed application's safe schema head revision."""
+    from alembic.script import ScriptDirectory
+
+    scripts = ScriptDirectory.from_config(cfg)
+    head = scripts.get_revision(f"{_APPLICATION_SCHEMA_BRANCH}@head")
+    if head is None or not _database_has_revision(
+        cfg, (head.revision,), _APPLICATION_SCHEMA_MINIMUM_REVISION
+    ):
+        raise RuntimeError(
+            "installed migration package does not contain the required "
+            f"application schema revision {_APPLICATION_SCHEMA_MINIMUM_REVISION}"
+        )
+    return str(head.revision)
+
+
+def _required_postgres_revisions(cfg) -> tuple[str, ...]:
+    required = [_application_schema_head(cfg)]
+    if _cutover_is_authorized():
+        required.append(_CELERY_RIVER_CUTOVER_REVISION)
+    return tuple(required)
+
+
+def _postgres_revision_status(
+    cfg,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    current = _current_postgres_heads(cfg)
+    required = _required_postgres_revisions(cfg)
+    missing = tuple(
+        revision
+        for revision in required
+        if not _database_has_revision(cfg, current, revision)
+    )
+    return current, required, missing
+
+
 def _effective_postgres_upgrade_revision(cfg, requested_revision: str) -> str:
-    """Keep an ordinary upgrade below the explicit Celery-to-River cutover."""
+    """Apply safe schema by default and include River only with explicit opt-in."""
     if requested_revision != "head":
         return requested_revision
-    if os.getenv(_CELERY_RIVER_CUTOVER_ENV) == "1":
-        return requested_revision
-
-    current_heads = _current_postgres_heads(cfg)
-    if _database_has_revision(cfg, current_heads, _CELERY_RIVER_CUTOVER_REVISION):
-        # The cutover already ran in this database. Never turn an upgrade into a
-        # backwards target merely because a one-shot authorization is absent.
-        return requested_revision
+    _application_schema_head(cfg)
+    if _cutover_is_authorized():
+        return "heads"
 
     logger.info(
-        "Deferring Celery-to-River cutover revision %s; set %s=1 to apply it",
+        "Deferring Celery-to-River cutover revision %s; applying the %s branch. "
+        "Set %s=1 only for the authorized ownership cutover",
         _CELERY_RIVER_CUTOVER_REVISION,
+        _APPLICATION_SCHEMA_BRANCH,
         _CELERY_RIVER_CUTOVER_ENV,
     )
-    return _PRE_CELERY_RIVER_CUTOVER_REVISION
+    return f"{_APPLICATION_SCHEMA_BRANCH}@head"
 
 
 def _run_upgrade(ns: argparse.Namespace) -> int:
@@ -178,6 +217,13 @@ def _run_upgrade(ns: argparse.Namespace) -> int:
     cfg = _make_alembic_config(explicit_db)
     revision = _effective_postgres_upgrade_revision(cfg, ns.revision)
     command.upgrade(cfg, revision)
+    if ns.revision == "head":
+        _current, _required, missing = _postgres_revision_status(cfg)
+        if missing:
+            raise RuntimeError(
+                "PostgreSQL migration finished without required revision(s): "
+                + ", ".join(missing)
+            )
     return _run_river_upgrade()
 
 
@@ -218,6 +264,19 @@ def _run_current(ns: argparse.Namespace) -> int:
 
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.current(cfg, verbose=ns.verbose)
+    return 0
+
+
+def _run_postgres_status(ns: argparse.Namespace) -> int:
+    """Show whether PostgreSQL satisfies this application's migration contract."""
+    cfg = _make_alembic_config(getattr(ns, "db", None))
+    current, required, missing = _postgres_revision_status(cfg)
+    print(f"Current PostgreSQL revision heads: {', '.join(current) or '(base)'}")
+    print(f"Required PostgreSQL revisions: {', '.join(required)}")
+    if missing:
+        print(f"Pending required PostgreSQL revisions: {', '.join(missing)}")
+        return 1 if bool(getattr(ns, "check", False)) else 0
+    print("PostgreSQL application schema is current.")
     return 0
 
 
@@ -440,6 +499,20 @@ def _register_postgres_subcommands(
     cur = sub.add_parser("current", help="Show current revision.")
     cur.add_argument("-v", "--verbose", action="store_true")
     cur.set_defaults(func=_run_current)
+
+    status = sub.add_parser(
+        "status", help="Show whether required PostgreSQL migrations are applied."
+    )
+    status.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Exit 1 if a required migration is pending, 0 if the application "
+            "schema is current. Read-only; the River cutover is required only "
+            f"when {_CELERY_RIVER_CUTOVER_ENV}=1."
+        ),
+    )
+    status.set_defaults(func=_run_postgres_status)
 
     hist = sub.add_parser("history", help="Show migration history.")
     hist.add_argument("-v", "--verbose", action="store_true")

--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -78,6 +78,15 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
         "--ignore=tests/test_0066_celery_river_cutover_postgres.py"
     )
 
+    coverage_step = next(
+        step
+        for step in workflow["jobs"]["coverage"]["steps"]
+        if step.get("name") == "Run coverage-gated test contract"
+    )
+    assert coverage_step["env"][_POSTGRES_TEST_URI_ENV] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+
 
 def test_live_e2e_allows_the_disposable_cutover_migration() -> None:
     workflow = yaml.safe_load(

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -107,13 +107,19 @@ def migrated_to_0065(
         admin_engine.dispose()
 
 
-def _revision(engine: Engine) -> str:
+def _revisions(engine: Engine) -> set[str]:
     with engine.connect() as connection:
-        return str(
-            connection.execute(
+        return {
+            str(row[0])
+            for row in connection.execute(
                 sa.text("SELECT version_num FROM alembic_version")
-            ).scalar_one()
-        )
+            )
+        }
+
+
+def _table_exists(engine: Engine, table_name: str) -> bool:
+    with engine.connect() as connection:
+        return bool(sa.inspect(connection).has_table(table_name))
 
 
 def _routes(engine: Engine, migration: ModuleType) -> list[tuple[str, str, bool, int]]:
@@ -143,11 +149,11 @@ def test_0066_real_postgres_refuses_without_opt_in_without_advancing_revision(
     with pytest.raises(RuntimeError, match=f"{_CUTOVER_ENV}=1"):
         command.upgrade(_migration_config(), "0066")
 
-    assert _revision(migrated_to_0065.engine) == "0065"
+    assert _revisions(migrated_to_0065.engine) == {"0065"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 
-def test_application_migrator_defers_0066_without_opt_in(
+def test_application_migrator_applies_safe_schema_without_0066_opt_in(
     migrated_to_0065: PostgresMigrationHarness,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -159,7 +165,9 @@ def test_application_migrator_defers_0066_without_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revision(migrated_to_0065.engine) == "0065"
+    assert _revisions(migrated_to_0065.engine) == {"0071"}
+    assert _table_exists(migrated_to_0065.engine, "dev_runs")
+    assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
 
 
@@ -172,7 +180,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
 
     command.upgrade(_migration_config(), "0066")
 
-    assert _revision(migrated_to_0065.engine) == "0066"
+    assert _revisions(migrated_to_0065.engine) == {"0066"}
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
     ]
@@ -181,17 +189,62 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revision(migrated_to_0065.engine) == "0071"
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
     ]
 
     command.downgrade(_migration_config(), "0065")
 
-    assert _revision(migrated_to_0065.engine) == "0065"
+    assert _revisions(migrated_to_0065.engine) == {"0065"}
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "celery", False, 3) for kind in sorted(migration._KINDS)
     ]
+
+
+def test_application_migrator_opt_in_applies_both_heads(
+    migrated_to_0065: PostgresMigrationHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _migration()
+    monkeypatch.setenv(_CUTOVER_ENV, "1")
+
+    from dev_health_ops.migrate import _run_upgrade
+
+    assert _run_upgrade(Namespace(db=None, revision="head")) == 0
+
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _table_exists(migrated_to_0065.engine, "dev_runs")
+    assert _routes(migrated_to_0065.engine, migration) == [
+        (kind, "river", False, 2) for kind in sorted(migration._KINDS)
+    ]
+
+
+def test_old_linear_0071_provenance_converges_to_both_heads(
+    migrated_to_0065: PostgresMigrationHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Databases that applied the former 0066 -> 0071 chain remain valid.
+
+    Before the branch split, Alembic recorded only 0071 even though 0066 had
+    retargeted the routes. Reapplying the new 0066 sibling is intentionally
+    idempotent and restores explicit two-head provenance without another route
+    generation change.
+    """
+    migration = _migration()
+    monkeypatch.setenv(_CUTOVER_ENV, "1")
+    command.upgrade(_migration_config(), "heads")
+    command.stamp(_migration_config(), "0071", purge=True)
+    before = _routes(migrated_to_0065.engine, migration)
+
+    assert _revisions(migrated_to_0065.engine) == {"0071"}
+
+    from dev_health_ops.migrate import _run_upgrade
+
+    assert _run_upgrade(Namespace(db=None, revision="head")) == 0
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _routes(migrated_to_0065.engine, migration) == before
 
 
 def test_0066_real_postgres_locks_routes_before_retargeting(

--- a/tests/test_ask_dev_feature_flag.py
+++ b/tests/test_ask_dev_feature_flag.py
@@ -79,7 +79,8 @@ def test_migration_0067_is_additive_idempotent_and_preserves_other_gates() -> No
         "dev_health_ops.alembic.versions.0067_seed_ask_dev_feature_flag"
     )
     assert migration.revision == "0067"
-    assert migration.down_revision == "0066"
+    assert migration.down_revision == "0065"
+    assert migration.branch_labels == ("application_schema",)
     engine = create_engine("sqlite:///:memory:")
     try:
         with engine.connect() as conn:

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -104,7 +104,7 @@ def test_canonical_incident_feature_seed_is_global_only_and_idempotent() -> None
         engine.dispose()
 
 
-def test_canonical_incident_feature_seed_is_in_single_head_graph() -> None:
+def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> None:
     migration = _canonical_incident_migration_module()
     config = Config(str(Path(__file__).parents[1] / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
@@ -112,17 +112,20 @@ def test_canonical_incident_feature_seed_is_in_single_head_graph() -> None:
 
     assert migration.down_revision == "0041"
     assert migration.revision in revisions
-    # The invariant this test is named for is that the graph has exactly ONE
-    # head — i.e. nobody branched the chain — not that the head is any
-    # particular revision. Pinning the literal head ("0064") made every
-    # legitimately-added migration fail this test: CUT-05 added
-    # 0065_add_fixed_schedule_occurrences and the pin was left behind, which
-    # is churn that teaches people to bump the number without reading why.
-    # The head must still be the highest-numbered revision, so a stray branch
-    # or an out-of-order down_revision is caught rather than waved through.
+    # Ordinary schema and the explicitly authorized River ownership cutover
+    # intentionally branch after 0065. Keep this seed on the ordinary schema
+    # lineage, and pin both named heads so an accidental third branch or an
+    # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert len(heads) == 1, f"migration graph has branched: {heads}"
-    assert heads[0] == max(revisions)
+    assert set(heads) == {"0066", "0071"}
+    application_head = scripts.get_revision("application_schema@head").revision
+    assert application_head == max(revisions)
+    application_revisions = {
+        script.revision
+        for script in scripts.iterate_revisions(application_head, "base")
+    }
+    assert migration.revision in application_revisions
+    assert scripts.get_revision("river_cutover@head").revision == "0066"
     assert scripts.get_revision("0043").down_revision == "0042"
     assert scripts.get_revision("0044").down_revision == "0043"
     assert scripts.get_revision("0045").down_revision == "0044"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -53,7 +53,7 @@ class TestAlembicDirResolution:
         package_dir = Path(migrate_mod.__file__).resolve().parent
         assert package_dir / "alembic" == _ALEMBIC_DIR
 
-    def test_postgres_revision_graph_has_unique_single_head(self):
+    def test_postgres_revision_graph_has_expected_branch_heads(self):
         cfg = _make_alembic_config(
             db_url="postgresql+asyncpg://unused:unused@localhost/unused"
         )
@@ -64,7 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert len(heads) == 1
+        assert set(heads) == {"0066", "0071"}
+        assert script.get_revision("river_cutover@head").revision == "0066"
+        assert script.get_revision("application_schema@head").revision == "0071"
         assert revisions
 
 
@@ -178,9 +180,15 @@ class TestCommandDispatch:
     @pytest.fixture(autouse=True)
     def _isolate_revision_selection(self):
         """Keep command-dispatch tests independent of live database state."""
-        with patch(
-            "dev_health_ops.migrate._effective_postgres_upgrade_revision",
-            side_effect=lambda _cfg, requested_revision: requested_revision,
+        with (
+            patch(
+                "dev_health_ops.migrate._effective_postgres_upgrade_revision",
+                side_effect=lambda _cfg, requested_revision: requested_revision,
+            ),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0071",), ("0071",), ()),
+            ),
         ):
             yield
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -14,6 +14,7 @@ from dev_health_ops.migrate import (
     _run_clickhouse_repair,
     _run_clickhouse_status,
     _run_clickhouse_upgrade,
+    _run_postgres_status,
     _run_upgrade,
 )
 
@@ -46,6 +47,11 @@ class TestMigrateRouting:
             (["migrate", "postgres", "upgrade", "abc123"], "_run_upgrade"),
             (["migrate", "postgres", "downgrade", "base"], "_run_downgrade"),
             (["migrate", "postgres", "current"], "_run_current"),
+            (["migrate", "postgres", "status"], "_run_postgres_status"),
+            (
+                ["migrate", "postgres", "status", "--check"],
+                "_run_postgres_status",
+            ),
             (["migrate", "postgres", "history"], "_run_history"),
             (["migrate", "postgres", "heads"], "_run_heads"),
             (["migrate", "clickhouse"], "_run_clickhouse_upgrade"),
@@ -63,6 +69,7 @@ class TestMigrateRouting:
             (["migrate", "upgrade", "abc123"], "_run_upgrade"),
             (["migrate", "downgrade", "base"], "_run_downgrade"),
             (["migrate", "current"], "_run_current"),
+            (["migrate", "status", "--check"], "_run_postgres_status"),
             (["migrate", "history"], "_run_history"),
             (["migrate", "heads"], "_run_heads"),
         ],
@@ -157,16 +164,18 @@ class TestMigrateRouting:
 
 
 class TestPostgresUpgrade:
-    def test_cutover_deferral_is_revisited_when_alembic_head_changes(self) -> None:
+    def test_application_schema_and_cutover_are_separate_heads(self) -> None:
         from alembic.script import ScriptDirectory
 
         cfg = _make_alembic_config(
             "postgresql+asyncpg://unused:unused@localhost:5432/unused"
         )
-        current_head = ScriptDirectory.from_config(cfg).get_current_head()
+        scripts = ScriptDirectory.from_config(cfg)
 
-        assert current_head == "0071"
-        assert _database_has_revision(cfg, (current_head,), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0071"}
+        assert scripts.get_revision("application_schema@head").revision == "0071"
+        assert _database_has_revision(cfg, ("0071",), "0065")
+        assert not _database_has_revision(cfg, ("0071",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(
@@ -177,7 +186,7 @@ class TestPostgresUpgrade:
         assert not _database_has_revision(cfg, ("0065",), "0066")
 
     @pytest.mark.parametrize("raw", [None, "", "0"])
-    def test_disabled_cutover_opt_in_defers_head_at_0065(
+    def test_disabled_cutover_opt_in_applies_application_schema_branch(
         self, monkeypatch: pytest.MonkeyPatch, raw: str | None
     ) -> None:
         if raw is None:
@@ -188,15 +197,19 @@ class TestPostgresUpgrade:
         with (
             patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
             patch(
-                "dev_health_ops.migrate._current_postgres_heads", return_value=("0051",)
+                "dev_health_ops.migrate._application_schema_head",
+                return_value="0071",
             ),
-            patch("dev_health_ops.migrate._database_has_revision", return_value=False),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0071",), ("0071",), ()),
+            ),
             patch("alembic.command.upgrade") as upgrade,
             patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
         ):
             assert _run_upgrade(_ns(revision="head")) == 0
 
-        upgrade.assert_called_once_with(cfg, "0065")
+        upgrade.assert_called_once_with(cfg, "application_schema@head")
 
     def test_explicit_cutover_opt_in_keeps_head(
         self, monkeypatch: pytest.MonkeyPatch
@@ -205,16 +218,22 @@ class TestPostgresUpgrade:
         cfg = MagicMock()
         with (
             patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
-            patch("dev_health_ops.migrate._current_postgres_heads") as current_heads,
+            patch(
+                "dev_health_ops.migrate._application_schema_head",
+                return_value="0071",
+            ),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0066", "0071"), ("0071", "0066"), ()),
+            ),
             patch("alembic.command.upgrade") as upgrade,
             patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
         ):
             assert _run_upgrade(_ns(revision="head")) == 0
 
-        current_heads.assert_not_called()
-        upgrade.assert_called_once_with(cfg, "head")
+        upgrade.assert_called_once_with(cfg, "heads")
 
-    def test_unset_opt_in_does_not_move_an_applied_cutover_backwards(
+    def test_upgrade_fails_if_required_application_revision_remains_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER", raising=False)
@@ -222,15 +241,20 @@ class TestPostgresUpgrade:
         with (
             patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
             patch(
-                "dev_health_ops.migrate._current_postgres_heads", return_value=("0066",)
+                "dev_health_ops.migrate._application_schema_head",
+                return_value="0071",
             ),
-            patch("dev_health_ops.migrate._database_has_revision", return_value=True),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0065",), ("0071",), ("0071",)),
+            ),
             patch("alembic.command.upgrade") as upgrade,
             patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
+            pytest.raises(RuntimeError, match="required revision.*0071"),
         ):
-            assert _run_upgrade(_ns(revision="head")) == 0
+            _run_upgrade(_ns(revision="head"))
 
-        upgrade.assert_called_once_with(cfg, "head")
+        upgrade.assert_called_once_with(cfg, "application_schema@head")
 
     def test_explicit_revision_keeps_direct_alembic_guard(
         self, monkeypatch: pytest.MonkeyPatch
@@ -239,14 +263,42 @@ class TestPostgresUpgrade:
         cfg = MagicMock()
         with (
             patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
-            patch("dev_health_ops.migrate._current_postgres_heads") as current_heads,
+            patch("dev_health_ops.migrate._application_schema_head") as app_head,
             patch("alembic.command.upgrade") as upgrade,
             patch("dev_health_ops.migrate._run_river_upgrade", return_value=0),
         ):
             assert _run_upgrade(_ns(revision="0066")) == 0
 
-        current_heads.assert_not_called()
+        app_head.assert_not_called()
         upgrade.assert_called_once_with(cfg, "0066")
+
+
+class TestPostgresStatus:
+    def test_check_fails_when_required_revision_is_pending(self, capsys) -> None:
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0065",), ("0071",), ("0071",)),
+            ),
+        ):
+            assert _run_postgres_status(_ns(check=True)) == 1
+
+        assert "Pending required PostgreSQL revisions: 0071" in capsys.readouterr().out
+
+    def test_check_passes_when_application_schema_is_current(self, capsys) -> None:
+        cfg = MagicMock()
+        with (
+            patch("dev_health_ops.migrate._make_alembic_config", return_value=cfg),
+            patch(
+                "dev_health_ops.migrate._postgres_revision_status",
+                return_value=(("0071",), ("0071",), ()),
+            ),
+        ):
+            assert _run_postgres_status(_ns(check=True)) == 0
+
+        assert "PostgreSQL application schema is current." in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Split the PostgreSQL migration graph after `0065` into an always-applied `application_schema` branch and an explicitly authorized `river_cutover` branch.
- Let ordinary migrations create Ask Dev persistence and other additive schema through `0071` without changing Celery execution ownership.
- Add a read-only PostgreSQL migration status check and fail closed when a required application revision is still missing after migration.
- Run the real PostgreSQL migration suite in the merge-queue coverage job by supplying its existing Postgres service DSN.
- Update CLI and River operator documentation for the two-head migration contract.

## Contract preserved

Additive River support and application schema may be installed while dormant. Only revision `0066`, which activates Celery-to-River route ownership, requires `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1`.

## Validation

- `bash ci/local_validate.sh`: 9,538 passed, 71 skipped; lint, mypy, Go, ClickHouse scratch migration, and live-engine gates passed.
- Real PostgreSQL migration suite: 6 passed, including dormant-schema migration, both-head cutover, downgrade, route locking, and old-linear-history convergence.
- Red/green reproduction: an unflagged migration advanced a disposable database from `0065` to `0071`, created `dev_runs` and `dev_conversations`, and left all 24 routes on Celery.

SCREENSHOT-WAIVER: Backend migration, CI, tests, and documentation only; no rendered UI changed.

Closes CHAOS-3264

Linear: https://linear.app/fullchaos/issue/CHAOS-3264/ask-dev-production-usage-endpoint-crashes-because-persistence
