### PR TITLE
fix(ask-dev): CHAOS-3265 readiness tests use the sanitized wire tool id

### DIFF
--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -37,6 +37,7 @@ from dev_health_ops.llm.agent.contracts import (
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.readiness import READINESS_ECHO_TOOL_ID
 from dev_health_ops.llm.credentials import (
     BYO_LLM_BASE_URL_FALLBACK_ALERT_THRESHOLD,
     BYO_LLM_BASE_URL_FALLBACK_ALERT_WINDOW,
@@ -100,7 +101,7 @@ class FakeReadinessProvider:
         if self.calls == 1:
             return AgentDecisionResult(
                 decision=AgentToolRequest(
-                    "readiness_echo", {"nonce": "ready-v1"}, "call-1"
+                    READINESS_ECHO_TOOL_ID, {"nonce": "ready-v1"}, "call-1"
                 ),
                 usage=AgentUsage(input_tokens=3, output_tokens=2),
                 latency_ms=1,

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -40,6 +40,7 @@ from dev_health_ops.llm.agent.policy import AgentProviderSource
 from dev_health_ops.llm.agent.readiness import (
     PLATFORM_READINESS_SETTING_KEY,
     PLATFORM_SETTINGS_ORG_ID,
+    READINESS_ECHO_TOOL_ID,
     READINESS_SETTING_KEY,
     AgentReadinessOutcome,
     AgentReadinessRecord,
@@ -79,7 +80,7 @@ class FakeReadinessProvider:
         if self.calls == 1:
             return AgentDecisionResult(
                 decision=AgentToolRequest(
-                    "readiness_echo", {"nonce": "ready-v1"}, "call-1"
+                    READINESS_ECHO_TOOL_ID, {"nonce": "ready-v1"}, "call-1"
                 ),
                 usage=AgentUsage(input_tokens=3, output_tokens=2),
                 latency_ms=1,


### PR DESCRIPTION
## Summary
Fixes the main breakage lane-team-lead flagged: 7 tests from #1348 (CHAOS-3265) failing on clean `origin/main` post-merge, symptom `readiness == "unsupported_model"` instead of `"ready"`.

## Root cause
`#1348`'s two new test files (`test_platform_ask_dev.py`, `test_llm_settings.py`) were authored/rebased against a `main` tree that didn't yet have `#1347` (CHAOS-3286: sanitize dotted tool names at the OpenAI wire boundary), which renamed the readiness probe's tool id from `"readiness_echo"` to `READINESS_ECHO_TOOL_ID = "readiness_echo.v1"` (`src/dev_health_ops/llm/agent/readiness.py`). Both new `FakeReadinessProvider` fixtures still hardcoded the old literal, so `AgentReadinessService.certify()`'s tool-id match against the real constant failed on every call, classifying as `INVALID_RESPONSE` → `unsupported_model` instead of `ready`.

`#1347` itself already fixed `test_ask_dev.py`'s pre-existing fixture at the time (that file already reads `"readiness_echo.v1"` on main today) — but the two files added by `#1348` were new, never touched by that fix, and batch-merging `#1347` and `#1348` together (each individually green against a tree without the other) composed into this untested combination.

Confirmed via `src/dev_health_ops/llm/agent/readiness.py` on current main, not a blind string patch — both fixtures now import and use `READINESS_ECHO_TOOL_ID` directly instead of a hardcoded literal, so a future rename can't silently drift the same way again.

## Verification
- Fail-before: all 7 exact tests reported, reverted to the pre-fix state, all fail with the exact reported symptom (`readiness == "unsupported_model"`).
- Pass-after: same 7 tests green with the fix.
- Full targeted suite: 89 passed (`test_platform_ask_dev.py`, `test_ask_dev.py`, `test_llm_settings.py`, `test_production_runtime.py`, `test_acceptance_openai_runtime.py`, `test_ask_dev_compose.py`).
- `ruff format --check`, `ruff check`, `mypy` clean on both touched files (and full-repo via pre-commit/pre-push hooks).

## Test plan
- [x] Fail-before/pass-after on the 7 named tests
- [x] Full targeted suite green
- [x] ruff + mypy clean