### PR TITLE
fix(ask-dev): correct GPT-5 readiness exchange

### DIFF
--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -10,7 +10,10 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from dev_health_ops.llm.providers._http import make_hardened_async_httpx_client
-from dev_health_ops.llm.providers.openai_capabilities import supports_temperature
+from dev_health_ops.llm.providers.openai_capabilities import (
+    chat_completion_reasoning_effort,
+    supports_temperature,
+)
 
 from .contracts import (
     AgentDecisionResult,
@@ -169,11 +172,16 @@ class OpenAICompatibleAgentProvider:
             "model": self.model,
             "messages": [self._message_payload(item) for item in messages],
             "tools": [self._tool_payload(item) for item in tools] or None,
-            "tool_choice": "auto" if tools else None,
+            "tool_choice": (
+                ("auto" if allow_final_answer else "required") if tools else None
+            ),
             "max_completion_tokens": max_output_tokens,
         }
         if supports_temperature(self.model):
             completion_kwargs["temperature"] = 0
+        reasoning_effort = chat_completion_reasoning_effort(self.model)
+        if reasoning_effort is not None:
+            completion_kwargs["reasoning_effort"] = reasoning_effort
         if allow_final_answer:
             completion_kwargs["response_format"] = {
                 "type": "json_schema",

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -136,7 +136,12 @@ class AgentReadinessService:
                 "type": "object",
                 "additionalProperties": False,
                 "required": ["nonce"],
-                "properties": {"nonce": {"const": "ready-v1"}},
+                "properties": {
+                    "nonce": {
+                        "type": "string",
+                        "const": "ready-v1",
+                    }
+                },
             }
             first = await provider.decide(
                 [

--- a/src/dev_health_ops/llm/providers/openai_capabilities.py
+++ b/src/dev_health_ops/llm/providers/openai_capabilities.py
@@ -12,3 +12,16 @@ def supports_temperature(model: str) -> bool:
     """
 
     return not model.strip().lower().startswith(("gpt-5", "o1", "o3"))
+
+
+def chat_completion_reasoning_effort(model: str) -> str | None:
+    """Return the Chat Completions reasoning control required by GPT-5.
+
+    GPT-5 counts reasoning tokens against ``max_completion_tokens``. Keeping
+    the default reasoning effort can exhaust the bounded Ask Dev response
+    budget before the model emits its required structured decision.
+    """
+
+    if model.strip().lower().startswith("gpt-5"):
+        return "minimal"
+    return None

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -101,7 +101,9 @@ async def test_normalizes_native_tool_decision_and_usage() -> None:
     assert result.usage.cached_input_tokens == 3
     sent = client.chat.completions.calls[0]
     assert sent["tools"][0]["function"]["name"] == "lookup"
+    assert sent["tool_choice"] == "required"
     assert sent["temperature"] == 0
+    assert "reasoning_effort" not in sent
     assert "response_format" not in sent
 
 
@@ -133,6 +135,7 @@ async def test_gpt5_request_omits_unsupported_temperature() -> None:
     sent = client.chat.completions.calls[0]
     assert sent["model"] == "gpt-5-nano"
     assert "temperature" not in sent
+    assert sent["reasoning_effort"] == "minimal"
 
 
 @pytest.mark.asyncio
@@ -586,6 +589,7 @@ async def test_tool_result_continuation_allows_tools_and_strict_final_answer() -
         "refusal",
     ]
     assert schema["properties"]["value"]["anyOf"][0]["required"] == ["ok"]
+    assert client.chat.completions.calls[0]["tool_choice"] == "auto"
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_readiness.py
+++ b/tests/llm/agent/test_readiness.py
@@ -82,7 +82,12 @@ async def test_certification_proves_tool_continuation_and_final_answer() -> None
         "type": "object",
         "additionalProperties": False,
         "required": ["nonce"],
-        "properties": {"nonce": {"const": "ready-v1"}},
+        "properties": {
+            "nonce": {
+                "type": "string",
+                "const": "ready-v1",
+            }
+        },
     }
 
 


### PR DESCRIPTION
## Summary

- Fix the strict readiness response schema rejected by OpenAI because a `const` field lacked its required JSON type.
- Send GPT-5 Chat Completions with `reasoning_effort=minimal` so the bounded completion budget produces the required structured decision instead of being exhausted by reasoning tokens.
- Require a native tool on pre-tool turns while retaining automatic tool/final-answer selection after tool continuation.

## Live failure and proof

The merged #1336 removed the unsupported `temperature` parameter but did not complete live readiness. Against the configured platform `openai` / `gpt-5-nano` endpoint:

1. The first native tool request was accepted.
2. OpenAI rejected the second turn at `param=response_format` because `properties.value.anyOf[0].properties.nonce` used `const` without `type`.
3. After correcting that schema, the default reasoning effort consumed the entire bounded completion budget and returned `finish_reason=length` with no structured content.
4. With the corrected schema, minimal reasoning, and required first tool selection, the complete two-turn synthetic readiness exchange succeeded against the real OpenAI endpoint.

This does not implement CHAOS-3254: parallel tool-call suppression remains a separate issue.

## Validation

- `bash ci/local_validate.sh`: 9,552 passed, 73 skipped; Ruff, mypy, Go, River compatibility, isolated ClickHouse migration, and live-engine proof passed.
- Focused agent/readiness/admin tests: 40 passed.
- Live OpenAI GPT-5 Nano two-turn synthetic readiness exchange: passed.
- Authenticated deployed `/api/v1/dev` user-turn acceptance remains to be exercised after deployment.

SCREENSHOT-WAIVER: Backend provider request contract and tests only; no rendered UI changed.

Closes CHAOS-3263

Follow-up to #1336.

Linear: https://linear.app/fullchaos/issue/CHAOS-3263/ask-dev-openai-gpt-5-readiness-sends-incompatible-request-and-reports
