### PR TITLE
fix(ask-dev): CHAOS-3289 insufficient-evidence guard for unresolved named-entity answers

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import re
 import time
 from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping
@@ -59,8 +60,10 @@ from .contracts import (
     DevScopeResolution,
     DevToolRequest,
     DevToolResult,
+    DirectScope,
     FreshnessState,
     MetricID,
+    QuestionClass,
     ScopeResolutionOutcome,
     ToolID,
     dev_error_remediation,
@@ -91,6 +94,51 @@ def _dev_tool_request_limit_maximum() -> int:
         ):
             return constraint.le
     raise RuntimeError("dev_tool_request.v1 limit field must declare an upper bound")
+
+
+# CHAOS-3289: when resolve_scope.v1 was never attempted, the only remaining
+# signal that the question named a specific entity is the question text
+# itself. This pattern is deliberately narrow (an explicit, capitalized
+# entity name adjacent to one of the entity nouns Ask Dev tools actually
+# support, in one of a handful of common orderings) to keep false positives
+# on ordinary organization-wide prose vanishingly rare -- it is a backstop
+# for the exact fabricated-premise shape this issue reproduces (a genuinely
+# grounded, evidence-backed answer narrated under a name that was never
+# resolved), not a general NLU pass. Known residual gap: lowercase/slug
+# names and paraphrases outside these orderings still bypass it (tracked as
+# follow-up -- see CHAOS-3289's linked extension issue).
+_ENTITY_NAME_PATTERN = r"[A-Z][A-Za-z0-9&/'\-]*(?:\s+[A-Z][A-Za-z0-9&/'\-]*){0,3}"
+_ENTITY_NOUN_PATTERN = (
+    r"project|repository|repo|team|issue|pull request|deployment|incident|work unit"
+)
+
+# "status of/about/regarding/for/with/going on with the <Name> <noun>"
+_NAMED_ENTITY_REFERENCE = re.compile(
+    r"\b(?:status of|about|regarding|for|with|on|going on with|happening with)\s+"
+    r"(?:the\s+)?"
+    rf"({_ENTITY_NAME_PATTERN})"
+    rf"\s+(?:{_ENTITY_NOUN_PATTERN})\b"
+)
+
+# "the <Name> <noun> status" / "the <Name> <noun>'s status" -- the noun and
+# "status" trail the name instead of a leading preposition triggering it
+# (e.g. "What's the Ask Dev project status?").
+_NAMED_ENTITY_NOUN_STATUS = re.compile(
+    rf"\b({_ENTITY_NAME_PATTERN})\s+(?:{_ENTITY_NOUN_PATTERN})'?s?\s+status\b"
+)
+
+# "<noun> <Name>" -- the noun leads the name instead of trailing a
+# preposition (e.g. "Can you check project Ask Dev status?").
+_ENTITY_NOUN_LEADING = re.compile(
+    rf"\b(?:{_ENTITY_NOUN_PATTERN})\s+({_ENTITY_NAME_PATTERN})\b"
+)
+
+
+def _named_entity_phrases(text: str) -> frozenset[str]:
+    phrases = set(_NAMED_ENTITY_REFERENCE.findall(text))
+    phrases.update(_NAMED_ENTITY_NOUN_STATUS.findall(text))
+    phrases.update(_ENTITY_NOUN_LEADING.findall(text))
+    return frozenset(match.casefold() for match in phrases)
 
 
 _HARD_LIMIT_MAXIMA: dict[str, int | float] = {
@@ -428,6 +476,12 @@ class DevOrchestrator:
         terminal_written = False
         repair_count = 0
         retry_count = 0
+        # CHAOS-3289: track whether this run ever attempted resolve_scope.v1
+        # for a named entity, and that attempt's most recent outcome, so a
+        # final answer cannot silently narrate a named entity under
+        # organization scope that was never confirmed to exist.
+        resolve_scope_attempted = False
+        last_resolve_scope_outcome: ScopeResolutionOutcome | None = None
         selected_event_sink = event_sink or self._event_sink
 
         async def transition(state: RunState, safe_code: str | None = None) -> None:
@@ -782,6 +836,30 @@ class DevOrchestrator:
                     )
                     if (
                         tool_request.tool_id is ToolID.RESOLVE_SCOPE
+                        and committed_resolution is not None
+                    ):
+                        # CHAOS-3289: record every resolve_scope.v1 attempt
+                        # that actually produced an outcome (not just
+                        # successful ones -- ambiguous/not-found count too)
+                        # so a final answer can be judged against the run's
+                        # most recent named-entity resolution attempt.
+                        #
+                        # An attempt that produced NO outcome at all (the
+                        # call was rejected as malformed, or timed out --
+                        # execution.result.scope_resolution is None) must
+                        # NOT flip resolve_scope_attempted: doing so would
+                        # silently disarm every check below (neither the
+                        # ambiguous/not-found branch nor the
+                        # never-attempted/no-evidence branch would fire),
+                        # which is a worse outcome than never having called
+                        # the tool at all. Leaving resolve_scope_attempted
+                        # false here makes an errored call fall through to
+                        # the same empty-claims/named-phrase backstop that
+                        # covers "resolve_scope.v1 was never called".
+                        resolve_scope_attempted = True
+                        last_resolve_scope_outcome = committed_resolution.outcome
+                    if (
+                        tool_request.tool_id is ToolID.RESOLVE_SCOPE
                         and execution.result.status == "success"
                         and committed_resolution is not None
                         and committed_scope is not None
@@ -898,6 +976,20 @@ class DevOrchestrator:
                                 "answer_validation_failed",
                                 "The answer exceeds grounded-result limits.",
                             ),
+                        )
+                    unresolved_entity_error = self._unresolved_named_entity_error(
+                        question=request.question,
+                        question_class=request.question_class,
+                        authorized_scope=authorized_scope,
+                        resolve_scope_attempted=resolve_scope_attempted,
+                        last_resolve_scope_outcome=last_resolve_scope_outcome,
+                        answer=answer,
+                    )
+                    if unresolved_entity_error is not None:
+                        code, message = unresolved_entity_error
+                        return await finish(
+                            RunState.INSUFFICIENT_EVIDENCE,
+                            error=error(code, message),
                         )
                     return await finish(RunState.COMPLETED, answer=answer)
 
@@ -1314,6 +1406,84 @@ class DevOrchestrator:
             stale_required_sources=stale,
             as_of=as_of,
         )
+
+    @staticmethod
+    def _unresolved_named_entity_error(
+        *,
+        question: str,
+        question_class: QuestionClass,
+        authorized_scope: DevScope,
+        resolve_scope_attempted: bool,
+        last_resolve_scope_outcome: ScopeResolutionOutcome | None,
+        answer: DevAnswer,
+    ) -> tuple[str, str] | None:
+        """CHAOS-3289: a status answer must never narrate a named entity that
+        was never confirmed to exist.
+
+        Organization scope is a legitimate, fully executable answer target on
+        its own (CHAOS-3255) -- this only fires for STATUS-class questions
+        still running under organization scope, and only in the cases that
+        actually indicate a fabricated premise:
+
+        * the run's own most recent resolve_scope.v1 attempt for a named
+          entity came back ambiguous or not-found, yet the model still tried
+          to finalize a substantive answer instead of disclosing that; or
+        * resolve_scope.v1 was never attempted at all and the answer carries
+          no evidence-backed claims -- an organization-wide answer with real
+          support has real claims; one with neither a resolution attempt nor
+          any claim is exactly the fabricated-narrative shape reported in
+          CHAOS-3289 (the model skipped resolving "the X project" entirely
+          and narrated organization-wide tool output under that name); or
+        * resolve_scope.v1 was never attempted and the question names a
+          specific entity (``_named_entity_phrases``) that the answer's own
+          text still narrates -- this is the mixed variant of the same
+          defect: the model can hold genuine, evidence-backed organization-
+          wide claims (passing the empty-claims check above) while still
+          attributing them to a name it never resolved. Both are fabricated
+          premises; only the second needs the model's own words as evidence
+          since the run produced no resolve_scope.v1 call to judge instead.
+
+        Returns the ``(code, message)`` for the forced insufficient-evidence
+        termination, or ``None`` when the answer is not this failure shape.
+        """
+        if question_class is not QuestionClass.STATUS:
+            return None
+        if authorized_scope.direct_scope is not DirectScope.ORGANIZATION:
+            return None
+        if answer.status in {
+            AnswerStatus.INSUFFICIENT_EVIDENCE,
+            AnswerStatus.REFUSED,
+            AnswerStatus.ERROR,
+        }:
+            return None
+        if last_resolve_scope_outcome is ScopeResolutionOutcome.AMBIGUOUS:
+            return ("scope_ambiguous", "The requested scope is ambiguous.")
+        if last_resolve_scope_outcome is ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND:
+            return ("scope_not_found", "The requested scope was not found.")
+        if not resolve_scope_attempted:
+            if not answer.claims:
+                return (
+                    "insufficient_evidence",
+                    "The answer does not include evidence-backed claims for "
+                    "the requested entity.",
+                )
+            named_phrases = _named_entity_phrases(question)
+            if named_phrases:
+                narrated_texts = (
+                    answer.direct_summary,
+                    *(claim.text for claim in answer.claims),
+                )
+                if any(
+                    phrase in text.casefold()
+                    for phrase in named_phrases
+                    for text in narrated_texts
+                ):
+                    return (
+                        "insufficient_evidence",
+                        "The answer narrates a status for a named entity "
+                        "that was never resolved.",
+                    )
+        return None
 
     @staticmethod
     def _canonical_tool_request(

--- a/src/dev_health_ops/api/dev/prompts/composer.py
+++ b/src/dev_health_ops/api/dev/prompts/composer.py
@@ -40,6 +40,14 @@ _FIXED_POLICY_SECTIONS = (
         "Return exactly one normalized decision: registered tool request, dev_answer.v1 final "
         "answer, typed disambiguation, or refusal. Do not reveal private reasoning.",
     ),
+    (
+        "named_entity_resolution",
+        "When the question names a specific project, repository, issue, pull request, or work "
+        "unit, call resolve_scope.v1 with that name before requesting any status, change, "
+        "metric, or evidence tool. Never present an answer that describes a named entity "
+        "resolve_scope.v1 did not confirm exists; if it returns not-found or ambiguous, say so "
+        "instead of answering about the organization under the entity's name.",
+    ),
 )
 
 

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -24,7 +24,7 @@ from dev_health_ops.api.dev.orchestrator import (
     OrchestratorResult,
     RunState,
 )
-from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry, ToolRequestRejected
 from dev_health_ops.llm.agent.contracts import (
     AgentDisambiguation,
     AgentFinalAnswer,
@@ -171,9 +171,14 @@ def _orchestrator(
     )
 
 
-async def _run(orchestrator: DevOrchestrator, cancellation=None) -> OrchestratorResult:
+async def _run(
+    orchestrator: DevOrchestrator,
+    cancellation=None,
+    *,
+    request: DevMessageRequest | None = None,
+) -> OrchestratorResult:
     return await orchestrator.run(
-        request=_request(),
+        request=request or _request(),
         org_id="org_fullchaos",
         user_id="user_01",
         permission_fingerprint="permissions_01",
@@ -987,6 +992,525 @@ async def test_unresolved_named_entity_never_falls_back_to_organization_scope() 
     # the status tool keeps executing against the last committed scope
     # rather than silently regressing to an unauthorized/ambiguous one.
     assert calls[1].scope.direct_scope.value == "organization"
+
+
+# --- CHAOS-3289: questions about nonexistent entities must not be answered
+# --- as if the named entity exists.
+
+
+def _status_request() -> DevMessageRequest:
+    payload = deepcopy(positive_fixtures()["dev_message_request.v1"])
+    payload["question_class"] = "status"
+    return DevMessageRequest.model_validate(payload)
+
+
+def _ambiguous_resolution() -> DevScopeResolution:
+    from dev_health_ops.api.dev.contract_fixtures import NOW
+
+    scope = _scope_dict(direct_scope="organization")
+    candidate_scope = _scope_dict(
+        direct_scope="project",
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": "project-a",
+                "display_label": "Ask Dev A",
+                "repository_id": None,
+            }
+        ],
+    )
+    return DevScopeResolution.model_validate(
+        {
+            "schema_version": "dev_scope_resolution.v1",
+            "requested_scope": scope,
+            "resolved_scope": None,
+            "outcome": "ambiguous",
+            "authorized_repository_ids": [],
+            "authorized_entity_ids": [],
+            "candidates": [
+                {
+                    "entity_ref": candidate_scope["entity_refs"][0],
+                    "repository_id": None,
+                    "reason": "Multiple authorized entities match the requested query.",
+                }
+            ],
+            "fallbacks": [],
+            "warnings": [],
+            "resolved_at": NOW,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_answer_after_not_found_resolution_is_insufficient_evidence() -> (
+    None
+):
+    """CHAOS-3289: resolve_scope.v1 correctly reports not-found for a named
+    entity that does not exist, but nothing previously stopped the model
+    from still narrating an organization-wide answer under that entity's
+    name. The run must terminate insufficient_evidence instead."""
+
+    script_id = "status-not-found"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev project", "limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_resolve_scope_registry(
+                calls=calls, resolve_scope_result=_not_found_resolution()
+            ),
+            scope_resolver=resolve,
+        ),
+        request=_status_request(),
+    )
+
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "scope_not_found"
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+async def test_status_answer_after_ambiguous_resolution_is_insufficient_evidence() -> (
+    None
+):
+    """Same shape as the not-found case, but the model's last resolve_scope.v1
+    attempt came back ambiguous. Presenting an organization-wide narrative
+    under the (unpicked) entity's name is exactly as unsafe as not-found."""
+
+    script_id = "status-ambiguous"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev", "limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_resolve_scope_registry(
+                calls=calls, resolve_scope_result=_ambiguous_resolution()
+            ),
+            scope_resolver=resolve,
+        ),
+        request=_status_request(),
+    )
+
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "scope_ambiguous"
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+async def test_status_answer_skipping_resolve_scope_with_no_claims_is_insufficient_evidence() -> (
+    None
+):
+    """The literal reported defect: from inherited organization scope, the
+    model skips resolve_scope.v1 entirely, calls status_snapshot.v1 directly,
+    and would otherwise narrate a nonexistent named entity's status under an
+    ungrounded (zero-claim) summary. The run must not complete/partial that."""
+
+    script_id = "status-skip-resolve"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_resolve_scope_registry(
+                calls=calls, resolve_scope_result=_not_found_resolution()
+            ),
+            scope_resolver=resolve,
+        ),
+        request=_status_request(),
+    )
+
+    assert [request.tool_id.value for request in calls] == ["status_snapshot.v1"]
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "insufficient_evidence"
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+async def test_status_answer_after_errored_resolve_scope_attempt_is_insufficient_evidence() -> (
+    None
+):
+    """CHAOS-3289 regression: a resolve_scope.v1 call that is rejected as
+    malformed (or times out) never produces a scope_resolution, so
+    execution.result.scope_resolution is None -- distinct from a resolution
+    that came back and definitively said ambiguous/not-found. Naively
+    flipping resolve_scope_attempted=True for this call (without a real
+    outcome to judge) would leave last_resolve_scope_outcome=None, which
+    matches NEITHER the ambiguous/not-found branch NOR the
+    not-resolve_scope_attempted branch -- silently disarming every guard
+    check and letting a fabricated-name narrative straight through. An
+    errored resolve_scope.v1 attempt must be treated the same as never
+    calling it at all."""
+
+    script_id = "status-resolve-errored"
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    async def execute(_context, request: DevToolRequest) -> DevToolResult:
+        calls.append(request)
+        if request.tool_id is ToolID.RESOLVE_SCOPE:
+            raise ToolRequestRejected("scope resolution fields are invalid")
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+    # The rejected resolve_scope.v1 call leaves one required source
+    # unavailable, so dev_answer.v1's own coverage invariant requires a
+    # degraded (not complete) status here -- orthogonal to the CHAOS-3289
+    # guard under test, but required for the candidate to pass schema
+    # validation and actually reach that guard.
+    degraded_answer = _answer_with_no_claims(script_id=script_id)
+    degraded_answer.update({"status": "degraded", "metrics": [], "evidence": []})
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev project", "limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(degraded_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+            scope_resolver=resolve,
+        ),
+        request=_status_request(),
+    )
+
+    assert [request.tool_id.value for request in calls] == [
+        "resolve_scope.v1",
+        "status_snapshot.v1",
+    ]
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "insufficient_evidence"
+    assert result.answer is None
+
+
+def _answer_with_organization_scoped_claim(*, script_id: str) -> dict:
+    """The stock claim fixture hardcodes a repository validity_scope; this
+    test commits organization scope instead, so re-point the claim's
+    validity_scope at organization scope while keeping its evidence/metric
+    references, which the default registry's canonical tool result already
+    provides (dev_tool_result.v1 fixture: ev_01 / metric_01)."""
+    payload = _answer(script_id=script_id)
+    payload["claims"][0]["validity_scope"] = _scope_dict(direct_scope="organization")
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_grounded_organization_wide_status_answer_still_completes() -> None:
+    """A genuinely organization-wide status answer with real evidence-backed
+    claims must not be blocked just because resolve_scope.v1 was never
+    called -- CHAOS-3255 made organization scope a fully valid, executable
+    answer target on its own."""
+
+    script_id = "status-grounded-org-wide"
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_organization_scoped_claim(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            scope_resolver=resolve,
+        ),
+        request=_status_request(),
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.claims
+
+
+def _status_request_naming_entity(*, question: str) -> DevMessageRequest:
+    payload = deepcopy(positive_fixtures()["dev_message_request.v1"])
+    payload["question_class"] = "status"
+    payload["question"] = question
+    return DevMessageRequest.model_validate(payload)
+
+
+def _answer_narrating_named_entity(*, script_id: str, direct_summary: str) -> dict:
+    """A genuinely grounded (evidence-backed, non-empty claims) answer whose
+    own text still attributes the finding to a named entity -- the mixed
+    variant of CHAOS-3289: the empty-claims backstop alone cannot catch this,
+    since claims are real; only the narration itself gives it away."""
+    payload = _answer_with_organization_scoped_claim(script_id=script_id)
+    payload["direct_summary"] = direct_summary
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_status_answer_narrating_unresolved_named_entity_with_real_claims_is_blocked() -> (
+    None
+):
+    """CHAOS-3289 mixed variant: the model never calls resolve_scope.v1,
+    produces genuine organization-wide evidence-backed claims (so the
+    empty-claims check does not fire), but still narrates those claims as
+    if they were about the named entity the question asked about. This must
+    be caught by the question-text/answer-text cross-check, not just the
+    claims-emptiness heuristic."""
+
+    script_id = "status-mixed-fabrication"
+    question = "What's the status of the Ask Dev project"
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_narrating_named_entity(
+                            script_id=script_id,
+                            direct_summary=(
+                                "The status of the Ask Dev project is currently "
+                                "partial based on recent deployment activity."
+                            ),
+                        )
+                    )
+                ),
+            ],
+            script_id=script_id,
+            scope_resolver=resolve,
+        ),
+        request=_status_request_naming_entity(question=question),
+    )
+
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "insufficient_evidence"
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "question",
+    [
+        # noun+status trails the name instead of a leading preposition.
+        "What's the Ask Dev project status?",
+        # the noun leads the name instead of trailing a preposition.
+        "Can you check project Ask Dev status?",
+        # a connector phrase the original preposition list did not cover.
+        "What's going on with the Ask Dev project?",
+    ],
+)
+async def test_status_answer_narrating_unresolved_named_entity_other_phrasings_is_blocked(
+    question: str,
+) -> None:
+    """CHAOS-3289 hardening: a Codex adversarial review of this same guard
+    found that the original preposition-led regex (``status of/about/
+    regarding/for the <Name> <noun>``) missed common real-world phrasings
+    where the noun trails the name+status, or leads the name, or uses a
+    connector outside the original preposition list -- letting the mixed
+    fabrication variant through under ordinary rewording. Each of these
+    must still be blocked."""
+
+    script_id = "status-mixed-fabrication-phrasing"
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_narrating_named_entity(
+                            script_id=script_id,
+                            direct_summary=(
+                                "The status of the Ask Dev project is currently "
+                                "partial based on recent deployment activity."
+                            ),
+                        )
+                    )
+                ),
+            ],
+            script_id=script_id,
+            scope_resolver=resolve,
+        ),
+        request=_status_request_naming_entity(question=question),
+    )
+
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.error is not None
+    assert result.error.code == "insufficient_evidence"
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+async def test_status_answer_about_a_different_topic_with_real_claims_still_completes() -> (
+    None
+):
+    """The narrow name-shape backstop must not fire on a genuinely
+    organization-wide answer just because the question happens to name an
+    entity elsewhere in its phrasing -- only when the answer's own text
+    echoes that name."""
+
+    script_id = "status-mixed-unrelated"
+    question = "What's the status of the Ask Dev project"
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(input_tokens=100, output_tokens=10),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_narrating_named_entity(
+                            script_id=script_id,
+                            direct_summary=(
+                                "Twelve work items completed across the organization "
+                                "in the selected period."
+                            ),
+                        )
+                    )
+                ),
+            ],
+            script_id=script_id,
+            scope_resolver=resolve,
+        ),
+        request=_status_request_naming_entity(question=question),
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
 
 
 def test_hard_defaults_can_only_be_configured_downward() -> None:


### PR DESCRIPTION
## Summary

Fixes CHAOS-3289: a status question naming a nonexistent entity ("What's the status of the Ask Dev project") was answered as if the entity existed. The run never called `resolve_scope.v1` (or called it and got ambiguous/not-found back), yet the final answer narrated organization-wide tool output under the asked-about entity's name — a fabricated-premise answer.

## Root cause / fix

`resolve_scope.v1` itself was already fixed by CHAOS-3256 (not-found returns not-found, no org fallback). This defect is the layer above: nothing enforced that a **status question naming an entity** actually produces a resolved-entity answer, a typed disambiguation, or an explicit not-found/insufficient-evidence — the model could skip `resolve_scope.v1` entirely, or call it and get not-found, and still narrate a status under the org's data.

Orchestrator-level fix, deliberately **not touching `answer_validator.py`** (owned by a separate lane working CHAOS-3288/3290):

- `DevOrchestrator.run` now tracks the run's `resolve_scope.v1` attempts (`resolve_scope_attempted`, `last_resolve_scope_outcome`).
- At `AgentFinalAnswer` time, `_unresolved_named_entity_error()` forces `RunState.INSUFFICIENT_EVIDENCE` instead of `COMPLETED` for `QuestionClass.STATUS` answers still under organization scope, in the shapes that indicate a fabricated premise:
  1. the run's last `resolve_scope.v1` attempt came back **ambiguous** or **not-found**, yet the model still tried to finalize a substantive answer; or
  2. `resolve_scope.v1` was **never attempted** and the answer carries **zero evidence-backed claims** (the literal repro shape); or
  3. `resolve_scope.v1` was **never attempted**, the answer has real claims (so (2) doesn't fire), but the answer's own text still echoes a named entity the question asked about (the *mixed variant* — genuine org-wide evidence narrated under a fabricated name).
- `prompts/composer.py` gained an explicit `named_entity_resolution` policy section as defense in depth (call `resolve_scope.v1` before other tools when a question names an entity; never describe org-wide results under an unresolved name).

Legitimate organization-wide STATUS answers with real grounded claims are unaffected — CHAOS-3255 made organization scope a fully valid, executable answer target on its own, and this guard never fires once real, non-echoing claims exist.

### Fixes applied after a Codex adversarial review of the above

- **HIGH**: an errored/rejected/timed-out `resolve_scope.v1` call (`ToolRequestRejected`/`ToolExecutionTimedOut`, so `execution.result.scope_resolution` is `None`) was flipping `resolve_scope_attempted=True` with no real outcome to judge — silently disarming *every* guard check (neither the ambiguous/not-found branch nor the never-attempted/no-evidence branch would fire), which is worse than never having called the tool. Fixed: such an attempt is now treated identically to never having called `resolve_scope.v1` at all.
- **HIGH**: the question/answer text-echo regex only recognized `status of/about/regarding/for the X project`-shaped phrasing. Broadened to also catch noun-trailing-status (`the X project status`) and noun-leading-name (`check project X status`) orderings, plus a few more connector words (`with`, `on`, `going on with`, `happening with`).

Both fixes are mutation-verified (see Tests below). Three MED findings and one narrower residual regex gap from the same reviews were **not** fixed here — deferred to CHAOS-3292 (see below) as they require larger design decisions (cross-question-class enforcement, per-attempt resolution tracking, and a live-confirmed false-positive-rate concern in a pre-existing, unrelated heuristic) that exceed this PR's minimal-blast-radius scope.

## Scoping rationale

The guard covers **`QuestionClass.STATUS` only** — this matches the literal reported repro with minimal blast radius. Extension to `REMAINING_WORK`/`OBSERVED_CHANGE`/other question classes is tracked as follow-up (CHAOS-3292), since the system prompt already asks the model to resolve named entities before *any* tool, but the runtime guard doesn't yet enforce that universally.

## Tests

8 new/extended orchestrator tests, each mutation-verified (reverted the specific guard clause in isolation, confirmed *only* the intended test(s) failed, restored):
- `test_status_answer_after_not_found_resolution_is_insufficient_evidence`
- `test_status_answer_after_ambiguous_resolution_is_insufficient_evidence`
- `test_status_answer_skipping_resolve_scope_with_no_claims_is_insufficient_evidence` (literal repro)
- `test_grounded_organization_wide_status_answer_still_completes` (no false positive on legit org-wide answers)
- `test_status_answer_narrating_unresolved_named_entity_with_real_claims_is_blocked` (mixed variant)
- `test_status_answer_about_a_different_topic_with_real_claims_still_completes` (no false positive on unrelated org-wide text)
- `test_status_answer_after_errored_resolve_scope_attempt_is_insufficient_evidence` (new — HIGH finding #1 regression)
- `test_status_answer_narrating_unresolved_named_entity_other_phrasings_is_blocked[...]` ×3 (new — HIGH finding #2 regression, parametrized over the phrasings Codex found bypassing the original regex)

Full ask-dev suite: 411/411 pass (`tests/api/dev/`, excluding the live-ClickHouse-only file). `bash ci/local_validate.sh`: fully green twice (9674 then 9678 tests — before and after the post-review fixes — plus lint/mypy/go/river/ClickHouse-scratch-migrate/argMax-live-exec).

## Live re-verification (real BYO gpt-4o-mini, seeded stack)

Verified against a disposable second API process running this worktree's patched code inside the existing container (the running `dev-health-api-1` bind-mounts the main checkout, not this worktree — see `/tmp/claude/chaos-3289-fix-verify/SUMMARY.md` for the exact methodology, torn down after verification, nothing left outside `/tmp`).

- **Negative case** (fabricated "Ask Dev project", no such project exists): **5/5 runs correctly blocked**, zero fabrication in any run. Representative: *"Scope resolution for Ask Dev project within organization ... is forbidden/not found. No authorized entities ..."*
- **Positive control** ("Fullchaos project", the org's real project): **1/10 runs completed with a genuine grounded answer**; the other 9 were blocked (5 empty-claims, 1 scope_ambiguous, 1 scope_not_found, 2 model self-refusal). Traced this is **not a regression from this PR's changes** — it's pre-existing behavior in the empty-claims heuristic, unrelated to both HIGH-finding fixes above. This confirms live one of the Codex MED findings; filed as the top item in the follow-up issue rather than fixed here given the severity asymmetry (a fabricated answer is the trust violation this ticket exists to close; an over-cautious refusal is degraded-but-safe UX) and that a principled fix is a larger design change.

Full evidence (dev_runs/dev_tool_calls rows, SSE payloads, methodology): `/tmp/claude/chaos-3289-fix-verify/`.

## Follow-up

Filed **CHAOS-3292** for: (1) extending the guard to REMAINING_WORK/OBSERVED_CHANGE and other question classes, (2) per-attempt (not just latest) resolve_scope.v1 outcome tracking, (3) remaining regex-backstop gaps (lowercase/slug names), and (4) the live-confirmed empty-claims false-positive-rate finding above.

## Test plan

- [x] `bash ci/local_validate.sh` fully green (twice — before and after the post-Codex-review fixes)
- [x] 8 new/extended tests, all mutation-verified
- [x] Live re-verification: negative case blocked 5/5, positive control demonstrated to still complete (with a documented, pre-existing, unrelated reliability caveat filed as follow-up)
- [x] Codex adversarial review (two passes — pre and post the HIGH-finding fixes)