### PR TITLE
fix(ask-dev): scripted list_metrics call uses the sanitized wire name

### DIFF
--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -27,6 +27,7 @@ _WIRE_READINESS_ECHO = "readiness_echo_v1"
 _WIRE_QUERY_METRIC = "query_metric_v1"
 _WIRE_SEARCH_EVIDENCE = "search_evidence_v1"
 _WIRE_DATA_HEALTH = "data_health_v1"
+_WIRE_LIST_METRICS = "list_metrics_v1"
 
 # CHAOS-3262: the literal metric-catalog acceptance question. When this exact
 # question is observed, the script deterministically drives a single
@@ -94,7 +95,7 @@ def _list_metrics_script(
                     "id": "scripted-call-list-metrics-v1",
                     "type": "function",
                     "function": {
-                        "name": "list_metrics.v1",
+                        "name": _WIRE_LIST_METRICS,
                         "arguments": json.dumps({"limit": 8}, separators=(",", ":")),
                     },
                 }


### PR DESCRIPTION
Composition break between #1343 (added `_list_metrics_script` with the dotted `list_metrics.v1` function name) and #1347 (adapter now expects sanitized wire names): merged in the same batch, `test_list_metrics_acceptance` fails on clean main with `internal_error/INVALID_RESPONSE`, `tool_call_count=0` — blocking the full unit gate for every rebased branch.

Fix: send `_WIRE_LIST_METRICS = "list_metrics_v1"` like every other scripted call site (the tool-RESULT ids stay canonical dotted, correctly).

Verified: `test_list_metrics_acceptance.py` fails on clean origin/main (isolated by lane-ops-adapters in a pristine worktree), passes with this fix; `test_acceptance_openai_runtime.py` + `tests/llm` 126 passed; ruff clean.

Relates CHAOS-3262 / CHAOS-3286.

https://claude.ai/code/session_01SkNkWExqmszydT1qEaG3Nv