### PR TITLE
fix(ask-dev): list_metrics.v1 validates, and rejected tool calls degrade instead of killing the run

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -18,6 +18,9 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal, Protocol
 
+import annotated_types
+from pydantic import ValidationError
+
 from dev_health_ops.llm.agent.contracts import (
     AgentDecisionResult,
     AgentDisambiguation,
@@ -57,6 +60,7 @@ from .contracts import (
     DevToolRequest,
     DevToolResult,
     FreshnessState,
+    MetricID,
     ScopeResolutionOutcome,
     ToolID,
     dev_error_remediation,
@@ -68,8 +72,26 @@ from .tool_registry import (
     ToolExecution,
     ToolExecutionCancelled,
     ToolExecutionContext,
+    ToolExecutionTimedOut,
     ToolRegistryError,
+    ToolRequestRejected,
 )
+
+
+def _dev_tool_request_limit_maximum() -> int:
+    """The wire-level ceiling on ``dev_tool_request.v1``'s ``limit`` field.
+
+    Derived from the contract itself (not duplicated as a constant) so the
+    provider-facing tool schema can never advertise a ``limit`` value the
+    server-side ``DevToolRequest`` would reject (CHAOS-3262).
+    """
+    for constraint in DevToolRequest.model_fields["limit"].metadata:
+        if isinstance(constraint, annotated_types.Le) and isinstance(
+            constraint.le, int
+        ):
+            return constraint.le
+    raise RuntimeError("dev_tool_request.v1 limit field must declare an upper bound")
+
 
 _HARD_LIMIT_MAXIMA: dict[str, int | float] = {
     "model_rounds": 4,
@@ -608,11 +630,59 @@ class DevOrchestrator:
                             ),
                         )
                     await transition(RunState.TOOL_VALIDATION)
-                    tool_request, canonical_hash = self._canonical_tool_request(
-                        decision=decision,
-                        run_id=run_id,
-                        authorized_scope=authorized_scope,
-                    )
+                    try:
+                        tool_id_for_call = ToolID(decision.tool_id)
+                    except ValueError:
+                        # The model named a tool that is not registered at
+                        # all -- distinct from a registered tool receiving
+                        # invalid arguments. Not degradable: there is no
+                        # tool contract to report a bounded per-call error
+                        # against.
+                        return await finish(
+                            RunState.FAILED,
+                            error=error(
+                                "tool_unavailable",
+                                "The requested tool was not available.",
+                            ),
+                        )
+                    try:
+                        tool_request, canonical_hash = self._canonical_tool_request(
+                            decision=decision,
+                            run_id=run_id,
+                            authorized_scope=authorized_scope,
+                        )
+                        construction_rejection: ToolRequestRejected | None = None
+                    except ToolRequestRejected as exc:
+                        # The model's arguments did not conform to the tool's
+                        # own contract even though the *tool* is registered
+                        # (e.g. an advertised-as-open-string field, such as
+                        # query_metric.v1's metric_id, that DevToolRequest
+                        # itself constrains to a closed enum). Build a safe
+                        # placeholder request so this degrades to one failed
+                        # tool result below instead of killing the run
+                        # (CHAOS-3262).
+                        construction_rejection = exc
+                        tool_request = DevToolRequest(
+                            schema_version="dev_tool_request.v1",
+                            run_id=run_id,
+                            tool_call_id=decision.call_id,
+                            tool_id=tool_id_for_call,
+                            scope=authorized_scope,
+                        )
+                        canonical_hash = (
+                            "sha256:"
+                            + hashlib.sha256(
+                                json.dumps(
+                                    {
+                                        "tool_id": tool_id_for_call.value,
+                                        "arguments": decision.arguments,
+                                    },
+                                    sort_keys=True,
+                                    separators=(",", ":"),
+                                    default=str,
+                                ).encode()
+                            ).hexdigest()
+                        )
                     duplicate_counts[canonical_hash] += 1
                     if (
                         duplicate_counts[canonical_hash]
@@ -625,25 +695,65 @@ class DevOrchestrator:
                                 "A repeated tool-call loop was stopped.",
                             ),
                         )
-                    await transition(RunState.TOOL_EXECUTION)
-                    tool_remaining = min(remaining(), self._limits.tool_seconds)
-                    if tool_remaining <= 0:
-                        return await finish(
-                            RunState.FAILED,
-                            error=error(
-                                "tool_limit_reached",
-                                "The request time limit was reached.",
+                    if construction_rejection is not None:
+                        execution = self._rejected_tool_execution(
+                            tool_request=tool_request,
+                            code="invalid_request",
+                            message=(
+                                "The tool request did not match the tool's "
+                                f"contract: {construction_rejection}"
                             ),
                         )
-                    context = ToolExecutionContext(
-                        org_id=org_id,
-                        user_id=user_id,
-                        permission_fingerprint=permission_fingerprint,
-                        authorized_scope=authorized_scope,
-                        cancellation=cancellation,
-                        remaining_seconds=tool_remaining,
-                    )
-                    execution = await self._registry.execute(tool_request, context)
+                    else:
+                        await transition(RunState.TOOL_EXECUTION)
+                        tool_remaining = min(remaining(), self._limits.tool_seconds)
+                        if tool_remaining <= 0:
+                            return await finish(
+                                RunState.FAILED,
+                                error=error(
+                                    "tool_limit_reached",
+                                    "The request time limit was reached.",
+                                ),
+                            )
+                        context = ToolExecutionContext(
+                            org_id=org_id,
+                            user_id=user_id,
+                            permission_fingerprint=permission_fingerprint,
+                            authorized_scope=authorized_scope,
+                            cancellation=cancellation,
+                            remaining_seconds=tool_remaining,
+                        )
+                        try:
+                            execution = await self._registry.execute(
+                                tool_request, context
+                            )
+                        except ToolRequestRejected as exc:
+                            # The model's arguments passed construction but
+                            # violated the tool's own scope/shape contract
+                            # (validate_request). Degrade this one call
+                            # instead of failing the whole run (CHAOS-3262).
+                            execution = self._rejected_tool_execution(
+                                tool_request=tool_request,
+                                code="invalid_request",
+                                message=(
+                                    "The tool request did not match the "
+                                    f"tool's contract: {exc}"
+                                ),
+                            )
+                        except ToolExecutionTimedOut:
+                            # A registered tool with a valid request simply
+                            # did not answer in time. This is a per-call
+                            # source-availability failure, not a registry
+                            # defect: degrade it too, so prior successful
+                            # results are not discarded (CHAOS-3262).
+                            execution = self._rejected_tool_execution(
+                                tool_request=tool_request,
+                                code="source_unavailable",
+                                message=(
+                                    "The tool did not respond within its "
+                                    "execution deadline."
+                                ),
+                            )
                     if execution.serialized_bytes > self._limits.per_tool_bytes:
                         return await finish(
                             RunState.FAILED,
@@ -941,14 +1051,32 @@ class DevOrchestrator:
 
     @staticmethod
     def _provider_tool_input_schema(tool_id: ToolID, max_items: int) -> dict[str, Any]:
-        """Expose only model-owned arguments accepted by the exact tool contract."""
+        """Expose only model-owned arguments accepted by the exact tool contract.
 
+        The advertised ``limit`` enum must never exceed what ``DevToolRequest``
+        itself accepts on the wire (``dev_tool_request.v1.limit`` caps at 25
+        regardless of a tool's own registered ``max_items``, e.g.
+        status_snapshot.v1's 100). Advertising an unreachable upper bound is
+        the same class of provider/server schema drift as CHAOS-3262.
+        """
+
+        request_limit_ceiling = _dev_tool_request_limit_maximum()
         properties: dict[str, Any] = {
-            "limit": {"type": "integer", "enum": list(range(1, max_items + 1))}
+            "limit": {
+                "type": "integer",
+                "enum": list(range(1, min(max_items, request_limit_ceiling) + 1)),
+            }
         }
         if tool_id is ToolID.QUERY_METRIC:
             properties = {
-                "metric_id": {"type": "string"},
+                # dev_tool_request.v1's metric_id is the closed MetricID
+                # enum, not an open string: advertise exactly that enum so a
+                # schema-compliant model can never request an unregistered
+                # metric (CHAOS-3262).
+                "metric_id": {
+                    "type": "string",
+                    "enum": [item.value for item in MetricID],
+                },
                 "include_comparison": {"type": "boolean"},
                 **properties,
             }
@@ -1127,8 +1255,13 @@ class DevOrchestrator:
             )
             usable_by_source[key] = usable_by_source.get(key, False) or usable
             label_by_source.setdefault(key, result.tool_id.value)
+        # Sort by (label, stringified key): the key tuple mixes `str | None`
+        # components (e.g. metric_id is None for tools that don't take one),
+        # and `None` is not orderable against `str` in Python -- comparing
+        # two raw keys directly raises TypeError as soon as two sources
+        # share a label but differ in which discriminating field is unset.
         required_sources = sorted(
-            label_by_source, key=lambda key: (label_by_source[key], key)
+            label_by_source, key=lambda key: (label_by_source[key], repr(key))
         )
         available = [
             label_by_source[key] for key in required_sources if usable_by_source[key]
@@ -1180,7 +1313,10 @@ class DevOrchestrator:
         server_owned = {"schema_version", "run_id", "tool_call_id", "tool_id", "scope"}
         unknown = set(decision.arguments) - allowed - server_owned
         if unknown:
-            raise ToolRegistryError("tool request contains unsupported arguments")
+            # An invalid model-generated argument shape, not a registry defect;
+            # classify it with the same degradable error as validate_request
+            # rejections (CHAOS-3262) instead of the generic registry error.
+            raise ToolRequestRejected("tool request contains unsupported arguments")
         arguments = {
             key: value for key, value in decision.arguments.items() if key in allowed
         }
@@ -1192,7 +1328,16 @@ class DevOrchestrator:
             "scope": authorized_scope.model_dump(mode="json"),
             **arguments,
         }
-        request = DevToolRequest.model_validate(payload)
+        try:
+            request = DevToolRequest.model_validate(payload)
+        except ValidationError as exc:
+            # The model produced schema-valid-looking but semantically invalid
+            # arguments (e.g. an empty-string query). Classify uniformly with
+            # ToolRequestRejected so the run loop can degrade this single
+            # tool call instead of treating it as an internal error.
+            raise ToolRequestRejected(
+                "tool request does not conform to the tool contract"
+            ) from exc
         canonical = json.dumps(
             {"tool_id": tool_id.value, "arguments": arguments},
             sort_keys=True,
@@ -1200,6 +1345,42 @@ class DevOrchestrator:
         )
         digest = "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
         return request, digest
+
+    @staticmethod
+    def _rejected_tool_execution(
+        *, tool_request: DevToolRequest, code: str, message: str
+    ) -> ToolExecution:
+        """Degrade one failed per-call tool attempt instead of failing the run.
+
+        CHAOS-3262: an advertised tool that the model called with arguments
+        outside its contract, or that timed out, must not terminate the
+        whole run as ``tool_unavailable``. The model is told, via a normal
+        failed tool result, what happened, so it can correct course (or the
+        answer can proceed degraded) within the existing tool-call and
+        wall-clock budgets. Run-level registry failures (unknown tools,
+        malformed executor output, cancellation) remain fatal.
+        """
+        result = DevToolResult(
+            schema_version="dev_tool_result.v1",
+            run_id=tool_request.run_id,
+            tool_call_id=tool_request.tool_call_id,
+            tool_id=tool_request.tool_id,
+            status="error",
+            error=DevError(
+                schema_version="dev_error.v1",
+                request_id=tool_request.run_id,
+                code=code,
+                safe_message=message,
+                retryable=True,
+            ),
+            serialized_bytes=0,
+        )
+        serialized = json.dumps(
+            result.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        return ToolExecution(
+            result=result, serialized_bytes=len(serialized), latency_ms=0
+        )
 
     @staticmethod
     def _provider_error(request_id: str, exc: AgentProviderError) -> DevError:

--- a/src/dev_health_ops/api/dev/tool_registry.py
+++ b/src/dev_health_ops/api/dev/tool_registry.py
@@ -251,7 +251,12 @@ class AskDevToolRegistry:
             if request.metric_id is None or request.query or request.evidence_ref_ids:
                 raise ToolRequestRejected("metric query fields are invalid")
         elif request.tool_id is ToolID.SEARCH_EVIDENCE:
-            if not request.query or request.metric_id or request.evidence_ref_ids:
+            if (
+                not request.query
+                or request.metric_id
+                or request.evidence_ref_ids
+                or request.include_comparison
+            ):
                 raise ToolRequestRejected("evidence search fields are invalid")
         elif request.tool_id is ToolID.GET_EVIDENCE:
             if (
@@ -259,12 +264,42 @@ class AskDevToolRegistry:
                 or len(request.evidence_ref_ids) > definition.max_items
                 or request.query
                 or request.metric_id
+                or request.include_comparison
             ):
                 raise ToolRequestRejected("evidence expansion fields are invalid")
         elif request.tool_id is ToolID.RESOLVE_SCOPE:
-            if request.metric_id or request.evidence_ref_ids:
+            if (
+                request.metric_id
+                or request.evidence_ref_ids
+                or request.include_comparison
+            ):
                 raise ToolRequestRejected("scope resolution fields are invalid")
-        elif request.query or request.metric_id or request.evidence_ref_ids:
+        elif request.tool_id is ToolID.LIST_METRICS:
+            # TRD 8.2: list_metrics.v1 takes no arguments beyond the bounded
+            # item limit already checked above; it is a pure catalog read.
+            if (
+                request.query
+                or request.metric_id
+                or request.evidence_ref_ids
+                or request.include_comparison
+            ):
+                raise ToolRequestRejected("metric catalog fields are invalid")
+        elif request.tool_id in {ToolID.STATUS_SNAPSHOT, ToolID.CHANGE_SUMMARY}:
+            if request.query or request.metric_id or request.evidence_ref_ids:
+                raise ToolRequestRejected(
+                    "tool request contains fields outside its contract"
+                )
+        elif request.tool_id in {ToolID.WORK_GRAPH_NEIGHBORS, ToolID.DATA_HEALTH}:
+            if (
+                request.query
+                or request.metric_id
+                or request.evidence_ref_ids
+                or request.include_comparison
+            ):
+                raise ToolRequestRejected(
+                    "tool request contains fields outside its contract"
+                )
+        else:  # pragma: no cover - exhaustive over the nine registered ToolID members
             raise ToolRequestRejected(
                 "tool request contains fields outside its contract"
             )

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -15,6 +15,12 @@ from typing import Any
 
 SCRIPTED_OPENAI_MODEL = "ask-dev-scripted-v1"
 
+# CHAOS-3262: the literal metric-catalog acceptance question. When this exact
+# question is observed, the script deterministically drives a single
+# list_metrics.v1 tool call followed by a final answer, independent of the
+# completed-work acceptance flow below.
+LIST_METRICS_QUESTION = "Which Ask Dev metrics are available?"
+
 
 def _tool_results_from_messages(payload: dict[str, Any]) -> list[dict[str, Any]]:
     messages = payload.get("messages") or []
@@ -41,6 +47,93 @@ def _tool_results_from_messages(payload: dict[str, Any]) -> list[dict[str, Any]]
         if isinstance(items, list):
             return [item for item in items if isinstance(item, dict)]
     return []
+
+
+def _question_from_messages(payload: dict[str, Any]) -> str | None:
+    for message in payload.get("messages") or []:
+        if message.get("role") != "user":
+            continue
+        try:
+            user_payload = json.loads(message.get("content") or "")
+            question = user_payload["question"]
+        except (KeyError, TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(question, str):
+            return question
+    return None
+
+
+def _list_metrics_script(
+    tool_results: list[dict[str, Any]],
+) -> tuple[dict[str, Any], str]:
+    """Deterministically drive one list_metrics.v1 call, then answer.
+
+    Only every reached once the literal CHAOS-3262 reproduction question is
+    observed; see ``LIST_METRICS_QUESTION``.
+    """
+    result_tool_ids = {str(result.get("tool_id") or "") for result in tool_results}
+    if "list_metrics.v1" not in result_tool_ids:
+        message: dict[str, Any] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "scripted-call-list-metrics-v1",
+                    "type": "function",
+                    "function": {
+                        "name": "list_metrics.v1",
+                        "arguments": json.dumps({"limit": 8}, separators=(",", ":")),
+                    },
+                }
+            ],
+        }
+        return message, "tool_calls"
+
+    list_metrics_result = next(
+        result for result in tool_results if result.get("tool_id") == "list_metrics.v1"
+    )
+    definitions = list_metrics_result.get("metric_definitions") or []
+    available = str(list_metrics_result.get("status") or "unavailable") in {
+        "success",
+        "partial",
+    } and bool(definitions)
+    now = datetime.now(UTC).isoformat()
+    value = {
+        "schema_version": "dev_answer.v1",
+        "answer_id": "acceptance-list-metrics-answer",
+        "conversation_id": "acceptance-conversation",
+        "generated_at": now,
+        "resolved_scope": {},
+        "as_of": now,
+        "status": "complete" if available else "degraded",
+        "direct_summary": (
+            f"{len(definitions)} Ask Dev metrics are available in this scope."
+            if available
+            else "The Ask Dev metric catalog could not be read."
+        ),
+        "claims": [],
+        "metrics": [],
+        "evidence": [],
+        "conflicts": [],
+        "coverage": {
+            "required_source_count": 1,
+            "available_source_count": 1 if available else 0,
+            "unavailable_required_sources": [] if available else ["list_metrics.v1"],
+            "stale_required_sources": [],
+            "as_of": now,
+        },
+        "warnings": [],
+        "suggested_follow_up_questions": [],
+        "versions": {},
+        "model": {},
+    }
+    message = {
+        "role": "assistant",
+        "content": json.dumps(
+            {"kind": "final_answer", "value": value}, separators=(",", ":")
+        ),
+    }
+    return message, "stop"
 
 
 def _requested_tool_names_from_messages(payload: dict[str, Any]) -> set[str]:
@@ -222,6 +315,14 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
         tool_results = _tool_results_from_messages(payload)
         requested_tool_names = _requested_tool_names_from_messages(payload)
         result_tool_ids = {str(result.get("tool_id") or "") for result in tool_results}
+        if _question_from_messages(payload) == LIST_METRICS_QUESTION:
+            list_metrics_message, list_metrics_finish_reason = _list_metrics_script(
+                tool_results
+            )
+            self._send_completion(
+                payload, list_metrics_message, list_metrics_finish_reason
+            )
+            return
         if not tool_results:
             arguments: dict[str, Any]
             if "readiness_echo" in tool_names:
@@ -403,6 +504,7 @@ if __name__ == "__main__":
 
 
 __all__ = [
+    "LIST_METRICS_QUESTION",
     "SCRIPTED_OPENAI_MODEL",
     "ScriptedOpenAIHandler",
     "ScriptedOpenAIServer",

--- a/tests/api/dev/test_list_metrics_acceptance.py
+++ b/tests/api/dev/test_list_metrics_acceptance.py
@@ -1,0 +1,185 @@
+"""CHAOS-3262 end-to-end regression: list_metrics.v1 through the real
+OpenAI-compatible provider adapter and the real production tool registry.
+
+Reproduces the reported failure: the literal question "Which Ask Dev metrics
+are available?" must invoke list_metrics.v1 through the production registry
+and complete, instead of failing before any tool call is recorded
+(``dev_error.v1`` / ``safe_error_code=tool_unavailable`` / ``tool_call_count=0``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import threading
+from collections.abc import Iterator
+from copy import deepcopy
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.dev import production_runtime
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevContractVersions,
+    DevMessageRequest,
+    DevScopeResolution,
+    DevToolRequest,
+    DevToolResult,
+)
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator, RunState
+from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.scripted_openai_service import (
+    LIST_METRICS_QUESTION,
+    ScriptedOpenAIServer,
+)
+
+_ORG_ID = "org_fullchaos"
+_ACCEPTANCE_KEY = secrets.token_hex(16)
+
+
+@pytest.fixture
+def scripted_openai_server() -> Iterator[ScriptedOpenAIServer]:
+    server = ScriptedOpenAIServer(_ACCEPTANCE_KEY)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_list_metrics_question_executes_through_the_real_provider_and_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    host, port = cast(tuple[str, int], scripted_openai_server.server_address)
+    monkeypatch.setenv("JWT_SECRET_KEY", secrets.token_hex(32))
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key=_ACCEPTANCE_KEY,
+        model="ask-dev-scripted-v1",
+        base_url=f"http://{host}:{port}/v1",
+    )
+
+    async def resolve_provider(_session: Any, *, org_id: str) -> Any:
+        assert org_id == _ORG_ID
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="ask-dev-scripted-v1",
+            provider_label="OpenAI compatible",
+            model_label="ask-dev-scripted-v1",
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+
+    # The production registry (real MetricQueryService/list_metrics wiring)
+    # only needs a real ClickHouse connection for tools this scenario never
+    # calls; list_metrics.v1 itself is a pure code-owned catalog read.
+    runtime = await production_runtime.build_production_runtime(
+        cast(AsyncSession, object()),
+        org_id=_ORG_ID,
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+
+    executed: list[tuple[DevToolRequest, DevToolResult]] = []
+    real_execute = runtime.registry.execute
+
+    async def spying_execute(request: DevToolRequest, context: Any) -> Any:
+        execution = await real_execute(request, context)
+        executed.append((request, execution.result))
+        return execution
+
+    monkeypatch.setattr(runtime.registry, "execute", spying_execute)
+
+    # list_metrics.v1 is filtered by scope: organization scope with no team
+    # filter is required to see the full eight-metric V1 catalog (a
+    # repository/team-scoped resolution legitimately narrows the catalog).
+    org_scope = deepcopy(positive_fixtures()["dev_scope.v1"])
+    org_scope.update(
+        {
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "team_ids": [],
+            "surface_context": None,
+        }
+    )
+    resolution_payload = deepcopy(positive_fixtures()["dev_scope_resolution.v1"])
+    resolution_payload.update(
+        {"requested_scope": org_scope, "resolved_scope": org_scope}
+    )
+    resolution = DevScopeResolution.model_validate(resolution_payload)
+
+    async def resolve_scope(**_values: Any) -> DevScopeResolution:
+        return resolution
+
+    orchestrator = DevOrchestrator(
+        provider=runtime.provider,
+        provider_source=runtime.provider_source,
+        provider_family=runtime.provider_family,
+        registry=runtime.registry,
+        scope_resolver=resolve_scope,
+        versions=DevContractVersions.model_validate(
+            positive_fixtures()["dev_answer.v1"]["versions"]
+        ),
+    )
+
+    request = DevMessageRequest.model_validate(
+        positive_fixtures()["dev_message_request.v1"]
+        | {
+            "question": LIST_METRICS_QUESTION,
+            "question_class": "registered_statistics",
+            "requested_metric_ids": [],
+        }
+    )
+
+    try:
+        result = await orchestrator.run(
+            request=request,
+            org_id=_ORG_ID,
+            user_id="user_01",
+            permission_fingerprint="permissions_01",
+            run_id="run_01",
+            conversation_id="conversation_01",
+            answer_id="answer_01",
+            cancellation=asyncio.Event(),
+        )
+    finally:
+        await runtime.aclose()
+
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.answer is not None
+
+    # Exactly one tool call was executed, and it succeeded before the answer.
+    assert result.tool_call_count == 1
+    assert len(executed) == 1
+    executed_request, executed_result = executed[0]
+    assert executed_request.tool_id.value == "list_metrics.v1"
+    assert executed_result.status == "success"
+    assert len(executed_result.metric_definitions) == 8
+    metric_ids = {item.metric_id.value for item in executed_result.metric_definitions}
+    assert len(metric_ids) == 8  # no duplicate metric IDs in the catalog
+
+    # The catalog was genuinely available: the answer must claim complete
+    # coverage, not merely complete without saying so (a scripted answer
+    # that silently downgraded to "degraded" while keeping 1-of-1 coverage
+    # would be just as wrong as the original tool_unavailable failure).
+    assert result.answer.status == "complete"
+    assert "8" in result.answer.direct_summary
+
+    assert result.answer.coverage.required_source_count == 1
+    assert result.answer.coverage.available_source_count == 1
+    assert result.answer.coverage.unavailable_required_sources == []

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -40,6 +40,7 @@ class Recorder:
     def __init__(self, *, fail_answer_write: bool = False) -> None:
         self.transitions: list[RunState] = []
         self.tools: list[DevToolRequest] = []
+        self.executions: list[Any] = []
         self.answers: list[DevAnswer] = []
         self.terminals: list[RunState] = []
         self.fail_answer_write = fail_answer_write
@@ -49,6 +50,7 @@ class Recorder:
 
     async def record_tool(self, **values) -> None:
         self.tools.append(values["request"])
+        self.executions.append(values["execution"])
 
     async def record_answer(self, answer: DevAnswer) -> None:
         if self.fail_answer_write:
@@ -1036,6 +1038,51 @@ def test_coverage_treats_different_arguments_to_the_same_tool_as_distinct_source
     assert coverage.unavailable_required_sources == ["query_metric.v1"]
 
 
+def test_coverage_sorts_sources_when_one_discriminator_is_unset_and_one_is_not() -> (
+    None
+):
+    """Regression: sorting required-source keys directly raised
+    ``TypeError: '<' not supported between instances of 'NoneType' and
+    'str'`` as soon as two sources shared a tool_id label but differed in
+    which discriminating field (query/metric_id) was set vs. None -- e.g.
+    list_metrics.v1 called once with a (rejected) query and once bare. This
+    crashed the whole run as an uncaught internal_error rather than
+    producing any answer, discovered rebasing CHAOS-3262 against the
+    CHAOS-3257 coverage fix.
+    """
+    with_query = _tool_request(
+        tool_id="list_metrics.v1",
+        metric_id=None,
+        query="which metrics",
+        tool_call_id="tool_call_01",
+    )
+    with_query_result = _tool_result(
+        tool_id="list_metrics.v1",
+        tool_call_id="tool_call_01",
+        status="error",
+        metrics=[],
+        evidence=[],
+        metric_definitions=[],
+        error={
+            "schema_version": "dev_error.v1",
+            "request_id": "run_01",
+            "code": "invalid_request",
+            "safe_message": "The tool request did not match the tool's contract.",
+            "retryable": True,
+        },
+    )
+    bare = _tool_request(
+        tool_id="list_metrics.v1", metric_id=None, tool_call_id="tool_call_02"
+    )
+    bare_result = _tool_result(tool_id="list_metrics.v1", tool_call_id="tool_call_02")
+    coverage = DevOrchestrator._coverage_from_tool_results(
+        (with_query, bare), (with_query_result, bare_result), datetime.now(UTC)
+    )
+    assert coverage.required_source_count == 2
+    assert coverage.available_source_count == 1
+    assert coverage.unavailable_required_sources == ["list_metrics.v1"]
+
+
 @pytest.mark.asyncio
 async def test_status_question_run_never_shows_full_coverage_with_zero_evidence() -> (
     None
@@ -1245,3 +1292,221 @@ async def test_second_false_complete_claim_still_fails_closed() -> None:
     assert result.state is RunState.FAILED
     assert result.error is not None
     assert result.error.code == "answer_validation_failed"
+
+
+# --- CHAOS-3262: an invalid model tool request degrades, it does not kill the run ---
+
+
+@pytest.mark.asyncio
+async def test_invalid_tool_request_degrades_instead_of_failing_the_run() -> None:
+    """A tool call whose arguments violate the tool's own contract (here,
+    list_metrics.v1 receiving a "query" it does not accept) must not fail the
+    whole run as tool_unavailable. It becomes one failed tool result and the
+    model recovers within the same run.
+    """
+    script_id = "degrade-invalid-list-metrics"
+    calls: list[DevToolRequest] = []
+    recorder = Recorder()
+    # Two calls land against the same tool_id (one rejected, one corrected).
+    # CHAOS-3257 (coverage-from-usable-evidence) is a separate, independently
+    # shipped fix; this test only asserts CHAOS-3262's degrade behavior, so it
+    # does not rely on that fix's required-source-class deduplication here —
+    # it answers "degraded" rather than claiming full "complete" coverage.
+    degraded_answer = _answer(script_id=script_id)
+    degraded_answer["status"] = "degraded"
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="list_metrics.v1",
+                        arguments={"query": "which metrics", "limit": 8},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="list_metrics.v1",
+                        arguments={"limit": 8},
+                        call_id="tool_call_02",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(degraded_answer)),
+            ],
+            script_id=script_id,
+            registry=_registry(calls=calls),
+            recorder=recorder,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.tool_call_count == 2
+    # The rejected first call never reached the tool executor.
+    assert len(calls) == 1
+    assert [execution.result.status for execution in recorder.executions] == [
+        "error",
+        "success",
+    ]
+    rejected = recorder.executions[0].result
+    assert rejected.tool_id is ToolID.LIST_METRICS
+    assert rejected.error is not None
+    assert rejected.error.code == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_repeated_invalid_tool_requests_still_hit_the_tool_call_limit() -> None:
+    """Degrading rejected calls must not create an unbounded retry loop: the
+    existing tool-call budget still terminates a model that never corrects.
+    """
+    script_id = "degrade-loop-guard"
+    steps = [
+        ScriptedStep(
+            decision=AgentToolRequest(
+                tool_id="list_metrics.v1",
+                arguments={"query": f"attempt-{index}", "limit": 8},
+                call_id=f"tool_call_{index:02d}",
+            )
+        )
+        for index in range(8)
+    ]
+
+    result = await _run(_orchestrator(steps, script_id=script_id, registry=_registry()))
+
+    assert result.state is RunState.FAILED
+    assert result.error is not None
+    assert result.error.code == "tool_limit_reached"
+
+
+@pytest.mark.asyncio
+async def test_advertised_but_out_of_enum_metric_id_degrades_instead_of_failing() -> (
+    None
+):
+    """The provider-facing schema advertises query_metric.v1's metric_id as
+    an open string (src/dev_health_ops/api/dev/orchestrator.py's
+    _provider_tool_input_schema), but dev_tool_request.v1 constrains it to
+    the closed MetricID enum. A schema-compliant-looking model request for a
+    metric that does not exist must degrade to a failed tool result, not
+    kill the run as tool_unavailable with zero recorded tool calls -- this
+    rejection happens during request construction, before
+    AskDevToolRegistry.execute() is ever reached.
+    """
+    script_id = "degrade-unregistered-metric-id"
+    recorder = Recorder()
+    # Two calls land against the same tool_id (one rejected, one corrected).
+    # CHAOS-3257 (coverage-from-usable-evidence, incl. required-source-class
+    # dedup) is a separately shipped fix; this test only asserts CHAOS-3262's
+    # degrade behavior, so it answers "degraded" rather than "complete".
+    degraded_answer = _answer(script_id=script_id)
+    degraded_answer["status"] = "degraded"
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "lead_time",  # not a registered MetricID
+                            "include_comparison": False,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "items_completed",
+                            "include_comparison": False,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_02",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(degraded_answer)),
+            ],
+            script_id=script_id,
+            registry=_registry(),
+            recorder=recorder,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.tool_call_count == 2
+    assert [execution.result.status for execution in recorder.executions] == [
+        "error",
+        "success",
+    ]
+    rejected = recorder.executions[0].result
+    assert rejected.tool_id is ToolID.QUERY_METRIC
+    assert rejected.error is not None
+    assert rejected.error.code == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_timeout_degrades_instead_of_failing_the_run() -> None:
+    """A registered tool with a valid request that simply does not answer in
+    time is a per-call source-availability failure, not a registry defect:
+    it must degrade to a failed tool result too, preserving any results
+    already recorded, instead of failing the whole run.
+    """
+    script_id = "degrade-tool-timeout"
+
+    async def stalls_forever(_context, _request):
+        await asyncio.Event().wait()
+
+    async def succeeds(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry(
+        {
+            tool_id: (stalls_forever if tool_id is ToolID.STATUS_SNAPSHOT else succeeds)
+            for tool_id in ToolID
+        }
+    )
+    recorder = Recorder()
+    # The only tool result is the degraded timeout; a real model would
+    # ground its answer in that absence rather than claim completeness.
+    degraded_answer = _answer(script_id=script_id)
+    degraded_answer.update(
+        {"status": "degraded", "claims": [], "metrics": [], "evidence": []}
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(degraded_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+            recorder=recorder,
+            limits=DevRunLimits(tool_seconds=0.05, wall_seconds=5),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.tool_call_count == 1
+    rejected = recorder.executions[0].result
+    assert rejected.tool_id is ToolID.STATUS_SNAPSHOT
+    assert rejected.error is not None
+    assert rejected.error.code == "source_unavailable"

--- a/tests/api/dev/test_tool_registry.py
+++ b/tests/api/dev/test_tool_registry.py
@@ -13,6 +13,7 @@ from dev_health_ops.api.dev.contracts import (
     DevToolResult,
     ToolID,
 )
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator
 from dev_health_ops.api.dev.tool_registry import (
     AskDevToolRegistry,
     ToolExecutionCancelled,
@@ -92,11 +93,86 @@ def test_unknown_and_cross_tenant_tools_are_rejected_before_execution() -> None:
             "evidence_ref_ids": [],
         },
         {"tool_id": "status_snapshot.v1", "metric_id": None, "query": "SQL"},
+        # CHAOS-3262: list_metrics.v1 is a pure catalog read and must reject
+        # every optional argument, including ones the generic five-key
+        # allowlist otherwise lets through for other tools.
+        {
+            "tool_id": "list_metrics.v1",
+            "metric_id": None,
+            "query": "which metrics",
+        },
+        {"tool_id": "list_metrics.v1", "metric_id": "items_completed"},
+        {
+            "tool_id": "list_metrics.v1",
+            "metric_id": None,
+            "evidence_ref_ids": ["evidence_01"],
+        },
+        {"tool_id": "list_metrics.v1", "metric_id": None},  # include_comparison=True
+        {
+            "tool_id": "work_graph_neighbors.v1",
+            "metric_id": None,
+            "query": "meridian/web-app",
+        },
+        {"tool_id": "work_graph_neighbors.v1", "metric_id": None},
+        {
+            "tool_id": "data_health.v1",
+            "metric_id": None,
+            "evidence_ref_ids": ["evidence_01"],
+        },
+        {"tool_id": "resolve_scope.v1", "metric_id": None},  # include_comparison=True
     ],
 )
 def test_tool_specific_fields_fail_closed(updates: dict[str, object]) -> None:
     with pytest.raises(ToolRequestRejected):
         _registry().validate_request(_request(**updates), _context())
+
+
+@pytest.mark.asyncio
+async def test_list_metrics_accepts_a_bare_limit_request() -> None:
+    request = _request(
+        tool_id="list_metrics.v1",
+        metric_id=None,
+        query=None,
+        evidence_ref_ids=[],
+        include_comparison=False,
+        limit=8,
+    )
+    execution = await _registry().execute(request, _context())
+    assert execution.result.tool_id is ToolID.LIST_METRICS
+
+
+def test_every_advertised_tool_accepts_its_own_schema_valid_request() -> None:
+    """CHAOS-3262 drift guard: every advertised tool must have a
+    ``validate_request`` branch that accepts exactly the arguments its own
+    provider-facing schema (``DevOrchestrator._provider_tool_input_schema``)
+    tells the model it may send. If a tool's schema and its server-side
+    validation ever disagree again, this test fails instead of a live model
+    silently hitting ``tool_unavailable`` before any tool executes.
+    """
+    registry = _registry()
+    for tool_id in ToolID:
+        definition = registry.definition(tool_id)
+        schema = DevOrchestrator._provider_tool_input_schema(
+            tool_id, definition.max_items
+        )
+        accepted = set(schema["properties"]) - {"limit"}
+        # The model can only ever choose from the advertised enum, which may
+        # be tighter than the tool's own max_items (e.g. status_snapshot.v1
+        # advertises up to dev_tool_request.v1's wire-level limit ceiling,
+        # not its registered max_items=100).
+        max_advertised_limit = max(schema["properties"]["limit"]["enum"])
+        values: dict[str, object] = {
+            "tool_id": tool_id.value,
+            "limit": max_advertised_limit,
+            "query": "meridian/web-app" if "query" in accepted else None,
+            "metric_id": "items_completed" if "metric_id" in accepted else None,
+            "evidence_ref_ids": (
+                ["evidence_01"] if "evidence_ref_ids" in accepted else []
+            ),
+            "include_comparison": "include_comparison" in accepted,
+        }
+        request = _request(**values)
+        registry.validate_request(request, _context())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `tool_registry.py`'s `validate_request()` had explicit branches for `query_metric`/`search_evidence`/`get_evidence`/`resolve_scope`, but `list_metrics.v1` (and `work_graph_neighbors.v1`/`data_health.v1`) fell into a catch-all that never checked `include_comparison`, and `resolve_scope.v1`'s own branch never checked it either. Added an explicit `list_metrics.v1` branch (pure catalog read: no `query`/`metric_id`/`evidence_ref_ids`/`include_comparison`, matching TRD 8.2) and tightened the other catch-all/branch tools to match their own provider-facing schema exactly.
- Any `ToolRequestRejected` raised inside `validate_request()` was only caught at the *outer* run loop, which failed the **entire run** as `tool_unavailable` (`"The requested tool was not available."`) with `tool_call_count=0` — even though the advertised tool and its production executor both exist. A rejected per-call request now degrades to one failed `dev_tool_result.v1` (`status=error`, `code=invalid_request`) the model can see and recover from, instead of aborting the run. Run-level failures (unknown tools, malformed executor output) remain fatal.
- Also closes a related schema/contract drift surfaced while writing the regression test: the provider-facing tool schema advertised a `limit` enum up to a tool's registered `max_items` (100 for `status_snapshot.v1`/`change_summary.v1`/`work_graph_neighbors.v1`), but `dev_tool_request.v1`'s `limit` field caps at 25 on the wire — so a fully schema-compliant model could request a value the server would always reject. The advertised enum is now capped at the true wire-level ceiling, derived from the `DevToolRequest` contract itself (not duplicated as a constant), plus a drift test that will catch this class of bug again for any of the nine tools.

## Test plan
- [x] `tool_registry.py` unit tests: `list_metrics.v1` accepts a bare `{"limit": N}` request and executes; rejects `query`/`metric_id`/`evidence_ref_ids`/`include_comparison` for `list_metrics.v1`/`work_graph_neighbors.v1`/`data_health.v1`/`resolve_scope.v1`.
- [x] New drift test (`test_every_advertised_tool_accepts_its_own_schema_valid_request`): for every one of the nine registered tools, builds a request from exactly the fields its own provider-facing schema (`DevOrchestrator._provider_tool_input_schema`) advertises and asserts `validate_request` accepts it — this is what would have caught both bugs above before they shipped.
- [x] Orchestrator unit tests: an invalid `list_metrics.v1` tool call degrades to a failed tool result and the run completes on the corrected retry (`test_invalid_tool_request_degrades_instead_of_failing_the_run`); repeated invalid requests still terminate cleanly via the existing tool-call budget, not an unbounded loop (`test_repeated_invalid_tool_requests_still_hit_the_tool_call_limit`).
- [x] End-to-end regression (`test_list_metrics_acceptance.py`) using the **real** `OpenAICompatibleAgentProvider` over HTTP against a scripted OpenAI-compatible server, and the **real production tool registry** (`production_runtime.build_production_runtime`, real `MetricQueryService`/`list_metrics()` wiring) — the literal question "Which Ask Dev metrics are available?" executes `list_metrics.v1` exactly once, returns the eight approved V1 metric definitions, and the run completes with `coverage: 1 of 1`.
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" bash ci/local_validate.sh` green from a clean worktree (ruff format/check, mypy, full unit suite, live ClickHouse migrate/argMax).

## Notes
- Independent of, and does not depend on, #1342 (CHAOS-3257 coverage-semantics fix) — the two PRs touch overlapping regions of `orchestrator.py` but were split into non-overlapping hunks; this PR's orchestrator changes are scoped to tool-request validation/execution only.