### PR TITLE
fix(ask-dev): resolve named entities before executing status tools (CHAOS-3256)

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -664,6 +664,26 @@ class DevOrchestrator:
                     tool_results.append(execution.result)
                     tool_requests.append(tool_request)
                     tool_bytes_total = next_total
+                    committed_resolution = execution.result.scope_resolution
+                    committed_scope = (
+                        committed_resolution.resolved_scope
+                        if committed_resolution is not None
+                        else None
+                    )
+                    if (
+                        tool_request.tool_id is ToolID.RESOLVE_SCOPE
+                        and execution.result.status == "success"
+                        and committed_resolution is not None
+                        and committed_scope is not None
+                        and committed_scope.organization_id == org_id
+                    ):
+                        # A named-entity resolve_scope.v1 match commits a new
+                        # server-authorized scope for every subsequent tool
+                        # call in this run (CHAOS-3256) — the prior immutable
+                        # authorized_scope must not keep being reused once the
+                        # model has resolved a more specific entity.
+                        resolution = committed_resolution
+                        authorized_scope = committed_scope
                     provider_continuation += (
                         AgentMessage(
                             AgentMessageRole.ASSISTANT,

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -76,11 +76,13 @@ from .prompts import PROMPT_VERSION
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
 from .scope_service import (
+    DIRECT_SCOPE_KINDS,
     EntityKind,
     ScopeRef,
     ScopeRequestCache,
     ScopeResolutionService,
     ScopeResolveRequest,
+    ScopeSearchRequest,
     TimeRangeRequest,
 )
 from .status_change_service import (
@@ -106,6 +108,12 @@ ACCEPTANCE_OPENAI_MODEL = SCRIPTED_OPENAI_MODEL
 _ACCEPTANCE_OPENAI_DISCLOSURE_KEY = "ask_dev_scripted_acceptance"
 _ACCEPTANCE_OPENAI_HOSTS = frozenset(
     {"127.0.0.1", "localhost", "ask-dev-scripted-openai"}
+)
+# Named-entity resolution never searches organization scope itself (CHAOS-3256):
+# resolve_scope.v1 only disambiguates the direct scopes an organization search
+# can return an authorized match for.
+_SEARCHABLE_SCOPE_KINDS: tuple[EntityKind, ...] = tuple(
+    sorted(DIRECT_SCOPE_KINDS - {EntityKind.ORGANIZATION}, key=lambda kind: kind.value)
 )
 
 
@@ -599,12 +607,31 @@ async def _assemble_production_runtime(
     )
     evidence_by_id: dict[str, Any] = {}
 
-    async def resolve_scope(_context, request):
-        resolution = await _resolve_exact_contract(
-            scope_service,
-            org_id=org_id,
-            permission_fingerprint=_context.permission_fingerprint,
-            requested_scope=request.scope,
+    async def resolve_scope(context, request):
+        query = (request.query or "").strip()
+        if not query:
+            resolution = await _resolve_exact_contract(
+                scope_service,
+                org_id=org_id,
+                permission_fingerprint=context.permission_fingerprint,
+                requested_scope=request.scope,
+            )
+            return _tool_result(request, scope_resolution=resolution)
+        # A named entity in the model's query is resolved through the same
+        # canonical authorized search service the GraphQL scope search field
+        # uses, never by re-resolving the caller's already-authorized scope
+        # (CHAOS-3256). Exact matches commit a new authorized scope for
+        # subsequent tool calls; ambiguous/not-found results never fall back
+        # to organization scope.
+        resolution = await scope_service.resolve_query_contract(
+            org_id,
+            context.permission_fingerprint,
+            ScopeSearchRequest(
+                query=query,
+                kinds=_SEARCHABLE_SCOPE_KINDS,
+                limit=request.limit,
+            ),
+            base_scope=request.scope,
         )
         return _tool_result(request, scope_resolution=resolution)
 

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -14,7 +14,7 @@ import json
 import re
 from collections import OrderedDict
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime, time, timedelta, timezone
 from enum import StrEnum
 from typing import Protocol
@@ -526,6 +526,103 @@ class ScopeResolutionService:
         )
         self._cache.put(cache_key, result)
         return result
+
+    async def resolve_query_contract(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        request: ScopeSearchRequest,
+        *,
+        base_scope: DevScope,
+        resolved_at: datetime | None = None,
+    ) -> DevScopeResolution:
+        """Resolve a model-owned free-text query into an authorized direct scope.
+
+        This is the canonical seam ``resolve_scope.v1`` uses when the model
+        names an entity: it searches only the authenticated organization's
+        authorized catalog (never free-form SQL/GraphQL, never a
+        model-authored ID) and commits an exact match, returns typed
+        candidates when ambiguous, or reports not-found/forbidden. An
+        unresolved or ambiguous query never silently falls back to
+        organization scope (CHAOS-3256).
+
+        Ambiguity is always probed against the full ``MAX_CANDIDATES`` page,
+        never the model-owned ``request.limit``: truncating the search
+        *before* checking for a second match would let a caller-supplied
+        ``limit=1`` silently pick an arbitrary one of several real matches
+        and report it as an exact commit. ``request.limit`` only bounds how
+        many typed candidates are returned once the outcome is ambiguous.
+        """
+        probe_request = (
+            request
+            if request.limit == MAX_CANDIDATES
+            else replace(request, limit=MAX_CANDIDATES)
+        )
+        result = await self.search(org_id, permission_fingerprint, probe_request)
+        resolved_at = resolved_at or datetime.now(timezone.utc)
+        if not result.candidates:
+            return DevScopeResolution(
+                schema_version="dev_scope_resolution.v1",
+                requested_scope=base_scope,
+                resolved_scope=None,
+                outcome=ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND,
+                authorized_repository_ids=[],
+                authorized_entity_ids=[],
+                candidates=[],
+                fallbacks=[],
+                warnings=["No authorized entity matched the requested query."],
+                resolved_at=resolved_at,
+            )
+        if len(result.candidates) > 1:
+            return DevScopeResolution(
+                schema_version="dev_scope_resolution.v1",
+                requested_scope=base_scope,
+                resolved_scope=None,
+                outcome=ScopeResolutionOutcome.AMBIGUOUS,
+                authorized_repository_ids=[],
+                authorized_entity_ids=[],
+                candidates=[
+                    DevDisambiguationCandidate(
+                        entity_ref=self._contract_entity_ref(candidate),
+                        repository_id=candidate.repository_id,
+                        reason="Multiple authorized entities match the requested query.",
+                    )
+                    for candidate in result.candidates[: request.limit]
+                ],
+                fallbacks=[],
+                warnings=[],
+                resolved_at=resolved_at,
+            )
+        entity = result.candidates[0]
+        is_repository = entity.kind is EntityKind.REPOSITORY
+        resolved_scope = DevScope(
+            schema_version="dev_scope.v1",
+            organization_id=org_id,
+            direct_scope=DirectScope(entity.kind.value),
+            repositories=[entity.canonical_id] if is_repository else [],
+            entity_refs=[] if is_repository else [self._contract_entity_ref(entity)],
+            team_ids=[],
+            time_range=base_scope.time_range,
+            comparison_range=base_scope.comparison_range,
+            surface_context=None,
+        )
+        repository_ids = sorted(
+            ({entity.canonical_id} if is_repository else set())
+            | ({entity.repository_id} if entity.repository_id else set())
+        )
+        entity_ids = [] if is_repository else [entity.canonical_id]
+        return DevScopeResolution(
+            schema_version="dev_scope_resolution.v1",
+            requested_scope=base_scope,
+            resolved_scope=resolved_scope,
+            outcome=ScopeResolutionOutcome.EXACT,
+            authorized_repository_ids=repository_ids,
+            authorized_entity_ids=entity_ids,
+            candidates=[],
+            fallbacks=[],
+            warnings=[],
+            resolved_at=resolved_at,
+        )
 
     async def resolve_contract(
         self,

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -747,6 +747,246 @@ async def test_noncooperative_provider_is_cancelled_by_the_orchestrator() -> Non
     assert cancelled.is_set()
 
 
+# --- CHAOS-3256: resolve named entities before executing status tools ---
+
+
+def _scope_dict(
+    *,
+    direct_scope: str,
+    repositories: list[str] | None = None,
+    entity_refs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    from dev_health_ops.api.dev.contract_fixtures import END, PREVIOUS_START, START
+
+    return {
+        "schema_version": "dev_scope.v1",
+        "organization_id": "org_fullchaos",
+        "direct_scope": direct_scope,
+        "repositories": repositories or [],
+        "entity_refs": entity_refs or [],
+        "team_ids": [],
+        "time_range": {"start": START, "end": END, "timezone": "America/Los_Angeles"},
+        "comparison_range": {
+            "start": PREVIOUS_START,
+            "end": START,
+            "timezone": "America/Los_Angeles",
+        },
+        "surface_context": None,
+    }
+
+
+def _organization_resolution() -> DevScopeResolution:
+    from dev_health_ops.api.dev.contract_fixtures import NOW
+
+    scope = _scope_dict(direct_scope="organization")
+    return DevScopeResolution.model_validate(
+        {
+            "schema_version": "dev_scope_resolution.v1",
+            "requested_scope": scope,
+            "resolved_scope": scope,
+            "outcome": "inherited",
+            "authorized_repository_ids": [],
+            "authorized_entity_ids": [],
+            "candidates": [],
+            "fallbacks": [],
+            "warnings": [],
+            "resolved_at": NOW,
+        }
+    )
+
+
+def _project_resolution() -> DevScopeResolution:
+    from dev_health_ops.api.dev.contract_fixtures import NOW
+
+    scope = _scope_dict(
+        direct_scope="project",
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": "project-ask-dev",
+                "display_label": "Ask Dev",
+                "repository_id": None,
+            }
+        ],
+    )
+    return DevScopeResolution.model_validate(
+        {
+            "schema_version": "dev_scope_resolution.v1",
+            "requested_scope": scope,
+            "resolved_scope": scope,
+            "outcome": "exact",
+            "authorized_repository_ids": [],
+            "authorized_entity_ids": ["project-ask-dev"],
+            "candidates": [],
+            "fallbacks": [],
+            "warnings": [],
+            "resolved_at": NOW,
+        }
+    )
+
+
+def _not_found_resolution() -> DevScopeResolution:
+    from dev_health_ops.api.dev.contract_fixtures import NOW
+
+    scope = _scope_dict(direct_scope="organization")
+    return DevScopeResolution.model_validate(
+        {
+            "schema_version": "dev_scope_resolution.v1",
+            "requested_scope": scope,
+            "resolved_scope": None,
+            "outcome": "forbidden_or_not_found",
+            "authorized_repository_ids": [],
+            "authorized_entity_ids": [],
+            "candidates": [],
+            "fallbacks": [],
+            "warnings": ["No authorized entity matched the requested query."],
+            "resolved_at": NOW,
+        }
+    )
+
+
+def _answer_with_no_claims(*, script_id: str) -> dict:
+    """The stock answer fixture's claim hardcodes a repository validity_scope;
+    these tests commit a different (project/organization) scope mid-run, so
+    drop claims to avoid an unrelated validity_scope mismatch and keep the
+    assertions focused on which scope the status tool received."""
+    payload = _answer(script_id=script_id)
+    payload["claims"] = []
+    return payload
+
+
+def _resolve_scope_registry(
+    *, calls: list[DevToolRequest], resolve_scope_result: DevScopeResolution
+) -> AskDevToolRegistry:
+    async def execute(_context, request: DevToolRequest) -> DevToolResult:
+        calls.append(request)
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        if request.tool_id is ToolID.RESOLVE_SCOPE:
+            payload["scope_resolution"] = resolve_scope_result.model_dump(mode="json")
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+
+@pytest.mark.asyncio
+async def test_resolved_project_scope_is_committed_for_the_status_tool() -> None:
+    """The literal question "What's the status of the Ask Dev project" asked
+    from inherited organization scope must have status_snapshot.v1 receive
+    project scope, not the stale organization scope the run started with."""
+
+    script_id = "resolve-then-status"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev project", "limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_resolve_scope_registry(
+                calls=calls, resolve_scope_result=_project_resolution()
+            ),
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert [request.tool_id.value for request in calls] == [
+        "resolve_scope.v1",
+        "status_snapshot.v1",
+    ]
+    assert calls[0].scope.direct_scope.value == "organization"
+    # The status tool must receive the newly-committed project scope, not
+    # the organization scope the run inherited.
+    assert calls[1].scope.direct_scope.value == "project"
+    assert calls[1].scope.entity_refs[0].entity_id == "project-ask-dev"
+    assert result.answer is not None
+    committed_scope = result.answer.resolved_scope.resolved_scope
+    assert committed_scope is not None
+    assert committed_scope.direct_scope.value == "project"
+
+
+@pytest.mark.asyncio
+async def test_unresolved_named_entity_never_falls_back_to_organization_scope() -> None:
+    """An explicit reference that resolves to nothing must never leave the
+    subsequent tool calls silently widened back to organization scope."""
+
+    script_id = "resolve-not-found"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "some-other-tenant-project", "limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_resolve_scope_registry(
+                calls=calls, resolve_scope_result=_not_found_resolution()
+            ),
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    # The not-found result must not clobber the previously authorized scope;
+    # the status tool keeps executing against the last committed scope
+    # rather than silently regressing to an unauthorized/ambiguous one.
+    assert calls[1].scope.direct_scope.value == "organization"
+
+
 def test_hard_defaults_can_only_be_configured_downward() -> None:
     assert DevRunLimits().model_rounds == 4
     assert DevRunLimits(model_rounds=2).model_rounds == 2

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import secrets
 from typing import Any, cast
 
 import pytest
@@ -318,6 +319,148 @@ async def test_production_runtime_wires_exactly_the_nine_registered_tools(
     assert execution.result.metric_definitions
     assert execution.result.metric_definitions[0].description
     assert execution.result.metric_definitions[0].supported_time_grains
+    await runtime.aclose()
+
+
+async def _build_runtime_for_resolve_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Any:
+    async def resolve_provider(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=cast(Any, FakeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    # Constructed at runtime, never a literal secret-shaped string in source.
+    monkeypatch.setenv("JWT_SECRET_KEY", secrets.token_hex(32))
+    return await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id="org_fullchaos",
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_with_a_query_searches_the_authorized_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3256: a named-entity query must not re-resolve the caller's scope."""
+
+    async def fake_query_dicts(_client, sql, params):
+        if "FROM projects FINAL" in sql:
+            assert params["org_id"] == "org_fullchaos"
+            assert params["query"] == "ask dev"
+            return [
+                {
+                    "canonical_id": "project-ask-dev",
+                    "label": "Ask Dev",
+                    "repository_id": None,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    runtime = await _build_runtime_for_resolve_scope(monkeypatch)
+    org_scope = DevScope.model_validate(
+        {
+            **positive_fixtures()["dev_scope.v1"],
+            "organization_id": "org_fullchaos",
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "surface_context": None,
+        }
+    )
+
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.RESOLVE_SCOPE,
+            scope=org_scope,
+            query="ask dev",
+            limit=25,
+        ),
+        ToolExecutionContext(
+            org_id="org_fullchaos",
+            user_id="user_01",
+            permission_fingerprint="permissions_01",
+            authorized_scope=org_scope,
+            cancellation=asyncio.Event(),
+            remaining_seconds=5,
+        ),
+    )
+
+    resolution = execution.result.scope_resolution
+    assert resolution is not None
+    assert resolution.outcome.value == "exact"
+    assert resolution.resolved_scope is not None
+    assert resolution.resolved_scope.direct_scope.value == "project"
+    assert resolution.resolved_scope.entity_refs[0].entity_id == "project-ask-dev"
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_without_a_query_keeps_resolving_the_current_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty/omitted query keeps the pre-existing re-authorization behavior."""
+
+    async def fake_query_dicts(_client, sql, params):
+        del sql, params
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    runtime = await _build_runtime_for_resolve_scope(monkeypatch)
+    org_scope = DevScope.model_validate(
+        {
+            **positive_fixtures()["dev_scope.v1"],
+            "organization_id": "org_fullchaos",
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "surface_context": None,
+        }
+    )
+
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.RESOLVE_SCOPE,
+            scope=org_scope,
+            limit=25,
+        ),
+        ToolExecutionContext(
+            org_id="org_fullchaos",
+            user_id="user_01",
+            permission_fingerprint="permissions_01",
+            authorized_scope=org_scope,
+            cancellation=asyncio.Event(),
+            remaining_seconds=5,
+        ),
+    )
+
+    resolution = execution.result.scope_resolution
+    assert resolution is not None
+    # No connected repos in this fake catalog -> explicit insufficient
+    # evidence, never a fabricated exact organization scope (CHAOS-3255).
+    assert resolution.outcome.value == "unresolved"
+    assert resolution.resolved_scope is None
     await runtime.aclose()
 
 

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from dev_health_ops.api.dev.contracts import DirectScope
+from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
     EntityKind,
@@ -93,6 +93,24 @@ def _entity(
         canonical_id=canonical_id,
         label=label,
         repository_id=repository_id,
+    )
+
+
+def _org_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.ORGANIZATION,
+        repositories=[],
+        entity_refs=[],
+        team_ids=[],
+        time_range=DevTimeRange(
+            start=datetime(2026, 6, 28, tzinfo=timezone.utc),
+            end=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            timezone="UTC",
+        ),
+        comparison_range=None,
+        surface_context=None,
     )
 
 
@@ -798,3 +816,193 @@ async def test_team_filtered_organization_scope_skips_repository_enumeration() -
     assert result.authorized_repository_ids == []
     assert catalog.organization_repository_ids_calls == 0
     assert not any("organization-natively" in warning for warning in result.warnings)
+
+
+# --- CHAOS-3256: resolve named entities before executing status tools ---
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_commits_exact_named_project_scope() -> None:
+    project = _entity(EntityKind.PROJECT, "project-ask-dev", "Ask Dev")
+    catalog = FakeCatalog([project])
+    service = ScopeResolutionService(catalog)
+    base_scope = _org_scope()
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(
+            query="ask dev",
+            kinds=(EntityKind.PROJECT, EntityKind.REPOSITORY),
+            limit=25,
+        ),
+        base_scope=base_scope,
+        resolved_at=datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.EXACT
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.PROJECT
+    assert result.resolved_scope.entity_refs[0].entity_id == "project-ask-dev"
+    assert result.authorized_entity_ids == ["project-ask-dev"]
+    assert result.requested_scope == base_scope
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_commits_exact_named_repository_scope() -> None:
+    repository = _entity(EntityKind.REPOSITORY, "repo-a", "full-chaos/dev-health")
+    catalog = FakeCatalog([repository])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(
+            query="dev-health", kinds=(EntityKind.REPOSITORY,), limit=25
+        ),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.EXACT
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope.REPOSITORY
+    assert result.resolved_scope.repositories == ["repo-a"]
+    assert result.authorized_repository_ids == ["repo-a"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind",
+    [
+        EntityKind.REPOSITORY,
+        EntityKind.PROJECT,
+        EntityKind.WORK_UNIT,
+        EntityKind.ISSUE,
+        EntityKind.PULL_REQUEST,
+    ],
+)
+async def test_resolve_query_contract_covers_every_supported_direct_scope(
+    kind: EntityKind,
+) -> None:
+    entity = _entity(
+        kind,
+        f"{kind.value}:id",
+        f"{kind.value} label",
+        repository_id="repo-a" if kind is not EntityKind.REPOSITORY else None,
+    )
+    catalog = FakeCatalog([entity])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(query=f"{kind.value} label", kinds=(kind,), limit=25),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.EXACT
+    assert result.resolved_scope is not None
+    assert result.resolved_scope.direct_scope is DirectScope(kind.value)
+    if kind is EntityKind.REPOSITORY:
+        assert result.resolved_scope.repositories == [entity.canonical_id]
+        assert result.authorized_repository_ids == [entity.canonical_id]
+    else:
+        assert result.resolved_scope.entity_refs[0].entity_id == entity.canonical_id
+        assert result.authorized_repository_ids == ["repo-a"]
+        assert result.authorized_entity_ids == [entity.canonical_id]
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_returns_typed_ambiguous_candidates() -> None:
+    catalog = FakeCatalog(
+        [
+            _entity(EntityKind.PROJECT, "project-z", "Platform"),
+            _entity(EntityKind.PROJECT, "project-a", "platform"),
+        ]
+    )
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(query="platform", kinds=(EntityKind.PROJECT,), limit=25),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.AMBIGUOUS
+    assert result.resolved_scope is None
+    assert [candidate.entity_ref.entity_id for candidate in result.candidates] == [
+        "project-a",
+        "project-z",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_detects_ambiguity_despite_a_narrow_limit() -> (
+    None
+):
+    """A caller-supplied ``limit=1`` must never truncate the search before
+    ambiguity is checked -- that would let it silently commit an arbitrary
+    one of several real matches as if it were the unique exact answer."""
+    catalog = FakeCatalog(
+        [
+            _entity(EntityKind.PROJECT, "project-z", "Platform"),
+            _entity(EntityKind.PROJECT, "project-a", "platform"),
+        ]
+    )
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(query="platform", kinds=(EntityKind.PROJECT,), limit=1),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.AMBIGUOUS
+    assert result.resolved_scope is None
+    # The typed candidate list itself still honors the caller's requested
+    # limit; only the exact-vs-ambiguous decision must not be truncated.
+    assert len(result.candidates) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_not_found_never_falls_back_to_organization() -> (
+    None
+):
+    catalog = FakeCatalog([])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(
+            query="does not exist", kinds=(EntityKind.PROJECT,), limit=25
+        ),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND
+    assert result.resolved_scope is None
+    assert result.candidates == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_query_contract_cross_tenant_entity_is_not_found() -> None:
+    # The production catalog is tenant-scoped in every SQL query (org_id is
+    # part of every WHERE clause); a fake catalog that never returns another
+    # tenant's rows for this query models that authorization boundary.
+    catalog = FakeCatalog([])
+    service = ScopeResolutionService(catalog)
+
+    result = await service.resolve_query_contract(
+        "org-a",
+        "perm-a",
+        ScopeSearchRequest(
+            query="other-tenant-project", kinds=(EntityKind.PROJECT,), limit=25
+        ),
+        base_scope=_org_scope(),
+    )
+
+    assert result.outcome is ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND
+    assert result.resolved_scope is None


### PR DESCRIPTION
## Summary

Fixes CHAOS-3256: the production `resolve_scope.v1` executor ignored the model's validated `query`/`limit` inputs entirely, calling `_resolve_exact_contract(..., requested_scope=request.scope)` — i.e. re-resolving the caller's already-authorized scope. Asking "What's the status of the Ask Dev project" from inherited organization scope therefore ran `status_snapshot.v1` against the organization, never the named project, even when the model correctly called `resolve_scope.v1` with a query.

## Fix

- **`scope_service.py`** — new `ScopeResolutionService.resolve_query_contract`: the canonical seam `resolve_scope.v1` uses when the model names an entity. Searches only the authenticated organization's authorized catalog (never free-form SQL/GraphQL, never a model-authored ID):
  - Exact match → commits a new authorized `DevScope` (project/work-unit/repository/issue/PR) for the resolved entity.
  - Multiple matches → typed `AMBIGUOUS` candidates.
  - No matches → `FORBIDDEN_OR_NOT_FOUND`; **never** falls back to organization scope.
- **`production_runtime.py`** — `resolve_scope` executor now calls `resolve_query_contract` when the model supplies a non-empty `query`, searching across every non-organization direct-scope kind. An empty/omitted query keeps the prior re-authorization behavior (defensive fallback; the tool's exposed JSON schema marks `query` required).
- **`orchestrator.py`** — `DevOrchestrator.run` now commits a successful `resolve_scope.v1` exact match's `resolved_scope` as `authorized_scope` for every subsequent tool call in the run, instead of reusing the single immutable scope captured before the model's first decision round. Guarded to only fire for `ToolID.RESOLVE_SCOPE`, only on `status == "success"`, only when `resolved_scope` is non-`None`, and only when it belongs to the authenticated `org_id` (defense in depth; the catalog is already tenant-scoped).

## Adversarial-review fix

Codex found a HIGH: `resolve_query_contract` passed the model-owned `request.limit` straight through to `search()`, so a caller-supplied `limit=1` with 2 real matches in the catalog silently truncated the search results to 1 *before* the ambiguity check — committing an arbitrary one of several matches as `EXACT` instead of reporting `AMBIGUOUS`.

Fix: `resolve_query_contract` now always probes with `limit` pinned to `MAX_CANDIDATES` (25) via `dataclasses.replace`, decides exact/ambiguous/not-found against that untruncated result, and only truncates to the caller's requested `limit` when building the typed candidate list for an ambiguous outcome. Added `test_resolve_query_contract_detects_ambiguity_despite_a_narrow_limit`.

## Tests

- `tests/api/dev/test_scope_service.py` — `resolve_query_contract` across every supported direct scope kind (repository/project/work_unit/issue/pull_request), ambiguous candidates, not-found/cross-tenant never falling back to org scope, and the narrow-limit ambiguity regression.
- `tests/api/dev/test_production_runtime.py` — `resolve_scope` executor with a query searches the authorized catalog and resolves to the named entity; without a query keeps the legacy re-authorization path.
- `tests/api/dev/test_orchestrator.py` — full orchestrator run for the literal question "What's the status of the Ask Dev project" from inherited organization scope, asserting `status_snapshot.v1` receives project scope (not organization scope) and the final answer's `resolved_scope` reflects the committed project scope; a second test proves an unresolved named-entity reference never regresses subsequent tool calls back to organization scope.

## Gate / review

- `bash ci/local_validate.sh` — fully green (ruff format/check, mypy, go, river, ClickHouse scratch migrate, full unit suite 9500+ passed, argMax live-exec proof) both before and after the adversarial-review fix.
- Two rounds of Codex adversarial review (`--effort high`):
  - **Round 1**: HIGH — `resolve_query_contract` truncated to the model's requested `limit` before checking ambiguity — fixed (see above).
  - **Round 2**: re-reviewed the fix; 16 focused tests passed, the cache/watermark interaction is correct. One residual **MED disclosed, not fixed**: `ScopeResolutionService.search()` itself asks the catalog for at most `limit` rows before `_dedupe_entities()`; a hypothetical catalog implementation that returns multiple raw rows for the same canonical entity (e.g. a future join-based search) could theoretically still under-count distinct matches within that page. The production `ClickHouseAuthorizedEntityCatalog.search()` is not affected today — every kind's query is a direct single-table `SELECT ... FROM <table> FINAL WHERE ...` with no join that could duplicate rows per entity, so one row always equals one entity. Flagging as a protocol-contract expectation (`AuthorizedEntityCatalog.search()` implementations must not return duplicate `(kind, canonical_id)` rows within their own `limit`) for whoever builds the next catalog implementation, rather than fixing a non-reachable path now.

## Test plan

- [x] `bash ci/local_validate.sh` fully green
- [x] Codex adversarial review (2 rounds), the reachable finding resolved and re-verified; one non-reachable protocol-level edge case disclosed above

## Depends on

Independent of CHAOS-3255 (different code paths); no merge-order requirement, though both touch `scope_service.py` in non-overlapping regions.
