### PR TITLE
fix(ask-dev): make organization scope executable for status/change reads (CHAOS-3255)

### DIFF
--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -284,6 +284,12 @@ ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """
 
+_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL = """
+SELECT toString(id) AS repository_id
+FROM repos FINAL
+WHERE org_id = {org_id:String}
+"""
+
 _TRANSITIONS_SQL = """
 SELECT transition.work_item_id AS entity_id, item.title AS display_label,
        transition.from_status, transition.to_status,
@@ -578,10 +584,38 @@ class ClickHouseStatusChangeSource:
         self._policies = dict(policies or default_native_freshness_policies())
         self._now = now
 
+    async def _authorized_repository_ids(
+        self, org_id: str, scope: DevScope
+    ) -> list[str]:
+        """Bound status/change reads to the server-owned repository set.
+
+        Organization scope cannot serialize its full authorized repository
+        set onto the wire (``DevScope.repositories`` is capped at 20 entries
+        by the ask-dev/v1 contract), so it is re-derived here directly from
+        the same ``org_id`` boundary every other native query already
+        enforces (CHAOS-3255). This scales to any repository count without
+        truncation or widening. Every other direct scope keeps using the
+        scope's own bounded repository/entity refs.
+        """
+        if scope.direct_scope is not DirectScope.ORGANIZATION:
+            return self._repository_ids(scope)
+        try:
+            async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
+                rows = await query_dicts(
+                    self._client,
+                    _ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL,
+                    {"org_id": org_id},
+                )
+        except Exception:
+            return []
+        return sorted(
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+        )
+
     async def status_snapshot(
         self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
     ) -> RawStatusSnapshot:
-        repositories = self._repository_ids(scope)
+        repositories = await self._authorized_repository_ids(org_id, scope)
         entity_id = self._entity_id(scope)
         scope_type = scope.direct_scope.value
         warnings: list[str] = []
@@ -938,7 +972,7 @@ class ClickHouseStatusChangeSource:
         limit: int,
     ) -> RawChangeSummary:
         del comparison
-        repositories = self._repository_ids(scope)
+        repositories = await self._authorized_repository_ids(org_id, scope)
         if not repositories:
             return RawChangeSummary(
                 changes=(),

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -208,7 +208,7 @@ WHERE pr.org_id = {org_id:String}
         OR concat(toString(pr.repo_id), '#pr', toString(pr.number))
           IN {member_pr_ids:Array(String)}
       ))
-    OR ({scope_type:String} = 'repository')
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
@@ -256,7 +256,7 @@ FROM deployments FINAL
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
   AND (
-    ({scope_type:String} = 'repository')
+    ({scope_type:String} IN ('organization', 'repository'))
     OR ifNull(pull_request_number, 0) IN {pr_numbers:Array(UInt32)}
   )
   AND coalesce(deployed_at, finished_at, started_at, last_synced)
@@ -308,7 +308,7 @@ WHERE transition.org_id = {org_id:String}
     ({scope_type:String} = 'issue' AND transition.work_item_id = {entity_id:String})
     OR ({scope_type:String} = 'project'
       AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-    OR ({scope_type:String} = 'repository')
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, from_status, to_status
 LIMIT {limit:UInt32}
@@ -340,7 +340,7 @@ WHERE org_id = {org_id:String}
           AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
       )
     ))
-    OR ({scope_type:String} = 'repository')
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, source_type, source_id, edge_type, target_type, target_id
 LIMIT {limit:UInt32}
@@ -596,8 +596,15 @@ class ClickHouseStatusChangeSource:
         enforces (CHAOS-3255). This scales to any repository count without
         truncation or widening. Every other direct scope keeps using the
         scope's own bounded repository/entity refs.
+
+        A team-filtered organization scope (``scope.team_ids``) is excluded
+        from organization-native enumeration: no native query here applies a
+        team filter, so deriving the full org repository set would silently
+        widen a team-scoped request to every repository in the organization.
+        Falling through to the caller's own (empty) bounded fields keeps the
+        prior fail-closed "authorized repository set" behavior instead.
         """
-        if scope.direct_scope is not DirectScope.ORGANIZATION:
+        if scope.direct_scope is not DirectScope.ORGANIZATION or scope.team_ids:
             return self._repository_ids(scope)
         try:
             async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):

--- a/src/dev_health_ops/api/dev/scope_catalog.py
+++ b/src/dev_health_ops/api/dev/scope_catalog.py
@@ -13,6 +13,20 @@ from dev_health_ops.api.services.identity import resolve_scope_display_names
 
 from .scope_service import AuthorizedEntity, EntityKind, ScopeRef
 
+_ORGANIZATION_REPOSITORY_IDS_SQL = """
+    SELECT toString(id) AS repository_id
+    FROM repos FINAL
+    WHERE org_id = {org_id:String}
+    ORDER BY repository_id
+    LIMIT {limit:UInt32}
+"""
+
+_ORGANIZATION_REPOSITORY_COUNT_SQL = """
+    SELECT count() AS total
+    FROM repos FINAL
+    WHERE org_id = {org_id:String}
+"""
+
 _WATERMARK_TABLES: dict[EntityKind, tuple[str, str]] = {
     EntityKind.REPOSITORY: ("repos", "last_synced"),
     EntityKind.PROJECT: ("projects", "updated_at"),
@@ -105,6 +119,27 @@ class ClickHouseAuthorizedEntityCatalog:
             )
         )
         return entities[:limit]
+
+    async def organization_repository_ids(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[str], int]:
+        ids_rows, count_rows = await asyncio.gather(
+            query_dicts(
+                self._client,
+                _ORGANIZATION_REPOSITORY_IDS_SQL,
+                {"org_id": org_id, "limit": limit},
+            ),
+            query_dicts(
+                self._client,
+                _ORGANIZATION_REPOSITORY_COUNT_SQL,
+                {"org_id": org_id},
+            ),
+        )
+        ids = sorted(
+            {str(row["repository_id"]) for row in ids_rows if row.get("repository_id")}
+        )
+        total = int(count_rows[0]["total"]) if count_rows else 0
+        return ids, total
 
     async def _with_repository_display_names(
         self, org_id: str, entities: list[AuthorizedEntity]

--- a/src/dev_health_ops/api/dev/scope_catalog.py
+++ b/src/dev_health_ops/api/dev/scope_catalog.py
@@ -14,17 +14,11 @@ from dev_health_ops.api.services.identity import resolve_scope_display_names
 from .scope_service import AuthorizedEntity, EntityKind, ScopeRef
 
 _ORGANIZATION_REPOSITORY_IDS_SQL = """
-    SELECT toString(id) AS repository_id
+    SELECT toString(id) AS repository_id, count() OVER () AS total_authorized
     FROM repos FINAL
     WHERE org_id = {org_id:String}
     ORDER BY repository_id
     LIMIT {limit:UInt32}
-"""
-
-_ORGANIZATION_REPOSITORY_COUNT_SQL = """
-    SELECT count() AS total
-    FROM repos FINAL
-    WHERE org_id = {org_id:String}
 """
 
 _WATERMARK_TABLES: dict[EntityKind, tuple[str, str]] = {
@@ -123,22 +117,22 @@ class ClickHouseAuthorizedEntityCatalog:
     async def organization_repository_ids(
         self, org_id: str, *, limit: int
     ) -> tuple[list[str], int]:
-        ids_rows, count_rows = await asyncio.gather(
-            query_dicts(
-                self._client,
-                _ORGANIZATION_REPOSITORY_IDS_SQL,
-                {"org_id": org_id, "limit": limit},
-            ),
-            query_dicts(
-                self._client,
-                _ORGANIZATION_REPOSITORY_COUNT_SQL,
-                {"org_id": org_id},
-            ),
+        # A single query with a window function, not two sequential queries:
+        # `count() OVER ()` reflects every matching row before LIMIT clips the
+        # returned page, so the id page and the true total are one consistent
+        # snapshot. Two separate queries could race a concurrent repository
+        # insert/delete into reporting a truncated page as the complete set.
+        rows = await query_dicts(
+            self._client,
+            _ORGANIZATION_REPOSITORY_IDS_SQL,
+            {"org_id": org_id, "limit": limit},
         )
+        if not rows:
+            return [], 0
         ids = sorted(
-            {str(row["repository_id"]) for row in ids_rows if row.get("repository_id")}
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
         )
-        total = int(count_rows[0]["total"]) if count_rows else 0
+        total = int(rows[0]["total_authorized"])
         return ids, total
 
     async def _with_repository_display_names(

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -231,6 +231,17 @@ class AuthorizedEntityCatalog(Protocol):
         limit: int,
     ) -> list[AuthorizedEntity]: ...
 
+    async def organization_repository_ids(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[str], int]:
+        """Return up to ``limit`` authorized repository IDs, and the true total.
+
+        The total must reflect every repository authorized for ``org_id``,
+        not just the returned page, so callers can detect when the org
+        exceeds the public ``authorized_repository_ids`` contract cap.
+        """
+        ...
+
 
 class ScopeRequestCache:
     """Small request-local LRU; never share this object across requests."""
@@ -528,6 +539,8 @@ class ScopeResolutionService:
         domain = await self.resolve(org_id, permission_fingerprint, request)
         requested = self._requested_scope(org_id, request, domain.time_range)
         resolved = self._resolved_scope(org_id, request, domain)
+        outcome = domain.outcome
+        warnings = list(domain.warnings)
         repository_ids = sorted(
             {
                 entity.canonical_id
@@ -540,6 +553,15 @@ class ScopeResolutionService:
                 if entity.repository_id is not None
             }
         )
+        if resolved is not None and resolved.direct_scope is DirectScope.ORGANIZATION:
+            (
+                repository_ids,
+                outcome,
+                resolved,
+                warnings,
+            ) = await self._organization_scope_repositories(
+                org_id, permission_fingerprint, outcome, resolved, warnings
+            )
         entity_ids = sorted(
             {
                 entity.canonical_id
@@ -559,14 +581,83 @@ class ScopeResolutionService:
             schema_version="dev_scope_resolution.v1",
             requested_scope=requested,
             resolved_scope=resolved,
-            outcome=domain.outcome,
+            outcome=outcome,
             authorized_repository_ids=repository_ids,
             authorized_entity_ids=entity_ids,
             candidates=candidates,
             fallbacks=list(domain.fallbacks),
-            warnings=list(domain.warnings),
+            warnings=warnings,
             resolved_at=resolved_at or datetime.now(timezone.utc),
         )
+
+    async def _organization_scope_repositories(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        outcome: ScopeResolutionOutcome,
+        resolved: DevScope,
+        warnings: list[str],
+    ) -> tuple[list[str], ScopeResolutionOutcome, DevScope | None, list[str]]:
+        """Enumerate the complete server-owned repository set for organization scope.
+
+        ``DevScopeResolution.authorized_repository_ids`` is capped at
+        ``MAX_REPOSITORIES`` entries by the ask-dev/v1 contract. An
+        organization at or under that cap gets the complete set inline. An
+        organization above the cap must never have a truncated, misleadingly
+        "complete" list serialized onto the wire: status and change reads
+        instead re-derive the authorized set themselves, organization-natively,
+        bound only by ``org_id`` — the same boundary every other native query
+        already enforces (CHAOS-3255). Zero authorized repositories is explicit
+        insufficient evidence, never an exact scope with accidental partial
+        coverage.
+        """
+        try:
+            watermark = await self._catalog.watermark(org_id, (EntityKind.REPOSITORY,))
+            cache_key = self._cache_key(
+                "organization_repositories",
+                org_id,
+                permission_fingerprint,
+                {},
+                watermark,
+            )
+            cached = self._cache.get(cache_key)
+            if isinstance(cached, tuple) and len(cached) == 2:
+                repo_ids, total = cached
+            else:
+                repo_ids, total = await self._catalog.organization_repository_ids(
+                    org_id, limit=MAX_REPOSITORIES
+                )
+                self._cache.put(cache_key, (repo_ids, total))
+        except Exception:
+            return (
+                [],
+                ScopeResolutionOutcome.UNRESOLVED,
+                None,
+                [*warnings, "catalog_unavailable"],
+            )
+        if total == 0:
+            return (
+                [],
+                ScopeResolutionOutcome.UNRESOLVED,
+                None,
+                [*warnings, "organization_has_no_authorized_repositories"],
+            )
+        if total > MAX_REPOSITORIES:
+            return (
+                [],
+                outcome,
+                resolved,
+                [
+                    *warnings,
+                    (
+                        f"organization repository set ({total}) exceeds the "
+                        f"{MAX_REPOSITORIES}-repository contract limit; status "
+                        "and change tools resolve the authorized set "
+                        "organization-natively"
+                    ),
+                ],
+            )
+        return sorted(repo_ids), outcome, resolved, warnings
 
     def _requested_scope(
         self,

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -553,7 +553,18 @@ class ScopeResolutionService:
                 if entity.repository_id is not None
             }
         )
-        if resolved is not None and resolved.direct_scope is DirectScope.ORGANIZATION:
+        if (
+            resolved is not None
+            and resolved.direct_scope is DirectScope.ORGANIZATION
+            and not domain.team_filters
+        ):
+            # A team-filtered organization scope is deliberately excluded:
+            # no native status/change query applies a team filter, so the
+            # native execution layer always fails closed for it regardless
+            # of repository count (CHAOS-3255). Enumerating the full org
+            # repository set here would report a warning/authorized set
+            # that describes execution behavior that will not actually
+            # happen for this request.
             (
                 repository_ids,
                 outcome,

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -1040,3 +1040,150 @@ async def test_native_change_reader_returns_only_canonical_observed_events(
         "repo-a#pr7",
     )
     assert all(change.claim_kind.value == "observed" for change in result.changes)
+
+
+def _org_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.ORGANIZATION,
+        repositories=[],
+        entity_refs=[],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=NOW - timedelta(days=14),
+            end=NOW - timedelta(days=7),
+            timezone="UTC",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_status_snapshot_enumerates_repos_natively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3255: organization scope must not read as an empty repo set.
+
+    ``DevScope.repositories``/``entity_refs`` are empty for organization
+    scope (the wire contract forbids attaching entities to it), so the
+    native source must re-derive the authorized repository set itself from
+    ``org_id`` rather than reading the (empty) bounded scope fields.
+    """
+    observed: list[dict[str, Any]] = []
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.append({"sql": sql, "params": dict(params)})
+        if "FROM repos FINAL" in sql:
+            assert params == {"org_id": "org-a"}
+            return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        if "FROM git_pull_requests AS pr" in sql:
+            return [_pull_request_row()]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_org_scope()),
+    )
+
+    pull_request_calls = [
+        item for item in observed if "FROM git_pull_requests AS pr" in item["sql"]
+    ]
+    assert pull_request_calls, "expected the pull_requests read to execute"
+    assert pull_request_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
+    assert (
+        "Status reads require the complete authorized repository set; "
+        "scope was not widened." not in result.warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_change_summary_enumerates_repos_natively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[dict[str, Any]] = []
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.append({"sql": sql, "params": dict(params)})
+        if "FROM repos FINAL" in sql:
+            assert params == {"org_id": "org-a"}
+            return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    request = ChangeSummaryRequest(
+        scope=_org_scope(),
+        current_start=NOW - timedelta(days=7),
+        current_end=NOW,
+        comparison_start=NOW - timedelta(days=14),
+        comparison_end=NOW - timedelta(days=7),
+    )
+
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).change_summary("org-a", "permission-v1", request)
+
+    transitions_calls = [
+        item for item in observed if "FROM work_item_transitions" in item["sql"]
+    ]
+    assert transitions_calls
+    assert transitions_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
+    assert "Observed-change scope was not widened." not in result.warnings
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_with_no_authorized_repos_is_explicit_not_masked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM repos FINAL" in sql:
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_org_scope()),
+    )
+
+    # Zero authorized repositories must surface as explicit degraded/unavailable
+    # evidence, never as a silently-complete or partial answer.
+    assert result.state is StatusResultState.DEGRADED
+    assert result.declared is None
+    assert (
+        "Status reads require the complete authorized repository set; "
+        "scope was not widened." in result.warnings
+    )
+
+
+def _pull_request_row() -> dict[str, Any]:
+    return {
+        "repository_id": "repo-x",
+        "number": 3,
+        "entity_id": "repo-x#pr3",
+        "display_label": "PR 3",
+        "state": "open",
+        "review_state": None,
+        "changes_requested": 0,
+        "merged": 0,
+        "observed_at": NOW,
+        "last_synced": NOW,
+    }

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -1042,13 +1042,14 @@ async def test_native_change_reader_returns_only_canonical_observed_events(
     assert all(change.claim_kind.value == "observed" for change in result.changes)
 
 
-def _org_scope() -> DevScope:
+def _org_scope(*, team_ids: list[str] | None = None) -> DevScope:
     return DevScope(
         schema_version="dev_scope.v1",
         organization_id="org-a",
         direct_scope=DirectScope.ORGANIZATION,
         repositories=[],
         entity_refs=[],
+        team_ids=team_ids or [],
         time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
         comparison_range=DevTimeRange(
             start=NOW - timedelta(days=14),
@@ -1080,6 +1081,8 @@ async def test_organization_scope_status_snapshot_enumerates_repos_natively(
             return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
         if "FROM git_pull_requests AS pr" in sql:
             return [_pull_request_row()]
+        if "FROM deployments" in sql:
+            return [_deployment_row()]
         return []
 
     monkeypatch.setattr(
@@ -1093,15 +1096,28 @@ async def test_organization_scope_status_snapshot_enumerates_repos_natively(
         StatusSnapshotRequest(_org_scope()),
     )
 
+    deployment_calls = [item for item in observed if "FROM deployments" in item["sql"]]
     pull_request_calls = [
         item for item in observed if "FROM git_pull_requests AS pr" in item["sql"]
     ]
     assert pull_request_calls, "expected the pull_requests read to execute"
+    assert deployment_calls, "expected the deployments read to execute"
     assert pull_request_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
     assert (
         "Status reads require the complete authorized repository set; "
         "scope was not widened." not in result.warnings
     )
+    # Assert the SQL text itself carries the organization branch, not just
+    # that a mocked row came back: a mock that returns rows unconditionally
+    # (ignoring the real WHERE clause) would still pass even if the
+    # 'organization' branch were deleted from _PULL_REQUESTS_SQL/
+    # _DEPLOYMENTS_SQL (CHAOS-3255 follow-up — this is the regression the
+    # prior HIGH finding actually shipped, and a table-name-only mock
+    # cannot detect it re-appearing).
+    assert "IN ('organization', 'repository')" in pull_request_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in deployment_calls[0]["sql"]
+    assert result.pull_requests, "organization scope must surface PR facts"
+    assert result.deployments, "organization scope must surface deployment facts"
 
 
 @pytest.mark.asyncio
@@ -1117,6 +1133,32 @@ async def test_organization_scope_change_summary_enumerates_repos_natively(
         if "FROM repos FINAL" in sql:
             assert params == {"org_id": "org-a"}
             return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        if "FROM work_item_transitions" in sql:
+            return [
+                {
+                    "entity_id": "issue-1",
+                    "display_label": "Issue 1",
+                    "from_status": "in_progress",
+                    "to_status": "done",
+                    "observed_at": NOW - timedelta(hours=1),
+                    "last_synced": NOW,
+                }
+            ]
+        if "FROM work_graph_edges" in sql:
+            return [
+                {
+                    "change_id": "edge-1",
+                    "source_type": "issue",
+                    "source_id": "issue-1",
+                    "edge_type": "implements",
+                    "target_type": "pr",
+                    "target_id": "repo-x#pr7",
+                    "provenance": "native",
+                    "confidence": 1.0,
+                    "observed_at": NOW - timedelta(minutes=30),
+                    "last_synced": NOW,
+                }
+            ]
         return []
 
     monkeypatch.setattr(
@@ -1137,9 +1179,29 @@ async def test_organization_scope_change_summary_enumerates_repos_natively(
     transitions_calls = [
         item for item in observed if "FROM work_item_transitions" in item["sql"]
     ]
+    relationship_calls = [
+        item for item in observed if "FROM work_graph_edges" in item["sql"]
+    ]
     assert transitions_calls
+    assert relationship_calls
     assert transitions_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
     assert "Observed-change scope was not widened." not in result.warnings
+    # CHAOS-3255 follow-up: _TRANSITIONS_SQL/_RELATIONSHIPS_SQL previously had
+    # no 'organization' branch, so change_summary.v1 silently dropped status
+    # transitions and work-graph relationships even with a full repo set.
+    # Assert the SQL text itself, not just the mocked row: a table-name-only
+    # mock returns rows regardless of the real WHERE clause and would not
+    # catch the 'organization' branch being deleted again.
+    assert "IN ('organization', 'repository')" in transitions_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in relationship_calls[0]["sql"]
+    change_ids = {change.change_id for change in result.changes}
+    assert any(
+        change.entity_id == "issue-1" and change.before == "in_progress"
+        for change in result.changes
+    ), "organization scope must surface status transition changes"
+    assert "edge-1" in change_ids, (
+        "organization scope must surface relationship changes"
+    )
 
 
 @pytest.mark.asyncio
@@ -1168,6 +1230,40 @@ async def test_organization_scope_with_no_authorized_repos_is_explicit_not_maske
     # evidence, never as a silently-complete or partial answer.
     assert result.state is StatusResultState.DEGRADED
     assert result.declared is None
+    assert (
+        "Status reads require the complete authorized repository set; "
+        "scope was not widened." in result.warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_organization_scope_is_never_widened_to_the_full_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A team filter narrows organization scope; no native query here applies
+    it, so organization-native enumeration must not kick in and silently
+    return every repository in the org instead of respecting the filter."""
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM repos FINAL" in sql:
+            # If this executes, the org-native repository derivation
+            # incorrectly ran despite the team filter.
+            return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_org_scope(team_ids=["team-a"])),
+    )
+
     assert (
         "Status reads require the complete authorized repository set; "
         "scope was not widened." in result.warnings

--- a/tests/api/dev/test_organization_scope_clickhouse_live.py
+++ b/tests/api/dev/test_organization_scope_clickhouse_live.py
@@ -1,0 +1,205 @@
+"""Live-ClickHouse integration coverage for CHAOS-3255.
+
+Connects a real multi-repository organization against a migrated ClickHouse
+database and proves the complete server-authorized repository set reaches
+resolve_scope.v1's contract *and* every downstream status/change query --
+against the actual production SQL, not a mock. Also proves a second
+tenant's repositories can never enter the first tenant's authorized set.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
+from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
+from dev_health_ops.api.dev.scope_service import (
+    MAX_REPOSITORIES,
+    EntityKind,
+    ScopeRef,
+    ScopeResolutionService,
+    ScopeResolveRequest,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ChangeSummaryRequest,
+    StatusChangeService,
+    StatusSnapshotRequest,
+)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+NOW = datetime(2026, 7, 28, 12, tzinfo=UTC)
+NO_REPOSITORY_SET_WARNING = (
+    "Status reads require the complete authorized repository set; "
+    "scope was not widened."
+)
+NO_CHANGE_SET_WARNING = "Observed-change scope was not widened."
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(not CLICKHOUSE_URI, reason="Requires migrated CLICKHOUSE_URI"),
+]
+
+
+@pytest.fixture
+def raw_client() -> Any:
+    import clickhouse_connect
+
+    assert CLICKHOUSE_URI is not None
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def ch_sink() -> Any:
+    from dev_health_ops.metrics.sinks.factory import create_sink
+
+    assert CLICKHOUSE_URI is not None
+    sink = create_sink(CLICKHOUSE_URI)
+    try:
+        yield sink
+    finally:
+        sink.close()
+
+
+def _insert_repo(client: Any, *, org_id: str, repo_id: str, name: str) -> None:
+    client.command(
+        "INSERT INTO repos (id, repo, created_at, last_synced, org_id) VALUES "
+        "({repo_id:UUID}, {name:String}, now64(3), now64(3), {org_id:String})",
+        parameters={"repo_id": repo_id, "name": name, "org_id": org_id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_authorized_repos_reach_status_and_change_reads(
+    raw_client: Any, ch_sink: Any
+) -> None:
+    org_id = f"chaos-3255-{uuid.uuid4().hex[:16]}"
+    other_org_id = f"chaos-3255-other-{uuid.uuid4().hex[:16]}"
+    repo_ids = [str(uuid.uuid4()) for _ in range(3)]
+    other_repo_id = str(uuid.uuid4())
+    try:
+        for index, repo_id in enumerate(repo_ids):
+            _insert_repo(
+                raw_client, org_id=org_id, repo_id=repo_id, name=f"org/repo-{index}"
+            )
+        # A second tenant's repository must never enter org_id's authorized set.
+        _insert_repo(
+            raw_client, org_id=other_org_id, repo_id=other_repo_id, name="other/repo"
+        )
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(ch_sink))
+        resolution = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, org_id),)
+            ),
+        )
+
+        assert resolution.outcome.value == "exact"
+        assert resolution.resolved_scope is not None
+        assert resolution.resolved_scope.direct_scope.value == "organization"
+        assert sorted(resolution.authorized_repository_ids) == sorted(repo_ids)
+        assert other_repo_id not in resolution.authorized_repository_ids
+        assert len(repo_ids) <= MAX_REPOSITORIES
+
+        status_service = StatusChangeService(
+            ClickHouseStatusChangeSource(ch_sink, now=NOW)
+        )
+        scope = resolution.resolved_scope
+        assert scope.comparison_range is not None
+        comparison_range = scope.comparison_range
+
+        snapshot = await status_service.status_snapshot(
+            org_id, "permission-live", StatusSnapshotRequest(scope)
+        )
+        assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+
+        change = await status_service.change_summary(
+            org_id,
+            "permission-live",
+            ChangeSummaryRequest(
+                scope=scope,
+                current_start=scope.time_range.start,
+                current_end=scope.time_range.end,
+                comparison_start=comparison_range.start,
+                comparison_end=comparison_range.end,
+            ),
+        )
+        assert NO_CHANGE_SET_WARNING not in change.warnings
+    finally:
+        raw_client.command(
+            "ALTER TABLE repos DELETE WHERE org_id IN ({org_id:String}, {other_org_id:String})",
+            parameters={"org_id": org_id, "other_org_id": other_org_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_above_contract_limit_stays_organization_native(
+    raw_client: Any, ch_sink: Any
+) -> None:
+    """An org above the 20-repository wire cap must resolve exact + non-empty
+    status reads without ever serializing a truncated repository list."""
+    org_id = f"chaos-3255-wide-{uuid.uuid4().hex[:16]}"
+    repo_ids = [str(uuid.uuid4()) for _ in range(MAX_REPOSITORIES + 5)]
+    try:
+        for index, repo_id in enumerate(repo_ids):
+            _insert_repo(
+                raw_client, org_id=org_id, repo_id=repo_id, name=f"org/repo-{index}"
+            )
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(ch_sink))
+        resolution = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, org_id),)
+            ),
+        )
+
+        assert resolution.outcome.value == "exact"
+        assert resolution.resolved_scope is not None
+        # Never a truncated, misleadingly "complete" 20-entry list.
+        assert resolution.authorized_repository_ids == []
+        assert any("exceeds" in warning for warning in resolution.warnings)
+
+        status_service = StatusChangeService(
+            ClickHouseStatusChangeSource(ch_sink, now=NOW)
+        )
+        snapshot = await status_service.status_snapshot(
+            org_id, "permission-live", StatusSnapshotRequest(resolution.resolved_scope)
+        )
+        # The native source re-derives the full >20 repository set itself;
+        # it must not fall back to the empty-repositories unavailable path.
+        assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    finally:
+        raw_client.command(
+            "ALTER TABLE repos DELETE WHERE org_id = {org_id:String}",
+            parameters={"org_id": org_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_with_no_connected_repos_is_explicit(
+    raw_client: Any, ch_sink: Any
+) -> None:
+    org_id = f"chaos-3255-empty-{uuid.uuid4().hex[:16]}"
+
+    service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(ch_sink))
+    resolution = await service.resolve_contract(
+        org_id,
+        "permission-live",
+        ScopeResolveRequest(explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, org_id),)),
+    )
+
+    assert resolution.outcome.value == "unresolved"
+    assert resolution.resolved_scope is None
+    assert resolution.authorized_repository_ids == []

--- a/tests/api/dev/test_scope_catalog.py
+++ b/tests/api/dev/test_scope_catalog.py
@@ -118,10 +118,14 @@ async def test_organization_repository_ids_is_tenant_scoped_and_reports_true_tot
         observed.append({"sql": sql, "params": params})
         assert "org_id = {org_id:String}" in sql
         assert params["org_id"] == "org-a"
-        if "count()" in sql:
-            return [{"total": 25}]
         assert params["limit"] == 20
-        return [{"repository_id": f"repo-{index:02}"} for index in range(20)]
+        # A single query carries both the page and the true total (via a
+        # window function) so a concurrent insert/delete between two
+        # separate queries can never desync a truncated page from the count.
+        return [
+            {"repository_id": f"repo-{index:02}", "total_authorized": 25}
+            for index in range(20)
+        ]
 
     monkeypatch.setattr(
         "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
@@ -133,8 +137,9 @@ async def test_organization_repository_ids_is_tenant_scoped_and_reports_true_tot
     assert total == 25
     assert len(ids) == 20
     assert ids == sorted(ids)
-    assert len(observed) == 2
-    assert any("FROM repos FINAL" in item["sql"] for item in observed)
+    assert len(observed) == 1
+    assert "count() OVER ()" in observed[0]["sql"]
+    assert "FROM repos FINAL" in observed[0]["sql"]
 
 
 @pytest.mark.asyncio
@@ -142,9 +147,9 @@ async def test_organization_repository_ids_empty_org_reports_zero_total(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def fake_query_dicts(
-        _client: object, sql: str, _params: dict[str, Any]
+        _client: object, _sql: str, _params: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        return [{"total": 0}] if "count()" in sql else []
+        return []
 
     monkeypatch.setattr(
         "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts

--- a/tests/api/dev/test_scope_catalog.py
+++ b/tests/api/dev/test_scope_catalog.py
@@ -104,3 +104,54 @@ def test_catalog_rejects_supporting_evidence_kind() -> None:
         ClickHouseAuthorizedEntityCatalog._query_for(
             cast(EntityKind, "deployment"), exact=False
         )
+
+
+@pytest.mark.asyncio
+async def test_organization_repository_ids_is_tenant_scoped_and_reports_true_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[dict[str, Any]] = []
+
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.append({"sql": sql, "params": params})
+        assert "org_id = {org_id:String}" in sql
+        assert params["org_id"] == "org-a"
+        if "count()" in sql:
+            return [{"total": 25}]
+        assert params["limit"] == 20
+        return [{"repository_id": f"repo-{index:02}"} for index in range(20)]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    ids, total = await catalog.organization_repository_ids("org-a", limit=20)
+
+    assert total == 25
+    assert len(ids) == 20
+    assert ids == sorted(ids)
+    assert len(observed) == 2
+    assert any("FROM repos FINAL" in item["sql"] for item in observed)
+
+
+@pytest.mark.asyncio
+async def test_organization_repository_ids_empty_org_reports_zero_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_query_dicts(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return [{"total": 0}] if "count()" in sql else []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    ids, total = await catalog.organization_repository_ids("org-a", limit=20)
+
+    assert ids == []
+    assert total == 0

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -770,3 +770,31 @@ async def test_non_organization_scope_never_queries_organization_repositories() 
     assert result.resolved_scope is not None
     assert result.resolved_scope.direct_scope is DirectScope.REPOSITORY
     assert catalog.organization_repository_ids_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_organization_scope_skips_repository_enumeration() -> None:
+    """A team filter narrows organization scope, but no native status/change
+    query applies team filters, so the native execution layer always fails
+    closed for this case regardless of repository count (CHAOS-3255). The
+    contract layer must not report a repository set or a warning describing
+    organization-native execution that will not actually happen."""
+    team = _entity(EntityKind.TEAM, "team-a", "Platform")
+    catalog = FakeCatalog([team], organization_repositories=["repo-a", "repo-b"])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            team_filter_refs=(ScopeRef(EntityKind.TEAM, team.canonical_id),),
+            allow_organization_fallback=True,
+        ),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.FILTERED
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.ORGANIZATION
+    assert result.authorized_repository_ids == []
+    assert catalog.organization_repository_ids_calls == 0
+    assert not any("organization-natively" in warning for warning in result.warnings)

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -18,13 +18,21 @@ from dev_health_ops.api.dev.scope_service import (
 
 
 class FakeCatalog:
-    def __init__(self, entities: list[AuthorizedEntity]) -> None:
+    def __init__(
+        self,
+        entities: list[AuthorizedEntity],
+        *,
+        organization_repositories: list[str] | None = None,
+    ) -> None:
         self.entities = entities
+        self.organization_repositories = organization_repositories or []
         self.exact_calls = 0
         self.search_calls = 0
         self.watermark_calls = 0
+        self.organization_repository_ids_calls = 0
         self.fail_exact = False
         self.fail_watermark = False
+        self.fail_organization_repository_ids = False
 
     async def watermark(self, org_id: str, kinds: tuple[EntityKind, ...]) -> str:
         self.watermark_calls += 1
@@ -62,6 +70,15 @@ class FakeCatalog:
             for entity in self.entities
             if entity.kind in kinds and query.casefold() in entity.label.casefold()
         ][:limit]
+
+    async def organization_repository_ids(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[str], int]:
+        self.organization_repository_ids_calls += 1
+        if self.fail_organization_repository_ids:
+            raise RuntimeError("organization repository catalog unavailable")
+        ids = sorted(self.organization_repositories)
+        return ids[:limit], len(ids)
 
 
 def _entity(
@@ -628,3 +645,128 @@ def test_repository_set_cannot_mix_direct_scope_kinds() -> None:
                 ScopeRef(EntityKind.ISSUE, "jira:A-1"),
             )
         )
+
+
+# --- CHAOS-3255: organization scope must be executable for status/change reads ---
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_enumerates_complete_authorized_repository_set() -> (
+    None
+):
+    catalog = FakeCatalog([], organization_repositories=["repo-b", "repo-a", "repo-c"])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),)
+        ),
+        resolved_at=datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.EXACT
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.ORGANIZATION
+    assert result.authorized_repository_ids == ["repo-a", "repo-b", "repo-c"]
+    assert catalog.organization_repository_ids_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_with_zero_repositories_is_insufficient_evidence() -> (
+    None
+):
+    catalog = FakeCatalog([], organization_repositories=[])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),)
+        ),
+        resolved_at=datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.UNRESOLVED
+    assert result.resolved_scope is None
+    assert result.authorized_repository_ids == []
+    assert "organization_has_no_authorized_repositories" in result.warnings
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_above_contract_limit_is_not_truncated() -> None:
+    repositories = [f"repo-{index:02}" for index in range(25)]
+    catalog = FakeCatalog([], organization_repositories=repositories)
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),)
+        ),
+        resolved_at=datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.EXACT
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.ORGANIZATION
+    # Never serialize a truncated, misleadingly "complete" 20-entry list.
+    assert result.authorized_repository_ids == []
+    assert any("exceeds" in warning for warning in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_repository_catalog_failure_is_unresolved() -> None:
+    catalog = FakeCatalog([], organization_repositories=["repo-a"])
+    catalog.fail_organization_repository_ids = True
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),)
+        ),
+        resolved_at=datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.UNRESOLVED
+    assert result.resolved_scope is None
+    assert "catalog_unavailable" in result.warnings
+
+
+@pytest.mark.asyncio
+async def test_organization_scope_repository_enumeration_is_request_cached() -> None:
+    catalog = FakeCatalog([], organization_repositories=["repo-a", "repo-b"])
+    service = ScopeResolutionService(catalog)
+    request = ScopeResolveRequest(
+        explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),)
+    )
+
+    first = await service.resolve_contract("org-a", "perm-a", request)
+    second = await service.resolve_contract("org-a", "perm-a", request)
+
+    assert first.authorized_repository_ids == second.authorized_repository_ids
+    assert catalog.organization_repository_ids_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_organization_scope_never_queries_organization_repositories() -> None:
+    repository = _entity(EntityKind.REPOSITORY, "repo-a", "full-chaos/dev-health")
+    catalog = FakeCatalog([repository], organization_repositories=["repo-a"])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.REPOSITORY, repository.canonical_id),)
+        ),
+    )
+
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.REPOSITORY
+    assert catalog.organization_repository_ids_calls == 0


### PR DESCRIPTION
## Summary

Fixes CHAOS-3255: organization scope (an approved V1 direct scope) was not executable for status/change reads. Organization resolved to `outcome=exact` while contributing zero repository IDs, so `status_snapshot.v1`/`change_summary.v1` always refused with "Status reads require the complete authorized repository set; scope was not widened." even when the org had connected repositories and status data.

## Root cause

- `ScopeResolutionService.resolve_contract` (`scope_service.py`) built `authorized_repository_ids` only from `REPOSITORY`-kind entities or `entity.repository_id`; organization scope resolves to a single `AuthorizedEntity(ORGANIZATION, org_id, ...)` with no repository IDs attached, so the list was always empty.
- `ClickHouseStatusChangeSource.status_snapshot`/`change_summary` (`native_status_change.py`) read `scope.repositories`/`scope.entity_refs` directly, both empty by contract for organization scope, and refused the read.
- Adversarial review turned up a deeper layer: even after wiring the repository set through, `_PULL_REQUESTS_SQL`, `_DEPLOYMENTS_SQL`, `_TRANSITIONS_SQL`, and `_RELATIONSHIPS_SQL` had no `scope_type = 'organization'` branch in their `WHERE` disjunctions (unlike the five *_CHANGES_SQL queries, which already supported it) — so status/change reads for org scope would still silently return zero facts.

## Fix

- `ScopeResolutionService.resolve_contract` now enumerates the organization's complete authorized repository set via a new `AuthorizedEntityCatalog.organization_repository_ids` method.
  - Org at or under the 20-repository contract cap (`MAX_REPOSITORIES`, matching `DevScopeResolution.authorized_repository_ids`'s `max_length`) → full list inline.
  - Org above the cap → `authorized_repository_ids` stays empty (never truncated to a misleadingly "complete" 20-entry list) with an explanatory warning; outcome/resolved_scope are preserved as organization scope.
  - Zero authorized repos → outcome downgrades to `unresolved` (`resolved_scope=None`), an explicit insufficient-evidence result rather than an exact-but-empty scope.
  - A team-filtered organization scope is excluded from this enumeration (see below).
- `ClickHouseAuthorizedEntityCatalog.organization_repository_ids` fetches the id page and true total in a **single** query using `count() OVER ()` (verified live against ClickHouse that it reflects the pre-`LIMIT` total), so a concurrent repo insert/delete between two sequential queries can never desync a truncated page from the reported count.
- `ClickHouseStatusChangeSource._authorized_repository_ids` re-derives the authorized repository set directly from `org_id` for organization scope — an organization-native execution path that scales to any repository count without ever serializing a bounded list, bypassing the wire contract's 20-entry cap entirely for the actual query execution. **Excluded when `scope.team_ids` is non-empty** — no native query here applies a team filter, so auto-deriving the full org repo set for a team-filtered request would silently widen it; that case falls through to the pre-existing fail-closed behavior instead.
- Added `scope_type = 'organization'` to the four native SQL queries that were missing it, matching the pattern already used by the five delivery-change queries.

## Tests

- `tests/api/dev/test_scope_service.py` — org-scope repository enumeration (full set inline, zero-repos → unresolved, above-cap → non-truncated + warning, catalog failure → unresolved, request-level caching, non-org scope never queries org repos).
- `tests/api/dev/test_scope_catalog.py` — `organization_repository_ids` is tenant-scoped and reports the true total from a single window-function query.
- `tests/api/dev/test_native_status_change.py` — org-scope status/change reads surface actual PR/deployment/transition/relationship facts (not just the absence of the old warning), zero-repo org is explicit/degraded not masked, team-filtered org scope is never silently widened.
- `tests/api/dev/test_organization_scope_clickhouse_live.py` (new, `@pytest.mark.clickhouse`) — live-ClickHouse integration: a multi-repo org's full authorized set reaches `status_snapshot.v1`/`change_summary.v1`; an org above the cap stays organization-native and non-truncated; an empty org gets explicit insufficient evidence; a second tenant's repositories never enter the first tenant's authorized set. Verified locally against a running ClickHouse instance (inserted/cleaned synthetic data, zero residual rows afterward).

## Gate / review

- `bash ci/local_validate.sh` — fully green (ruff format/check, mypy, go, river, ClickHouse scratch migrate, full unit suite 9500+ passed, argMax live-exec proof), re-run after every round of fixes below.
- Two rounds of Codex adversarial review (`--effort high`), all findings fixed and re-reviewed:
  - **Round 1**: HIGH — organization `status_snapshot.v1` remained effectively empty (missing `scope_type='organization'` branches on 4 queries) — fixed. MED — team-filtered organization scope silently widened to every repo — fixed (guard on `scope.team_ids`). MED — organization `change_summary.v1` silently omitted transitions/relationships — fixed (same branch fix). MED — repository id-page/count race in `scope_catalog.py` — fixed (single window-function query, verified live against ClickHouse).
  - **Round 2**: MED — the new org-branch tests matched on table name only and would still pass with the organization branch deleted again (table-name-only mock can't detect a missing WHERE-clause branch) — fixed by asserting the literal SQL text; mutation-verified (reverted the fix, confirmed the strengthened tests fail, restored). LOW — the >20-repo warning was still emitted for a team-filtered org even though the team-filter guard prevents organization-native execution for that case, making the warning misleading — fixed by skipping repository enumeration entirely when a team filter is present.
- **Disclosed residual risk (not fixed, out of scope for this ticket)**: team filtering is not applied by any native status/change SQL query in this file — a team-filtered *direct repository* scope has the same limitation as team-filtered organization scope. This predates this change; CHAOS-3255 only ensured organization scope doesn't newly widen around it.

## Test plan

- [x] `bash ci/local_validate.sh` fully green
- [x] Live ClickHouse integration test passes against a real instance
- [x] Two rounds of Codex adversarial review, all findings resolved and re-verified
- [x] Mutation-verified the strengthened regression tests actually fail when the fix is reverted
