### PR TITLE
fix(ci): governance gate fails all merge-group runs (--slurp with --jq)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -49,7 +49,7 @@ jobs:
                 -f owner="$GITHUB_REPOSITORY_OWNER" \
                 -f name="$REPOSITORY_NAME" \
                 -F number="$pr_number" \
-                --jq '.[0].data.repository.pullRequest.mergeQueueEntry as $current | [.[].data.repository.pullRequest.mergeQueueEntry.mergeQueue.entries.nodes[] | select(.position <= $current.position) | (.pullRequest.body // "")] | join("\n")'
+                | jq -r '.[0].data.repository.pullRequest.mergeQueueEntry as $current | [.[].data.repository.pullRequest.mergeQueueEntry.mergeQueue.entries.nodes[] | select(.position <= $current.position) | (.pullRequest.body // "")] | join("\n")'
             )"
           fi
           delimiter="pr_body_$(uuidgen)"

--- a/tests/test_governance_workflow.py
+++ b/tests/test_governance_workflow.py
@@ -50,10 +50,18 @@ def test_governance_workflow_resolves_all_merge_group_pr_bodies(
     fake_gh = tmp_path / "gh"
     gh_args = tmp_path / "gh-args.txt"
     github_output = tmp_path / "github-output.txt"
+    slurped_pages = (
+        '[{"data":{"repository":{"pullRequest":{"mergeQueueEntry":{"position":2,'
+        '"mergeQueue":{"entries":{"nodes":['
+        '{"position":1,"pullRequest":{"body":"first PR evidence"}},'
+        '{"position":2,"pullRequest":{"body":"second PR evidence"}},'
+        '{"position":3,"pullRequest":{"body":"queued-behind evidence"}}'
+        '],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}}}]'
+    )
     fake_gh.write_text(
         "#!/usr/bin/env bash\n"
         'printf \'%s\\n\' "$@" > "$GH_ARGS_FILE"\n'
-        "printf 'first PR evidence\\nsecond PR evidence\\n'\n",
+        f"printf '%s\\n' '{slurped_pages}'\n",
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
@@ -89,4 +97,10 @@ def test_governance_workflow_resolves_all_merge_group_pr_bodies(
     assert "--slurp" in invocation
     assert "entries(first:100,after:$endCursor)" in invocation
     assert "pageInfo{hasNextPage endCursor}" in invocation
-    assert "position <= $current.position" in invocation
+    # gh rejects --slurp combined with --jq, so the filter must run as a
+    # standalone jq stage rather than ride along on the gh invocation.
+    assert "--jq" not in invocation
+    script = _governance_context_script()
+    assert "position <= $current.position" in script
+    # The queued-behind entry (position 3 > current position 2) must be excluded.
+    assert "queued-behind evidence" not in github_output.read_text(encoding="utf-8")


### PR DESCRIPTION
Every `merge_group` Governance Gate run fails at "Resolve governance context": current runner gh versions reject `--slurp` combined with `--jq`, so the step exits 1, the required check goes red, and the merge queue silently dequeues green PRs (observed on #1344 tonight; every queued group shows the same failure).

Fix: pipe the slurped paginated output through standalone `jq -r` — filter unchanged.

This PR's own merge-group run executes the patched workflow (merge_group runs use the workflow from the merged tree), so it can pass through the queue and unblock the train (#1340, #1341, #1342, #1343, then re-queues of #1344/#1345/#1348).

https://claude.ai/code/session_01SkNkWExqmszydT1qEaG3Nv