### PR TITLE
fix(ask-dev): prevent prompt and evidence payloads from entering application logs

### DIFF
--- a/docs/operate/observe/logs.md
+++ b/docs/operate/observe/logs.md
@@ -19,3 +19,35 @@ Do not log:
 - unnecessary personal data.
 
 Use correlation identifiers to connect API, worker, queue, provider, and storage events.
+
+## Ask Dev provider-client logging
+
+Ask Dev's orchestrator and OpenAI-compatible provider adapter never log
+conversation, evidence, or tool-result content themselves. The only path by
+which that content could otherwise reach ordinary application logs is the
+third-party HTTP/provider client libraries' own debug logging, which by
+default inherits the process root log level.
+
+Raising `LOG_LEVEL` to `DEBUG` (for example, temporarily, for local
+diagnostics via `compose.yml`) does **not** enable that content logging for
+Ask Dev. The `openai`, `httpx`, and `httpcore` loggers are pinned to
+`WARNING` unconditionally, regardless of the configured root level, because
+at `DEBUG` these libraries log the full outbound request body — including
+the system policy prompt, prior conversation turns, the current question,
+resolved scope, and tool-result payloads — and response headers/bodies.
+
+What remains observable at every log level:
+
+- request and run identifiers;
+- provider and model fingerprints;
+- latency, token usage, and estimated cost;
+- a classified, sanitized error code and whether it is retryable (see
+  `AgentProviderErrorCode` / `DevError.code`) — never a raw provider
+  response body or exception text.
+
+Supported diagnostic workflow: correlate a failing Ask Dev request by its
+run ID and `safe_error_code` in `dev_runs` and exported telemetry, not by
+raising `LOG_LEVEL` and inspecting `docker compose logs api`. If a live
+provider integration needs deeper inspection, use the operator-owned
+external model server's own logs (for example, LM Studio) — this contract
+does not extend to those processes, only to FullChaos-operated ones.

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -14,6 +14,7 @@ from dev_health_ops.llm.providers.openai_capabilities import (
     chat_completion_reasoning_effort,
     supports_temperature,
 )
+from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
 from .contracts import (
     AgentDecisionResult,
@@ -118,6 +119,13 @@ class OpenAICompatibleAgentProvider:
         self._http_client: Any | None = None
         if client is None:
             from openai import AsyncOpenAI
+
+            # The OpenAI SDK's own import-time logging setup can reset the
+            # content-carrying client loggers back to DEBUG if the operator
+            # OPENAI_LOG env var is set, overriding configure_logging()'s
+            # WARNING pin -- reassert it immediately after this (possibly
+            # first-ever) import (CHAOS-3258).
+            pin_content_carrying_client_loggers()
 
             self._http_client = make_hardened_async_httpx_client()
             client = AsyncOpenAI(

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -17,6 +17,7 @@ from dev_health_ops.llm.errors import (
     is_retryable,
     retry_delay,
 )
+from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
 from ._http import make_hardened_async_httpx_client
 from .base import (
@@ -150,6 +151,11 @@ class LocalProvider(LLMProviderBase):
         if self._client is None:
             try:
                 from openai import AsyncOpenAI
+
+                # See CHAOS-3258: the SDK's own import-time logging setup
+                # can reset content-carrying client loggers to DEBUG when
+                # the operator OPENAI_LOG env var is set; reassert the pin.
+                pin_content_carrying_client_loggers()
 
                 self._client = AsyncOpenAI(
                     api_key=self.api_key,

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -29,6 +29,7 @@ from dev_health_ops.llm.errors import (
     retry_delay,
 )
 from dev_health_ops.llm.json_utils import validate_json_or_empty
+from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
 from ._http import make_hardened_async_httpx_client, make_hardened_httpx_client
 from .base import (
@@ -552,6 +553,11 @@ class _OpenAIProviderBase(LLMProviderBase):
         if self._client is None:
             from openai import AsyncOpenAI
 
+            # See CHAOS-3258: the SDK's own import-time logging setup can
+            # reset content-carrying client loggers to DEBUG when the
+            # operator OPENAI_LOG env var is set; reassert the pin.
+            pin_content_carrying_client_loggers()
+
             self._client = AsyncOpenAI(
                 api_key=self.cfg.api_key,
                 base_url=self.cfg.base_url,
@@ -562,6 +568,10 @@ class _OpenAIProviderBase(LLMProviderBase):
 
     def _validate_model_on_startup(self) -> None:
         from openai import OpenAI
+
+        # See CHAOS-3258: reassert the content-carrying client logger pin
+        # immediately after this (possibly first-ever) SDK import.
+        pin_content_carrying_client_loggers()
 
         client = OpenAI(
             api_key=self.cfg.api_key,

--- a/src/dev_health_ops/logging_config.py
+++ b/src/dev_health_ops/logging_config.py
@@ -26,6 +26,45 @@ TRACE_LOG_LEVEL = 5
 if logging.getLevelName(TRACE_LOG_LEVEL) == f"Level {TRACE_LOG_LEVEL}":
     logging.addLevelName(TRACE_LOG_LEVEL, "TRACE")
 
+# Loggers owned by HTTP/provider client SDKs that log full request/response
+# bodies (prompts, tool schemas, tool-result payloads, endpoint URLs) at
+# DEBUG. Ask Dev never logs conversation or evidence content itself (see
+# openai_compatible.py / orchestrator.py), so the only leak vector is these
+# third-party loggers inheriting an operator-raised root LOG_LEVEL (e.g.
+# DEBUG, set via compose.yml for local diagnostics). They are pinned to
+# WARNING regardless of root LOG_LEVEL so enabling debug logging elsewhere in
+# the application can never copy tenant conversation or evidence content into
+# ordinary application logs (CHAOS-3258).
+#
+# - "openai": the OpenAI Python SDK (openai._base_client logs the full
+#   "Request options" -- messages, tools, schemas -- at DEBUG).
+# - "httpx": logs request/response lines; DEBUG adds headers.
+# - "httpcore": httpx's transport; DEBUG logs raw connection/wire detail.
+_CONTENT_CARRYING_CLIENT_LOGGERS = ("openai", "httpx", "httpcore")
+
+
+def pin_content_carrying_client_loggers() -> None:
+    """(Re)pin the content-carrying client loggers to WARNING.
+
+    ``configure_logging()`` calls this at process startup, but it must also
+    be called again immediately after any lazy ``import openai`` (see
+    ``llm/agent/openai_compatible.py``, ``llm/providers/openai.py``,
+    ``llm/providers/local.py``). The OpenAI Python SDK runs its own logging
+    setup exactly once, at import time (``openai._utils._logs.setup_logging``),
+    and -- when the operator sets the standard ``OPENAI_LOG`` env var to
+    ``"debug"``/``"info"`` -- that setup unconditionally resets the
+    ``openai`` and ``httpx`` loggers, regardless of what
+    ``configure_logging()`` already pinned. Because Ask Dev imports the SDK
+    lazily, per first use, that reset happens well after process-startup
+    ``configure_logging()`` has already run, silently reopening the exact
+    content-logging leak CHAOS-3258 closes. Reapplying this pin immediately
+    after the (possibly first-ever) import closes that import-order gap;
+    since Python caches the module, this only needs to happen once per
+    process, at each known import call site.
+    """
+    for name in _CONTENT_CARRYING_CLIENT_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
 
 def _resolve_log_level(raw: str) -> int:
     """Convert a level name to its numeric value, falling back to INFO."""
@@ -72,9 +111,14 @@ def configure_logging(level: str | None = None) -> None:
         root.addHandler(handler)
     root.setLevel(log_level)
 
-    # Silence noisy third-party loggers
+    # Silence noisy third-party loggers.
     for noisy in ("uvicorn.access", "watchfiles"):
         logging.getLogger(noisy).setLevel(logging.WARNING)
+    # Pinned unconditionally -- never derived from log_level -- so a DEBUG
+    # root level can never resurrect provider request/response body logging
+    # (CHAOS-3258). Must also be reapplied after any lazy `import openai`
+    # (see pin_content_carrying_client_loggers's docstring for why).
+    pin_content_carrying_client_loggers()
 
 
 def uvicorn_log_config(level: str | None = None) -> dict[str, Any]:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,417 @@
+"""Regression coverage for CHAOS-3258: safe provider-client logging.
+
+Ask Dev's orchestrator and OpenAI-compatible adapter never call a logger
+directly (see openai_compatible.py / orchestrator.py). The only leak vector
+is the OpenAI Python SDK's own debug logging ("Request options: ...", which
+includes the full outbound message list -- system policy prompt, prior
+conversation turns, the current question, and tool-result payloads) and
+httpx/httpcore's debug logging, both of which otherwise inherit an
+operator-raised root LOG_LEVEL (e.g. DEBUG, set via compose.yml for local
+diagnostics).
+
+This drives real requests through the production ``OpenAICompatibleAgentProvider``
+over a real local HTTP server -- using the actual ``openai``/``httpx``/``httpcore``
+machinery, not a hand-rolled fake client -- so the SDK's own debug logging is
+genuinely exercised. A test that only asserted "no sentinel in the logs"
+without first proving the harness can observe a leak would pass vacuously if
+nothing were ever logged at all; ``test_leak_harness_actually_observes_a_leak_when_unpatched``
+closes that gap by temporarily undoing the fix and confirming the sentinel
+does appear.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.llm.agent.contracts import (
+    AgentFinalAnswer,
+    AgentMessage,
+    AgentMessageRole,
+    AgentToolDefinition,
+    AgentToolRequest,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError
+from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.logging_config import configure_logging
+
+_CONTENT_CARRYING_CLIENT_LOGGERS = ("openai", "httpx", "httpcore")
+
+
+def _sentinel(name: str) -> str:
+    # Neutral, non-secret-shaped runtime-constructed marker (never a literal
+    # committed to source) so gitleaks never sees anything resembling a real
+    # credential, per repo convention for secret-shaped test fixtures.
+    return f"SENTINEL-{name.upper()}-{secrets.token_hex(12)}"
+
+
+class _Scenario:
+    SUCCESS = "success"
+    PROVIDER_FAILURE = "provider_failure"
+    TIMEOUT = "timeout"
+    RETRY_THEN_SUCCESS = "retry_then_success"
+    INVALID_RESPONSE = "invalid_response"
+
+
+def _completion_response(
+    *, tool_call: dict[str, Any] | None, content: str | None
+) -> dict:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    finish_reason = "stop"
+    if tool_call is not None:
+        message["content"] = None
+        message["tool_calls"] = [tool_call]
+        finish_reason = "tool_calls"
+    return {
+        "id": "chatcmpl-sentinel-test",
+        "object": "chat.completion",
+        "created": 1_785_283_200,
+        "model": "sentinel-test-model",
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": {"prompt_tokens": 7, "completion_tokens": 5, "total_tokens": 12},
+    }
+
+
+def _tool_call(call_id: str) -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": "query_metric.v1",
+            "arguments": json.dumps({"metric_id": "items_completed"}),
+        },
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _FakeServer
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)  # drain the request body; content is irrelevant here
+        self.server.request_count += 1
+        scenario = self.server.scenario
+        if scenario == _Scenario.SUCCESS:
+            self._write_json(
+                200, _completion_response(tool_call=_tool_call("call-1"), content=None)
+            )
+        elif scenario == _Scenario.PROVIDER_FAILURE:
+            self._write_json(
+                400,
+                {"error": {"message": "bad request", "type": "invalid_request_error"}},
+            )
+        elif scenario == _Scenario.TIMEOUT:
+            time.sleep(2.0)
+            self._write_json(
+                200, _completion_response(tool_call=_tool_call("call-1"), content=None)
+            )
+        elif scenario == _Scenario.RETRY_THEN_SUCCESS:
+            if self.server.request_count == 1:
+                self._write_json(
+                    429,
+                    {"error": {"message": "rate limited", "type": "rate_limit_error"}},
+                )
+            else:
+                self._write_json(
+                    200,
+                    _completion_response(tool_call=_tool_call("call-1"), content=None),
+                )
+        elif scenario == _Scenario.INVALID_RESPONSE:
+            self._write_json(
+                200, _completion_response(tool_call=None, content="not-a-json-decision")
+            )
+        else:  # pragma: no cover - defensive
+            self.send_error(500)
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+class _FakeServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, scenario: str) -> None:
+        super().__init__(("127.0.0.1", 0), _Handler)
+        self.scenario = scenario
+        self.request_count = 0
+
+
+@pytest.fixture
+def fake_server() -> Iterator[Any]:
+    server: _FakeServer | None = None
+
+    def start(scenario: str) -> _FakeServer:
+        nonlocal server
+        server = _FakeServer(scenario)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server
+
+    yield start
+    if server is not None:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture(autouse=True)
+def restore_client_logger_levels() -> Iterator[None]:
+    """Never let a test leak DEBUG-level SDK logging into the rest of the suite."""
+    saved = {
+        name: logging.getLogger(name).level for name in _CONTENT_CARRYING_CLIENT_LOGGERS
+    }
+    yield
+    for name, level in saved.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def _sentinel_bundle() -> dict[str, str]:
+    return {
+        "question": _sentinel("question"),
+        "prior_question": _sentinel("prior-question"),
+        "prior_answer": _sentinel("prior-answer"),
+        "evidence": _sentinel("evidence"),
+        "credential": _sentinel("credential"),
+        "tool_result": _sentinel("tool-result"),
+    }
+
+
+async def _exercise_scenario(
+    *,
+    base_url: str,
+    sentinels: dict[str, str],
+    timeout_seconds: float = 5.0,
+    provider: OpenAICompatibleAgentProvider | None = None,
+) -> AgentProviderError | None:
+    """Drive one full round-trip (plus a tool-result round) through the real adapter.
+
+    Returns the raised AgentProviderError, if any, so callers can assert on
+    the failure-path scenarios without the sentinel assertions ever being
+    skipped by an uncaught exception.
+
+    Accepts an already-constructed ``provider`` so a caller can force logger
+    levels between construction and the first request -- necessary because
+    the constructor itself now reasserts the safe logger levels right after
+    its lazy SDK import (CHAOS-3258), which would otherwise immediately
+    undo a level change made only *before* construction.
+    """
+    if provider is None:
+        provider = OpenAICompatibleAgentProvider(
+            api_key="sentinel-test-key", model="agent-model", base_url=base_url
+        )
+    tool = AgentToolDefinition(
+        "query_metric.v1",
+        "Query a bounded metric.",
+        {"type": "object", "properties": {}},
+    )
+    messages = [
+        AgentMessage(AgentMessageRole.SYSTEM, f"policy prompt {sentinels['evidence']}"),
+        AgentMessage(AgentMessageRole.USER, sentinels["prior_question"]),
+        AgentMessage(AgentMessageRole.ASSISTANT, sentinels["prior_answer"]),
+        AgentMessage(AgentMessageRole.USER, sentinels["question"]),
+    ]
+    try:
+        first = await provider.decide(
+            messages, [tool], {"type": "object"}, timeout_seconds, 256
+        )
+        if isinstance(first.decision, AgentToolRequest):
+            tool_result_payload = json.dumps(
+                {
+                    "status": "success",
+                    "credential": sentinels["credential"],
+                    "value": sentinels["tool_result"],
+                }
+            )
+            follow_up = [
+                *messages,
+                AgentMessage(
+                    AgentMessageRole.ASSISTANT, "", tool_request=first.decision
+                ),
+                AgentMessage(
+                    AgentMessageRole.TOOL,
+                    tool_result_payload,
+                    tool_call_id=first.decision.call_id,
+                ),
+            ]
+            second = await provider.decide(
+                follow_up, [tool], {"type": "object"}, timeout_seconds, 256
+            )
+            assert isinstance(second.decision, AgentFinalAnswer | AgentToolRequest)
+        return None
+    except AgentProviderError as exc:
+        return exc
+    finally:
+        await provider.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scenario", "expect_error", "timeout_seconds"),
+    [
+        (_Scenario.SUCCESS, False, 5.0),
+        (_Scenario.PROVIDER_FAILURE, True, 5.0),
+        (_Scenario.TIMEOUT, True, 0.05),
+        (_Scenario.RETRY_THEN_SUCCESS, False, 5.0),
+        (_Scenario.INVALID_RESPONSE, True, 5.0),
+    ],
+)
+async def test_sentinels_never_reach_logs_under_debug_root_logging(
+    fake_server: Any,
+    caplog: pytest.LogCaptureFixture,
+    scenario: str,
+    expect_error: bool,
+    timeout_seconds: float,
+) -> None:
+    server = fake_server(scenario)
+    host, port = cast(tuple[str, int], server.server_address)
+    sentinels = _sentinel_bundle()
+
+    configure_logging(level="DEBUG")
+    caplog.set_level(logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG):
+        error = await _exercise_scenario(
+            base_url=f"http://{host}:{port}/v1",
+            sentinels=sentinels,
+            timeout_seconds=timeout_seconds,
+        )
+
+    assert (error is not None) is expect_error
+
+    captured = caplog.text
+    for label, value in sentinels.items():
+        assert value not in captured, (
+            f"sentinel {label!r} leaked into application logs under DEBUG root logging"
+        )
+    # The fix must be a targeted, content-specific clamp -- not a blunt "turn
+    # off logging" hammer that would trivially satisfy the assertion above by
+    # silencing everything. A plain application logger (this test's own
+    # module, standing in for e.g. an orchestrator logger emitting safe
+    # request/run IDs, fingerprints, latency, usage, or error class) must
+    # still propagate at the configured DEBUG root level.
+    app_logger = logging.getLogger(__name__)
+    app_logger.debug("safe operational metadata marker for %s", scenario)
+    assert app_logger.getEffectiveLevel() == logging.DEBUG
+    assert f"safe operational metadata marker for {scenario}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_leak_harness_actually_observes_a_leak_when_unpatched(
+    fake_server: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Prove the regression test above is a real measurement, not a vacuous pass.
+
+    Undo the CHAOS-3258 fix for this one test (restored by the autouse
+    fixture) and confirm the question sentinel DOES appear in captured logs.
+    If this test ever stops failing-when-unpatched, the suite above could
+    pass for the wrong reason: nothing being logged at all.
+    """
+    server = fake_server(_Scenario.SUCCESS)
+    host, port = cast(tuple[str, int], server.server_address)
+    sentinels = _sentinel_bundle()
+    base_url = f"http://{host}:{port}/v1"
+
+    configure_logging(level="DEBUG")
+    # Construct the provider BEFORE forcing DEBUG: the constructor itself now
+    # reasserts the safe levels right after its lazy SDK import (CHAOS-3258),
+    # so forcing the levels first and constructing after would immediately
+    # (and correctly) get overridden -- that's the fix working, not a broken
+    # self-check. Force the "no fix at all" baseline strictly between
+    # construction and the first request instead.
+    provider = OpenAICompatibleAgentProvider(
+        api_key="sentinel-test-key", model="agent-model", base_url=base_url
+    )
+    for name in _CONTENT_CARRYING_CLIENT_LOGGERS:
+        logging.getLogger(name).setLevel(logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG):
+        error = await _exercise_scenario(
+            base_url=base_url, sentinels=sentinels, provider=provider
+        )
+
+    assert error is None
+    assert sentinels["question"] in caplog.text, (
+        "expected the unpatched SDK loggers to leak the question sentinel; "
+        "if this fails, the harness above cannot be trusted to catch a "
+        "regression"
+    )
+
+
+def test_openai_log_env_var_does_not_reopen_content_logging_in_a_fresh_process() -> (
+    None
+):
+    """Codex adversarial finding: OPENAI_LOG import-time reset bypass.
+
+    The OpenAI Python SDK runs its own logging setup exactly once, at
+    import time (``openai._utils._logs.setup_logging``), and when the
+    operator sets the standard ``OPENAI_LOG`` env var to "debug"/"info" it
+    unconditionally resets the "openai" and "httpx" loggers to that level --
+    regardless of what ``configure_logging()`` already pinned. Because Ask
+    Dev's provider adapters all import the SDK lazily (per first use, well
+    after process-startup ``configure_logging()`` already ran), this can
+    silently reopen full request/response body logging in production.
+
+    Module import state can't be reliably reset within this pytest process
+    (once "openai" is imported once in the session, later imports are
+    cached and setup_logging() never runs again), so this must run in a
+    genuinely fresh interpreter to be a real measurement.
+    """
+    script = textwrap.dedent(
+        """
+        import logging
+        from dev_health_ops.logging_config import configure_logging
+        configure_logging(level="DEBUG")
+        from dev_health_ops.llm.agent.openai_compatible import (
+            OpenAICompatibleAgentProvider,
+        )
+        OpenAICompatibleAgentProvider(
+            api_key="k", model="agent-model", base_url="http://127.0.0.1:1/v1"
+        )
+        # Prefixed and printed after everything else so ordinary JSON log
+        # lines (root is DEBUG here, and other libraries log at import time
+        # too) can never be mistaken for this result.
+        print("RESULT", logging.getLogger("openai").getEffectiveLevel())
+        print("RESULT", logging.getLogger("httpx").getEffectiveLevel())
+        print("RESULT", logging.getLogger("httpcore").getEffectiveLevel())
+        """
+    )
+    env = {**os.environ, "LOG_LEVEL": "DEBUG", "OPENAI_LOG": "debug"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    levels = [
+        int(line.split(" ", 1)[1])
+        for line in result.stdout.strip().splitlines()
+        if line.startswith("RESULT ")
+    ]
+    assert levels == [logging.WARNING, logging.WARNING, logging.WARNING], (
+        "OPENAI_LOG=debug reopened content-carrying client logging after the "
+        f"lazy SDK import; got effective levels {levels} "
+        f"(want all == {logging.WARNING}). stdout:\\n{result.stdout}\\n"
+        f"stderr:\\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Fixes CHAOS-3258. Ask Dev's orchestrator and OpenAI-compatible adapter never log conversation, evidence, or tool-result content themselves (verified: zero `logger.*` calls in `orchestrator.py` / `llm/agent/*.py`). The only leak vector is the `openai`/`httpx`/`httpcore` SDK loggers inheriting an operator-raised root `LOG_LEVEL` (e.g. `DEBUG`, settable via `compose.yml` for local diagnostics) — at `DEBUG`, `openai._base_client` logs the full outbound "Request options", including the system policy prompt, prior conversation turns, the current question, resolved scope, and tool-result payloads. This was observed with the literal user question and a prior status answer showing up in `docker compose logs api`.

- Pin `openai`/`httpx`/`httpcore` to `WARNING` **unconditionally** in `configure_logging()`, regardless of root `LOG_LEVEL` (previously only `uvicorn.access`/`watchfiles` were pinned).
- **Codex adversarial review (round 1) found this alone was insufficient**: the OpenAI SDK's own import-time logging setup (`openai/__init__.py` → `_utils._logs.setup_logging()`) unconditionally resets `openai`/`httpx` to `DEBUG` when the operator sets the standard `OPENAI_LOG` env var — and since Ask Dev imports the SDK lazily (per first request, well after process-startup `configure_logging()` already ran), that reset silently reopens the leak. Reproduced in a fresh process by Codex. **Fixed** by extracting `pin_content_carrying_client_loggers()` and reapplying it immediately after each of the 3 lazy `from openai import ...` call sites in the codebase (`openai_compatible.py`, `providers/openai.py` ×2, `providers/local.py`).
- Provider errors were already sanitized (no raw response bodies logged); safe request/run IDs, provider/model fingerprints, latency, usage, and error classification remain observable — proven directly in the regression test.
- Added operator documentation for the safe logging contract and supported diagnostic workflow to `docs/operate/observe/logs.md` (already in mkdocs nav).

## Test plan
- [x] `tests/test_logging_config.py` drives **real** requests through the production `OpenAICompatibleAgentProvider` over a real local HTTP server — actual `openai`/`httpx`/`httpcore` machinery, not a hand-mocked client — across 5 scenarios (success, provider failure/400, timeout, retry-then-success/429, invalid response) with sentinel question/prior-turn/evidence/credential(neutral, runtime-generated)/tool-result strings, asserting none leak under `DEBUG` root logging.
- [x] **Verified as a real measurement, not vacuous**: temporarily reverted the fix and confirmed all 5 scenarios genuinely leaked every sentinel pre-fix (captured in the PR description commit history); a permanent in-suite self-check test (`test_leak_harness_actually_observes_a_leak_when_unpatched`) does the same revert/assert-leak.
- [x] `test_openai_log_env_var_does_not_reopen_content_logging_in_a_fresh_process` — genuinely fresh subprocess (`LOG_LEVEL=DEBUG` + `OPENAI_LOG=debug`, real interpreter) proving effective levels stay `WARNING`; verified it fails without the import-order fix (measured `openai`/`httpx` at `DEBUG`=10 pre-fix, `WARNING`=30 post-fix).
- [x] `bash ci/local_validate.sh` — full gate green (ruff, mypy, go, unit suite incl. docs build, argMax live-exec proof).