### PR TITLE
fix(api): load a safe sync coverage window

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2328",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2332",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2328
+        "line": 2332
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2468",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2472",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2468
+        "line": 2472
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2231",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2235",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2231
+        "line": 2235
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2372",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2376",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2372
+        "line": 2376
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1961,6 +1961,10 @@ async def get_sync_config_coverage(
         default=HISTORY_LOOKBACK_DAYS,
         ge=1,
         le=3650,
+        description=(
+            "Maximum history window. The response may use a smaller effective "
+            "window when the requested sync-unit history exceeds safety limits."
+        ),
     ),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -350,8 +350,15 @@ class SyncCoverageSummaryResponse(BaseModel):
     provider: str
     generated_at: datetime
     data_basis: Literal["planner", "legacy"]
-    history_lookback_days: int
-    truncated_before: datetime
+    history_lookback_days: int = Field(
+        description=(
+            "Effective history window used for this response. May be smaller than "
+            "the requested upper bound when the recent sync-unit history is too large."
+        )
+    )
+    truncated_before: datetime = Field(
+        description="Oldest timestamp included by the effective history window."
+    )
     overall: SyncCoverageOverall
     datasets: list[SyncCoverageDataset]
     sources: list[SyncCoverageSource]

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -12,7 +12,7 @@ from time import monotonic
 from typing import Any, Protocol
 
 from croniter import croniter as Croniter
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select, union
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only
 
@@ -673,6 +673,245 @@ async def _has_schedule_row(
     return (await session.execute(stmt)).scalar_one_or_none() is not None
 
 
+@dataclass(frozen=True)
+class _CoverageLookbackSelection:
+    effective_days: int
+    requested_unit_window_count: int
+    effective_unit_window_count: int
+    unit_window_limit: int
+
+
+def _terminal_unit_base_filters(
+    org_id: str,
+    scope: EffectiveScope,
+) -> list[Any]:
+    source_ids = [source.id for source in scope.sources]
+    query_dataset_keys = _query_dataset_keys_for_scope(scope.dataset_keys)
+    return [
+        SyncRunUnit.org_id == org_id,
+        SyncRunUnit.integration_id == scope.integration_id,
+        SyncRunUnit.source_id.in_(source_ids),
+        SyncRunUnit.dataset_key.in_(query_dataset_keys),
+        SyncRunUnit.status.in_(REQUESTED_UNIT_STATUSES),
+        SyncRunUnit.since_at.is_not(None),
+        SyncRunUnit.before_at.is_not(None),
+        SyncRun.org_id == org_id,
+    ]
+
+
+def _work_item_window_weight(scope: EffectiveScope) -> int:
+    return max(
+        sum(1 for key in scope.dataset_keys if _is_work_item_family_dataset_key(key)),
+        1,
+    )
+
+
+async def _weighted_unit_window_count(
+    session: AsyncSession,
+    scope: EffectiveScope,
+    unit_rows: Any,
+    *,
+    limit: int,
+) -> int:
+    bounded_units = unit_rows.limit(limit + 1).subquery()
+    stmt = select(
+        func.coalesce(
+            func.sum(
+                case(
+                    (
+                        bounded_units.c.dataset_key
+                        == _WORK_ITEMS_CANONICAL_DATASET_KEY,
+                        _work_item_window_weight(scope),
+                    ),
+                    else_=1,
+                )
+            ),
+            0,
+        )
+    ).select_from(bounded_units)
+    return int((await session.execute(stmt)).scalar_one())
+
+
+def _latest_success_unit_rows(
+    org_id: str,
+    scope: EffectiveScope,
+) -> Any:
+    base_filters = _terminal_unit_base_filters(org_id, scope)
+    latest_success_ranked = (
+        select(
+            SyncRunUnit.id.label("unit_id"),
+            SyncRunUnit.dataset_key.label("dataset_key"),
+            func.row_number()
+            .over(
+                partition_by=(SyncRunUnit.source_id, SyncRunUnit.dataset_key),
+                order_by=(
+                    SyncRunUnit.before_at.desc(),
+                    SyncRunUnit.updated_at.desc(),
+                ),
+            )
+            .label("row_num"),
+        )
+        .select_from(SyncRunUnit)
+        .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+        .where(*base_filters, SyncRunUnit.status == SyncRunUnitStatus.SUCCESS.value)
+        .subquery()
+    )
+    return select(
+        latest_success_ranked.c.unit_id,
+        latest_success_ranked.c.dataset_key,
+    ).where(latest_success_ranked.c.row_num == 1)
+
+
+async def _recent_backfill_run_ids_for_lookback(
+    session: AsyncSession,
+    org_id: str,
+    config: SyncConfiguration,
+    truncated_before: datetime,
+    *,
+    limit: int,
+) -> set[uuid.UUID] | None:
+    stmt = select(BackfillJob.celery_task_id).where(
+        BackfillJob.org_id == org_id,
+        BackfillJob.sync_config_id == config.id,
+        BackfillJob.created_at >= truncated_before,
+    )
+    rows = list((await session.execute(stmt.limit(limit + 1))).all())
+    if len(rows) > limit:
+        return None
+    run_ids: set[uuid.UUID] = set()
+    for job in rows:
+        run_id_str = _backfill_job_sync_run_id(job)
+        if run_id_str is None:
+            continue
+        try:
+            run_ids.add(uuid.UUID(run_id_str))
+        except ValueError:
+            continue
+    return run_ids
+
+
+async def _coverage_unit_window_count(
+    session: AsyncSession,
+    org_id: str,
+    config: SyncConfiguration,
+    scope: EffectiveScope,
+    truncated_before: datetime,
+    *,
+    limit: int,
+) -> int:
+    if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
+        return 0
+    base_filters = _terminal_unit_base_filters(org_id, scope)
+    recent_units = (
+        select(
+            SyncRunUnit.id.label("unit_id"),
+            SyncRunUnit.dataset_key.label("dataset_key"),
+        )
+        .select_from(SyncRunUnit)
+        .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+        .where(*base_filters, SyncRunUnit.updated_at >= truncated_before)
+    )
+    recent_backfill_run_ids = await _recent_backfill_run_ids_for_lookback(
+        session,
+        org_id,
+        config,
+        truncated_before,
+        limit=limit,
+    )
+    if recent_backfill_run_ids is None:
+        return limit + 1
+    unit_queries: list[Any] = [
+        recent_units,
+        _latest_success_unit_rows(org_id, scope),
+    ]
+    if recent_backfill_run_ids:
+        backfill_units = (
+            select(
+                SyncRunUnit.id.label("unit_id"),
+                SyncRunUnit.dataset_key.label("dataset_key"),
+            )
+            .select_from(SyncRunUnit)
+            .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+            .where(
+                *base_filters,
+                SyncRunUnit.sync_run_id.in_(recent_backfill_run_ids),
+            )
+        )
+        unit_queries.append(backfill_units)
+    unit_rows = union(*unit_queries)
+    return await _weighted_unit_window_count(
+        session,
+        scope,
+        unit_rows,
+        limit=limit,
+    )
+
+
+async def _select_coverage_lookback(
+    session: AsyncSession,
+    org_id: str,
+    config: SyncConfiguration,
+    scope: EffectiveScope,
+    *,
+    requested_days: int,
+    generated_at: datetime,
+) -> _CoverageLookbackSelection:
+    """Choose the largest window whose expanded unit set fits the memory cap."""
+
+    unit_window_limit = MAX_COVERAGE_UNIT_WINDOWS
+    counts: dict[int, int] = {}
+
+    async def count_for(days: int) -> int:
+        if days not in counts:
+            counts[days] = await _coverage_unit_window_count(
+                session,
+                org_id,
+                config,
+                scope,
+                generated_at - timedelta(days=days),
+                limit=unit_window_limit,
+            )
+        return counts[days]
+
+    requested_count = await count_for(requested_days)
+    if requested_count <= unit_window_limit:
+        return _CoverageLookbackSelection(
+            effective_days=requested_days,
+            requested_unit_window_count=requested_count,
+            effective_unit_window_count=requested_count,
+            unit_window_limit=unit_window_limit,
+        )
+
+    minimum_count = await count_for(1)
+    if minimum_count > unit_window_limit:
+        raise SyncCoverageComplexityError(
+            stage="expanded_unit_windows",
+            limit=unit_window_limit,
+            observed=minimum_count,
+        )
+
+    low = 1
+    high = requested_days - 1
+    effective_days = 1
+    effective_count = minimum_count
+    while low <= high:
+        candidate_days = (low + high) // 2
+        candidate_count = await count_for(candidate_days)
+        if candidate_count <= unit_window_limit:
+            effective_days = candidate_days
+            effective_count = candidate_count
+            low = candidate_days + 1
+        else:
+            high = candidate_days - 1
+
+    return _CoverageLookbackSelection(
+        effective_days=effective_days,
+        requested_unit_window_count=requested_count,
+        effective_unit_window_count=effective_count,
+        unit_window_limit=unit_window_limit,
+    )
+
+
 async def _terminal_unit_windows(
     session: AsyncSession,
     org_id: str,
@@ -683,18 +922,7 @@ async def _terminal_unit_windows(
 ) -> list[UnitWindow]:
     if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
         return []
-    source_ids = [source.id for source in scope.sources]
-    query_dataset_keys = _query_dataset_keys_for_scope(scope.dataset_keys)
-    base_filters = [
-        SyncRunUnit.org_id == org_id,
-        SyncRunUnit.integration_id == scope.integration_id,
-        SyncRunUnit.source_id.in_(source_ids),
-        SyncRunUnit.dataset_key.in_(query_dataset_keys),
-        SyncRunUnit.status.in_(REQUESTED_UNIT_STATUSES),
-        SyncRunUnit.since_at.is_not(None),
-        SyncRunUnit.before_at.is_not(None),
-        SyncRun.org_id == org_id,
-    ]
+    base_filters = _terminal_unit_base_filters(org_id, scope)
     # Deliberately project only the columns used by interval math. Selecting
     # the ORM entities hydrates SyncRunUnit.result/error and SyncRun.result/error
     # for every unit in the lookback; those JSON/text payloads are unrelated to
@@ -1404,9 +1632,10 @@ async def build_sync_coverage_summary(
     lookback_days: int = HISTORY_LOOKBACK_DAYS,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Query persisted sync state and return a config-scoped coverage summary."""
+    """Return coverage within the largest memory-safe window up to ``lookback_days``."""
 
     started_at = monotonic()
+    requested_lookback_days = lookback_days
     log_context = {
         "org_id": org_id,
         "sync_config_id": str(config.id),
@@ -1425,8 +1654,36 @@ async def build_sync_coverage_summary(
             )
             budget = _CoverageQueryBudget()
             now = ensure_utc(generated_at or datetime.now(timezone.utc))
-            truncated_before = now - timedelta(days=lookback_days)
             scope = await resolve_effective_scope(session, org_id, config, budget)
+            lookback = await _select_coverage_lookback(
+                session,
+                org_id,
+                config,
+                scope,
+                requested_days=requested_lookback_days,
+                generated_at=now,
+            )
+            lookback_days = lookback.effective_days
+            log_context = {
+                **log_context,
+                "history_lookback_days": lookback_days,
+                "requested_history_lookback_days": requested_lookback_days,
+            }
+            if lookback_days != requested_lookback_days:
+                logger.warning(
+                    "sync_coverage_history_window_reduced",
+                    extra={
+                        **log_context,
+                        "effective_history_lookback_days": lookback_days,
+                        "complexity_stage": "expanded_unit_windows",
+                        "complexity_limit": lookback.unit_window_limit,
+                        "complexity_observed": (lookback.requested_unit_window_count),
+                        "effective_unit_window_count": (
+                            lookback.effective_unit_window_count
+                        ),
+                    },
+                )
+            truncated_before = now - timedelta(days=lookback_days)
             schedule = await _active_schedule(session, org_id, config)
             has_schedule = await _has_schedule_row(session, org_id, config)
             windows = await _terminal_unit_windows(

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -467,12 +467,132 @@ async def test_sync_coverage_rejects_history_before_query_budget_is_exceeded(
         if "sync_run_units" in statement.lower() and "select" in statement.lower()
     ]
     assert unit_queries, "overflow path did not execute a measured unit query"
+    assert any("sum(" in statement for statement in unit_queries)
     assert all(" limit " in statement for statement in unit_queries)
     assert any(
         record.message == "sync_coverage_summary_complexity_rejected"
         and getattr(record, "complexity_stage") == "recent_units"
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_selects_largest_safe_history_window(
+    client, session_maker, monkeypatch, caplog
+):
+    """Large recent-unit histories return a truthful reduced window, not a 422."""
+
+    caplog.set_level("WARNING", logger="dev_health_ops.api.services.sync_coverage")
+    monkeypatch.setattr(sync_coverage_module, "MAX_COVERAGE_UNIT_WINDOWS", 2)
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    reference = datetime.now(timezone.utc)
+    for age_days in (120, 60, 10):
+        before = reference - timedelta(days=age_days)
+        await _seed_unit(
+            session_maker,
+            scope,
+            since=before - timedelta(hours=1),
+            before=before,
+            status="failed",
+            updated_at=before,
+        )
+    old_success = reference - timedelta(days=150)
+    await _seed_unit(
+        session_maker,
+        scope,
+        since=old_success - timedelta(hours=1),
+        before=old_success,
+        updated_at=old_success,
+    )
+    backfill_unit = reference - timedelta(days=61)
+    backfill_run_id = await _seed_unit(
+        session_maker,
+        scope,
+        since=backfill_unit - timedelta(hours=1),
+        before=backfill_unit,
+        status="failed",
+        updated_at=backfill_unit,
+    )
+    backfill_created_at = reference - timedelta(days=58)
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="failed",
+                since_date=(backfill_unit - timedelta(hours=1)).date(),
+                before_date=backfill_unit.date(),
+                total_chunks=1,
+                failed_chunks=1,
+                celery_task_id=f"sync_run:{backfill_run_id}",
+                created_at=backfill_created_at,
+                updated_at=backfill_created_at,
+            )
+        )
+        await session.commit()
+
+    response = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert 10 < data["history_lookback_days"] <= 58
+    generated_at = datetime.fromisoformat(data["generated_at"])
+    truncated_before = datetime.fromisoformat(data["truncated_before"])
+    assert generated_at - truncated_before == timedelta(
+        days=data["history_lookback_days"]
+    )
+    assert any(
+        record.message == "sync_coverage_history_window_reduced"
+        and getattr(record, "requested_history_lookback_days") == 180
+        and getattr(record, "effective_history_lookback_days")
+        == data["history_lookback_days"]
+        and getattr(record, "complexity_stage") == "expanded_unit_windows"
+        and getattr(record, "complexity_limit") == 2
+        and getattr(record, "complexity_observed") == 3
+        and getattr(record, "effective_unit_window_count") == 2
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_preflight_deduplicates_recent_latest_successes(
+    client, session_maker, monkeypatch
+):
+    monkeypatch.setattr(sync_coverage_module, "MAX_COVERAGE_UNIT_WINDOWS", 2)
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    async with session_maker() as session:
+        extra_source = IntegrationSource(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            provider="github",
+            source_type="repository",
+            external_id="acme/other",
+            name="other",
+            full_name="acme/other",
+            metadata_={"planner_managed_sync_config_id": scope["config_id"]},
+            is_enabled=True,
+        )
+        session.add(extra_source)
+        await session.commit()
+        extra_source_id = str(extra_source.id)
+
+    before = datetime.now(timezone.utc) - timedelta(minutes=30)
+    for source_id in (scope["source_id"], extra_source_id):
+        await _seed_unit(
+            session_maker,
+            scope,
+            since=before - timedelta(hours=1),
+            before=before,
+            updated_at=before,
+            source_id=source_id,
+        )
+
+    response = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["history_lookback_days"] == 180
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- treat the requested `history_lookback_days` as a maximum and select the largest safe effective coverage window
- preflight the exact deduplicated unit population used by coverage, including recent units, latest successful units, and recent backfill-linked units
- preserve the hard complexity/memory bound from #1337 while returning truthful `history_lookback_days` and `truncated_before` metadata
- emit a structured `sync_coverage_history_window_reduced` log when the API narrows the window

## Production failure

The admin sync page always requested the 180-day default. For the affected configuration, the API repeatedly reached the hard sentinel and rejected the request:

```
history_lookback_days=180
complexity_stage=recent_units
complexity_limit=40000
complexity_observed=40001
```

Retrying repeated the same request, so the page could never load even though a smaller history window was safe.

## Safety

The adaptive selector uses bounded SQL counts and a binary search over integer-day windows. It does not materialize the oversized unit set, and it retains the existing hard rejection when even the minimum window is unsafe.

## Validation

- `bash ci/local_validate.sh`
  - 9,694 passed, 73 skipped
  - ruff format/check, mypy, Go, River compatibility, ClickHouse migrations, and live argMax proof passed
- focused sync coverage suite: 69 passed
- transitional inventory contract: 66 passed

SCREENSHOT-WAIVER: Backend-only API behavior; no rendered UI change.