### PR TITLE
docs(ask-dev): close CHAOS-3215 documentation gate for the /dev workspace

### DIFF
--- a/docs-data/ia/operate.tsv
+++ b/docs-data/ia/operate.tsv
@@ -42,6 +42,7 @@ op-rb-worker	op-runbooks	/operate/runbooks/worker-or-queue-failure/	Worker or qu
 op-rb-sync	op-runbooks	/operate/runbooks/sync-or-backfill-failure/	Sync coverage or backfill failure	runbook	true	public	planned	false	
 op-rb-db	op-runbooks	/operate/runbooks/database-or-migration-failure/	Database, storage, or migration failure	runbook	true	public	planned	false	
 op-rb-auth	op-runbooks	/operate/runbooks/provider-authentication-failure/	Provider authentication failure	runbook	true	public	planned	false	
+op-rb-ask-dev-proxy	op-runbooks	/operate/runbooks/ask-dev-web-proxy-or-browser-failure/	Ask Dev web proxy or browser failure	runbook	true	public	planned	false	
 op-rb-perf	op-runbooks	/operate/runbooks/performance-or-rate-limit/	Performance, rate limit, or saturation	runbook	true	public	planned	false	
 op-rb-backup	op-runbooks	/operate/runbooks/backup-or-restore-failure/	Backup or restore failure	runbook	true	public	planned	false	
 op-rb-dr	op-runbooks	/operate/runbooks/disaster-recovery/	Disaster recovery	runbook	true	public	planned	false	

--- a/docs/contribute/review-and-release/releases.md
+++ b/docs/contribute/review-and-release/releases.md
@@ -120,3 +120,36 @@ a separate product change and is not part of this V1 release.
   transcript fields.
 - **Reliability:** closing the browser stream signals cancellation and waits for
   a durable `cancelled` terminal state before the stream task is released.
+
+## Ask Dev Wave 3 full-page workspace and shared UI core release note
+
+- **New:** `dev-health-web` adds the full-page `/dev` investigation workspace
+  and a shared conversational UI core (conversation client, SSE parser/state
+  machine, transcript, structured `dev_answer.v1` renderer, citation/evidence
+  and metric components, history/retention UI) consumed by both `/dev` and the
+  permanent app-shell Ask Dev window through one `AskDevProvider` instance
+  mounted in the authenticated app layout. Same-origin, server-only
+  `/api/v1/dev/**` route handlers proxy every browser call; access tokens,
+  provider credentials, and raw upstream error bodies never reach the browser.
+- **Changed:** none of the existing platform-admin Context Fabric Validation
+  console (`/superadmin/context-fabric/validation`) changes; it remains an
+  independent, LLM-independent diagnostic surface not reachable from `/dev` or
+  the Ask Dev window.
+- **Known limited:** the composer's per-conversation retention selector shown
+  in an earlier build was removed — retention is organization-admin policy
+  only (0-day or 30-day) and was never honored per-conversation server-side.
+  Live verification against a real OpenAI-backed organization surfaced a
+  release-blocking defect in the Ops-side tool-call adapter (dotted
+  `*.v1`-suffixed tool names are rejected by the OpenAI Chat Completions API),
+  tracked separately as CHAOS-3286; it blocks the real-provider answer path
+  for both platform and BYO OpenAI connections until fixed and does not
+  originate in this release's web code.
+- **Reliability/accessibility hardening:** a follow-up hardening pass (tracked
+  under CHAOS-3215) fixes a cross-tenant conversation-state leak on
+  organization switch, a request-race that could route a question to the
+  wrong conversation, screen-reader announcement noise during streaming,
+  reduced-motion support, and several keyboard/focus gaps found during
+  adversarial review; see the linked pull request for the exact fix list.
+- **Rollback:** disable Ask Dev or roll back the `dev-health-web` binary; no
+  database migration is introduced by the web-side workspace or shared UI
+  core.

--- a/docs/operate/runbooks/ask-dev-web-proxy-or-browser-failure.md
+++ b/docs/operate/runbooks/ask-dev-web-proxy-or-browser-failure.md
@@ -1,0 +1,60 @@
+---
+page_id: op-rb-ask-dev-proxy
+summary: Recover Ask Dev web proxy, SSE stream, browser-state, and cancellation failures without exposing prompts, tokens, or provider payloads.
+content_type: runbook
+owner: platform-operations
+source_of_truth:
+  - dev-health-web src/app/api/v1/dev/_proxy.ts
+  - docs/contribute/architecture/contracts.md
+applicability: current
+lifecycle: active
+---
+
+# Ask Dev web proxy or browser failure
+
+Use this runbook when the permanent Ask Dev window or the `/dev` workspace fails to start, stream, or cancel a run, or when a browser report describes lost state, a stuck stream, or an unexpected error surface. Ask Dev's browser surface never talks to Ops directly: every request crosses one same-origin, server-only proxy in `dev-health-web` before it reaches the authenticated `/api/v1/dev/**` Ops routes.
+{: .fc-page-lede }
+
+## Preserve the incident context
+
+Record:
+
+- organization, user, conversation ID, and run ID (opaque identifiers only);
+- affected surface (permanent window vs. `/dev` workspace) and browser/OS;
+- first and latest failure time;
+- the safe `dev_error.v1` code shown to the user, if any;
+- whether the failure is one run, one user, one organization, or platform-wide;
+- whether the failure is on submission, mid-stream, on cancellation, or on history/evidence load.
+
+Do not record prompts, questions, provider request or response payloads, chain-of-thought, tool call arguments or results, access tokens, or provider credentials. The proxy and the Ops runtime are both designed so none of these ever reach browser-visible logs or analytics; if you find one that has, treat it as a security event and follow the security incident process, not this runbook.
+
+## Classify the failure
+
+| Failure | Evidence | Response |
+| --- | --- | --- |
+| Proxy rejects the request before it reaches Ops | `dev_web_error.v1` with a same-origin/CSRF or payload-limit reason, no upstream call logged | Confirm the request is a genuine same-origin browser call; a stale or replayed request from a proxy/CDN layer is expected to fail here |
+| Upstream Ops call never starts | Web logs show no outbound call; readiness or entitlement check failed first | Check the organization's Ask Dev entitlement and readiness state through the admin API (`GET /api/v1/admin/ask-dev`) before assuming the proxy is broken |
+| Stream starts, then stalls with no terminal event | SSE connection open, no `done` or error event within the expected window | Check Ops-side run admission (one active run per user, five per organization, 20 user requests per 15 minutes, 100 organization requests per hour) and the runtime ceilings (four model rounds, six tool calls, 45 seconds total); a run that silently exceeds a ceiling should still emit a safe terminal error — a stall with no terminal event at all is a bug, not an admission rejection |
+| Provider call fails (400/401/429/5xx from the model provider) | Ops logs show an upstream provider HTTP error; browser shows a generic `provider_unavailable`/`source_unavailable` safe error | The proxy and the Ops adapter never forward raw provider error bodies to the browser — this is by design (see [`safeUpstreamError` boundary](#the-safeupstreamerror-boundary) below). Diagnose the real provider error from Ops-side logs only, never by relaxing the browser-facing error allowlist |
+| Cancellation does not stop the run | User closes the panel or clicks stop; a later answer still arrives or the run is not recorded `cancelled` | Confirm the browser actually closed the SSE connection (a backgrounded tab or a proxy/CDN keep-alive can mask this); Ops treats a closed stream as a cancellation signal and waits for the recorder to persist a durable `cancelled` terminal state before releasing the stream task — a run that keeps executing after a genuinely closed connection is a reliability bug, not expected behavior |
+| Conversation/history/evidence load fails or returns unexpectedly empty | `GET /api/v1/dev/conversations/{id}/transcript` or an evidence-expansion call fails or 404s | A cross-tenant, cross-user, expired, retention-zero, or deleted conversation/evidence reference intentionally returns the same not-found response as a missing one — this is the correct fail-closed behavior, not a bug, unless the requesting user genuinely owns the referenced conversation |
+| Browser state looks wrong after switching organizations | Stale conversation/transcript visible after an org switch or during impersonation | Confirm the web build includes the org-scoped state reset fix (CHAOS-3215 hardening); a build without it is known to leak the previous organization's Ask Dev state in the browser until a full page reload |
+
+## The `safeUpstreamError` boundary
+
+The `dev-health-web` proxy (`src/app/api/v1/dev/_proxy.ts`) enforces `import "server-only"`, checks same-origin/CSRF on every mutation, applies a payload limit, forwards the authenticated session's access token to Ops on the outbound leg only, and always responds `no-store`. Upstream Ops error bodies are never passed through raw: a dedicated allowlist function admits only `code`, `safe_message`, `retryable`, `request_id`, and `limit_reset_at` from an upstream error — any other field, including a raw provider error body, is collapsed to a generic safe message before it reaches the browser. SSE stream bytes are forwarded verbatim up to a byte cap; the client-side stream parser (`dev-health-web` `src/lib/dev/client.ts`) independently validates every event against its declared type before rendering it, rejecting a payload that doesn't match its event type.
+
+When triaging, never work around this boundary by inspecting or forwarding raw upstream error content to a customer or into a browser-visible surface — diagnose from Ops-side logs, which are allowed to contain more detail (still never prompts, tool payloads, or credentials; see [Privacy and data-handling responsibilities](../../admin/security-and-audit/privacy.md#ask-dev-data-boundary)).
+
+## Recover
+
+1. Confirm the affected scope: one run, one user, one organization, or platform-wide.
+2. Check Ask Dev entitlement, readiness, and emergency-disable state for the affected organization (`GET /api/v1/admin/ask-dev`).
+3. Check Ops-side logs for the actual upstream failure (provider error, admission rejection, storage failure) — never infer this from the browser-visible safe error alone.
+4. For a stuck or non-terminating stream, verify the run's server-side terminal state directly; do not tell the customer to retry until Ops confirms the run actually reached a terminal state (or force one operator-side if the recorder itself is stuck).
+5. For an organization-wide or platform-wide failure, use the organization emergency disable (or the global feature decision as the last resort) to stop new runs while the root cause is fixed; this does not delete BYO credentials, retained conversations, or their retention/deletion policy.
+6. Re-enable normal operation and verify one real run end-to-end before closing the incident.
+
+## Security escalation
+
+A raw prompt, tool payload, chain-of-thought, access token, or provider credential observed in browser state, a URL, a client-visible log, or an analytics event is a security event, not a routine proxy failure — stop, preserve non-secret evidence, and follow the security incident process rather than continuing this runbook.

--- a/docs/operate/runbooks/index.md
+++ b/docs/operate/runbooks/index.md
@@ -13,6 +13,7 @@ lifecycle: active
 - [Worker or queue failure](worker-or-queue-failure.md)
 - [Database or migration failure](database-or-migration-failure.md)
 - [Provider authentication failure](provider-authentication-failure.md)
+- [Ask Dev web proxy or browser failure](ask-dev-web-proxy-or-browser-failure.md)
 - [Performance or rate-limit failure](performance-or-rate-limit.md)
 - [Backup or restore failure](backup-or-restore-failure.md)
 - [Disaster recovery](disaster-recovery.md)

--- a/docs/use/ai-workflows/index.md
+++ b/docs/use/ai-workflows/index.md
@@ -79,7 +79,7 @@ the scope already committed to an active conversation.
 Choose **Workspace** to expand the same conversation into `/dev` for a longer
 investigation, history, evidence, and metric detail. The window and `/dev` share
 one conversation, scope, streamed run, answer, feedback record, and retention
-choice; expanding or minimizing does not run the question again. **Ask Dev about
+policy; expanding or minimizing does not run the question again. **Ask Dev about
 this** actions use an approved route and entity allowlist and show the inherited
 scope before submission. They never copy arbitrary page content or submit a
 suggested question automatically.
@@ -96,8 +96,9 @@ Ask Dev or organization-administrator entitlement does not grant access to it.
 
 ## Ask Dev conversation history
 
-Ask Dev keeps a conversation only under the retention choice shown when the
-conversation starts:
+Ask Dev keeps a conversation only under your organization's retention policy.
+An organization administrator sets this policy for every conversation in the
+workspace; it is not a choice made when an individual conversation starts:
 
 - **Do not retain** removes the question, validated answer, run, tool audit,
   and feedback after the request reaches a terminal state. A minimal deletion
@@ -108,8 +109,8 @@ conversation starts:
 
 You can delete a saved conversation before it expires. Dev Health does not use
 Ask Dev conversation content to train models. Disabling Ask Dev stops new use;
-it does not silently delete saved history, whose selected retention and delete
-controls continue to apply.
+it does not silently delete saved history, whose organization-set retention
+policy and delete controls continue to apply.
 
 The permanent window and `/dev` load this same saved transcript; opening the
 workspace does not copy or fork it. History contains the question and committed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
           - Worker or queue failure: operate/runbooks/worker-or-queue-failure.md
           - Database or migration failure: operate/runbooks/database-or-migration-failure.md
           - Provider authentication failure: operate/runbooks/provider-authentication-failure.md
+          - Ask Dev web proxy or browser failure: operate/runbooks/ask-dev-web-proxy-or-browser-failure.md
           - Performance or rate limit: operate/runbooks/performance-or-rate-limit.md
           - Backup or restore failure: operate/runbooks/backup-or-restore-failure.md
           - Disaster recovery: operate/runbooks/disaster-recovery.md


### PR DESCRIPTION
## Summary

Closes the documentation-completion gate for CHAOS-3215 (Ask Dev Wave 3 — `/dev` full-page workspace + shared conversational UI core, dev-health-web PR #823/#813). The user guide, administrator guide, and developer/architecture contract docs were already substantially complete from CHAOS-3213/3214/3217; this fills the remaining gaps specific to the `/dev` full-page workspace itself.

- **New operator runbook**: `operate/runbooks/ask-dev-web-proxy-or-browser-failure.md` — web proxy/SSE/browser-state/cancellation troubleshooting and the `safeUpstreamError` trust-boundary explanation. Wired into `mkdocs.yml` nav and `docs-data/ia/operate.tsv` (the publication-gate IA manifest — caught by `tests/docs/test_built_site_links.py` on first attempt, since mkdocs nav alone isn't sufficient).
- **New release note**: "Ask Dev Wave 3 full-page workspace and shared UI core" in `contribute/review-and-release/releases.md`, covering the web-side shipment, the retention-selector removal, and cross-referencing CHAOS-3286 (the real-OpenAI-provider tool-name defect found during verification).
- **Retention wording fix**: `use/ai-workflows/index.md` reworded to clarify retention is an organization-administrator policy applied to every conversation — not a per-conversation choice "shown when the conversation starts" — now that the composer's non-functional per-conversation retention selector has been removed on the web side.

## Verification

- `python -m mkdocs build --strict` — clean.
- `pytest tests/docs/` — 112 passed (this includes the canonical-publication-gate IA check).

CHAOS-3215