### PR TITLE
fix(ask-dev): scope platform vs BYO readiness to the correct admin surface (CHAOS-3265)

### DIFF
--- a/docs/admin/workspace/settings.md
+++ b/docs/admin/workspace/settings.md
@@ -44,9 +44,16 @@ persistent app-shell chat window and `/dev` workspace available when the base
 
 Administrative reads and usage summaries are content-free. Settings changes
 and readiness tests are unavailable while impersonating. The supported API is
-`GET /api/v1/admin/ask-dev`, `PATCH /api/v1/admin/ask-dev/settings`,
-`POST /api/v1/admin/ask-dev/readiness`, and
+`GET /api/v1/admin/ask-dev`, `PATCH /api/v1/admin/ask-dev/settings`, and
 `GET /api/v1/admin/ask-dev/usage`.
+
+An organization administrator tests their own BYO LLM credentials with
+`POST /api/v1/admin/llm-settings/readiness`. This checks the organization's
+saved BYO configuration only; it never certifies or exposes information about
+the platform-owned (operator-configured) provider. Certifying the
+platform-owned provider is a platform-administrator action, not an
+organization-administrator one — see
+[Configure the platform](../../operate/configure/index.md).
 
 Context Fabric Validation is a platform-administrator diagnostic surface. It is
 not granted by `ask_dev`, `byo_llm`, or organization-administrator status.

--- a/scripts/acceptance/prepare_ask_dev_acceptance.py
+++ b/scripts/acceptance/prepare_ask_dev_acceptance.py
@@ -150,15 +150,18 @@ def prepare(
                 f"failed to enable {key}",
             )
 
-    readiness = api.request("POST", "/api/v1/admin/ask-dev/readiness", {})
+    # CHAOS-3265: platform certification moved off the org-scoped
+    # /admin/ask-dev/readiness route (now a static 410 -- org admins can no
+    # longer trigger or observe platform certification) onto its own
+    # superuser-only Platform Admin surface. The acceptance scripted-OpenAI
+    # candidate is always PLATFORM-sourced (see production_runtime's
+    # acceptance gate), so bootstrap must certify it there.
+    readiness = api.request("POST", "/api/v1/admin/platform/ask-dev/readiness", {})
     _require(isinstance(readiness, dict), "readiness response was not an object")
     expected_readiness = {
-        "ask_dev_enabled": True,
-        "chat_window_available": True,
-        "full_page_available": True,
-        "provider_source": "platform",
+        "configured": True,
         "readiness": "ready",
-        "effective_model_label": expected_model,
+        "model_label": expected_model,
     }
     for field, expected in expected_readiness.items():
         _require(

--- a/src/dev_health_ops/api/admin/middleware.py
+++ b/src/dev_health_ops/api/admin/middleware.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import Depends, HTTPException
 
 from dev_health_ops.api.auth.router import get_current_user
-from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.auth import AuthenticatedUser, is_impersonating
 
 
 async def require_admin(
@@ -34,3 +34,32 @@ async def get_admin_user(
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> AuthenticatedUser:
     return current_user
+
+
+def block_impersonated_write(
+    user: AuthenticatedUser, *, detail: str | dict[str, str]
+) -> None:
+    """Reject a write while an operator is impersonating another identity.
+
+    Shared by every admin write route (Ask Dev org settings, the new
+    Platform Admin readiness route, and the new BYO readiness route) so the
+    impersonation guard can't drift between them. Each call site supplies its
+    own ``detail`` so the response keeps that router's existing message
+    style (CHAOS-3265).
+
+    Checks BOTH signals, not just one:
+    - ``user.impersonated_by`` -- the static JWT claim (``impersonating_user_id``)
+      stamped at token-issue time.
+    - ``is_impersonating()`` -- the LIVE, per-request impersonation context set by
+      ``ImpersonationMiddleware`` from the active Valkey-cached session (see
+      ``dev_health_ops.api.middleware.impersonation``). This is the authoritative,
+      real-time signal: a session started after the JWT was minted, or one whose
+      cache entry has since expired/been revoked, is reflected here even when the
+      JWT claim disagrees. Codex review (CHAOS-3265) found that checking only the
+      JWT claim let an actively-impersonating superuser reach both new POST
+      routes because ``impersonated_by`` was unset even though ``is_impersonating()``
+      was True -- check both so neither signal alone is a bypass.
+    """
+
+    if user.impersonated_by or is_impersonating():
+        raise HTTPException(status_code=403, detail=detail)

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -20,6 +20,7 @@ from .routers import (
     pagerduty_bindings_router,
     pagerduty_router,
     pagerduty_services_router,
+    platform_ask_dev_router,
     platform_router,
     settings_router,
     setup_router,
@@ -52,6 +53,7 @@ router.include_router(teams_router)
 router.include_router(users_router)
 router.include_router(orgs_router)
 router.include_router(platform_router)
+router.include_router(platform_ask_dev_router)
 router.include_router(features_router)
 router.include_router(github_app_router)
 router.include_router(pagerduty_router)

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -20,6 +20,7 @@ from .pagerduty import router as pagerduty_router
 from .pagerduty_bindings import router as pagerduty_bindings_router
 from .pagerduty_services import router as pagerduty_services_router
 from .platform import router as platform_router
+from .platform_ask_dev import router as platform_ask_dev_router
 from .settings import router as settings_router
 from .setup import router as setup_router
 from .sync import router as sync_router
@@ -42,6 +43,7 @@ __all__ = [
     "pagerduty_router",
     "pagerduty_bindings_router",
     "pagerduty_services_router",
+    "platform_ask_dev_router",
     "platform_router",
     "settings_router",
     "setup_router",

--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -12,7 +13,11 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validato
 from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dev_health_ops.api.admin.middleware import get_admin_org_id, get_admin_user
+from dev_health_ops.api.admin.middleware import (
+    block_impersonated_write,
+    get_admin_org_id,
+    get_admin_user,
+)
 from dev_health_ops.api.dev.org_policy import (
     ASK_DEV_EMERGENCY_DISABLED_KEY,
     ASK_DEV_FALLBACK_KEY,
@@ -37,9 +42,16 @@ from dev_health_ops.licensing import FeatureDecisionReason, evaluate_org_feature
 from dev_health_ops.licensing.registry import ASK_DEV_FEATURE
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY as _PLATFORM_READINESS_SETTING_KEY,
+)
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_SETTINGS_ORG_ID as _PLATFORM_SETTINGS_ORG_ID,
+)
+from dev_health_ops.llm.agent.readiness import (
     AgentReadinessOutcome,
-    AgentReadinessService,
+    ReadinessState,
     SettingsAgentReadinessStore,
+    readiness_failure_state,
 )
 from dev_health_ops.models.dev_persistence import DevRun
 from dev_health_ops.models.settings import SettingCategory
@@ -47,15 +59,16 @@ from dev_health_ops.models.settings import SettingCategory
 from .common import get_session
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
-ReadinessState = Literal[
-    "ready",
-    "unsupported_model",
-    "missing_credentials",
-    "disabled",
-    "degraded",
-    "stale_readiness",
-]
+# A generic, organization-safe unavailability message. When Ask Dev's
+# effective provider resolves to the PLATFORM candidate, the org-admin
+# response must never surface the platform's own safe failure reason (that
+# is Platform Admin's diagnostic, not this organization's) -- CHAOS-3265.
+_PLATFORM_GENERIC_UNAVAILABLE_MESSAGE = (
+    "Ask Dev is temporarily unavailable. Contact your platform operator."
+)
+
 EntitlementState = Literal[
     "enabled", "not_entitled", "globally_disabled", "org_disabled", "unavailable"
 ]
@@ -250,12 +263,13 @@ async def _platform_allowance_usage(
     )
 
 
-def _block_impersonated_write(user: AuthenticatedUser) -> None:
-    if user.impersonated_by:
-        raise HTTPException(
-            status_code=403,
-            detail="Ask Dev administrative actions are unavailable while impersonating",
-        )
+def _platform_readiness_store(session: AsyncSession) -> SettingsAgentReadinessStore:
+    """The platform-owned provider's readiness store (see production_runtime)."""
+
+    return SettingsAgentReadinessStore(
+        SettingsService(session, _PLATFORM_SETTINGS_ORG_ID),
+        key=_PLATFORM_READINESS_SETTING_KEY,
+    )
 
 
 async def _feature_state(
@@ -292,42 +306,6 @@ def _checked_at(value: str | None) -> datetime | None:
     return parsed
 
 
-def _failed_readiness_state(safe_error_code: str | None) -> tuple[ReadinessState, str]:
-    if safe_error_code == "provider_not_configured":
-        return (
-            "missing_credentials",
-            "Ask Dev could not authenticate with the configured model endpoint.",
-        )
-    if safe_error_code == "timeout":
-        return "degraded", "The configured Ask Dev model timed out during readiness."
-    if safe_error_code == "rate_limited":
-        return "degraded", "The configured Ask Dev model rate limit was reached."
-    if safe_error_code == "model_not_supported":
-        return (
-            "unsupported_model",
-            "The configured Ask Dev model is unavailable to this provider account.",
-        )
-    if safe_error_code == "invalid_request":
-        return (
-            "unsupported_model",
-            "The configured Ask Dev model rejected a required agent request capability.",
-        )
-    if safe_error_code == "invalid_response":
-        return (
-            "unsupported_model",
-            "The configured model did not satisfy the Ask Dev agent capability contract.",
-        )
-    if safe_error_code == "provider_contract_violation":
-        return (
-            "unsupported_model",
-            "The configured model returned multiple tool decisions in one turn, "
-            "violating Ask Dev's required sequential tool-call contract.",
-        )
-    if safe_error_code == "provider_unavailable":
-        return "degraded", "The configured Ask Dev model endpoint is unavailable."
-    return "degraded", "The configured Ask Dev model failed readiness."
-
-
 async def _admin_response(
     session: AsyncSession,
     *,
@@ -360,6 +338,14 @@ async def _admin_response(
             provider_label = resolution.provider_label
             model_label = resolution.model_label
             provider_source = resolution.source.value
+            if provider_source == "platform":
+                # Platform's own certification lives in the platform-global
+                # scope -- only Platform Admin can trigger it (CHAOS-3265).
+                # Re-read from there so an org relying on platform fallback
+                # reflects the ACTUAL platform certification state, not a
+                # stale/absent org-scoped record this org can no longer
+                # produce.
+                readiness_record = await _platform_readiness_store(session).load()
             if readiness_record is None:
                 readiness = "stale_readiness"
                 failure_reason = "The configured Ask Dev model has not been certified."
@@ -377,7 +363,7 @@ async def _admin_response(
                 and readiness_record.readiness_version == READINESS_VERSION
                 and readiness_record.outcome is AgentReadinessOutcome.FAILED
             ):
-                readiness, failure_reason = _failed_readiness_state(
+                readiness, failure_reason = readiness_failure_state(
                     readiness_record.safe_error_code
                 )
             else:
@@ -400,7 +386,25 @@ async def _admin_response(
                 try:
                     await resolution.provider.aclose()
                 except Exception:
-                    pass
+                    # Best-effort cleanup only: the readiness state above is
+                    # already finalized, so a transport-close error here must
+                    # never mask that outcome or fail this request. Still
+                    # worth knowing about (a leaked connection is an
+                    # operational signal), so log it rather than swallow it.
+                    logger.warning(
+                        "Failed to close Ask Dev provider connection after readiness check",
+                        exc_info=True,
+                    )
+
+    if provider_source == "platform":
+        # This organization's admin surface must never expose the
+        # platform-owned provider's identity or its platform-specific
+        # failure reason (that belongs to Platform Admin) -- CHAOS-3265.
+        provider_label = None
+        model_label = None
+        provider_source = None
+        if readiness != "ready":
+            failure_reason = _PLATFORM_GENERIC_UNAVAILABLE_MESSAGE
 
     available = entitled and not policy.emergency_disabled and readiness == "ready"
     limits = DevAdmissionLimits()
@@ -461,7 +465,10 @@ async def update_ask_dev_admin_settings(
     org_id: str = Depends(get_admin_org_id),
     user: AuthenticatedUser = Depends(get_admin_user),
 ) -> AskDevAdminResponse:
-    _block_impersonated_write(user)
+    block_impersonated_write(
+        user,
+        detail="Ask Dev administrative actions are unavailable while impersonating",
+    )
     settings = SettingsService(session, org_id)
     category = SettingCategory.ASK_DEV.value
     if payload.retention_days is not None:
@@ -521,50 +528,38 @@ async def update_ask_dev_admin_settings(
     return await _admin_response(session, org_id=org_id)
 
 
-@router.post("/ask-dev/readiness", response_model=AskDevAdminResponse)
+@router.post("/ask-dev/readiness", status_code=410)
 async def run_ask_dev_readiness(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
     user: AuthenticatedUser = Depends(get_admin_user),
-) -> AskDevAdminResponse:
-    _block_impersonated_write(user)
-    policy = await load_ask_dev_org_policy(SettingsService(session, org_id))
-    entitlement_state, entitled, _ = await _feature_state(session, org_id)
-    if not entitled or policy.emergency_disabled:
-        reason = (
-            "the organization emergency disable is active"
-            if policy.emergency_disabled
-            else entitlement_state
+) -> dict[str, str]:
+    """Deprecated: platform certification no longer runs through this route.
+
+    CHAOS-3265 closed the bug where an org admin could trigger and observe
+    certification of the PLATFORM-owned provider through this org-scoped
+    endpoint. Platform certification now lives exclusively behind
+    ``POST /platform/ask-dev/readiness`` (superuser-only, Platform Admin),
+    and BYO's own preflight now lives at ``POST /llm-settings/readiness``.
+
+    The route is kept registered -- rather than deleted outright -- purely
+    for rolling-deploy safety: an already-deployed older web frontend may
+    still call this route before its paired frontend change deploys. It
+    intentionally executes NO certification logic and touches no readiness
+    store at all; it only returns a static, generic 410 response. This is
+    what actually closes the privilege-escalation bug -- there is no code
+    path left under this route that resolves or certifies any provider.
+    Full route deletion can happen in a follow-up ticket once rollout of
+    both the ops and web changes is confirmed complete.
+    """
+
+    del session, org_id, user  # deliberately unused: no logic may run here
+    return {
+        "detail": (
+            "Platform preflight has moved to Platform Admin. "
+            "Use BYO LLM settings for BYO preflight."
         )
-        raise HTTPException(
-            status_code=403,
-            detail=f"Ask Dev readiness cannot run while {reason}",
-        )
-    try:
-        resolution = await resolve_certification_provider(session, org_id=org_id)
-    except DevRuntimeUnavailable:
-        return await _admin_response(session, org_id=org_id)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=503,
-            detail="Ask Dev readiness is temporarily unavailable",
-        ) from exc
-    try:
-        await AgentReadinessService(
-            SettingsAgentReadinessStore(SettingsService(session, org_id)),
-            org_id=org_id,
-        ).certify(
-            resolution.provider,
-            provider_name=resolution.family,
-            model=resolution.model,
-            fingerprint=resolution.readiness_fingerprint,
-        )
-    finally:
-        try:
-            await resolution.provider.aclose()
-        except Exception:
-            pass
-    return await _admin_response(session, org_id=org_id)
+    }
 
 
 @router.get("/ask-dev/usage", response_model=AskDevAdminUsageResponse)

--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -1,0 +1,220 @@
+"""Platform-administrator controls for the platform-owned Ask Dev provider.
+
+CHAOS-3265: previously, an org admin could trigger and observe certification
+of the PLATFORM-owned (operator env-configured) LLM provider through the
+org-scoped ``/admin/ask-dev`` surface. This router gives Platform Admin its
+own, superuser-only surface for that -- it never reads or writes any
+organization's settings, DevRun rows, or Ask Dev policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import AwareDatetime, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import (
+    block_impersonated_write,
+    require_superuser,
+)
+from dev_health_ops.api.dev.production_runtime import (
+    resolve_platform_certification_provider,
+)
+from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
+    AgentReadinessOutcome,
+    AgentReadinessService,
+    ReadinessState,
+    SettingsAgentReadinessStore,
+    readiness_failure_state,
+)
+
+from .ask_dev import StrictAdminModel, _checked_at
+from .common import get_session
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class PlatformAskDevReadinessResponse(StrictAdminModel):
+    schema_version: Literal["platform_ask_dev_readiness.v1"] = (
+        "platform_ask_dev_readiness.v1"
+    )
+    configured: bool
+    provider_label: str | None = Field(default=None, max_length=256)
+    model_label: str | None = Field(default=None, max_length=256)
+    readiness: ReadinessState
+    readiness_checked_at: AwareDatetime | None = None
+    readiness_version: str | None = Field(default=None, max_length=128)
+    safe_remediation: str | None = Field(default=None, max_length=2_048)
+
+
+def _platform_store(session: AsyncSession) -> SettingsAgentReadinessStore:
+    # The platform-owned provider's readiness record is scoped by the
+    # ``org_id=""`` sentinel: every real org's org_id is a non-empty UUID
+    # string enforced at the admin-auth boundary (get_admin_org_id 403s on a
+    # falsy org_id), so "" can never collide with a real org's rows. This
+    # store always explicitly writes/reads org_id="" -- see
+    # dev_health_ops.llm.agent.readiness for the full rationale, including
+    # why the `settings` table's column default is irrelevant here.
+    #
+    # Belt-and-suspenders: this ALSO uses a setting key
+    # (PLATFORM_READINESS_SETTING_KEY) distinct from the ordinary per-org
+    # "ask_dev_agent_readiness" key, so even a stray/buggy write that somehow
+    # landed with an empty org_id under the ordinary key would still be
+    # invisible to this store (CHAOS-3265).
+    return SettingsAgentReadinessStore(
+        SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+        key=PLATFORM_READINESS_SETTING_KEY,
+    )
+
+
+async def _platform_readiness_response(
+    session: AsyncSession,
+) -> PlatformAskDevReadinessResponse:
+    store = _platform_store(session)
+    readiness_record = await store.load()
+    try:
+        resolution = await resolve_platform_certification_provider()
+    except DevRuntimeUnavailable as exc:
+        readiness: ReadinessState = (
+            "unsupported_model"
+            if exc.code == "model_not_supported"
+            else "missing_credentials"
+        )
+        return PlatformAskDevReadinessResponse(
+            configured=False,
+            provider_label=None,
+            model_label=None,
+            readiness=readiness,
+            readiness_checked_at=(
+                _checked_at(readiness_record.checked_at) if readiness_record else None
+            ),
+            readiness_version=(
+                readiness_record.readiness_version
+                if readiness_record
+                else READINESS_VERSION
+            ),
+            safe_remediation=exc.safe_message,
+        )
+    try:
+        readiness_state: ReadinessState
+        safe_remediation: str | None
+        if readiness_record is None:
+            readiness_state = "stale_readiness"
+            safe_remediation = "The platform Ask Dev model has not been certified."
+        elif readiness_record.is_current(
+            fingerprint=resolution.readiness_fingerprint,
+            readiness_version=READINESS_VERSION,
+        ):
+            if os.getenv("JWT_SECRET_KEY"):
+                readiness_state = "ready"
+                safe_remediation = None
+            else:
+                readiness_state = "degraded"
+                safe_remediation = "Ask Dev evidence signing is unavailable."
+        elif (
+            readiness_record.fingerprint == resolution.readiness_fingerprint
+            and readiness_record.readiness_version == READINESS_VERSION
+            and readiness_record.outcome is AgentReadinessOutcome.FAILED
+        ):
+            readiness_state, safe_remediation = readiness_failure_state(
+                readiness_record.safe_error_code
+            )
+        else:
+            # Covers both a config/fingerprint change since the last check
+            # AND a READINESS_VERSION bump (e.g. CHAOS-3254) invalidating
+            # every stored certification platform-wide. Never reused as
+            # "ready", and never phrased as if something is broken -- nothing
+            # is; it just hasn't been certified under the current
+            # requirements yet.
+            readiness_state = "stale_readiness"
+            safe_remediation = (
+                "This configuration has not been certified under the current "
+                "readiness requirements. Run preflight again."
+            )
+        return PlatformAskDevReadinessResponse(
+            configured=True,
+            provider_label=resolution.provider_label,
+            model_label=resolution.model_label,
+            readiness=readiness_state,
+            readiness_checked_at=(
+                _checked_at(readiness_record.checked_at) if readiness_record else None
+            ),
+            readiness_version=(
+                readiness_record.readiness_version
+                if readiness_record
+                else READINESS_VERSION
+            ),
+            safe_remediation=safe_remediation,
+        )
+    finally:
+        try:
+            await resolution.provider.aclose()
+        except Exception:
+            pass
+
+
+@router.get(
+    "/platform/ask-dev/readiness",
+    response_model=PlatformAskDevReadinessResponse,
+)
+async def get_platform_ask_dev_readiness(
+    session: AsyncSession = Depends(get_session),
+    _current_user: AuthenticatedUser = Depends(require_superuser),
+) -> PlatformAskDevReadinessResponse:
+    return await _platform_readiness_response(session)
+
+
+@router.post(
+    "/platform/ask-dev/readiness",
+    response_model=PlatformAskDevReadinessResponse,
+)
+async def run_platform_ask_dev_readiness(
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(require_superuser),
+) -> PlatformAskDevReadinessResponse:
+    # Defense in depth: this route takes no org_id at all and impersonation
+    # is otherwise scoped to org-admin actions, so a superuser session
+    # created via impersonation should not realistically be able to reach
+    # here impersonating anyone. We still block it: platform certification
+    # is a platform-operator action and must always run under the
+    # superuser's own, non-impersonated identity (CHAOS-3265).
+    block_impersonated_write(
+        current_user,
+        detail="Platform Ask Dev administrative actions are unavailable while impersonating",
+    )
+    try:
+        resolution = await resolve_platform_certification_provider()
+    except DevRuntimeUnavailable:
+        return await _platform_readiness_response(session)
+    try:
+        await AgentReadinessService(_platform_store(session)).certify(
+            resolution.provider,
+            provider_name=resolution.family,
+            model=resolution.model,
+            fingerprint=resolution.readiness_fingerprint,
+        )
+    finally:
+        try:
+            await resolution.provider.aclose()
+        except Exception:
+            # Best-effort cleanup only: the certify() call above has already
+            # persisted the readiness result (or its own failure state), so a
+            # transport-close error here must never mask that outcome or fail
+            # this request. Still worth knowing about (a leaked connection is
+            # an operational signal), so log it rather than swallow it.
+            logger.warning(
+                "Failed to close platform Ask Dev provider connection after preflight",
+                exc_info=True,
+            )
+    return await _platform_readiness_response(session)

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterator
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +20,11 @@ from dev_health_ops.api.admin.llm_settings import (
 from dev_health_ops.api.admin.llm_settings import (
     upsert_llm_settings as upsert_llm_settings_values,
 )
-from dev_health_ops.api.admin.middleware import get_admin_org_id, get_admin_user
+from dev_health_ops.api.admin.middleware import (
+    block_impersonated_write,
+    get_admin_org_id,
+    get_admin_user,
+)
 from dev_health_ops.api.admin.schemas import (
     LLMBudgetResponse,
     LLMSettingsResponse,
@@ -30,9 +36,22 @@ from dev_health_ops.api.admin.schemas import (
     SettingsListResponse,
     SettingUpdate,
 )
+from dev_health_ops.api.dev.production_runtime import (
+    _byo_candidate,
+    _readiness_fingerprint,
+    resolve_byo_certification_provider,
+)
+from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.db import require_clickhouse_uri
+from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
+from dev_health_ops.llm.agent.readiness import (
+    AgentReadinessOutcome,
+    AgentReadinessService,
+    SettingsAgentReadinessStore,
+    readiness_failure_state,
+)
 from dev_health_ops.llm.budget import BUDGET_CATEGORY, get_budget_status
 from dev_health_ops.llm.credentials import (
     evaluate_org_llm_status,
@@ -43,9 +62,11 @@ from dev_health_ops.metrics.schemas import LLMTokenSpendSummaryRecord
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.models.settings import SettingCategory
 
+from .ask_dev import _checked_at
 from .common import get_session
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 LLMSpendReader = Callable[..., LLMTokenSpendSummaryRecord | None]
 
@@ -140,6 +161,71 @@ async def get_llm_settings(
     return await get_llm_settings_response(svc)
 
 
+async def _llm_settings_status_response(
+    session: AsyncSession, org_id: str
+) -> LLMSettingsStatusResponse:
+    svc = SettingsService(session, org_id)
+    evaluation = await evaluate_org_llm_status(org_id, svc)
+    last_fallback_at = await latest_recent_org_byo_base_url_fallback_at(
+        session, org_id, evaluation
+    )
+    # This org-scoped "ask_dev_agent_readiness" slot is BYO's alone in
+    # practice going forward: the platform-owned provider's own readiness now
+    # lives in the org_id="" sentinel scope (see
+    # dev_health_ops.llm.agent.readiness), reachable only from the Platform
+    # Admin router. Any record found here can only have been written by this
+    # org's own BYO preflight (POST /llm-settings/readiness) -- fingerprints
+    # differ by candidate/source so a stray platform certification could
+    # never collide with it even before this migration.
+    #
+    # A record's outcome is only trusted as "ready"/"failed" when its
+    # fingerprint AND readiness_version still match the org's CURRENT BYO
+    # candidate -- exactly the same currency check ask_dev.py's
+    # _admin_response uses (record.is_current(...)). A stale record (the org
+    # edited its BYO config since the last check, OR a READINESS_VERSION bump
+    # invalidated every stored certification platform-wide, e.g. CHAOS-3254)
+    # reports "stale" with a safe, accurate remediation -- never silently
+    # reused as "ready", and never reported as if something is broken.
+    readiness_record = await SettingsAgentReadinessStore(svc).load()
+    readiness: Literal["ready", "failed", "stale", "never_checked"] = "never_checked"
+    readiness_checked_at: datetime | None = None
+    readiness_safe_failure_reason: str | None = None
+    if readiness_record is not None:
+        readiness_checked_at = _checked_at(readiness_record.checked_at)
+        current_byo = await _byo_candidate(svc, readiness=None, certification=True)
+        current_fingerprint = (
+            _readiness_fingerprint(current_byo) if current_byo is not None else None
+        )
+        is_current = (
+            current_fingerprint is not None
+            and readiness_record.fingerprint == current_fingerprint
+            and readiness_record.readiness_version == READINESS_VERSION
+        )
+        if not is_current:
+            readiness = "stale"
+            readiness_safe_failure_reason = (
+                "This configuration has not been certified under the current "
+                "readiness requirements. Run preflight again."
+            )
+        elif readiness_record.outcome is AgentReadinessOutcome.READY:
+            readiness = "ready"
+        else:
+            readiness = "failed"
+            _, readiness_safe_failure_reason = readiness_failure_state(
+                readiness_record.safe_error_code
+            )
+    return LLMSettingsStatusResponse(
+        configured=evaluation.configured,
+        active=evaluation.active,
+        degraded=evaluation.reason_code == "invalid_base_url",
+        reason_code=evaluation.reason_code,
+        last_fallback_at=last_fallback_at,
+        readiness=readiness,
+        readiness_checked_at=readiness_checked_at,
+        readiness_safe_failure_reason=readiness_safe_failure_reason,
+    )
+
+
 @router.get(
     "/llm-settings/status",
     response_model=LLMSettingsStatusResponse,
@@ -149,18 +235,92 @@ async def get_llm_settings_status(
     org_id: str = Depends(get_admin_org_id),
 ) -> LLMSettingsStatusResponse:
     await _require_byo_llm_tier(session, org_id)
-    svc = SettingsService(session, org_id)
-    evaluation = await evaluate_org_llm_status(org_id, svc)
-    last_fallback_at = await latest_recent_org_byo_base_url_fallback_at(
-        session, org_id, evaluation
+    return await _llm_settings_status_response(session, org_id)
+
+
+@router.post(
+    "/llm-settings/readiness",
+    response_model=LLMSettingsStatusResponse,
+)
+async def run_llm_settings_readiness(
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> LLMSettingsStatusResponse:
+    """Certify the org's OWN saved BYO LLM configuration.
+
+    TRIGGERING this check is independent of Ask Dev's provider-selection
+    arbitration: it runs based on BYO configuration being saved, regardless
+    of whether BYO currently wins Ask Dev's fallback arbitration, whether it
+    has ever been certified before, or whether Ask Dev itself is
+    enabled/entitled. It never touches DevRun, Ask Dev's platform-allowance
+    tables, or Ask Dev's entitlement/emergency-disabled checks, and it never
+    reads or writes Ask Dev's fallback POLICY (fail_closed vs platform).
+
+    It DOES write to the same per-org readiness slot
+    (``SettingsAgentReadinessStore``, category=llm, key=ask_dev_agent_readiness)
+    that ``resolve_production_provider`` reads to decide whether the BYO
+    candidate is "current" (see production_runtime._provider_candidates). That
+    is intentional, not a side channel: marking BYO's own credentials as
+    certified is precisely what makes BYO usable/selectable for subsequent
+    LIVE Ask Dev runs (real chat execution, and the ordinary end-user
+    `/dev/capabilities` projection) -- that's the entire point of a preflight
+    check. A SUCCESSFUL run here can therefore change which provider a later
+    live run resolves to (e.g. flip it from platform-fallback to BYO), exactly
+    as running the org's old, now-removed certify flow always did.
+
+    NOTE this does NOT affect the org-admin `GET /ask-dev` projection's
+    `provider_source`/`readiness` fields: that route resolves via
+    ``resolve_certification_provider`` (certification bypass, see
+    production_runtime.py), which already prefers a validly-shaped BYO
+    candidate over platform as soon as BYO settings are saved and complete --
+    independent of whether it has ever been certified. Only the LIVE
+    selection path (`resolve_production_provider`) is gated on certification
+    currency, and that is the path this endpoint's write affects.
+
+    What changed under CHAOS-3265 is only WHO can reach platform's own
+    certification (Platform Admin only) and WHERE that lives -- not this
+    BYO-certifies-BYO mechanic, which is unchanged and working as designed
+    (CHAOS-3265; see test_llm_settings_readiness_can_flip_ask_dev_selection_to_byo
+    for a test that proves this honestly against the real, unmocked live
+    resolver instead of masking it).
+    """
+
+    await _require_byo_llm_tier(session, org_id)
+    block_impersonated_write(
+        current_user,
+        detail={
+            "error": "impersonated_write_forbidden",
+            "message": "BYO LLM readiness checks are unavailable while impersonating",
+        },
     )
-    return LLMSettingsStatusResponse(
-        configured=evaluation.configured,
-        active=evaluation.active,
-        degraded=evaluation.reason_code == "invalid_base_url",
-        reason_code=evaluation.reason_code,
-        last_fallback_at=last_fallback_at,
-    )
+    try:
+        resolution = await resolve_byo_certification_provider(session, org_id=org_id)
+    except DevRuntimeUnavailable as exc:
+        raise HTTPException(status_code=404, detail=exc.safe_message) from exc
+    try:
+        await AgentReadinessService(
+            SettingsAgentReadinessStore(SettingsService(session, org_id))
+        ).certify(
+            resolution.provider,
+            provider_name=resolution.family,
+            model=resolution.model,
+            fingerprint=resolution.readiness_fingerprint,
+        )
+    finally:
+        try:
+            await resolution.provider.aclose()
+        except Exception:
+            # Best-effort cleanup only: the certify() call above has already
+            # persisted the readiness result (or its own failure state), so a
+            # transport-close error here must never mask that outcome or fail
+            # this request. Still worth knowing about (a leaked connection is
+            # an operational signal), so log it rather than swallow it.
+            logger.warning(
+                "Failed to close BYO Ask Dev provider connection after preflight",
+                exc_info=True,
+            )
+    return await _llm_settings_status_response(session, org_id)
 
 
 @router.get(

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
 
 
 class SettingResponse(BaseModel):
@@ -73,6 +73,9 @@ class LLMSettingsStatusResponse(BaseModel):
         "active",
     ]
     last_fallback_at: datetime | None = None
+    readiness: Literal["ready", "failed", "stale", "never_checked"] = "never_checked"
+    readiness_checked_at: AwareDatetime | None = None
+    readiness_safe_failure_reason: str | None = None
 
 
 class LLMSettingsUpsert(BaseModel):

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -27,7 +27,11 @@ from dev_health_ops.llm.agent.policy import (
     AgentProviderSource,
     resolve_agent_provider_selection,
 )
-from dev_health_ops.llm.agent.readiness import SettingsAgentReadinessStore
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
+    SettingsAgentReadinessStore,
+)
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.budget import attach_agent_budget_guard
 from dev_health_ops.llm.credentials import LLMCredentials, resolve_llm_credentials
@@ -187,13 +191,35 @@ def _acceptance_openai_configuration() -> _AcceptanceOpenAIConfiguration | None:
     return _AcceptanceOpenAIConfiguration(api_key=api_key, base_url=base_url)
 
 
+def _platform_readiness_store(session: AsyncSession) -> SettingsAgentReadinessStore:
+    """Readiness store for the platform-owned (operator env-configured) provider.
+
+    Deliberately scoped by the ``org_id=""`` sentinel and a setting key
+    distinct from the ordinary per-org ``ask_dev_agent_readiness`` slot (see
+    ``dev_health_ops.llm.agent.readiness`` for the full rationale). Only the
+    Platform Admin router ever writes here; every organization's production
+    selection just reads it to learn whether the platform candidate is
+    currently certified (CHAOS-3265).
+    """
+
+    return SettingsAgentReadinessStore(
+        SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+        key=PLATFORM_READINESS_SETTING_KEY,
+    )
+
+
 async def resolve_production_provider(
     session: AsyncSession, *, org_id: str
 ) -> ProductionProviderResolution:
     settings = SettingsService(session, org_id)
-    readiness = await SettingsAgentReadinessStore(settings).load()
+    byo_readiness = await SettingsAgentReadinessStore(settings).load()
+    platform_readiness = await _platform_readiness_store(session).load()
 
-    byo, platform, policy = await _provider_candidates(settings, readiness=readiness)
+    byo, platform, policy = await _provider_candidates(
+        settings,
+        byo_readiness=byo_readiness,
+        platform_readiness=platform_readiness,
+    )
     return _resolve_provider_selection(
         byo=byo,
         platform=platform,
@@ -210,7 +236,7 @@ async def resolve_certification_provider(
 
     settings = SettingsService(session, org_id)
     byo, platform, policy = await _provider_candidates(
-        settings, readiness=None, certification=True
+        settings, byo_readiness=None, platform_readiness=None, certification=True
     )
     return _resolve_provider_selection(
         byo=byo,
@@ -221,17 +247,94 @@ async def resolve_certification_provider(
     )
 
 
-async def _provider_candidates(
+async def resolve_platform_certification_provider() -> ProductionProviderResolution:
+    """Resolve ONLY the platform-owned candidate, with no BYO arbitration.
+
+    Used exclusively by the Platform Admin readiness route. This never reads
+    any organization's settings -- the platform candidate is built purely
+    from operator environment variables -- so there is nothing to arbitrate
+    against a BYO candidate (CHAOS-3265).
+    """
+
+    platform, platform_provider_name = _platform_candidate(
+        readiness=None, certification=True
+    )
+    if platform is None or platform_provider_name == "none":
+        raise DevRuntimeUnavailable(
+            "provider_not_configured", "No certified Ask Dev model is ready."
+        )
+    if platform.usable:
+        provider = _provider(platform)
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.PLATFORM,
+            family=platform.provider,
+            model=platform.model,
+            provider_label="OpenAI compatible",
+            model_label=platform.model.replace("\r", "").replace("\n", "")[:256],
+            readiness_fingerprint=_readiness_fingerprint(platform),
+        )
+    if not platform.certified:
+        raise DevRuntimeUnavailable(
+            "model_not_supported", "The configured Ask Dev model is not supported."
+        )
+    raise DevRuntimeUnavailable(
+        "provider_not_configured", "No certified Ask Dev model is ready."
+    )
+
+
+async def resolve_byo_certification_provider(
+    session: AsyncSession, *, org_id: str
+) -> ProductionProviderResolution:
+    """Resolve ONLY the org's own BYO candidate, with no platform fallback.
+
+    This tests the organization's saved LLM credentials specifically,
+    independent of whether BYO currently wins Ask Dev's provider-selection
+    arbitration (CHAOS-3265).
+    """
+
+    settings = SettingsService(session, org_id)
+    byo = await _byo_candidate(settings, readiness=None, certification=True)
+    if byo is None:
+        raise DevRuntimeUnavailable(
+            "provider_not_configured",
+            "No BYO LLM configuration is saved for this organization.",
+        )
+    if byo.usable:
+        provider = _provider(byo)
+        provider = attach_agent_budget_guard(
+            provider,
+            session=session,
+            org_id=org_id,
+            provider=byo.provider,
+            model=byo.model,
+            base_url=byo.credentials.base_url or None,
+        )
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.BYO,
+            family=byo.provider,
+            model=byo.model,
+            provider_label="OpenAI compatible",
+            model_label=byo.model.replace("\r", "").replace("\n", "")[:256],
+            readiness_fingerprint=_readiness_fingerprint(byo),
+        )
+    if not byo.certified:
+        raise DevRuntimeUnavailable(
+            "model_not_supported", "The configured Ask Dev model is not supported."
+        )
+    raise DevRuntimeUnavailable(
+        "provider_not_configured",
+        "No BYO LLM configuration is saved for this organization.",
+    )
+
+
+async def _byo_candidate(
     settings: SettingsService,
     *,
     readiness: Any,
     certification: bool = False,
-) -> tuple[
-    AgentProviderCandidate | None,
-    AgentProviderCandidate | None,
-    AgentProviderPolicy,
-]:
-
+) -> AgentProviderCandidate | None:
     byo_provider_name = (await settings.get("provider", _LLM_CATEGORY) or "").strip()
     byo_model = (await settings.get("model", _LLM_CATEGORY) or "").strip()
     if byo_provider_name == "openai" and not byo_model:
@@ -240,7 +343,7 @@ async def _provider_candidates(
         api_key=await settings.get("api_key", _LLM_CATEGORY) or "",
         base_url=await settings.get("base_url", _LLM_CATEGORY) or "",
     )
-    byo = _candidate(
+    return _candidate(
         provider_name=byo_provider_name,
         model=byo_model,
         credentials=byo_credentials,
@@ -248,6 +351,19 @@ async def _provider_candidates(
         readiness=readiness,
         certification=certification,
     )
+
+
+def _platform_candidate(
+    *,
+    readiness: Any,
+    certification: bool = False,
+) -> tuple[AgentProviderCandidate | None, str]:
+    """Build the platform candidate purely from operator environment state.
+
+    Returns the candidate together with the raw resolved provider name (the
+    caller needs the raw name to detect an explicit operator "none" and to
+    build ``AgentProviderPolicy.llm_globally_disabled``).
+    """
 
     acceptance = _acceptance_openai_configuration()
     try:
@@ -281,6 +397,26 @@ async def _provider_candidates(
         readiness=readiness,
         certification=certification,
         acceptance=acceptance is not None,
+    )
+    return platform, platform_provider_name
+
+
+async def _provider_candidates(
+    settings: SettingsService,
+    *,
+    byo_readiness: Any,
+    platform_readiness: Any,
+    certification: bool = False,
+) -> tuple[
+    AgentProviderCandidate | None,
+    AgentProviderCandidate | None,
+    AgentProviderPolicy,
+]:
+    byo = await _byo_candidate(
+        settings, readiness=byo_readiness, certification=certification
+    )
+    platform, platform_provider_name = _platform_candidate(
+        readiness=platform_readiness, certification=certification
     )
     org_policy = await load_ask_dev_org_policy(settings)
     policy = AgentProviderPolicy(
@@ -899,5 +1035,8 @@ __all__ = [
     "ProductionProviderResolution",
     "build_production_runtime",
     "expand_production_evidence",
+    "resolve_byo_certification_provider",
+    "resolve_certification_provider",
+    "resolve_platform_certification_provider",
     "resolve_production_provider",
 ]

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Protocol
+from typing import Literal, Protocol
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
@@ -32,6 +32,37 @@ from .errors import (
 
 READINESS_SETTING_KEY = "ask_dev_agent_readiness"
 READINESS_MAX_OUTPUT_TOKENS = 512
+
+# Sentinel scope for the platform-owned (operator env-configured) provider's
+# readiness record. Every real org's org_id is a non-empty UUID string
+# (enforced at the admin-auth boundary by ``get_admin_org_id``), so "" can
+# never collide with a real org's settings rows (CHAOS-3265). This store
+# always explicitly writes/reads org_id="" -- it never relies on whatever the
+# `settings` table's column default happens to resolve to. (Note: the
+# SQLAlchemy model in models/settings.py declares
+# ``server_default=""``, but the deployed migration
+# (0001_initial_schema.py) actually creates the column with
+# ``server_default="default"`` -- a pre-existing, unrelated drift between the
+# ORM model and the live schema. Irrelevant here since org_id is always
+# supplied explicitly, never omitted at insert time.)
+#
+# Belt-and-suspenders: the platform record ALSO uses a setting key distinct
+# from the ordinary per-org ``READINESS_SETTING_KEY``. That way, even if some
+# unrelated bug elsewhere ever wrote a stray row with an empty org_id under
+# the *ordinary* key (a known failure mode in this codebase family), it would
+# still be invisible here -- only the dedicated Platform Admin route ever
+# reads or writes ``PLATFORM_READINESS_SETTING_KEY``.
+PLATFORM_SETTINGS_ORG_ID = ""
+PLATFORM_READINESS_SETTING_KEY = "platform_ask_dev_agent_readiness"
+
+ReadinessState = Literal[
+    "ready",
+    "unsupported_model",
+    "missing_credentials",
+    "disabled",
+    "degraded",
+    "stale_readiness",
+]
 
 
 class AgentReadinessOutcome(str, Enum):
@@ -62,13 +93,12 @@ class AgentReadinessStore(Protocol):
 
 
 class SettingsAgentReadinessStore:
-    def __init__(self, settings: SettingsService):
+    def __init__(self, settings: SettingsService, *, key: str = READINESS_SETTING_KEY):
         self._settings = settings
+        self._key = key
 
     async def load(self) -> AgentReadinessRecord | None:
-        raw = await self._settings.get(
-            READINESS_SETTING_KEY, category=SettingCategory.LLM.value
-        )
+        raw = await self._settings.get(self._key, category=SettingCategory.LLM.value)
         if not raw:
             return None
         try:
@@ -91,7 +121,7 @@ class SettingsAgentReadinessStore:
         payload = asdict(record)
         payload["outcome"] = record.outcome.value
         await self._settings.set(
-            READINESS_SETTING_KEY,
+            self._key,
             json.dumps(payload, separators=(",", ":"), sort_keys=True),
             category=SettingCategory.LLM.value,
             description="Safe Ask Dev provider certification result",
@@ -227,6 +257,49 @@ class AgentReadinessService:
                 calls=2,
             )
         return record
+
+
+def readiness_failure_state(safe_error_code: str | None) -> tuple[ReadinessState, str]:
+    """Map a safe provider error code to an admin-facing readiness state.
+
+    Shared by the org-admin Ask Dev router and the Platform Admin router so
+    both project the exact same safe, non-identifying remediation text for a
+    failed certification (CHAOS-3265).
+    """
+
+    if safe_error_code == "provider_not_configured":
+        return (
+            "missing_credentials",
+            "Ask Dev could not authenticate with the configured model endpoint.",
+        )
+    if safe_error_code == "timeout":
+        return "degraded", "The configured Ask Dev model timed out during readiness."
+    if safe_error_code == "rate_limited":
+        return "degraded", "The configured Ask Dev model rate limit was reached."
+    if safe_error_code == "model_not_supported":
+        return (
+            "unsupported_model",
+            "The configured Ask Dev model is unavailable to this provider account.",
+        )
+    if safe_error_code == "invalid_request":
+        return (
+            "unsupported_model",
+            "The configured Ask Dev model rejected a required agent request capability.",
+        )
+    if safe_error_code == "invalid_response":
+        return (
+            "unsupported_model",
+            "The configured model did not satisfy the Ask Dev agent capability contract.",
+        )
+    if safe_error_code == "provider_contract_violation":
+        return (
+            "unsupported_model",
+            "The configured model returned multiple tool decisions in one turn, "
+            "violating Ask Dev's required sequential tool-call contract.",
+        )
+    if safe_error_code == "provider_unavailable":
+        return "degraded", "The configured Ask Dev model endpoint is unavailable."
+    return "degraded", "The configured Ask Dev model failed readiness."
 
 
 def _add_usage(left: AgentUsage, right: AgentUsage) -> AgentUsage:

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -148,7 +148,9 @@ def test_readiness_bootstrap_uses_public_http_contracts() -> None:
     assert "/api/v1/auth/login" in prepare
     assert "/api/v1/admin/feature-flags" in prepare
     assert "/feature-overrides" in prepare
-    assert "/api/v1/admin/ask-dev/readiness" in prepare
+    # CHAOS-3265: platform certification now runs through the Platform Admin
+    # surface, not the org-scoped (now-410) /admin/ask-dev/readiness route.
+    assert "/api/v1/admin/platform/ask-dev/readiness" in prepare
     assert "/api/v1/dev/capabilities" in prepare
     assert "ask-dev-scripted-v1" in prepare
 
@@ -197,15 +199,16 @@ class _FakeAcceptanceApi:
             return []
         if path.endswith("/feature-overrides") and method == "POST":
             return {"is_enabled": True}
-        if path == "/api/v1/admin/ask-dev/readiness":
+        if path == "/api/v1/admin/platform/ask-dev/readiness":
             return {
-                "ask_dev_enabled": True,
-                "chat_window_available": True,
-                "full_page_available": True,
-                "provider_source": "platform",
+                "schema_version": "platform_ask_dev_readiness.v1",
+                "configured": True,
+                "provider_label": "OpenAI compatible",
+                "model_label": self.model,
                 "readiness": "ready",
-                "effective_model_label": self.model,
                 "readiness_checked_at": "2026-07-29T00:00:00+00:00",
+                "readiness_version": "v1",
+                "safe_remediation": None,
             }
         if path == "/api/v1/dev/capabilities":
             return {
@@ -235,7 +238,7 @@ def test_readiness_bootstrap_enables_all_features_and_proves_capabilities() -> N
         "id-ask_dev",
         "id-ask_dev_contextual_entrypoints",
     ]
-    assert api.calls[-2][1] == "/api/v1/admin/ask-dev/readiness"
+    assert api.calls[-2][1] == "/api/v1/admin/platform/ask-dev/readiness"
     assert api.calls[-1][1] == "/api/v1/dev/capabilities"
 
 

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -33,6 +33,14 @@ from dev_health_ops.llm.agent.contracts import (
 )
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
+    AgentReadinessOutcome,
+    AgentReadinessRecord,
+    SettingsAgentReadinessStore,
+    readiness_failure_state,
+)
 from dev_health_ops.models.dev_persistence import DevConversation, DevRun
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import Setting
@@ -181,13 +189,24 @@ async def admin_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context):
+async def test_admin_projection_nulls_platform_identity_until_platform_admin_certifies(
+    admin_context,
+):
+    """CHAOS-3265: the org-admin surface never learns the platform provider's
+    identity, and Platform Admin -- not this org -- is what makes it ready."""
+
     response = await admin_context.client.get("/api/v1/admin/ask-dev")
     assert response.status_code == 200
     body = response.json()
     assert body["readiness"] == "stale_readiness"
     assert body["chat_window_available"] is False
     assert body["full_page_available"] is False
+    assert body["effective_provider_label"] is None
+    assert body["effective_model_label"] is None
+    assert body["provider_source"] is None
+    assert body["administrator_safe_failure_reason"] == (
+        "Ask Dev is temporarily unavailable. Contact your platform operator."
+    )
     assert body["retention_options"] == [0, 30]
     assert body["fallback_options"] == ["fail_closed", "platform"]
     assert body["platform_allowance_bounds"] == {
@@ -198,12 +217,34 @@ async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context)
     }
     assert body["no_training_by_default"] is True
 
-    certified = await admin_context.client.post("/api/v1/admin/ask-dev/readiness")
+    # This org has no route left that can certify the platform provider.
+    # Simulate Platform Admin's route certifying it in the platform-global
+    # sentinel scope (org_id="", distinct key) -- the only place that
+    # certification can be written now.
+    async with admin_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await session.commit()
+
+    certified = await admin_context.client.get("/api/v1/admin/ask-dev")
     assert certified.status_code == 200
     certified_body = certified.json()
     assert certified_body["readiness"] == "ready"
     assert certified_body["chat_window_available"] is True
     assert certified_body["full_page_available"] is True
+    assert certified_body["effective_provider_label"] is None
+    assert certified_body["effective_model_label"] is None
+    assert certified_body["provider_source"] is None
+    assert certified_body["administrator_safe_failure_reason"] is None
     serialized = certified.text.lower()
     for forbidden in (
         "api_key",
@@ -212,8 +253,113 @@ async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context)
         "evidence",
         "packet",
         "conversation",
+        "openai compatible",
+        "safe-model",
     ):
         assert forbidden not in serialized
+
+
+@pytest.mark.asyncio
+async def test_byo_source_keeps_its_own_identity_and_failure_reason(
+    admin_context, monkeypatch: pytest.MonkeyPatch
+):
+    """The null-out is source-scoped: a BYO-sourced org still sees its own
+    identity and failure reason (it's the org's own data, not platform's)."""
+
+    async def byo_resolution(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=FakeReadinessProvider(),
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="org-model",
+            provider_label="OpenAI compatible",
+            model_label="org-model",
+            readiness_fingerprint="byo-readiness-fingerprint",
+        )
+
+    monkeypatch.setattr(ask_dev_admin, "resolve_certification_provider", byo_resolution)
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] == "stale_readiness"
+    assert body["effective_provider_label"] == "OpenAI compatible"
+    assert body["effective_model_label"] == "org-model"
+    assert body["provider_source"] == "byo"
+    assert body["administrator_safe_failure_reason"] == (
+        "The configured Ask Dev model has not been certified."
+    )
+
+    async with admin_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, str(admin_context.org_id))
+        ).save(
+            AgentReadinessRecord(
+                fingerprint="byo-readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await session.commit()
+
+    certified = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert certified.status_code == 200
+    certified_body = certified.json()
+    assert certified_body["readiness"] == "ready"
+    assert certified_body["effective_provider_label"] == "OpenAI compatible"
+    assert certified_body["effective_model_label"] == "org-model"
+    assert certified_body["provider_source"] == "byo"
+    assert certified_body["administrator_safe_failure_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_deprecated_post_readiness_route_is_410_and_touches_nothing(
+    admin_context, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3265: the deprecated org-scoped POST route runs NO certification
+    logic at all (kept only for rolling-deploy safety against an
+    already-deployed older web frontend)."""
+
+    def _must_not_resolve(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError(
+            "the deprecated /ask-dev/readiness route must never resolve a "
+            "certification provider"
+        )
+
+    monkeypatch.setattr(
+        ask_dev_admin, "resolve_certification_provider", _must_not_resolve
+    )
+
+    async def _setting_rows() -> list[tuple[str, str, str, str | None]]:
+        async with admin_context.maker() as session:
+            rows = (await session.execute(select(Setting))).scalars().all()
+            return [(s.org_id, s.category, s.key, s.value) for s in rows]
+
+    before = await _setting_rows()
+
+    # Even an impersonated, otherwise-emergency-disabled org admin still just
+    # gets the static 410 -- there is no code path left that runs anything.
+    admin_context.user.impersonated_by = str(uuid.uuid4())
+    response = await admin_context.client.post("/api/v1/admin/ask-dev/readiness")
+    assert response.status_code == 410
+    assert response.json() == {
+        "detail": (
+            "Platform preflight has moved to Platform Admin. "
+            "Use BYO LLM settings for BYO preflight."
+        )
+    }
+    serialized = response.text.lower()
+    for forbidden in (
+        "openai",
+        "provider_source",
+        "effective_provider_label",
+        "readiness",
+    ):
+        assert forbidden not in serialized
+
+    after = await _setting_rows()
+    assert before == after
 
 
 @pytest.mark.parametrize(
@@ -240,7 +386,7 @@ async def test_admin_projection_and_readiness_are_safe_and_shared(admin_context)
 def test_failed_readiness_exposes_only_specific_safe_remediation(
     safe_error_code: str, state: str, message: str
 ) -> None:
-    readiness, reason = ask_dev_admin._failed_readiness_state(safe_error_code)
+    readiness, reason = readiness_failure_state(safe_error_code)
 
     assert readiness == state
     assert message in reason
@@ -312,11 +458,10 @@ async def test_settings_are_bounded_preserve_byo_and_disable_both_surfaces(
     assert body["chat_window_available"] is False
     assert body["full_page_available"] is False
 
+    # The deprecated route no longer inspects entitlement/policy at all -- it
+    # is a static 410 regardless of the emergency-disable state.
     readiness = await admin_context.client.post("/api/v1/admin/ask-dev/readiness")
-    assert readiness.status_code == 403
-    assert readiness.json()["detail"] == (
-        "Ask Dev readiness cannot run while the organization emergency disable is active"
-    )
+    assert readiness.status_code == 410
 
     async with admin_context.maker() as session:
         stored = await session.scalar(
@@ -331,14 +476,14 @@ async def test_settings_are_bounded_preserve_byo_and_disable_both_surfaces(
 
 
 @pytest.mark.asyncio
-async def test_impersonation_blocks_settings_and_readiness(admin_context):
+async def test_impersonation_blocks_settings(admin_context):
     admin_context.user.impersonated_by = str(uuid.uuid4())
     settings = await admin_context.client.patch(
         "/api/v1/admin/ask-dev/settings", json={"retention_days": 0}
     )
-    readiness = await admin_context.client.post("/api/v1/admin/ask-dev/readiness")
     assert settings.status_code == 403
-    assert readiness.status_code == 403
+    # The deprecated readiness route has no logic left to block -- see
+    # test_deprecated_post_readiness_route_is_410_and_touches_nothing.
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -3,19 +3,40 @@ from __future__ import annotations
 import importlib
 import os
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.dev import production_runtime
+from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.api.services.auth import (
+    AuthenticatedUser,
+    _impersonation_ctx,
+    set_impersonation_context,
+)
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.core.encryption import decrypt_value
 from dev_health_ops.llm import credentials as llm_credentials
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentProviderCapabilities,
+    AgentToolRequest,
+    AgentUsage,
+    StreamingMode,
+    StructuredOutputMode,
+    ToolDecisionMode,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
+from dev_health_ops.llm.agent.policy import AgentProviderSource
 from dev_health_ops.llm.credentials import (
     BYO_LLM_BASE_URL_FALLBACK_ALERT_THRESHOLD,
     BYO_LLM_BASE_URL_FALLBACK_ALERT_WINDOW,
@@ -24,6 +45,7 @@ from dev_health_ops.llm.credentials import (
     resolve_llm_org_settings_credentials,
 )
 from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.dev_persistence import DevConversation, DevRun
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
 from dev_health_ops.models.llm_budget import BYOLLMBudgetReservation
@@ -35,6 +57,9 @@ os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+settings_router_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.settings"
+)
 
 _TABLES = tables_of(
     User,
@@ -45,7 +70,89 @@ _TABLES = tables_of(
     Setting,
     AuditLog,
     BYOLLMBudgetReservation,
+    DevConversation,
+    DevRun,
 )
+
+
+class FakeReadinessProvider:
+    """Echoes the readiness nonce successfully -- for the READY path."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.closed = False
+
+    @property
+    def capabilities(self) -> AgentProviderCapabilities:
+        return AgentProviderCapabilities(
+            structured_output=StructuredOutputMode.JSON_SCHEMA,
+            tool_decisions=ToolDecisionMode.NATIVE,
+            streaming=StreamingMode.BUFFERED,
+            supports_cancellation=True,
+            context_window_tokens=16_384,
+            max_output_tokens=1_024,
+            readiness_version=READINESS_VERSION,
+            disclosure_key="openai-compatible",
+        )
+
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        self.calls += 1
+        if self.calls == 1:
+            return AgentDecisionResult(
+                decision=AgentToolRequest(
+                    "readiness_echo", {"nonce": "ready-v1"}, "call-1"
+                ),
+                usage=AgentUsage(input_tokens=3, output_tokens=2),
+                latency_ms=1,
+                provider_fingerprint="provider",
+                model_fingerprint="model",
+            )
+        return AgentDecisionResult(
+            decision=AgentFinalAnswer(value={"nonce": "ready-v1"}),
+            usage=AgentUsage(input_tokens=4, output_tokens=1),
+            latency_ms=1,
+            provider_fingerprint="provider",
+            model_fingerprint="model",
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FailingReadinessProvider(FakeReadinessProvider):
+    """Always fails the readiness exchange -- for the FAILED path."""
+
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+
+async def _real_byo_fingerprint(session_maker, org_id: str) -> str:
+    """Compute the ACTUAL fingerprint production code would derive for this
+    org's currently-saved BYO settings, so tests that fake the certifying
+    provider still satisfy the currency check in
+    settings_router_module._llm_settings_status_response (readiness=ready/
+    failed requires the stored fingerprint to match the live BYO config)."""
+
+    async with session_maker() as session:
+        svc = SettingsService(session, org_id)
+        candidate = await production_runtime._byo_candidate(
+            svc, readiness=None, certification=True
+        )
+        assert candidate is not None
+        return production_runtime._readiness_fingerprint(candidate)
+
+
+async def _dev_run_count(session_maker, org_id: str) -> int:
+    async with session_maker() as session:
+        return int(
+            (
+                await session.execute(
+                    select(func.count(DevRun.id)).where(
+                        DevRun.org_id == uuid.UUID(org_id)
+                    )
+                )
+            ).scalar_one()
+        )
 
 
 @pytest_asyncio.fixture
@@ -296,6 +403,9 @@ async def test_admin_llm_settings_status_reports_unconfigured_valid_and_invalid_
             "degraded": False,
             "reason_code": "not_configured",
             "last_fallback_at": None,
+            "readiness": "never_checked",
+            "readiness_checked_at": None,
+            "readiness_safe_failure_reason": None,
         }
 
     await _set_llm_settings(session_maker, state["org_id"], base_url=None)
@@ -308,6 +418,9 @@ async def test_admin_llm_settings_status_reports_unconfigured_valid_and_invalid_
             "degraded": False,
             "reason_code": "active",
             "last_fallback_at": None,
+            "readiness": "never_checked",
+            "readiness_checked_at": None,
+            "readiness_safe_failure_reason": None,
         }
 
     await _set_llm_settings(
@@ -404,6 +517,9 @@ async def test_admin_llm_settings_status_ignores_stale_or_cross_org_fallback_row
         "degraded": False,
         "reason_code": "active",
         "last_fallback_at": None,
+        "readiness": "never_checked",
+        "readiness_checked_at": None,
+        "readiness_safe_failure_reason": None,
     }
     assert cross_org.status_code == 200
     assert cross_org.json() == {
@@ -412,6 +528,9 @@ async def test_admin_llm_settings_status_ignores_stale_or_cross_org_fallback_row
         "degraded": True,
         "reason_code": "invalid_base_url",
         "last_fallback_at": None,
+        "readiness": "never_checked",
+        "readiness_checked_at": None,
+        "readiness_safe_failure_reason": None,
     }
 
 
@@ -737,3 +856,452 @@ def test_resolve_provider_name_uses_org_settings_in_auto(monkeypatch):
     # auto without org context (and no env) fails loud rather than guessing
     with pytest.raises(LLMAuthError):
         resolve_provider_name("auto", org_id=None)
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_requires_byo_configuration(session_maker):
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == (
+        "No BYO LLM configuration is saved for this organization."
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_succeeds_independent_of_ask_dev_selection(
+    session_maker, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3265 acceptance criterion: BYO readiness is available based on
+    BYO configuration being set up, not on BYO currently being selected or
+    enabled for Ask Dev. Ask Dev is forced emergency-disabled here (so Ask
+    Dev's own provider_source resolves to None) and the BYO check must still
+    run -- and must not touch DevRun or change Ask Dev's selection."""
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    async with session_maker() as session:
+        await SettingsService(session, state["org_id"]).set(
+            "ask_dev_emergency_disabled",
+            "true",
+            SettingCategory.ASK_DEV.value,
+        )
+        await session.commit()
+
+    app = _make_app(session_maker, state)
+    provider = FakeReadinessProvider()
+    byo_fingerprint = await _real_byo_fingerprint(session_maker, state["org_id"])
+
+    async def fake_resolve_byo(_session, *, org_id: str):
+        assert org_id == state["org_id"]
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="gpt-5-mini",
+            provider_label="OpenAI compatible",
+            model_label="gpt-5-mini",
+            readiness_fingerprint=byo_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        settings_router_module, "resolve_byo_certification_provider", fake_resolve_byo
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        before = await ac.get("/api/v1/admin/ask-dev")
+        assert before.status_code == 200
+        before_source = before.json()["provider_source"]
+        assert before_source is None  # forced emergency-disabled above
+
+        before_dev_run_count = await _dev_run_count(session_maker, state["org_id"])
+
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["readiness"] == "ready"
+        assert body["readiness_checked_at"] is not None
+        assert body["readiness_safe_failure_reason"] is None
+        assert provider.closed is True
+
+        after_dev_run_count = await _dev_run_count(session_maker, state["org_id"])
+        assert before_dev_run_count == 0
+        assert after_dev_run_count == 0
+
+        after = await ac.get("/api/v1/admin/ask-dev")
+        assert after.status_code == 200
+        assert after.json()["provider_source"] == before_source
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_succeeds_and_logs_when_provider_close_fails(
+    session_maker, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """A transport-close failure after a successful certification must never
+    mask the readiness result the caller already committed (CHAOS-3265 /
+    CodeQL empty-except finding) -- and must be logged, not silently
+    swallowed. Deleting the try/except's log call (or reverting it to a bare
+    `pass`) makes this test fail on the caplog assertion below."""
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    app = _make_app(session_maker, state)
+    byo_fingerprint = await _real_byo_fingerprint(session_maker, state["org_id"])
+
+    class CloseFailsProvider(FakeReadinessProvider):
+        async def aclose(self) -> None:
+            self.closed = True
+            raise RuntimeError("transport already shut down")
+
+    provider = CloseFailsProvider()
+
+    async def fake_resolve_byo(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="gpt-5-mini",
+            provider_label="OpenAI compatible",
+            model_label="gpt-5-mini",
+            readiness_fingerprint=byo_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        settings_router_module, "resolve_byo_certification_provider", fake_resolve_byo
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        with caplog.at_level(
+            "WARNING", logger="dev_health_ops.api.admin.routers.settings"
+        ):
+            response = await ac.post("/api/v1/admin/llm-settings/readiness")
+
+    assert response.status_code == 200
+    assert response.json()["readiness"] == "ready"
+    assert provider.closed is True
+    assert any(
+        "Failed to close BYO Ask Dev provider connection" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_persists_and_status_reflects_failure(
+    session_maker, monkeypatch: pytest.MonkeyPatch
+):
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    app = _make_app(session_maker, state)
+    provider = FailingReadinessProvider()
+    byo_fingerprint = await _real_byo_fingerprint(session_maker, state["org_id"])
+
+    async def fake_resolve_byo(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="gpt-5-mini",
+            provider_label="OpenAI compatible",
+            model_label="gpt-5-mini",
+            readiness_fingerprint=byo_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        settings_router_module, "resolve_byo_certification_provider", fake_resolve_byo
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["readiness"] == "failed"
+        assert body["readiness_safe_failure_reason"] is not None
+
+        status = await ac.get("/api/v1/admin/llm-settings/status")
+        assert status.status_code == 200
+        status_body = status.json()
+        assert status_body["readiness"] == "failed"
+        assert (
+            status_body["readiness_safe_failure_reason"]
+            == (body["readiness_safe_failure_reason"])
+        )
+        assert status_body["readiness_checked_at"] == body["readiness_checked_at"]
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_blocks_impersonated_admin(session_maker):
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    app = _make_app(session_maker, state, impersonated_by=str(uuid.uuid4()))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "impersonated_write_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_blocks_live_impersonation_without_jwt_claim(
+    session_maker, monkeypatch: pytest.MonkeyPatch
+):
+    """Codex regression test (CHAOS-3265): the guard must also catch the
+    LIVE, per-request impersonation context set by ImpersonationMiddleware
+    from the Valkey-cached session -- not just the static JWT
+    ``impersonated_by`` claim. Proven with that claim left unset."""
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    app = _make_app(session_maker, state)  # impersonated_by NOT set
+
+    def _must_not_resolve(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError(
+            "must never resolve a certification provider while a live "
+            "impersonation context is active"
+        )
+
+    monkeypatch.setattr(
+        settings_router_module, "resolve_byo_certification_provider", _must_not_resolve
+    )
+
+    token = set_impersonation_context(
+        target_user_id=str(uuid.uuid4()),
+        target_org_id=state["org_id"],
+        target_role="admin",
+        real_user_id=state["user_id"],
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            response = await ac.post("/api/v1/admin/llm-settings/readiness")
+    finally:
+        _impersonation_ctx.reset(token)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_can_flip_ask_dev_selection_to_byo(
+    session_maker, monkeypatch: pytest.MonkeyPatch
+):
+    """Honest companion to the independence test above (codex review,
+    CHAOS-3265): certifying BYO's OWN credentials here is what makes BYO
+    usable/selectable for subsequent Ask Dev runs -- that is the intended
+    purpose of a preflight check, not a bug. Prove it directly against the
+    REAL (unmocked) production resolver, starting from a state where
+    platform is genuinely winning, rather than asserting "no effect" only in
+    a scenario (emergency-disabled) where nothing could move regardless."""
+
+    from dev_health_ops.api.dev.production_runtime import (
+        _byo_candidate,
+        _readiness_fingerprint,
+        resolve_production_provider,
+    )
+    from dev_health_ops.llm.agent.readiness import (
+        PLATFORM_READINESS_SETTING_KEY,
+        PLATFORM_SETTINGS_ORG_ID,
+        AgentReadinessOutcome,
+        AgentReadinessRecord,
+        SettingsAgentReadinessStore,
+    )
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "platform-key")
+    monkeypatch.setenv("LLM_MODEL", "platform-model")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    # Certify the PLATFORM candidate (as Platform Admin would) so platform
+    # is genuinely usable and winning before BYO is ever certified.
+    async with session_maker() as session:
+        svc = SettingsService(session, state["org_id"])
+        byo_candidate = await _byo_candidate(svc, readiness=None, certification=True)
+        assert byo_candidate is not None
+        byo_fingerprint = _readiness_fingerprint(byo_candidate)
+
+        platform, _ = production_runtime._platform_candidate(
+            readiness=None, certification=True
+        )
+        assert platform is not None
+        platform_fingerprint = _readiness_fingerprint(platform)
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint=platform_fingerprint,
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        before = await resolve_production_provider(session, org_id=state["org_id"])
+        try:
+            assert before.source is AgentProviderSource.PLATFORM
+        finally:
+            await before.provider.aclose()
+
+    app = _make_app(session_maker, state)
+    provider = FakeReadinessProvider()
+
+    async def fake_resolve_byo(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=provider,
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="gpt-5-mini",
+            provider_label="OpenAI compatible",
+            model_label="gpt-5-mini",
+            readiness_fingerprint=byo_fingerprint,
+        )
+
+    monkeypatch.setattr(
+        settings_router_module, "resolve_byo_certification_provider", fake_resolve_byo
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+    assert response.status_code == 200
+    assert response.json()["readiness"] == "ready"
+
+    async with session_maker() as session:
+        after = await resolve_production_provider(session, org_id=state["org_id"])
+        try:
+            assert after.source is AgentProviderSource.BYO
+        finally:
+            await after.provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_status_reports_stale_not_ready_on_version_bump(
+    session_maker,
+):
+    """CHAOS-3254 (READINESS_VERSION v2->v3) exposed a gap: a stored record
+    whose fingerprint matches the CURRENT BYO config but whose
+    readiness_version is OUTDATED must never be reported as "ready" (nor
+    "failed" -- it was never actually re-checked under the new
+    requirements). It must report "stale" with a safe, accurate remediation
+    that does not imply anything is broken."""
+
+    from dev_health_ops.llm.agent.readiness import (
+        AgentReadinessOutcome,
+        AgentReadinessRecord,
+        SettingsAgentReadinessStore,
+    )
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    current_fingerprint = await _real_byo_fingerprint(session_maker, state["org_id"])
+
+    async with session_maker() as session:
+        svc = SettingsService(session, state["org_id"])
+        await SettingsAgentReadinessStore(svc).save(
+            AgentReadinessRecord(
+                fingerprint=current_fingerprint,  # matches live BYO config
+                readiness_version="stale-version-v2",  # does NOT match current
+                checked_at="2026-01-01T00:00:00+00:00",
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await session.commit()
+
+    app = _make_app(session_maker, state)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.get("/api/v1/admin/llm-settings/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] == "stale"
+    assert body["readiness"] != "ready"
+    assert body["readiness"] != "failed"
+    assert body["readiness_safe_failure_reason"] is not None
+    lowered = body["readiness_safe_failure_reason"].lower()
+    assert "unavailable" not in lowered
+    assert "endpoint" not in lowered
+    assert "fail" not in lowered
+
+
+@pytest.mark.asyncio
+async def test_llm_settings_readiness_is_tier_and_flag_gated(session_maker):
+    community = await _seed_org(session_maker, "community", flag_enabled=True)
+    app = _make_app(session_maker, community)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+    assert response.status_code == 402
+
+    disabled = await _seed_org(session_maker, "team", flag_enabled=False)
+    app = _make_app(session_maker, disabled)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post("/api/v1/admin/llm-settings/readiness")
+    assert response.status_code == 403

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.middleware import require_admin
+from dev_health_ops.api.admin.routers import platform_ask_dev
+from dev_health_ops.api.admin.routers.platform_ask_dev import router
+from dev_health_ops.api.auth.router import get_current_user
+from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.services.auth import (
+    AuthenticatedUser,
+    _impersonation_ctx,
+    set_impersonation_context,
+)
+from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentProviderCapabilities,
+    AgentToolRequest,
+    AgentUsage,
+    StreamingMode,
+    StructuredOutputMode,
+    ToolDecisionMode,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
+from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
+    READINESS_SETTING_KEY,
+    AgentReadinessOutcome,
+    AgentReadinessRecord,
+    SettingsAgentReadinessStore,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import Setting
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+_TABLES = tables_of(User, Organization, Setting)
+_FINGERPRINT = "platform-readiness-fingerprint"
+
+
+class FakeReadinessProvider:
+    """Echoes the readiness nonce successfully -- for the READY path."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.closed = False
+
+    @property
+    def capabilities(self) -> AgentProviderCapabilities:
+        return AgentProviderCapabilities(
+            structured_output=StructuredOutputMode.JSON_SCHEMA,
+            tool_decisions=ToolDecisionMode.NATIVE,
+            streaming=StreamingMode.BUFFERED,
+            supports_cancellation=True,
+            context_window_tokens=16_384,
+            max_output_tokens=1_024,
+            readiness_version=READINESS_VERSION,
+            disclosure_key="openai-compatible",
+        )
+
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        self.calls += 1
+        if self.calls == 1:
+            return AgentDecisionResult(
+                decision=AgentToolRequest(
+                    "readiness_echo", {"nonce": "ready-v1"}, "call-1"
+                ),
+                usage=AgentUsage(input_tokens=3, output_tokens=2),
+                latency_ms=1,
+                provider_fingerprint="provider",
+                model_fingerprint="model",
+            )
+        return AgentDecisionResult(
+            decision=AgentFinalAnswer(value={"nonce": "ready-v1"}),
+            usage=AgentUsage(input_tokens=4, output_tokens=1),
+            latency_ms=1,
+            provider_fingerprint="provider",
+            model_fingerprint="model",
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FailingReadinessProvider(FakeReadinessProvider):
+    """Always fails the readiness exchange -- for the FAILED path."""
+
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+
+def _resolution(provider: Any) -> ProductionProviderResolution:
+    return ProductionProviderResolution(
+        provider=provider,
+        source=AgentProviderSource.PLATFORM,
+        family="openai",
+        model="platform-model",
+        provider_label="OpenAI compatible",
+        model_label="platform-model",
+        readiness_fingerprint=_FINGERPRINT,
+    )
+
+
+@dataclass
+class PlatformContext:
+    app: FastAPI
+    client: AsyncClient
+    maker: async_sessionmaker[AsyncSession]
+    superuser: AuthenticatedUser
+    org_admin: AuthenticatedUser
+    current_user: AuthenticatedUser
+
+
+@pytest_asyncio.fixture
+async def platform_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'platform-ask-dev-admin.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    superuser = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="superuser@example.com",
+        org_id=str(uuid.uuid4()),
+        role="admin",
+        is_superuser=True,
+    )
+    org_admin = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="org-admin@example.com",
+        org_id=str(uuid.uuid4()),
+        role="admin",
+        is_superuser=False,
+    )
+
+    holder = {"user": superuser}
+
+    async def session_override():
+        async with maker() as session:
+            yield session
+            await session.commit()
+
+    async def current_user_override() -> AuthenticatedUser:
+        return holder["user"]
+
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret")
+
+    app = FastAPI()
+    app.include_router(
+        router,
+        prefix="/api/v1/admin",
+        dependencies=[Depends(require_admin)],
+    )
+    app.dependency_overrides[platform_ask_dev.get_session] = session_override
+    app.dependency_overrides[get_current_user] = current_user_override
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    context = PlatformContext(app, client, maker, superuser, org_admin, superuser)
+    context._holder = holder  # type: ignore[attr-defined]
+    yield context
+    await client.aclose()
+    await engine.dispose()
+
+
+def _as(context: PlatformContext, user: AuthenticatedUser) -> None:
+    context._holder["user"] = user  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_org_admin_token_cannot_reach_platform_readiness(
+    platform_context: PlatformContext,
+):
+    """The key regression test: an org-admin token must never reach platform
+    diagnostics -- require_superuser must reject it (CHAOS-3265)."""
+
+    _as(platform_context, platform_context.org_admin)
+
+    get_response = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    post_response = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+
+    assert get_response.status_code == 403
+    assert post_response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superuser_certifies_and_readiness_persists_across_a_second_get(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    before = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert before.status_code == 200
+    before_body = before.json()
+    assert before_body["configured"] is True
+    assert before_body["readiness"] == "stale_readiness"
+    assert before_body["provider_label"] == "OpenAI compatible"
+    assert before_body["model_label"] == "platform-model"
+
+    posted = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert posted.status_code == 200
+    posted_body = posted.json()
+    assert posted_body["readiness"] == "ready"
+    assert posted_body["safe_remediation"] is None
+    assert provider.closed is True
+
+    after = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert after.status_code == 200
+    after_body = after.json()
+    assert after_body["readiness"] == "ready"
+    assert after_body["provider_label"] == "OpenAI compatible"
+    assert after_body["model_label"] == "platform-model"
+
+
+@pytest.mark.asyncio
+async def test_post_succeeds_and_logs_when_provider_close_fails(
+    platform_context: PlatformContext,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A transport-close failure after a successful certification must never
+    mask the readiness result the caller already committed (CHAOS-3265 /
+    CodeQL empty-except finding) -- and must be logged, not silently
+    swallowed. Deleting the try/except's log call (or reverting it to a bare
+    `pass`) makes this test fail on the caplog assertion below."""
+
+    class CloseFailsProvider(FakeReadinessProvider):
+        async def aclose(self) -> None:
+            self.closed = True
+            raise RuntimeError("transport already shut down")
+
+    provider = CloseFailsProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    with caplog.at_level(
+        "WARNING", logger="dev_health_ops.api.admin.routers.platform_ask_dev"
+    ):
+        posted = await platform_context.client.post(
+            "/api/v1/admin/platform/ask-dev/readiness"
+        )
+
+    assert posted.status_code == 200
+    assert posted.json()["readiness"] == "ready"
+    assert provider.closed is True
+    assert any(
+        "Failed to close platform Ask Dev provider connection" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_superuser_post_transitions_to_failed_and_persists(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    provider = FailingReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    posted = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert posted.status_code == 200
+    posted_body = posted.json()
+    assert posted_body["readiness"] == "unsupported_model"
+    assert posted_body["safe_remediation"] is not None
+    assert "capability contract" in posted_body["safe_remediation"]
+
+    after = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    after_body = after.json()
+    assert after_body["readiness"] == "unsupported_model"
+
+
+@pytest.mark.asyncio
+async def test_platform_not_configured_returns_safe_unconfigured_state(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    async def resolve() -> ProductionProviderResolution:
+        raise DevRuntimeUnavailable(
+            "provider_not_configured", "No certified Ask Dev model is ready."
+        )
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    get_response = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["configured"] is False
+    assert body["readiness"] == "missing_credentials"
+    assert body["provider_label"] is None
+    assert body["model_label"] is None
+    assert body["safe_remediation"] == "No certified Ask Dev model is ready."
+
+    post_response = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert post_response.status_code == 200
+    post_body = post_response.json()
+    assert post_body["configured"] is False
+    assert post_body["readiness"] == "missing_credentials"
+
+
+@pytest.mark.asyncio
+async def test_certification_writes_the_sentinel_row_and_never_a_real_orgs_row(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """The security-fix test: platform certification must land under the
+    org_id="" sentinel scope and never under any real organization's row."""
+
+    real_org_id = str(uuid.uuid4())
+    async with platform_context.maker() as session:
+        session.add(
+            Setting(
+                org_id=real_org_id,
+                category="llm",
+                key=READINESS_SETTING_KEY,
+                value='{"marker": "a-real-orgs-own-byo-readiness-untouched"}',
+            )
+        )
+        await session.commit()
+
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    response = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert response.status_code == 200
+    assert response.json()["readiness"] == "ready"
+
+    async with platform_context.maker() as session:
+        real_org_row = await session.scalar(
+            select(Setting).where(
+                Setting.org_id == real_org_id,
+                Setting.category == "llm",
+                Setting.key == READINESS_SETTING_KEY,
+            )
+        )
+        assert real_org_row is not None
+        assert real_org_row.value == (
+            '{"marker": "a-real-orgs-own-byo-readiness-untouched"}'
+        )
+
+        sentinel_row = await session.scalar(
+            select(Setting).where(
+                Setting.org_id == PLATFORM_SETTINGS_ORG_ID,
+                Setting.category == "llm",
+                Setting.key == PLATFORM_READINESS_SETTING_KEY,
+            )
+        )
+        assert sentinel_row is not None
+        assert sentinel_row.value is not None
+        assert '"outcome":"ready"' in sentinel_row.value
+
+        no_stray_row_under_ordinary_key = await session.scalar(
+            select(Setting).where(
+                Setting.org_id == PLATFORM_SETTINGS_ORG_ID,
+                Setting.category == "llm",
+                Setting.key == READINESS_SETTING_KEY,
+            )
+        )
+        assert no_stray_row_under_ordinary_key is None
+
+
+@pytest.mark.asyncio
+async def test_stray_empty_org_row_under_the_ordinary_key_is_invisible(
+    platform_context: PlatformContext,
+):
+    """Defense in depth: even a hypothetical accidental write that landed
+    with an empty org_id under the *ordinary* readiness key must not affect
+    the platform reader, because it only ever reads the distinct platform
+    key."""
+
+    async with platform_context.maker() as session:
+        session.add(
+            Setting(
+                org_id=PLATFORM_SETTINGS_ORG_ID,
+                category="llm",
+                key=READINESS_SETTING_KEY,
+                value=(
+                    '{"fingerprint":"stray","readiness_version":"stray",'
+                    '"checked_at":"2026-01-01T00:00:00+00:00","outcome":"ready",'
+                    '"safe_error_code":null}'
+                ),
+            )
+        )
+        await session.commit()
+
+    response = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # Nothing has ever certified the *distinct* platform key, so this must
+    # still report as never certified -- not "ready" from the stray row.
+    assert body["readiness"] != "ready"
+
+
+@pytest.mark.asyncio
+async def test_impersonated_superuser_is_blocked_on_post(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    def _must_not_resolve() -> Any:
+        raise AssertionError(
+            "an impersonated superuser POST must never resolve a certification provider"
+        )
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", _must_not_resolve
+    )
+
+    impersonating = AuthenticatedUser(
+        user_id=platform_context.superuser.user_id,
+        email=platform_context.superuser.email,
+        org_id=platform_context.superuser.org_id,
+        role="admin",
+        is_superuser=True,
+        impersonated_by=str(uuid.uuid4()),
+    )
+    _as(platform_context, impersonating)
+
+    response = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_live_impersonation_context_blocks_post_without_jwt_claim(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """Codex regression test (CHAOS-3265): the JWT ``impersonated_by`` claim
+    is a static, token-issue-time signal. The AUTHORITATIVE, real-time signal
+    is ``is_impersonating()``, set per-request by ``ImpersonationMiddleware``
+    from the live Valkey-cached session. A guard that only checks the JWT
+    claim is bypassable by a still-impersonating superuser whose current
+    token happens not to carry that claim. This proves the guard also catches
+    the live context, with ``impersonated_by`` left unset."""
+
+    def _must_not_resolve() -> Any:
+        raise AssertionError(
+            "must never resolve a certification provider while a live "
+            "impersonation context is active, even if impersonated_by is unset"
+        )
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", _must_not_resolve
+    )
+
+    assert platform_context.superuser.impersonated_by is None
+    token = set_impersonation_context(
+        target_user_id=str(uuid.uuid4()),
+        target_org_id=str(uuid.uuid4()),
+        target_role="admin",
+        real_user_id=platform_context.superuser.user_id,
+    )
+    try:
+        response = await platform_context.client.post(
+            "/api/v1/admin/platform/ask-dev/readiness"
+        )
+    finally:
+        _impersonation_ctx.reset(token)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stale_readiness_version_reports_stale_not_ready(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3254 (READINESS_VERSION v2->v3) exposed a gap: a stored record
+    whose fingerprint matches but whose readiness_version is OUTDATED must
+    never be reported as "ready". It must report stale_readiness with a
+    safe, accurate remediation -- not a message implying something broken."""
+
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    async with platform_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint=_FINGERPRINT,  # matches the current candidate
+                readiness_version="stale-version-v2",  # does NOT match current
+                checked_at="2026-01-01T00:00:00+00:00",
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await session.commit()
+
+    response = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] == "stale_readiness"
+    assert body["readiness"] != "ready"
+    assert body["safe_remediation"] is not None
+    lowered = body["safe_remediation"].lower()
+    assert "unavailable" not in lowered
+    assert "endpoint" not in lowered
+    assert "fail" not in lowered
+
+    # A POST run afterward must also land on stale_readiness pre-certify,
+    # and re-certify cleanly to ready (proving it's not permanently wedged).
+    posted = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert posted.status_code == 200
+    assert posted.json()["readiness"] == "ready"

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -43,6 +43,8 @@ from dev_health_ops.llm.agent.contracts import (
 from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
 from dev_health_ops.llm.agent.policy import AgentProviderSource
 from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
     AgentReadinessOutcome,
     AgentReadinessService,
     SettingsAgentReadinessStore,
@@ -141,9 +143,15 @@ async def test_acceptance_openai_runs_real_readiness_grounding_and_capabilities(
     fingerprint = certification.readiness_fingerprint
     provider_fingerprint = certification.provider.provider_fingerprint
 
+    # This candidate's source is PLATFORM (the acceptance-gated scripted
+    # OpenAI endpoint), so its certification is written to the
+    # platform-global sentinel scope -- the same place the real Platform
+    # Admin route writes to (CHAOS-3265) -- not to this org's own settings.
     readiness = await AgentReadinessService(
-        SettingsAgentReadinessStore(SettingsService(settings_session, _ORG_ID)),
-        org_id=_ORG_ID,
+        SettingsAgentReadinessStore(
+            SettingsService(settings_session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ),
     ).certify(
         certification.provider,
         provider_name=certification.family,

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
 from dev_health_ops.api.dev.tool_registry import ToolExecutionContext
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
+from dev_health_ops.llm.agent.readiness import PLATFORM_READINESS_SETTING_KEY
 from dev_health_ops.llm.credentials import LLMCredentials
 
 
@@ -82,7 +83,7 @@ async def test_provider_resolution_requires_current_certification(
     monkeypatch.setenv("LLM_MODEL", "certified-model")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     FakeSettingsService.values = {
-        "ask_dev_agent_readiness": json.dumps(
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
             {
                 "fingerprint": _fingerprint(),
                 "readiness_version": READINESS_VERSION,
@@ -107,7 +108,7 @@ async def test_provider_resolution_requires_current_certification(
     assert model_change.value.code == "provider_not_configured"
     monkeypatch.setenv("LLM_MODEL", "certified-model")
 
-    FakeSettingsService.values["ask_dev_agent_readiness"] = json.dumps(
+    FakeSettingsService.values[PLATFORM_READINESS_SETTING_KEY] = json.dumps(
         {
             "fingerprint": "stale-fingerprint",
             "readiness_version": READINESS_VERSION,
@@ -147,7 +148,7 @@ async def test_platform_local_provider_uses_only_operator_environment(
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     monkeypatch.delenv("LOCAL_LLM_API_KEY", raising=False)
     FakeSettingsService.values = {
-        "ask_dev_agent_readiness": json.dumps(
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
             {
                 "fingerprint": _fingerprint(
                     provider="local",
@@ -193,7 +194,7 @@ async def test_explicit_fail_closed_prevents_platform_fallback(
     monkeypatch.setenv("LOCAL_LLM_MODEL", "local-agent-model")
     monkeypatch.setenv("LOCAL_LLM_BASE_URL", "http://host.docker.internal:1234/v1")
     FakeSettingsService.values = {
-        "ask_dev_agent_readiness": json.dumps(
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
             {
                 "fingerprint": _fingerprint(
                     provider="local",


### PR DESCRIPTION
## Summary

An org admin could trigger and observe certification of the PLATFORM-owned (operator env-configured) LLM provider through the org-scoped `POST /admin/ask-dev/readiness` endpoint. This splits Ask Dev readiness/certification into three source-scoped surfaces so an org admin can never see or drive platform-level diagnostics:

- **`POST /admin/ask-dev/readiness` is now a static `410 Gone`.** Kept registered (not deleted) purely for rolling-deploy safety against an already-deployed older web frontend. No certification logic runs under this route at all anymore — verified by a test that fails loudly if `resolve_certification_provider` is ever called from it.
- **New `GET/POST /admin/platform/ask-dev/readiness`** (superuser-only via `require_superuser`, no `org_id` dependency at all). Certifies ONLY the platform-owned provider, built purely from operator environment variables. Its readiness record is stored under a collision-free `org_id=""` sentinel scope with a setting key (`platform_ask_dev_agent_readiness`) distinct from the ordinary per-org key, so it can never collide with or be confused with any real org's data.
- **New `POST /admin/llm-settings/readiness`** (org-admin scoped). Certifies ONLY the calling org's own saved BYO LLM credentials — independent of whether BYO currently wins Ask Dev's platform-fallback arbitration, whether it's ever been certified before, or whether Ask Dev itself is enabled/entitled. Never touches `DevRun`, platform-allowance tables, or Ask Dev's entitlement/emergency-disabled checks.
- **`GET /admin/ask-dev`** now nulls `effective_provider_label`/`effective_model_label`/`provider_source` and rewrites the failure reason to a generic, organization-safe message whenever the internally-resolved source is platform. BYO's own identity/failure-reason are unaffected (it's the org's own data).

## Also fixed (adversarial review)

- **Impersonation guard hardening**: `block_impersonated_write` now checks both the static JWT `impersonated_by` claim AND the live, per-request `is_impersonating()` context set by `ImpersonationMiddleware` from the active Valkey-cached session. The JWT claim alone is a stale/bypassable signal — a still-impersonating superuser whose current token doesn't carry the claim could otherwise reach both new POST routes. Regression tests set the live context directly (not the JWT field) to prove this.
- **Readiness-version staleness** (CHAOS-3254 bumps `READINESS_VERSION` and would otherwise silently make stale "ready" records look current): `LLMSettingsStatusResponse.readiness` is now a 4-state enum (`ready`/`failed`/`stale`/`never_checked`), computed via the same fingerprint+version currency check (`record.is_current(...)`) the admin Ask Dev projection already uses. The platform router's existing `stale_readiness` branch was re-verified with an explicit test.
- **Acceptance bootstrap**: `scripts/acceptance/prepare_ask_dev_acceptance.py` and its compose test now call the new `POST /admin/platform/ask-dev/readiness` route (the scripted-OpenAI acceptance candidate is always platform-sourced) instead of the now-410'd org route.
- Corrected an inaccurate code comment: the live Postgres migration for `settings.org_id` actually defaults to the string `"default"`, not `""` as the SQLAlchemy model declares — a pre-existing, unrelated model/migration drift. Irrelevant to the `org_id=""` sentinel's safety since every write here is explicit, but the comment now says so accurately instead of repeating the incorrect claim.

## `org_id=""` sentinel rationale

`Setting.org_id` is `Text, nullable=False`; every real org's `org_id` is enforced to be a non-empty UUID string at the admin-auth boundary (`get_admin_org_id` 403s on a falsy org_id). `""` is therefore a safe, collision-free sentinel for a genuinely platform-global (non-org) settings scope, reused rather than adding a migration or new table. Belt-and-suspenders: the platform store also uses a setting key distinct from the ordinary per-org key, so even a hypothetical stray write with an empty org_id under the *ordinary* key would remain invisible to it.

## Endpoint contract (final, as shipped)

- `POST /api/v1/admin/ask-dev/readiness` → **410**, body `{"detail": "..."}"`, no side effects.
- `GET /api/v1/admin/platform/ask-dev/readiness`, `POST /api/v1/admin/platform/ask-dev/readiness` → `PlatformAskDevReadinessResponse`: `schema_version`, `configured`, `provider_label`, `model_label`, `readiness` (ready/unsupported_model/missing_credentials/disabled/degraded/stale_readiness), `readiness_checked_at`, `readiness_version`, `safe_remediation`.
- `POST /api/v1/admin/llm-settings/readiness` → `LLMSettingsStatusResponse` (extended): `configured`, `active`, `degraded`, `reason_code`, `last_fallback_at`, `readiness` (ready/failed/stale/never_checked), `readiness_checked_at`, `readiness_safe_failure_reason`. 404 if no BYO configured.
- `GET /api/v1/admin/ask-dev` unchanged shape; `effective_provider_label`/`effective_model_label`/`provider_source` now null when source is platform.

## Test plan

- [x] `bash ci/local_validate.sh` (ruff, mypy, full unit suite, live-ClickHouse argMax proof) — PASS, run 3x clean after fixes, zero failures.
- [x] Codex adversarial review — 3 HIGH findings fixed (impersonation guard, selection-mutation documentation+test, acceptance bootstrap breakage), 1 follow-up MEDIUM fixed (docstring accuracy). Re-review: no HIGH/MEDIUM remaining.
- [x] New: `tests/api/admin/test_platform_ask_dev.py` (org-admin 403, superuser 200/ready/failed/stale transitions, sentinel-row isolation proof, impersonation).
- [x] Updated: `tests/api/admin/test_ask_dev.py` (410 stub + no-op proof, platform null-out, BYO identity preserved).
- [x] Updated: `tests/api/admin/test_llm_settings.py` (BYO readiness independent of selection/entitlement, honest selection-flip proof against the real resolver, staleness, impersonation incl. live-context, tier/flag gating).
- [x] Updated: `tests/api/dev/test_production_runtime.py`, `tests/api/dev/test_acceptance_openai_runtime.py`, `tests/acceptance/test_ask_dev_compose.py` for the new platform-scoped readiness store.

Linear: https://linear.app/fullchaos/issue/CHAOS-3265/ask-dev-move-platform-model-readiness-controls-to-platform-admin