### PR TITLE
fix(ask-dev): derive answer coverage from usable evidence, not tool status

### DIFF
--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -23,10 +23,17 @@ _NON_REPAIRABLE_VALIDATION_MARKERS = (
     "unknown evidence",
     "unknown metric",
     "observed claims require",
-    "complete answer requires",
     "recommendations require",
     "inferred claims cannot",
 )
+# "complete answer requires all required sources fresh and available"
+# (DevAnswer.validate_answer_invariants) is deliberately repairable, not
+# listed above: server-derived coverage overwrites whatever the model
+# proposed, so the model can genuinely be one bounded correction away from
+# a valid answer -- e.g. it claimed "complete" while a tool's own warning
+# said a required source was unavailable. Giving it one repair attempt
+# (schema_repairs) lets it reissue the same grounded data under an accurate
+# status instead of hard-failing a run that has usable evidence (CHAOS-3257).
 
 
 class AnswerValidationError(ValueError):

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -56,6 +56,7 @@ from .contracts import (
     DevScopeResolution,
     DevToolRequest,
     DevToolResult,
+    FreshnessState,
     ScopeResolutionOutcome,
     ToolID,
 )
@@ -392,6 +393,7 @@ class DevOrchestrator:
         started = self._monotonic()
         events: list[OrchestratorEvent] = []
         tool_results: list[DevToolResult] = []
+        tool_requests: list[DevToolRequest] = []
         tool_bytes_total = 0
         duplicate_counts: Counter[str] = Counter()
         budget = ProviderBudget(self._limits)
@@ -659,6 +661,7 @@ class DevOrchestrator:
                             ),
                         )
                     tool_results.append(execution.result)
+                    tool_requests.append(tool_request)
                     tool_bytes_total = next_total
                     provider_continuation += (
                         AgentMessage(
@@ -724,7 +727,7 @@ class DevOrchestrator:
                                 for item in canonical_evidence
                             ],
                             "coverage": self._coverage_from_tool_results(
-                                tuple(tool_results), now
+                                tuple(tool_requests), tuple(tool_results), now
                             ).model_dump(mode="json"),
                             "versions": self._versions.model_dump(mode="json"),
                             "model": model.model_dump(mode="json"),
@@ -1060,7 +1063,11 @@ class DevOrchestrator:
         A ``success``/``partial`` status alone is not evidence of coverage: a
         source that returned zero facts because a required upstream source
         (e.g. the authorized repository set) was unavailable must not be
-        reported as an available required source (CHAOS-3257).
+        reported as an available required source (CHAOS-3257). A
+        ``data_health`` list is only usable if at least one entry reports
+        something other than ``unavailable`` -- a partial data-health result
+        that exhaustively lists every source as unavailable is itself the
+        "nothing is available" case, not evidence of availability.
         """
         return bool(
             result.metrics
@@ -1068,38 +1075,82 @@ class DevOrchestrator:
             or result.status_facts
             or result.graph_edges
             or result.metric_definitions
-            or result.data_health
+            or any(
+                item.freshness is not FreshnessState.UNAVAILABLE
+                for item in result.data_health
+            )
+        )
+
+    @staticmethod
+    def _required_source_key(
+        request: DevToolRequest,
+    ) -> tuple[str, str | None, str | None, tuple[str, ...]]:
+        """Identify the distinct required source one tool request represents.
+
+        Two calls to the *same* tool are the same required source only if
+        they ask for the same discriminating data. `query_metric.v1` called
+        for ``items_completed`` and again for ``cycle_time_p50_hours`` are
+        two distinct required sources, not one, even though a retry of the
+        identical ``items_completed`` request is one (CHAOS-3257).
+        """
+        return (
+            request.tool_id.value,
+            request.metric_id.value if request.metric_id is not None else None,
+            request.query,
+            tuple(sorted(request.evidence_ref_ids)),
         )
 
     @classmethod
     def _coverage_from_tool_results(
-        cls, tool_results: tuple[DevToolResult, ...], as_of: datetime
+        cls,
+        tool_requests: tuple[DevToolRequest, ...],
+        tool_results: tuple[DevToolResult, ...],
+        as_of: datetime,
     ) -> DevCoverage:
-        # `required_source_count` counts required *source classes* (the
-        # distinct tools the model decided this answer needed), not raw tool
-        # invocations: a tool retried or called with different arguments
-        # still represents one required source.
-        required_sources = sorted({result.tool_id.value for result in tool_results})
-        usable_by_source: dict[str, bool] = {}
-        for result in tool_results:
+        if len(tool_requests) != len(tool_results):
+            raise ValueError("tool requests and results must be paired one-to-one")
+        # `required_source_count` counts required *source classes* -- the
+        # distinct (tool, discriminating-argument) asks the model made, not
+        # raw tool invocations: a retried, identical request is one required
+        # source; two different requests to the same tool are two.
+        usable_by_source: dict[
+            tuple[str, str | None, str | None, tuple[str, ...]], bool
+        ] = {}
+        label_by_source: dict[
+            tuple[str, str | None, str | None, tuple[str, ...]], str
+        ] = {}
+        for request, result in zip(tool_requests, tool_results, strict=True):
+            key = cls._required_source_key(request)
             usable = result.status == "success" or (
                 result.status == "partial" and cls._tool_result_has_usable_data(result)
             )
-            source = result.tool_id.value
-            usable_by_source[source] = usable_by_source.get(source, False) or usable
+            usable_by_source[key] = usable_by_source.get(key, False) or usable
+            label_by_source.setdefault(key, result.tool_id.value)
+        required_sources = sorted(
+            label_by_source, key=lambda key: (label_by_source[key], key)
+        )
         available = [
-            source for source in required_sources if usable_by_source.get(source, False)
+            label_by_source[key] for key in required_sources if usable_by_source[key]
         ]
         unavailable = [
-            source
-            for source in required_sources
-            if not usable_by_source.get(source, False)
+            label_by_source[key]
+            for key in required_sources
+            if not usable_by_source[key]
         ]
         stale = sorted(
             {
                 result.tool_id.value
                 for result in tool_results
-                if any(item.freshness == "stale" for item in result.data_health)
+                if any(
+                    item.freshness is FreshnessState.STALE
+                    for item in result.data_health
+                )
+                or any(
+                    item.freshness is FreshnessState.STALE for item in result.metrics
+                )
+                or any(
+                    item.freshness is FreshnessState.STALE for item in result.evidence
+                )
             }
         )
         return DevCoverage(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1054,27 +1054,59 @@ class DevOrchestrator:
         return canonical_metrics, canonical_evidence
 
     @staticmethod
+    def _tool_result_has_usable_data(result: DevToolResult) -> bool:
+        """Whether a tool result carries any fact an answer could ground on.
+
+        A ``success``/``partial`` status alone is not evidence of coverage: a
+        source that returned zero facts because a required upstream source
+        (e.g. the authorized repository set) was unavailable must not be
+        reported as an available required source (CHAOS-3257).
+        """
+        return bool(
+            result.metrics
+            or result.evidence
+            or result.status_facts
+            or result.graph_edges
+            or result.metric_definitions
+            or result.data_health
+        )
+
+    @classmethod
     def _coverage_from_tool_results(
-        tool_results: tuple[DevToolResult, ...], as_of: datetime
+        cls, tool_results: tuple[DevToolResult, ...], as_of: datetime
     ) -> DevCoverage:
+        # `required_source_count` counts required *source classes* (the
+        # distinct tools the model decided this answer needed), not raw tool
+        # invocations: a tool retried or called with different arguments
+        # still represents one required source.
+        required_sources = sorted({result.tool_id.value for result in tool_results})
+        usable_by_source: dict[str, bool] = {}
+        for result in tool_results:
+            usable = result.status == "success" or (
+                result.status == "partial" and cls._tool_result_has_usable_data(result)
+            )
+            source = result.tool_id.value
+            usable_by_source[source] = usable_by_source.get(source, False) or usable
         available = [
-            result for result in tool_results if result.status in {"success", "partial"}
+            source for source in required_sources if usable_by_source.get(source, False)
         ]
         unavailable = [
-            result.tool_id.value
-            for result in tool_results
-            if result.status in {"unavailable", "error"}
+            source
+            for source in required_sources
+            if not usable_by_source.get(source, False)
         ]
-        stale = [
-            result.tool_id.value
-            for result in tool_results
-            if any(item.freshness == "stale" for item in result.data_health)
-        ]
+        stale = sorted(
+            {
+                result.tool_id.value
+                for result in tool_results
+                if any(item.freshness == "stale" for item in result.data_health)
+            }
+        )
         return DevCoverage(
-            required_source_count=len(tool_results),
+            required_source_count=len(required_sources),
             available_source_count=len(available),
-            unavailable_required_sources=sorted(set(unavailable)),
-            stale_required_sources=sorted(set(stale)),
+            unavailable_required_sources=unavailable,
+            stale_required_sources=stale,
             as_of=as_of,
         )
 

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -121,6 +121,12 @@ def _tool_result(**overrides: object) -> DevToolResult:
     return DevToolResult.model_validate(payload)
 
 
+def _tool_request(**overrides: object) -> DevToolRequest:
+    payload = deepcopy(positive_fixtures()["dev_tool_request.v1"])
+    payload.update(overrides)
+    return DevToolRequest.model_validate(payload)
+
+
 def _registry(*, calls: list[DevToolRequest] | None = None) -> AskDevToolRegistry:
     async def execute(_context, request: DevToolRequest) -> DevToolResult:
         if calls is not None:
@@ -654,6 +660,7 @@ def test_coverage_excludes_empty_partial_results_from_availability() -> None:
     """Literal CHAOS-3257 repro: a partial status snapshot with zero facts and
     a missing-repository-set warning must read as unavailable, not covered.
     """
+    request = _tool_request(tool_id="status_snapshot.v1", metric_id=None)
     result = _tool_result(
         tool_id="status_snapshot.v1",
         status="partial",
@@ -665,7 +672,9 @@ def test_coverage_excludes_empty_partial_results_from_availability() -> None:
         data_health=[],
         warnings=["authorized_repository_set_unavailable"],
     )
-    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (request,), (result,), datetime.now(UTC)
+    )
     assert coverage.required_source_count == 1
     assert coverage.available_source_count == 0
     assert coverage.unavailable_required_sources == ["status_snapshot.v1"]
@@ -675,6 +684,7 @@ def test_coverage_counts_partial_with_usable_evidence_as_available() -> None:
     """A genuinely partial result that still carries usable facts is coverage,
     unlike an empty partial (contrast with the test above).
     """
+    request = _tool_request(tool_id="status_snapshot.v1", metric_id=None)
     result = _tool_result(
         tool_id="status_snapshot.v1",
         status="partial",
@@ -692,12 +702,17 @@ def test_coverage_counts_partial_with_usable_evidence_as_available() -> None:
         data_health=[],
         warnings=["some_children_unavailable"],
     )
-    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (request,), (result,), datetime.now(UTC)
+    )
     assert coverage.available_source_count == 1
     assert coverage.unavailable_required_sources == []
 
 
 def test_coverage_marks_error_and_unavailable_status_as_unavailable() -> None:
+    error_request = _tool_request(
+        tool_id="search_evidence.v1", metric_id=None, query="meridian/web-app"
+    )
     error_result = _tool_result(
         tool_id="search_evidence.v1",
         status="error",
@@ -712,6 +727,7 @@ def test_coverage_marks_error_and_unavailable_status_as_unavailable() -> None:
             "retryable": True,
         },
     )
+    unavailable_request = _tool_request(tool_id="data_health.v1", metric_id=None)
     unavailable_result = _tool_result(
         tool_id="data_health.v1",
         status="unavailable",
@@ -721,7 +737,9 @@ def test_coverage_marks_error_and_unavailable_status_as_unavailable() -> None:
         warnings=["provider_unreachable"],
     )
     coverage = DevOrchestrator._coverage_from_tool_results(
-        (error_result, unavailable_result), datetime.now(UTC)
+        (error_request, unavailable_request),
+        (error_result, unavailable_result),
+        datetime.now(UTC),
     )
     assert coverage.required_source_count == 2
     assert coverage.available_source_count == 0
@@ -731,7 +749,8 @@ def test_coverage_marks_error_and_unavailable_status_as_unavailable() -> None:
     ]
 
 
-def test_coverage_flags_stale_required_sources_independent_of_availability() -> None:
+def test_coverage_flags_stale_data_health_as_stale() -> None:
+    request = _tool_request(tool_id="data_health.v1", metric_id=None)
     result = _tool_result(
         tool_id="data_health.v1",
         status="success",
@@ -750,22 +769,170 @@ def test_coverage_flags_stale_required_sources_independent_of_availability() -> 
             }
         ],
     )
-    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (request,), (result,), datetime.now(UTC)
+    )
     assert coverage.available_source_count == 1
     assert coverage.stale_required_sources == ["data_health.v1"]
 
 
-def test_coverage_dedupes_required_source_count_by_tool_not_invocation() -> None:
-    """required_source_count counts required source classes, not raw tool
-    invocations: two calls to the same tool are one required source.
+def test_coverage_flags_stale_metric_payload_as_stale() -> None:
+    """Staleness embedded in a returned metric (not just data_health.v1) must
+    also be surfaced -- a stale metric answering a query is not fresh
+    coverage even though the tool call itself succeeded.
     """
-    first = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_01")
-    second = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_02")
+    request = _tool_request(tool_id="query_metric.v1")
+    stale_metric = deepcopy(positive_fixtures()["dev_metric_ref.v1"])
+    stale_metric["freshness"] = "stale"
+    result = _tool_result(
+        tool_id="query_metric.v1",
+        status="success",
+        evidence=[],
+        metric_definitions=[],
+        metrics=[stale_metric],
+    )
     coverage = DevOrchestrator._coverage_from_tool_results(
-        (first, second), datetime.now(UTC)
+        (request,), (result,), datetime.now(UTC)
+    )
+    assert coverage.available_source_count == 1
+    assert coverage.stale_required_sources == ["query_metric.v1"]
+
+
+def test_coverage_data_health_with_only_unavailable_entries_is_not_usable() -> None:
+    """A partial data_health.v1 result whose every entry reports
+    unavailable is the "nothing is available" case, not evidence that the
+    source responded -- a non-empty list alone must not count as coverage.
+    """
+    request = _tool_request(tool_id="data_health.v1", metric_id=None)
+    result = _tool_result(
+        tool_id="data_health.v1",
+        status="partial",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        data_health=[
+            {
+                "source_system": "work_items",
+                "freshness": "unavailable",
+                "last_successful_at": None,
+                "coverage": 0.0,
+                "warning": "provider not configured",
+            },
+            {
+                "source_system": "repositories",
+                "freshness": "unavailable",
+                "last_successful_at": None,
+                "coverage": 0.0,
+                "warning": "provider not configured",
+            },
+        ],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (request,), (result,), datetime.now(UTC)
+    )
+    assert coverage.available_source_count == 0
+    assert coverage.unavailable_required_sources == ["data_health.v1"]
+
+
+def test_coverage_data_health_with_one_available_entry_is_usable() -> None:
+    """The mirror of the previous test: if at least one data_health entry is
+    not unavailable, the source did answer with something real.
+    """
+    request = _tool_request(tool_id="data_health.v1", metric_id=None)
+    result = _tool_result(
+        tool_id="data_health.v1",
+        status="partial",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        data_health=[
+            {
+                "source_system": "work_items",
+                "freshness": "fresh",
+                "last_successful_at": positive_fixtures()["dev_evidence_ref.v1"][
+                    "observed_at"
+                ],
+                "coverage": 1.0,
+                "warning": None,
+            },
+            {
+                "source_system": "repositories",
+                "freshness": "unavailable",
+                "last_successful_at": None,
+                "coverage": 0.0,
+                "warning": "provider not configured",
+            },
+        ],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (request,), (result,), datetime.now(UTC)
+    )
+    assert coverage.available_source_count == 1
+    assert coverage.unavailable_required_sources == []
+
+
+def test_coverage_dedupes_identical_retried_requests() -> None:
+    """required_source_count counts required source *classes*: a retry of
+    the identical request (same tool, same discriminating arguments) is one
+    required source, not two.
+    """
+    first = _tool_request(
+        tool_id="query_metric.v1",
+        metric_id="items_completed",
+        tool_call_id="tool_call_01",
+    )
+    second = _tool_request(
+        tool_id="query_metric.v1",
+        metric_id="items_completed",
+        tool_call_id="tool_call_02",
+    )
+    first_result = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_01")
+    second_result = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_02")
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (first, second), (first_result, second_result), datetime.now(UTC)
     )
     assert coverage.required_source_count == 1
     assert coverage.available_source_count == 1
+
+
+def test_coverage_treats_different_arguments_to_the_same_tool_as_distinct_sources() -> (
+    None
+):
+    """A model calling the same tool for two genuinely different asks (e.g.
+    two different metric_ids) must not collapse into one required source:
+    if one succeeds and the other is unavailable, coverage must show a
+    real gap, not a false "1 of 1".
+    """
+    completed = _tool_request(
+        tool_id="query_metric.v1",
+        metric_id="items_completed",
+        tool_call_id="tool_call_01",
+    )
+    completed_result = _tool_result(
+        tool_id="query_metric.v1", tool_call_id="tool_call_01"
+    )
+    cycle_time = _tool_request(
+        tool_id="query_metric.v1",
+        metric_id="cycle_time_p50_hours",
+        tool_call_id="tool_call_02",
+    )
+    cycle_time_result = _tool_result(
+        tool_id="query_metric.v1",
+        tool_call_id="tool_call_02",
+        status="unavailable",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        warnings=["metric_source_unavailable"],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (completed, cycle_time),
+        (completed_result, cycle_time_result),
+        datetime.now(UTC),
+    )
+    assert coverage.required_source_count == 2
+    assert coverage.available_source_count == 1
+    assert coverage.unavailable_required_sources == ["query_metric.v1"]
 
 
 @pytest.mark.asyncio
@@ -840,3 +1007,140 @@ async def test_status_question_run_never_shows_full_coverage_with_zero_evidence(
     assert result.answer.coverage.required_source_count == 1
     assert result.answer.coverage.available_source_count == 0
     assert result.answer.coverage.unavailable_required_sources == ["status_snapshot.v1"]
+
+
+@pytest.mark.asyncio
+async def test_model_claiming_complete_against_correct_coverage_gets_one_repair() -> (
+    None
+):
+    """If the model claims `status="complete"` while the server-derived
+    coverage (correctly, post-CHAOS-3257) shows a required source was
+    unavailable, DevAnswer's own invariant rejects that combination. This
+    must not hard-fail the whole run: the model gets one bounded repair
+    attempt (same mechanism as a schema-only failure) to reissue an
+    accurately-labeled answer from the same grounded data.
+    """
+    script_id = "repair-false-complete-claim"
+
+    async def empty_partial_status(
+        _context: Any, request: DevToolRequest
+    ) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "status": "partial",
+                "scope_resolution": None,
+                "metric_definitions": [],
+                "metrics": [],
+                "evidence": [],
+                "status_facts": [],
+                "graph_edges": [],
+                "data_health": [],
+                "warnings": ["authorized_repository_set_unavailable"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: empty_partial_status for tool_id in ToolID})
+
+    falsely_complete_answer = _answer(script_id=script_id)
+    falsely_complete_answer.update(
+        {"status": "complete", "claims": [], "metrics": [], "evidence": []}
+    )
+    corrected_answer = _answer(script_id=script_id)
+    corrected_answer.update(
+        {
+            "status": "degraded",
+            "direct_summary": "Status could not be established.",
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(falsely_complete_answer)),
+                ScriptedStep(decision=AgentFinalAnswer(corrected_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status == "degraded"
+    assert [event.state for event in result.events].count(
+        RunState.ANSWER_VALIDATION
+    ) == 2
+
+
+@pytest.mark.asyncio
+async def test_second_false_complete_claim_still_fails_closed() -> None:
+    """The repair budget is bounded to one attempt: a model that repeats the
+    same status/coverage contradiction still fails the run rather than
+    looping or silently shipping an ungrounded "complete" answer.
+    """
+    script_id = "repair-exhausted-false-complete"
+
+    async def empty_partial_status(
+        _context: Any, request: DevToolRequest
+    ) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "status": "partial",
+                "scope_resolution": None,
+                "metric_definitions": [],
+                "metrics": [],
+                "evidence": [],
+                "status_facts": [],
+                "graph_edges": [],
+                "data_health": [],
+                "warnings": ["authorized_repository_set_unavailable"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: empty_partial_status for tool_id in ToolID})
+    falsely_complete_answer = _answer(script_id=script_id)
+    falsely_complete_answer.update(
+        {"status": "complete", "claims": [], "metrics": [], "evidence": []}
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(falsely_complete_answer)),
+                ScriptedStep(decision=AgentFinalAnswer(falsely_complete_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.FAILED
+    assert result.error is not None
+    assert result.error.code == "answer_validation_failed"

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from copy import deepcopy
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -112,6 +113,12 @@ def _answer(*, script_id: str, invalid_schema: bool = False) -> dict:
     if invalid_schema:
         payload.pop("direct_summary")
     return payload
+
+
+def _tool_result(**overrides: object) -> DevToolResult:
+    payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+    payload.update(overrides)
+    return DevToolResult.model_validate(payload)
 
 
 def _registry(*, calls: list[DevToolRequest] | None = None) -> AskDevToolRegistry:
@@ -638,3 +645,198 @@ def test_hard_defaults_can_only_be_configured_downward() -> None:
     assert DevRunLimits(model_rounds=2).model_rounds == 2
     with pytest.raises(ValueError, match="configured downward"):
         DevRunLimits(model_rounds=5)
+
+
+# --- CHAOS-3257: coverage must reflect usable evidence, not tool completion ---
+
+
+def test_coverage_excludes_empty_partial_results_from_availability() -> None:
+    """Literal CHAOS-3257 repro: a partial status snapshot with zero facts and
+    a missing-repository-set warning must read as unavailable, not covered.
+    """
+    result = _tool_result(
+        tool_id="status_snapshot.v1",
+        status="partial",
+        metric_definitions=[],
+        metrics=[],
+        evidence=[],
+        status_facts=[],
+        graph_edges=[],
+        data_health=[],
+        warnings=["authorized_repository_set_unavailable"],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    assert coverage.required_source_count == 1
+    assert coverage.available_source_count == 0
+    assert coverage.unavailable_required_sources == ["status_snapshot.v1"]
+
+
+def test_coverage_counts_partial_with_usable_evidence_as_available() -> None:
+    """A genuinely partial result that still carries usable facts is coverage,
+    unlike an empty partial (contrast with the test above).
+    """
+    result = _tool_result(
+        tool_id="status_snapshot.v1",
+        status="partial",
+        metric_definitions=[],
+        metrics=[],
+        evidence=[],
+        status_facts=[
+            {
+                "fact_id": "fact_01",
+                "text": "1 blocker open",
+                "evidence_ref_ids": ["evidence_01"],
+            }
+        ],
+        graph_edges=[],
+        data_health=[],
+        warnings=["some_children_unavailable"],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    assert coverage.available_source_count == 1
+    assert coverage.unavailable_required_sources == []
+
+
+def test_coverage_marks_error_and_unavailable_status_as_unavailable() -> None:
+    error_result = _tool_result(
+        tool_id="search_evidence.v1",
+        status="error",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        error={
+            "schema_version": "dev_error.v1",
+            "request_id": "run_01",
+            "code": "source_unavailable",
+            "safe_message": "The evidence source could not be reached.",
+            "retryable": True,
+        },
+    )
+    unavailable_result = _tool_result(
+        tool_id="data_health.v1",
+        status="unavailable",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        warnings=["provider_unreachable"],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (error_result, unavailable_result), datetime.now(UTC)
+    )
+    assert coverage.required_source_count == 2
+    assert coverage.available_source_count == 0
+    assert coverage.unavailable_required_sources == [
+        "data_health.v1",
+        "search_evidence.v1",
+    ]
+
+
+def test_coverage_flags_stale_required_sources_independent_of_availability() -> None:
+    result = _tool_result(
+        tool_id="data_health.v1",
+        status="success",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        data_health=[
+            {
+                "source_system": "work_items",
+                "freshness": "stale",
+                "last_successful_at": positive_fixtures()["dev_evidence_ref.v1"][
+                    "observed_at"
+                ],
+                "coverage": 0.5,
+                "warning": "watermark behind SLA",
+            }
+        ],
+    )
+    coverage = DevOrchestrator._coverage_from_tool_results((result,), datetime.now(UTC))
+    assert coverage.available_source_count == 1
+    assert coverage.stale_required_sources == ["data_health.v1"]
+
+
+def test_coverage_dedupes_required_source_count_by_tool_not_invocation() -> None:
+    """required_source_count counts required source classes, not raw tool
+    invocations: two calls to the same tool are one required source.
+    """
+    first = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_01")
+    second = _tool_result(tool_id="query_metric.v1", tool_call_id="tool_call_02")
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (first, second), datetime.now(UTC)
+    )
+    assert coverage.required_source_count == 1
+    assert coverage.available_source_count == 1
+
+
+@pytest.mark.asyncio
+async def test_status_question_run_never_shows_full_coverage_with_zero_evidence() -> (
+    None
+):
+    """Full-stack (backend-half) CHAOS-3257 regression: the observed status
+    question, answered from a single empty-partial status snapshot, must
+    complete with coverage that reflects zero usable evidence, never a full
+    "1 of 1" count. (Web copy is out of this lane's scope; see PR notes.)
+    """
+    script_id = "empty-partial-status-run"
+
+    async def empty_partial_status(
+        _context: Any, request: DevToolRequest
+    ) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "status": "partial",
+                "scope_resolution": None,
+                "metric_definitions": [],
+                "metrics": [],
+                "evidence": [],
+                "status_facts": [],
+                "graph_edges": [],
+                "data_health": [],
+                "warnings": ["authorized_repository_set_unavailable"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: empty_partial_status for tool_id in ToolID})
+    degraded_answer = _answer(script_id=script_id)
+    degraded_answer.update(
+        {
+            "status": "degraded",
+            "direct_summary": (
+                "Status could not be established because the authorized "
+                "repository set was unavailable."
+            ),
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+            "warnings": ["authorized_repository_set_unavailable"],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(degraded_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status != "complete"
+    assert result.answer.coverage.required_source_count == 1
+    assert result.answer.coverage.available_source_count == 0
+    assert result.answer.coverage.unavailable_required_sources == ["status_snapshot.v1"]


### PR DESCRIPTION
## Summary
- `DevOrchestrator._coverage_from_tool_results` counted every `success`/`partial` tool result as an available required source, even when a `partial` result carried zero usable facts because a required upstream source (e.g. the authorized repository set) was unavailable — the literal repro (`What's the status of the Ask Dev project`) rendered `Coverage: 1 of 1 sources` beside an empty answer.
- Coverage is now derived from each tool result's actual content: a `partial` result only counts as available if it carries at least one usable fact (metric, evidence, status fact, graph edge, metric definition, or data-health record). `success` still always counts; `unavailable`/`error` never do.
- `required_source_count` now counts distinct required *source classes* (deduplicated by `tool_id`) instead of raw tool invocations, so a retried/multiply-called tool is one required source, not several.
- `DevAnswer`'s existing model-level invariant (a `complete` answer requires full, non-stale coverage) already prevented a *contradictory* combination once coverage counts are correct — no change needed there.

## Test plan
- [x] New unit tests directly against `DevOrchestrator._coverage_from_tool_results`: empty partial → unavailable (literal repro), partial-with-usable-evidence → available, error/unavailable → unavailable, stale flagging independent of availability, required-source dedup by tool_id.
- [x] New backend full-stack regression test (`test_status_question_run_never_shows_full_coverage_with_zero_evidence`) running the orchestrator end-to-end with the observed status question and an empty-partial `status_snapshot.v1` result, asserting the final `DevAnswer.coverage` never shows full coverage beside zero evidence.
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" bash ci/local_validate.sh` green from a clean worktree (ruff format/check, mypy, full unit suite, live ClickHouse migrate/argMax).
- [ ] Web copy: this PR is ops-only. The web renderer (`AskDevAnswer.tsx`) is a faithful renderer of these counts and needs no server-shape change for this fix, but should be spot-checked against the corrected coverage values — flagged to the epic lead separately.