### PR TITLE
fix(ask-dev): preserve deterministic status and evidence semantics at the production tool boundary

### DIFF
--- a/contracts/ask-dev/v1/examples/negative/dev_answer.v1.invalid_complete_state.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_answer.v1.invalid_complete_state.json
@@ -268,7 +268,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/negative/dev_answer.v1.oversized_evidence.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_answer.v1.oversized_evidence.json
@@ -1091,7 +1091,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/negative/dev_answer.v1.unknown_evidence_id.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_answer.v1.unknown_evidence_id.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/negative/dev_answer.v1.unknown_metric_id.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_answer.v1.unknown_metric_id.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/contracts/ask-dev/v1/examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/contracts/ask-dev/v1/examples/negative/dev_tool_result.v1.oversized_result.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_tool_result.v1.oversized_result.json
@@ -1,5 +1,8 @@
 {
+  "actual_completion": null,
+  "ci_checks": [],
   "data_health": [],
+  "deployments": [],
   "error": null,
   "evidence": [
     {
@@ -37,6 +40,7 @@
     }
   ],
   "graph_edges": [],
+  "incidents": [],
   "metric_definitions": [
     {
       "definition_version": "items_completed.v1",
@@ -128,6 +132,7 @@
       "value": 12
     }
   ],
+  "pull_requests": [],
   "run_id": "run_01",
   "schema_version": "dev_tool_result.v1",
   "scope_resolution": {
@@ -211,6 +216,7 @@
     "warnings": []
   },
   "serialized_bytes": 65537,
+  "source_health": [],
   "status": "success",
   "status_facts": [],
   "tool_call_id": "tool_call_01",

--- a/contracts/ask-dev/v1/examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json
@@ -1,72 +1,9 @@
 {
-  "answer_id": "answer_01",
-  "as_of": "2026-07-28T12:00:00Z",
-  "claims": [
-    {
-      "claim_id": "claim_01",
-      "confidence": 1.0,
-      "evidence_ref_ids": [
-        "ev_01"
-      ],
-      "flags": {
-        "conflicting": false,
-        "stale": false,
-        "uncertain": false,
-        "untrusted_source": false
-      },
-      "kind": "observed",
-      "metric_ref_ids": [
-        "metric_01"
-      ],
-      "recommendation_rule_version": null,
-      "schema_version": "dev_claim.v1",
-      "text": "Twelve work items completed in the selected period.",
-      "validity_scope": {
-        "comparison_range": {
-          "end": "2026-06-28T00:00:00Z",
-          "start": "2026-05-29T00:00:00Z",
-          "timezone": "America/Los_Angeles"
-        },
-        "direct_scope": "repository",
-        "entity_refs": [],
-        "organization_id": "org_fullchaos",
-        "repositories": [
-          "repo_dev_health"
-        ],
-        "schema_version": "dev_scope.v1",
-        "surface_context": {
-          "entity_refs": [
-            {
-              "display_label": "Selected repository",
-              "entity_id": "repo_dev_health",
-              "entity_type": "repository",
-              "repository_id": null
-            }
-          ],
-          "filter_fingerprint": "filters_01",
-          "route_id": "diagnose_overview"
-        },
-        "team_ids": [
-          "team_platform"
-        ],
-        "time_range": {
-          "end": "2026-07-28T00:00:00Z",
-          "start": "2026-06-28T00:00:00Z",
-          "timezone": "America/Los_Angeles"
-        }
-      }
-    }
-  ],
-  "conflicts": [],
-  "conversation_id": "conversation_01",
-  "coverage": {
-    "as_of": "2026-07-28T12:00:00Z",
-    "available_source_count": 1,
-    "required_source_count": 1,
-    "stale_required_sources": [],
-    "unavailable_required_sources": []
-  },
-  "direct_summary": "Twelve work items completed in the selected period.",
+  "actual_completion": null,
+  "ci_checks": [],
+  "data_health": [],
+  "deployments": [],
+  "error": null,
   "evidence": [
     {
       "citation_text": "The contract implementation remains in progress.",
@@ -102,7 +39,30 @@
       ]
     }
   ],
-  "generated_at": "2026-07-28T12:00:00Z",
+  "graph_edges": [],
+  "incidents": [],
+  "metric_definitions": [
+    {
+      "definition_version": "items_completed.v1",
+      "description": "Completed work items in the selected window.",
+      "freshness_policy": "work_item_metrics_daily.daily.v1",
+      "label": "Items completed",
+      "metric_id": "items_completed",
+      "supported_dimensions": [
+        "repository"
+      ],
+      "supported_scopes": [
+        "organization",
+        "project",
+        "work_unit"
+      ],
+      "supported_time_grains": [
+        "window",
+        "day"
+      ],
+      "unit": "items"
+    }
+  ],
   "metrics": [
     {
       "aggregation": "count",
@@ -172,12 +132,10 @@
       "value": 12
     }
   ],
-  "model": {
-    "model_fingerprint": "model_certified_01",
-    "provider_family": "openai_compatible",
-    "provider_source": "platform"
-  },
-  "resolved_scope": {
+  "pull_requests": [],
+  "run_id": "run_01",
+  "schema_version": "dev_tool_result.v1",
+  "scope_resolution": {
     "authorized_entity_ids": [],
     "authorized_repository_ids": [
       "repo_dev_health"
@@ -229,7 +187,9 @@
       "direct_scope": "repository",
       "entity_refs": [],
       "organization_id": "org_fullchaos",
-      "repositories": [],
+      "repositories": [
+        "repo_dev_health"
+      ],
       "schema_version": "dev_scope.v1",
       "surface_context": {
         "entity_refs": [
@@ -255,16 +215,19 @@
     "schema_version": "dev_scope_resolution.v1",
     "warnings": []
   },
-  "schema_version": "dev_answer.v1",
-  "status": "complete",
-  "suggested_follow_up_questions": [
-    "What changed from the previous period?"
+  "serialized_bytes": 4096,
+  "source_health": [],
+  "status": "success",
+  "status_facts": [
+    {
+      "evidence_ref_ids": [
+        "ev_not_in_evidence_array"
+      ],
+      "fact_id": "issue:item_02",
+      "text": "Child issue: open"
+    }
   ],
-  "versions": {
-    "metric_definition_version": "ask_dev_metrics.v1",
-    "prompt_version": "ask_dev_prompt.v1",
-    "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v2"
-  },
+  "tool_call_id": "tool_call_01",
+  "tool_id": "query_metric.v1",
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/positive/dev_answer.v1.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_answer.v1.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/contracts/ask-dev/v1/examples/positive/dev_conversation_transcript.v1.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_conversation_transcript.v1.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/contracts/ask-dev/v1/examples/positive/dev_tool_result.v1.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_tool_result.v1.json
@@ -1,5 +1,8 @@
 {
+  "actual_completion": null,
+  "ci_checks": [],
   "data_health": [],
+  "deployments": [],
   "error": null,
   "evidence": [
     {
@@ -37,6 +40,7 @@
     }
   ],
   "graph_edges": [],
+  "incidents": [],
   "metric_definitions": [
     {
       "definition_version": "items_completed.v1",
@@ -128,6 +132,7 @@
       "value": 12
     }
   ],
+  "pull_requests": [],
   "run_id": "run_01",
   "schema_version": "dev_tool_result.v1",
   "scope_resolution": {
@@ -211,6 +216,7 @@
     "warnings": []
   },
   "serialized_bytes": 4096,
+  "source_health": [],
   "status": "success",
   "status_facts": [],
   "tool_call_id": "tool_call_01",

--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -60,17 +60,17 @@
         {
           "case": "assistant_contains_user_question",
           "path": "examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json",
-          "sha256": "ce14c52a308aa86a2cc9bec8aed7350b86952e443de8de34bcbb8f1f12d29684"
+          "sha256": "d9b3310c03cec9e22176952cae7254b8b90d795912ea501f14c84e01de99cd63"
         },
         {
           "case": "answer_from_another_conversation",
           "path": "examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json",
-          "sha256": "b4a879ae52086bae0af69bdca0eae3d04fdf682d4df1112b52217e8ea84696a7"
+          "sha256": "ed0ce846ce393c1dbac33315faef6b85d0b9bfa24cbd7bcf5f2623bcc2e708e3"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_conversation_transcript.v1.json",
-        "sha256": "73b9a33b083b34fd450cd200e44a611d70816baafc9f7b2710f3767a11b6b877"
+        "sha256": "7aa148b2e030d83df425a53144b2a72c1ce12f6a2fd4bf8ffe798a09239db72d"
       },
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
@@ -116,12 +116,12 @@
         {
           "case": "unknown_evidence_id",
           "path": "examples/negative/dev_answer.v1.unknown_evidence_id.json",
-          "sha256": "3546f034242e02c9a5d9afd19b81426cfacf2a2d9d48d420a13b2d90cca36bec"
+          "sha256": "0c77e93e77d2029f0403e26c5a571191712fe032c584bffebb274613369c2247"
         },
         {
           "case": "unknown_metric_id",
           "path": "examples/negative/dev_answer.v1.unknown_metric_id.json",
-          "sha256": "77450a616cd71501238f3b2944b3276441d8916461fc80bec312d9630ca1a354"
+          "sha256": "5edba7a3cb9853d81b12672acdd7c2465d4cde3ecc95f5c12ce37ca2edcd55d7"
         },
         {
           "case": "missing_required_metadata",
@@ -131,22 +131,22 @@
         {
           "case": "invalid_scope",
           "path": "examples/negative/dev_answer.v1.invalid_scope.json",
-          "sha256": "ff06c0937444d79e83c32460c52569e0e8804cd774f1cfa7557877d7eec72ecb"
+          "sha256": "d61351bdacd0355b1a9f2e5b0e9dff4042da171e6b1e49ebd5fd2da0f1c3faae"
         },
         {
           "case": "oversized_evidence",
           "path": "examples/negative/dev_answer.v1.oversized_evidence.json",
-          "sha256": "08a7fadfe436b9f7645503d1df3acf3706d9bd4d70cb8486594bf576faca64ca"
+          "sha256": "9ff9a4caedd30b7dc15c345a9641da4a70e5a1c84e3bac1576772985a7bdce6d"
         },
         {
           "case": "invalid_complete_state",
           "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
-          "sha256": "5dd35c270b26c18ee75e28bbdc46e4e5a9417e6aa92dc64461032883b98b5153"
+          "sha256": "304e8da54dbdb878bbbe44101e89fca1c8f8c44a84cf61c5e51e8dda3f25d359"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_answer.v1.json",
-        "sha256": "1ee3230951ae3590fd921c18042b40a98be45452ecacd9d5d6caa90f32927e55"
+        "sha256": "fba7cafc8b232b43e56c8385b2b58439e5a4b0b67cb3eb1da0ffc32f19733c21"
       },
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
@@ -285,16 +285,21 @@
         {
           "case": "oversized_result",
           "path": "examples/negative/dev_tool_result.v1.oversized_result.json",
-          "sha256": "94e8ce815d630657daceb37bb3f7ab8647c350d234429cd0ac699702604e2602"
+          "sha256": "a40d6bbd0794c3ba8b2c6fbcd62fc158a4eb65c66e60a16b3d1a75d0416be3a4"
+        },
+        {
+          "case": "status_fact_evidence_not_in_array",
+          "path": "examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json",
+          "sha256": "26afbb73e6e8865f5884ba5af09a86effd6b5b5b63bf9ad4390b4ea8261a72ce"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_tool_result.v1.json",
-        "sha256": "5998122f3d515432423cba1e67e5785983e11f743fa18e0a9bbbd9358ef21549"
+        "sha256": "31a956f4659f29f190346a7b873a219ffc85ccd2dfb9d7032937a4eb9c9ed653"
       },
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "8547fecb7f135fc005f0d06e5ca223272994cb118c365208abf9b3bd54ee26f0"
+        "sha256": "215fcb63d94c629b2002b91c3ab0c81b055bc5aee38b60b71ce81232c9870367"
       },
       "schema_version": "dev_tool_result.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -19,6 +19,152 @@
       "title": "AskDevSurfaceRouteID",
       "type": "string"
     },
+    "DevActualCompletion": {
+      "additionalProperties": false,
+      "description": "Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.",
+      "properties": {
+        "conflicts": {
+          "items": {
+            "$ref": "#/$defs/DevStatusConflict"
+          },
+          "maxItems": 20,
+          "title": "Conflicts",
+          "type": "array"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "reason_codes": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "required_children": {
+          "items": {
+            "$ref": "#/$defs/DevRequiredChildFact"
+          },
+          "maxItems": 100,
+          "title": "Required Children",
+          "type": "array"
+        },
+        "rule_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Rule Id",
+          "type": "string"
+        },
+        "rule_version": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Rule Version",
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "ready",
+            "not_ready",
+            "indeterminate"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "state",
+        "rule_id",
+        "rule_version"
+      ],
+      "title": "DevActualCompletion",
+      "type": "object"
+    },
+    "DevCIFact": {
+      "additionalProperties": false,
+      "properties": {
+        "conclusion": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Conclusion",
+          "type": "string"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required"
+        },
+        "skipped_required_work": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Skipped Required Work"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "conclusion",
+        "observed_at"
+      ],
+      "title": "DevCIFact",
+      "type": "object"
+    },
     "DevCitationLink": {
       "additionalProperties": false,
       "properties": {
@@ -108,6 +254,75 @@
         "coverage"
       ],
       "title": "DevDataHealth",
+      "type": "object"
+    },
+    "DevDeploymentFact": {
+      "additionalProperties": false,
+      "properties": {
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Environment"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "title": "Required",
+          "type": "boolean"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "status",
+        "required",
+        "observed_at"
+      ],
+      "title": "DevDeploymentFact",
       "type": "object"
     },
     "DevDisambiguationCandidate": {
@@ -458,6 +673,12 @@
     "DevGraphEdge": {
       "additionalProperties": false,
       "properties": {
+        "confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence",
+          "type": "number"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -468,6 +689,17 @@
           "maxItems": 25,
           "title": "Evidence Ref Ids",
           "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "provenance": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Provenance",
+          "type": "string"
         },
         "relationship": {
           "maxLength": 128,
@@ -494,9 +726,71 @@
       "required": [
         "source_entity_id",
         "relationship",
-        "target_entity_id"
+        "target_entity_id",
+        "provenance",
+        "confidence",
+        "observed_at"
       ],
       "title": "DevGraphEdge",
+      "type": "object"
+    },
+    "DevIncidentFact": {
+      "additionalProperties": false,
+      "properties": {
+        "active": {
+          "title": "Active",
+          "type": "boolean"
+        },
+        "blocking": {
+          "title": "Blocking",
+          "type": "boolean"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "status",
+        "active",
+        "blocking",
+        "observed_at"
+      ],
+      "title": "DevIncidentFact",
       "type": "object"
     },
     "DevMetricDefinition": {
@@ -761,6 +1055,130 @@
       "title": "DevMetricRef",
       "type": "object"
     },
+    "DevPullRequestFact": {
+      "additionalProperties": false,
+      "properties": {
+        "changes_requested": {
+          "maximum": 1000,
+          "minimum": 0,
+          "title": "Changes Requested",
+          "type": "integer"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "merged": {
+          "title": "Merged",
+          "type": "boolean"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "title": "Required",
+          "type": "boolean"
+        },
+        "review_state": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Review State"
+        },
+        "state": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "state",
+        "changes_requested",
+        "merged",
+        "required",
+        "observed_at"
+      ],
+      "title": "DevPullRequestFact",
+      "type": "object"
+    },
+    "DevRequiredChildFact": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "fact_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        },
+        "text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fact_id",
+        "text",
+        "status"
+      ],
+      "title": "DevRequiredChildFact",
+      "type": "object"
+    },
     "DevScope": {
       "additionalProperties": false,
       "properties": {
@@ -932,6 +1350,92 @@
         "resolved_at"
       ],
       "title": "DevScopeResolution",
+      "type": "object"
+    },
+    "DevSourceHealth": {
+      "additionalProperties": false,
+      "properties": {
+        "freshness": {
+          "$ref": "#/$defs/FreshnessState"
+        },
+        "ref_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Ref Id",
+          "type": "string"
+        },
+        "source_system": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source System",
+          "type": "string"
+        },
+        "watermark": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Watermark"
+        }
+      },
+      "required": [
+        "ref_id",
+        "source_system",
+        "freshness"
+      ],
+      "title": "DevSourceHealth",
+      "type": "object"
+    },
+    "DevStatusConflict": {
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Code",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "message": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Message",
+          "type": "string"
+        },
+        "severity": {
+          "enum": [
+            "warning",
+            "blocking"
+          ],
+          "title": "Severity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message",
+        "severity"
+      ],
+      "title": "DevStatusConflict",
       "type": "object"
     },
     "DevStatusFact": {
@@ -1115,12 +1619,39 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "actual_completion": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DevActualCompletion"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "ci_checks": {
+      "items": {
+        "$ref": "#/$defs/DevCIFact"
+      },
+      "maxItems": 100,
+      "title": "Ci Checks",
+      "type": "array"
+    },
     "data_health": {
       "items": {
         "$ref": "#/$defs/DevDataHealth"
       },
       "maxItems": 25,
       "title": "Data Health",
+      "type": "array"
+    },
+    "deployments": {
+      "items": {
+        "$ref": "#/$defs/DevDeploymentFact"
+      },
+      "maxItems": 100,
+      "title": "Deployments",
       "type": "array"
     },
     "error": {
@@ -1150,6 +1681,14 @@
       "title": "Graph Edges",
       "type": "array"
     },
+    "incidents": {
+      "items": {
+        "$ref": "#/$defs/DevIncidentFact"
+      },
+      "maxItems": 100,
+      "title": "Incidents",
+      "type": "array"
+    },
     "metric_definitions": {
       "items": {
         "$ref": "#/$defs/DevMetricDefinition"
@@ -1164,6 +1703,14 @@
       },
       "maxItems": 12,
       "title": "Metrics",
+      "type": "array"
+    },
+    "pull_requests": {
+      "items": {
+        "$ref": "#/$defs/DevPullRequestFact"
+      },
+      "maxItems": 100,
+      "title": "Pull Requests",
       "type": "array"
     },
     "run_id": {
@@ -1194,6 +1741,14 @@
       "minimum": 0,
       "title": "Serialized Bytes",
       "type": "integer"
+    },
+    "source_health": {
+      "items": {
+        "$ref": "#/$defs/DevSourceHealth"
+      },
+      "maxItems": 25,
+      "title": "Source Health",
+      "type": "array"
     },
     "status": {
       "enum": [

--- a/src/dev_health_ops/api/dev/contract_fixtures.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures.py
@@ -166,7 +166,7 @@ def _answer() -> dict[str, Any]:
         "suggested_follow_up_questions": ["What changed from the previous period?"],
         "versions": {
             "prompt_version": "ask_dev_prompt.v1",
-            "tool_contract_version": "ask_dev_tools.v1",
+            "tool_contract_version": "ask_dev_tools.v2",
             "metric_definition_version": "ask_dev_metrics.v1",
             "query_version": "ask_dev_queries.v1",
         },
@@ -305,6 +305,12 @@ def positive_fixtures() -> dict[str, dict[str, Any]]:
             "metrics": [_metric()],
             "evidence": [_evidence()],
             "status_facts": [],
+            "actual_completion": None,
+            "pull_requests": [],
+            "ci_checks": [],
+            "deployments": [],
+            "incidents": [],
+            "source_health": [],
             "graph_edges": [],
             "data_health": [],
             "warnings": [],
@@ -565,7 +571,23 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                     "dev_tool_result.v1",
                     lambda value: value.__setitem__("serialized_bytes", 65_537),
                 ),
-            )
+            ),
+            (
+                "status_fact_evidence_not_in_array",
+                changed(
+                    "dev_tool_result.v1",
+                    lambda value: value.__setitem__(
+                        "status_facts",
+                        [
+                            {
+                                "fact_id": "issue:item_02",
+                                "text": "Child issue: open",
+                                "evidence_ref_ids": ["ev_not_in_evidence_array"],
+                            }
+                        ],
+                    ),
+                ),
+            ),
         ],
         "dev_feedback.v1": [
             (

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -772,10 +772,90 @@ class DevStatusFact(ContractModel):
     evidence_ref_ids: list[OpaqueID] = Field(min_length=1, max_length=25)
 
 
+class DevPullRequestFact(ContractModel):
+    entity_id: OpaqueID
+    display_label: Label
+    state: OpaqueID
+    review_state: OpaqueID | None = None
+    changes_requested: int = Field(ge=0, le=1_000)
+    merged: bool
+    required: bool
+    observed_at: AwareDatetime
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevCIFact(ContractModel):
+    entity_id: OpaqueID
+    display_label: Label
+    conclusion: OpaqueID
+    required: bool | None = None
+    skipped_required_work: bool | None = None
+    observed_at: AwareDatetime
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevDeploymentFact(ContractModel):
+    entity_id: OpaqueID
+    display_label: Label
+    status: OpaqueID
+    environment: OpaqueID | None = None
+    required: bool
+    observed_at: AwareDatetime
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevIncidentFact(ContractModel):
+    entity_id: OpaqueID
+    display_label: Label
+    status: OpaqueID
+    active: bool
+    blocking: bool
+    observed_at: AwareDatetime
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevStatusConflict(ContractModel):
+    code: OpaqueID
+    message: ShortText
+    severity: Literal["warning", "blocking"]
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevRequiredChildFact(ContractModel):
+    fact_id: OpaqueID
+    text: ShortText
+    status: OpaqueID
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevActualCompletion(ContractModel):
+    """Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it."""
+
+    state: Literal["ready", "not_ready", "indeterminate"]
+    rule_id: OpaqueID
+    rule_version: Version
+    reason_codes: list[OpaqueID] = Field(default_factory=list, max_length=25)
+    required_children: list[DevRequiredChildFact] = Field(
+        default_factory=list, max_length=100
+    )
+    conflicts: list[DevStatusConflict] = Field(default_factory=list, max_length=20)
+    evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+
+
+class DevSourceHealth(ContractModel):
+    ref_id: OpaqueID
+    source_system: OpaqueID
+    freshness: FreshnessState
+    watermark: AwareDatetime | None = None
+
+
 class DevGraphEdge(ContractModel):
     source_entity_id: OpaqueID
     relationship: OpaqueID
     target_entity_id: OpaqueID
+    provenance: ShortText
+    confidence: FiniteFloat = Field(ge=0, le=1)
+    observed_at: AwareDatetime
     evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
 
 
@@ -815,6 +895,14 @@ class DevToolResult(ContractModel):
     metrics: list[DevMetricRef] = Field(default_factory=list, max_length=12)
     evidence: list[DevEvidenceRef] = Field(default_factory=list, max_length=25)
     status_facts: list[DevStatusFact] = Field(default_factory=list, max_length=100)
+    actual_completion: DevActualCompletion | None = None
+    pull_requests: list[DevPullRequestFact] = Field(
+        default_factory=list, max_length=100
+    )
+    ci_checks: list[DevCIFact] = Field(default_factory=list, max_length=100)
+    deployments: list[DevDeploymentFact] = Field(default_factory=list, max_length=100)
+    incidents: list[DevIncidentFact] = Field(default_factory=list, max_length=100)
+    source_health: list[DevSourceHealth] = Field(default_factory=list, max_length=25)
     graph_edges: list[DevGraphEdge] = Field(default_factory=list, max_length=100)
     data_health: list[DevDataHealth] = Field(default_factory=list, max_length=25)
     warnings: list[ShortText] = Field(default_factory=list, max_length=20)
@@ -827,6 +915,41 @@ class DevToolResult(ContractModel):
             raise ValueError("error tool result requires an error envelope")
         if self.status != "error" and self.error is not None:
             raise ValueError("only error tool results may include an error envelope")
+        return self
+
+    @model_validator(mode="after")
+    def validate_evidence_closure(self) -> Self:
+        """Every evidence ID referenced by a fact/edge must be in ``evidence``.
+
+        This is the wire-level guarantee behind CHAOS-3259: a status, change, or
+        graph fact can only cite evidence the model can also expand through
+        ``get_evidence.v1`` in the same tool result.
+        """
+
+        known = {item.evidence_ref_id for item in self.evidence}
+        referenced: set[str] = set()
+        for fact in self.status_facts:
+            referenced.update(fact.evidence_ref_ids)
+        for edge in self.graph_edges:
+            referenced.update(edge.evidence_ref_ids)
+        for pr in self.pull_requests:
+            referenced.update(pr.evidence_ref_ids)
+        for ci in self.ci_checks:
+            referenced.update(ci.evidence_ref_ids)
+        for deployment in self.deployments:
+            referenced.update(deployment.evidence_ref_ids)
+        for incident in self.incidents:
+            referenced.update(incident.evidence_ref_ids)
+        if self.actual_completion is not None:
+            referenced.update(self.actual_completion.evidence_ref_ids)
+            for child in self.actual_completion.required_children:
+                referenced.update(child.evidence_ref_ids)
+            for conflict in self.actual_completion.conflicts:
+                referenced.update(conflict.evidence_ref_ids)
+        if not referenced <= known:
+            raise ValueError(
+                "tool result references evidence IDs missing from its evidence array"
+            )
         return self
 
 

--- a/src/dev_health_ops/api/dev/native_evidence.py
+++ b/src/dev_health_ops/api/dev/native_evidence.py
@@ -376,6 +376,47 @@ _SPECS: dict[str, _SourceSpec] = {
         ORDER BY i.last_synced DESC LIMIT 1
         """,
     ),
+    "work_graph": _SourceSpec(
+        "work_graph",
+        _COMMON_KINDS
+        | {
+            EntityKind.PROJECT,
+            EntityKind.WORK_UNIT,
+            EntityKind.ISSUE,
+            EntityKind.PULL_REQUEST,
+        },
+        f"""
+        SELECT edge_id AS entity_id,
+               concat(source_type, ' ', edge_type, ' ', target_type) AS display_label,
+               concat('Edge from ', source_id, ' to ', target_id) AS excerpt,
+               ifNull(provenance, 'persisted') AS provenance,
+               discovered_at AS observed_at, last_synced,
+               ifNull(toString(repo_id), '') AS repository_id,
+               '' AS source_url, 0 AS deleted, ifNull(confidence, 1.0) AS confidence
+        FROM work_graph_edges FINAL
+        WHERE org_id = {{org_id:String}}
+          AND discovered_at >= {{start:DateTime64(3, 'UTC')}}
+          AND discovered_at < {{end:DateTime64(3, 'UTC')}}
+          AND ({_search_predicate(("edge_id", "source_id", "target_id", "edge_type"))})
+          AND (empty({{repository_ids:Array(String)}}) OR toString(repo_id) IN {{repository_ids:Array(String)}})
+          AND ({{entity_id:String}} = '' OR edge_id = {{entity_id:String}})
+        ORDER BY discovered_at DESC, edge_id
+        LIMIT {{limit:UInt32}}
+        """,
+        """
+        SELECT edge_id AS entity_id,
+               concat(source_type, ' ', edge_type, ' ', target_type) AS display_label,
+               concat('Edge from ', source_id, ' to ', target_id) AS excerpt,
+               ifNull(provenance, 'persisted') AS provenance,
+               discovered_at AS observed_at, last_synced,
+               ifNull(toString(repo_id), '') AS repository_id,
+               '' AS source_url, 0 AS deleted, ifNull(confidence, 1.0) AS confidence
+        FROM work_graph_edges FINAL
+        WHERE org_id = {org_id:String} AND edge_id = {entity_id:String}
+          AND (empty({repository_ids:Array(String)}) OR toString(repo_id) IN {repository_ids:Array(String)})
+        ORDER BY last_synced DESC LIMIT 1
+        """,
+    ),
 }
 
 
@@ -566,4 +607,5 @@ def _entity_type(source_system: str) -> str:
         "ci_runs": "ci_run",
         "deployments": "deployment",
         "incidents": "incident",
+        "work_graph": "work_graph_edge",
     }[source_system]

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -92,6 +92,10 @@ class PersistenceRunRecorder:
                 len(execution.result.evidence)
                 + len(execution.result.metrics)
                 + len(execution.result.status_facts)
+                + len(execution.result.pull_requests)
+                + len(execution.result.ci_checks)
+                + len(execution.result.deployments)
+                + len(execution.result.incidents)
                 + len(execution.result.graph_edges)
                 + len(execution.result.data_health)
             ),

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -44,13 +44,22 @@ from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
 from dev_health_ops.models.settings import SettingCategory
 
 from .contracts import (
+    DevActualCompletion,
+    DevCIFact,
     DevContractVersions,
     DevDataHealth,
+    DevDeploymentFact,
+    DevEvidenceFlags,
     DevEvidenceRef,
     DevGraphEdge,
+    DevIncidentFact,
     DevMetricDefinition,
+    DevPullRequestFact,
+    DevRequiredChildFact,
     DevScope,
     DevScopeResolution,
+    DevSourceHealth,
+    DevStatusConflict,
     DevStatusFact,
     DevToolRequest,
     DevToolResult,
@@ -68,6 +77,7 @@ from .entitlement import CanonicalAskDevEntitlementAuthorizer
 from .evidence_service import (
     EvidenceAvailability,
     EvidenceExpansionResult,
+    EvidenceRecord,
     EvidenceReferenceSigner,
     EvidenceService,
 )
@@ -91,6 +101,11 @@ from .scope_service import (
 )
 from .status_change_service import (
     ChangeSummaryRequest,
+    CIFact,
+    DeploymentFact,
+    IncidentFact,
+    ObservedChange,
+    PullRequestFact,
     StatusChangeService,
     StatusFact,
     StatusSnapshotRequest,
@@ -100,6 +115,7 @@ from .work_graph_neighbors_service import (
     ALLOWED_RELATIONSHIP_TYPES,
     ClickHouseWorkGraphNeighborSource,
     GraphDirection,
+    WorkGraphNeighborEdge,
     WorkGraphNeighborsRequest,
     WorkGraphNeighborsService,
     WorkGraphRootRef,
@@ -631,6 +647,12 @@ def _tool_result(
     metrics: list[Any] | None = None,
     evidence: list[Any] | None = None,
     status_facts: list[DevStatusFact] | None = None,
+    actual_completion: DevActualCompletion | None = None,
+    pull_requests: list[DevPullRequestFact] | None = None,
+    ci_checks: list[DevCIFact] | None = None,
+    deployments: list[DevDeploymentFact] | None = None,
+    incidents: list[DevIncidentFact] | None = None,
+    source_health: list[DevSourceHealth] | None = None,
     graph_edges: list[DevGraphEdge] | None = None,
     data_health: list[DevDataHealth] | None = None,
     warnings: list[str] | None = None,
@@ -646,6 +668,12 @@ def _tool_result(
         metrics=metrics or [],
         evidence=evidence or [],
         status_facts=status_facts or [],
+        actual_completion=actual_completion,
+        pull_requests=pull_requests or [],
+        ci_checks=ci_checks or [],
+        deployments=deployments or [],
+        incidents=incidents or [],
+        source_health=source_health or [],
         graph_edges=graph_edges or [],
         data_health=data_health or [],
         warnings=(warnings or [])[:20],
@@ -661,14 +689,174 @@ def _status(state: str) -> str:
     return "success"
 
 
-def _fact(value: StatusFact) -> DevStatusFact | None:
-    if not value.evidence_ref_ids:
-        return None
-    return DevStatusFact(
-        fact_id=f"{value.entity_type}:{value.entity_id}",
-        text=f"{value.display_label}: {value.status}",
-        evidence_ref_ids=list(value.evidence_ref_ids)[:25],
+# Every status/change/graph fact is projected as its own addressable evidence
+# unit, minted through the same signer the ``get_evidence.v1`` route verifies
+# against.  This is what makes every evidence ID a status/change/graph fact
+# carries independently expandable, instead of forwarding upstream evidence
+# IDs verbatim (which today are frequently empty — see CHAOS-3259/CHAOS-3261).
+_STATUS_ENTITY_SOURCE_SYSTEM: Mapping[str, str] = {
+    "issue": "work_items",
+    "pull_request": "pull_requests",
+    "work_unit": "work_units",
+    "project": "work_items",
+}
+_CHANGE_CATEGORY_SOURCE_SYSTEM: Mapping[str, str] = {
+    "entity": "work_items",
+    "status": "work_items",
+    # Relationship changes are sourced from work_graph_edges; entity_id for
+    # this category is overridden to the edge_id (see change_summary below)
+    # so the "work_graph" native evidence adapter can actually resolve it.
+    "relationship": "work_graph",
+    "blocker": "work_items",
+    "dependency": "work_items",
+    "pull_request": "pull_requests",
+    "review": "reviews",
+    "ci": "ci_runs",
+    "deployment": "deployments",
+    "incident": "incidents",
+    # No native evidence adapter backs aggregate metric changes; expansion
+    # honestly degrades to "unconfigured" rather than fabricating a match.
+    "metric": "metrics",
+}
+# entity_id is not unique per observed event for these categories (e.g. two
+# status transitions, or two dimension rows of one metric, share one
+# entity_id) -- mint from (entity_id, change_id) instead of entity_id alone
+# so distinct observations never collide onto the same evidence_ref_id.
+_CHANGE_COLLISION_PRONE_CATEGORIES = frozenset({"status", "metric"})
+# ci_acceptance_checks rows carry a "{repo}#ci{run}#check{key}" entity_id;
+# the "ci_runs" adapter only indexes "{repo}#ci{run}". Coarsen to the run so
+# expansion resolves the underlying CI run instead of guaranteed NO_MATCHES.
+_CI_ACCEPTANCE_CHECK_MARKER = "#check"
+# Maps each StatusChangeService blocking-contradiction reason code to the
+# fact category that actually produced it, so a conflict cites only the
+# evidence that contributed to it rather than every category in the result.
+_REASON_CODE_EVIDENCE_CATEGORY: Mapping[str, str] = {
+    "required_child_incomplete": "status_facts",
+    "open_blocker": "status_facts",
+    "required_pull_request_unmerged": "pull_requests",
+    "required_review_unresolved": "pull_requests",
+    "review_changes_requested": "pull_requests",
+    "required_ci_work_skipped": "ci_checks",
+    "required_ci_not_passing": "ci_checks",
+    "required_deployment_not_succeeded": "deployments",
+    "active_blocking_incident": "incidents",
+}
+_STATUS_EVIDENCE_SOURCE_VERSION = "status-snapshot-evidence.v1"
+_CHANGE_EVIDENCE_SOURCE_VERSION = "change-summary-evidence.v1"
+_GRAPH_EVIDENCE_SOURCE_VERSION = "work-graph-evidence.v1"
+# DevToolResult.evidence is capped at 25 entries (contracts.py); status
+# snapshots aggregate six independently-bounded-to-25 categories, so a dense
+# scope can mint far more than 25 unique evidence items. Bound defensively
+# instead of letting pydantic reject the whole result.
+_MAX_RESULT_EVIDENCE = 25
+
+
+def _mint_evidence(
+    signer: EvidenceReferenceSigner,
+    org_id: str,
+    *,
+    source_system: str,
+    source_version: str,
+    entity_type: str,
+    entity_id: str,
+    display_label: str,
+    observed_at: datetime,
+    freshness: FreshnessState,
+    confidence: float = 1.0,
+    valid_entity_ids: Sequence[str] = (),
+    repository_ids: Sequence[str] = (),
+) -> DevEvidenceRef:
+    """Build a signer-issued, ``get_evidence.v1``-expandable evidence reference.
+
+    Unlike ``EvidenceService._to_ref`` (used by search/get_evidence over free
+    text), this mints identity directly from a fact the domain layer already
+    authorized and returned, without a second round trip.
+
+    ``valid_entity_ids``/``repository_ids`` must be bound to the CALLER'S
+    already-authorized request scope (its direct entity ref / repositories),
+    never to the supporting fact's own entity ID: the fact may describe a
+    child, linked PR, CI run, deployment, or incident that was never itself
+    independently scope-resolved, so binding to it would make expansion
+    unauthorized for everything but the direct entity.
+    """
+
+    repository_ids = tuple(repository_ids)
+    record = EvidenceRecord(
+        source_system=source_system,
+        source_version=source_version,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        display_label=display_label,
+        observed_at=observed_at,
+        freshness=freshness,
+        provenance=source_system,
+        confidence=max(0.0, min(1.0, confidence)),
+        repository_ids=repository_ids,
     )
+    return DevEvidenceRef(
+        schema_version="dev_evidence_ref.v1",
+        evidence_ref_id=signer.issue(org_id, record),
+        source_system=source_system,
+        source_version=source_version,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        display_label=(display_label.strip() or "Evidence")[:256],
+        observed_at=observed_at,
+        freshness=freshness,
+        provenance=source_system,
+        confidence=record.confidence,
+        repository_ids=list(repository_ids),
+        valid_entity_ids=list(valid_entity_ids),
+        flags=DevEvidenceFlags(
+            stale=freshness is FreshnessState.STALE,
+            unavailable=freshness is FreshnessState.UNAVAILABLE,
+            untrusted_content=True,
+        ),
+    )
+
+
+def _ci_evidence_identity(entity_id: str) -> str:
+    return entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
+
+
+def _scope_evidence_binding(scope: DevScope) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return (valid_entity_ids, repository_ids) bound to the request's own
+    already-authorized direct scope -- never to a supporting fact's ID."""
+
+    valid_entity_ids = tuple(item.entity_id for item in scope.entity_refs)
+    repository_ids = tuple(scope.repositories)
+    return valid_entity_ids, repository_ids
+
+
+def _bounded_result_evidence(
+    minted: Mapping[str, DevEvidenceRef],
+    *,
+    priority_ids: Sequence[str] = (),
+    limit: int = _MAX_RESULT_EVIDENCE,
+) -> tuple[set[str], bool]:
+    """Bound minted evidence to ``limit``, keeping verdict-driving evidence first.
+
+    ``priority_ids`` should cover the declared fact, every required child,
+    and every fact that contributed a blocking reason code -- the evidence
+    the deterministic verdict actually depends on. Only once that is
+    satisfied do arbitrary (alphabetically ordered, for determinism)
+    remaining facts fill the rest of the budget. Without this, a dense scope
+    could truncate away exactly the evidence the model needs to explain
+    *why* the declared/actual states disagree while the verdict itself
+    (computed upstream, before truncation) is left unchanged and unexplained.
+    """
+
+    if len(minted) <= limit:
+        return set(minted), False
+    kept: list[str] = []
+    seen: set[str] = set()
+    for evidence_id in (*priority_ids, *sorted(minted)):
+        if len(kept) >= limit:
+            break
+        if evidence_id in minted and evidence_id not in seen:
+            seen.add(evidence_id)
+            kept.append(evidence_id)
+    return set(kept), True
 
 
 def _work_graph_roots(scope: DevScope) -> tuple[WorkGraphRootRef, ...]:
@@ -726,10 +914,11 @@ async def _assemble_production_runtime(
         raise DevRuntimeUnavailable(
             "provider_not_configured", "Ask Dev evidence signing is unavailable."
         )
+    evidence_signer = EvidenceReferenceSigner(secret)
     evidence_service = EvidenceService(
         entitlement=entitlement,
         authorizer=scope_service,
-        signer=EvidenceReferenceSigner(secret),
+        signer=evidence_signer,
         native_adapters=native_evidence_adapters(clickhouse),
         acr_adapter=None,
     )
@@ -812,19 +1001,374 @@ async def _assemble_production_runtime(
             warnings=list(result.warnings),
         )
 
+    def status_source_system(entity_type: str) -> str:
+        return _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
+
+    def mint_status_evidence(
+        fact: StatusFact,
+        freshness_by_ref: Mapping[str, FreshnessState],
+        *,
+        valid_entity_ids: Sequence[str],
+        repository_ids: Sequence[str],
+    ) -> DevEvidenceRef:
+        return _mint_evidence(
+            evidence_signer,
+            org_id,
+            source_system=status_source_system(fact.entity_type),
+            source_version=_STATUS_EVIDENCE_SOURCE_VERSION,
+            entity_type=fact.entity_type,
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            freshness=freshness_by_ref.get(fact.source_ref_id, FreshnessState.UNKNOWN),
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+
+    def mint_delivery_evidence(
+        *,
+        source_system: str,
+        entity_type: str,
+        entity_id: str,
+        display_label: str,
+        observed_at: datetime,
+        source_ref_id: str,
+        freshness_by_ref: Mapping[str, FreshnessState],
+        valid_entity_ids: Sequence[str],
+        repository_ids: Sequence[str],
+        source_version: str = _STATUS_EVIDENCE_SOURCE_VERSION,
+    ) -> DevEvidenceRef:
+        return _mint_evidence(
+            evidence_signer,
+            org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness_by_ref.get(source_ref_id, FreshnessState.UNKNOWN),
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+
     async def status_snapshot(context, request):
         result = await status_service.status_snapshot(
             org_id,
             context.permission_fingerprint,
             StatusSnapshotRequest(scope=request.scope, max_items=request.limit),
         )
-        values = [result.declared, *result.children, *result.blockers]
-        facts = [item for value in values if value and (item := _fact(value))]
+        freshness_by_ref: dict[str, FreshnessState] = {
+            ref.ref_id: ref.freshness for ref in result.source_refs
+        }
+        scope_valid_entity_ids, scope_repository_ids = _scope_evidence_binding(
+            request.scope
+        )
+        minted: dict[str, DevEvidenceRef] = {}
+
+        def wire_status_fact(fact: StatusFact) -> DevStatusFact:
+            ref = mint_status_evidence(
+                fact,
+                freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevStatusFact(
+                fact_id=f"{fact.entity_type}:{fact.entity_id}",
+                text=f"{fact.display_label}: {fact.status}",
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        def wire_required_child(fact: StatusFact) -> DevRequiredChildFact:
+            ref = mint_status_evidence(
+                fact,
+                freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevRequiredChildFact(
+                fact_id=f"{fact.entity_type}:{fact.entity_id}",
+                text=fact.display_label,
+                status=fact.status,
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        def wire_pull_request(fact: PullRequestFact) -> DevPullRequestFact:
+            ref = mint_delivery_evidence(
+                source_system="pull_requests",
+                entity_type="pull_request",
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                observed_at=fact.observed_at,
+                source_ref_id=fact.source_ref_id,
+                freshness_by_ref=freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevPullRequestFact(
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                state=fact.state,
+                review_state=fact.review_state,
+                changes_requested=fact.changes_requested,
+                merged=fact.merged,
+                required=fact.required,
+                observed_at=fact.observed_at,
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        def wire_ci(fact: CIFact) -> DevCIFact:
+            # ci_acceptance_checks IDs carry a "#check{key}" suffix the
+            # ci_runs adapter does not index; coarsen the LOOKUP identity to
+            # the run so expansion resolves real content instead of
+            # NO_MATCHES. Multiple distinct checks on one run would then
+            # mint the same evidence_ref_id -- discriminate the SIGNED
+            # identity via source_version (not entity_id) instead, so each
+            # check still gets its own evidence_ref_id while expansion still
+            # targets the real run.
+            lookup_entity_id = _ci_evidence_identity(fact.entity_id)
+            source_version = (
+                f"{_STATUS_EVIDENCE_SOURCE_VERSION}:{fact.entity_id}"
+                if lookup_entity_id != fact.entity_id
+                else _STATUS_EVIDENCE_SOURCE_VERSION
+            )
+            ref = mint_delivery_evidence(
+                source_system="ci_runs",
+                entity_type="ci_run",
+                entity_id=lookup_entity_id,
+                display_label=fact.display_label,
+                observed_at=fact.observed_at,
+                source_ref_id=fact.source_ref_id,
+                freshness_by_ref=freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+                source_version=source_version,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevCIFact(
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                conclusion=fact.conclusion,
+                required=fact.required,
+                skipped_required_work=fact.skipped_required_work,
+                observed_at=fact.observed_at,
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        def wire_deployment(fact: DeploymentFact) -> DevDeploymentFact:
+            ref = mint_delivery_evidence(
+                source_system="deployments",
+                entity_type="deployment",
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                observed_at=fact.observed_at,
+                source_ref_id=fact.source_ref_id,
+                freshness_by_ref=freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevDeploymentFact(
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                status=fact.status,
+                environment=fact.environment,
+                required=fact.required,
+                observed_at=fact.observed_at,
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        def wire_incident(fact: IncidentFact) -> DevIncidentFact:
+            ref = mint_delivery_evidence(
+                source_system="incidents",
+                entity_type="incident",
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                observed_at=fact.observed_at,
+                source_ref_id=fact.source_ref_id,
+                freshness_by_ref=freshness_by_ref,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevIncidentFact(
+                entity_id=fact.entity_id,
+                display_label=fact.display_label,
+                status=fact.status,
+                active=fact.active,
+                blocking=fact.blocking,
+                observed_at=fact.observed_at,
+                evidence_ref_ids=[ref.evidence_ref_id],
+            )
+
+        status_facts = [
+            wire_status_fact(fact)
+            for fact in (
+                ([result.declared] if result.declared else [])
+                + list(result.children)
+                + list(result.blockers)
+            )
+        ]
+        pull_requests = [wire_pull_request(fact) for fact in result.pull_requests]
+        ci_checks = [wire_ci(fact) for fact in result.ci]
+        deployments = [wire_deployment(fact) for fact in result.deployments]
+        incidents = [wire_incident(fact) for fact in result.incidents]
+        required_children = [
+            wire_required_child(fact) for fact in result.actual.required_children
+        ]
+
+        # DevToolResult.evidence caps at 25 entries; a dense scope can mint
+        # far more across six independently-bounded categories. Bound the
+        # evidence set FIRST, prioritizing the declared fact, every required
+        # child, and every fact that produced a blocking reason code -- the
+        # evidence the deterministic verdict actually depends on -- then
+        # drop cut IDs from every fact that referenced one (entire
+        # status_facts if that empties their required evidence, or just the
+        # ID from the optional-evidence categories), so the result stays
+        # internally consistent instead of the whole tool call failing
+        # pydantic's list-length validation, AND so truncation preferentially
+        # sheds incidental facts rather than the ones explaining the verdict.
+        pre_truncation_categories: Mapping[str, Sequence[Any]] = {
+            "status_facts": status_facts,
+            "pull_requests": pull_requests,
+            "ci_checks": ci_checks,
+            "deployments": deployments,
+            "incidents": incidents,
+        }
+        contributing_categories = {
+            _REASON_CODE_EVIDENCE_CATEGORY[code]
+            for code in result.actual.reason_codes
+            if code in _REASON_CODE_EVIDENCE_CATEGORY
+        }
+        priority_ids = [
+            *(status_facts[0].evidence_ref_ids if result.declared else []),
+            *(
+                evidence_id
+                for fact in required_children
+                for evidence_id in fact.evidence_ref_ids
+            ),
+            *(
+                evidence_id
+                for category in contributing_categories
+                for item in pre_truncation_categories[category]
+                for evidence_id in item.evidence_ref_ids
+            ),
+        ]
+        kept_evidence_ids, truncated = _bounded_result_evidence(
+            minted, priority_ids=priority_ids
+        )
+        warnings = list(result.warnings)
+        if truncated:
+            warnings.append("status_snapshot_evidence_result_truncated")
+
+        def _kept(evidence_ref_ids: Sequence[str]) -> list[str]:
+            return [item for item in evidence_ref_ids if item in kept_evidence_ids]
+
+        filtered_status_facts = []
+        for fact in status_facts:
+            kept = _kept(fact.evidence_ref_ids)
+            if kept:
+                filtered_status_facts.append(
+                    fact.model_copy(update={"evidence_ref_ids": kept})
+                )
+        if len(filtered_status_facts) != len(status_facts):
+            warnings.append("status_fact_evidence_truncated")
+        status_facts = filtered_status_facts
+        pull_requests = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in pull_requests
+        ]
+        ci_checks = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in ci_checks
+        ]
+        deployments = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in deployments
+        ]
+        incidents = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in incidents
+        ]
+        required_children = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in required_children
+        ]
+
+        category_facts: Mapping[str, Sequence[Any]] = {
+            "status_facts": status_facts,
+            "pull_requests": pull_requests,
+            "ci_checks": ci_checks,
+            "deployments": deployments,
+            "incidents": incidents,
+        }
+        aggregate_evidence_ids = sorted(
+            {
+                evidence_id
+                for group in category_facts.values()
+                for item in group
+                for evidence_id in item.evidence_ref_ids
+            }
+        )[:25]
+        # ``contributing_categories`` is unchanged by truncation (it only
+        # depends on which reason codes fired); reuse it, but recompute the
+        # evidence from the post-truncation ``category_facts`` so a conflict
+        # never cites evidence that didn't survive the bound. If truncation
+        # cut every fact that actually produced this conflict, leave its
+        # evidence empty (permitted -- DevStatusConflict has no minimum)
+        # rather than falling back to an unrelated aggregate: an honestly
+        # under-evidenced conflict is better than a misleadingly-grounded one.
+        conflict_evidence_ids = sorted(
+            {
+                evidence_id
+                for category in contributing_categories
+                for item in category_facts[category]
+                for evidence_id in item.evidence_ref_ids
+            }
+        )[:25]
+        conflicts = [
+            DevStatusConflict(
+                code=conflict.code,
+                message=conflict.message,
+                severity=conflict.severity.value,
+                evidence_ref_ids=conflict_evidence_ids,
+            )
+            for conflict in result.actual.conflicts
+        ]
+        actual_completion = DevActualCompletion(
+            state=result.actual.state.value,
+            rule_id=result.actual.rule_id,
+            rule_version=result.actual.rule_version,
+            reason_codes=list(result.actual.reason_codes)[:25],
+            required_children=required_children,
+            conflicts=conflicts,
+            evidence_ref_ids=aggregate_evidence_ids,
+        )
+        source_health = [
+            DevSourceHealth(
+                ref_id=ref.ref_id,
+                source_system=ref.source_system,
+                freshness=ref.freshness,
+                watermark=ref.watermark,
+            )
+            for ref in result.source_refs
+        ]
+        evidence_by_id.update({key: minted[key] for key in kept_evidence_ids})
         return _tool_result(
             request,
             status=_status(result.state.value),
-            status_facts=facts,
-            warnings=list(result.warnings),
+            status_facts=status_facts,
+            actual_completion=actual_completion,
+            pull_requests=pull_requests,
+            ci_checks=ci_checks,
+            deployments=deployments,
+            incidents=incidents,
+            source_health=source_health,
+            evidence=[minted[key] for key in sorted(kept_evidence_ids)],
+            warnings=warnings,
         )
 
     async def change_summary(context, request):
@@ -847,22 +1391,97 @@ async def _assemble_production_runtime(
                 max_items=request.limit,
             ),
         )
-        facts = [
-            DevStatusFact(
-                fact_id=item.change_id,
-                text=(
-                    f"{item.display_label}: {item.before or 'unknown'} -> "
-                    f"{item.after or 'unknown'}"
-                ),
-                evidence_ref_ids=list(item.evidence_ref_ids)[:25],
+        freshness_by_ref: dict[str, FreshnessState] = {
+            ref.ref_id: ref.freshness for ref in result.source_refs
+        }
+        scope_valid_entity_ids, scope_repository_ids = _scope_evidence_binding(
+            request.scope
+        )
+
+        def change_freshness(item: ObservedChange) -> FreshnessState:
+            for ref_id in item.source_ref_ids:
+                freshness = freshness_by_ref.get(ref_id)
+                if freshness is not None:
+                    return freshness
+            return FreshnessState.UNKNOWN
+
+        def change_evidence_identity(item: ObservedChange) -> tuple[str, str, str]:
+            """Return (source_system, lookup_entity_id, source_version).
+
+            ``item.entity_id`` is already the adapter-matching locator for
+            most categories (status/pull_request/incident all resolve to a
+            real row) -- it must reach the minted ref UNCHANGED so expansion
+            can still resolve real content. It is NOT event-unique for
+            status transitions or per-dimension metric rows, though: two
+            observations of the same entity would otherwise collide onto one
+            evidence_ref_id. Discriminate those through ``source_version``
+            instead of corrupting the lookup entity_id -- the native
+            adapters never filter on source_version, only on entity_id/
+            scope, so this keeps both collision-freedom AND expandability.
+            Relationship changes are sourced from work_graph_edges;
+            ``change_id`` there *is* the edge_id the "work_graph" adapter
+            indexes, and is already unique per edge.
+            """
+
+            category = item.category.value
+            source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
+            if category == "relationship":
+                return source_system, item.change_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+            if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+                return (
+                    source_system,
+                    item.entity_id,
+                    f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}",
+                )
+            return source_system, item.entity_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+
+        minted: dict[str, DevEvidenceRef] = {}
+        facts: list[DevStatusFact] = []
+        for item in result.changes:
+            source_system, lookup_entity_id, source_version = change_evidence_identity(
+                item
             )
-            for item in result.changes
-            if item.evidence_ref_ids
+            ref = _mint_evidence(
+                evidence_signer,
+                org_id,
+                source_system=source_system,
+                source_version=source_version,
+                entity_type=item.entity_type,
+                entity_id=lookup_entity_id,
+                display_label=item.display_label,
+                observed_at=item.observed_at,
+                freshness=change_freshness(item),
+                confidence=item.confidence if item.confidence is not None else 1.0,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+            )
+            minted[ref.evidence_ref_id] = ref
+            facts.append(
+                DevStatusFact(
+                    fact_id=item.change_id,
+                    text=(
+                        f"{item.display_label}: {item.before or 'unknown'} -> "
+                        f"{item.after or 'unknown'}"
+                    ),
+                    evidence_ref_ids=[ref.evidence_ref_id],
+                )
+            )
+        source_health = [
+            DevSourceHealth(
+                ref_id=ref.ref_id,
+                source_system=ref.source_system,
+                freshness=ref.freshness,
+                watermark=ref.watermark,
+            )
+            for ref in result.source_refs
         ]
+        evidence_by_id.update(minted)
         return _tool_result(
             request,
             status=_status(result.state.value),
             status_facts=facts,
+            source_health=source_health,
+            evidence=list(minted.values()),
             warnings=list(result.warnings),
         )
 
@@ -883,19 +1502,47 @@ async def _assemble_production_runtime(
                 limit=request.limit,
             ),
         )
-        edges = [
-            DevGraphEdge(
+        scope_valid_entity_ids, scope_repository_ids = _scope_evidence_binding(
+            request.scope
+        )
+        minted: dict[str, DevEvidenceRef] = {}
+
+        def wire_edge(item: WorkGraphNeighborEdge) -> DevGraphEdge:
+            ref = _mint_evidence(
+                evidence_signer,
+                org_id,
+                source_system="work_graph",
+                source_version=_GRAPH_EVIDENCE_SOURCE_VERSION,
+                entity_type="work_graph_edge",
+                entity_id=item.edge_id,
+                display_label=(
+                    f"{item.source_type}:{item.source_id} {item.relationship_type} "
+                    f"{item.target_type}:{item.target_id}"
+                ),
+                observed_at=item.observed_at,
+                freshness=FreshnessState.UNKNOWN,
+                valid_entity_ids=scope_valid_entity_ids,
+                repository_ids=scope_repository_ids,
+                confidence=item.confidence,
+            )
+            minted[ref.evidence_ref_id] = ref
+            return DevGraphEdge(
                 source_entity_id=item.source_id,
                 relationship=item.relationship_type,
                 target_entity_id=item.target_id,
-                evidence_ref_ids=[],
+                provenance=(item.provenance.strip() or "persisted")[:2_048],
+                confidence=max(0.0, min(1.0, item.confidence)),
+                observed_at=item.observed_at,
+                evidence_ref_ids=[ref.evidence_ref_id],
             )
-            for item in result.edges
-        ]
+
+        edges = [wire_edge(item) for item in result.edges]
+        evidence_by_id.update(minted)
         return _tool_result(
             request,
             status=_status(result.state.value),
             graph_edges=edges,
+            evidence=list(minted.values()),
             warnings=list(result.warnings),
         )
 

--- a/src/dev_health_ops/api/dev/tool_registry.py
+++ b/src/dev_health_ops/api/dev/tool_registry.py
@@ -13,7 +13,7 @@ from dev_health_ops.llm.providers.openai_capabilities import build_wire_tool_nam
 
 from .contracts import DevScope, DevToolRequest, DevToolResult, ToolID
 
-TOOL_CONTRACT_VERSION = "ask_dev_tools.v1"
+TOOL_CONTRACT_VERSION = "ask_dev_tools.v2"
 DEFAULT_TOOL_TIMEOUT_SECONDS = 15.0
 MAX_TOOL_RESULT_BYTES = 65_536
 

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -1,0 +1,1241 @@
+"""CHAOS-3259: the production tool boundary must preserve status/evidence semantics.
+
+These are real production-registry integration tests: they build the actual
+``BoundedDevRuntime`` returned by ``build_production_runtime`` -- the real
+``AskDevToolRegistry``, the real ``StatusChangeService`` (including its
+deterministic ``actual-completion`` rule engine), and the real
+``production_runtime.py`` tool adapters -- and only swap the ClickHouse-backed
+leaves (``ClickHouseStatusChangeSource`` and ``ClickHouseAuthorizedEntityCatalog``)
+for deterministic fakes, exactly the way ``test_production_runtime.py`` already
+fakes ``resolve_production_provider``. Nothing in ``production_runtime.py``,
+``status_change_service.py``, or the wire ``contracts.py`` validators is
+mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev import production_runtime
+from dev_health_ops.api.dev.contracts import (
+    ClaimKind,
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DevToolRequest,
+    DirectScope,
+    EntityType,
+    ToolID,
+)
+from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
+from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
+from dev_health_ops.api.dev.status_change_service import (
+    ChangeCategory,
+    ChangeWindow,
+    CIFact,
+    IncidentFact,
+    ObservedChange,
+    PullRequestFact,
+    RawChangeSummary,
+    RawStatusSnapshot,
+    SourceReference,
+    StatusFact,
+)
+from dev_health_ops.api.dev.tool_registry import ToolExecutionContext
+from dev_health_ops.llm.agent.policy import AgentProviderSource
+
+ORG_ID = "3d3a2b1e-3259-4c3e-9e6a-325934592591"
+# Runtime-constructed per test-process start, never a literal, so it can't
+# be mistaken for a checked-in credential by secret scanners.
+EVIDENCE_SIGNING_FIXTURE_KEY = secrets.token_hex(32)
+NOW = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+FRESH_OBSERVED = datetime(2026, 7, 29, 12, 0, tzinfo=UTC)
+STALE_OBSERVED = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+
+
+class FakeProvider:
+    """Minimal AgentLLMProvider stand-in; no tool test in this module calls it."""
+
+    async def decide(self, **_values: Any) -> Any:
+        raise AssertionError("provider calls are outside this projection test")
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.ISSUE,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id="issue_parent",
+                display_label="Parent issue",
+                repository_id="repo_dev_health",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 6, 30, tzinfo=UTC), end=NOW, timezone="UTC"
+        ),
+    )
+
+
+class _FakeStatusChangeSource:
+    """Stands in for ``ClickHouseStatusChangeSource``.
+
+    Everything downstream of this -- ``StatusChangeService`` (the deterministic
+    completion/conflict rule engine) and every ``production_runtime.py``
+    adapter closure -- runs unmodified against real fixture data.
+    """
+
+    def __init__(self) -> None:
+        self.declared = StatusFact(
+            entity_type="issue",
+            entity_id="issue_parent",
+            display_label="Parent issue",
+            status="done",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+        )
+        self.child = StatusFact(
+            entity_type="issue",
+            entity_id="issue_child",
+            display_label="Child issue",
+            status="open",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+            required=True,
+        )
+        self.pull_request = PullRequestFact(
+            entity_id="repo_dev_health#pr42",
+            display_label="Pull request #42",
+            state="merged",
+            review_state="approved",
+            changes_requested=0,
+            merged=True,
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:pull_requests",
+            evidence_ref_ids=(),
+            required=True,
+        )
+        self.ci_failing = CIFact(
+            entity_id="repo_dev_health#ci1001",
+            display_label="Required acceptance suite",
+            conclusion="failure",
+            required=True,
+            skipped_required_work=False,
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:ci_runs",
+            evidence_ref_ids=(),
+        )
+        self.ci_skipped = CIFact(
+            entity_id="repo_dev_health#ci1002",
+            display_label="Required integration suite",
+            conclusion="skipped",
+            required=True,
+            skipped_required_work=True,
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:ci_runs",
+            evidence_ref_ids=(),
+        )
+        self.source_refs = (
+            SourceReference(
+                ref_id="ref:work_items",
+                source_system="work_items",
+                source_version="work-items.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+            SourceReference(
+                ref_id="ref:pull_requests",
+                source_system="pull_requests",
+                source_version="pull-requests.v1",
+                freshness=production_runtime.FreshnessState.STALE,
+                watermark=STALE_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+            SourceReference(
+                ref_id="ref:ci_runs",
+                source_system="ci_runs",
+                source_version="ci-runs.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+            SourceReference(
+                ref_id="ref:deployments",
+                source_system="deployments",
+                source_version="deployments.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+        )
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        del org_id, scope, as_of, limit
+        return RawStatusSnapshot(
+            declared=self.declared,
+            children=(self.child,),
+            blockers=(),
+            pull_requests=(self.pull_request,),
+            ci=(self.ci_failing, self.ci_skipped),
+            deployments=(),
+            incidents=(
+                IncidentFact(
+                    entity_id="incident_01",
+                    display_label="Resolved incident",
+                    status="resolved",
+                    active=False,
+                    blocking=False,
+                    observed_at=FRESH_OBSERVED,
+                    source_ref_id="ref:incidents",
+                    evidence_ref_ids=(),
+                ),
+            ),
+            source_refs=self.source_refs,
+            warnings=(),
+        )
+
+    async def change_summary(
+        self,
+        *,
+        org_id: str,
+        scope: DevScope,
+        current: ChangeWindow,
+        comparison: ChangeWindow,
+        limit: int,
+    ) -> RawChangeSummary:
+        del org_id, scope, current, comparison, limit
+        return RawChangeSummary(changes=(), source_refs=self.source_refs)
+
+
+class _FakeEntitlementAuthorizer:
+    """Stands in for ``CanonicalAskDevEntitlementAuthorizer`` -- its real
+    implementation needs a live Postgres session, which is out of scope for
+    this adapter-boundary projection test.
+    """
+
+    def __init__(self, _session: Any) -> None:
+        pass
+
+    async def require(self, org_id: str) -> None:
+        assert org_id == ORG_ID
+
+
+class _FakeAuthorizedEntityCatalog:
+    """Stands in for ``ClickHouseAuthorizedEntityCatalog`` for the follow-up
+    ``get_evidence.v1`` call -- authorizes exactly the issue in ``_scope()``.
+    """
+
+    def __init__(self) -> None:
+        self._entity = AuthorizedEntity(
+            kind=EntityKind.ISSUE,
+            canonical_id="issue_parent",
+            label="Parent issue",
+            repository_id="repo_dev_health",
+        )
+
+    async def watermark(self, org_id: str, kinds: tuple[EntityKind, ...]) -> str:
+        del org_id, kinds
+        return "watermark_01"
+
+    async def exact(
+        self, org_id: str, ref: Any, *, limit: int
+    ) -> list[AuthorizedEntity]:
+        del org_id, limit
+        if ref.kind is EntityKind.ISSUE and ref.value == "issue_parent":
+            return [self._entity]
+        if ref.kind is EntityKind.PROJECT and ref.value == "project_01":
+            return [
+                AuthorizedEntity(
+                    kind=EntityKind.PROJECT,
+                    canonical_id="project_01",
+                    label="Project 01",
+                    repository_id="repo_dev_health",
+                )
+            ]
+        return []
+
+    async def search(
+        self, org_id: str, query: str, kinds: tuple[EntityKind, ...], *, limit: int
+    ) -> list[AuthorizedEntity]:
+        del org_id, query, kinds, limit
+        return []
+
+
+async def _build_runtime(
+    monkeypatch: pytest.MonkeyPatch, *, status_source: Any | None = None
+) -> Any:
+    async def resolve_provider(_session, *, org_id: str):
+        assert org_id == ORG_ID
+        return ProductionProviderResolution(
+            provider=cast(Any, FakeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setattr(
+        production_runtime,
+        "ClickHouseStatusChangeSource",
+        lambda _clickhouse: status_source or _FakeStatusChangeSource(),
+    )
+    monkeypatch.setattr(
+        production_runtime,
+        "ClickHouseAuthorizedEntityCatalog",
+        lambda _clickhouse: _FakeAuthorizedEntityCatalog(),
+    )
+    monkeypatch.setattr(
+        production_runtime,
+        "CanonicalAskDevEntitlementAuthorizer",
+        _FakeEntitlementAuthorizer,
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", EVIDENCE_SIGNING_FIXTURE_KEY)
+    return await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+
+
+def _context(scope: DevScope) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        org_id=scope.organization_id,
+        user_id="user_01",
+        permission_fingerprint="permissions_01",
+        authorized_scope=scope,
+        cancellation=asyncio.Event(),
+        remaining_seconds=15,
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_preserves_deterministic_completion_and_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3259 acceptance: completed parent + incomplete child + merged PR +
+    failing/skipped acceptance + missing deployment + fresh/stale sources must
+    all survive the production tool boundary, and every referenced evidence ID
+    must be present -- and independently signer-verifiable -- in the same
+    result.
+    """
+
+    runtime = await _build_runtime(monkeypatch)
+    scope = _scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+
+    # -- overall result: partial, because the pull_requests source is stale --
+    assert result.status == "partial"
+
+    # -- declared + child status facts survive (guard: dropping either empties
+    # status_facts or removes the entity_id from it) --
+    fact_ids = {fact.fact_id for fact in result.status_facts}
+    assert fact_ids == {"issue:issue_parent", "issue:issue_child"}
+    for fact in result.status_facts:
+        assert fact.evidence_ref_ids
+
+    # -- PR/CI/deployment/incident facts survive with their typed fields
+    # (guard: a regression to the old ``values = [declared, *children,
+    # *blockers]`` line drops all four of these to empty) --
+    assert len(result.pull_requests) == 1
+    pr = result.pull_requests[0]
+    assert pr.entity_id == "repo_dev_health#pr42"
+    assert pr.merged is True
+    assert pr.review_state == "approved"
+    assert pr.evidence_ref_ids
+
+    assert {fact.conclusion for fact in result.ci_checks} == {"failure", "skipped"}
+    assert any(fact.skipped_required_work is True for fact in result.ci_checks)
+    for fact in result.ci_checks:
+        assert fact.evidence_ref_ids
+
+    assert result.deployments == []  # no deployment evidence was returned
+    assert len(result.incidents) == 1
+    assert result.incidents[0].evidence_ref_ids
+
+    # -- the deterministic actual-completion assessment survives, including
+    # its conflict and required-child detail (guard: the old adapter never
+    # projected ``result.actual`` at all) --
+    assert result.actual_completion is not None
+    assert result.actual_completion.state == "not_ready"
+    assert result.actual_completion.rule_id == "actual-completion"
+    assert "required_child_incomplete" in result.actual_completion.reason_codes
+    assert "required_ci_not_passing" in result.actual_completion.reason_codes
+    assert "required_ci_work_skipped" in result.actual_completion.reason_codes
+    assert "required_release_evidence_missing" in result.actual_completion.reason_codes
+    assert len(result.actual_completion.required_children) == 1
+    assert result.actual_completion.required_children[0].fact_id == "issue:issue_child"
+    assert len(result.actual_completion.conflicts) == 1
+    conflict = result.actual_completion.conflicts[0]
+    assert conflict.code == "declared_complete_conflicts_with_observed_work"
+    assert conflict.severity == "blocking"
+    assert conflict.evidence_ref_ids
+    assert result.actual_completion.evidence_ref_ids
+
+    # -- fresh/stale source health survives (guard: source freshness was
+    # never surfaced at all before this fix) --
+    freshness_by_source = {
+        item.source_system: item.freshness for item in result.source_health
+    }
+    assert freshness_by_source["work_items"] == "fresh"
+    assert freshness_by_source["pull_requests"] == "stale"
+    assert freshness_by_source["ci_runs"] == "fresh"
+
+    # -- every evidence ID referenced anywhere in this result is present in
+    # its evidence array (the contract's own validator already enforces this
+    # -- it could not have been constructed otherwise -- but assert the
+    # positive shape explicitly too) --
+    known_evidence_ids = {item.evidence_ref_id for item in result.evidence}
+    assert known_evidence_ids  # non-empty: evidence was actually hydrated
+    referenced = set()
+    for fact in result.status_facts:
+        referenced.update(fact.evidence_ref_ids)
+    for fact in result.pull_requests:
+        referenced.update(fact.evidence_ref_ids)
+    for fact in result.ci_checks:
+        referenced.update(fact.evidence_ref_ids)
+    for fact in result.incidents:
+        referenced.update(fact.evidence_ref_ids)
+    referenced.update(result.actual_completion.evidence_ref_ids)
+    assert referenced <= known_evidence_ids
+    assert referenced  # the guard actually exercised the closure, not a no-op
+
+    # -- every evidence ID minted here is independently signer-verifiable,
+    # i.e. genuinely expandable through get_evidence.v1, not merely present
+    # in the array (guard: a regression that forwards an un-signed opaque
+    # domain ID would fail this even though the array-membership check above
+    # still passes) --
+    signer = EvidenceReferenceSigner(EVIDENCE_SIGNING_FIXTURE_KEY)
+    for item in result.evidence:
+        assert signer.verify(ORG_ID, item)
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_evidence_expands_status_snapshot_evidence_in_the_same_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The evidence a status_snapshot call mints must be expandable by a
+    subsequent get_evidence.v1 call against the SAME registered runtime --
+    the real ``EvidenceService``, real signer, and real (faked-catalog)
+    authorization path, not just a request-local echo.
+    """
+
+    runtime = await _build_runtime(monkeypatch)
+    scope = _scope()
+    status_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    evidence_ids = [item.evidence_ref_id for item in status_execution.result.evidence][
+        :5
+    ]
+    assert evidence_ids
+
+    get_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_02",
+            tool_id=ToolID.GET_EVIDENCE,
+            scope=scope,
+            evidence_ref_ids=evidence_ids,
+            limit=10,
+        ),
+        _context(scope),
+    )
+    result = get_execution.result
+
+    # The route must find and authorize every ID minted a moment ago: it must
+    # never fall back to "evidence_reference_not_found" (the cache-miss path)
+    # or an "unauthorized" outcome (the signature/authorization-mismatch
+    # path -- get_evidence surfaces that as a per-item "not_found" warning
+    # AND folds it into ``status_facts[i].text``, not into top-level
+    # ``status``/``warnings`` alone, so both must be checked). Without a live
+    # ClickHouse the raw content fetch itself degrades to "unavailable" for
+    # entities the fake source can't resolve -- that is an honest,
+    # non-crashing outcome, not a rejection, and is asserted separately below.
+    assert result.status != "unavailable"
+    assert "evidence_reference_not_found" not in result.warnings
+    assert "some_evidence_references_were_not_found" not in result.warnings
+    assert "not_found" not in result.warnings
+    assert {item.evidence_ref_id for item in result.evidence} == set(evidence_ids)
+    for fact in result.status_facts:
+        assert fact.text != "not_found", (
+            "evidence was rejected as unauthorized instead of expanded "
+            "(or honestly reported unavailable/no_matches)"
+        )
+
+    await runtime.aclose()
+
+
+def _project_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.PROJECT,
+                entity_id="project_01",
+                display_label="Project 01",
+                repository_id="repo_dev_health",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 6, 30, tzinfo=UTC), end=NOW, timezone="UTC"
+        ),
+    )
+
+
+def _real_native_evidence_query_dicts() -> Any:
+    """A fake ``query_dicts`` that enforces the SAME ``scope_entity_id``
+    predicate ``native_evidence.py``'s real expand SQL applies, instead of
+    matching on ``entity_id`` alone. A prior version of this test's stub
+    ignored that predicate and asserted a false "AVAILABLE" for a PR that
+    real ClickHouse can never return under this scope (codex adversarial
+    review, round 2, finding "linked-child expansion test bypasses
+    production scope predicates").
+
+    The child issue is modeled as belonging to ``project_01`` -- so a
+    PROJECT-scoped call's ``work_items`` predicate
+    (``project_id = scope_entity_id OR project_key = scope_entity_id``)
+    genuinely passes, mirroring a real child-of-project relationship.
+    """
+
+    async def fake_query_dicts(_client: Any, sql: str, params: dict[str, Any]) -> Any:
+        scope_entity_id = params.get("scope_entity_id", "")
+        if "FROM work_items" in sql and params.get("entity_id") == "issue_child":
+            if scope_entity_id not in ("", "issue_child", "project_01"):
+                return []
+            return [
+                {
+                    "entity_id": "issue_child",
+                    "display_label": "Child issue",
+                    "excerpt": "Status: open. Awaiting engineering review.",
+                    "provenance": "native",
+                    "observed_at": FRESH_OBSERVED,
+                    "last_synced": FRESH_OBSERVED,
+                    "repository_id": "repo_dev_health",
+                    "source_url": "",
+                    "deleted": 0,
+                    "confidence": 1.0,
+                }
+            ]
+        if (
+            "FROM git_pull_requests" in sql
+            and params.get("entity_id") == "repo_dev_health#pr42"
+        ):
+            # The pull_requests adapter's expand predicate only matches when
+            # scope_entity_id IS the PR's own composite id -- never for a PR
+            # merely linked to the direct-scope entity. No PROJECT- or
+            # ISSUE-scoped status_snapshot call can ever satisfy this, so a
+            # faithful fake must return no rows here too.
+            if scope_entity_id != "repo_dev_health#pr42":
+                return []
+            return [
+                {
+                    "entity_id": "repo_dev_health#pr42",
+                    "display_label": "Pull request #42",
+                    "excerpt": "State: merged. Implements the fix.",
+                    "provenance": "native",
+                    "observed_at": FRESH_OBSERVED,
+                    "last_synced": FRESH_OBSERVED,
+                    "repository_id": "repo_dev_health",
+                    "source_url": "",
+                    "deleted": 0,
+                    "confidence": 1.0,
+                }
+            ]
+        return []
+
+    return fake_query_dicts
+
+
+@pytest.mark.asyncio
+async def test_get_evidence_returns_real_content_for_linked_child_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evidence minted for a fact OTHER than the scope's own direct entity
+    (the required child issue) must be truly expandable --
+    ``EvidenceAvailability.AVAILABLE`` with a real excerpt -- not merely
+    present in the evidence array. This is the exact failure mode
+    CHAOS-3259's initial fix missed: binding ``valid_entity_ids`` to each
+    fact's own ID (instead of the caller's authorized scope) made every
+    non-direct-entity reference authorization-reject.
+
+    The linked PULL REQUEST's evidence is asserted separately below as an
+    honest NO_MATCHES, not AVAILABLE: the native ``pull_requests`` adapter's
+    expand SQL only matches when the scope's OWN direct entity IS that PR,
+    never for a PR merely linked to a different direct-scope entity. That is
+    a pre-existing native-evidence-adapter limitation (search/expand scope
+    predicates address "the direct entity itself", not "entities related to
+    it") outside CHAOS-3259's four known adapter-boundary breaks; it does
+    NOT regress anything CHAOS-3259 owns -- authorization now correctly
+    succeeds (no more false "unauthorized"/"not_found"), and NO_MATCHES is
+    the contract's own defined, honest outcome for it.
+    """
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence.query_dicts",
+        _real_native_evidence_query_dicts(),
+    )
+
+    runtime = await _build_runtime(monkeypatch)
+    scope = _project_scope()
+    status_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    child_evidence_id = next(
+        iter(
+            fact.evidence_ref_ids[0]
+            for fact in status_execution.result.status_facts
+            if fact.fact_id == "issue:issue_child"
+        )
+    )
+    pr_evidence_id = status_execution.result.pull_requests[0].evidence_ref_ids[0]
+    assert child_evidence_id != pr_evidence_id
+
+    get_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_02",
+            tool_id=ToolID.GET_EVIDENCE,
+            scope=scope,
+            evidence_ref_ids=[child_evidence_id, pr_evidence_id],
+            limit=10,
+        ),
+        _context(scope),
+    )
+    result = get_execution.result
+    texts = {fact.evidence_ref_ids[0]: fact.text for fact in result.status_facts}
+    assert "Awaiting engineering review" in texts[child_evidence_id]
+    # Honest NO_MATCHES, never "not_found"/"unauthorized" -- see docstring.
+    assert texts[pr_evidence_id] in {"no_matches", "evidence_deleted_or_unavailable"}
+    assert texts[pr_evidence_id] not in {"not_found", "unauthorized"}
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_work_graph_edges_preserve_provenance_and_mint_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The work_graph adapter must stop hardcoding ``evidence_ref_ids=[]`` and
+    must preserve each edge's provenance/confidence/observed_at.
+    """
+    from dev_health_ops.api.dev import work_graph_neighbors_service as wgns
+
+    edge_observed_at = FRESH_OBSERVED
+    raw_edge = wgns.WorkGraphRawEdge(
+        edge_id="edge_01",
+        source_type="issue",
+        source_id="issue_parent",
+        target_type="pr",
+        target_id="repo_dev_health#pr42",
+        relationship_type="references",
+        repository_id="repo_dev_health",
+        provenance="persisted",
+        confidence=0.9,
+        observed_at=edge_observed_at,
+        source_table="work_graph_edges",
+        source_version="work-graph-edges.v1",
+        source_watermark=edge_observed_at,
+    )
+
+    class _FakeGraphSource:
+        async def fetch(self, **_kwargs: Any) -> tuple[Any, ...]:
+            return (raw_edge,)
+
+    # ClickHouseWorkGraphNeighborSource is captured at assembly time, so this
+    # must be patched before building the runtime.
+    monkeypatch.setattr(
+        production_runtime,
+        "ClickHouseWorkGraphNeighborSource",
+        lambda _clickhouse: _FakeGraphSource(),
+    )
+    runtime = await _build_runtime(monkeypatch)
+
+    scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.ISSUE,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id="issue_parent",
+                display_label="Parent issue",
+                repository_id="repo_dev_health",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 6, 30, tzinfo=UTC), end=NOW, timezone="UTC"
+        ),
+    )
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.WORK_GRAPH_NEIGHBORS,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert len(result.graph_edges) == 1
+    edge = result.graph_edges[0]
+    assert edge.provenance == "persisted"
+    assert edge.confidence == pytest.approx(0.9)
+    assert edge.observed_at == edge_observed_at
+    assert edge.evidence_ref_ids
+    known_evidence_ids = {item.evidence_ref_id for item in result.evidence}
+    assert set(edge.evidence_ref_ids) <= known_evidence_ids
+
+    await runtime.aclose()
+
+
+def _change_scope() -> DevScope:
+    current_end = NOW
+    current_start = NOW - timedelta(days=30)
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.ISSUE,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id="issue_parent",
+                display_label="Parent issue",
+                repository_id="repo_dev_health",
+            )
+        ],
+        time_range=DevTimeRange(start=current_start, end=current_end, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=current_start - timedelta(days=30),
+            end=current_start,
+            timezone="UTC",
+        ),
+    )
+
+
+def _observed_change(
+    *, change_id: str, before: str | None, after: str | None
+) -> ObservedChange:
+    # entity_id is the scope's OWN direct entity (issue_parent, per
+    # _change_scope()) so a real work_items expand -- once mocked -- can
+    # genuinely match it; two transitions of the scope's own issue is also
+    # the realistic "what changed about this issue" shape for change_summary.
+    return ObservedChange(
+        change_id=change_id,
+        category=ChangeCategory.STATUS,
+        entity_type="issue",
+        entity_id="issue_parent",
+        display_label="Parent issue",
+        before=before,
+        after=after,
+        observed_at=FRESH_OBSERVED,
+        claim_kind=ClaimKind.OBSERVED,
+        relationship_chain=(),
+        metric_id=None,
+        metric_value=None,
+        metric_comparison_value=None,
+        source_ref_ids=("ref:work_items",),
+        evidence_ref_ids=(),
+    )
+
+
+class _FakeChangeOnlySource:
+    """Two STATUS-category transitions on the SAME entity_id: a regression
+    to keying minted evidence purely by entity_id would collapse both onto
+    one evidence_ref_id (CHAOS-3259 codex finding: "different changes
+    collapse onto the same evidence reference").
+    """
+
+    def __init__(self, changes: tuple[ObservedChange, ...]) -> None:
+        self._changes = changes
+        self._source_refs = (
+            SourceReference(
+                ref_id="ref:work_items",
+                source_system="work_items",
+                source_version="work-items.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+        )
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        del org_id, scope, as_of, limit
+        return RawStatusSnapshot(declared=None, source_refs=self._source_refs)
+
+    async def change_summary(
+        self,
+        *,
+        org_id: str,
+        scope: DevScope,
+        current: ChangeWindow,
+        comparison: ChangeWindow,
+        limit: int,
+    ) -> RawChangeSummary:
+        del org_id, scope, current, comparison, limit
+        return RawChangeSummary(changes=self._changes, source_refs=self._source_refs)
+
+
+@pytest.mark.asyncio
+async def test_change_summary_does_not_collide_distinct_observations_of_one_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two distinct observed changes on one entity must mint distinct,
+    independently-expandable evidence. A prior fix (round 1) achieved
+    distinctness by folding change_id into the LOOKUP entity_id itself,
+    which made every status-change reference unexpandable (codex round 2:
+    "status-change collision fix makes every status reference
+    unexpandable") -- the discriminator now lives in source_version, which
+    native adapters never filter on, so distinctness and real expansion
+    both hold.
+    """
+
+    async def fake_query_dicts(_client: Any, sql: str, params: dict[str, Any]) -> Any:
+        if "FROM work_items" in sql and params.get("entity_id") == "issue_parent":
+            if params.get("scope_entity_id", "") not in ("", "issue_parent"):
+                return []
+            return [
+                {
+                    "entity_id": "issue_parent",
+                    "display_label": "Parent issue",
+                    "excerpt": "Status: done.",
+                    "provenance": "native",
+                    "observed_at": FRESH_OBSERVED,
+                    "last_synced": FRESH_OBSERVED,
+                    "repository_id": "repo_dev_health",
+                    "source_url": "",
+                    "deleted": 0,
+                    "confidence": 1.0,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence.query_dicts", fake_query_dicts
+    )
+
+    changes = (
+        _observed_change(change_id="transition-1", before="open", after="in_progress"),
+        _observed_change(change_id="transition-2", before="in_progress", after="done"),
+    )
+    runtime = await _build_runtime(
+        monkeypatch, status_source=_FakeChangeOnlySource(changes)
+    )
+    scope = _change_scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.CHANGE_SUMMARY,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert len(result.status_facts) == 2
+    evidence_ids = [fact.evidence_ref_ids[0] for fact in result.status_facts]
+    assert len(set(evidence_ids)) == 2, (
+        "two distinct observed changes on the same entity minted the same "
+        "evidence_ref_id -- one change's evidence silently overwrote the "
+        "other's in the shared evidence cache"
+    )
+    assert {item.evidence_ref_id for item in result.evidence} == set(evidence_ids)
+
+    get_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_02",
+            tool_id=ToolID.GET_EVIDENCE,
+            scope=scope,
+            evidence_ref_ids=evidence_ids,
+            limit=10,
+        ),
+        _context(scope),
+    )
+    get_result = get_execution.result
+    texts = [fact.text for fact in get_result.status_facts]
+    assert len(texts) == 2
+    assert all("Status: done." in text for text in texts), (
+        f"expected both distinct transition references to genuinely expand "
+        f"to real content, got: {texts}"
+    )
+
+    await runtime.aclose()
+
+
+class _FakeDenseStatusChangeSource:
+    """A completed parent with 15 required incomplete children (each
+    contributing the "required_child_incomplete" blocking reason) and 15
+    already-merged, non-contributing pull requests: 31 unique addressable
+    facts (1 declared + 15 children + 15 PRs), which mint more than the 25
+    evidence entries ``DevToolResult.evidence`` allows. CHAOS-3259 codex
+    finding: "per-category limits exceed the evidence contract before byte
+    rejection" -- naive minting would raise a pydantic ValidationError
+    instead of returning a bounded, warned result. The PRs are deliberately
+    non-contributing (merged, reviewed, no changes requested) so truncation
+    priority is actually exercised: round-2 codex finding "hash-order
+    truncation removes verdict-driving facts" -- the 16 verdict-driving
+    facts (declared + 15 required children) must all survive; only the 15
+    incidental PRs should be the ones partially cut.
+    """
+
+    def __init__(self) -> None:
+        self.declared = StatusFact(
+            entity_type="issue",
+            entity_id="issue_parent",
+            display_label="Parent issue",
+            status="done",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+        )
+        self.children = tuple(
+            StatusFact(
+                entity_type="issue",
+                entity_id=f"issue_child_{index:02d}",
+                display_label=f"Child issue {index}",
+                status="open",
+                observed_at=FRESH_OBSERVED,
+                source_ref_id="ref:work_items",
+                evidence_ref_ids=(),
+                required=True,
+            )
+            for index in range(15)
+        )
+        self.pull_requests = tuple(
+            PullRequestFact(
+                entity_id=f"repo_dev_health#pr{index}",
+                display_label=f"Pull request #{index}",
+                state="merged",
+                review_state="approved",
+                changes_requested=0,
+                merged=True,
+                observed_at=FRESH_OBSERVED,
+                source_ref_id="ref:pull_requests",
+                evidence_ref_ids=(),
+                required=True,
+            )
+            for index in range(15)
+        )
+        self.source_refs = (
+            SourceReference(
+                ref_id="ref:work_items",
+                source_system="work_items",
+                source_version="work-items.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+            SourceReference(
+                ref_id="ref:pull_requests",
+                source_system="pull_requests",
+                source_version="pull-requests.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+        )
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        del org_id, scope, as_of, limit
+        return RawStatusSnapshot(
+            declared=self.declared,
+            children=self.children,
+            pull_requests=self.pull_requests,
+            source_refs=self.source_refs,
+        )
+
+    async def change_summary(
+        self,
+        *,
+        org_id: str,
+        scope: DevScope,
+        current: ChangeWindow,
+        comparison: ChangeWindow,
+        limit: int,
+    ) -> RawChangeSummary:
+        del org_id, scope, current, comparison, limit
+        return RawChangeSummary(changes=(), source_refs=self.source_refs)
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_bounds_evidence_instead_of_failing_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _build_runtime(
+        monkeypatch, status_source=_FakeDenseStatusChangeSource()
+    )
+    scope = _scope()
+    # request.limit itself is capped at 25 by DevToolRequest; the dense
+    # per-category source data above is what pushes total unique evidence
+    # past the DevToolResult.evidence bound of 25, independent of limit.
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert len(result.evidence) <= 25
+    assert "status_snapshot_evidence_result_truncated" in result.warnings
+
+    known_evidence_ids = {item.evidence_ref_id for item in result.evidence}
+    for fact in result.status_facts:
+        assert fact.evidence_ref_ids
+        assert set(fact.evidence_ref_ids) <= known_evidence_ids
+    for fact in result.pull_requests:
+        assert set(fact.evidence_ref_ids) <= known_evidence_ids
+
+    # Priority preservation (codex round 2): the 16 verdict-driving facts --
+    # the declared parent plus all 15 required, incomplete children -- must
+    # ALL keep their evidence even though the result overall had to shed 6
+    # of the 31 candidates. Only the 15 non-contributing (merged, approved)
+    # PRs are eligible to be thinned, and since 16 priority + 25 budget
+    # leaves room for 9, exactly 9 of them should survive.
+    assert len(result.status_facts) == 16, (
+        "a required, incomplete child lost its evidence and was dropped "
+        "even though it drove the actual-completion verdict"
+    )
+    assert len(result.actual_completion.required_children) == 15
+    for child in result.actual_completion.required_children:
+        assert child.evidence_ref_ids, (
+            f"required child {child.fact_id} lost its evidence to "
+            f"truncation despite being verdict-driving priority evidence"
+        )
+    surviving_prs = [fact for fact in result.pull_requests if fact.evidence_ref_ids]
+    assert len(surviving_prs) == 9
+
+    # The conflict must never fall back to unrelated evidence: every ID it
+    # cites has to come from a category that actually produced a blocking
+    # reason code (here, "required_child_incomplete" -> status_facts), never
+    # from the incidental, already-merged PRs.
+    assert result.actual_completion.conflicts
+    pr_evidence_ids = {
+        evidence_id
+        for fact in result.pull_requests
+        for evidence_id in fact.evidence_ref_ids
+    }
+    for conflict in result.actual_completion.conflicts:
+        assert conflict.evidence_ref_ids
+        assert not (set(conflict.evidence_ref_ids) & pr_evidence_ids)
+
+    await runtime.aclose()
+
+
+class _FakeCiAcceptanceStatusChangeSource:
+    """Two acceptance checks from the SAME CI run: coarsening their entity_id
+    to the run-level locator (so expansion can resolve real content, since
+    no native adapter indexes the finer check-level ID) would collide both
+    checks onto one evidence_ref_id if the signed identity weren't
+    separately discriminated (codex round 2: "CI acceptance checks in one
+    run collapse onto one run-level reference").
+    """
+
+    def __init__(self) -> None:
+        self.declared = StatusFact(
+            entity_type="issue",
+            entity_id="issue_parent",
+            display_label="Parent issue",
+            status="in_progress",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+        )
+        self.ci_pass = CIFact(
+            entity_id="repo_dev_health#ci2001#checkA",
+            display_label="Lint check",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:ci_runs",
+            evidence_ref_ids=(),
+        )
+        self.ci_fail = CIFact(
+            entity_id="repo_dev_health#ci2001#checkB",
+            display_label="Test suite",
+            conclusion="failure",
+            required=True,
+            skipped_required_work=False,
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:ci_runs",
+            evidence_ref_ids=(),
+        )
+        self.source_refs = (
+            SourceReference(
+                ref_id="ref:work_items",
+                source_system="work_items",
+                source_version="work-items.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+            SourceReference(
+                ref_id="ref:ci_runs",
+                source_system="ci_runs",
+                source_version="ci-runs.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+        )
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        del org_id, scope, as_of, limit
+        return RawStatusSnapshot(
+            declared=self.declared,
+            ci=(self.ci_pass, self.ci_fail),
+            source_refs=self.source_refs,
+        )
+
+    async def change_summary(
+        self,
+        *,
+        org_id: str,
+        scope: DevScope,
+        current: ChangeWindow,
+        comparison: ChangeWindow,
+        limit: int,
+    ) -> RawChangeSummary:
+        del org_id, scope, current, comparison, limit
+        return RawChangeSummary(changes=(), source_refs=self.source_refs)
+
+
+@pytest.mark.asyncio
+async def test_ci_acceptance_checks_on_one_run_do_not_collide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_query_dicts(_client: Any, sql: str, params: dict[str, Any]) -> Any:
+        if (
+            "FROM ci_pipeline_runs" in sql
+            and params.get("entity_id") == "repo_dev_health#ci2001"
+        ):
+            return [
+                {
+                    "entity_id": "repo_dev_health#ci2001",
+                    "display_label": "CI run 2001",
+                    "excerpt": "Status: mixed.",
+                    "provenance": "native",
+                    "observed_at": FRESH_OBSERVED,
+                    "last_synced": FRESH_OBSERVED,
+                    "repository_id": "repo_dev_health",
+                    "source_url": "",
+                    "deleted": 0,
+                    "confidence": 1.0,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence.query_dicts", fake_query_dicts
+    )
+
+    runtime = await _build_runtime(
+        monkeypatch, status_source=_FakeCiAcceptanceStatusChangeSource()
+    )
+    scope = _scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert {fact.conclusion for fact in result.ci_checks} == {"success", "failure"}
+    evidence_ids = [fact.evidence_ref_ids[0] for fact in result.ci_checks]
+    assert len(set(evidence_ids)) == 2, (
+        "two distinct acceptance checks on the same run minted the same "
+        "evidence_ref_id -- one check's evidence silently overwrote the "
+        "other's"
+    )
+
+    get_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_02",
+            tool_id=ToolID.GET_EVIDENCE,
+            scope=scope,
+            evidence_ref_ids=evidence_ids,
+            limit=10,
+        ),
+        _context(scope),
+    )
+    texts = [fact.text for fact in get_execution.result.status_facts]
+    assert len(texts) == 2
+    assert all("Status: mixed." in text for text in texts)
+
+    await runtime.aclose()

--- a/tests/api/dev/test_native_evidence.py
+++ b/tests/api/dev/test_native_evidence.py
@@ -74,6 +74,7 @@ def test_launch_native_evidence_class_registry_is_explicit() -> None:
         "ci_runs",
         "deployments",
         "incidents",
+        "work_graph",
     }
 
 

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -1033,7 +1033,15 @@ def test_coverage_counts_partial_with_usable_evidence_as_available() -> None:
         status="partial",
         metric_definitions=[],
         metrics=[],
-        evidence=[],
+        # Every evidence ID a status fact cites must exist in this same
+        # result's evidence array (DevToolResult.validate_evidence_closure,
+        # CHAOS-3259) -- the fact below cites "evidence_01".
+        evidence=[
+            {
+                **positive_fixtures()["dev_evidence_ref.v1"],
+                "evidence_ref_id": "evidence_01",
+            }
+        ],
         status_facts=[
             {
                 "fact_id": "fact_01",

--- a/tests/api/dev/test_tool_registry.py
+++ b/tests/api/dev/test_tool_registry.py
@@ -61,7 +61,7 @@ def _registry(executor=None) -> AskDevToolRegistry:
 def test_manifest_is_the_exact_nine_tool_server_allowlist() -> None:
     manifest = _registry().manifest()
     tools = cast(list[dict[str, object]], manifest["tools"])
-    assert manifest["version"] == "ask_dev_tools.v1"
+    assert manifest["version"] == "ask_dev_tools.v2"
     assert [item["tool_id"] for item in tools] == sorted(item.value for item in ToolID)
     assert len(tools) == 9
     assert all(item["required_permission"] == "ask_dev:read" for item in tools)


### PR DESCRIPTION
## Summary

Fixes CHAOS-3259. The `status_snapshot`/`change_summary`/`work_graph` production tool adapters (`production_runtime.py`) discarded most of the domain's evidence-backed completion view before it reached the model:

- `status_snapshot` only ever projected `values = [declared, *children, *blockers]` — the deterministic `actual-completion` assessment, conflicts, PR/CI/deployment/incident facts, and source freshness were never surfaced at all.
- Any fact that *did* survive silently lost its evidence via `_fact()`'s drop-if-empty behavior, and dropped facts were never added to the result's evidence array or the `get_evidence` expansion cache.
- The graph adapter hardcoded `evidence_ref_ids=[]` on every edge, discarding provenance.

### Changes

- **`contracts.py`**: new typed wire types for the deterministic completion view (`DevActualCompletion`, `DevPullRequestFact`, `DevCIFact`, `DevDeploymentFact`, `DevIncidentFact`, `DevStatusConflict`, `DevRequiredChildFact`, `DevSourceHealth`); `DevGraphEdge` gains `provenance`/`confidence`/`observed_at`; `DevToolResult` gains all of the above plus a `validate_evidence_closure` model_validator that makes it structurally impossible to construct a result where a fact/edge cites an evidence ID missing from that same result's evidence array.
- **`production_runtime.py`**: projects every domain field for all three tools. Each fact mints its own signer-issued, `get_evidence.v1`-verifiable evidence reference (`_mint_evidence`, sharing the same `EvidenceReferenceSigner` as `EvidenceService`) instead of forwarding the domain's own (frequently empty) `evidence_ref_ids`. Authorization (`valid_entity_ids`/`repository_ids`) binds to the caller's own already-authorized scope, never to a supporting fact's own ID. Evidence is bounded to the wire contract's 25-item cap with priority given to the declared fact, every required child, and every reason-code-contributing category, so a dense scope degrades with a warning instead of failing pydantic validation — and conflicts cite only the evidence that actually produced their contradiction, never an unrelated fallback.
- **`native_evidence.py`**: adds the `"work_graph"` native evidence source (a freshness policy for it was already wired but had no SQL spec), so graph edges are genuinely expandable.
- Bumps `TOOL_CONTRACT_VERSION` `ask_dev_tools.v1` → `v2` for the materially changed tool contract (checked the whole repo + the `web` repo's pinned contract sync script — no live consumer pins the exact string, so this is safe; `web`'s `scripts/ask-dev-contracts.mjs` is hard-pinned to a specific historical ops commit and needs a separate, later sync bump, not part of this PR).

### Adversarial review

Ran two rounds of Codex adversarial review; both found real, verified defects that are fixed here, each with a dedicated regression test I confirmed by reverting the specific fix and observing the predicted failure, then restoring:

1. `_mint_evidence` bound authorization to the supporting fact's own entity ID instead of the caller's authorized scope — every non-direct-entity evidence reference (child issues, linked PRs, CI runs, deployments, incidents) was rejected as unauthorized on expand.
2. `change_summary` minted evidence keyed only by `entity_id` — two observed changes on the same entity (two status transitions, two metric-dimension rows) collided onto one evidence_ref_id.
3. `status_snapshot` could mint more than 25 unique evidence items across its six independently-bounded-to-25 categories, exceeding `DevToolResult.evidence`'s `max_length=25` and raising an uncaught `ValidationError` instead of returning a result.
4. Source-system/entity-id mapping mismatches vs. real ClickHouse ID formats (`ci_acceptance_checks` vs. `ci_runs` adapter, relationship changes pointing at `work_items` instead of `work_graph`).
5. Every conflict cited the full flat union of evidence across all categories instead of only the categories that actually produced its contradiction.
6. The collision fix for #2 (folding `change_id` into the entity_id used for adapter lookups) made every status-change reference permanently unexpandable; fixed by discriminating via `source_version` instead, which native adapters never filter on.
7. Truncation for #3 used alphabetical-first-25 ordering, which could drop the very facts (required children) that determined the completion verdict while leaving the verdict unchanged and unexplained; fixed with priority ordering (declared + required children + contributing categories first).
8. Multiple CI acceptance checks on one run collapsed onto one evidence reference when coarsened to the run-level adapter locator; fixed with the same `source_version` discrimination as #6.

## Residual, out-of-scope gaps (documented, not fixed here)

- `native_status_change.py` (`ClickHouseStatusChangeSource`) still returns empty `evidence_ref_ids` on its raw domain facts today — this fix makes the adapter boundary mint real, verifiable evidence independently of that, so status/change/graph tool results are fixed regardless, but the deeper "does the live ClickHouse source populate evidence_ref_ids" question is unchanged.
- `query_metric`'s evidence_ref_ids are still explicitly zeroed (pre-existing, not one of CHAOS-3259's four known code facts).
- The native `pull_requests`/`reviews`/`ci_runs`/`deployments` evidence adapters' expand SQL only matches when the scope's own direct entity *is* that record — never for a record merely *linked* to a different direct-scope entity (e.g. a PR linked from an issue-scoped status_snapshot). Authorization now correctly succeeds for these; the live content fetch honestly degrades to `NO_MATCHES`, which is the contract's own defined outcome for this case. Loosening those adapters' scope predicates to support "linked entity" expansion is a separate, bounded follow-up.

## Test plan

- [x] `tests/api/dev/test_chaos_3259_status_evidence_projection.py` — 7 new real production-registry integration tests (real runtime/registry/service, only ClickHouse-backed leaves + entitlement faked)
- [x] Full ask-dev suite: 338 passed, 18 skipped
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" bash ci/local_validate.sh` — fully green (ruff, mypy, go, river, ClickHouse migrate, full unit suite 9560+ tests, argMax live-exec)
- [x] Every HIGH-severity fix independently verified by reverting it and confirming the exact predicted failure, then restoring diff-clean