### PR TITLE
fix(ask-dev): multi-metric grounding repair prompts + empty-answer grounding floor (CHAOS-3288, CHAOS-3290)

### DIFF
--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -36,11 +36,30 @@ _NON_REPAIRABLE_VALIDATION_MARKERS = (
 # status instead of hard-failing a run that has usable evidence (CHAOS-3257).
 
 
+_MAX_REPAIR_DETAIL_CHARS = 500
+
+
 class AnswerValidationError(ValueError):
-    def __init__(self, message: str, *, code: str, repairable: bool) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        repairable: bool,
+        detail: tuple[str, ...] = (),
+    ) -> None:
         super().__init__(message)
         self.code = code
         self.repairable = repairable
+        # Short, safe, model-facing description of exactly what failed, used
+        # to build an actionable schema-repair prompt turn (CHAOS-3288)
+        # instead of a generic "fix your JSON" instruction the model cannot
+        # act on. Bounded and built only from our own raised messages / the
+        # `msg` field of pydantic error dicts -- never raw echoed input
+        # values, which pydantic keeps in a separate `input`/`ctx` field we
+        # do not touch.
+        joined = "; ".join(part for part in detail if part) or message
+        self.detail = joined[:_MAX_REPAIR_DETAIL_CHARS]
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,10 +115,15 @@ def validate_answer_candidate(
         repairable = not any(
             marker in details for marker in _NON_REPAIRABLE_VALIDATION_MARKERS
         )
+        # `error["msg"]` is the clean "Value error, <our message>" or
+        # "Field required" text; pydantic keeps the echoed input value in a
+        # separate `input`/`ctx` key we deliberately never read here, so
+        # this cannot leak tool/evidence payload content into the prompt.
         raise AnswerValidationError(
             "answer does not conform to dev_answer.v1",
             code="answer_validation_failed",
             repairable=repairable,
+            detail=tuple(str(error.get("msg", "")) for error in exc.errors()),
         ) from exc
 
     if (

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -36,7 +36,32 @@ _NON_REPAIRABLE_VALIDATION_MARKERS = (
 # status instead of hard-failing a run that has usable evidence (CHAOS-3257).
 
 
-_MAX_REPAIR_DETAIL_CHARS = 500
+_MAX_REPAIR_DETAIL_CHARS = 200
+
+
+def _bounded_detail(messages: tuple[str, ...], *, limit: int) -> str:
+    """Join messages up to `limit` chars without cutting one mid-sentence.
+
+    A naive join-then-slice can end on a fragment like "Extra inputs are
+    not" (from a 30-forbidden-field answer), which the repair prompt would
+    then present as if it were the complete reason. Keep only whole
+    messages that fit and note how many were dropped instead.
+    """
+    non_empty = [part for part in messages if part]
+    kept: list[str] = []
+    total = 0
+    for index, msg in enumerate(non_empty):
+        addition = msg if not kept else f"; {msg}"
+        if total + len(addition) > limit:
+            if not kept:
+                # Even the first whole message doesn't fit: better a
+                # visibly-truncated fragment than an empty detail string.
+                return msg[:limit]
+            omitted = len(non_empty) - index
+            return "; ".join(kept) + f" (+{omitted} more)"
+        kept.append(msg)
+        total += len(addition)
+    return "; ".join(kept)
 
 
 class AnswerValidationError(ValueError):
@@ -57,9 +82,13 @@ class AnswerValidationError(ValueError):
         # act on. Bounded and built only from our own raised messages / the
         # `msg` field of pydantic error dicts -- never raw echoed input
         # values, which pydantic keeps in a separate `input`/`ctx` field we
-        # do not touch.
-        joined = "; ".join(part for part in detail if part) or message
-        self.detail = joined[:_MAX_REPAIR_DETAIL_CHARS]
+        # do not touch. (One documented exception: pydantic's
+        # `iteration_error` embeds the underlying iterator exception's own
+        # text in `msg`; DevAnswer has no field whose validation iterates a
+        # caller-supplied generator today, so this is not currently
+        # reachable, but `msg` is not categorically safe for every possible
+        # future field type -- see CHAOS-3288 review notes.)
+        self.detail = _bounded_detail(detail, limit=_MAX_REPAIR_DETAIL_CHARS) or message
 
 
 @dataclass(frozen=True, slots=True)
@@ -111,19 +140,35 @@ def validate_answer_candidate(
             else DevAnswer.model_validate(payload)
         )
     except ValidationError as exc:
-        details = str(exc).casefold()
-        repairable = not any(
-            marker in details for marker in _NON_REPAIRABLE_VALIDATION_MARKERS
-        )
         # `error["msg"]` is the clean "Value error, <our message>" or
         # "Field required" text; pydantic keeps the echoed input value in a
         # separate `input`/`ctx` key we deliberately never read here, so
         # this cannot leak tool/evidence payload content into the prompt.
+        # For a missing required field, `loc` is one of our own fixed
+        # dev_answer.v1 field names (never model-echoed content), so naming
+        # it makes an otherwise-generic "Field required" actionable; for
+        # every other error type we keep `msg` alone rather than risk
+        # echoing a model-controlled key (e.g. an unexpected extra field).
+        messages = tuple(
+            f"{'.'.join(str(part) for part in error['loc'])}: {error.get('msg', '')}"
+            if error.get("type") == "missing" and error.get("loc")
+            else str(error.get("msg", ""))
+            for error in exc.errors()
+        )
+        # Classify repairability from the same safe messages, never from
+        # `str(exc)` -- pydantic's rendered exception text also includes
+        # `input_value=...`, so a coincidental echoed input (e.g. the model
+        # sending status="unknown metric") could otherwise match one of the
+        # markers below and wrongly mark an unrelated error non-repairable.
+        details = " ".join(messages).casefold()
+        repairable = not any(
+            marker in details for marker in _NON_REPAIRABLE_VALIDATION_MARKERS
+        )
         raise AnswerValidationError(
             "answer does not conform to dev_answer.v1",
             code="answer_validation_failed",
             repairable=repairable,
-            detail=tuple(str(error.get("msg", "")) for error in exc.errors()),
+            detail=messages,
         ) from exc
 
     if (

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -11,7 +12,9 @@ from pydantic import ValidationError
 from .contracts import (
     AnswerStatus,
     DevAnswer,
+    DevClaim,
     DevContractVersions,
+    DevCoverage,
     DevEvidenceRef,
     DevMetricRef,
     DevModelMetadata,
@@ -39,35 +42,53 @@ _NON_REPAIRABLE_VALIDATION_MARKERS = (
 
 _MAX_REPAIR_DETAIL_CHARS = 200
 
-# CHAOS-3290: a complete (or substantively-worded partial) answer must never
-# be an empty shell. A degenerate reasoning-exhausted run can still satisfy
-# every other invariant above (identity, scope, canonical evidence/metric
-# equality all vacuously pass over empty lists) while carrying zero claims,
-# zero metrics, and zero evidence -- a silent non-answer presented as
-# success. PRD §8 forbids a material status claim without evidence; this is
-# the degenerate case where there is no material claim *or* evidence at all.
+# CHAOS-3290: a complete (or substantive-partial) answer must never be an
+# empty shell. A degenerate reasoning-exhausted run can still satisfy every
+# other invariant above (identity, scope, canonical evidence/metric equality
+# all vacuously pass over empty lists) while carrying zero *material*
+# grounding -- a silent non-answer presented as success. PRD §8 forbids a
+# material status claim without evidence; this is the degenerate case where
+# there is no material claim or evidence at all.
 #
-# The floor cannot simply be "claims/metrics/evidence must be non-empty"
-# unconditionally: a metric-catalog question (list_metrics.v1 only) has no
-# tool output that is representable as a claim, metric, or evidence ref at
-# all (DevMetricDefinition has no value to ground a DevMetricRef with, and
-# mints no DevEvidenceRef), so a genuinely thorough catalog answer is
+# "Zero grounding" is NOT "claims/metrics/evidence are all empty" (adversarial
+# review, CHAOS-3290 follow-up): a single unsupported ``inferred`` claim
+# (confidence < 1) needs no metric_ref_ids/evidence_ref_ids at all under
+# DevClaim's own schema, so a model can add one fabricated inferred claim
+# ("Delivery performance improved substantially across every team.") and
+# make ``answer.claims`` non-empty without grounding anything. The floor must
+# check whether *any* claim actually references a metric or evidence ID, not
+# merely whether the claims array is non-empty.
+#
+# The floor also cannot simply require claims/metrics/evidence to be
+# non-empty unconditionally: a metric-catalog question (list_metrics.v1
+# only) has no tool output representable as a claim, metric, or evidence ref
+# at all (DevMetricDefinition has no value to ground a DevMetricRef with,
+# and mints no DevEvidenceRef), so a genuinely thorough catalog answer is
 # legitimately empty across all three arrays -- the only signal left is
-# whether the free-text summary actually reflects the retrieved catalog or
-# is a generic stub. Neither length nor "contains a number" is that signal
-# (live-reproduced CHAOS-3290 follow-up): a platform run that called only
-# list_metrics.v1 for a metric-comparison question produced "cycle time p50
-# and Average WIP are defined metrics over a 30-day window with daily
-# granularity. The metric definitions indicate:" -- long, and "30" makes it
-# match a bare digit check, but it never actually read the returned catalog;
-# it echoed the metric names *from the user's own question* and the literal
-# admission "I don't have the actual numeric data" was the real tell. The
-# machine identifiers a model can only plausibly produce by having actually
-# read the tool result (a snake_case metric_id or its "<id>.v<n>"
-# definition_version, e.g. "cycle_time_p50_hours.v1") are not something a
-# paraphrase of the question coincidentally reproduces, unlike the
-# human-readable label ("Cycle time p50") or an incidental day-count.
-_MIN_UNGROUNDED_SUMMARY_CHARS = 150
+# whether the free-text summary actually reflects the retrieved catalog.
+# Neither "contains a number" nor "the summary states the retrieved count"
+# is safe there (both live-reproduced and adversarially reproduced): "cycle
+# time p50 ... over a 30-day window" matches a bare digit check without
+# ever reading the catalog, and "I have 1 unresolved limitation..." matches
+# a bare count check purely by coincidence when only one definition exists.
+# Require covering at least half of the retrieved definitions' machine
+# identifiers (a snake_case metric_id or its "<id>.v<n>" definition_version)
+# instead -- a paraphrase of the question, an echoed user-supplied
+# identifier, or an incidental number cannot coincidentally satisfy that at
+# scale, and a single coincidental match is never enough once more than one
+# definition exists.
+#
+# For a substantive-but-ungrounded partial, prose length is not a safe
+# distinguishing signal either (adversarial review): a *short*, confident,
+# fabricated narrative ("Delivery performance improved substantially across
+# every team.") is exactly as untrustworthy as a long one. Use
+# ``answer.coverage`` instead -- it is server-computed and fully
+# overwritten by the orchestrator before validation (never model-authored),
+# so a model cannot forge it. A partial with zero grounding is honest only
+# if the server's own coverage accounting shows a real gap (a required
+# source unavailable, stale, or short of the required count); if coverage
+# reports everything available, an ungrounded partial is just as
+# structurally impossible as an ungrounded complete.
 _GROUNDABLE_TOOL_RESULT_FIELDS = (
     "metrics",
     "evidence",
@@ -77,6 +98,24 @@ _GROUNDABLE_TOOL_RESULT_FIELDS = (
     "deployments",
     "incidents",
 )
+
+
+def _claim_has_grounding_reference(claim: DevClaim) -> bool:
+    return bool(claim.metric_ref_ids or claim.evidence_ref_ids)
+
+
+def _answer_has_material_grounding(answer: DevAnswer) -> bool:
+    """Whether the answer carries anything an evidence-linked reader could
+    actually check: a metric, an evidence entry, or a claim that references
+    at least one of either. A claim with no reference at all (an
+    unsupported ``inferred`` assertion) does not count -- see the
+    module-level comment above.
+    """
+    return (
+        bool(answer.metrics)
+        or bool(answer.evidence)
+        or any(_claim_has_grounding_reference(claim) for claim in answer.claims)
+    )
 
 
 def _tool_results_offer_groundable_material(
@@ -96,17 +135,15 @@ def _tool_results_offer_groundable_material(
     )
 
 
-def _summary_reflects_retrieved_catalog(
+def _summary_covers_retrieved_catalog(
     summary: str, tool_results: tuple[DevToolResult, ...]
 ) -> bool:
-    """Whether `summary` reflects a retrieved metric catalog instead of just
-    restating the question -- the one signal a model cannot produce without
-    having actually read the tool result it was given (see the module-level
-    comment above). Either it names a machine identifier (a snake_case
-    metric_id or its "<id>.v<n>" definition_version), or it states the exact
-    count of definitions actually retrieved -- both require having read the
-    result; neither is something a paraphrase of the question coincidentally
-    reproduces.
+    """Whether `summary` demonstrably reflects the retrieved metric catalog
+    -- the one signal a model cannot produce without having actually read
+    the tool result it was given (see the module-level comment above).
+    Requires naming the machine identifier (metric_id or definition_version)
+    of at least half of the definitions actually retrieved; anything looser
+    is gameable (see the review notes above).
     """
     folded = summary.casefold()
     definitions = [
@@ -114,16 +151,28 @@ def _summary_reflects_retrieved_catalog(
         for result in tool_results
         for definition in result.metric_definitions
     ]
-    identifiers = (
-        identifier
-        for definition in definitions
-        for identifier in (definition.metric_id, definition.definition_version)
+    if not definitions:
+        return False
+
+    def _named(definition) -> bool:
+        return any(
+            identifier and identifier.casefold() in folded
+            for identifier in (definition.metric_id, definition.definition_version)
+        )
+
+    covered = sum(1 for definition in definitions if _named(definition))
+    return covered >= math.ceil(len(definitions) / 2)
+
+
+def _coverage_reports_a_gap(coverage: DevCoverage) -> bool:
+    """Whether the server's own (non-model-authored) coverage accounting
+    shows a genuine reason data could be missing.
+    """
+    return bool(
+        coverage.available_source_count < coverage.required_source_count
+        or coverage.unavailable_required_sources
+        or coverage.stale_required_sources
     )
-    if any(
-        identifier and identifier.casefold() in folded for identifier in identifiers
-    ):
-        return True
-    return bool(definitions) and str(len(definitions)) in summary
 
 
 def _bounded_detail(messages: tuple[str, ...], *, limit: int) -> str:
@@ -327,7 +376,7 @@ def validate_answer_candidate(
     # so this never overrides a real rejection; it only catches the shape
     # those checks vacuously allow through: nothing to check because there
     # is nothing there.
-    if not (answer.claims or answer.metrics or answer.evidence):
+    if not _answer_has_material_grounding(answer):
         summary = answer.direct_summary.strip()
         if answer.status is AnswerStatus.COMPLETE:
             if _tool_results_offer_groundable_material(context.tool_results):
@@ -341,31 +390,30 @@ def validate_answer_candidate(
                     code="answer_grounding_floor_not_met",
                     repairable=False,
                 )
-            if not _summary_reflects_retrieved_catalog(summary, context.tool_results):
+            if not _summary_covers_retrieved_catalog(summary, context.tool_results):
                 # No groundable material was available at all (e.g. a
                 # metric-catalog question) -- the only remaining honest
-                # signal is whether the summary names a machine identifier
-                # from the retrieved catalog instead of just restating the
-                # question in its own words.
+                # signal is whether the summary demonstrably covers the
+                # retrieved catalog instead of just restating the question.
                 raise AnswerValidationError(
                     "complete answer has no structured grounding and its "
                     "summary does not reflect retrieved data",
                     code="answer_grounding_floor_not_met",
                     repairable=False,
                 )
-        elif (
-            answer.status is AnswerStatus.PARTIAL
-            and len(summary) >= _MIN_UNGROUNDED_SUMMARY_CHARS
+        elif answer.status is AnswerStatus.PARTIAL and not _coverage_reports_a_gap(
+            answer.coverage
         ):
-            # A partial answer presenting long, confident-sounding prose
-            # with zero structured grounding is exactly as untrustworthy as
-            # a complete one -- "partial" alone does not excuse an
-            # unsupported narrative (CHAOS-3290). An honestly short/modest
-            # partial ("no data available yet") is not gated: it never
-            # claimed to be a substantive answer in the first place.
+            # A partial answer with zero grounding is only honest if the
+            # server's own coverage accounting explains why -- a required
+            # source unavailable, stale, or short of the required count.
+            # If coverage reports everything available, an ungrounded
+            # partial is exactly as untrustworthy as an ungrounded
+            # complete, regardless of how short or modest its prose reads
+            # (CHAOS-3290 review: prose length is not a safe signal here).
             raise AnswerValidationError(
-                "substantive partial answer carries no claim, metric, or "
-                "evidence grounding",
+                "partial answer carries no claim, metric, or evidence "
+                "grounding and reports no coverage gap to explain why",
                 code="answer_grounding_floor_not_met",
                 repairable=False,
             )

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -48,17 +48,20 @@ def _bounded_detail(messages: tuple[str, ...], *, limit: int) -> str:
     messages that fit and note how many were dropped instead.
     """
     non_empty = [part for part in messages if part]
+    # Reserve room for the worst-case " (+N more)" suffix up front so
+    # appending it can never itself push the result past `limit`.
+    suffix_reserve = len(f" (+{len(non_empty)} more)")
     kept: list[str] = []
     total = 0
     for index, msg in enumerate(non_empty):
         addition = msg if not kept else f"; {msg}"
-        if total + len(addition) > limit:
+        if total + len(addition) > limit - suffix_reserve:
             if not kept:
                 # Even the first whole message doesn't fit: better a
                 # visibly-truncated fragment than an empty detail string.
                 return msg[:limit]
             omitted = len(non_empty) - index
-            return "; ".join(kept) + f" (+{omitted} more)"
+            return ("; ".join(kept) + f" (+{omitted} more)")[:limit]
         kept.append(msg)
         total += len(addition)
     return "; ".join(kept)

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -53,15 +53,20 @@ _MAX_REPAIR_DETAIL_CHARS = 200
 # all (DevMetricDefinition has no value to ground a DevMetricRef with, and
 # mints no DevEvidenceRef), so a genuinely thorough catalog answer is
 # legitimately empty across all three arrays -- the only signal left is
-# whether the free-text summary actually reflects retrieved data or is a
-# generic stub. Length alone is not that signal: a deterministic catalog
-# summary can legitimately be short ("8 Ask Dev metrics are available in
-# this scope."), while the real CHAOS-3290 stub ("Available Ask Dev metrics
-# and their definitions.") is a *similar* length but names no concrete
-# retrieved fact. Requiring at least one number (a count, an id suffix like
-# ".v1", anything reflecting the catalog actually being read) plus a small
-# absolute floor catches the stub without penalizing a terse-but-real one.
-_MIN_CATALOG_SUMMARY_CHARS = 20
+# whether the free-text summary actually reflects the retrieved catalog or
+# is a generic stub. Neither length nor "contains a number" is that signal
+# (live-reproduced CHAOS-3290 follow-up): a platform run that called only
+# list_metrics.v1 for a metric-comparison question produced "cycle time p50
+# and Average WIP are defined metrics over a 30-day window with daily
+# granularity. The metric definitions indicate:" -- long, and "30" makes it
+# match a bare digit check, but it never actually read the returned catalog;
+# it echoed the metric names *from the user's own question* and the literal
+# admission "I don't have the actual numeric data" was the real tell. The
+# machine identifiers a model can only plausibly produce by having actually
+# read the tool result (a snake_case metric_id or its "<id>.v<n>"
+# definition_version, e.g. "cycle_time_p50_hours.v1") are not something a
+# paraphrase of the question coincidentally reproduces, unlike the
+# human-readable label ("Cycle time p50") or an incidental day-count.
 _MIN_UNGROUNDED_SUMMARY_CHARS = 150
 _GROUNDABLE_TOOL_RESULT_FIELDS = (
     "metrics",
@@ -89,6 +94,36 @@ def _tool_results_offer_groundable_material(
         for result in tool_results
         for field in _GROUNDABLE_TOOL_RESULT_FIELDS
     )
+
+
+def _summary_reflects_retrieved_catalog(
+    summary: str, tool_results: tuple[DevToolResult, ...]
+) -> bool:
+    """Whether `summary` reflects a retrieved metric catalog instead of just
+    restating the question -- the one signal a model cannot produce without
+    having actually read the tool result it was given (see the module-level
+    comment above). Either it names a machine identifier (a snake_case
+    metric_id or its "<id>.v<n>" definition_version), or it states the exact
+    count of definitions actually retrieved -- both require having read the
+    result; neither is something a paraphrase of the question coincidentally
+    reproduces.
+    """
+    folded = summary.casefold()
+    definitions = [
+        definition
+        for result in tool_results
+        for definition in result.metric_definitions
+    ]
+    identifiers = (
+        identifier
+        for definition in definitions
+        for identifier in (definition.metric_id, definition.definition_version)
+    )
+    if any(
+        identifier and identifier.casefold() in folded for identifier in identifiers
+    ):
+        return True
+    return bool(definitions) and str(len(definitions)) in summary
 
 
 def _bounded_detail(messages: tuple[str, ...], *, limit: int) -> str:
@@ -306,11 +341,12 @@ def validate_answer_candidate(
                     code="answer_grounding_floor_not_met",
                     repairable=False,
                 )
-            if len(summary) < _MIN_CATALOG_SUMMARY_CHARS or not _NUMBER.search(summary):
+            if not _summary_reflects_retrieved_catalog(summary, context.tool_results):
                 # No groundable material was available at all (e.g. a
                 # metric-catalog question) -- the only remaining honest
-                # signal is whether the summary reflects real retrieved
-                # content instead of restating the question.
+                # signal is whether the summary names a machine identifier
+                # from the retrieved catalog instead of just restating the
+                # question in its own words.
                 raise AnswerValidationError(
                     "complete answer has no structured grounding and its "
                     "summary does not reflect retrieved data",

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -9,6 +9,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from .contracts import (
+    AnswerStatus,
     DevAnswer,
     DevContractVersions,
     DevEvidenceRef,
@@ -37,6 +38,57 @@ _NON_REPAIRABLE_VALIDATION_MARKERS = (
 
 
 _MAX_REPAIR_DETAIL_CHARS = 200
+
+# CHAOS-3290: a complete (or substantively-worded partial) answer must never
+# be an empty shell. A degenerate reasoning-exhausted run can still satisfy
+# every other invariant above (identity, scope, canonical evidence/metric
+# equality all vacuously pass over empty lists) while carrying zero claims,
+# zero metrics, and zero evidence -- a silent non-answer presented as
+# success. PRD §8 forbids a material status claim without evidence; this is
+# the degenerate case where there is no material claim *or* evidence at all.
+#
+# The floor cannot simply be "claims/metrics/evidence must be non-empty"
+# unconditionally: a metric-catalog question (list_metrics.v1 only) has no
+# tool output that is representable as a claim, metric, or evidence ref at
+# all (DevMetricDefinition has no value to ground a DevMetricRef with, and
+# mints no DevEvidenceRef), so a genuinely thorough catalog answer is
+# legitimately empty across all three arrays -- the only signal left is
+# whether the free-text summary actually reflects retrieved data or is a
+# generic stub. Length alone is not that signal: a deterministic catalog
+# summary can legitimately be short ("8 Ask Dev metrics are available in
+# this scope."), while the real CHAOS-3290 stub ("Available Ask Dev metrics
+# and their definitions.") is a *similar* length but names no concrete
+# retrieved fact. Requiring at least one number (a count, an id suffix like
+# ".v1", anything reflecting the catalog actually being read) plus a small
+# absolute floor catches the stub without penalizing a terse-but-real one.
+_MIN_CATALOG_SUMMARY_CHARS = 20
+_MIN_UNGROUNDED_SUMMARY_CHARS = 150
+_GROUNDABLE_TOOL_RESULT_FIELDS = (
+    "metrics",
+    "evidence",
+    "status_facts",
+    "pull_requests",
+    "ci_checks",
+    "deployments",
+    "incidents",
+)
+
+
+def _tool_results_offer_groundable_material(
+    tool_results: tuple[DevToolResult, ...],
+) -> bool:
+    """Whether any executed tool in this run returned something an answer
+    could have cited as a claim, metric, or evidence reference.
+
+    False only for tool calls whose only possible output is definitional/
+    catalog data (currently: list_metrics.v1's ``metric_definitions``),
+    which has no representation anywhere in ``dev_answer.v1``.
+    """
+    return any(
+        getattr(result, field)
+        for result in tool_results
+        for field in _GROUNDABLE_TOOL_RESULT_FIELDS
+    )
 
 
 def _bounded_detail(messages: tuple[str, ...], *, limit: int) -> str:
@@ -232,6 +284,53 @@ def validate_answer_candidate(
             raise AnswerValidationError(
                 "numeric claim lacks a metric or source reference",
                 code="answer_validation_failed",
+                repairable=False,
+            )
+
+    # CHAOS-3290 grounding floor -- see the constants above for the full
+    # reasoning. Only reachable once every other invariant already passed,
+    # so this never overrides a real rejection; it only catches the shape
+    # those checks vacuously allow through: nothing to check because there
+    # is nothing there.
+    if not (answer.claims or answer.metrics or answer.evidence):
+        summary = answer.direct_summary.strip()
+        if answer.status is AnswerStatus.COMPLETE:
+            if _tool_results_offer_groundable_material(context.tool_results):
+                # Real tool material existed (metrics, evidence, status
+                # facts, ...) and none of it made it into the answer at
+                # all -- structurally impossible under PRD §8 regardless of
+                # what the prose says.
+                raise AnswerValidationError(
+                    "complete answer carries no claim, metric, or evidence "
+                    "grounding despite groundable tool results",
+                    code="answer_grounding_floor_not_met",
+                    repairable=False,
+                )
+            if len(summary) < _MIN_CATALOG_SUMMARY_CHARS or not _NUMBER.search(summary):
+                # No groundable material was available at all (e.g. a
+                # metric-catalog question) -- the only remaining honest
+                # signal is whether the summary reflects real retrieved
+                # content instead of restating the question.
+                raise AnswerValidationError(
+                    "complete answer has no structured grounding and its "
+                    "summary does not reflect retrieved data",
+                    code="answer_grounding_floor_not_met",
+                    repairable=False,
+                )
+        elif (
+            answer.status is AnswerStatus.PARTIAL
+            and len(summary) >= _MIN_UNGROUNDED_SUMMARY_CHARS
+        ):
+            # A partial answer presenting long, confident-sounding prose
+            # with zero structured grounding is exactly as untrustworthy as
+            # a complete one -- "partial" alone does not excuse an
+            # unsupported narrative (CHAOS-3290). An honestly short/modest
+            # partial ("no data available yet") is not gated: it never
+            # claimed to be a substantive answer in the first place.
+            raise AnswerValidationError(
+                "substantive partial answer carries no claim, metric, or "
+                "evidence grounding",
+                code="answer_grounding_floor_not_met",
                 repairable=False,
             )
     return answer

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -555,12 +555,36 @@ class DevOrchestrator:
                     )
 
                 await transition(RunState.MODEL_DECISION)
-                composed = self._composer.compose(
-                    question=request.question,
-                    scope=resolution,
-                    prior_turns=prior_turns,
-                    tool_results=tuple(tool_results),
-                )
+                try:
+                    composed = self._composer.compose(
+                        question=request.question,
+                        scope=resolution,
+                        prior_turns=prior_turns,
+                        tool_results=tuple(tool_results),
+                    )
+                except ValueError as exc:
+                    # A synthetic repair turn (CHAOS-3288) added on top of an
+                    # already-large caller-supplied conversation history can
+                    # push PromptComposer over its byte budget. That is a
+                    # bounded-budget condition, not an unexpected server
+                    # error: classify it the same way as the other prompt/
+                    # tool budget limits in this run loop instead of falling
+                    # through to the generic internal_error handler below,
+                    # which would misrepresent a repairable rejection as an
+                    # opaque failure. Only this specific, known budget
+                    # message is reclassified; any other ValueError from the
+                    # composer (e.g. a malformed prior-turn role) still
+                    # surfaces as internal_error so it gets investigated
+                    # rather than silently mislabeled as a budget limit.
+                    if "exceeds prompt budget" not in str(exc):
+                        raise
+                    return await finish(
+                        RunState.FAILED,
+                        error=error(
+                            "tool_limit_reached",
+                            "The conversation history budget was reached.",
+                        ),
+                    )
                 prompt_checksum = composed.checksum
                 prompt_bytes = len(composed.system_text.encode()) + len(
                     composed.user_text.encode()

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -918,6 +918,24 @@ class DevOrchestrator:
                                 ),
                             )
                             continue
+                        if exc.code == "answer_grounding_floor_not_met":
+                            # CHAOS-3290: a complete/substantive answer with
+                            # no claim, metric, or evidence grounding at all
+                            # is a silent non-answer, not a malformed one --
+                            # surface it as the same honest "nothing usable
+                            # was found" outcome the run already uses
+                            # elsewhere (AgentDisambiguation/AgentRefusal
+                            # below), not the scarier "validation failed"
+                            # error a real grounding violation gets.
+                            return await finish(
+                                RunState.INSUFFICIENT_EVIDENCE,
+                                error=error(
+                                    "insufficient_evidence",
+                                    "The answer did not include enough "
+                                    "grounded detail to present as a "
+                                    "result.",
+                                ),
+                            )
                         return await finish(
                             RunState.FAILED,
                             error=error(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -874,10 +874,23 @@ class DevOrchestrator:
                             and repair_count < self._limits.schema_repairs
                         ):
                             repair_count += 1
+                            # Tell the model exactly what was wrong instead of
+                            # a generic "fix your JSON" instruction it cannot
+                            # act on -- e.g. it claimed status=complete while
+                            # a queried metric was stale, and a bare "schema
+                            # validation failed" note gives it nothing to
+                            # change (CHAOS-3288). `exc.detail` is bounded and
+                            # never contains echoed tool/evidence content.
                             prior_turns = prior_turns + (
                                 PromptConversationTurn(
                                     role="assistant",
-                                    content="The previous response failed schema validation. Return one corrected dev_answer.v1 object.",
+                                    content=(
+                                        "The previous response failed validation: "
+                                        f"{exc.detail}. Return one corrected "
+                                        "dev_answer.v1 object that fixes exactly "
+                                        "that issue and keeps everything else "
+                                        "grounded in the same tool results."
+                                    ),
                                 ),
                             )
                             continue

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -121,7 +121,17 @@ def _list_metrics_script(
         "as_of": now,
         "status": "complete" if available else "degraded",
         "direct_summary": (
-            f"{len(definitions)} Ask Dev metrics are available in this scope."
+            (
+                f"{len(definitions)} Ask Dev metrics are available in this scope: "
+                + ", ".join(
+                    str(
+                        definition.get("definition_version")
+                        or definition.get("metric_id")
+                    )
+                    for definition in definitions
+                )
+                + "."
+            )
             if available
             else "The Ask Dev metric catalog could not be read."
         ),

--- a/tests/api/dev/test_answer_validator.py
+++ b/tests/api/dev/test_answer_validator.py
@@ -133,3 +133,149 @@ def test_numeric_inference_requires_metric_or_source_reference() -> None:
     ]
     with pytest.raises(AnswerValidationError, match="numeric claim"):
         validate_answer_candidate(payload, _context())
+
+
+# --- CHAOS-3290: a complete/substantive answer cannot be an empty shell ---
+
+
+def _context_without_groundable_material() -> AnswerValidationContext:
+    """A run whose only executed tool is a catalog/definitional one
+    (list_metrics.v1 in production): it returns `metric_definitions` but
+    mints no `metrics`/`evidence`/other groundable fact, exactly like the
+    real tool result behind the CHAOS-3290 live reproduction.
+    """
+    fixtures = positive_fixtures()
+    answer = DevAnswer.model_validate(fixtures["dev_answer.v1"])
+    tool_result = deepcopy(fixtures["dev_tool_result.v1"])
+    tool_result.update(
+        {
+            "metrics": [],
+            "evidence": [],
+            "status_facts": [],
+            "pull_requests": [],
+            "ci_checks": [],
+            "deployments": [],
+            "incidents": [],
+        }
+    )
+    return AnswerValidationContext(
+        conversation_id=answer.conversation_id,
+        answer_id=answer.answer_id,
+        scope_resolution=DevScopeResolution.model_validate(
+            fixtures["dev_scope_resolution.v1"]
+        ),
+        versions=DevContractVersions.model_validate(answer.versions),
+        model=DevModelMetadata.model_validate(answer.model),
+        tool_results=(DevToolResult.model_validate(tool_result),),
+    )
+
+
+def _empty_payload(*, status: str, direct_summary: str) -> dict:
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload.update(
+        {
+            "status": status,
+            "direct_summary": direct_summary,
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+            "coverage": {
+                "required_source_count": 1,
+                "available_source_count": 1,
+                "unavailable_required_sources": [],
+                "stale_required_sources": [],
+                "as_of": payload["as_of"],
+            },
+        }
+    )
+    return payload
+
+
+def test_complete_answer_with_available_grounding_cannot_be_empty() -> None:
+    """PRD §8: a complete answer with material tool output (real metrics/
+    evidence existed for this run) but zero claims, metrics, and evidence
+    of its own is structurally impossible, regardless of what its prose
+    says.
+    """
+    payload = _empty_payload(
+        status="complete",
+        direct_summary=(
+            "Everything checked out fine across the board this period, no "
+            "issues to report anywhere in the organization's delivery."
+        ),
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context())
+    assert raised.value.code == "answer_grounding_floor_not_met"
+    assert raised.value.repairable is False
+
+
+def test_complete_catalog_answer_with_a_stub_summary_is_rejected() -> None:
+    """Literal CHAOS-3290 live reproduction: a platform gpt-5-nano run for
+    the metrics-catalog question (list_metrics.v1 only -- no metric/
+    evidence/claim is representable for that tool) terminated
+    terminal_reason=complete with empty claims/metrics/evidence and the
+    stub summary "Available Ask Dev metrics and their definitions." -- a
+    silent non-answer presented as success with favorable (1-of-1)
+    coverage and no visible error.
+    """
+    payload = _empty_payload(
+        status="complete",
+        direct_summary="Available Ask Dev metrics and their definitions.",
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context_without_groundable_material())
+    assert raised.value.code == "answer_grounding_floor_not_met"
+    assert raised.value.repairable is False
+
+
+def test_complete_catalog_answer_with_a_real_listing_is_not_a_stub() -> None:
+    """The same list_metrics.v1-only tool shape, but with the prose that a
+    thorough catalog answer actually requires (as the real BYO gpt-4o-mini
+    run for the identical question produced), must not be penalized just
+    because a metric catalog has nothing representable as a claim, metric,
+    or evidence ref -- there is nothing to falsely present as grounded here.
+    """
+    payload = _empty_payload(
+        status="complete",
+        direct_summary=(
+            "The available Ask Dev metrics are as follows: "
+            "1. Items completed -- Completed work items in the selected "
+            "window. 2. Cycle time p50 -- Median work-item cycle time in "
+            "hours. 3. Average WIP -- Average work-in-progress across "
+            "daily snapshots. 4. Deployments -- Deployments recorded in "
+            "the selected window."
+        ),
+    )
+    answer = validate_answer_candidate(payload, _context_without_groundable_material())
+    assert answer.status == "complete"
+
+
+def test_substantive_partial_narrative_cannot_be_ungrounded() -> None:
+    """A partial answer presenting long, confident-sounding prose with zero
+    structured grounding is exactly as untrustworthy as a complete one
+    (CHAOS-3290) -- "partial" alone is not an excuse for an unsupported
+    narrative when real tool material existed to ground it in.
+    """
+    payload = _empty_payload(
+        status="partial",
+        direct_summary=(
+            "Delivery throughput climbed steadily this period while review "
+            "latency held flat, and the organization's overall investment "
+            "mix shifted meaningfully toward new feature work across every "
+            "team without any material regression worth flagging."
+        ),
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context())
+    assert raised.value.code == "answer_grounding_floor_not_met"
+
+
+def test_honest_short_partial_is_not_penalized() -> None:
+    """An honestly modest partial answer ("no data yet") never claimed to
+    be a substantive result in the first place and must not be gated by
+    the grounding floor.
+    """
+    payload = _empty_payload(status="partial", direct_summary="No data available yet.")
+    answer = validate_answer_candidate(payload, _context_without_groundable_material())
+    assert answer.status == "partial"

--- a/tests/api/dev/test_answer_validator.py
+++ b/tests/api/dev/test_answer_validator.py
@@ -62,6 +62,54 @@ def test_schema_only_failure_allows_one_bounded_repair() -> None:
     with pytest.raises(AnswerValidationError) as raised:
         validate_answer_candidate(payload, _context())
     assert raised.value.repairable is True
+    # CHAOS-3288: a missing-field detail names the actual field (one of our
+    # own fixed dev_answer.v1 field names, never model-echoed content) so a
+    # bare "Field required" repair prompt is actionable.
+    assert "direct_summary" in raised.value.detail
+    assert "Field required" in raised.value.detail
+
+
+def test_repairability_is_classified_from_safe_messages_not_echoed_input() -> None:
+    """CHAOS-3288 review: repairability must not depend on `str(exc)`, which
+    also renders the model's own (echoed) input value. Two unrelated invalid
+    `status` values that happen to produce the identical safe message must
+    get the identical classification, even when one value's *text* happens
+    to collide with a non-repairable marker like "unknown metric".
+    """
+    baseline = deepcopy(positive_fixtures()["dev_answer.v1"])
+
+    ordinary_payload = deepcopy(baseline)
+    ordinary_payload["status"] = "not-a-status"
+    with pytest.raises(AnswerValidationError) as ordinary:
+        validate_answer_candidate(ordinary_payload, _context())
+
+    colliding_payload = deepcopy(baseline)
+    colliding_payload["status"] = "unknown metric"
+    with pytest.raises(AnswerValidationError) as colliding:
+        validate_answer_candidate(colliding_payload, _context())
+
+    assert ordinary.value.repairable is True
+    assert colliding.value.repairable is True
+    assert "unknown metric" not in colliding.value.detail.casefold()
+
+
+def test_many_validation_errors_produce_a_bounded_detail_without_a_cut_word() -> None:
+    """CHAOS-3288 review: bounding the joined detail must not slice through
+    the middle of a message. A large number of forbidden extra fields
+    produces many identical "Extra inputs are not permitted" errors; the
+    bounded detail must end on a whole message (or an explicit omitted
+    count), never a truncated fragment like "Extra inputs are not".
+    """
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload.update({f"unexpected_extra_field_{i}": i for i in range(30)})
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context())
+    detail = raised.value.detail
+    assert len(detail) <= 200
+    assert not detail.rstrip().endswith("Extra inputs are not")
+    assert detail.endswith("more)") or detail.strip().endswith(
+        "Extra inputs are not permitted"
+    )
 
 
 def test_server_identity_scope_and_runtime_metadata_cannot_be_rewritten() -> None:

--- a/tests/api/dev/test_answer_validator.py
+++ b/tests/api/dev/test_answer_validator.py
@@ -170,22 +170,38 @@ def _context_without_groundable_material() -> AnswerValidationContext:
     )
 
 
-def _empty_payload(*, status: str, direct_summary: str) -> dict:
+def _empty_payload(
+    *,
+    status: str,
+    direct_summary: str,
+    claims: list | None = None,
+    coverage_gap: bool = False,
+) -> dict:
     payload = deepcopy(positive_fixtures()["dev_answer.v1"])
     payload.update(
         {
             "status": status,
             "direct_summary": direct_summary,
-            "claims": [],
+            "claims": claims if claims is not None else [],
             "metrics": [],
             "evidence": [],
-            "coverage": {
-                "required_source_count": 1,
-                "available_source_count": 1,
-                "unavailable_required_sources": [],
-                "stale_required_sources": [],
-                "as_of": payload["as_of"],
-            },
+            "coverage": (
+                {
+                    "required_source_count": 1,
+                    "available_source_count": 0,
+                    "unavailable_required_sources": ["list_metrics.v1"],
+                    "stale_required_sources": [],
+                    "as_of": payload["as_of"],
+                }
+                if coverage_gap
+                else {
+                    "required_source_count": 1,
+                    "available_source_count": 1,
+                    "unavailable_required_sources": [],
+                    "stale_required_sources": [],
+                    "as_of": payload["as_of"],
+                }
+            ),
         }
     )
     return payload
@@ -249,21 +265,74 @@ def test_complete_catalog_answer_with_a_real_listing_is_not_a_stub() -> None:
     assert answer.status == "complete"
 
 
-def test_complete_catalog_answer_stating_the_exact_retrieved_count_is_not_a_stub() -> (
-    None
-):
-    """The scripted deterministic acceptance path's list_metrics.v1 answer
-    ("N Ask Dev metrics are available in this scope.") never names a
-    machine identifier -- it states only the exact count of definitions
-    actually retrieved. That still requires having read the tool result
-    (an incidental number like a window's day count cannot coincidentally
-    equal it) and must not be rejected as a stub.
+def test_complete_catalog_answer_stating_only_the_count_is_still_a_stub() -> None:
+    """Codex adversarial review (CHAOS-3290 follow-up): accepting the bare
+    retrieved *count* as proof of having read the catalog is gameable --
+    "I have 1 unresolved limitation and cannot provide the requested metric
+    catalog." coincidentally contains "1" when exactly one definition was
+    retrieved, with zero relationship to the catalog. Only naming the
+    definitions' own machine identifiers counts; a bare count never does,
+    regardless of how many were retrieved.
     """
     context = _context_without_groundable_material()
     retrieved_count = len(context.tool_results[0].metric_definitions)
     payload = _empty_payload(
         status="complete",
         direct_summary=f"{retrieved_count} Ask Dev metrics are available in this scope.",
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, context)
+    assert raised.value.code == "answer_grounding_floor_not_met"
+
+
+def test_complete_catalog_answer_covering_half_the_definitions_is_not_a_stub() -> None:
+    """A real, thorough catalog answer only needs to demonstrably cover at
+    least half of what was actually retrieved (naming every one of a large
+    catalog verbatim is not required for the answer to be genuine).
+    """
+    fixtures = positive_fixtures()
+    tool_result = deepcopy(fixtures["dev_tool_result.v1"])
+    real_metric_ids = [
+        "items_completed",
+        "cycle_time_p50_hours",
+        "avg_wip",
+        "deployments_count",
+    ]
+    definitions = []
+    for metric_id in real_metric_ids:
+        definition = deepcopy(tool_result["metric_definitions"][0])
+        definition["metric_id"] = metric_id
+        definition["definition_version"] = f"{metric_id}.v1"
+        definitions.append(definition)
+    tool_result.update(
+        {
+            "metric_definitions": definitions,
+            "metrics": [],
+            "evidence": [],
+            "status_facts": [],
+            "pull_requests": [],
+            "ci_checks": [],
+            "deployments": [],
+            "incidents": [],
+        }
+    )
+    answer = DevAnswer.model_validate(fixtures["dev_answer.v1"])
+    context = AnswerValidationContext(
+        conversation_id=answer.conversation_id,
+        answer_id=answer.answer_id,
+        scope_resolution=DevScopeResolution.model_validate(
+            fixtures["dev_scope_resolution.v1"]
+        ),
+        versions=DevContractVersions.model_validate(answer.versions),
+        model=DevModelMetadata.model_validate(answer.model),
+        tool_results=(DevToolResult.model_validate(tool_result),),
+    )
+    payload = _empty_payload(
+        status="complete",
+        direct_summary=(
+            "Two of the four registered metrics: items_completed.v1 and "
+            "cycle_time_p50_hours.v1."
+        ),
     )
     answer = validate_answer_candidate(payload, context)
     assert answer.status == "complete"
@@ -316,10 +385,70 @@ def test_substantive_partial_narrative_cannot_be_ungrounded() -> None:
 
 
 def test_honest_short_partial_is_not_penalized() -> None:
-    """An honestly modest partial answer ("no data yet") never claimed to
-    be a substantive result in the first place and must not be gated by
-    the grounding floor.
+    """An honestly modest partial answer ("no data yet") is only honest
+    because the server's own coverage accounting backs it up -- a required
+    source really is reported unavailable here. It must not be gated by the
+    grounding floor.
     """
-    payload = _empty_payload(status="partial", direct_summary="No data available yet.")
+    payload = _empty_payload(
+        status="partial", direct_summary="No data available yet.", coverage_gap=True
+    )
     answer = validate_answer_candidate(payload, _context_without_groundable_material())
     assert answer.status == "partial"
+
+
+def test_short_confident_partial_with_favorable_coverage_is_still_rejected() -> None:
+    """Codex adversarial review (CHAOS-3290 follow-up): prose length is not
+    a safe grounding signal -- a *short*, confident, fabricated-sounding
+    narrative ("Delivery performance improved substantially across every
+    team.") is exactly as untrustworthy as a long one when there is zero
+    structured grounding and the server's own coverage reports nothing
+    missing. Must be rejected regardless of brevity.
+    """
+    payload = _empty_payload(
+        status="partial",
+        direct_summary="Delivery performance improved substantially across every team.",
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context())
+    assert raised.value.code == "answer_grounding_floor_not_met"
+
+
+def test_unsupported_inferred_claim_does_not_disable_the_grounding_floor() -> None:
+    """Codex adversarial review (CHAOS-3290 follow-up): DevClaim permits an
+    ``inferred`` claim with confidence < 1 and zero metric/evidence refs.
+    Adding exactly one such claim previously made ``answer.claims``
+    non-empty and disabled the entire grounding floor, letting a complete
+    answer with a stub summary and one fabricated, unreferenced claim
+    through. The floor must check whether any claim actually references a
+    metric or evidence ID, not merely whether the claims array is
+    non-empty.
+    """
+    payload = _empty_payload(
+        status="complete",
+        direct_summary="Available Ask Dev metrics and their definitions.",
+        claims=[
+            {
+                "schema_version": "dev_claim.v1",
+                "claim_id": "unsupported_claim_01",
+                "kind": "inferred",
+                "text": "Delivery performance improved substantially across every team.",
+                "confidence": 0.5,
+                "evidence_ref_ids": [],
+                "metric_ref_ids": [],
+                "validity_scope": positive_fixtures()["dev_scope_resolution.v1"][
+                    "resolved_scope"
+                ],
+                "flags": {
+                    "stale": False,
+                    "uncertain": False,
+                    "conflicting": False,
+                    "untrusted_source": False,
+                },
+                "recommendation_rule_version": None,
+            }
+        ],
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context_without_groundable_material())
+    assert raised.value.code == "answer_grounding_floor_not_met"

--- a/tests/api/dev/test_answer_validator.py
+++ b/tests/api/dev/test_answer_validator.py
@@ -241,14 +241,58 @@ def test_complete_catalog_answer_with_a_real_listing_is_not_a_stub() -> None:
         direct_summary=(
             "The available Ask Dev metrics are as follows: "
             "1. Items completed -- Completed work items in the selected "
-            "window. 2. Cycle time p50 -- Median work-item cycle time in "
-            "hours. 3. Average WIP -- Average work-in-progress across "
-            "daily snapshots. 4. Deployments -- Deployments recorded in "
-            "the selected window."
+            "window. Definition version: items_completed.v1. "
+            "2. Cycle time p50 -- Median work-item cycle time in hours."
         ),
     )
     answer = validate_answer_candidate(payload, _context_without_groundable_material())
     assert answer.status == "complete"
+
+
+def test_complete_catalog_answer_stating_the_exact_retrieved_count_is_not_a_stub() -> (
+    None
+):
+    """The scripted deterministic acceptance path's list_metrics.v1 answer
+    ("N Ask Dev metrics are available in this scope.") never names a
+    machine identifier -- it states only the exact count of definitions
+    actually retrieved. That still requires having read the tool result
+    (an incidental number like a window's day count cannot coincidentally
+    equal it) and must not be rejected as a stub.
+    """
+    context = _context_without_groundable_material()
+    retrieved_count = len(context.tool_results[0].metric_definitions)
+    payload = _empty_payload(
+        status="complete",
+        direct_summary=f"{retrieved_count} Ask Dev metrics are available in this scope.",
+    )
+    answer = validate_answer_candidate(payload, context)
+    assert answer.status == "complete"
+
+
+def test_complete_catalog_answer_naming_the_metrics_but_not_the_catalog_is_a_stub() -> (
+    None
+):
+    """Live-reproduced follow-up: a platform run for a metric-comparison
+    question called only list_metrics.v1, then answered status=complete
+    with a summary that names the metrics *from the user's own question*
+    ("cycle time p50 and Average WIP are defined metrics over a 30-day
+    window...") without ever citing anything from the catalog it actually
+    retrieved, and admitted "I don't have the actual numeric data in this
+    thread." Long, and "30" satisfies a bare digit check, but it never
+    reflects the retrieved catalog -- this must still be rejected.
+    """
+    payload = _empty_payload(
+        status="complete",
+        direct_summary=(
+            "I don’t have the actual numeric data in this thread. Based on "
+            "the available tool results, cycle time p50 and Items Completed "
+            "are defined metrics over a 30-day window with daily "
+            "granularity. The metric definitions indicate:"
+        ),
+    )
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context_without_groundable_material())
+    assert raised.value.code == "answer_grounding_floor_not_met"
 
 
 def test_substantive_partial_narrative_cannot_be_ungrounded() -> None:

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -287,6 +287,12 @@ async def test_orchestrator_overwrites_all_server_owned_answer_metadata() -> Non
                 "stale_required_sources": [],
                 "as_of": candidate["as_of"],
             },
+            # Not "complete"/"partial": this test makes zero tool calls and
+            # is about server-owned metadata overwriting, not about whether
+            # an empty answer is trustworthy -- the CHAOS-3290 grounding
+            # floor (which gates complete/substantive-partial answers with
+            # nothing else in the payload) has its own dedicated tests.
+            "status": "degraded",
         }
     )
 

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -61,6 +61,35 @@ class Recorder:
         self.terminals.append(values["state"])
 
 
+class RecordingProvider:
+    """Wraps ScriptedAgentProvider to capture the exact messages sent on
+    each decide() call, so a test can assert on the repair-prompt content
+    the orchestrator built (CHAOS-3288)."""
+
+    def __init__(self, steps: list[ScriptedStep], *, script_id: str) -> None:
+        self._inner = ScriptedAgentProvider(steps, script_id=script_id)
+        self.calls: list[tuple[Any, ...]] = []
+
+    @property
+    def capabilities(self):
+        return self._inner.capabilities
+
+    @property
+    def provider_fingerprint(self) -> str:
+        return self._inner.provider_fingerprint
+
+    @property
+    def model_fingerprint(self) -> str:
+        return self._inner.model_fingerprint
+
+    async def decide(self, **kwargs):
+        self.calls.append(tuple(kwargs["messages"]))
+        return await self._inner.decide(**kwargs)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
 def _request() -> DevMessageRequest:
     return DevMessageRequest.model_validate(
         positive_fixtures()["dev_message_request.v1"]
@@ -1758,3 +1787,104 @@ async def test_tool_execution_timeout_degrades_instead_of_failing_the_run() -> N
     assert rejected.tool_id is ToolID.STATUS_SNAPSHOT
     assert rejected.error is not None
     assert rejected.error.code == "source_unavailable"
+
+
+# --- CHAOS-3288: an informative repair prompt for a stale-coverage rejection ---
+
+
+@pytest.mark.asyncio
+async def test_stale_complete_repair_prompt_includes_the_actual_validation_reason() -> (
+    None
+):
+    """Literal CHAOS-3288 repro shape: two query_metric.v1 rounds return
+    real but stale data, the model answers status=complete, and the
+    (correct, CHAOS-3257) coverage invariant rejects it. The old generic
+    "fix your JSON" repair prompt gave the model nothing to act on; the
+    repair turn must now name the actual reason so a real model has a
+    chance to self-correct instead of repeating the same mistake and
+    exhausting the one repair attempt.
+    """
+    script_id = "stale-complete-repair-detail"
+
+    async def query_metric_executor(
+        _context: Any, request: DevToolRequest
+    ) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        metric = deepcopy(payload["metrics"][0])
+        metric["freshness"] = "stale"
+        metric["metric_ref_id"] = f"metric:{request.metric_id}"
+        metric["metric_id"] = request.metric_id
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "status": "partial",
+                "metrics": [metric],
+                "evidence": [],
+                "metric_definitions": [],
+                "warnings": ["source_stale"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry(
+        {tool_id: query_metric_executor for tool_id in ToolID}
+    )
+    falsely_complete = _answer(script_id=script_id)
+    falsely_complete.update(
+        {"status": "complete", "claims": [], "metrics": [], "evidence": []}
+    )
+    corrected = _answer(script_id=script_id)
+    corrected.update(
+        {"status": "degraded", "claims": [], "metrics": [], "evidence": []}
+    )
+
+    provider = RecordingProvider(
+        [
+            ScriptedStep(
+                decision=AgentToolRequest(
+                    tool_id="query_metric.v1",
+                    arguments={
+                        "metric_id": "cycle_time_p50_hours",
+                        "include_comparison": False,
+                        "limit": 12,
+                    },
+                    call_id="tool_call_01",
+                )
+            ),
+            ScriptedStep(
+                decision=AgentToolRequest(
+                    tool_id="query_metric.v1",
+                    arguments={
+                        "metric_id": "avg_wip",
+                        "include_comparison": False,
+                        "limit": 12,
+                    },
+                    call_id="tool_call_02",
+                )
+            ),
+            ScriptedStep(decision=AgentFinalAnswer(falsely_complete)),
+            ScriptedStep(decision=AgentFinalAnswer(corrected)),
+        ],
+        script_id=script_id,
+    )
+
+    result = await _run(
+        _orchestrator([], script_id=script_id, registry=registry, provider=provider)
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status == "degraded"
+    # 2 tool rounds + 1 rejected final answer + 1 repaired final answer.
+    assert len(provider.calls) == 4
+    repair_messages = provider.calls[3]
+    repair_user_message = next(
+        message for message in repair_messages if message.role.value == "user"
+    )
+    assert (
+        "complete answer requires all required sources fresh and available"
+        in repair_user_message.content
+    )
+    assert "The previous response failed validation" in repair_user_message.content

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -24,6 +24,7 @@ from dev_health_ops.api.dev.orchestrator import (
     OrchestratorResult,
     RunState,
 )
+from dev_health_ops.api.dev.prompts import PromptConversationTurn
 from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
 from dev_health_ops.llm.agent.contracts import (
     AgentDisambiguation,
@@ -200,7 +201,12 @@ def _orchestrator(
     )
 
 
-async def _run(orchestrator: DevOrchestrator, cancellation=None) -> OrchestratorResult:
+async def _run(
+    orchestrator: DevOrchestrator,
+    cancellation=None,
+    *,
+    prior_turns: tuple = (),
+) -> OrchestratorResult:
     return await orchestrator.run(
         request=_request(),
         org_id="org_fullchaos",
@@ -210,6 +216,7 @@ async def _run(orchestrator: DevOrchestrator, cancellation=None) -> Orchestrator
         conversation_id="conversation_01",
         answer_id="answer_01",
         cancellation=cancellation or asyncio.Event(),
+        prior_turns=prior_turns,
     )
 
 
@@ -1888,3 +1895,84 @@ async def test_stale_complete_repair_prompt_includes_the_actual_validation_reaso
         in repair_user_message.content
     )
     assert "The previous response failed validation" in repair_user_message.content
+
+
+@pytest.mark.asyncio
+async def test_repair_turn_overflow_is_a_classified_budget_limit_not_internal_error() -> (
+    None
+):
+    """CHAOS-3288 review: a synthetic repair turn appended on top of an
+    already-near-budget caller-supplied conversation history can push
+    PromptComposer over its byte cap on the retry round. That must surface
+    as a classified tool_limit_reached (the same bounded-budget family as
+    every other limit in this run loop), not fall through to a generic,
+    uninformative internal_error that misrepresents a repairable rejection
+    as an unexpected server failure.
+    """
+    script_id = "repair-turn-budget-overflow"
+
+    async def query_metric_executor(
+        _context: Any, request: DevToolRequest
+    ) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        metric = deepcopy(payload["metrics"][0])
+        metric["freshness"] = "stale"
+        metric["metric_ref_id"] = f"metric:{request.metric_id}"
+        metric["metric_id"] = request.metric_id
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "status": "partial",
+                "metrics": [metric],
+                "evidence": [],
+                "metric_definitions": [],
+                "warnings": ["source_stale"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry(
+        {tool_id: query_metric_executor for tool_id in ToolID}
+    )
+    falsely_complete = _answer(script_id=script_id)
+    falsely_complete.update(
+        {"status": "complete", "claims": [], "metrics": [], "evidence": []}
+    )
+
+    # Three large prior turns close to PromptComposer's 32,768-byte budget,
+    # matching the boundary reproduced in review: an assistant/user/
+    # assistant sequence whose serialized history sits a few hundred bytes
+    # under the cap on its own.
+    huge_prior_turns = (
+        PromptConversationTurn(role="assistant", content="a" * 12_500),
+        PromptConversationTurn(role="user", content="b" * 8_000),
+        PromptConversationTurn(role="assistant", content="c" * 12_000),
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="query_metric.v1",
+                        arguments={
+                            "metric_id": "cycle_time_p50_hours",
+                            "include_comparison": False,
+                            "limit": 12,
+                        },
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(falsely_complete)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        ),
+        prior_turns=huge_prior_turns,
+    )
+
+    assert result.state is RunState.FAILED
+    assert result.error is not None
+    assert result.error.code == "tool_limit_reached"


### PR DESCRIPTION
## Summary

Combined fix for two related, overlapping Ask Dev launch-blocker bugs, both root-caused via live reproduction against the real BYO/platform providers on the seeded local stack.

### CHAOS-3288 — multi-metric comparison answers fail grounding validation after correct orchestration

Root cause (confirmed via live instrumented reproduction): the model answered `status="complete"` while a queried metric carried `freshness="stale"`. The existing CHAOS-3257 coverage invariant correctly rejects "complete" next to a stale required source — that invariant was never wrong. The actual defect was the schema-repair retry prompt: it told the model only *"The previous response failed schema validation. Return one corrected dev_answer.v1 object"* — generic text that gave the model nothing to act on, so its one repair attempt resent essentially the same answer and the run hard-failed even though every fact needed for a grounded, accurately-labeled answer already existed.

- `AnswerValidationError` now carries a short, bounded `detail` string built only from our own messages / pydantic's `error["msg"]` (never the echoed `input`/`ctx` value), and the repair turn includes it.
- Hardened after self-review: the detail-bounding never cuts a message mid-sentence, repairability is classified from the same safe messages (never `str(exc)`, which also renders echoed input), and a synthetic repair turn that pushes an already-large caller history over the prompt budget is classified as `tool_limit_reached`, not a generic `internal_error`.
- Live re-verified against the real BYO path through `/api/v1/dev`: the model now downgrades to `status=partial` on the first repair attempt instead of exhausting the budget and failing.

### CHAOS-3290 — a complete/substantive answer with zero claims/metrics/evidence was silently accepted as success

Live convergence pass: a platform run terminated `terminal_reason=complete` with empty `claims`/`metrics`/`evidence`, favorable coverage, and a stub summary — a silent non-answer presented as success. Added a new grounding-floor invariant, gated on the answer having zero *material* grounding (a metric, an evidence entry, or a claim that references either), that:

- Rejects `complete` when real tool material existed and none of it made it into the answer (general PRD §8 case).
- For the metric-catalog case (no groundable material can exist at all, e.g. `list_metrics.v1`-only), requires the summary to demonstrably reflect the retrieved catalog (name at least half of the retrieved definitions' machine identifiers) instead of just restating the question.
- For `partial`, requires the server-computed (non-model-authored) `coverage` to report a genuine gap — a confident, unsupported narrative with favorable coverage is rejected regardless of length.

Rejections use a new `answer_grounding_floor_not_met` code, mapped by the orchestrator to `insufficient_evidence` with a safe remediation message ("The investigation stopped safely. The answer did not include enough grounded detail to present as a result.") instead of the scarier generic grounding-validation-failed banner.

**Codex adversarial review** (run from the ops repo root) found three real bypasses in the first version of the floor — closed in a follow-up commit:
1. An unsupported `inferred` claim (no refs required by schema) made `claims` non-empty and disabled the floor entirely.
2. The catalog check's count-based fallback could be satisfied by an unrelated coincidental digit.
3. The partial-narrative check used prose length, which a short fabricated narrative could dodge.

Live re-verified again after the fix (via a temporary branch checkout so the dev-mode bind-mounted API container picked it up): the same real degenerate answer now correctly surfaces as `insufficient_evidence` instead of silently succeeding.

## Test plan
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" bash ci/local_validate.sh` — full local gate green (lint, mypy, Go, river, ClickHouse migrations, full unit suite 9679 passed, argMax live-exec proof) on the final commit.
- [x] `tests/api/dev` full suite: 426 passed, plus 2 pre-existing unrelated ClickHouse-schema failures (`test_status_change_clickhouse_live.py`, not touched by this change).
- [x] Fail-before/pass-after regression tests for both defects and all three adversarially-found bypasses.
- [x] Codex adversarial review from the repo root; all HIGH/MED findings fixed.
- [x] Live re-verified against the real BYO/platform providers through `/api/v1/dev` on the running seeded stack for both defects.

Linear: CHAOS-3288, CHAOS-3290 (blocks Wave 4 entry).

## Positive-control completion rate (patched vs unpatched A/B)

Per request: the CHAOS-3289 lane's live verification found the positive
control ("Fullchaos project" status question, real BYO gpt-4o-mini)
completed genuinely only 1/10 times pre-existing, mostly blocked by an
existing empty-claims heuristic (CHAOS-3292). Ran n=6 of the same question
against this PR's patched code and n=6 against pre-this-PR `main`
(commit bbfbf9169, includes CHAOS-3289) side-by-side in the same
environment (disposable in-container instances, same technique as the
CHAOS-3289 lane; full detail in `/tmp/claude/chaos-3288-3290-positive-control/SUMMARY.md`):

**0/6 genuine completions on both sides — this PR does not materially
change the completion rate.**

| | Patched (this PR) | Baseline (pre-PR) |
|---|---|---|
| Genuine completion | 0/6 | 0/6 |
| Model self-refusal (resolve_scope found nothing) | 3/6 | 3/6 |
| scope_ambiguous / scope_not_found | 1/6 | 1/6 |
| Pre-existing empty-claims backstop (CHAOS-3292) | 1/6 | 2/6 |
| **This PR's new CHAOS-3290 grounding floor** | **1/6** | n/a |

This PR's own grounding floor fired in exactly 1/6 patched runs, and in that
run `resolve_scope.v1` had already failed to find the entity at all
(0 items) — there was no real data to ground an answer in, so it's a correct
catch, not an over-refusal of a legitimate answer. No run on either side
showed this PR blocking an answer that had real retrieved data behind it
(contrast: the pre-existing backstop blocked baseline runs with 50 and 10
real retrieved items — an existing CHAOS-3292 issue, not touched here).

The dominant driver of the low completion rate on both sides (5/6 patched,
4/6 baseline) is `resolve_scope.v1` failing to resolve "Fullchaos project"
as a distinct entity in this org's seed data — a pre-existing
scope-resolution-quality confound (CHAOS-3256/CHAOS-3292 territory)
unrelated to and not worsened by this PR. n=6/side is what the time budget
allowed; a larger n and/or a more reliably-resolvable positive-control
entity would further isolate this confound.
