### PR TITLE
fix(ask-dev): sanitize dotted tool names at the OpenAI wire boundary

### DIFF
--- a/src/dev_health_ops/api/dev/tool_registry.py
+++ b/src/dev_health_ops/api/dev/tool_registry.py
@@ -9,6 +9,8 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
+from dev_health_ops.llm.providers.openai_capabilities import build_wire_tool_name_map
+
 from .contracts import DevScope, DevToolRequest, DevToolResult, ToolID
 
 TOOL_CONTRACT_VERSION = "ask_dev_tools.v1"
@@ -201,6 +203,12 @@ class AskDevToolRegistry:
         expected = set(ToolID)
         if set(definitions) != expected:
             raise RuntimeError("tool metadata must cover the exact V1 registry")
+        # Explicitly rejected at registry build time (CHAOS-3286): the
+        # OpenAI-compatible adapter sanitizes each dotted tool_id into a
+        # wire-legal function name; this asserts the real V1 registry can
+        # never collide under that mapping, rather than only ever being
+        # caught defensively at request time.
+        build_wire_tool_name_map(item.value for item in ToolID)
         if set(executors) != expected:
             missing = sorted(item.value for item in expected - set(executors))
             extra = sorted(str(item) for item in set(executors) - expected)

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -11,7 +11,9 @@ from typing import Any, cast
 
 from dev_health_ops.llm.providers._http import make_hardened_async_httpx_client
 from dev_health_ops.llm.providers.openai_capabilities import (
+    build_wire_tool_name_map,
     chat_completion_reasoning_effort,
+    sanitize_tool_name,
     supports_parallel_tool_calls,
     supports_temperature,
 )
@@ -191,6 +193,13 @@ class OpenAICompatibleAgentProvider:
                 AgentProviderErrorCode.CANCELLED,
                 provider_dispatched=False,
             )
+        # Built before any request is dispatched: a mapping collision is a
+        # registry-construction bug (two distinct tool_ids sanitizing to the
+        # same wire name), never a provider-caused failure, so it must
+        # surface as a plain, uncaught error rather than an AgentProviderError
+        # (CHAOS-3286). Callers that own a fixed registry (AskDevToolRegistry)
+        # additionally assert this can't happen at registry build time.
+        wire_tool_ids = build_wire_tool_name_map(item.tool_id for item in tools)
         started = time.monotonic()
         create_completion = cast(Any, self._client.chat.completions.create)
         allow_final_answer = not tools or any(
@@ -259,7 +268,9 @@ class OpenAICompatibleAgentProvider:
 
         try:
             decision = self._normalize_response(
-                response, allowed_tool_ids=frozenset(item.tool_id for item in tools)
+                response,
+                allowed_tool_ids=frozenset(item.tool_id for item in tools),
+                wire_tool_ids=wire_tool_ids,
             )
         except _SequentialToolContractViolation:
             raise AgentProviderError(
@@ -315,7 +326,10 @@ class OpenAICompatibleAgentProvider:
                     "id": message.tool_request.call_id,
                     "type": "function",
                     "function": {
-                        "name": message.tool_request.tool_id,
+                        # Replaying prior-round history: sanitize here too so
+                        # every outbound function name is wire-legal,
+                        # consistent with _tool_payload (CHAOS-3286).
+                        "name": sanitize_tool_name(message.tool_request.tool_id),
                         "arguments": json.dumps(
                             dict(message.tool_request.arguments),
                             separators=(",", ":"),
@@ -331,7 +345,13 @@ class OpenAICompatibleAgentProvider:
         return {
             "type": "function",
             "function": {
-                "name": tool.tool_id,
+                # OpenAI's native tools[].function.name must match
+                # ^[a-zA-Z0-9_-]+$; the canonical registry tool_id (e.g.
+                # "query_metric.v1") is dotted and illegal on the wire.
+                # Sanitized here at the boundary only -- reverse-mapped back
+                # to the canonical tool_id in _normalize_response
+                # (CHAOS-3286).
+                "name": sanitize_tool_name(tool.tool_id),
                 "description": tool.description,
                 "parameters": OpenAICompatibleAgentProvider._structural_schema(
                     tool.input_schema
@@ -506,15 +526,27 @@ class OpenAICompatibleAgentProvider:
             target[str(name)] = definition
 
     @staticmethod
-    def _normalize_response(response: Any, *, allowed_tool_ids: frozenset[str]) -> Any:
+    def _normalize_response(
+        response: Any,
+        *,
+        allowed_tool_ids: frozenset[str],
+        wire_tool_ids: Mapping[str, str],
+    ) -> Any:
         message = response.choices[0].message
         tool_calls = getattr(message, "tool_calls", None) or []
         if len(tool_calls) > 1:
             raise _SequentialToolContractViolation("only one tool decision is allowed")
         if tool_calls:
             call = tool_calls[0]
-            tool_id = str(call.function.name)
-            if tool_id not in allowed_tool_ids:
+            # Native tool_calls[].function.name is the wire-sanitized name
+            # (CHAOS-3286); reverse-map back to the canonical tool_id before
+            # any further validation or persistence. The JSON decision-
+            # envelope fallback path below is unaffected -- it's Ask Dev's
+            # own structured-output schema, not a native tool definition, so
+            # it is never subject to OpenAI's function-name wire constraint
+            # and continues to use the canonical dotted tool_id directly.
+            tool_id = wire_tool_ids.get(str(call.function.name))
+            if tool_id is None:
                 raise ValueError("tool decision is not registered")
             arguments = json.loads(call.function.arguments)
             if not isinstance(arguments, dict):

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -32,6 +32,12 @@ from .errors import (
 
 READINESS_SETTING_KEY = "ask_dev_agent_readiness"
 READINESS_MAX_OUTPUT_TOKENS = 512
+# Dotted, matching the shape of every real registry tool_id (e.g.
+# "query_metric.v1"), so certification genuinely exercises the
+# OpenAI-compatible adapter's wire-name sanitize/reverse-map round trip for a
+# name-illegal tool_id -- a registry regression fails preflight here, not the
+# first real user question (CHAOS-3286).
+READINESS_ECHO_TOOL_ID = "readiness_echo.v1"
 
 
 class AgentReadinessOutcome(str, Enum):
@@ -123,7 +129,7 @@ class AgentReadinessService:
         usage = AgentUsage()
         try:
             tool = AgentToolDefinition(
-                tool_id="readiness_echo",
+                tool_id=READINESS_ECHO_TOOL_ID,
                 description="Return the supplied nonce.",
                 input_schema={
                     "type": "object",

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -13,7 +13,20 @@ from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
+from dev_health_ops.llm.providers.openai_capabilities import is_wire_legal_tool_name
+
 SCRIPTED_OPENAI_MODEL = "ask-dev-scripted-v1"
+# Sanitized (wire-legal) counterparts of the canonical dotted registry tool
+# ids this scripted server simulates a model choosing among. Must track
+# whatever OpenAICompatibleAgentProvider.sanitize_tool_name actually
+# produces -- kept as simple literals here (not by importing the sanitize
+# function) so this scripted acceptance surface independently reflects what
+# a real model would be offered and could choose, rather than silently
+# following any future change to the sanitize implementation (CHAOS-3286).
+_WIRE_READINESS_ECHO = "readiness_echo_v1"
+_WIRE_QUERY_METRIC = "query_metric_v1"
+_WIRE_SEARCH_EVIDENCE = "search_evidence_v1"
+_WIRE_DATA_HEALTH = "data_health_v1"
 
 
 def _tool_results_from_messages(payload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -219,23 +232,41 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
             return
         self.server.requests.append(payload)
         tool_names = [item["function"]["name"] for item in payload.get("tools") or []]
+        # Enforce OpenAI's real function-name wire constraint (CHAOS-3286): a
+        # regression that reintroduces a dotted (or otherwise illegal) tool
+        # name must fail scripted deterministic acceptance exactly as it
+        # would fail against the real API, not pass silently.
+        illegal = [name for name in tool_names if not is_wire_legal_tool_name(name)]
+        if illegal:
+            self._write_json(
+                400,
+                {
+                    "error": {
+                        "message": f"Invalid 'tools[].function.name': {illegal[0]!r}",
+                        "type": "invalid_request_error",
+                        "param": "tools[].function.name",
+                        "code": "invalid_value",
+                    }
+                },
+            )
+            return
         tool_results = _tool_results_from_messages(payload)
         requested_tool_names = _requested_tool_names_from_messages(payload)
         result_tool_ids = {str(result.get("tool_id") or "") for result in tool_results}
         if not tool_results:
             arguments: dict[str, Any]
-            if "readiness_echo" in tool_names:
-                tool_name = "readiness_echo"
+            if _WIRE_READINESS_ECHO in tool_names:
+                tool_name = _WIRE_READINESS_ECHO
                 arguments = {"nonce": "ready-v1"}
-            elif "query_metric.v1" in tool_names:
-                tool_name = "query_metric.v1"
+            elif _WIRE_QUERY_METRIC in tool_names:
+                tool_name = _WIRE_QUERY_METRIC
                 arguments = {
                     "metric_id": "items_completed",
                     "include_comparison": True,
                     "limit": 12,
                 }
             else:
-                tool_name = "status_snapshot.v1"
+                tool_name = "status_snapshot_v1"
                 arguments = {}
             message: dict[str, Any] = {
                 "role": "assistant",
@@ -253,10 +284,10 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
             }
             finish_reason = "tool_calls"
         elif (
-            "readiness_echo" not in tool_names
+            _WIRE_READINESS_ECHO not in tool_names
             and "query_metric.v1" in result_tool_ids
             and "search_evidence.v1" not in result_tool_ids
-            and "search_evidence.v1" in tool_names
+            and _WIRE_SEARCH_EVIDENCE in tool_names
         ):
             message = {
                 "role": "assistant",
@@ -266,7 +297,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
                         "id": "scripted-call-search-evidence-v1",
                         "type": "function",
                         "function": {
-                            "name": "search_evidence.v1",
+                            "name": _WIRE_SEARCH_EVIDENCE,
                             "arguments": json.dumps(
                                 {
                                     # The acceptance corpus guarantees this repository
@@ -285,11 +316,11 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
             }
             finish_reason = "tool_calls"
         elif (
-            "readiness_echo" not in tool_names
+            _WIRE_READINESS_ECHO not in tool_names
             and "query_metric.v1" in result_tool_ids
             and "search_evidence.v1" in result_tool_ids
             and "data_health.v1" not in result_tool_ids
-            and "data_health.v1" in tool_names
+            and _WIRE_DATA_HEALTH in tool_names
         ):
             message = {
                 "role": "assistant",
@@ -299,7 +330,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
                         "id": "scripted-call-data-health-v1",
                         "type": "function",
                         "function": {
-                            "name": "data_health.v1",
+                            "name": _WIRE_DATA_HEALTH,
                             "arguments": "{}",
                         },
                     }
@@ -309,7 +340,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
         else:
             value = (
                 {"nonce": "ready-v1"}
-                if "readiness_echo" in requested_tool_names
+                if _WIRE_READINESS_ECHO in requested_tool_names
                 else _acceptance_answer(tool_results)
             )
             message = {
@@ -321,6 +352,14 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
             }
             finish_reason = "stop"
         self._send_completion(payload, message, finish_reason)
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
 
     def _send_completion(
         self,
@@ -346,12 +385,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
                 "total_tokens": 12,
             },
         }
-        encoded = json.dumps(response, separators=(",", ":")).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(encoded)))
-        self.end_headers()
-        self.wfile.write(encoded)
+        self._write_json(200, response)
 
     def log_message(self, _format: str, *_args: object) -> None:
         return

--- a/src/dev_health_ops/llm/providers/openai_capabilities.py
+++ b/src/dev_health_ops/llm/providers/openai_capabilities.py
@@ -2,6 +2,63 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable
+
+# OpenAI's Chat Completions API requires tools[].function.name (and the
+# native tool_calls[].function.name a model echoes back) to match this
+# pattern. Ask Dev's canonical registry tool identifiers are dotted
+# (e.g. "query_metric.v1"), which is illegal on the wire -- every real
+# OpenAI-backed request using one 400s (CHAOS-3286).
+_WIRE_LEGAL_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+_WIRE_ILLEGAL_CHARACTER = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_tool_name(tool_id: str) -> str:
+    """Map a canonical tool_id to an OpenAI wire-legal ``function.name``.
+
+    Deterministic and applied only at the adapter's outbound wire boundary:
+    every character outside ``[a-zA-Z0-9_-]`` (in practice just ``.``) is
+    replaced with ``_``. The canonical dotted ``tool_id`` remains the
+    identifier used everywhere else -- contracts, persistence, telemetry,
+    and Ask Dev's own JSON decision-envelope fallback schema (which is not
+    subject to this wire constraint at all, since it's a JSON Schema string
+    enum inside ``response_format``, not a native ``tools[]`` definition).
+    """
+
+    return _WIRE_ILLEGAL_CHARACTER.sub("_", tool_id)
+
+
+def is_wire_legal_tool_name(name: str) -> bool:
+    """Return whether ``name`` already satisfies OpenAI's function-name pattern."""
+
+    return bool(_WIRE_LEGAL_TOOL_NAME.match(name))
+
+
+def build_wire_tool_name_map(tool_ids: Iterable[str]) -> dict[str, str]:
+    """Build the wire-name -> canonical-tool_id reverse map for one request.
+
+    Raises ``ValueError`` if two distinct tool_ids would sanitize to the same
+    wire name -- a mapping collision must never silently misroute a tool
+    decision. Callers that own a fixed, closed tool registry (e.g.
+    ``AskDevToolRegistry``) should additionally assert collision-freedom at
+    registry build time so this can never happen at request time in
+    production; this function is the shared, generic enforcement any caller
+    (including a synthetic readiness probe) gets for free.
+    """
+
+    reverse: dict[str, str] = {}
+    for tool_id in tool_ids:
+        wire_name = sanitize_tool_name(tool_id)
+        existing = reverse.get(wire_name)
+        if existing is not None and existing != tool_id:
+            raise ValueError(
+                f"tool name mapping collision: {existing!r} and {tool_id!r} "
+                f"both sanitize to {wire_name!r}"
+            )
+        reverse[wire_name] = tool_id
+    return reverse
+
 
 def supports_temperature(model: str) -> bool:
     """Return whether the model accepts a caller-selected temperature.

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -73,7 +73,7 @@ class FakeReadinessProvider:
         if self.calls == 1:
             return AgentDecisionResult(
                 decision=AgentToolRequest(
-                    "readiness_echo", {"nonce": "ready-v1"}, "call-1"
+                    "readiness_echo.v1", {"nonce": "ready-v1"}, "call-1"
                 ),
                 usage=AgentUsage(input_tokens=3, output_tokens=2),
                 latency_ms=1,

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
 
+import httpx
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -456,3 +457,40 @@ async def test_partial_acceptance_gate_never_falls_back_to_live_platform(
     with pytest.raises(DevRuntimeUnavailable) as exc_info:
         await resolve_certification_provider(settings_session, org_id=_ORG_ID)
     assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_scripted_server_enforces_the_openai_tool_name_regex(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """CHAOS-3286: this scripted acceptance surface must not silently accept
+    a dotted (or otherwise wire-illegal) tools[].function.name. Without this
+    enforcement, a regression that reintroduces a canonical dotted tool_id
+    on the wire would pass scripted deterministic acceptance while every
+    real OpenAI-backed request 400s -- exactly how this bug went undetected.
+    """
+    host, port = cast(tuple[str, int], scripted_openai_server.server_address)
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"http://{host}:{port}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {_ACCEPTANCE_KEY}"},
+            json={
+                "model": "ask-dev-scripted-v1",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "query_metric.v1",
+                            "description": "d",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "tool_choice": "auto",
+            },
+        )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "tools" in body["error"]["param"]

--- a/tests/api/dev/test_tool_registry.py
+++ b/tests/api/dev/test_tool_registry.py
@@ -21,6 +21,7 @@ from dev_health_ops.api.dev.tool_registry import (
     ToolRequestRejected,
     UnknownToolError,
 )
+from dev_health_ops.llm.providers.openai_capabilities import build_wire_tool_name_map
 
 
 def _request(**updates: object) -> DevToolRequest:
@@ -66,6 +67,29 @@ def test_manifest_is_the_exact_nine_tool_server_allowlist() -> None:
     assert all(
         item["scope_policy"] == "exact_server_authorized_scope" for item in tools
     )
+
+
+def test_registry_construction_asserts_wire_tool_name_collision_freedom() -> None:
+    """CHAOS-3286: constructing the real V1 registry proves, at build time,
+    that none of its nine dotted tool_ids sanitize to the same OpenAI wire
+    function name. If a future tool_id addition ever collided, registry
+    construction itself would raise -- not just a defensive request-time
+    check inside the wire adapter.
+    """
+    assert build_wire_tool_name_map(item.value for item in ToolID) == {
+        "resolve_scope_v1": "resolve_scope.v1",
+        "list_metrics_v1": "list_metrics.v1",
+        "query_metric_v1": "query_metric.v1",
+        "status_snapshot_v1": "status_snapshot.v1",
+        "change_summary_v1": "change_summary.v1",
+        "work_graph_neighbors_v1": "work_graph_neighbors.v1",
+        "search_evidence_v1": "search_evidence.v1",
+        "get_evidence_v1": "get_evidence.v1",
+        "data_health_v1": "data_health.v1",
+    }
+    # The registry constructor itself performs this same assertion; proving
+    # it doesn't raise is the build-time guarantee this test exists for.
+    _registry()
 
 
 def test_unknown_and_cross_tenant_tools_are_rejected_before_execution() -> None:

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -109,6 +109,107 @@ async def test_normalizes_native_tool_decision_and_usage() -> None:
 
 
 @pytest.mark.asyncio
+async def test_native_tool_request_sanitizes_dotted_tool_name() -> None:
+    """CHAOS-3286: OpenAI rejects dotted tools[].function.name outright.
+
+    Every real OpenAI-backed request using a canonical registry tool_id
+    (e.g. "query_metric.v1") 400s with "Invalid 'tools[0].function.name'"
+    because OpenAI requires ^[a-zA-Z0-9_-]+$. The adapter must sanitize the
+    outbound name and reverse-map a model's wire-legal response back to the
+    canonical tool_id -- which is what the rest of Ask Dev (contracts,
+    persistence, telemetry) expects to see.
+    """
+    call = SimpleNamespace(
+        id="call-1",
+        # A real model can only echo back the wire-legal name it was
+        # offered -- never the canonical dotted tool_id.
+        function=SimpleNamespace(
+            name="query_metric_v1", arguments='{"metric_id":"items_completed"}'
+        ),
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [
+            AgentToolDefinition(
+                "query_metric.v1",
+                "Query a bounded metric.",
+                {"type": "object", "properties": {"metric_id": {"type": "string"}}},
+            )
+        ],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert sent["tools"][0]["function"]["name"] == "query_metric_v1"
+    # The canonical dotted tool_id survives the round trip -- everything
+    # downstream of the adapter (ToolID enum, persistence, telemetry)
+    # continues to see the identifier it already expects.
+    assert result.decision == AgentToolRequest(
+        "query_metric.v1", {"metric_id": "items_completed"}, "call-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_call_with_unregistered_wire_name_fails_closed() -> None:
+    call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(name="not_a_real_tool", arguments="{}"),
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [
+                AgentToolDefinition(
+                    "query_metric.v1", "Query a metric.", {"type": "object"}
+                )
+            ],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_tool_name_mapping_collision_fails_loudly_not_silently() -> None:
+    """A registry bug (two tool_ids sanitizing to the same wire name) must
+    surface as a plain, uncaught error -- never silently misroute a tool
+    decision to the wrong canonical tool_id, and never be misclassified as
+    an ordinary provider failure (CHAOS-3286).
+    """
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(content="{}")]),
+    )
+
+    with pytest.raises(ValueError, match="tool name mapping collision"):
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [
+                AgentToolDefinition("query.metric", "d", {"type": "object"}),
+                AgentToolDefinition("query_metric", "d", {"type": "object"}),
+            ],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+
+@pytest.mark.asyncio
 async def test_native_tool_request_disables_parallel_tool_calls() -> None:
     """CHAOS-3254: the wire request must enforce the sequential contract.
 
@@ -577,7 +678,10 @@ async def test_literal_reproduction_question_completes_through_sequential_rounds
         return SimpleNamespace(
             id=call_id,
             function=SimpleNamespace(
-                name="query_metric.v1",
+                # A real model can only echo back the wire-sanitized name it
+                # was offered (CHAOS-3286), never the canonical dotted
+                # tool_id -- see test_native_tool_request_sanitizes_dotted_name.
+                name="query_metric_v1",
                 arguments=json.dumps(
                     {"metric_id": metric_id, "include_comparison": True}
                 ),

--- a/tests/llm/agent/test_readiness.py
+++ b/tests/llm/agent/test_readiness.py
@@ -53,7 +53,7 @@ async def test_certification_proves_tool_continuation_and_final_answer() -> None
     provider = CapturingScriptedProvider(
         [
             ScriptedStep(
-                AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-1"),
+                AgentToolRequest("readiness_echo.v1", {"nonce": "ready-v1"}, "call-1"),
                 AgentUsage(5, 2),
             ),
             ScriptedStep(AgentFinalAnswer({"nonce": "ready-v1"}), AgentUsage(4, 3)),
@@ -114,10 +114,10 @@ async def test_repeated_tool_request_on_final_answer_turn_fails_closed() -> None
     provider = ScriptedAgentProvider(
         [
             ScriptedStep(
-                AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-1")
+                AgentToolRequest("readiness_echo.v1", {"nonce": "ready-v1"}, "call-1")
             ),
             ScriptedStep(
-                AgentToolRequest("readiness_echo", {"nonce": "ready-v1"}, "call-2")
+                AgentToolRequest("readiness_echo.v1", {"nonce": "ready-v1"}, "call-2")
             ),
         ]
     )

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -89,7 +89,9 @@ def _tool_call(call_id: str) -> dict[str, Any]:
         "id": call_id,
         "type": "function",
         "function": {
-            "name": "query_metric.v1",
+            # A real model can only echo back the wire-legal name it was
+            # offered, never the canonical dotted tool_id (CHAOS-3286).
+            "name": "query_metric_v1",
             "arguments": json.dumps({"metric_id": "items_completed"}),
         },
     }


### PR DESCRIPTION
## Summary

Fixes CHAOS-3286 (Urgent). **Stacked on #1340** (base = `fix/chaos-3254-sequential-tools`, same file — this diff is the incremental change only; it will auto-retarget to `main` once #1340 merges).

The Ask Dev OpenAI-compatible adapter sends registry tool names verbatim (`query_metric.v1`, `search_evidence.v1`, ...) as `tools[].function.name`. OpenAI Chat Completions requires `^[a-zA-Z0-9_-]+$` — dots are illegal. **Every real OpenAI-backed request failed with HTTP 400**, platform and BYO alike.

**Live-verified** (2026-07-30, real OpenAI API, org key — status + error fields only, no prompts/credentials):
- dotted `"query_metric.v1"` on `gpt-4o-mini` (BYO) → **HTTP 400** `invalid_request_error`/`invalid_value`, `param: "tools[0].function.name"`, message: `"Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'."` — matches the ticket's reproduction verbatim.
- dotted name on `gpt-5-nano` (platform model) → same **HTTP 400**.
- sanitized `"query_metric_v1"` on `gpt-4o-mini` → **HTTP 200**.

## Fix

- New `sanitize_tool_name()` / `is_wire_legal_tool_name()` / `build_wire_tool_name_map()` in `openai_capabilities.py`: deterministic dot→underscore mapping with collision detection, shared by the adapter, the tool registry, and the scripted acceptance server.
- `openai_compatible.py` sanitizes outbound `tools[].function.name` and replayed `tool_calls[].function.name`; builds the reverse map once per call **before dispatch**; `_normalize_response` reverse-maps a native `tool_calls[].function.name` back to the canonical dotted `tool_id` before any validation or persistence. A mapping collision raises a plain, **uncaught** `ValueError` before any request is sent — a registry-construction bug, never an ordinary provider failure, so it's never silently misclassified through the `AgentProviderError` vocabulary. The JSON decision-envelope fallback path is untouched: it's Ask Dev's own structured-output schema (a `response_format` string enum), not a native tool definition, so it was never subject to OpenAI's function-name wire constraint.
- `AskDevToolRegistry.__init__` asserts **build-time** collision-freedom over the real nine `ToolID` values, not only a request-time defensive check.
- Renamed the readiness synthetic probe tool_id `"readiness_echo"` → `"readiness_echo.v1"` so real preflight certification genuinely exercises the sanitize/reverse-map round trip for a dotted name: a future name-illegal registry addition now fails preflight, not the first real user question.
- `scripted_openai_service.py` validates incoming `tools[].function.name` against the real OpenAI regex and returns the same-shaped 400 the live API returns if violated, so this class of bug can't regress silently through scripted deterministic acceptance again (this is exactly how it went undetected the first time).

No change to canonical tool identifiers outside the provider wire boundary — contracts, persistence, and telemetry all continue to use the dotted `ToolID` values unchanged.

## Test plan
- [x] Adapter-level: outbound sanitize + inbound reverse-map round trip; unregistered-wire-name fails closed; mapping collision raises loudly (not silently, not misclassified).
- [x] Registry-level: `AskDevToolRegistry` construction asserts build-time collision-freedom over the real `ToolID` set.
- [x] `test_acceptance_openai_runtime.py`'s existing full acceptance flow passes end-to-end through the renamed dotted readiness probe + real production `ToolID` registry (proves the round trip for a realistic name shape during real preflight).
- [x] New scripted-server test posts a raw dotted name directly at the scripted acceptance server and asserts it 400s exactly like the live API does.
- [x] `bash ci/local_validate.sh` — full gate green (ruff, mypy, go, unit suite, argMax live-exec proof).
- [x] Codex adversarial review: **approve, no material findings** (confirmed no other tool-name wire-construction call sites were missed, collision detection covers native + history-replay paths, JSON fallback correctly excluded).