### PR TITLE
fix(ask-dev): exhaustion error identity + per-role budget policy scaffold (CHAOS-3285)

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1644,6 +1644,14 @@ class DevOrchestrator:
             AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION: (
                 "provider_contract_violation"
             ),
+            # CHAOS-3285: output/reasoning-budget exhaustion is a structural,
+            # non-retryable model-capability mismatch, not an opaque
+            # application failure -- reuse the existing "model_not_supported"
+            # public code rather than the internal_error bucket
+            # INVALID_RESPONSE previously fell into for this exact symptom.
+            # A dedicated dev_error.v1 code is CHAOS-3294's v2 vocabulary to
+            # own, not invented here.
+            AgentProviderErrorCode.OUTPUT_EXHAUSTED: "model_not_supported",
         }
         code = code_map[exc.code]
         return DevError(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -687,6 +687,15 @@ class DevOrchestrator:
                             or cancellation.is_set()
                             else RunState.FAILED
                         )
+                        # A non-retryable failure that still returned a
+                        # response (e.g. OUTPUT_EXHAUSTED) billed real
+                        # tokens for it; the guarded provider already
+                        # reconciled that cost against the BYO budget
+                        # reservation (CHAOS-3285), so the run's own terminal
+                        # usage total must include it too rather than
+                        # silently reporting the exhausted call as free.
+                        if provider_error.usage is not None:
+                            budget.add(provider_error.usage)
                         return await finish(
                             state,
                             error=self._provider_error(

--- a/src/dev_health_ops/llm/agent/budget_policy.py
+++ b/src/dev_health_ops/llm/agent/budget_policy.py
@@ -1,0 +1,89 @@
+"""Per-model-family reasoning/output token budget policy for Ask Dev's agent.
+
+Separate from ``llm/providers/openai_capabilities.py`` on purpose:
+``openai_capabilities`` is shared with the non-agent batch/completion
+providers (``providers/openai.py``, ``providers/local.py``) and must not
+silently change behavior for that path. The agent's *token accounting*
+policy is agent-specific and, per CHAOS-3285, role-aware -- it lives here so
+it can evolve (per-role visible-output budgets, reasoning headroom) without
+touching the batch path's request-shape predicates.
+
+CHAOS-3285 commit 2 wires this module into the adapter with every family's
+``reasoning_headroom_tokens`` pinned to ``0``: the mechanism is in place, but
+the wire value is byte-identical to pre-commit-2 behavior. The actual
+headroom numbers are decided by the live per-role probe (CHAOS-3285 plan
+§6.6) and the coupled run-total/cost changes it requires (risk R1), and land
+in a later commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev_health_ops.llm.providers.openai_capabilities import (
+    chat_completion_reasoning_effort,
+)
+
+BUDGET_POLICY_VERSION = "ask-dev-budget-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelFamilyBudget:
+    family: str
+    reasoning_counted_in_output: bool
+    reasoning_headroom_tokens: int
+    reasoning_effort: str | None
+
+    def request_max_completion_tokens(self, visible_cap: int) -> int:
+        """Return the wire ``max_completion_tokens`` value for a visible-output cap.
+
+        For families whose hidden reasoning tokens count against the same
+        wire budget as visible output (``reasoning_counted_in_output``), the
+        request value is the visible cap plus the family's explicit
+        reasoning headroom. For every other family the request value is the
+        visible cap unchanged.
+        """
+
+        if not self.reasoning_counted_in_output:
+            return visible_cap
+        return visible_cap + self.reasoning_headroom_tokens
+
+
+def _family_for(model: str) -> str:
+    normalized = model.strip().lower()
+    if normalized.startswith("gpt-5"):
+        return "gpt-5"
+    if normalized.startswith(("o1", "o3", "o4")):
+        return "o-series"
+    return "default"
+
+
+def model_family_budget(model: str) -> ModelFamilyBudget:
+    """Resolve the token-budget policy for a model, by family.
+
+    Family membership mirrors the reasoning-tier predicates already
+    established (and live-verified) in ``openai_capabilities``:
+    ``chat_completion_reasoning_effort`` only fires for ``gpt-5*``, and the
+    o-series reasoning models (``o1``/``o3``/``o4``) are the family excluded
+    from ``supports_temperature`` alongside ``gpt-5*``. Both families count
+    hidden reasoning tokens against the same ``max_completion_tokens`` wire
+    budget as visible output; every other model does not.
+    """
+
+    family = _family_for(model)
+    reasoning_counted_in_output = family in ("gpt-5", "o-series")
+    return ModelFamilyBudget(
+        family=family,
+        reasoning_counted_in_output=reasoning_counted_in_output,
+        # Pinned at 0 for every family in CHAOS-3285 commit 2 -- see module
+        # docstring. Wiring only; no behavior change yet.
+        reasoning_headroom_tokens=0,
+        reasoning_effort=chat_completion_reasoning_effort(model),
+    )
+
+
+__all__ = [
+    "BUDGET_POLICY_VERSION",
+    "ModelFamilyBudget",
+    "model_family_budget",
+]

--- a/src/dev_health_ops/llm/agent/contracts.py
+++ b/src/dev_health_ops/llm/agent/contracts.py
@@ -65,6 +65,12 @@ class AgentUsage:
     output_tokens: int = 0
     estimated_cost_microusd: int | None = None
     cached_input_tokens: int | None = None
+    # Hidden reasoning tokens billed as part of output_tokens on
+    # reasoning-tier models (gpt-5*, o-series). None when the provider
+    # response carries no completion_tokens_details.reasoning_tokens field --
+    # distinct from 0, which means the provider reported the field as zero
+    # (CHAOS-3285).
+    reasoning_tokens: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/llm/agent/errors.py
+++ b/src/dev_health_ops/llm/agent/errors.py
@@ -15,6 +15,8 @@ from dev_health_ops.llm.errors import (
     classify_provider_error,
 )
 
+from .contracts import AgentUsage
+
 
 class AgentProviderErrorCode(str, Enum):
     DISABLED = "disabled"
@@ -62,10 +64,19 @@ class AgentProviderError(RuntimeError):
         *,
         retryable: bool = False,
         provider_dispatched: bool = True,
+        usage: AgentUsage | None = None,
     ):
         self.code = code
         self.retryable = retryable
         self.provider_dispatched = provider_dispatched
+        # Populated whenever the provider actually returned a response before
+        # this error was raised (e.g. OUTPUT_EXHAUSTED, a malformed decision,
+        # or a sequential-tool-contract violation): the caller still billed
+        # real tokens for that response. Both the BYO budget reservation
+        # reconciliation (guard_byo_call's exception path) and the
+        # orchestrator's terminal run accounting (ProviderBudget.add) read
+        # this so a failed call is never silently free (CHAOS-3285).
+        self.usage = usage
         super().__init__(_SAFE_MESSAGES[code])
 
 

--- a/src/dev_health_ops/llm/agent/errors.py
+++ b/src/dev_health_ops/llm/agent/errors.py
@@ -29,6 +29,7 @@ class AgentProviderErrorCode(str, Enum):
     BUDGET_EXHAUSTED = "budget_exhausted"
     BUDGET_UNAVAILABLE = "budget_unavailable"
     PROVIDER_CONTRACT_VIOLATION = "provider_contract_violation"
+    OUTPUT_EXHAUSTED = "output_exhausted"
 
 
 _SAFE_MESSAGES = {
@@ -46,6 +47,10 @@ _SAFE_MESSAGES = {
     AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION: (
         "The model provider returned more than one tool decision in a single "
         "turn, violating the sequential decision contract."
+    ),
+    AgentProviderErrorCode.OUTPUT_EXHAUSTED: (
+        "The model provider exhausted its output/reasoning token budget "
+        "before completing a response."
     ),
 }
 

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -270,6 +270,16 @@ class OpenAICompatibleAgentProvider:
                 cancel_task.cancel()
                 await asyncio.gather(cancel_task, return_exceptions=True)
 
+        # Normalized once the response is in hand, so it is available to
+        # attach to every raise path below -- not only the success path. A
+        # provider that reported output/reasoning exhaustion, a sequential-
+        # tool-contract violation, or an otherwise malformed decision still
+        # returned (and billed) a real response; discarding it before it is
+        # read poisons BYO budget reconciliation into "usage_unavailable",
+        # which disables enforcement and then rejects every later call
+        # without dispatching it (CHAOS-3285).
+        agent_usage = self._normalize_usage(response)
+
         try:
             # A model that ran out of its output/reasoning token budget
             # reports finish_reason="length" -- checked, and raised, before
@@ -280,7 +290,9 @@ class OpenAICompatibleAgentProvider:
             # JSON payload alike: the finish_reason alone is dispositive
             # (CHAOS-3285).
             if getattr(response.choices[0], "finish_reason", None) == "length":
-                raise AgentProviderError(AgentProviderErrorCode.OUTPUT_EXHAUSTED)
+                raise AgentProviderError(
+                    AgentProviderErrorCode.OUTPUT_EXHAUSTED, usage=agent_usage
+                )
             decision = self._normalize_response(
                 response,
                 allowed_tool_ids=frozenset(item.tool_id for item in tools),
@@ -288,7 +300,7 @@ class OpenAICompatibleAgentProvider:
             )
         except _SequentialToolContractViolation:
             raise AgentProviderError(
-                AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION
+                AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION, usage=agent_usage
             ) from None
         except (
             AttributeError,
@@ -297,7 +309,18 @@ class OpenAICompatibleAgentProvider:
             ValueError,
             json.JSONDecodeError,
         ):
-            raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE) from None
+            raise AgentProviderError(
+                AgentProviderErrorCode.INVALID_RESPONSE, usage=agent_usage
+            ) from None
+        return AgentDecisionResult(
+            decision=decision,
+            usage=agent_usage,
+            latency_ms=max(0, round((time.monotonic() - started) * 1000)),
+            provider_fingerprint=self.provider_fingerprint,
+            model_fingerprint=self.model_fingerprint,
+        )
+
+    def _normalize_usage(self, response: Any) -> AgentUsage:
         usage = getattr(response, "usage", None)
         input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
         output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
@@ -305,26 +328,20 @@ class OpenAICompatibleAgentProvider:
         cached_tokens = getattr(prompt_details, "cached_tokens", None)
         completion_details = getattr(usage, "completion_tokens_details", None)
         reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
-        return AgentDecisionResult(
-            decision=decision,
-            usage=AgentUsage(
+        return AgentUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_input_tokens=(
+                int(cached_tokens) if cached_tokens is not None else None
+            ),
+            reasoning_tokens=(
+                int(reasoning_tokens) if reasoning_tokens is not None else None
+            ),
+            estimated_cost_microusd=_estimated_cost_microusd(
+                model=self.model,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
-                cached_input_tokens=(
-                    int(cached_tokens) if cached_tokens is not None else None
-                ),
-                reasoning_tokens=(
-                    int(reasoning_tokens) if reasoning_tokens is not None else None
-                ),
-                estimated_cost_microusd=_estimated_cost_microusd(
-                    model=self.model,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                ),
             ),
-            latency_ms=max(0, round((time.monotonic() - started) * 1000)),
-            provider_fingerprint=self.provider_fingerprint,
-            model_fingerprint=self.model_fingerprint,
         )
 
     @staticmethod

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -279,6 +279,22 @@ class OpenAICompatibleAgentProvider:
         # which disables enforcement and then rejects every later call
         # without dispatching it (CHAOS-3285).
         agent_usage = self._normalize_usage(response)
+        # A response with no usage object at all normalizes to 0 input / 0
+        # output above; a response that genuinely reports zero of both is
+        # indistinguishable from that and, per the same invariant the
+        # success path already relies on (a valid completion cannot consume
+        # zero input AND zero output tokens), can't be real either. Only
+        # attach usage to the raised error when it's actually informative --
+        # otherwise a failure with unreported usage would reconcile as a
+        # real $0 call (poisoning nothing, but silently making an unknown
+        # cost look free) instead of the pre-existing conservative
+        # "usage unavailable" handling for genuinely unreported usage
+        # (CHAOS-3285).
+        reported_usage = (
+            agent_usage
+            if agent_usage.input_tokens or agent_usage.output_tokens
+            else None
+        )
 
         try:
             # A model that ran out of its output/reasoning token budget
@@ -291,7 +307,7 @@ class OpenAICompatibleAgentProvider:
             # (CHAOS-3285).
             if getattr(response.choices[0], "finish_reason", None) == "length":
                 raise AgentProviderError(
-                    AgentProviderErrorCode.OUTPUT_EXHAUSTED, usage=agent_usage
+                    AgentProviderErrorCode.OUTPUT_EXHAUSTED, usage=reported_usage
                 )
             decision = self._normalize_response(
                 response,
@@ -300,7 +316,8 @@ class OpenAICompatibleAgentProvider:
             )
         except _SequentialToolContractViolation:
             raise AgentProviderError(
-                AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION, usage=agent_usage
+                AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION,
+                usage=reported_usage,
             ) from None
         except (
             AttributeError,
@@ -310,7 +327,7 @@ class OpenAICompatibleAgentProvider:
             json.JSONDecodeError,
         ):
             raise AgentProviderError(
-                AgentProviderErrorCode.INVALID_RESPONSE, usage=agent_usage
+                AgentProviderErrorCode.INVALID_RESPONSE, usage=reported_usage
             ) from None
         return AgentDecisionResult(
             decision=decision,

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -267,6 +267,16 @@ class OpenAICompatibleAgentProvider:
                 await asyncio.gather(cancel_task, return_exceptions=True)
 
         try:
+            # A model that ran out of its output/reasoning token budget
+            # reports finish_reason="length" -- checked, and raised, before
+            # any attempt to parse message content as JSON (below, inside
+            # _normalize_response), so exhaustion never masquerades as
+            # malformed output (INVALID_RESPONSE). This covers both an empty
+            # ``content`` and a truncated-but-technically-parseable partial
+            # JSON payload alike: the finish_reason alone is dispositive
+            # (CHAOS-3285).
+            if getattr(response.choices[0], "finish_reason", None) == "length":
+                raise AgentProviderError(AgentProviderErrorCode.OUTPUT_EXHAUSTED)
             decision = self._normalize_response(
                 response,
                 allowed_tool_ids=frozenset(item.tool_id for item in tools),
@@ -289,6 +299,8 @@ class OpenAICompatibleAgentProvider:
         output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
         prompt_details = getattr(usage, "prompt_tokens_details", None)
         cached_tokens = getattr(prompt_details, "cached_tokens", None)
+        completion_details = getattr(usage, "completion_tokens_details", None)
+        reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
         return AgentDecisionResult(
             decision=decision,
             usage=AgentUsage(
@@ -296,6 +308,9 @@ class OpenAICompatibleAgentProvider:
                 output_tokens=output_tokens,
                 cached_input_tokens=(
                     int(cached_tokens) if cached_tokens is not None else None
+                ),
+                reasoning_tokens=(
+                    int(reasoning_tokens) if reasoning_tokens is not None else None
                 ),
                 estimated_cost_microusd=_estimated_cost_microusd(
                     model=self.model,

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -19,6 +19,7 @@ from dev_health_ops.llm.providers.openai_capabilities import (
 )
 from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
+from .budget_policy import model_family_budget
 from .contracts import (
     AgentDecisionResult,
     AgentDisambiguation,
@@ -205,6 +206,7 @@ class OpenAICompatibleAgentProvider:
         allow_final_answer = not tools or any(
             message.role is AgentMessageRole.TOOL for message in messages
         )
+        budget = model_family_budget(self.model)
         completion_kwargs: dict[str, Any] = {
             "model": self.model,
             "messages": [self._message_payload(item) for item in messages],
@@ -212,7 +214,9 @@ class OpenAICompatibleAgentProvider:
             "tool_choice": (
                 ("auto" if allow_final_answer else "required") if tools else None
             ),
-            "max_completion_tokens": max_output_tokens,
+            "max_completion_tokens": budget.request_max_completion_tokens(
+                max_output_tokens
+            ),
         }
         if tools and supports_parallel_tool_calls(self.model):
             # Ask Dev's runtime is a sequential one-decision-per-round state

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -303,6 +303,12 @@ def readiness_failure_state(safe_error_code: str | None) -> tuple[ReadinessState
             "The configured model returned multiple tool decisions in one turn, "
             "violating Ask Dev's required sequential tool-call contract.",
         )
+    if safe_error_code == "output_exhausted":
+        return (
+            "unsupported_model",
+            "The configured Ask Dev model exhausted its output/reasoning "
+            "token budget before completing a valid response.",
+        )
     if safe_error_code == "provider_unavailable":
         return "degraded", "The configured Ask Dev model endpoint is unavailable."
     return "degraded", "The configured Ask Dev model failed readiness."
@@ -317,8 +323,12 @@ def _add_usage(left: AgentUsage, right: AgentUsage) -> AgentUsage:
         cost = (left.estimated_cost_microusd or 0) + (
             right.estimated_cost_microusd or 0
         )
+    reasoning_tokens = None
+    if left.reasoning_tokens is not None or right.reasoning_tokens is not None:
+        reasoning_tokens = (left.reasoning_tokens or 0) + (right.reasoning_tokens or 0)
     return AgentUsage(
         input_tokens=left.input_tokens + right.input_tokens,
         output_tokens=left.output_tokens + right.output_tokens,
         estimated_cost_microusd=cost,
+        reasoning_tokens=reasoning_tokens,
     )

--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -785,10 +785,17 @@ def _usage_from_exception(
         else getattr(usage, "prompt_tokens_details", None)
         or getattr(usage, "input_tokens_details", None)
     )
+    cached_tokens = _usage_value(details, "cached_tokens")
+    if cached_tokens is None:
+        # Ask Dev's provider-neutral AgentUsage contract (attached to
+        # AgentProviderError -- CHAOS-3285) reports cached tokens as a flat
+        # field rather than the raw provider's nested *_tokens_details
+        # object; fall back to it when there is no nested detail to read.
+        cached_tokens = _usage_value(usage, "cached_input_tokens")
     return (
         _usage_value(usage, "prompt_tokens", "input_tokens"),
         _usage_value(usage, "completion_tokens", "output_tokens"),
-        _usage_value(details, "cached_tokens"),
+        cached_tokens,
     )
 
 

--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -792,11 +792,20 @@ def _usage_from_exception(
         # field rather than the raw provider's nested *_tokens_details
         # object; fall back to it when there is no nested detail to read.
         cached_tokens = _usage_value(usage, "cached_input_tokens")
-    return (
-        _usage_value(usage, "prompt_tokens", "input_tokens"),
-        _usage_value(usage, "completion_tokens", "output_tokens"),
-        cached_tokens,
-    )
+    input_tokens = _usage_value(usage, "prompt_tokens", "input_tokens")
+    output_tokens = _usage_value(usage, "completion_tokens", "output_tokens")
+    # Same 0/0-is-unreported guard as _agent_usage()'s success-path
+    # extraction: a valid completion can never consume zero input AND zero
+    # output tokens, so a failure whose usage reports exactly that (or whose
+    # producer defaulted both to 0 because the field was actually absent)
+    # must reconcile as unreported/conservative, never as a real $0 charge
+    # (CHAOS-3285). Defense in depth: the OpenAI-compatible adapter already
+    # withholds usage in this case, but any other exception source
+    # attaching a technically-present, all-zero usage object hits the same
+    # rule here.
+    if input_tokens == 0 and output_tokens == 0:
+        return None, None, None
+    return input_tokens, output_tokens, cached_tokens
 
 
 def _agent_usage(item: Any) -> tuple[int | None, int | None, int | None]:

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -381,6 +381,11 @@ async def test_deprecated_post_readiness_route_is_410_and_touches_nothing(
             "unsupported_model",
             "sequential tool-call contract",
         ),
+        (
+            "output_exhausted",
+            "unsupported_model",
+            "output/reasoning token budget",
+        ),
     ],
 )
 def test_failed_readiness_exposes_only_specific_safe_remediation(

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -603,6 +603,35 @@ async def test_provider_contract_violation_is_a_safe_error_not_internal_error() 
 
 
 @pytest.mark.asyncio
+async def test_output_exhausted_is_a_safe_error_not_internal_error() -> None:
+    """CHAOS-3285: before this fix, output-budget exhaustion surfaced from
+    the adapter as INVALID_RESPONSE, which this orchestrator maps to the
+    opaque "internal_error" public code -- exactly the live symptom the
+    ticket describes ("readiness green, first real question fails, provider
+    error presented"). OUTPUT_EXHAUSTED must map to a stable, non-internal
+    public code (reusing "model_not_supported") and stay non-retryable.
+    """
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    error=AgentProviderError(
+                        AgentProviderErrorCode.OUTPUT_EXHAUSTED,
+                        retryable=False,
+                    )
+                )
+            ],
+            script_id="output-exhausted",
+        )
+    )
+    assert result.state is RunState.FAILED
+    assert result.error is not None
+    assert result.error.code == "model_not_supported"
+    assert result.error.code != "internal_error"
+    assert result.error.retryable is False
+
+
+@pytest.mark.asyncio
 async def test_multi_metric_question_completes_through_sequential_tool_rounds() -> None:
     """CHAOS-3254 acceptance: a naturally multi-metric question completes
     through one tool request per round -- through a final answer -- and

--- a/tests/llm/agent/test_budget_policy.py
+++ b/tests/llm/agent/test_budget_policy.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.llm.agent.budget_policy import (
+    BUDGET_POLICY_VERSION,
+    ModelFamilyBudget,
+    model_family_budget,
+)
+
+
+def test_budget_policy_version_is_pinned() -> None:
+    assert BUDGET_POLICY_VERSION == "ask-dev-budget-v1"
+
+
+@pytest.mark.parametrize(
+    ("model", "family", "reasoning_counted_in_output", "reasoning_effort"),
+    [
+        ("gpt-5-nano", "gpt-5", True, "minimal"),
+        ("gpt-5-mini", "gpt-5", True, "minimal"),
+        ("GPT-5-Nano", "gpt-5", True, "minimal"),
+        ("o1-mini", "o-series", True, None),
+        ("o3-mini", "o-series", True, None),
+        ("o4-mini", "o-series", True, None),
+        ("gpt-4o-mini", "default", False, None),
+        ("agent-model", "default", False, None),
+    ],
+)
+def test_model_family_budget_resolves_family_and_reasoning_accounting(
+    model: str,
+    family: str,
+    reasoning_counted_in_output: bool,
+    reasoning_effort: str | None,
+) -> None:
+    """Family resolution mirrors the live-verified predicates in
+    openai_capabilities (chat_completion_reasoning_effort fires only for
+    gpt-5*; o1/o3/o4 are the o-series reasoning family) rather than
+    reimplementing them, so the two modules cannot silently drift apart.
+    """
+    budget = model_family_budget(model)
+
+    assert budget.family == family
+    assert budget.reasoning_counted_in_output is reasoning_counted_in_output
+    assert budget.reasoning_effort == reasoning_effort
+
+
+@pytest.mark.parametrize("model", ["gpt-5-nano", "o3-mini", "gpt-4o-mini"])
+def test_reasoning_headroom_is_pinned_to_zero_for_every_family(model: str) -> None:
+    """CHAOS-3285 commit 2: the mechanism is wired, but no family gets a
+    nonzero headroom yet -- the live per-role probe (plan §6.6) decides the
+    actual numbers in a later commit. A nonzero headroom here would silently
+    change the wire request before that measurement exists.
+    """
+    assert model_family_budget(model).reasoning_headroom_tokens == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "visible_cap"),
+    [
+        ("gpt-5-nano", 4_096),
+        ("o3-mini", 512),
+        ("gpt-4o-mini", 4_096),
+        ("local-model", 1),
+    ],
+)
+def test_request_max_completion_tokens_is_unchanged_at_zero_headroom(
+    model: str, visible_cap: int
+) -> None:
+    """Behavior-unchanged proof: with reasoning_headroom_tokens == 0 (the
+    only value any family has in this commit), the wire
+    max_completion_tokens value must be byte-identical to the pre-commit-2
+    behavior of sending max_output_tokens verbatim, for every family --
+    reasoning-counted or not.
+    """
+    budget = model_family_budget(model)
+
+    assert budget.request_max_completion_tokens(visible_cap) == visible_cap
+
+
+def test_request_max_completion_tokens_adds_headroom_only_for_reasoning_counted_family() -> (
+    None
+):
+    """Proves the formula itself (independent of today's headroom=0 wiring):
+    a reasoning-counted family adds its headroom on top of the visible cap;
+    a non-reasoning family never does, even if given a nonzero headroom by
+    mistake.
+    """
+    reasoning_family = ModelFamilyBudget(
+        family="gpt-5",
+        reasoning_counted_in_output=True,
+        reasoning_headroom_tokens=8_192,
+        reasoning_effort="minimal",
+    )
+    non_reasoning_family = ModelFamilyBudget(
+        family="default",
+        reasoning_counted_in_output=False,
+        reasoning_headroom_tokens=8_192,
+        reasoning_effort=None,
+    )
+
+    assert reasoning_family.request_max_completion_tokens(4_096) == 4_096 + 8_192
+    assert non_reasoning_family.request_max_completion_tokens(4_096) == 4_096

--- a/tests/llm/agent/test_errors.py
+++ b/tests/llm/agent/test_errors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from dev_health_ops.llm.agent.errors import (
+    AgentProviderError,
     AgentProviderErrorCode,
     safe_agent_provider_error,
 )
@@ -53,3 +54,19 @@ def test_safe_agent_provider_error_preserves_safe_failure_category(
     assert error.code is code
     assert error.retryable is retryable
     assert "temperature" not in str(error)
+
+
+def test_output_exhausted_is_non_retryable_and_carries_no_provider_content() -> None:
+    """CHAOS-3285: exhaustion is a structural, non-retryable model-capability
+    mismatch (retrying the same request with the same budget cannot help),
+    distinct from every other AgentProviderErrorCode member, none of which
+    is OUTPUT_EXHAUSTED.
+    """
+    error = AgentProviderError(AgentProviderErrorCode.OUTPUT_EXHAUSTED)
+
+    assert error.retryable is False
+    assert error.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+    assert error.code not in {
+        AgentProviderErrorCode.INVALID_RESPONSE,
+        AgentProviderErrorCode.INVALID_REQUEST,
+    }

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -938,6 +938,73 @@ async def test_tool_result_continuation_allows_tools_and_strict_final_answer() -
 
 
 @pytest.mark.asyncio
+async def test_combined_tools_auto_and_strict_grammar_shape_pinned_together() -> None:
+    """CHAOS-3285 plan §6.2: the wire shape sent on every production round
+    >= 2 -- tools present *and* tool_choice:"auto" *and* a strict
+    json_schema response_format *and* parallel_tool_calls:false, all
+    simultaneously -- is the exact shape certification never sent
+    (readiness's two probe calls each send only a subset). Pin all four in
+    one kwargs dict from a single round so a regression in any one clause
+    fails this test.
+    """
+    client = Client(
+        [response(content=json.dumps({"kind": "final_answer", "value": {"ok": True}}))]
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+    request = AgentToolRequest("lookup", {"id": "WU-1"}, "call-1")
+
+    await provider.decide(
+        [
+            AgentMessage(AgentMessageRole.USER, "question"),
+            AgentMessage(AgentMessageRole.ASSISTANT, "", tool_request=request),
+            AgentMessage(AgentMessageRole.TOOL, '{"result":1}', tool_call_id="call-1"),
+        ],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object", "properties": {"ok": {"type": "boolean"}}},
+        1,
+        256,
+    )
+
+    sent = client.chat.completions.calls[0]
+    assert sent["tools"] is not None and len(sent["tools"]) == 1
+    assert sent["tool_choice"] == "auto"
+    assert sent["parallel_tool_calls"] is False
+    assert sent["response_format"]["json_schema"]["strict"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["gpt-5-nano", "o3-mini", "agent-model"])
+async def test_max_completion_tokens_unchanged_for_every_family_at_zero_headroom(
+    model: str,
+) -> None:
+    """Behavior-unchanged proof for CHAOS-3285 commit 2's budget_policy
+    wiring: at reasoning_headroom_tokens == 0 (the only value any family has
+    today), the wire max_completion_tokens must equal the caller's visible
+    cap verbatim -- byte-identical to the pre-commit-2 behavior -- for a
+    reasoning-counted family (gpt-5, o-series) and the default family alike.
+    """
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model=model, client=client
+    )
+
+    await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        4_096,
+    )
+
+    assert client.chat.completions.calls[0]["max_completion_tokens"] == 4_096
+
+
+@pytest.mark.asyncio
 async def test_finish_reason_length_with_empty_content_raises_output_exhausted() -> (
     None
 ):

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -48,10 +48,13 @@ def response(
     content: str | None = None,
     tool_call: Any = None,
     tool_calls: list[Any] | None = None,
+    finish_reason: str = "stop",
+    reasoning_tokens: int | None = None,
 ) -> Any:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
+                finish_reason=finish_reason,
                 message=SimpleNamespace(
                     content=content,
                     tool_calls=(
@@ -61,13 +64,16 @@ def response(
                         if tool_call
                         else []
                     ),
-                )
+                ),
             )
         ],
         usage=SimpleNamespace(
             prompt_tokens=11,
             completion_tokens=7,
             prompt_tokens_details=SimpleNamespace(cached_tokens=3),
+            completion_tokens_details=SimpleNamespace(
+                reasoning_tokens=reasoning_tokens
+            ),
         ),
     )
 
@@ -929,6 +935,138 @@ async def test_tool_result_continuation_allows_tools_and_strict_final_answer() -
     ]
     assert schema["properties"]["value"]["anyOf"][0]["required"] == ["ok"]
     assert client.chat.completions.calls[0]["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_length_with_empty_content_raises_output_exhausted() -> (
+    None
+):
+    """CHAOS-3285: before this fix, a reasoning model that ran out of its
+    output budget mid-decision returned finish_reason="length" with empty
+    content, which json.loads() turned into a JSONDecodeError, classified as
+    INVALID_RESPONSE -> internal_error (an opaque application failure for
+    what is actually a structural model-capability mismatch). finish_reason
+    is now read and dispositive before any JSON parsing is attempted.
+    """
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="gpt-5-nano",
+        client=Client([response(content="", finish_reason="length")]),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+    assert caught.value.code is not AgentProviderErrorCode.INVALID_RESPONSE
+    assert caught.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_length_with_truncated_partial_content_still_exhausted() -> (
+    None
+):
+    """Belt-and-braces (plan §3.3): a truncated-but-technically-parseable
+    partial JSON payload is the *worse* case, because it can validate and
+    silently pass through as a malformed-but-plausible decision. finish_reason
+    alone must be dispositive regardless of whether content happens to parse.
+    """
+    truncated = '{"kind": "final_answer", "value": {"ok"'
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="gpt-5-nano",
+        client=Client([response(content=truncated, finish_reason="length")]),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_stop_does_not_raise_output_exhausted() -> None:
+    """The fail-before/pass-after control: an ordinary, non-exhausted
+    malformed response (finish_reason="stop") must still classify as
+    INVALID_RESPONSE, exactly as before this change -- proving the new
+    finish_reason check is additive, not a wholesale reclassification of
+    every malformed response as exhaustion.
+    """
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(content="not-json", finish_reason="stop")]),
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_reasoning_tokens_surfaced_on_agent_usage() -> None:
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call, reasoning_tokens=192)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-nano", client=client
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    assert result.usage.reasoning_tokens == 192
+
+
+@pytest.mark.asyncio
+async def test_missing_reasoning_tokens_detail_surfaces_as_none_not_zero() -> None:
+    """None (field absent/unreported) must stay distinguishable from an
+    explicit 0 -- collapsing them would make a provider that never reports
+    reasoning usage indistinguishable from one that reported zero reasoning
+    tokens, corrupting the accounting CHAOS-3285's later commits build on.
+    """
+    call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    client = Client([response(tool_call=call, reasoning_tokens=None)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="agent-model", client=client
+    )
+
+    result = await provider.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+        {"type": "object"},
+        1,
+        256,
+    )
+
+    assert result.usage.reasoning_tokens is None
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -1112,6 +1112,80 @@ async def test_finish_reason_length_attaches_billed_usage_to_the_error() -> None
 
 
 @pytest.mark.asyncio
+async def test_finish_reason_length_with_zero_reported_usage_withholds_usage() -> None:
+    """CHAOS-3285 follow-up: a valid completion can never consume zero input
+    AND zero output tokens (the same invariant budget.py's _agent_usage()
+    already relies on for the success path). A provider that reports
+    exactly that on an exhausted response must not have that zero usage
+    attached to the error -- otherwise guard_byo_call reconciles the
+    reservation as a real $0 charge and silently drops the actual
+    (unreported) cost from BYO budget accounting instead of holding the
+    reservation conservatively.
+    """
+    exhausted = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="", tool_calls=[]),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-nano", client=Client([exhausted])
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+    assert caught.value.usage is None
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_length_with_no_usage_object_withholds_usage() -> None:
+    """A response that omits ``usage`` entirely normalizes to the same 0/0
+    shape as one that reports literal zeros -- both must be treated as
+    unreported, not as a free call.
+    """
+    exhausted = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="", tool_calls=[]),
+            )
+        ],
+        usage=None,
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-nano", client=Client([exhausted])
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+    assert caught.value.usage is None
+
+
+@pytest.mark.asyncio
 async def test_contract_violation_and_invalid_response_also_attach_usage() -> None:
     """CHAOS-3285 audit: OUTPUT_EXHAUSTED was the reported finding, but every
     raise path inside the same try block discards response.usage the same

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -1064,6 +1064,105 @@ async def test_finish_reason_length_with_truncated_partial_content_still_exhaust
 
 
 @pytest.mark.asyncio
+async def test_finish_reason_length_attaches_billed_usage_to_the_error() -> None:
+    """CHAOS-3285: before this fix, OUTPUT_EXHAUSTED was raised before
+    response.usage was ever read, so the error carried no usage data at
+    all -- downstream, guard_byo_call's exception handler
+    (dev_health_ops.llm.budget) treats a usage-less failure as
+    "usage_unavailable", which poisons the whole BYO budget window and
+    rejects every later call without dispatching it. Reviewer's exact
+    reproduction: a parseable finish_reason="length" response reporting 40
+    input / 256 output / 240 reasoning tokens must still surface those
+    numbers on the raised error.
+    """
+    exhausted = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="", tool_calls=[]),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=40,
+            completion_tokens=256,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=240),
+        ),
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-nano", client=Client([exhausted])
+    )
+
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+    usage = caught.value.usage
+    assert usage is not None
+    assert usage.input_tokens == 40
+    assert usage.output_tokens == 256
+    assert usage.reasoning_tokens == 240
+    assert usage.cached_input_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_contract_violation_and_invalid_response_also_attach_usage() -> None:
+    """CHAOS-3285 audit: OUTPUT_EXHAUSTED was the reported finding, but every
+    raise path inside the same try block discards response.usage the same
+    way once a response has been received -- a sequential-tool-contract
+    violation and a malformed-but-received decision both still billed real
+    tokens and must not be reconciled as usage_unavailable either.
+    """
+    first = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    second = SimpleNamespace(
+        id="call-2", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(tool_calls=[first, second])]),
+    )
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [AgentToolDefinition("lookup", "Lookup", {"type": "object"})],
+            {"type": "object"},
+            1,
+            256,
+        )
+    assert caught.value.code is AgentProviderErrorCode.PROVIDER_CONTRACT_VIOLATION
+    assert caught.value.usage is not None
+    assert caught.value.usage.input_tokens == 11
+    assert caught.value.usage.output_tokens == 7
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="agent-model",
+        client=Client([response(content="not-json", finish_reason="stop")]),
+    )
+    with pytest.raises(AgentProviderError) as caught:
+        await provider.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            [],
+            {"type": "object"},
+            1,
+            256,
+        )
+    assert caught.value.code is AgentProviderErrorCode.INVALID_RESPONSE
+    assert caught.value.usage is not None
+    assert caught.value.usage.input_tokens == 11
+    assert caught.value.usage.output_tokens == 7
+
+
+@pytest.mark.asyncio
 async def test_finish_reason_stop_does_not_raise_output_exhausted() -> None:
     """The fail-before/pass-after control: an ordinary, non-exhausted
     malformed response (finish_reason="stop") must still classify as

--- a/tests/llm/test_byo_budget.py
+++ b/tests/llm/test_byo_budget.py
@@ -13,10 +13,17 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm.agent.contracts import (
+    AgentMessage,
+    AgentMessageRole,
+    AgentToolDefinition,
+)
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
 from dev_health_ops.llm.budget import (
     BYOBudgetAccountingError,
     BYOBudgetExceeded,
+    attach_agent_budget_guard,
     attach_llm_budget_guard,
     cost_micro_usd,
     get_budget_status,
@@ -742,3 +749,151 @@ async def test_openai_retry_is_rejected_before_second_network_attempt(
         await guarded.complete("test")
 
     assert client.responses.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_output_exhaustion_reconciles_with_actual_cost_and_leaves_budget_admissible(
+    session_maker, monkeypatch
+):
+    """CHAOS-3285 integration reproduction through attach_agent_budget_guard.
+
+    Before the fix: OUTPUT_EXHAUSTED was raised by the adapter before
+    response.usage was ever read, so the exception reaching guard_byo_call's
+    exception handler carried no usage. _reconcile_reservation then marked
+    the reservation "usage_unavailable" (not "failed" with a real cost) --
+    and any reservation in that state poisons the whole calendar-month
+    window (get_budget_status short-circuits to enforcement_available=False
+    for every subsequent call), so the very next request is rejected with
+    BUDGET_UNAVAILABLE *without ever dispatching to the provider*.
+
+    After the fix: the adapter attaches the real billed usage to the raised
+    AgentProviderError, so the reservation reconciles as an ordinary FAILED
+    call with its actual token cost, and the budget window stays admissible
+    -- the next request still dispatches.
+    """
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 1_000_000)
+
+    @asynccontextmanager
+    async def budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", budget_session
+    )
+
+    # Reviewer's exact reproduction: a parseable finish_reason="length"
+    # response reporting 40 input / 256 output / 240 reasoning tokens.
+    exhausted_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="", tool_calls=[]),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=40,
+            completion_tokens=256,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=240),
+        ),
+    )
+    ok_call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="lookup", arguments="{}")
+    )
+    ok_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content=None, tool_calls=[ok_call]),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=5,
+            completion_tokens=5,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=None),
+        ),
+    )
+
+    class Completions:
+        def __init__(self, responses):
+            self.responses = responses
+            self.calls = 0
+
+        async def create(self, **_kwargs):
+            self.calls += 1
+            return self.responses.pop(0)
+
+    completions = Completions([exhausted_response, ok_response])
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    provider = OpenAICompatibleAgentProvider(
+        api_key="unused", model="gpt-5-mini", client=client
+    )
+    async with session_maker() as unused_session:
+        guarded = attach_agent_budget_guard(
+            provider,
+            session=unused_session,
+            org_id=org_id,
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+
+    tools = [AgentToolDefinition("lookup", "Lookup", {"type": "object"})]
+
+    with pytest.raises(AgentProviderError) as caught:
+        await guarded.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            tools,
+            {"type": "object"},
+            1,
+            256,
+        )
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+
+    expected_cost = cost_micro_usd(
+        provider="openai",
+        model="gpt-5-mini",
+        base_url=None,
+        input_tokens=40,
+        output_tokens=256,
+        cached_input_tokens=0,
+    )
+    assert expected_cost is not None
+
+    async with session_maker() as session:
+        rows = list((await session.execute(select(BYOLLMBudgetReservation))).scalars())
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert rows[0].actual_micro_usd == expected_cost
+    assert (rows[0].input_tokens, rows[0].output_tokens) == (40, 256)
+
+    async with session_maker() as session:
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+    assert status.reason != "usage_unavailable"
+    assert status.enforcement_available is True
+    assert status.used_micro_usd == expected_cost
+
+    # The window must remain admissible: the next request still dispatches
+    # to the provider rather than being rejected pre-dispatch.
+    result = await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")],
+        tools,
+        {"type": "object"},
+        1,
+        256,
+    )
+    assert completions.calls == 2
+    assert result.decision.tool_id == "lookup"
+
+    async with session_maker() as session:
+        rows = list((await session.execute(select(BYOLLMBudgetReservation))).scalars())
+    assert len(rows) == 2
+    assert sorted(row.status for row in rows) == ["failed", "succeeded"]

--- a/tests/llm/test_byo_budget.py
+++ b/tests/llm/test_byo_budget.py
@@ -897,3 +897,106 @@ async def test_output_exhaustion_reconciles_with_actual_cost_and_leaves_budget_a
         rows = list((await session.execute(select(BYOLLMBudgetReservation))).scalars())
     assert len(rows) == 2
     assert sorted(row.status for row in rows) == ["failed", "succeeded"]
+
+
+@pytest.mark.asyncio
+async def test_zero_token_exhaustion_holds_reservation_instead_of_reconciling_as_free(
+    session_maker, monkeypatch
+):
+    """CHAOS-3285 follow-up integration reproduction.
+
+    A provider can report finish_reason="length" with a usage object whose
+    prompt_tokens/completion_tokens are both exactly 0 (or omit ``usage``
+    entirely, which normalizes to the same shape) -- a valid completion can
+    never actually consume zero of both, so this is unreported usage, not a
+    free call. Before this follow-up fix, the adapter still attached that
+    all-zero usage to the raised error, and guard_byo_call reconciled the
+    reservation as status="failed" with actual_micro_usd=0: a genuinely
+    unknown cost silently became a real $0 charge, dropping it from BYO
+    budget accounting entirely.
+
+    After the fix, usage is withheld from the error in this case, so the
+    reservation reconciles the same conservative way the codebase already
+    handles any other genuinely-unreported-usage failure (pre-existing
+    behavior, unrelated to and not reintroducing the window-poisoning bug
+    the OTHER CHAOS-3285 integration test above guards against for the
+    reported-usage case): held as "usage_unavailable", never as a $0 charge.
+    """
+    org_id = str(uuid.uuid4())
+    await _configure(session_maker, org_id, 1_000_000)
+
+    @asynccontextmanager
+    async def budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", budget_session
+    )
+
+    exhausted_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="", tool_calls=[]),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+    )
+
+    class Completions:
+        def __init__(self, responses):
+            self.responses = responses
+            self.calls = 0
+
+        async def create(self, **_kwargs):
+            self.calls += 1
+            return self.responses.pop(0)
+
+    completions = Completions([exhausted_response])
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    provider = OpenAICompatibleAgentProvider(
+        api_key="unused", model="gpt-5-mini", client=client
+    )
+    async with session_maker() as unused_session:
+        guarded = attach_agent_budget_guard(
+            provider,
+            session=unused_session,
+            org_id=org_id,
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+
+    tools = [AgentToolDefinition("lookup", "Lookup", {"type": "object"})]
+
+    with pytest.raises(AgentProviderError) as caught:
+        await guarded.decide(
+            [AgentMessage(AgentMessageRole.USER, "question")],
+            tools,
+            {"type": "object"},
+            1,
+            256,
+        )
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+
+    async with session_maker() as session:
+        rows = list((await session.execute(select(BYOLLMBudgetReservation))).scalars())
+    assert len(rows) == 1
+    assert rows[0].status == "usage_unavailable"
+    assert rows[0].actual_micro_usd is None
+
+    async with session_maker() as session:
+        status = await get_budget_status(
+            SettingsService(session, org_id),
+            provider="openai",
+            model="gpt-5-mini",
+            base_url=None,
+        )
+    assert status.reason == "usage_unavailable"
+    assert status.enforcement_available is False


### PR DESCRIPTION
## CHAOS-3285 (partial) — exhaustion as a first-class provider error + per-role budget policy scaffold

First two slices of the CHAOS-3285 provider-readiness plan (the pre-CHAOS-3294 landable set). The role model / production-representative probes / capability profiles follow in a separate PR per the plan's stack.

### Commit 1 — `OUTPUT_EXHAUSTED` error identity

- New `AgentProviderErrorCode.OUTPUT_EXHAUSTED` (non-retryable). `finish_reason == "length"` is detected **before** `json.loads`, for both empty and truncated-but-parseable content — exhaustion no longer masquerades as `INVALID_RESPONSE` → public `internal_error`; it maps to `model_not_supported` with budget-specific readiness remediation.
- `usage.completion_tokens_details.reasoning_tokens` is read and surfaced on `AgentUsage` (previously read nowhere in the repo).

### Commit 2 — `budget_policy.py` (behavior-neutral)

- `ModelFamilyBudget` per model family (gpt-5*, o-series, default) with `reasoning_headroom_tokens` wiring; **headroom = 0 for all families in this PR**, proven byte-identical wire kwargs per family by test. Actual headroom values await the live per-role probe and the coupled run-total/`model_rounds` changes (plan risk R1), per the ratified per-role envelope decision on the issue.
- Request-shape pinning tests: the combined `tools + tool_choice:auto + strict response_format` production shape asserted in one kwargs dict; per-family clause-by-clause pinning.

### Commits 3–4 — usage propagation hardening (from adversarial review, both reproduced by execution)

- Raising `OUTPUT_EXHAUSTED` before reading `response.usage` poisoned the BYO monthly budget window (`usage_unavailable` reservation → enforcement disabled → next request rejected without dispatch). Normalized usage is now attached to all three post-response raise sites and reconciled as a **failed call with actual token cost**; the orchestrator adds the exhausted call's tokens to run terminal usage.
- Zero-token / absent usage on an exhausted response no longer reconciles as a real $0 call: the success path's 0/0-is-unreported invariant now applies to the exception path (adapter + defense-in-depth in `_usage_from_exception`), holding the conservative reservation instead.

### Verification

Fail-before/pass-after evidence for every behavior change (including the reviewer's exact reproductions as permanent integration tests through `attach_agent_budget_guard`). Sibling pre-usage raise paths audited. Full `ci/local_validate.sh` gate green (ruff, mypy, go, FULL unit suite, live-ClickHouse argMax proof); 2 restricted Codex adversarial passes on the branch.

SCREENSHOT-WAIVER: backend only.

https://claude.ai/code/session_01PikpG981BnDre1BVMFNgc2
