### PR TITLE
fix(ask-dev): enforce sequential tool decisions on OpenAI-compatible requests

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -294,7 +294,7 @@
       },
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "4a50d7e3853ddb25c6eb0b2141d6156000547aed28244f9659e4ee18b4a9b13e"
+        "sha256": "8547fecb7f135fc005f0d06e5ca223272994cb118c365208abf9b3bd54ee26f0"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -330,7 +330,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "1cd0ad8794e65be66b741fe0b5cc4d3d347785f23a1c8c6cfaf127c51dfcf37e"
+        "sha256": "e26991bfcfd4ef628bcfbb6186fcbe1f9034c6259910f85d6d9ab779df1fea49"
       },
       "schema_version": "dev_stream_event.v1"
     },
@@ -348,7 +348,7 @@
       },
       "schema": {
         "path": "schemas/dev_error.v1.schema.json",
-        "sha256": "e68386046905c634c118564dd3d74447fc55387c57d84a6a79ce903f0a4c3907"
+        "sha256": "eb78a38684caab42ef2c88c6a33f558330855b86b9b847024560dfeb68581514"
       },
       "schema_version": "dev_error.v1"
     }

--- a/contracts/ask-dev/v1/schemas/dev_error.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_error.v1.schema.json
@@ -27,6 +27,7 @@
         "insufficient_evidence",
         "answer_validation_failed",
         "cancelled",
+        "provider_contract_violation",
         "internal_error"
       ],
       "title": "Code",

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -532,6 +532,7 @@
             "insufficient_evidence",
             "answer_validation_failed",
             "cancelled",
+            "provider_contract_violation",
             "internal_error"
           ],
           "title": "Code",

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -215,6 +215,7 @@
             "insufficient_evidence",
             "answer_validation_failed",
             "cancelled",
+            "provider_contract_violation",
             "internal_error"
           ],
           "title": "Code",

--- a/docs/operate/maintain/upgrade.md
+++ b/docs/operate/maintain/upgrade.md
@@ -72,3 +72,23 @@ reference before reading source content. Rollback removes the additive fields,
 services, and route without a storage rollback. Verify native evidence remains
 available when ACR is absent or unavailable, and keep Ask Dev interaction
 surfaces disabled until the matching web contract artifacts are deployed.
+
+## Ask Dev sequential-tool-call wire contract compatibility
+
+The OpenAI-compatible provider's readiness certification fingerprint folds in
+a `READINESS_VERSION` constant. This deploy bumps it (v2 -> v3) because the
+outbound wire contract changed: native tool requests now send
+`parallel_tool_calls` (gated by model family). A v2 certification never
+demonstrated that its endpoint accepts the new parameter.
+
+**Expected state immediately after deploy**: every previously stored
+readiness certification -- platform and BYO -- reads as not-current. Ask Dev
+capability endpoints report degraded/not-ready readiness until preflight
+re-runs and re-certifies each configured provider connection. This is
+expected, one-time, self-healing behavior, not an incident: no data migration
+or manual database change is required.
+
+**Remediation**: run Ask Dev preflight/readiness certification for the
+platform connection and every configured workspace BYO connection after this
+deploy. Do not treat the transient not-ready state as a provider outage or
+attempt to restore the prior fingerprint.

--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -317,6 +317,12 @@ def _failed_readiness_state(safe_error_code: str | None) -> tuple[ReadinessState
             "unsupported_model",
             "The configured model did not satisfy the Ask Dev agent capability contract.",
         )
+    if safe_error_code == "provider_contract_violation":
+        return (
+            "unsupported_model",
+            "The configured model returned multiple tool decisions in one turn, "
+            "violating Ask Dev's required sequential tool-call contract.",
+        )
     if safe_error_code == "provider_unavailable":
         return "degraded", "The configured Ask Dev model endpoint is unavailable."
     return "degraded", "The configured Ask Dev model failed readiness."

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -887,12 +887,34 @@ class DevError(ContractModel):
         "insufficient_evidence",
         "answer_validation_failed",
         "cancelled",
+        "provider_contract_violation",
         "internal_error",
     ]
     safe_message: ShortText
     retryable: bool
     limit_reset_at: AwareDatetime | None = None
     remediation: list[ShortText] = Field(default_factory=list, max_length=5)
+
+
+# Safe, stable remediation text keyed by DevError.code, shared by the live
+# orchestrator error projection (DevOrchestrator._provider_error) and the
+# idempotent-replay projection (router._replayed_result) so a client sees the
+# same guidance whether it observes a fresh run or a replayed one (CHAOS-3254).
+_DEV_ERROR_REMEDIATION: dict[str, tuple[str, ...]] = {
+    "provider_contract_violation": (
+        "Confirm the configured OpenAI-compatible endpoint honors "
+        "parallel_tool_calls=false and returns exactly one tool call per "
+        "decision.",
+        "If this is a self-hosted or third-party OpenAI-compatible server, "
+        "verify it supports sequential single-tool-call decisions before "
+        "certifying it for Ask Dev.",
+    ),
+}
+
+
+def dev_error_remediation(code: str) -> list[str]:
+    """Return the safe remediation list for a DevError code, or none."""
+    return list(_DEV_ERROR_REMEDIATION.get(code, ()))
 
 
 class StreamEventType(StrEnum):

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -58,6 +58,7 @@ from .contracts import (
     DevToolResult,
     ScopeResolutionOutcome,
     ToolID,
+    dev_error_remediation,
 )
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from .prompts import PromptComposer, PromptConversationTurn
@@ -1131,13 +1132,18 @@ class DevOrchestrator:
             AgentProviderErrorCode.CANCELLED: "cancelled",
             AgentProviderErrorCode.BUDGET_EXHAUSTED: "cost_limit_reached",
             AgentProviderErrorCode.BUDGET_UNAVAILABLE: "provider_unavailable",
+            AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION: (
+                "provider_contract_violation"
+            ),
         }
+        code = code_map[exc.code]
         return DevError(
             schema_version="dev_error.v1",
             request_id=request_id,
-            code=code_map[exc.code],
+            code=code,
             safe_message=str(exc),
             retryable=exc.retryable,
+            remediation=dev_error_remediation(code),
         )
 
 

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -53,6 +53,7 @@ from .contracts import (
     DevMessageRequest,
     DevScope,
     DevTranscriptEntry,
+    dev_error_remediation,
 )
 from .entitlement import (
     AskDevEntitlementDeniedError,
@@ -586,6 +587,11 @@ def _replayed_result(
                     "The prior Ask Dev request did not complete with an answer."
                 ),
                 retryable=code in {"provider_unavailable", "source_unavailable"},
+                # A replayed run must carry the same corrective guidance a
+                # live failure with this code would (CHAOS-3254) -- never
+                # silently drop remediation just because the client is
+                # reading back an idempotent replay instead of a fresh run.
+                remediation=dev_error_remediation(code),
             )
         except ValueError:
             error = DevError(

--- a/src/dev_health_ops/llm/agent/errors.py
+++ b/src/dev_health_ops/llm/agent/errors.py
@@ -28,6 +28,7 @@ class AgentProviderErrorCode(str, Enum):
     CANCELLED = "cancelled"
     BUDGET_EXHAUSTED = "budget_exhausted"
     BUDGET_UNAVAILABLE = "budget_unavailable"
+    PROVIDER_CONTRACT_VIOLATION = "provider_contract_violation"
 
 
 _SAFE_MESSAGES = {
@@ -42,6 +43,10 @@ _SAFE_MESSAGES = {
     AgentProviderErrorCode.CANCELLED: "The model request was cancelled.",
     AgentProviderErrorCode.BUDGET_EXHAUSTED: "The organization BYO LLM budget was reached.",
     AgentProviderErrorCode.BUDGET_UNAVAILABLE: "BYO LLM budget accounting is temporarily unavailable.",
+    AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION: (
+        "The model provider returned more than one tool decision in a single "
+        "turn, violating the sequential decision contract."
+    ),
 }
 
 

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 from dev_health_ops.llm.providers._http import make_hardened_async_httpx_client
 from dev_health_ops.llm.providers.openai_capabilities import (
     chat_completion_reasoning_effort,
+    supports_parallel_tool_calls,
     supports_temperature,
 )
 
@@ -37,7 +38,14 @@ from .errors import (
     safe_agent_provider_error,
 )
 
-READINESS_VERSION = "ask-dev-agent-v2"
+READINESS_VERSION = "ask-dev-agent-v3"
+"""Bumped v2 -> v3 for CHAOS-3254: the outbound wire contract changed (native
+tool requests now send ``parallel_tool_calls``, gated by model family -- see
+``supports_parallel_tool_calls``). A v2-certified endpoint has never been
+asked to accept the new parameter, so it must be re-certified rather than
+treated as still current. ``provider_fingerprint`` folds this constant in,
+so bumping it invalidates every existing stored readiness record for every
+provider instance (see ``AgentReadinessRecord.is_current``)."""
 PLATFORM_PRICE_BOOK_VERSION = "openai-2026-07-29"
 
 _DECISION_FIELDS = frozenset(
@@ -53,6 +61,18 @@ _DECISION_FIELDS = frozenset(
         "message",
     }
 )
+
+
+class _SequentialToolContractViolation(ValueError):
+    """A provider returned more than one native tool call in one decision.
+
+    Ask Dev's runtime is a sequential bounded state machine: exactly one tool
+    request per model decision. This is distinct from other malformed/invalid
+    provider responses (``AgentProviderErrorCode.INVALID_RESPONSE``) because
+    it must be classified as a stable provider/decision contract error rather
+    than an opaque application ``internal_error`` (CHAOS-3254).
+    """
+
 
 _STRUCTURAL_SCHEMA_KEYS = frozenset(
     {
@@ -177,6 +197,13 @@ class OpenAICompatibleAgentProvider:
             ),
             "max_completion_tokens": max_output_tokens,
         }
+        if tools and supports_parallel_tool_calls(self.model):
+            # Ask Dev's runtime is a sequential one-decision-per-round state
+            # machine (TRD 11-12, 20.4). Explicitly disabling native parallel
+            # tool calls keeps a standards-compliant OpenAI-compatible model
+            # from returning multiple tool calls in one response, which the
+            # normalizer must otherwise reject (CHAOS-3254).
+            completion_kwargs["parallel_tool_calls"] = False
         if supports_temperature(self.model):
             completion_kwargs["temperature"] = 0
         reasoning_effort = chat_completion_reasoning_effort(self.model)
@@ -226,6 +253,10 @@ class OpenAICompatibleAgentProvider:
             decision = self._normalize_response(
                 response, allowed_tool_ids=frozenset(item.tool_id for item in tools)
             )
+        except _SequentialToolContractViolation:
+            raise AgentProviderError(
+                AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION
+            ) from None
         except (
             AttributeError,
             IndexError,
@@ -471,7 +502,7 @@ class OpenAICompatibleAgentProvider:
         message = response.choices[0].message
         tool_calls = getattr(message, "tool_calls", None) or []
         if len(tool_calls) > 1:
-            raise ValueError("only one tool decision is allowed")
+            raise _SequentialToolContractViolation("only one tool decision is allowed")
         if tool_calls:
             call = tool_calls[0]
             tool_id = str(call.function.name)

--- a/src/dev_health_ops/llm/providers/openai_capabilities.py
+++ b/src/dev_health_ops/llm/providers/openai_capabilities.py
@@ -25,3 +25,36 @@ def chat_completion_reasoning_effort(model: str) -> str | None:
     if model.strip().lower().startswith("gpt-5"):
         return "minimal"
     return None
+
+
+def supports_parallel_tool_calls(model: str) -> bool:
+    """Return whether the wire API accepts the ``parallel_tool_calls`` control.
+
+    Unlike ``supports_temperature``, GPT-5 is NOT bucketed with the o-series
+    models here. Live-verified against the real OpenAI Chat Completions API
+    (2026-07-30, org key, request/response bodies not retained -- only HTTP
+    status and the safe error-classification fields):
+
+    * ``gpt-5-mini`` and ``gpt-5-nano`` with
+      ``tools`` + ``tool_choice: "auto"`` + ``reasoning_effort: "minimal"`` +
+      ``parallel_tool_calls: false`` -> HTTP 200 (accepted).
+    * ``o3-mini`` and ``o4-mini`` with the same request shape (no
+      ``reasoning_effort``, which this adapter never sends for o-series) ->
+      HTTP 400 ``invalid_request_error`` / ``unsupported_parameter`` /
+      ``param: "parallel_tool_calls"`` for both.
+    * ``o1-mini`` was not accessible under the probing key (404
+      model_not_found) -- inconclusive on its own, but excluded anyway since
+      it shares the o1/o3/o4 Chat Completions reasoning-model family and
+      community reports (e.g. langchain#29704, semantic-kernel#10365,
+      litellm#8980) independently confirm o1 rejects this parameter too.
+
+    So only the true o-series reasoning models reject this parameter outright;
+    GPT-5's Chat Completions surface accepts it and needs it disabled just
+    like any other tool-calling model to enforce Ask Dev's sequential
+    one-decision contract on the wire (CHAOS-3254). For o-series models the
+    contract is instead enforced purely on the response side (see
+    ``OpenAICompatibleAgentProvider._normalize_response``), so omitting the
+    field there is a verified necessity, not an assumption.
+    """
+
+    return not model.strip().lower().startswith(("o1", "o3", "o4"))

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -230,6 +230,11 @@ async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context)
         ("invalid_request", "unsupported_model", "required agent request capability"),
         ("invalid_response", "unsupported_model", "capability contract"),
         ("provider_unavailable", "degraded", "endpoint is unavailable"),
+        (
+            "provider_contract_violation",
+            "unsupported_model",
+            "sequential tool-call contract",
+        ),
     ],
 )
 def test_failed_readiness_exposes_only_specific_safe_remediation(

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -518,6 +518,107 @@ async def test_provider_timeout_is_caller_enforced_and_terminal_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_provider_contract_violation_is_a_safe_error_not_internal_error() -> None:
+    """CHAOS-3254: a defensive multiple-tool-call provider response must not
+    surface as the opaque application ``internal_error`` bucket. It must be a
+    stable, distinguishable safe error with useful operator remediation.
+    """
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    error=AgentProviderError(
+                        AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION,
+                        retryable=False,
+                    )
+                )
+            ],
+            script_id="provider-contract-violation",
+        )
+    )
+    assert result.state is RunState.FAILED
+    assert result.error is not None
+    assert result.error.code == "provider_contract_violation"
+    assert result.error.code != "internal_error"
+    assert result.error.retryable is False
+    assert result.error.remediation
+
+
+@pytest.mark.asyncio
+async def test_multi_metric_question_completes_through_sequential_tool_rounds() -> None:
+    """CHAOS-3254 acceptance: a naturally multi-metric question completes
+    through one tool request per round -- through a final answer -- and
+    stays within the existing tool/round budgets. This is the scripted
+    deterministic acceptance path for the literal reproduction question:
+    "What is the current delivery metric and project timing across the org
+    look like compared the previous period?"
+    """
+    script_id = "multi-metric-sequential"
+    executed: list[DevToolRequest] = []
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "items_completed",
+                            "include_comparison": True,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "cycle_time_p50_hours",
+                            "include_comparison": True,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_02",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "avg_wip",
+                            "include_comparison": True,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_03",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(_answer(script_id=script_id))),
+            ],
+            script_id=script_id,
+            registry=_registry(calls=executed),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.tool_call_count == 3
+    assert [request.metric_id for request in executed] == [
+        "items_completed",
+        "cycle_time_p50_hours",
+        "avg_wip",
+    ]
+    assert all(request.include_comparison is True for request in executed)
+    # One model decision per round, through the final answer: no batching of
+    # multiple tool requests into a single round.
+    model_decision_rounds = [
+        event for event in result.events if event.state is RunState.MODEL_DECISION
+    ]
+    assert len(model_decision_rounds) == 4
+    # Well within the six-call/four-round budgets (TRD 12).
+    assert result.tool_call_count <= DevRunLimits().tool_calls
+    assert len(model_decision_rounds) <= DevRunLimits().model_rounds
+
+
+@pytest.mark.asyncio
 async def test_operator_downward_per_tool_byte_limit_is_enforced() -> None:
     result = await _run(
         _orchestrator(

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -102,9 +102,137 @@ async def test_normalizes_native_tool_decision_and_usage() -> None:
     sent = client.chat.completions.calls[0]
     assert sent["tools"][0]["function"]["name"] == "lookup"
     assert sent["tool_choice"] == "required"
+    assert sent["parallel_tool_calls"] is False
     assert sent["temperature"] == 0
     assert "reasoning_effort" not in sent
     assert "response_format" not in sent
+
+
+@pytest.mark.asyncio
+async def test_native_tool_request_disables_parallel_tool_calls() -> None:
+    """CHAOS-3254: the wire request must enforce the sequential contract.
+
+    Ask Dev is a sequential one-decision-per-round state machine. Whenever
+    native tools are offered on an OpenAI-compatible model that accepts the
+    control, the outbound request must explicitly disable
+    ``parallel_tool_calls`` so a standards-compliant model cannot return more
+    than one tool call in a single response.
+    """
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert sent["parallel_tool_calls"] is False
+
+
+@pytest.mark.asyncio
+async def test_request_without_tools_omits_parallel_tool_calls_control() -> None:
+    client = Client(
+        [
+            response(
+                content=json.dumps({"kind": "refusal", "code": "no", "message": "no"})
+            )
+        ]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert sent["tools"] is None
+    assert sent["tool_choice"] is None
+    assert "parallel_tool_calls" not in sent
+
+
+@pytest.mark.asyncio
+async def test_gpt5_request_disables_parallel_tool_calls() -> None:
+    """GPT-5's Chat Completions surface accepts parallel_tool_calls=false.
+
+    Live-verified against the real API (2026-07-30): gpt-5-mini and
+    gpt-5-nano both return HTTP 200 for a tools + tool_choice:auto +
+    reasoning_effort:minimal + parallel_tool_calls:false request. GPT-5 is
+    NOT bucketed with the o-series reasoning models for this control (see
+    test_o_series_reasoning_model_omits_parallel_tool_calls_control) --
+    only supports_temperature/reasoning_effort bucket it that way, for an
+    unrelated constraint (CHAOS-3254/CHAOS-3263).
+    """
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-nano", client=client
+    )
+
+    await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert sent["parallel_tool_calls"] is False
+    assert sent["reasoning_effort"] == "minimal"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["o3-mini", "o4-mini"])
+async def test_o_series_reasoning_model_omits_parallel_tool_calls_control(
+    model: str,
+) -> None:
+    """o-series reasoning models reject parallel_tool_calls with a 400.
+
+    Live-verified against the real API (2026-07-30): both o3-mini and
+    o4-mini, with tools + tool_choice:auto + parallel_tool_calls:false,
+    return HTTP 400 invalid_request_error/unsupported_parameter,
+    param="parallel_tool_calls" (o1-mini was inaccessible under the probing
+    key -- 404 model_not_found -- but is excluded on the same family basis;
+    see supports_parallel_tool_calls's docstring). The sequential contract is
+    still enforced for this model family, but on the response side only (see
+    test_multiple_native_tool_calls_fail_closed), since sending the field at
+    all would break the request outright.
+    """
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model=model, client=client
+    )
+
+    await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert "parallel_tool_calls" not in sent
 
 
 @pytest.mark.asyncio
@@ -379,6 +507,15 @@ async def test_malformed_json_decisions_fail_closed(payload: dict[str, object]) 
 
 @pytest.mark.asyncio
 async def test_multiple_native_tool_calls_fail_closed() -> None:
+    """CHAOS-3254: a defensive multi-call response must not become internal_error.
+
+    Even with parallel_tool_calls=false on the outbound request (see
+    test_native_tool_request_disables_parallel_tool_calls), a provider may
+    still violate the sequential contract. That must fail closed as a
+    stable, distinguishable provider/decision contract error -- never the
+    opaque application ``internal_error`` bucket that ``INVALID_RESPONSE``
+    maps to (see DevOrchestrator._provider_error).
+    """
     first = SimpleNamespace(
         id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
     )
@@ -400,7 +537,105 @@ async def test_multiple_native_tool_calls_fail_closed() -> None:
             256,
         )
 
-    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+    assert caught.value.code is AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION
+    assert caught.value.code is not AgentProviderErrorCode.INVALID_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_literal_reproduction_question_completes_through_sequential_rounds() -> (
+    None
+):
+    """CHAOS-3254/CHAOS-3260 reproduction: a naturally multi-metric question.
+
+    ``What is the current delivery metric and project timing across the org
+    look like compared the previous period?`` previously failed before any
+    tool executed (safe_error_code=internal_error, tool_call_count=0) because
+    the LM Studio-style provider correctly returned three native tool calls
+    in one response and the request never disabled parallel tool calls. This
+    proves the fix end to end at the adapter: one native tool request per
+    round -- each with a comparison -- through a final answer, with no
+    generic internal error and with parallel_tool_calls explicitly disabled
+    on every tool-bearing request.
+    """
+    question = (
+        "What is the current delivery metric and project timing across the "
+        "org look like compared the previous period?"
+    )
+    metric_tool = AgentToolDefinition(
+        "query_metric.v1",
+        "Query a bounded metric.",
+        {
+            "type": "object",
+            "properties": {
+                "metric_id": {"type": "string"},
+                "include_comparison": {"type": "boolean"},
+            },
+        },
+    )
+
+    def tool_call(call_id: str, metric_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=call_id,
+            function=SimpleNamespace(
+                name="query_metric.v1",
+                arguments=json.dumps(
+                    {"metric_id": metric_id, "include_comparison": True}
+                ),
+            ),
+        )
+
+    client = Client(
+        [
+            response(tool_call=tool_call("call-1", "items_completed")),
+            response(tool_call=tool_call("call-2", "cycle_time_p50_hours")),
+            response(tool_call=tool_call("call-3", "avg_wip")),
+            response(
+                content=json.dumps(
+                    {
+                        "kind": "final_answer",
+                        "value": {"status": "partial"},
+                    }
+                )
+            ),
+        ]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    messages: list[AgentMessage] = [AgentMessage(AgentMessageRole.USER, question)]
+    tool_requests: list[AgentToolRequest] = []
+    for _ in range(3):
+        result = await provider.decide(
+            messages, [metric_tool], {"type": "object"}, 1, 256
+        )
+        assert isinstance(result.decision, AgentToolRequest)
+        tool_requests.append(result.decision)
+        messages = [
+            *messages,
+            AgentMessage(AgentMessageRole.ASSISTANT, "", tool_request=result.decision),
+            AgentMessage(
+                AgentMessageRole.TOOL,
+                json.dumps({"status": "success"}),
+                tool_call_id=result.decision.call_id,
+            ),
+        ]
+
+    final = await provider.decide(messages, [metric_tool], {"type": "object"}, 1, 256)
+    assert isinstance(final.decision, AgentFinalAnswer)
+
+    assert [request.arguments["metric_id"] for request in tool_requests] == [
+        "items_completed",
+        "cycle_time_p50_hours",
+        "avg_wip",
+    ]
+    assert all(
+        request.arguments["include_comparison"] is True for request in tool_requests
+    )
+    # One native tool call per round -- never more than one in a single
+    # response -- and the sequential contract explicitly enforced on the wire.
+    for call in client.chat.completions.calls:
+        assert call["parallel_tool_calls"] is False
 
 
 def test_decision_schema_hoists_final_and_tool_definitions_for_root_refs() -> None:

--- a/tests/llm/agent/test_readiness.py
+++ b/tests/llm/agent/test_readiness.py
@@ -7,6 +7,10 @@ from dev_health_ops.llm.agent.contracts import (
     AgentToolRequest,
     AgentUsage,
 )
+from dev_health_ops.llm.agent.openai_compatible import (
+    OpenAICompatibleAgentProvider,
+    _fingerprint,
+)
 from dev_health_ops.llm.agent.readiness import (
     READINESS_MAX_OUTPUT_TOKENS,
     AgentReadinessOutcome,
@@ -132,3 +136,38 @@ async def test_repeated_tool_request_on_final_answer_turn_fails_closed() -> None
 async def test_scripted_provider_supports_shared_lifecycle() -> None:
     provider = ScriptedAgentProvider([])
     await provider.aclose()
+
+
+def test_wire_contract_change_invalidates_a_pre_change_readiness_record() -> None:
+    """CHAOS-3254: bumping READINESS_VERSION must invalidate stale certifications.
+
+    A provider certified under the prior wire contract (before native tool
+    requests started explicitly sending ``parallel_tool_calls``) never
+    demonstrated that its endpoint accepts the new parameter. Simulate
+    exactly that pre-change persisted record and confirm the CURRENT
+    provider no longer treats it as current -- it must be re-certified, not
+    silently trusted to handle a request shape it was never tested against.
+    """
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", base_url="http://127.0.0.1:1/v1"
+    )
+    stale_readiness_version = "ask-dev-agent-v2"
+    stale_fingerprint = _fingerprint(
+        "openai-compatible", provider.base_url, stale_readiness_version
+    )
+    pre_change_record = AgentReadinessRecord(
+        fingerprint=stale_fingerprint,
+        readiness_version=stale_readiness_version,
+        checked_at="2026-01-01T00:00:00+00:00",
+        outcome=AgentReadinessOutcome.READY,
+    )
+
+    # The wire contract genuinely changed -- confirm this isn't a vacuous
+    # comparison against itself.
+    assert stale_readiness_version != provider.capabilities.readiness_version
+    assert stale_fingerprint != provider.provider_fingerprint
+
+    assert not pre_change_record.is_current(
+        fingerprint=provider.provider_fingerprint,
+        readiness_version=provider.capabilities.readiness_version,
+    )


### PR DESCRIPTION
## Summary

Fixes CHAOS-3254 (and duplicate CHAOS-3260). Ask Dev's runtime is a sequential bounded state machine — exactly one tool decision per model round — but the OpenAI-compatible adapter never told the wire API that. A standards-compliant model returning multiple native tool calls in one response (observed with LM Studio / `google/gemma-4-e4b` on the literal question *"What is the current delivery metric and project timing across the org look like compared the previous period?"*) failed before any tool executed, with `safe_error_code=internal_error` and `tool_call_count=0`.

- Native tool requests now send `parallel_tool_calls: false`, gated by a new `supports_parallel_tool_calls(model)` capability check in `openai_capabilities.py` (same home as `supports_temperature`/`chat_completion_reasoning_effort`).
- **Live-verified against the real OpenAI API** (2026-07-30, HTTP status + safe error-classification fields only, no prompts/credentials retained):
  - `gpt-5-mini`, `gpt-5-nano` + `parallel_tool_calls:false` → **HTTP 200** (accepted)
  - `o3-mini`, `o4-mini` + `parallel_tool_calls:false` → **HTTP 400** `invalid_request_error` / `unsupported_parameter` / `param: "parallel_tool_calls"`
  - So GPT-5 is **not** bucketed with the o-series exclusion for this control (unlike `supports_temperature`) — evidence is recorded directly in the function's docstring.
- A provider that still returns >1 tool call is now classified as a new, stable `AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION` / `DevError` code `provider_contract_violation` with operator remediation — never the opaque `internal_error` bucket `INVALID_RESPONSE` mapped to.
- `READINESS_VERSION` bumped v2→v3 (folds into `provider_fingerprint`) so a certification made before this wire-contract change — which never demonstrated `parallel_tool_calls` acceptance — is treated as stale and re-certified, not silently trusted.
- Centralized `DevError` remediation lookup (`dev_error_remediation`) so the idempotent-replay path (`router._replayed_result`) carries the same guidance as a live failure, and the admin readiness projection (`_failed_readiness_state`) recognizes `provider_contract_violation` instead of falling through to a generic degraded state.
- Regenerated `contracts/ask-dev/v1` schema/manifest for the new `DevError.code` literal (`export_contracts.py write`, exact diff, no drift).

Adversarially reviewed by Codex (2 rounds): round 1 found the stale-readiness, incomplete o-series exclusion, replay-remediation-drop, and admin-projection gaps above — all fixed and covered by new tests.

## Test plan
- [x] Outbound request-shape tests: `parallel_tool_calls:false` sent for standard + gpt-5 models; omitted for o3-mini/o4-mini; omitted when no tools.
- [x] `test_multiple_native_tool_calls_fail_closed` updated to assert the new `PROVIDER_CONTRACT_VIOLATION` classification (not `INVALID_RESPONSE`/`internal_error`).
- [x] Literal reproduction question exercised through 3 sequential native tool-call rounds + final answer at the adapter level (fake wire client, no live network).
- [x] Orchestrator-level multi-metric test (`items_completed`/`cycle_time_p50_hours`/`avg_wip`, one tool request per round through final answer) within the existing 6-call/4-round budget.
- [x] `test_wire_contract_change_invalidates_a_pre_change_readiness_record` — simulated pre-change v2 record is no longer current.
- [x] Replay + admin-readiness-projection coverage for `provider_contract_violation`.
- [x] `bash ci/local_validate.sh` — full gate green (ruff, mypy, go, unit suite incl. contracts drift + docs, argMax live-exec proof).

## Deploy consequence (READINESS_VERSION v2 -> v3)

`provider_fingerprint` folds in `READINESS_VERSION`, which this PR bumps.
**Expected state immediately after deploy**: every previously stored Ask Dev
readiness certification — platform and BYO — reads as not-current, since a
v2 certification never demonstrated its endpoint accepts the new
`parallel_tool_calls` parameter. Ask Dev capability endpoints will report
degraded/not-ready readiness until preflight re-runs and re-certifies each
configured provider connection. This is expected, one-time, self-healing
behavior — not an incident, and no manual data change is required.

**Remediation**: run Ask Dev preflight/readiness certification for the
platform connection and every configured workspace BYO connection right
after this deploys. Documented in `docs/operate/maintain/upgrade.md` under
"Ask Dev sequential-tool-call wire contract compatibility". Flagging for
Wave 4's rollout runbook.
