### PR TITLE
feat(ask-dev): server-owned intent interpretation and named-subject preflight (CHAOS-3292)

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -74,7 +74,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "1f8bb8b787ebacfb6373053cab676c2e3f15c5c20b59971b178d2895c545e21f"
+        "sha256": "b7c1e321eca3616507d09d47cc6516a9999fcfba2e047b572a6f78f778926639"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -1211,6 +1211,8 @@
           "enum": [
             "accepted",
             "resolving_scope",
+            "interpreting",
+            "resolving_subjects",
             "model_decision",
             "tool_validation",
             "tool_execution",

--- a/docs-data/ia/contribute.tsv
+++ b/docs-data/ia/contribute.tsv
@@ -8,6 +8,7 @@ con-platform	con-arch	/contribute/architecture/platform/	Platform architecture	a
 con-storage	con-arch	/contribute/architecture/data-and-storage/	Data and storage boundaries	architecture	true	public	planned	false	
 con-contracts	con-arch	/contribute/architecture/contracts/	Stable contracts and source-of-truth rules	architecture	true	public	planned	false	
 con-ask-dev-v2	con-arch	/contribute/architecture/ask-dev-contracts-v2/	Ask Dev v2 contracts (Wave 3.1)	architecture	true	public	planned	false	
+con-ask-dev-preflight	con-arch	/contribute/architecture/ask-dev-subject-preflight/	Ask Dev subject preflight	architecture	true	public	planned	false	
 con-dev	contribute	/contribute/development/	Develop and test	landing	true	public	planned	false	
 con-commands	con-dev	/contribute/development/commands/	Common development commands	task-guide	true	public	planned	false	
 con-tests	con-dev	/contribute/development/testing/	Testing layers and local validation	task-guide	true	public	planned	false	

--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -58,11 +58,17 @@ A subject is recognized two ways. A name beside a kind noun ("the Ask Dev
 project", "project Ask Dev") is typed directly. A bare name with no such noun
 ("How is Nightfall doing?") is still recognized, and is resolved across every
 searchable kind — but because we cannot be sure a bare capitalized word was a
-subject at all, failing to resolve one does **not** stop the run. It falls back
-to today's behaviour: an organization-wide answer with the previous
-named-entity backstop re-armed, which compares the name against the model's own
-answer text and stops only an answer that actually narrates it. "What is our
-DORA score?" therefore still answers normally.
+subject at all, failing to resolve one does **not** stop the run. Instead the
+run widens to organization scope and the previous named-entity backstop is
+re-armed, comparing the name against the model's own answer text and stopping
+only an answer that actually narrates it. "What is our DORA score?" therefore
+still answers normally.
+
+The widening is the load-bearing part. Asked from a project page, "How is
+Nightfall doing?" would otherwise keep that page's project as its scope and
+report *its* numbers under the name Nightfall — the same misattribution, one
+layer down. Dropping the page subject removes the entity that could be
+mislabelled.
 
 Page context is used as the subject only when the question named nothing at
 all, including nothing we merely failed to type. Substituting the page's
@@ -90,9 +96,12 @@ never falls back to organization scope.
 Each mention resolves to exactly one of five outcomes: an exact match,
 ambiguous candidates, no authorized match, a temporarily unavailable catalog,
 or an unsupported kind. Committing requires the name to **equal** an entity's
-label or identifier: the catalog's text search matches substrings, so a sole
-result for a partial name ("the Dev project") is offered back as a candidate
-rather than committed as though it were what you meant.
+label or identifier, and that equality lookup runs first, before the bounded
+substring search: the substring query orders by label and truncates in SQL, so
+an exactly-named entity can otherwise fall off the end of a crowded result page
+and never be considered. A sole substring result for a partial name ("the Dev
+project") is offered back as a candidate rather than committed as though it
+were what you meant.
 
 Every catalog query is filtered by organization in
 SQL, so an entity belonging to another tenant is simply absent — it reads as

--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -54,6 +54,21 @@ in flight.
 
 ### Interpretation
 
+A subject is recognized two ways. A name beside a kind noun ("the Ask Dev
+project", "project Ask Dev") is typed directly. A bare name with no such noun
+("How is Nightfall doing?") is still recognized, and is resolved across every
+searchable kind — but because we cannot be sure a bare capitalized word was a
+subject at all, failing to resolve one does **not** stop the run. It falls back
+to today's behaviour: an organization-wide answer with the previous
+named-entity backstop re-armed, which compares the name against the model's own
+answer text and stops only an answer that actually narrates it. "What is our
+DORA score?" therefore still answers normally.
+
+Page context is used as the subject only when the question named nothing at
+all, including nothing we merely failed to type. Substituting the page's
+project for a name we could not parse would answer about one entity under
+another's name.
+
 Intent comes from deterministic recognizers over a normalized question, with
 an optional constrained model fallback for low-confidence cases. The
 recognizers do lexical matching, and the important property is not the
@@ -74,7 +89,12 @@ never falls back to organization scope.
 
 Each mention resolves to exactly one of five outcomes: an exact match,
 ambiguous candidates, no authorized match, a temporarily unavailable catalog,
-or an unsupported kind. Every catalog query is filtered by organization in
+or an unsupported kind. Committing requires the name to **equal** an entity's
+label or identifier: the catalog's text search matches substrings, so a sole
+result for a partial name ("the Dev project") is offered back as a candidate
+rather than committed as though it were what you meant.
+
+Every catalog query is filtered by organization in
 SQL, so an entity belonging to another tenant is simply absent — it reads as
 "no authorized match", never as "forbidden", and nothing about it appears in
 any user-visible string.
@@ -102,7 +122,7 @@ advertised exactly as before.
 | Every named subject resolved | The answer, scoped to that subject |
 | The question named nothing | An organization-wide answer, as before |
 | A named subject does not exist here | "No matching subject was found" |
-| A name matches several entities | A request to say which one |
+| A name matches several entities, or only partially | A request to say which one |
 | The catalog is briefly unavailable | "Temporarily unavailable", retryable |
 | A named team, or several named subjects at once | "Not supported yet" |
 
@@ -121,9 +141,12 @@ did before: no interpretation, no preflight, every tool advertised, and the
 previous named-entity backstop still terminating.
 
 With it on, that backstop is kept as defense in depth but is **telemetry
-only** — it records a content-free reason code on the run row and does not
-change the outcome. A firing there means the new path missed something and is
-worth investigating, not worth acting on mid-run.
+only** once a subject is committed — it records a content-free reason code on
+the run row and does not change the outcome. A firing there means the new path
+missed something and is worth investigating, not worth acting on mid-run. The
+one exception is a run that saw a bare name it could not resolve: there the
+server has no committed subject to judge against, so the backstop stays
+terminal for the reasons that are evidence about that name.
 
 ## Diagnostics
 

--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -1,0 +1,133 @@
+---
+page_id: con-ask-dev-preflight
+summary: How Ask Dev interprets a question and resolves every named subject before any evidence tool runs.
+content_type: architecture
+owner: engineering
+source_of_truth:
+  - src/dev_health_ops/api/dev/question_interpreter.py
+  - src/dev_health_ops/api/dev/subject_preflight.py
+  - src/dev_health_ops/api/dev/preflight_outcomes.py
+  - src/dev_health_ops/api/dev/orchestrator.py
+  - Amendment TRD v2 -- Ask Dev Wave 3.1 (Linear, project Ask Dev)
+applicability: current
+lifecycle: active
+---
+
+# Ask Dev subject preflight
+
+Ask Dev decides what a question is about, and which authorized entity it
+names, **on the server and before the model is asked anything**. A named
+subject that the catalog cannot confirm stops the run: no status, change,
+metric, or evidence tool executes without an exact, committed subject.
+{: .fc-page-lede }
+
+This page describes the runtime behavior CHAOS-3292 introduced. The wire
+contracts it produces are described in
+[Ask Dev v2 contracts](ask-dev-contracts-v2.md).
+
+## Why it exists
+
+The previous design asked the model to resolve a name first and then judged
+the finished answer afterwards. Both halves were advisory. The prompt told the
+model to call `resolve_scope.v1` before any status tool, and a post-hoc check
+compared entity names extracted from the question against the model's own
+answer text. That check could only ever act by **deleting an answer that had
+already been produced**: a miss left a fabricated premise standing, and a false
+positive destroyed a good answer.
+
+Committing the subject before the model round inverts this. The model is
+*given* a resolved scope in its prompt instead of being asked to earn one, so
+there is no opportunity to narrate an unresolved name in the first place.
+
+## The phases
+
+A run now passes through two new states between scope authorization and the
+first model round:
+
+| State | What happens |
+| --- | --- |
+| `interpreting` | The question is classified into one of twelve launch intents, and every named subject is extracted as an ordered *mention*. |
+| `resolving_subjects` | Each mention is resolved against the organization's authorized catalog, and the outcome is appended to a resolution ledger. |
+
+Both are non-terminal, so a run parked in either one correctly reads as still
+in flight.
+
+### Interpretation
+
+Intent comes from deterministic recognizers over a normalized question, with
+an optional constrained model fallback for low-confidence cases. The
+recognizers do lexical matching, and the important property is not the
+technique but the failure mode: a recognizer only picks a member of a closed
+enum, so a miss degrades to a bounded investigation — the behavior Ask Dev
+already had — and **can never delete an answer or widen a scope**.
+
+The client's `question_class` is recorded for audit and ignored for planning.
+
+The optional model fallback has no tools, no catalog access, and no scope
+authority. It receives the raw question and nothing else, and every span it
+proposes must be a literal substring of that question, which is what makes
+"it cannot author an entity name" structural rather than aspirational. Any
+provider error, timeout, or rejected proposal asks the user to clarify; it
+never falls back to organization scope.
+
+### Subject resolution
+
+Each mention resolves to exactly one of five outcomes: an exact match,
+ambiguous candidates, no authorized match, a temporarily unavailable catalog,
+or an unsupported kind. Every catalog query is filtered by organization in
+SQL, so an entity belonging to another tenant is simply absent — it reads as
+"no authorized match", never as "forbidden", and nothing about it appears in
+any user-visible string.
+
+Resolutions are recorded on an **append-only ledger**. A later success cannot
+erase an earlier unresolved mention: entries carry contiguous ordinals, the
+objects are immutable, and every update is checked against the previous
+snapshot. When a question names several subjects, the outcome is decided by
+the lowest-ordinal unresolved mention — "the first thing you named" — which is
+stable and independent of how fast the catalog answered.
+
+## What the model is offered
+
+Once a subject is committed there is nothing left for the model to resolve, so
+`resolve_scope.v1` is withheld for the rest of the run. This is a per-run tool
+allowlist, applied both to the tools advertised to the provider and re-checked
+when a tool call is dispatched. When no subject was committed — an
+organization-wide question, or a run with the feature off — every tool is
+advertised exactly as before.
+
+## Outcomes
+
+| Situation | What the user sees |
+| --- | --- |
+| Every named subject resolved | The answer, scoped to that subject |
+| The question named nothing | An organization-wide answer, as before |
+| A named subject does not exist here | "No matching subject was found" |
+| A name matches several entities | A request to say which one |
+| The catalog is briefly unavailable | "Temporarily unavailable", retryable |
+| A named team, or several named subjects at once | "Not supported yet" |
+
+The last row is a deliberate interim. A resolved team is recorded honestly as
+an exact match — the team demonstrably exists — but the current scope
+vocabulary cannot carry a team subject, and a cohort of several subjects has
+no faithful single-subject representation either. Answering under organization
+scope in either case would reintroduce exactly the defect this work closes.
+Both become real answers when team and multi-subject support land.
+
+## Rollout
+
+The whole path is behind the `ask_dev_wave_3_1` entitlement, which is
+explicit-enable and off by default. With it off, a run behaves exactly as it
+did before: no interpretation, no preflight, every tool advertised, and the
+previous named-entity backstop still terminating.
+
+With it on, that backstop is kept as defense in depth but is **telemetry
+only** — it records a content-free reason code on the run row and does not
+change the outcome. A firing there means the new path missed something and is
+worth investigating, not worth acting on mid-run.
+
+## Diagnostics
+
+Two closed-vocabulary columns on the run row record what happened:
+`preflight_outcome` (which branch the preflight took) and
+`legacy_guard_reason` (whether the retained backstop fired anyway). Neither
+can carry question text, an entity name, or catalog content.

--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -99,6 +99,11 @@ SQL, so an entity belonging to another tenant is simply absent — it reads as
 "no authorized match", never as "forbidden", and nothing about it appears in
 any user-visible string.
 
+When a name is ambiguous, the authorized candidates are recorded on the
+ledger, but the retained v1 answer surface has no field that can carry them —
+so a v1 client is told the name was ambiguous without being shown the choices.
+Closing that is CHAOS-3325.
+
 Resolutions are recorded on an **append-only ledger**. A later success cannot
 erase an earlier unresolved mention: entries carry contiguous ordinals, the
 objects are immutable, and every update is checked against the previous

--- a/docs/use/troubleshooting/no-or-incomplete-data.md
+++ b/docs/use/troubleshooting/no-or-incomplete-data.md
@@ -89,6 +89,15 @@ When the selected context is correct, continue to [Check synchronization status 
 
 For Investment, a result also depends on supported WorkUnits, effort values, categorization output, and the selected scope. Missing source material can reduce the result or leave no usable rows; it must not be interpreted as a deliberate zero distribution.
 
+## An Ask Dev answer that declines to name a subject
+
+"This question is not supported yet" from Ask Dev, for a question that names a
+team or names several subjects at once, is a capability boundary rather than a
+data gap. The subject was found; the answer shape for it is not built yet.
+Asking about a single project or repository instead will answer normally.
+
+Do not read this as "no data for that team". Nothing was looked up.
+
 ## Escalate runtime failures separately
 
 If workspace configuration and coverage are correct but synchronization, ingestion, workers, queues, or stores are failing, continue to the operator runbooks:

--- a/docs/use/troubleshooting/permissions-and-availability.md
+++ b/docs/use/troubleshooting/permissions-and-availability.md
@@ -17,6 +17,29 @@ lifecycle: active
 
 AI Attribution, several report subroutes, and some other product routes are currently marked preview in the product navigation source. Their absence from v2 navigation is intentional.
 
+## Ask Dev named a subject it could not confirm
+
+When you ask Ask Dev about a specific project, repository, team, issue, pull
+request, or work unit, the server resolves that name against your workspace's
+authorized catalog **before** it looks anything up. Three replies come from
+that step, and each means something different:
+
+- **"No matching subject was found."** No entity you are authorized to see
+  matches the name. This is also what you see for an entity that exists in a
+  different workspace, deliberately: the reply cannot be used to discover
+  whether something exists elsewhere. Check the spelling, or the workspace you
+  are signed in to.
+- **"More than one authorized entity matches..."** The name is ambiguous. Ask
+  again naming exactly which one you mean.
+- **"This answer is temporarily unavailable."** The catalog could not be
+  reached. This one is worth retrying in a few minutes; the others are not.
+
+Ask Dev will not answer about your whole organization under a name it could
+not confirm. If a question that names something specific comes back with one
+of these replies, that is the intended behaviour, not a lookup failure.
+
+Questions that name nothing specific still answer organization-wide as usual.
+
 ## Ask Dev metrics
 
 Ask Dev metric catalog and query fields require an authenticated workspace

--- a/docs/use/troubleshooting/permissions-and-availability.md
+++ b/docs/use/troubleshooting/permissions-and-availability.md
@@ -29,8 +29,9 @@ that step, and each means something different:
   different workspace, deliberately: the reply cannot be used to discover
   whether something exists elsewhere. Check the spelling, or the workspace you
   are signed in to.
-- **"More than one authorized entity matches..."** The name is ambiguous. Ask
-  again naming exactly which one you mean.
+- **"More than one authorized entity matches..."** The name is ambiguous, or
+  it is only part of a name. Ask again with the full name of exactly the one
+  you mean — a partial name is never resolved to a best guess.
 - **"This answer is temporarily unavailable."** The catalog could not be
   reached. This one is worth retrying in a few minutes; the others are not.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,6 +241,7 @@ nav:
           - Data and storage: contribute/architecture/data-and-storage.md
           - Stable contracts: contribute/architecture/contracts.md
           - Ask Dev v2 contracts: contribute/architecture/ask-dev-contracts-v2.md
+          - Ask Dev subject preflight: contribute/architecture/ask-dev-subject-preflight.md
       - Develop and test:
           - contribute/development/index.md
           - Commands: contribute/development/commands.md

--- a/src/dev_health_ops/alembic/versions/0072_widen_dev_run_states.py
+++ b/src/dev_health_ops/alembic/versions/0072_widen_dev_run_states.py
@@ -1,0 +1,97 @@
+"""Widen dev_runs.state for the CHAOS-3292 preflight and add run diagnostics.
+
+Revision ID: 0072
+Revises: 0071
+Create Date: 2026-07-31 00:00:00
+
+The subject preflight adds two non-terminal run states (``interpreting`` and
+``resolving_subjects``) between scope authorization and the first model round.
+``ck_dev_runs_state`` enumerates the legal states, so writing either one fails
+at persistence without this revision — the constraint is checked by the
+database, not by an import.
+
+Two nullable, content-free diagnostic columns land with them. There is no
+metrics, logging, tracing or statsd facility anywhere in ``api/dev`` to publish
+a counter to (a real observability stack is CHAOS-3218), so the preflight
+outcome and the demoted CHAOS-3289 backstop's reason code ride on the run row
+beside the existing ``safe_error_code`` / ``grounding_validation_status``
+diagnostics, under the same retention policy. Both are closed vocabularies:
+neither can carry question text, an entity name, or catalog content.
+
+Additive in both directions. It touches nothing the CHAOS-3299 persistence
+work owns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0072"
+down_revision: str | None = "0071"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_CONSTRAINT = "ck_dev_runs_state"
+_TABLE = "dev_runs"
+
+_PRIOR_STATES = (
+    "accepted",
+    "resolving_scope",
+    "model_decision",
+    "tool_validation",
+    "tool_execution",
+    "answer_validation",
+    "completed",
+    "insufficient_evidence",
+    "refused",
+    "failed",
+    "cancelled",
+)
+_NEW_STATES = ("interpreting", "resolving_subjects")
+
+
+def _state_check(states: Sequence[str]) -> str:
+    values = ", ".join(f"'{state}'" for state in states)
+    return f"state IN ({values})"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        _state_check(
+            (
+                *_PRIOR_STATES[:2],
+                *_NEW_STATES,
+                *_PRIOR_STATES[2:],
+            )
+        ),
+    )
+    op.add_column(
+        _TABLE, sa.Column("preflight_outcome", sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        _TABLE, sa.Column("legacy_guard_reason", sa.String(length=64), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(_TABLE, "legacy_guard_reason")
+    op.drop_column(_TABLE, "preflight_outcome")
+    # A run left in one of the new states would violate the narrowed
+    # constraint, so clear those rows to the nearest legal predecessor rather
+    # than failing the rollback on live data.
+    op.execute(
+        sa.text(
+            "UPDATE dev_runs SET state = 'resolving_scope' "
+            "WHERE state IN ('interpreting', 'resolving_subjects')"
+        )
+    )
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _state_check(_PRIOR_STATES))

--- a/src/dev_health_ops/alembic/versions/0073_seed_ask_dev_wave_3_1_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0073_seed_ask_dev_wave_3_1_feature_flag.py
@@ -1,0 +1,72 @@
+"""Seed the default-disabled Ask Dev Wave 3.1 entitlement.
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-07-31 00:00:00
+
+``ask_dev_wave_3_1`` is the Amendment TRD v2 §15 Phase A rollout gate for
+server-owned question interpretation and the named-subject preflight
+(CHAOS-3292). The row is globally available so the canonical feature decision
+can act as an operator kill switch, and the feature is registered as an
+explicit-enable one, so every tier stays denied until an organization or
+license override grants it. With the flag off a run behaves exactly as it does
+today.
+
+Follows ``0067``/``0070``: additive, idempotent, and preserved on rollback
+because organization and license overrides may reference the row.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0073"
+down_revision: str | None = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_FEATURE_KEY = "ask_dev_wave_3_1"
+_FEATURE_NAME = "Ask Dev Wave 3.1"
+_FEATURE_CATEGORY = "analytics"
+_FEATURE_MIN_TIER = "community"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO feature_flags
+                (id, key, name, category, min_tier, is_enabled, is_beta,
+                 is_deprecated, created_at, updated_at)
+            SELECT :id, :key, :name, :category, :min_tier,
+                   TRUE, TRUE, FALSE, :created_at, :updated_at
+            WHERE NOT EXISTS (
+                SELECT 1 FROM feature_flags WHERE key = :key
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": _FEATURE_KEY,
+            "name": _FEATURE_NAME,
+            "category": _FEATURE_CATEGORY,
+            "min_tier": _FEATURE_MIN_TIER,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    # Organization and license overrides may reference this row. Preserve the
+    # additive registration on rollback, matching the base Ask Dev entitlement.
+    pass

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -693,6 +693,11 @@ class DevAnswer(ContractModel):
 DevTranscriptRunState = Literal[
     "accepted",
     "resolving_scope",
+    # CHAOS-3292 preflight phases. A transcript can be fetched while a run is
+    # still in flight, so omitting these turned an in-progress run into a
+    # server error at transcript validation rather than a rejected state.
+    "interpreting",
+    "resolving_subjects",
     "model_decision",
     "tool_validation",
     "tool_execution",

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -151,6 +151,17 @@ def _named_entity_phrases(text: str) -> frozenset[str]:
 #: The server-owned copy for the legacy CHAOS-3289 backstop, reachable only
 #: from the flag-off (no-preflight) path. Split out of the predicate so a
 #: telemetry-only firing on the preflight path cannot produce public copy.
+#: The subset of guard reasons that say something about the *named entity*
+#: rather than about the shape of the answer. Only these keep the backstop
+#: terminal on a preflight run with an unresolved bare name.
+_NAME_SPECIFIC_GUARD_REASONS = frozenset(
+    {
+        "resolve_scope_ambiguous",
+        "resolve_scope_not_found",
+        "narrated_unresolved_entity",
+    }
+)
+
 _LEGACY_GUARD_TERMINALS: dict[str, tuple[str, str]] = {
     "resolve_scope_ambiguous": (
         "scope_ambiguous",
@@ -305,6 +316,7 @@ class RunRecorder(Protocol):
         provider_fingerprint: str | None,
         model_fingerprint: str | None,
         prompt_checksum: str | None,
+        prompt_version: str | None,
     ) -> None: ...
 
 
@@ -344,6 +356,7 @@ class NullRunRecorder:
         provider_fingerprint: str | None,
         model_fingerprint: str | None,
         prompt_checksum: str | None,
+        prompt_version: str | None,
     ) -> None:
         del (
             state,
@@ -354,6 +367,7 @@ class NullRunRecorder:
             provider_fingerprint,
             model_fingerprint,
             prompt_checksum,
+            prompt_version,
         )
 
 
@@ -506,6 +520,7 @@ class DevOrchestrator:
         provider_fingerprint: str | None = None
         model_fingerprint: str | None = None
         prompt_checksum: str | None = None
+        prompt_version: str | None = None
         resolution: DevScopeResolution | None = None
         provider_continuation: tuple[AgentMessage, ...] = ()
         terminal_written = False
@@ -557,6 +572,7 @@ class DevOrchestrator:
                 provider_fingerprint=provider_fingerprint,
                 model_fingerprint=model_fingerprint,
                 prompt_checksum=prompt_checksum,
+                prompt_version=prompt_version,
             )
             terminal_written = True
             event = OrchestratorEvent(
@@ -718,6 +734,10 @@ class DevOrchestrator:
                         prior_turns=prior_turns,
                         tool_results=tuple(tool_results),
                         allowed_tools=allowed_tools,
+                        subject_committed=(
+                            preflight_result is not None
+                            and preflight_result.committed_resolution is not None
+                        ),
                     )
                 except ValueError as exc:
                     # A synthetic repair turn (CHAOS-3288) added on top of an
@@ -743,6 +763,7 @@ class DevOrchestrator:
                         ),
                     )
                 prompt_checksum = composed.checksum
+                prompt_version = composed.version
                 prompt_bytes = len(composed.system_text.encode()) + len(
                     composed.user_text.encode()
                 )
@@ -1175,7 +1196,9 @@ class DevOrchestrator:
                     )
                     if guard_reason is not None:
                         if preflight_result is not None and not (
-                            self._legacy_guard_is_terminal(preflight_result)
+                            self._legacy_guard_is_terminal(
+                                preflight_result, guard_reason
+                            )
                         ):
                             # TRD §10: kept as defense in depth, but it must
                             # not create public copy or delete an answer once
@@ -1695,16 +1718,32 @@ class DevOrchestrator:
         return None
 
     @staticmethod
-    def _legacy_guard_is_terminal(preflight: SubjectPreflightResult | None) -> bool:
+    def _legacy_guard_is_terminal(
+        preflight: SubjectPreflightResult | None, reason: str
+    ) -> bool:
         """Whether a CHAOS-3289 guard firing may still terminate the run.
 
         A named seam rather than an inline condition so a mutation test can
         defeat exactly this decision and observe which acceptance case notices
         (TRD §10: on the preflight path a firing is a cutover defect to record,
         not an outcome to act on).
+
+        The flag-off path keeps every reason terminal — the backstop is the
+        only check there is. A preflight run that saw a bare name it could not
+        resolve keeps only the reasons that are *evidence about that name*: the
+        answer narrating it, or a resolution attempt that came back ambiguous
+        or not-found. ``no_evidence_backed_claims`` stays telemetry even then,
+        because it is a proxy for the shape of the answer rather than a
+        statement about the unresolved name, and terminating on it would fail
+        an ordinary organization-wide question that merely happens to contain
+        a capitalized acronym.
         """
 
-        return preflight is None
+        if preflight is None:
+            return True
+        return (
+            preflight.legacy_guard_required and reason in _NAME_SPECIFIC_GUARD_REASONS
+        )
 
     @staticmethod
     def _subject_gate_rejection(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -736,7 +736,7 @@ class DevOrchestrator:
                         allowed_tools=allowed_tools,
                         subject_committed=(
                             preflight_result is not None
-                            and preflight_result.committed_resolution is not None
+                            and preflight_result.has_committed_subject
                         ),
                     )
                 except ValueError as exc:
@@ -1193,6 +1193,11 @@ class DevOrchestrator:
                         resolve_scope_attempted=resolve_scope_attempted,
                         last_resolve_scope_outcome=last_resolve_scope_outcome,
                         answer=answer,
+                        extra_named_phrases=(
+                            preflight_result.unresolved_name_spans
+                            if preflight_result is not None
+                            else frozenset()
+                        ),
                     )
                     if guard_reason is not None:
                         if preflight_result is not None and not (
@@ -1647,6 +1652,7 @@ class DevOrchestrator:
         resolve_scope_attempted: bool,
         last_resolve_scope_outcome: ScopeResolutionOutcome | None,
         answer: DevAnswer,
+        extra_named_phrases: frozenset[str] = frozenset(),
     ) -> str | None:
         """CHAOS-3289: a status answer must never narrate a named entity that
         was never confirmed to exist.
@@ -1703,7 +1709,14 @@ class DevOrchestrator:
         if not resolve_scope_attempted:
             if not answer.claims:
                 return "no_evidence_backed_claims"
-            named_phrases = _named_entity_phrases(question)
+            # The legacy grammar only recognizes a name adjacent to an entity
+            # noun ("the X project"), so it is blind to a bare "X" — exactly
+            # the shape the preflight re-arms it for. The preflight's own
+            # unresolved spans are supplied here so the narration check can
+            # actually see them (CHAOS-3292).
+            named_phrases = _named_entity_phrases(question) | frozenset(
+                phrase.casefold() for phrase in extra_named_phrases
+            )
             if named_phrases:
                 narrated_texts = (
                     answer.direct_summary,

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -16,7 +16,6 @@ from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import StrEnum
 from typing import Any, Literal, Protocol
 
 import annotated_types
@@ -68,8 +67,16 @@ from .contracts import (
     ToolID,
     dev_error_remediation,
 )
+from .orchestrator_states import TERMINAL_STATES, RunState
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
+from .preflight_outcomes import TERMINAL_STATE_BY_OUTCOME, project_preflight_error
 from .prompts import PromptComposer, PromptConversationTurn
+from .subject_preflight import (
+    SUBJECT_BEARING_TOOLS,
+    PreflightDecision,
+    SubjectPreflight,
+    SubjectPreflightResult,
+)
 from .tool_registry import (
     AskDevToolRegistry,
     ToolExecution,
@@ -141,6 +148,29 @@ def _named_entity_phrases(text: str) -> frozenset[str]:
     return frozenset(match.casefold() for match in phrases)
 
 
+#: The server-owned copy for the legacy CHAOS-3289 backstop, reachable only
+#: from the flag-off (no-preflight) path. Split out of the predicate so a
+#: telemetry-only firing on the preflight path cannot produce public copy.
+_LEGACY_GUARD_TERMINALS: dict[str, tuple[str, str]] = {
+    "resolve_scope_ambiguous": (
+        "scope_ambiguous",
+        "The requested scope is ambiguous.",
+    ),
+    "resolve_scope_not_found": (
+        "scope_not_found",
+        "The requested scope was not found.",
+    ),
+    "no_evidence_backed_claims": (
+        "insufficient_evidence",
+        "The answer does not include evidence-backed claims for the requested entity.",
+    ),
+    "narrated_unresolved_entity": (
+        "insufficient_evidence",
+        "The answer narrates a status for a named entity that was never resolved.",
+    ),
+}
+
+
 _HARD_LIMIT_MAXIMA: dict[str, int | float] = {
     "model_rounds": 4,
     "tool_calls": 6,
@@ -160,31 +190,6 @@ _HARD_LIMIT_MAXIMA: dict[str, int | float] = {
     "estimated_cost_per_call_microusd": 1_000_000,
     "max_estimated_cost_microusd": ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
 }
-
-
-class RunState(StrEnum):
-    ACCEPTED = "accepted"
-    RESOLVING_SCOPE = "resolving_scope"
-    MODEL_DECISION = "model_decision"
-    TOOL_VALIDATION = "tool_validation"
-    TOOL_EXECUTION = "tool_execution"
-    ANSWER_VALIDATION = "answer_validation"
-    COMPLETED = "completed"
-    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
-    REFUSED = "refused"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-
-
-TERMINAL_STATES = frozenset(
-    {
-        RunState.COMPLETED,
-        RunState.INSUFFICIENT_EVIDENCE,
-        RunState.REFUSED,
-        RunState.FAILED,
-        RunState.CANCELLED,
-    }
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -272,6 +277,23 @@ class RunRecorder(Protocol):
 
     async def record_answer(self, answer: DevAnswer) -> None: ...
 
+    async def record_preflight(
+        self,
+        *,
+        preflight_outcome: str | None,
+        legacy_guard_reason: str | None,
+    ) -> None:
+        """Content-free run diagnostics (CHAOS-3292).
+
+        Both values are members of closed server-owned vocabularies — never
+        question text, entity names, or catalog content. There is no metrics,
+        logging, tracing or statsd facility anywhere in ``api/dev`` to publish
+        a divergence counter to (a real observability stack is CHAOS-3218), so
+        these ride on the run row beside the existing ``safe_error_code`` and
+        ``grounding_validation_status`` diagnostics.
+        """
+        ...
+
     async def terminal(
         self,
         *,
@@ -302,6 +324,14 @@ class NullRunRecorder:
 
     async def record_answer(self, answer: DevAnswer) -> None:
         del answer
+
+    async def record_preflight(
+        self,
+        *,
+        preflight_outcome: str | None,
+        legacy_guard_reason: str | None,
+    ) -> None:
+        del preflight_outcome, legacy_guard_reason
 
     async def terminal(
         self,
@@ -434,6 +464,7 @@ class DevOrchestrator:
         recorder: RunRecorder | None = None,
         event_sink: EventSink | None = None,
         monotonic: Callable[[], float] = time.monotonic,
+        preflight: SubjectPreflight | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -445,6 +476,10 @@ class DevOrchestrator:
         self._recorder = recorder or NullRunRecorder()
         self._event_sink = event_sink
         self._monotonic = monotonic
+        # ``None`` is the flag-off path: no interpretation, no subject
+        # resolution, every tool advertised, and the CHAOS-3289 backstop
+        # terminating exactly as it does today.
+        self._preflight = preflight
         self._composer = PromptComposer(registry)
 
     async def run(
@@ -593,6 +628,73 @@ class DevOrchestrator:
                     ),
                 )
 
+            # CHAOS-3292 preflight: interpret the question and resolve every
+            # named subject against the authorized catalog *before* the first
+            # model round, so no evidence-bearing tool can execute without an
+            # exact committed subject. Zero provider tokens are spent here.
+            preflight_result: SubjectPreflightResult | None = None
+            allowed_tools: frozenset[ToolID] = frozenset(ToolID)
+            if self._preflight is not None:
+                if cancellation.is_set():
+                    return await finish(
+                        RunState.CANCELLED,
+                        error=error("cancelled", "The request was cancelled."),
+                    )
+                try:
+                    preflight_result = await asyncio.wait_for(
+                        self._preflight.run(
+                            request=request,
+                            org_id=org_id,
+                            permission_fingerprint=permission_fingerprint,
+                            authorized_scope=authorized_scope,
+                            run_id=run_id,
+                            answer_id=answer_id,
+                            conversation_id=conversation_id,
+                            on_phase=transition,
+                        ),
+                        timeout=max(0.0, remaining()),
+                    )
+                except (TimeoutError, asyncio.TimeoutError):
+                    return await finish(
+                        RunState.FAILED,
+                        error=error(
+                            "tool_limit_reached", "The request time limit was reached."
+                        ),
+                    )
+                allowed_tools = preflight_result.allowed_tools
+                await self._recorder.record_preflight(
+                    preflight_outcome=preflight_result.diagnostic,
+                    legacy_guard_reason=None,
+                )
+                if preflight_result.decision is PreflightDecision.TERMINATE:
+                    assert preflight_result.answer is not None
+                    assert preflight_result.outcome is not None
+                    return await finish(
+                        TERMINAL_STATE_BY_OUTCOME[preflight_result.outcome],
+                        error=project_preflight_error(
+                            preflight_result.answer, request_id=request.request_id
+                        ),
+                    )
+                if preflight_result.committed_resolution is not None:
+                    committed = preflight_result.committed_resolution
+                    committed_scope = committed.resolved_scope
+                    if committed_scope is None or (
+                        committed_scope.organization_id != org_id
+                    ):  # pragma: no cover - committed_resolution_for always commits
+                        return await finish(
+                            RunState.FAILED,
+                            error=error(
+                                "scope_forbidden",
+                                "The requested scope is not authorized.",
+                            ),
+                        )
+                    # The model is *given* the subject rather than asked to
+                    # earn it: composer serializes ``resolved_scope`` into the
+                    # prompt, so this is the commit that removes the "narrate
+                    # an unresolved name" opportunity entirely.
+                    resolution = committed
+                    authorized_scope = committed_scope
+
             for round_index in range(self._limits.model_rounds):
                 del round_index
                 if cancellation.is_set():
@@ -615,6 +717,7 @@ class DevOrchestrator:
                         scope=resolution,
                         prior_turns=prior_turns,
                         tool_results=tuple(tool_results),
+                        allowed_tools=allowed_tools,
                     )
                 except ValueError as exc:
                     # A synthetic repair turn (CHAOS-3288) added on top of an
@@ -648,7 +751,7 @@ class DevOrchestrator:
                     AgentMessage(AgentMessageRole.USER, composed.user_text),
                     *provider_continuation,
                 )
-                tools = self._provider_tools()
+                tools = self._provider_tools(allowed_tools)
                 while True:
                     budget.require(prompt_bytes=prompt_bytes)
                     provider_timeout = min(self._limits.provider_seconds, remaining())
@@ -732,6 +835,17 @@ class DevOrchestrator:
                                 "The requested tool was not available.",
                             ),
                         )
+                    # Second enforcement point, deliberately redundant with the
+                    # pre-loop gate. The pre-loop gate decides whether the run
+                    # proceeds at all; this one decides whether *this call*
+                    # executes, and it is the seam a mutation can defeat — so
+                    # each must independently keep a subject-bearing tool from
+                    # running while any mention lacks a committed exact match.
+                    gate_rejection = self._subject_gate_rejection(
+                        tool_id=tool_id_for_call,
+                        allowed_tools=allowed_tools,
+                        preflight=preflight_result,
+                    )
                     try:
                         tool_request, canonical_hash = self._canonical_tool_request(
                             decision=decision,
@@ -782,7 +896,17 @@ class DevOrchestrator:
                                 "A repeated tool-call loop was stopped.",
                             ),
                         )
-                    if construction_rejection is not None:
+                    if gate_rejection is not None:
+                        # Degraded per-call rather than fatal (CHAOS-3262's
+                        # posture): the model is told the tool is unavailable
+                        # and can still answer from the committed subject. The
+                        # executor is never reached either way.
+                        execution = self._rejected_tool_execution(
+                            tool_request=tool_request,
+                            code="tool_unavailable",
+                            message=gate_rejection,
+                        )
+                    elif construction_rejection is not None:
                         execution = self._rejected_tool_execution(
                             tool_request=tool_request,
                             code="invalid_request",
@@ -1041,7 +1165,7 @@ class DevOrchestrator:
                                 "The answer exceeds grounded-result limits.",
                             ),
                         )
-                    unresolved_entity_error = self._unresolved_named_entity_error(
+                    guard_reason = self._legacy_named_entity_guard_reason(
                         question=request.question,
                         question_class=request.question_class,
                         authorized_scope=authorized_scope,
@@ -1049,12 +1173,28 @@ class DevOrchestrator:
                         last_resolve_scope_outcome=last_resolve_scope_outcome,
                         answer=answer,
                     )
-                    if unresolved_entity_error is not None:
-                        code, message = unresolved_entity_error
-                        return await finish(
-                            RunState.INSUFFICIENT_EVIDENCE,
-                            error=error(code, message),
-                        )
+                    if guard_reason is not None:
+                        if preflight_result is not None:
+                            # TRD §10: kept as defense in depth, but it must
+                            # not create public copy or delete an answer once
+                            # the server owns the subject. A firing here is a
+                            # cutover defect, so it is recorded and alerted on
+                            # rather than acted on. Until CHAOS-3297 lands real
+                            # answer frames, "a valid frame exists" is
+                            # substituted by: the preflight committed an exact
+                            # subject for every mention (or the question named
+                            # none) **and** the answer passed the existing
+                            # grounding validator, both true at this line.
+                            await self._recorder.record_preflight(
+                                preflight_outcome=preflight_result.diagnostic,
+                                legacy_guard_reason=guard_reason,
+                            )
+                        else:
+                            code, message = _LEGACY_GUARD_TERMINALS[guard_reason]
+                            return await finish(
+                                RunState.INSUFFICIENT_EVIDENCE,
+                                error=error(code, message),
+                            )
                     return await finish(RunState.COMPLETED, answer=answer)
 
                 if isinstance(decision, AgentDisambiguation):
@@ -1209,8 +1349,10 @@ class DevOrchestrator:
             cancellation_task.cancel()
             await asyncio.gather(cancellation_task, return_exceptions=True)
 
-    def _provider_tools(self) -> tuple[AgentToolDefinition, ...]:
-        manifest = self._registry.manifest()
+    def _provider_tools(
+        self, allowed_tools: frozenset[ToolID] | None = None
+    ) -> tuple[AgentToolDefinition, ...]:
+        manifest = self._registry.manifest(allowed_tool_ids=allowed_tools)
         tools = manifest["tools"]
         assert isinstance(tools, list)
         return tuple(
@@ -1472,7 +1614,7 @@ class DevOrchestrator:
         )
 
     @staticmethod
-    def _unresolved_named_entity_error(
+    def _legacy_named_entity_guard_reason(
         *,
         question: str,
         question_class: QuestionClass,
@@ -1480,9 +1622,18 @@ class DevOrchestrator:
         resolve_scope_attempted: bool,
         last_resolve_scope_outcome: ScopeResolutionOutcome | None,
         answer: DevAnswer,
-    ) -> tuple[str, str] | None:
+    ) -> str | None:
         """CHAOS-3289: a status answer must never narrate a named entity that
         was never confirmed to exist.
+
+        A **pure predicate** returning a closed-vocabulary reason code, never a
+        message: CHAOS-3292 demoted this to telemetry on the preflight path,
+        and telemetry must not be able to become public copy. The four user
+        messages now live in ``_LEGACY_GUARD_TERMINALS`` and are reachable only
+        from the flag-off path, where this remains the terminating
+        defense-in-depth check it is today. Removal is blocked on the cutover
+        issue (TRD §15 Phase D); what ships instead is the proof that disabling
+        it does not reduce the new path's correctness.
 
         Organization scope is a legitimate, fully executable answer target on
         its own (CHAOS-3255) -- this only fires for STATUS-class questions
@@ -1507,8 +1658,8 @@ class DevOrchestrator:
           premises; only the second needs the model's own words as evidence
           since the run produced no resolve_scope.v1 call to judge instead.
 
-        Returns the ``(code, message)`` for the forced insufficient-evidence
-        termination, or ``None`` when the answer is not this failure shape.
+        Returns a reason code from ``_LEGACY_GUARD_TERMINALS``, or ``None``
+        when the answer is not this failure shape.
         """
         if question_class is not QuestionClass.STATUS:
             return None
@@ -1521,16 +1672,12 @@ class DevOrchestrator:
         }:
             return None
         if last_resolve_scope_outcome is ScopeResolutionOutcome.AMBIGUOUS:
-            return ("scope_ambiguous", "The requested scope is ambiguous.")
+            return "resolve_scope_ambiguous"
         if last_resolve_scope_outcome is ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND:
-            return ("scope_not_found", "The requested scope was not found.")
+            return "resolve_scope_not_found"
         if not resolve_scope_attempted:
             if not answer.claims:
-                return (
-                    "insufficient_evidence",
-                    "The answer does not include evidence-backed claims for "
-                    "the requested entity.",
-                )
+                return "no_evidence_backed_claims"
             named_phrases = _named_entity_phrases(question)
             if named_phrases:
                 narrated_texts = (
@@ -1542,11 +1689,31 @@ class DevOrchestrator:
                     for phrase in named_phrases
                     for text in narrated_texts
                 ):
-                    return (
-                        "insufficient_evidence",
-                        "The answer narrates a status for a named entity "
-                        "that was never resolved.",
-                    )
+                    return "narrated_unresolved_entity"
+        return None
+
+    @staticmethod
+    def _subject_gate_rejection(
+        *,
+        tool_id: ToolID,
+        allowed_tools: frozenset[ToolID],
+        preflight: SubjectPreflightResult | None,
+    ) -> str | None:
+        """Deny-by-default: why this tool call must not execute, or ``None``.
+
+        Two independent clauses, mutated separately in the mutation suite:
+        the per-run availability allowlist, and the "every mention holds an
+        exact match" requirement for a subject-bearing tool.
+        """
+
+        if tool_id not in allowed_tools:
+            return "The requested tool is not available for this run."
+        if preflight is None or preflight.ledger is None:
+            return None
+        if tool_id not in SUBJECT_BEARING_TOOLS:
+            return None
+        if not preflight.all_subjects_committed:
+            return "The requested subject was not resolved."
         return None
 
     @staticmethod

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1174,7 +1174,9 @@ class DevOrchestrator:
                         answer=answer,
                     )
                     if guard_reason is not None:
-                        if preflight_result is not None:
+                        if preflight_result is not None and not (
+                            self._legacy_guard_is_terminal(preflight_result)
+                        ):
                             # TRD §10: kept as defense in depth, but it must
                             # not create public copy or delete an answer once
                             # the server owns the subject. A firing here is a
@@ -1691,6 +1693,18 @@ class DevOrchestrator:
                 ):
                     return "narrated_unresolved_entity"
         return None
+
+    @staticmethod
+    def _legacy_guard_is_terminal(preflight: SubjectPreflightResult | None) -> bool:
+        """Whether a CHAOS-3289 guard firing may still terminate the run.
+
+        A named seam rather than an inline condition so a mutation test can
+        defeat exactly this decision and observe which acceptance case notices
+        (TRD §10: on the preflight path a firing is a cutover defect to record,
+        not an outcome to act on).
+        """
+
+        return preflight is None
 
     @staticmethod
     def _subject_gate_rejection(

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -11,6 +11,7 @@ from typing import Literal
 from .contracts import DevAnswer, DevError, DevToolRequest
 from .orchestrator import RunState
 from .persistence.service import DevPersistenceService
+from .prompts import PROMPT_VERSION
 from .tool_registry import TOOL_CONTRACT_VERSION, ToolExecution
 
 
@@ -54,6 +55,22 @@ class PersistenceRunRecorder:
             user_id=self._user_id,
             run_id=self._run_id,
             state=state.value,
+        )
+
+    async def record_preflight(
+        self,
+        *,
+        preflight_outcome: str | None,
+        legacy_guard_reason: str | None,
+    ) -> None:
+        if preflight_outcome is None and legacy_guard_reason is None:
+            return
+        await self._service.record_run_diagnostics(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            preflight_outcome=preflight_outcome,
+            legacy_guard_reason=legacy_guard_reason,
         )
 
     async def record_tool(
@@ -131,7 +148,10 @@ class PersistenceRunRecorder:
         model_fingerprint: str | None,
         prompt_checksum: str | None,
     ) -> None:
-        prompt_version = "ask_dev_prompt.v1"
+        # Read from the composer rather than repeated as a literal: this row is
+        # the run's prompt provenance, and a hardcoded copy silently claims the
+        # previous prompt ran after CHAOS-3292 bumped it to v2.
+        prompt_version = PROMPT_VERSION
         if prompt_checksum is not None:
             prompt_version = f"{prompt_version}:sha256:{prompt_checksum}"
         terminal_reason = (

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -147,11 +147,12 @@ class PersistenceRunRecorder:
         provider_fingerprint: str | None,
         model_fingerprint: str | None,
         prompt_checksum: str | None,
+        prompt_version: str | None = None,
     ) -> None:
-        # Read from the composer rather than repeated as a literal: this row is
-        # the run's prompt provenance, and a hardcoded copy silently claims the
-        # previous prompt ran after CHAOS-3292 bumped it to v2.
-        prompt_version = PROMPT_VERSION
+        # Whichever prompt actually composed, not a literal: this row is the
+        # run's prompt provenance, and the composer now emits v1 or v2
+        # depending on whether the server committed a subject.
+        prompt_version = prompt_version or PROMPT_VERSION
         if prompt_checksum is not None:
             prompt_version = f"{prompt_version}:sha256:{prompt_checksum}"
         terminal_reason = (

--- a/src/dev_health_ops/api/dev/orchestrator_states.py
+++ b/src/dev_health_ops/api/dev/orchestrator_states.py
@@ -1,0 +1,51 @@
+"""The Ask Dev run-state vocabulary, as an import leaf.
+
+Split out of ``orchestrator`` for a structural reason, not a stylistic one:
+``preflight_outcomes`` maps a public outcome to the terminal run state, and
+``orchestrator`` imports the preflight. With ``RunState`` defined in
+``orchestrator`` that is a genuine import cycle, in which the name a module
+sees depends on which one an importer reached first — the same shape the
+contracts_v2 package split ``no_answer_policy`` out to avoid.
+
+``orchestrator`` re-exports both names, so every existing
+``from .orchestrator import RunState`` keeps working.
+
+Every member here must also appear in the ``ck_dev_runs_state`` CHECK
+constraint (``models/dev_persistence.py``); adding one without the matching
+Alembic revision fails at persistence, not at import.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["TERMINAL_STATES", "RunState"]
+
+
+class RunState(StrEnum):
+    ACCEPTED = "accepted"
+    RESOLVING_SCOPE = "resolving_scope"
+    # CHAOS-3292: server-owned interpretation and per-mention subject
+    # resolution, both before the first model round.
+    INTERPRETING = "interpreting"
+    RESOLVING_SUBJECTS = "resolving_subjects"
+    MODEL_DECISION = "model_decision"
+    TOOL_VALIDATION = "tool_validation"
+    TOOL_EXECUTION = "tool_execution"
+    ANSWER_VALIDATION = "answer_validation"
+    COMPLETED = "completed"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    REFUSED = "refused"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_STATES = frozenset(
+    {
+        RunState.COMPLETED,
+        RunState.INSUFFICIENT_EVIDENCE,
+        RunState.REFUSED,
+        RunState.FAILED,
+        RunState.CANCELLED,
+    }
+)

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -50,6 +50,11 @@ _RUN_STATES = _TERMINAL_RUN_STATES | frozenset(
     {
         "accepted",
         "resolving_scope",
+        # CHAOS-3292 preflight phases. Non-terminal by construction, so a run
+        # sitting in one correctly yields 409 concurrency_limited on replay
+        # rather than being treated as a finished run.
+        "interpreting",
+        "resolving_subjects",
         "model_decision",
         "tool_validation",
         "tool_execution",
@@ -839,6 +844,42 @@ class DevPersistenceService:
             return existing
         self._touch(conversation)
         return message
+
+    async def record_run_diagnostics(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        preflight_outcome: str | None = None,
+        legacy_guard_reason: str | None = None,
+    ) -> DevRun | None:
+        """Write the CHAOS-3292 content-free diagnostics on one run row.
+
+        Deliberately **not** part of ``update_run``: that method rewrites every
+        field it is given, clearing any it is not, so folding these in would
+        make an ordinary state transition wipe them. Both values are validated
+        as safe identifier tokens, so neither can carry question text, an
+        entity name, or catalog content even if a caller passed one.
+
+        A non-``None`` value never reverts to ``None``: the preflight records
+        its outcome once, and the demoted legacy guard may later add its reason
+        to the same row without erasing it.
+        """
+
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if preflight_outcome is not None:
+            run.preflight_outcome = _safe_token(
+                preflight_outcome, field="preflight_outcome", max_bytes=32
+            )
+        if legacy_guard_reason is not None:
+            run.legacy_guard_reason = _safe_token(
+                legacy_guard_reason, field="legacy_guard_reason", max_bytes=64
+            )
+        await self.session.flush()
+        return run
 
     async def update_run(
         self,

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -186,11 +186,24 @@ def _frame_versions(
     )
 
 
+#: Safe display label per public outcome. **Total over ``PublicOutcome``**, not
+#: over the outcomes this module happens to emit today: a partial vocabulary
+#: handler is a ``KeyError`` waiting for the first caller that reaches the
+#: missing member, and ``DENIED`` — unreachable from the preflight right now —
+#: was exactly that latent crash.
+#:
+#: Every value must equal the canonical label ``dev_answer.v2`` validates
+#: against (``answer._OUTCOME_DISPLAY_LABELS``); the totality test asserts both
+#: halves, so a member added without a label, or with a *wrong* label, fails at
+#: build time rather than on the one request that produces it.
 _DISPLAY_LABELS: Mapping[PublicOutcome, str] = {
+    PublicOutcome.ANSWERED: "Answered",
+    PublicOutcome.ANSWERED_WITH_GAPS: "Answered with some gaps",
     PublicOutcome.NEEDS_CLARIFICATION: "Needs clarification",
     PublicOutcome.NOT_FOUND: "Not found",
     PublicOutcome.TEMPORARILY_UNAVAILABLE: "Temporarily unavailable",
     PublicOutcome.UNSUPPORTED: "Not supported yet",
+    PublicOutcome.DENIED: "Not permitted",
     PublicOutcome.FAILED: "Something went wrong",
 }
 

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -1,0 +1,322 @@
+"""Outcome mapping and canonical copy for the CHAOS-3292 subject preflight.
+
+This module owns the translation from a per-mention ``ResolutionOutcome`` to
+the public vocabularies, and builds the ``dev_answer_frame.v1`` /
+``dev_answer.v2`` pair a preflight termination emits.
+
+Two structural properties matter more than the mapping itself:
+
+* **``FORBIDDEN_OR_NOT_FOUND`` is unreachable from here.** Not scrubbed, not
+  renamed, not filtered — the preflight simply has no code path that
+  constructs it. The token is baked into five published v1 JSON Schemas, so
+  renaming it would be a wire-contract change; unreachability is the closure
+  that does not touch the wire.
+* **Public copy comes only from closed tables.** ``CANONICAL_NO_ANSWER_COPY``
+  (landed with CHAOS-3294) for the four no-answer outcomes, and
+  ``CLARIFICATION_COPY`` here for ``needs_clarification`` — which is *not* a
+  no-answer outcome, so the contract's own allowlist projection does not
+  govern its ``direct_answer`` and this module must supply server-owned copy
+  itself.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+
+from .contracts import (
+    DevContractVersions,
+    DevError,
+    DevTimeRange,
+    dev_error_remediation,
+)
+from .contracts_v2 import (
+    DevAnswerFrame,
+    DevAnswerV2,
+    DevCoverageV2,
+    DevFrameVersions,
+    PublicOutcome,
+    QuestionIntentID,
+    ResolutionOutcome,
+    project_answer_v2_to_v1,
+)
+from .contracts_v2.plan import PLAN_REGISTRY
+from .contracts_v2.validators import CANONICAL_NO_ANSWER_COPY
+from .orchestrator_states import RunState
+from .question_interpreter import INTERPRETER_VERSION
+
+__all__ = [
+    "CLARIFICATION_COPY",
+    "PLAN_ID_BY_INTENT",
+    "PREFLIGHT_OUTCOME_BY_RESOLUTION",
+    "TERMINAL_STATE_BY_OUTCOME",
+    "build_preflight_answer",
+    "project_preflight_error",
+]
+
+#: The plan each launch intent would have executed. The registry is 1:1 with
+#: ``QuestionIntentID`` today; the mapping is written out rather than derived
+#: so a future second plan for one intent is a visible edit here.
+PLAN_ID_BY_INTENT: Mapping[QuestionIntentID, str] = {
+    QuestionIntentID.ENTITY_STATUS: "status.entity.v2",
+    QuestionIntentID.PORTFOLIO_STATUS: "status.portfolio.v1",
+    QuestionIntentID.REMAINING_WORK: "work.remaining.v1",
+    QuestionIntentID.OBSERVED_CHANGE: "change.observed.v1",
+    QuestionIntentID.REGISTERED_STATISTICS: "statistics.registered.v1",
+    QuestionIntentID.METRIC_COMPARISON: "metric.comparison.v1",
+    QuestionIntentID.DATA_TRUST: "trust.data.v1",
+    QuestionIntentID.PROJECT_HEALTH: "health.project.v1",
+    QuestionIntentID.TEAM_HEALTH: "health.team.v1",
+    QuestionIntentID.TEAM_WORKLOAD_BALANCE: "balance.team_workload.v1",
+    QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY: "deficiency.operational.v1",
+    QuestionIntentID.BOUNDED_INVESTIGATION: "investigation.bounded.v1",
+}
+
+# Import-time totality, in both directions: an intent added without a plan, or
+# a plan id that is not in the landed registry, breaks the import rather than
+# failing at runtime on the one request that happens to hit it.
+_missing_intents = sorted(
+    intent.value for intent in QuestionIntentID if intent not in PLAN_ID_BY_INTENT
+)
+if _missing_intents:
+    raise RuntimeError(f"question intents without a plan id: {_missing_intents}")
+_unregistered = sorted(set(PLAN_ID_BY_INTENT.values()) - PLAN_REGISTRY)
+if _unregistered:
+    raise RuntimeError(f"plan ids outside the landed plan registry: {_unregistered}")
+
+#: Per-mention resolution outcome to the public v2 outcome. ``EXACT_MATCH`` is
+#: deliberately absent: it is not a termination, it is the path that proceeds.
+PREFLIGHT_OUTCOME_BY_RESOLUTION: Mapping[ResolutionOutcome, PublicOutcome] = {
+    ResolutionOutcome.NO_AUTHORIZED_MATCH: PublicOutcome.NOT_FOUND,
+    ResolutionOutcome.AMBIGUOUS_CANDIDATES: PublicOutcome.NEEDS_CLARIFICATION,
+    ResolutionOutcome.CATALOG_UNAVAILABLE: PublicOutcome.TEMPORARILY_UNAVAILABLE,
+    ResolutionOutcome.UNSUPPORTED_KIND: PublicOutcome.UNSUPPORTED,
+}
+
+#: The v1 terminal run state each public outcome maps to on today's surface.
+TERMINAL_STATE_BY_OUTCOME: Mapping[PublicOutcome, RunState] = {
+    PublicOutcome.NOT_FOUND: RunState.INSUFFICIENT_EVIDENCE,
+    PublicOutcome.NEEDS_CLARIFICATION: RunState.INSUFFICIENT_EVIDENCE,
+    PublicOutcome.TEMPORARILY_UNAVAILABLE: RunState.FAILED,
+    PublicOutcome.UNSUPPORTED: RunState.FAILED,
+}
+
+#: ``needs_clarification`` is not one of ``NO_ANSWER_OUTCOMES``, so the
+#: contract's total field allowlist does not constrain its ``direct_answer``.
+#: Server-owned copy is supplied here instead, and — like the canonical
+#: no-answer table — it names nothing about the subject.
+CLARIFICATION_COPY: Mapping[str, str] = {
+    "ambiguous": (
+        "More than one authorized entity matches the name in this question. "
+        "Please ask again naming exactly which one you mean."
+    ),
+    "uninterpretable": (
+        "This question could not be interpreted confidently. Please rephrase "
+        "it, naming the project, repository, or team you are asking about."
+    ),
+}
+
+#: The v1 ``DevError`` code each preflight outcome terminates with today. Taken
+#: from ``compat._ERROR_OUTCOME_CODES`` for the four no-answer outcomes (via
+#: the projector, so there is one mapping) and from the orchestrator's own
+#: pre-existing ambiguity terminal for ``needs_clarification``.
+_AMBIGUOUS_V1_ERROR = ("scope_ambiguous", "The requested scope is ambiguous.")
+
+_PLATFORM_TOKEN = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*\.v\d+(?:\.\d+)*$")
+_SERVER_HANDLE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+#: Stable namespace for folding a non-UUID correlation id into a
+#: ``ServerHandle``. Mirrors ``router._storage_uuid``, which already folds
+#: arbitrary client-supplied ids to a UUID5 at the storage boundary.
+_HANDLE_NAMESPACE = uuid.UUID("6f9f5b12-6b2f-5a2e-9f2a-2f0a8f4c1d33")
+
+
+def _server_handle(value: str) -> str:
+    """A canonical dashed lowercase UUID for one correlation id.
+
+    ``ServerHandle`` admits only that grammar (CHAOS-3294 constraint #1), and
+    production already mints UUID run/answer/conversation ids. A caller that
+    supplies something else — a test harness, a legacy row — is folded
+    deterministically rather than rejected, because a correlation handle is
+    never a disclosure channel: hex digits and hyphens cannot spell a name.
+    """
+
+    lowered = value.lower()
+    if _SERVER_HANDLE.match(lowered):
+        return lowered
+    return str(uuid.uuid5(_HANDLE_NAMESPACE, value))
+
+
+def _platform_token(value: str, *, fallback: str) -> str:
+    """Coerce one declared version string into a ``PlatformVersionToken``.
+
+    ``DevContractVersions`` fields are free-form ``Version`` strings and
+    production uses hyphenated forms (``ask-dev-metrics.v1``) that the stricter
+    v2 provenance grammar does not admit. Hyphens fold to underscores; anything
+    still outside the grammar falls back to a server-owned constant rather than
+    failing the whole termination on a provenance field.
+    """
+
+    folded = value.strip().lower().replace("-", "_")
+    return folded if _PLATFORM_TOKEN.match(folded) else fallback
+
+
+def _frame_versions(
+    *, intent_id: QuestionIntentID, versions: DevContractVersions
+) -> DevFrameVersions:
+    return DevFrameVersions(
+        interpreter_version=INTERPRETER_VERSION,
+        plan_id=PLAN_ID_BY_INTENT[intent_id],
+        plan_version="ask_dev_plan.v1",
+        tool_contract_version=_platform_token(
+            versions.tool_contract_version, fallback="ask_dev_tools.v1"
+        ),
+        metric_definition_version=_platform_token(
+            versions.metric_definition_version, fallback="ask_dev_metrics.v1"
+        ),
+        query_version=_platform_token(
+            versions.query_version, fallback="ask_dev_queries.v1"
+        ),
+        prompt_version=_platform_token(
+            versions.prompt_version, fallback="ask_dev_prompt.v1"
+        ),
+    )
+
+
+_DISPLAY_LABELS: Mapping[PublicOutcome, str] = {
+    PublicOutcome.NEEDS_CLARIFICATION: "Needs clarification",
+    PublicOutcome.NOT_FOUND: "Not found",
+    PublicOutcome.TEMPORARILY_UNAVAILABLE: "Temporarily unavailable",
+    PublicOutcome.UNSUPPORTED: "Not supported yet",
+    PublicOutcome.FAILED: "Something went wrong",
+}
+
+
+def build_preflight_answer(
+    *,
+    outcome: PublicOutcome,
+    intent_id: QuestionIntentID,
+    versions: DevContractVersions,
+    run_id: str,
+    answer_id: str,
+    conversation_id: str,
+    generated_at: datetime,
+    clarification_key: str = "ambiguous",
+) -> DevAnswerV2:
+    """Build the v2 answer one preflight termination emits.
+
+    Never a content-bearing frame — that is CHAOS-3297's. For the four
+    no-answer outcomes the frame carries no provenance block at all and its
+    ``direct_answer`` is the canonical server sentence; the contract's own
+    ``validate_no_answer_projection`` re-derives that from the same table, so
+    an error here is a validation failure rather than a silent disclosure.
+    """
+
+    is_no_answer = outcome is not PublicOutcome.NEEDS_CLARIFICATION
+    frame = DevAnswerFrame(
+        schema_version="dev_answer_frame.v1",
+        frame_id=_server_handle(f"frame:{run_id}"),
+        run_id=_server_handle(run_id),
+        generated_at=generated_at,
+        public_outcome=outcome,
+        direct_answer=(
+            CANONICAL_NO_ANSWER_COPY[outcome.value]
+            if is_no_answer
+            else CLARIFICATION_COPY[clarification_key]
+        ),
+        coverage=DevCoverageV2(
+            required_source_count=0,
+            available_source_count=0,
+            unavailable_required_sources=(),
+            stale_required_sources=(),
+            as_of=generated_at,
+        ),
+        # A no-answer outcome carries no provenance block at all; a
+        # needs_clarification frame is not a no-answer outcome and
+        # validate_versions_presence requires one.
+        versions=(
+            None
+            if is_no_answer
+            else _frame_versions(intent_id=intent_id, versions=versions)
+        ),
+    )
+    return DevAnswerV2(
+        schema_version="dev_answer.v2",
+        answer_id=_server_handle(answer_id),
+        conversation_id=_server_handle(conversation_id),
+        run_id=_server_handle(run_id),
+        generated_at=generated_at,
+        public_outcome=outcome,
+        outcome_display_label=_DISPLAY_LABELS[outcome],
+        frame=frame,
+        narrative=None,
+    )
+
+
+def project_preflight_error(answer: DevAnswerV2, *, request_id: str) -> DevError:
+    """Project one preflight v2 answer to the v1 ``DevError`` the router streams.
+
+    For the four no-answer outcomes this delegates to the landed
+    ``compat.project_answer_v2_to_v1``, whose ``_project_error`` reads *nothing*
+    off the frame and builds code, message and remediation entirely from the
+    canonical tables. That is what makes "the internal combined outcome never
+    leaves the server" structural on the v1 surface too.
+
+    ``needs_clarification`` is handled separately and deliberately. The
+    projector maps it to a v1 ``DevAnswer`` carrying one **fabricated**
+    disambiguation candidate synthesised from ``frame.subject_ref`` — which a
+    preflight ambiguity does not have, since nothing was committed. Today's
+    orchestrator already terminates an ambiguous scope as
+    ``insufficient_evidence`` + ``scope_ambiguous``, and that is both the more
+    faithful statement and the shape the router and web client already handle.
+    The real candidate list is recorded on the resolution ledger; delivering it
+    to a user needs the v2 surface (CHAOS-3298) and persisted clarification
+    state (CHAOS-3299).
+    """
+
+    if answer.public_outcome is PublicOutcome.NEEDS_CLARIFICATION:
+        code, message = _AMBIGUOUS_V1_ERROR
+        return DevError(
+            schema_version="dev_error.v1",
+            request_id=request_id,
+            code=code,
+            safe_message=message,
+            retryable=False,
+            remediation=dev_error_remediation(code),
+        )
+    projected = project_answer_v2_to_v1(
+        answer,
+        organization_id="preflight",
+        time_range=_ZERO_RANGE,
+    )
+    if not isinstance(projected, DevError):  # pragma: no cover - defensive
+        raise RuntimeError(
+            "a preflight no-answer outcome must project to a v1 DevError"
+        )
+    # Re-emitted against the request's own correlation id: every other terminal
+    # error in the run loop carries request.request_id, and the projector uses
+    # run_id because a v2 answer has no request id. Code, copy, retryability
+    # and remediation are carried across verbatim from the canonical tables.
+    return DevError(
+        schema_version="dev_error.v1",
+        request_id=request_id,
+        code=projected.code,
+        safe_message=projected.safe_message,
+        retryable=projected.retryable,
+        remediation=list(projected.remediation),
+    )
+
+
+def _zero_range() -> DevTimeRange:
+    start = datetime(2000, 1, 1, tzinfo=UTC)
+    return DevTimeRange(start=start, end=start + timedelta(days=1), timezone="UTC")
+
+
+#: Required by the projector's signature but unreachable on the error path —
+#: ``_project_error`` builds no scope at all. A fixed, content-free range keeps
+#: the call total rather than passing the run's real window into a code path
+#: that must disclose nothing.
+_ZERO_RANGE = _zero_range()

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -272,9 +272,13 @@ def project_preflight_error(answer: DevAnswerV2, *, request_id: str) -> DevError
     orchestrator already terminates an ambiguous scope as
     ``insufficient_evidence`` + ``scope_ambiguous``, and that is both the more
     faithful statement and the shape the router and web client already handle.
-    The real candidate list is recorded on the resolution ledger; delivering it
-    to a user needs the v2 surface (CHAOS-3298) and persisted clarification
-    state (CHAOS-3299).
+    The real candidate list is recorded on the resolution ledger, so "ambiguous
+    targets return stable authorized candidates" holds at the ledger and v2
+    level — but **not** on the v1 surface, which has no candidate field to
+    carry them. That gap is CHAOS-3325 (a candidate block on
+    ``dev_answer_frame.v1``); delivery to a user additionally needs the v2
+    rendering surface (CHAOS-3298) and persisted clarification state
+    (CHAOS-3299).
     """
 
     if answer.public_outcome is PublicOutcome.NEEDS_CLARIFICATION:

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -13,6 +14,8 @@ from urllib.parse import urlsplit
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
+from dev_health_ops.licensing import evaluate_org_feature_async
+from dev_health_ops.licensing.registry import ASK_DEV_WAVE_3_1_FEATURE
 from dev_health_ops.llm.agent.contracts import AgentLLMProvider
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
 from dev_health_ops.llm.agent.openai_compatible import (
@@ -87,6 +90,7 @@ from .native_evidence import native_evidence_adapters
 from .native_status_change import ClickHouseStatusChangeSource
 from .org_policy import load_ask_dev_org_policy
 from .prompts import PROMPT_VERSION
+from .question_interpreter import QuestionInterpreter
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
 from .scope_service import (
@@ -110,6 +114,7 @@ from .status_change_service import (
     StatusFact,
     StatusSnapshotRequest,
 )
+from .subject_preflight import SubjectPreflight
 from .tool_registry import TOOL_CONTRACT_VERSION, AskDevToolRegistry
 from .work_graph_neighbors_service import (
     ALLOWED_RELATIONSHIP_TYPES,
@@ -1657,19 +1662,55 @@ async def _assemble_production_runtime(
             requested_scope=requested_scope,
         )
 
+    versions = DevContractVersions(
+        prompt_version=PROMPT_VERSION,
+        tool_contract_version=TOOL_CONTRACT_VERSION,
+        metric_definition_version=_METRIC_REGISTRY_VERSION,
+        query_version=_QUERY_BUNDLE_VERSION,
+    )
+    preflight = (
+        SubjectPreflight(
+            # No classifier is wired yet: the deterministic recognizers are the
+            # whole interpreter in production for now, and an unrecognized
+            # question degrades to bounded investigation exactly as today. The
+            # constrained-model fallback seam is built and tested, but turning
+            # it on adds a provider call to every low-confidence question and
+            # is a separate rollout decision.
+            interpreter=QuestionInterpreter(),
+            scope_service=scope_service,
+            versions=versions,
+        )
+        if await _wave_3_1_enabled(session, org_id)
+        else None
+    )
+
     return BoundedDevRuntime(
         provider=provider.provider,
         provider_source=provider.source.value,
         provider_family=provider.family,
         registry=registry,
         scope_resolver=scope_resolver,
-        versions=DevContractVersions(
-            prompt_version=PROMPT_VERSION,
-            tool_contract_version=TOOL_CONTRACT_VERSION,
-            metric_definition_version=_METRIC_REGISTRY_VERSION,
-            query_version=_QUERY_BUNDLE_VERSION,
-        ),
+        versions=versions,
+        preflight=preflight,
     )
+
+
+async def _wave_3_1_enabled(session: AsyncSession, org_id: str) -> bool:
+    """Whether this organization gets the CHAOS-3292 preflight.
+
+    Fail-closed **to today's behaviour**: any error evaluating the flag leaves
+    the preflight off, which is the pre-3292 run path with the CHAOS-3289
+    backstop still terminating. A rollout gate that failed *open* would ship an
+    unreviewed path on a storage error.
+    """
+
+    try:
+        decision = await evaluate_org_feature_async(
+            session, uuid.UUID(org_id), ASK_DEV_WAVE_3_1_FEATURE
+        )
+    except Exception:
+        return False
+    return bool(decision.allowed)
 
 
 async def expand_production_evidence(

--- a/src/dev_health_ops/api/dev/prompts/__init__.py
+++ b/src/dev_health_ops/api/dev/prompts/__init__.py
@@ -1,6 +1,7 @@
 """Versioned Ask Dev prompt composition."""
 
 from .composer import (
+    LEGACY_PROMPT_VERSION,
     MAX_PRIOR_CONTENT_BYTES,
     MAX_PRIOR_TURNS,
     PROMPT_VERSION,
@@ -12,6 +13,7 @@ from .composer import (
 __all__ = [
     "MAX_PRIOR_CONTENT_BYTES",
     "MAX_PRIOR_TURNS",
+    "LEGACY_PROMPT_VERSION",
     "PROMPT_VERSION",
     "ComposedPrompt",
     "PromptComposer",

--- a/src/dev_health_ops/api/dev/prompts/composer.py
+++ b/src/dev_health_ops/api/dev/prompts/composer.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Collection
 from dataclasses import dataclass
 
-from ..contracts import DevScopeResolution, DevToolResult
+from ..contracts import DevScopeResolution, DevToolResult, ToolID
 from ..tool_registry import AskDevToolRegistry
 
-PROMPT_VERSION = "ask_dev_prompt.v1"
+PROMPT_VERSION = "ask_dev_prompt.v2"
 MAX_PRIOR_TURNS = 12
 MAX_PRIOR_CONTENT_BYTES = 32_768
 MAX_TOOL_CONTEXT_BYTES = 262_144
@@ -40,13 +41,20 @@ _FIXED_POLICY_SECTIONS = (
         "Return exactly one normalized decision: registered tool request, dev_answer.v1 final "
         "answer, typed disambiguation, or refusal. Do not reveal private reasoning.",
     ),
+    # CHAOS-3292 replaced the v1 section, which made resolution *order* the
+    # enforcement ("call resolve_scope.v1 with that name before requesting any
+    # status tool"). Subject resolution is now server-owned and happens before
+    # the model is asked anything, so the instruction is no longer about what
+    # to call first — it is about not naming anything outside the subject the
+    # server already committed. Only the tools listed in this prompt's
+    # tool_registry are available for this run.
     (
-        "named_entity_resolution",
-        "When the question names a specific project, repository, issue, pull request, or work "
-        "unit, call resolve_scope.v1 with that name before requesting any status, change, "
-        "metric, or evidence tool. Never present an answer that describes a named entity "
-        "resolve_scope.v1 did not confirm exists; if it returns not-found or ambiguous, say so "
-        "instead of answering about the organization under the entity's name.",
+        "committed_subject",
+        "Scope and subject resolution are server owned and already complete. Answer only about "
+        "the subject in resolved_scope. Never name, describe, or attribute findings to any "
+        "project, repository, team, issue, pull request, or work unit outside it, and never "
+        "infer a subject from the question text. Request only tools this prompt lists; a tool "
+        "absent from the registry is unavailable for this run.",
     ),
 )
 
@@ -81,6 +89,7 @@ class PromptComposer:
         scope: DevScopeResolution,
         prior_turns: tuple[PromptConversationTurn, ...] = (),
         tool_results: tuple[DevToolResult, ...] = (),
+        allowed_tools: Collection[ToolID] | None = None,
     ) -> ComposedPrompt:
         if not question.strip():
             raise ValueError("question is required")
@@ -108,7 +117,10 @@ class PromptComposer:
                 {"id": section_id, "text": text}
                 for section_id, text in _FIXED_POLICY_SECTIONS
             ],
-            "tool_registry": self._registry.manifest(),
+            # The advertised registry is the per-run allowlist, so the system
+            # prompt and the provider tool definitions cannot disagree about
+            # which tools exist for this run.
+            "tool_registry": self._registry.manifest(allowed_tool_ids=allowed_tools),
         }
         system_text = json.dumps(system_payload, sort_keys=True, separators=(",", ":"))
         user_payload = {

--- a/src/dev_health_ops/api/dev/prompts/composer.py
+++ b/src/dev_health_ops/api/dev/prompts/composer.py
@@ -10,7 +10,14 @@ from dataclasses import dataclass
 from ..contracts import DevScopeResolution, DevToolResult, ToolID
 from ..tool_registry import AskDevToolRegistry
 
+#: The prompt a run with a server-committed subject receives.
 PROMPT_VERSION = "ask_dev_prompt.v2"
+#: The prompt a run *without* one receives — the flag-off path, and the
+#: organization-wide path where a name may still need resolving. Telling
+#: either that "subject resolution is already complete" would be false, and on
+#: the flag-off path it would also remove the only instruction that makes
+#: named-entity resolution happen at all.
+LEGACY_PROMPT_VERSION = "ask_dev_prompt.v1"
 MAX_PRIOR_TURNS = 12
 MAX_PRIOR_CONTENT_BYTES = 32_768
 MAX_TOOL_CONTEXT_BYTES = 262_144
@@ -41,21 +48,30 @@ _FIXED_POLICY_SECTIONS = (
         "Return exactly one normalized decision: registered tool request, dev_answer.v1 final "
         "answer, typed disambiguation, or refusal. Do not reveal private reasoning.",
     ),
-    # CHAOS-3292 replaced the v1 section, which made resolution *order* the
-    # enforcement ("call resolve_scope.v1 with that name before requesting any
-    # status tool"). Subject resolution is now server-owned and happens before
-    # the model is asked anything, so the instruction is no longer about what
-    # to call first — it is about not naming anything outside the subject the
-    # server already committed. Only the tools listed in this prompt's
-    # tool_registry are available for this run.
-    (
-        "committed_subject",
-        "Scope and subject resolution are server owned and already complete. Answer only about "
-        "the subject in resolved_scope. Never name, describe, or attribute findings to any "
-        "project, repository, team, issue, pull request, or work unit outside it, and never "
-        "infer a subject from the question text. Request only tools this prompt lists; a tool "
-        "absent from the registry is unavailable for this run.",
-    ),
+)
+
+# CHAOS-3292: the subject-resolution section depends on whether the server
+# already committed one. The v1 text makes resolution *order* the enforcement
+# and is still exactly right when it has not; the v2 text states that the
+# subject is settled and must not be widened. Emitting the v2 text on a run
+# with no committed subject would be false, and on the flag-off path it would
+# delete the only instruction that makes named-entity resolution happen.
+_UNCOMMITTED_SUBJECT_SECTION = (
+    "named_entity_resolution",
+    "When the question names a specific project, repository, issue, pull request, or work "
+    "unit, call resolve_scope.v1 with that name before requesting any status, change, "
+    "metric, or evidence tool. Never present an answer that describes a named entity "
+    "resolve_scope.v1 did not confirm exists; if it returns not-found or ambiguous, say so "
+    "instead of answering about the organization under the entity's name.",
+)
+
+_COMMITTED_SUBJECT_SECTION = (
+    "committed_subject",
+    "Scope and subject resolution are server owned and already complete for this request. "
+    "Answer only about the subject in resolved_scope. Never name, describe, or attribute "
+    "findings to any project, repository, team, issue, pull request, or work unit outside "
+    "it. Request only tools this prompt lists; a tool absent from the registry is "
+    "unavailable for this run.",
 )
 
 
@@ -90,6 +106,7 @@ class PromptComposer:
         prior_turns: tuple[PromptConversationTurn, ...] = (),
         tool_results: tuple[DevToolResult, ...] = (),
         allowed_tools: Collection[ToolID] | None = None,
+        subject_committed: bool = False,
     ) -> ComposedPrompt:
         if not question.strip():
             raise ValueError("question is required")
@@ -111,11 +128,17 @@ class PromptComposer:
         if len(serialized_tools) > MAX_TOOL_CONTEXT_BYTES:
             raise ValueError("tool context exceeds prompt budget")
 
+        version = PROMPT_VERSION if subject_committed else LEGACY_PROMPT_VERSION
+        subject_section = (
+            _COMMITTED_SUBJECT_SECTION
+            if subject_committed
+            else _UNCOMMITTED_SUBJECT_SECTION
+        )
         system_payload = {
-            "prompt_version": PROMPT_VERSION,
+            "prompt_version": version,
             "policy_sections": [
                 {"id": section_id, "text": text}
-                for section_id, text in _FIXED_POLICY_SECTIONS
+                for section_id, text in (*_FIXED_POLICY_SECTIONS, subject_section)
             ],
             # The advertised registry is the per-run allowlist, so the system
             # prompt and the provider tool definitions cannot disagree about
@@ -137,7 +160,7 @@ class PromptComposer:
         user_text = json.dumps(user_payload, sort_keys=True, separators=(",", ":"))
         checksum = hashlib.sha256(system_text.encode("utf-8")).hexdigest()
         return ComposedPrompt(
-            version=PROMPT_VERSION,
+            version=version,
             checksum=checksum,
             system_text=system_text,
             user_text=user_text,
@@ -146,6 +169,7 @@ class PromptComposer:
 
 
 __all__ = [
+    "LEGACY_PROMPT_VERSION",
     "PROMPT_VERSION",
     "ComposedPrompt",
     "PromptComposer",

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -275,6 +275,70 @@ def _candidate_from(match: re.Match[str]) -> _MentionCandidate | None:
     return _MentionCandidate(start=start, span=span, kind=kind)
 
 
+#: A bare capitalized or quoted span, with no kind noun anywhere beside it.
+_BARE_NAME = re.compile(rf"(?:{_QUOTED}|(?P<plain>{_NAME}))")
+
+_WORD_PUNCTUATION = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def _strip_word_punctuation(word: str) -> str:
+    """``what's`` -> ``whats``, so contractions match the stop-word list."""
+
+    return _WORD_PUNCTUATION.sub("", word)
+
+
+def _opens_a_sentence(question: str, start: int) -> bool:
+    prefix = question[:start].rstrip()
+    return not prefix or prefix[-1] in ".!?;:"
+
+
+def untyped_name_candidates(
+    question: str, typed: Sequence[str] = ()
+) -> tuple[str, ...]:
+    """Capitalized or quoted spans the kind-noun grammar did not claim.
+
+    "How is Nightfall doing?" names a subject as plainly as "the Nightfall
+    project" does; only the noun that would let us *type* it is missing. These
+    spans are resolved across every searchable kind, and — crucially — an
+    unresolved one does **not** terminate the run, because we are not confident
+    the span was a subject at all ("What is our DORA score?" would otherwise
+    break). It re-arms the legacy backstop instead, which judges the model's
+    own answer text and is exactly today's behaviour for this shape.
+    """
+
+    claimed = {value.casefold() for value in typed}
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in _BARE_NAME.finditer(question):
+        raw = match.group("quoted") or match.group("plain")
+        if raw is None:
+            continue
+        span = raw.strip()
+        if len(span) < 2 or len(span) > 256:
+            continue
+        start = match.start("quoted")
+        if start < 0:
+            start = match.start("plain")
+        normalized = _normalize(span)
+        words = [_strip_word_punctuation(word) for word in normalized.split(" ")]
+        words = [word for word in words if word]
+        if not words or all(word in _NAME_STOP_WORDS for word in words):
+            continue
+        # A single capitalized word that *opens* a sentence is capitalized by
+        # grammar, not by naming: "Anything about X?" must not mint a subject
+        # called "Anything". A multi-word span, or one anywhere else in the
+        # sentence, is still a candidate.
+        if len(words) == 1 and _opens_a_sentence(question, start):
+            continue
+        if normalized in seen or any(normalized in name for name in claimed):
+            continue
+        if any(name in normalized for name in claimed):
+            continue
+        seen.add(normalized)
+        found.append(span)
+    return tuple(found[:MAX_MENTIONS])
+
+
 def extract_mentions(
     question: str,
     *,
@@ -322,7 +386,12 @@ def extract_mentions(
         seen.add(key)
         ordered.append(candidate)
 
-    if not ordered:
+    # A context ref stands in for the subject only when the question named
+    # *nothing at all* — including a name the kind-noun grammar could not type.
+    # Substituting the page's project for a name we merely failed to parse is
+    # the fabricated-premise defect wearing a different costume: the run would
+    # answer about the page's entity under the name the user typed.
+    if not ordered and not untyped_name_candidates(question):
         for ref in context_refs:
             try:
                 kind = EntityKind(ref.entity_type.value)
@@ -698,6 +767,11 @@ class IntentClassifier(Protocol):
 class InterpretedQuestion:
     intent: DevQuestionIntent
     mentions: tuple[DevSubjectMention, ...]
+    #: Mention IDs minted from a bare name the kind-noun grammar could not
+    #: type. They are resolved across every searchable kind, and an unresolved
+    #: one re-arms the legacy backstop rather than terminating the run — see
+    #: ``untyped_name_candidates``.
+    untyped_mention_ids: frozenset[str] = frozenset()
 
     @property
     def mention_by_id(self) -> dict[str, DevSubjectMention]:
@@ -725,6 +799,7 @@ class QuestionInterpreter:
         mentions = extract_mentions(
             request.question, context_refs=context_refs, mint_id=self._mint_id
         )
+        mentions, untyped_ids = self._add_untyped_mentions(request.question, mentions)
         normalized = _normalize(request.question)
         signals = _Signals(
             normalized=normalized,
@@ -787,7 +862,47 @@ class QuestionInterpreter:
             client_hint_deprecation_warning=CLIENT_HINT_DEPRECATION_WARNING,
             generated_at=self._now(),
         )
-        return InterpretedQuestion(intent=intent, mentions=mentions)
+        return InterpretedQuestion(
+            intent=intent,
+            mentions=mentions,
+            untyped_mention_ids=frozenset(untyped_ids)
+            & {mention.mention_id for mention in mentions},
+        )
+
+    def _add_untyped_mentions(
+        self, question: str, mentions: tuple[DevSubjectMention, ...]
+    ) -> tuple[tuple[DevSubjectMention, ...], set[str]]:
+        """Mint a mention for each bare name the kind-noun grammar missed.
+
+        ``requested_entity_kind`` is a **declared default** for these, because
+        the user did not state a kind — the preflight searches every kind, and
+        the ledger's committed reference carries whichever kind actually
+        matched. Recording a default is the honest option: the alternative is
+        no mention at all, which is how an unresolved name reaches an answer.
+        """
+
+        typed = [mention.original_text_span for mention in mentions]
+        candidates = untyped_name_candidates(question, typed)
+        if not candidates:
+            return mentions, set()
+        merged = list(mentions)
+        untyped_ids: set[str] = set()
+        for span in candidates:
+            if len(merged) >= MAX_MENTIONS:
+                break
+            mention_id = self._mint_id()
+            untyped_ids.add(mention_id)
+            merged.append(
+                DevSubjectMention(
+                    schema_version="dev_subject_mention.v1",
+                    mention_id=mention_id,
+                    mention_ordinal=len(merged),
+                    original_text_span=span[:2048],
+                    requested_entity_kind=EntityKind.PROJECT,
+                    normalized_lookup_text=_normalize(span)[:2048],
+                )
+            )
+        return tuple(merged), untyped_ids
 
     async def _apply_fallback(
         self,
@@ -873,6 +988,20 @@ class QuestionInterpreter:
             # author an entity name" structural: a name it invented is not in
             # the user's question, so it cannot survive this check.
             if not raw_span or raw_span not in question:
+                return None
+            # Substring alone is too weak: a single character, or a fragment
+            # cutting across word boundaries, is present in almost any question
+            # and would let the classifier point at an arbitrary catalog entry
+            # while technically quoting the user.
+            if len(raw_span.strip()) < 2 or raw_span != raw_span.strip():
+                return None
+            if not re.search(rf"(?<!\w){re.escape(raw_span)}(?!\w)", question):
+                return None
+            if all(
+                _strip_word_punctuation(word) in _NAME_STOP_WORDS
+                for word in _normalize(raw_span).split(" ")
+                if word
+            ):
                 return None
             try:
                 kind = EntityKind(raw_kind)

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -1,0 +1,909 @@
+"""Server-owned question interpretation for Ask Dev (CHAOS-3292).
+
+Amendment TRD v2 §4.1: the interpreter is server-owned. This module turns one
+``dev_message_request`` into an authoritative ``dev_question_intent.v1`` plus
+the ordered ``dev_subject_mention.v1`` list the subject preflight resolves. It
+never executes a tool, never reads a catalog, and never widens a scope.
+
+On "no new regex heuristics"
+---------------------------
+
+The recognizers below do lexical matching over a normalized question, and this
+docstring says so rather than pretending otherwise. The load-bearing difference
+from the CHAOS-3289 backstop this work replaces is the **failure mode**, not the
+technique:
+
+* The 3289 pattern extracted a name from prose, compared it against
+  *model-authored answer text*, and **deleted an otherwise valid answer**
+  (``orchestrator._unresolved_named_entity_error``). A miss left a fabricated
+  answer standing; a false positive destroyed a good one.
+* A recognizer here only picks a member of the closed ``QuestionIntentID``
+  enum. A miss degrades to ``BOUNDED_INVESTIGATION`` — today's model-driven
+  path. **A recognizer can never delete an answer and can never widen scope.**
+  Whether a subject-bearing tool may execute is decided by *catalog resolution*
+  of the extracted mentions (``subject_preflight``), never by matching prose
+  against prose.
+
+Mention extraction is likewise lexical, and has a stated residual gap: a name
+must be adjacent to one of the closed kind nouns below. A lowercase slug or a
+noun-less name ("how is Nightfall doing?") produces no mention, so the run
+degrades to today's organization-wide behaviour with the legacy backstop still
+armed. That gap is narrower than fabricating a subject, and is the direction
+CHAOS-3301 widens.
+
+``interpretation_reasons`` carries **recognizer IDs only, never question
+text**, per the "no raw question or entity text in logs, traces, or metric
+labels" guardrail.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from .contracts import DevEntityRef, DevMessageRequest
+from .contracts_v2 import (
+    Cardinality,
+    DevQuestionIntent,
+    DevSubjectMention,
+    EntityKind,
+    QuestionIntentID,
+)
+from .metrics.definitions import METRIC_REGISTRY
+
+__all__ = [
+    "CLARIFICATION_REASONS",
+    "CLIENT_HINT_DEPRECATION_WARNING",
+    "FALLBACK_CONFIDENCE_FLOOR",
+    "INTERPRETER_VERSION",
+    "MAX_MENTIONS",
+    "ClassifierProposal",
+    "IntentClassifier",
+    "InterpretedQuestion",
+    "QuestionInterpreter",
+    "extract_mentions",
+]
+
+#: Satisfies ``base.PlatformVersionToken``, which
+#: ``DevFrameVersions.interpreter_version`` requires.
+INTERPRETER_VERSION = "intent_interpreter.v1"
+
+#: Below this the deterministic recognizers did not commit to an intent and the
+#: constrained model fallback (if one is wired) may propose one.
+FALLBACK_CONFIDENCE_FLOOR = 0.6
+
+#: ``DevSubjectMention.mention_ordinal`` is bounded at 24 by the contract.
+MAX_MENTIONS = 25
+
+_DETERMINISTIC_CONFIDENCE = 0.9
+_UNRECOGNIZED_CONFIDENCE = 0.4
+#: A model-assisted intent is never trusted as much as a recognizer hit.
+_MAX_FALLBACK_CONFIDENCE = 0.85
+
+#: Server-owned copy. The client's ``question_class`` is a non-authoritative
+#: hint the interpreter records and ignores for planning (TRD v2 §4.1).
+CLIENT_HINT_DEPRECATION_WARNING = (
+    "The client-supplied question_class is deprecated and is ignored for "
+    "planning; the server interprets the question itself."
+)
+
+#: Canonical, content-free clarification reasons. A reason is picked from this
+#: closed table — it is never assembled from question or entity text.
+CLARIFICATION_REASONS: Mapping[str, str] = {
+    "interpreter_unavailable": (
+        "The question could not be interpreted confidently. Please rephrase it, "
+        "naming the project, repository, or team you mean."
+    ),
+    "interpreter_rejected_extraction": (
+        "The question could not be interpreted confidently. Please name the "
+        "project, repository, or team you are asking about."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """NFKC, casefolded, whitespace-collapsed — the recognizer input form."""
+
+    return _WHITESPACE.sub(" ", unicodedata.normalize("NFKC", text).casefold()).strip()
+
+
+# ---------------------------------------------------------------------------
+# Mention extraction
+# ---------------------------------------------------------------------------
+
+#: The closed noun vocabulary a name must be adjacent to. Ordered longest-first
+#: so "pull request" wins over "pr" and "work unit" over "unit".
+_KIND_NOUNS: tuple[tuple[str, EntityKind], ...] = (
+    ("pull requests", EntityKind.PULL_REQUEST),
+    ("merge requests", EntityKind.PULL_REQUEST),
+    ("pull request", EntityKind.PULL_REQUEST),
+    ("merge request", EntityKind.PULL_REQUEST),
+    ("work units", EntityKind.WORK_UNIT),
+    ("work unit", EntityKind.WORK_UNIT),
+    ("repositories", EntityKind.REPOSITORY),
+    ("repository", EntityKind.REPOSITORY),
+    ("repos", EntityKind.REPOSITORY),
+    ("repo", EntityKind.REPOSITORY),
+    ("projects", EntityKind.PROJECT),
+    ("project", EntityKind.PROJECT),
+    ("teams", EntityKind.TEAM),
+    ("team", EntityKind.TEAM),
+    ("tickets", EntityKind.ISSUE),
+    ("ticket", EntityKind.ISSUE),
+    ("issues", EntityKind.ISSUE),
+    ("issue", EntityKind.ISSUE),
+    ("prs", EntityKind.PULL_REQUEST),
+    ("pr", EntityKind.PULL_REQUEST),
+)
+
+_KIND_BY_NOUN: Mapping[str, EntityKind] = dict(_KIND_NOUNS)
+
+_NOUN_ALTERNATION = "|".join(re.escape(noun) for noun, _kind in _KIND_NOUNS)
+
+#: A capitalized display name of one to four words.
+_NAME = r"[A-Z][A-Za-z0-9&/'\-]*(?:[ \t]+[A-Z][A-Za-z0-9&/'\-]*){0,3}"
+#: A quoted span; quoting is an explicit naming act, so no capitalization is
+#: required inside it.
+_QUOTED = r"[\"'‘’“”`](?P<quoted>[^\"'‘’“”`]{1,120})[\"'‘’“”`]"
+
+# Noun leading: "project Ask Dev", 'repo "dev-health-ops"'.
+_NOUN_LEADING = re.compile(
+    rf"\b(?P<noun>{_NOUN_ALTERNATION})\s+(?:{_QUOTED}|(?P<plain>{_NAME}))",
+)
+# Noun trailing: "the Ask Dev project", '"dev-health-ops" repo'.
+_NOUN_TRAILING = re.compile(
+    rf"(?:{_QUOTED}|(?P<plain>{_NAME}))\s+(?P<noun>{_NOUN_ALTERNATION})\b",
+)
+
+#: Capitalized words that are never a subject name on their own. A candidate
+#: consisting only of these is discarded, so "Our team is overburdened" does
+#: not mint a mention for "Our".
+_NAME_STOP_WORDS = frozenset(
+    {
+        "a",
+        "all",
+        "an",
+        "and",
+        "any",
+        "are",
+        "back",
+        "can",
+        "check",
+        "compare",
+        "could",
+        "did",
+        "do",
+        "does",
+        "each",
+        "every",
+        "find",
+        "for",
+        "get",
+        "give",
+        "has",
+        "have",
+        "help",
+        "how",
+        "in",
+        "is",
+        "it",
+        "its",
+        "list",
+        "look",
+        "many",
+        "me",
+        "my",
+        "need",
+        "new",
+        "no",
+        "of",
+        "old",
+        "on",
+        "one",
+        "or",
+        "other",
+        "our",
+        "please",
+        "review",
+        "same",
+        "see",
+        "should",
+        "show",
+        "some",
+        "status",
+        "tell",
+        "that",
+        "the",
+        "their",
+        "these",
+        "this",
+        "those",
+        "update",
+        "us",
+        "want",
+        "was",
+        "we",
+        "were",
+        "what",
+        "whats",
+        "when",
+        "where",
+        "which",
+        "who",
+        "why",
+        "would",
+        "your",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MentionCandidate:
+    start: int
+    span: str
+    kind: EntityKind
+    #: Set only for a typed context ref, whose canonical id is the lookup key.
+    lookup_text: str | None = None
+
+
+def _candidate_from(match: re.Match[str]) -> _MentionCandidate | None:
+    quoted = match.group("quoted")
+    plain = match.group("plain")
+    raw = quoted if quoted is not None else plain
+    if raw is None:
+        return None
+    span = raw.strip()
+    if len(span) < 2 or len(span) > 256:
+        return None
+    words = [word for word in _normalize(span).split(" ") if word]
+    if not words or all(word.strip("'’-") in _NAME_STOP_WORDS for word in words):
+        return None
+    kind = _KIND_BY_NOUN[match.group("noun").casefold()]
+    start = match.start("quoted") if quoted is not None else match.start("plain")
+    return _MentionCandidate(start=start, span=span, kind=kind)
+
+
+def extract_mentions(
+    question: str,
+    *,
+    context_refs: Sequence[DevEntityRef] = (),
+    mint_id: Callable[[], str] = lambda: str(uuid.uuid4()),
+) -> tuple[DevSubjectMention, ...]:
+    """Ordered, deduplicated subject mentions for one question.
+
+    Two input classes, in precedence order:
+
+    1. **Explicit user text** — a capitalized or quoted span adjacent to one of
+       the closed kind nouns. Always ordinal-first.
+    2. **Typed context refs** — the request's page/surface entity refs. These
+       are admitted **only when the question names nothing itself**. When the
+       user did name something, a context ref is a tiebreaker for ambiguity
+       (applied by ``subject_preflight``), never an override: silently
+       substituting page context for an unrecognized name is the fabrication
+       path in a different costume.
+    """
+
+    candidates: list[_MentionCandidate] = []
+    # A noun that is *followed* by a name binds to that name. Suppressing the
+    # trailing reading of the same noun occurrence is what keeps "Compare
+    # project Ask Dev" from minting a "Compare" project: one noun occurrence
+    # names one entity, and the leading form is the unambiguous one.
+    leading_noun_starts: set[int] = set()
+    for match in _NOUN_LEADING.finditer(question):
+        candidate = _candidate_from(match)
+        if candidate is not None:
+            leading_noun_starts.add(match.start("noun"))
+            candidates.append(candidate)
+    for match in _NOUN_TRAILING.finditer(question):
+        if match.start("noun") in leading_noun_starts:
+            continue
+        candidate = _candidate_from(match)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    ordered: list[_MentionCandidate] = []
+    seen: set[tuple[str, EntityKind]] = set()
+    for candidate in sorted(candidates, key=lambda item: (item.start, item.span)):
+        key = (_normalize(candidate.span), candidate.kind)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(candidate)
+
+    if not ordered:
+        for ref in context_refs:
+            try:
+                kind = EntityKind(ref.entity_type.value)
+            except ValueError:
+                continue
+            key = (_normalize(ref.entity_id), kind)
+            if key in seen:
+                continue
+            seen.add(key)
+            # A typed context ref already carries the catalog's own canonical
+            # id, so the id *is* the normalized lookup key — casefolding it
+            # would break an exact id match. The human-readable label stays in
+            # ``original_text_span``.
+            ordered.append(
+                _MentionCandidate(
+                    start=len(question) + len(ordered),
+                    span=ref.display_label,
+                    kind=kind,
+                    lookup_text=ref.entity_id,
+                )
+            )
+
+    mentions: list[DevSubjectMention] = []
+    for ordinal, candidate in enumerate(ordered[:MAX_MENTIONS]):
+        mentions.append(
+            DevSubjectMention(
+                schema_version="dev_subject_mention.v1",
+                mention_id=mint_id(),
+                mention_ordinal=ordinal,
+                original_text_span=candidate.span[:2048],
+                requested_entity_kind=candidate.kind,
+                normalized_lookup_text=(
+                    candidate.lookup_text or _normalize(candidate.span)
+                )[:2048],
+            )
+        )
+    return tuple(mentions)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic recognizers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _Signals:
+    normalized: str
+    mention_count: int
+    has_metric_alias: bool
+    has_requested_metrics: bool
+
+
+def _any_of(*phrases: str) -> Callable[[str], bool]:
+    closed = tuple(phrases)
+
+    def predicate(text: str) -> bool:
+        return any(phrase in text for phrase in closed)
+
+    return predicate
+
+
+_STATUS_ANCHORS = _any_of(
+    "status",
+    "current state",
+    "where are we on",
+    "where do we stand",
+    "how far along",
+    "done",
+    "complete",
+    "ready",
+    "release ready",
+    "release-ready",
+    "shippable",
+)
+_PORTFOLIO_ANCHORS = _any_of(
+    "portfolio",
+    "all projects",
+    "every project",
+    "across projects",
+    "our projects",
+    "each project",
+)
+_REMAINING_ANCHORS = _any_of(
+    "what's left",
+    "whats left",
+    "what is left",
+    "remaining",
+    "outstanding",
+    "still open",
+    "blocked",
+    "blocker",
+    "what should we do first",
+    "what do we do next",
+    "next up",
+)
+_CHANGE_ANCHORS = _any_of(
+    "what changed",
+    "what has changed",
+    "improved",
+    "got worse",
+    "regressed",
+    "regression",
+    "since last",
+    "since the",
+    "versus",
+    " vs ",
+    "compared to",
+    "compared with",
+    "week over week",
+    "trend",
+)
+_REGISTERED_STATS_ANCHORS = _any_of(
+    "what metrics",
+    "which metrics",
+    "which stats",
+    "what stats",
+    "what statistics",
+    "what can you measure",
+    "what can you report",
+    "available metrics",
+    "list metrics",
+    "list the metrics",
+    "metrics do you",
+    "metrics can you",
+)
+_COMPARISON_ANCHORS = _any_of(
+    "compare",
+    "comparison",
+    "versus",
+    " vs ",
+    "compared to",
+    "compared with",
+    "higher than",
+    "lower than",
+    "better than",
+    "worse than",
+    "against",
+    "benchmark",
+)
+_TRUST_ANCHORS = _any_of(
+    "stale",
+    "fresh",
+    "freshness",
+    "missing data",
+    "unconfigured",
+    "not configured",
+    "coverage",
+    "can i trust",
+    "can we trust",
+    "how reliable",
+    "data quality",
+    "up to date",
+    "up-to-date",
+)
+_HEALTH_ANCHORS = _any_of(
+    "health",
+    "healthy",
+    "at risk",
+    "at-risk",
+    "needs attention",
+    "how are things going",
+    "how is it going",
+    "trouble",
+)
+_TEAM_SUBJECT_ANCHORS = _any_of("team", "squad", "group")
+_PROJECT_SUBJECT_ANCHORS = _any_of(
+    "project", "repository", "repo", "service", "product"
+)
+_WORKLOAD_ANCHORS = _any_of(
+    "overburdened",
+    "overloaded",
+    "workload",
+    "work load",
+    "pressure",
+    "capacity",
+    "investment mix",
+    "allocation",
+    "balance",
+    "spread thin",
+    "bandwidth",
+)
+_DEFICIENCY_ANCHORS = _any_of(
+    "operational deficiencies",
+    "operational deficiency",
+    "operational gaps",
+    "what's broken operationally",
+    "whats broken operationally",
+    "operational risks",
+    "missing controls",
+    "process gaps",
+)
+_RANKING_ANCHORS = _any_of(
+    "top ",
+    "most ",
+    "least ",
+    "worst",
+    "best",
+    "rank",
+    "biggest",
+    "highest",
+    "lowest",
+    "which team",
+    "which project",
+)
+_PERIOD_COMPARISON_ANCHORS = _any_of(
+    "since last",
+    "last week",
+    "last month",
+    "last quarter",
+    "week over week",
+    "month over month",
+    "previous period",
+    "compared to last",
+    "trend",
+)
+_COHORT_COMPARISON_ANCHORS = _any_of(
+    "compared to other",
+    "versus other",
+    " vs other",
+    "against other",
+    "relative to other",
+    "benchmark",
+)
+
+
+def _metric_aliases() -> frozenset[str]:
+    """The closed set of metric names a question may name, from the registry."""
+
+    aliases: set[str] = set()
+    for metric_id, definition in METRIC_REGISTRY.items():
+        aliases.add(metric_id.value)
+        aliases.add(metric_id.value.replace("_", " "))
+        aliases.add(_normalize(definition.label))
+    return frozenset(alias for alias in aliases if len(alias) >= 4)
+
+
+_METRIC_ALIASES = _metric_aliases()
+
+
+@dataclass(frozen=True, slots=True)
+class _Recognizer:
+    recognizer_id: str
+    intent: QuestionIntentID
+    matches: Callable[[_Signals], bool]
+
+
+#: Ordered, first-match-wins. Ordering is the tiebreak; it is deliberate and
+#: pinned by test, so a question that satisfies two recognizers always resolves
+#: to the same intent.
+_RECOGNIZERS: tuple[_Recognizer, ...] = (
+    _Recognizer(
+        "stats.registered",
+        QuestionIntentID.REGISTERED_STATISTICS,
+        lambda s: _REGISTERED_STATS_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "metric.comparison",
+        QuestionIntentID.METRIC_COMPARISON,
+        lambda s: (
+            (s.has_metric_alias or s.has_requested_metrics)
+            and _COMPARISON_ANCHORS(s.normalized)
+        ),
+    ),
+    _Recognizer(
+        "trust.data",
+        QuestionIntentID.DATA_TRUST,
+        lambda s: _TRUST_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "deficiency.operational",
+        QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY,
+        lambda s: _DEFICIENCY_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "balance.team_workload",
+        QuestionIntentID.TEAM_WORKLOAD_BALANCE,
+        lambda s: (
+            _WORKLOAD_ANCHORS(s.normalized) and _TEAM_SUBJECT_ANCHORS(s.normalized)
+        ),
+    ),
+    _Recognizer(
+        "health.team",
+        QuestionIntentID.TEAM_HEALTH,
+        lambda s: _HEALTH_ANCHORS(s.normalized) and _TEAM_SUBJECT_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "health.project",
+        QuestionIntentID.PROJECT_HEALTH,
+        lambda s: (
+            _HEALTH_ANCHORS(s.normalized) and _PROJECT_SUBJECT_ANCHORS(s.normalized)
+        ),
+    ),
+    _Recognizer(
+        "change.observed",
+        QuestionIntentID.OBSERVED_CHANGE,
+        lambda s: _CHANGE_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "work.remaining",
+        QuestionIntentID.REMAINING_WORK,
+        lambda s: _REMAINING_ANCHORS(s.normalized),
+    ),
+    _Recognizer(
+        "status.portfolio",
+        QuestionIntentID.PORTFOLIO_STATUS,
+        lambda s: (
+            _STATUS_ANCHORS(s.normalized)
+            and (s.mention_count >= 2 or _PORTFOLIO_ANCHORS(s.normalized))
+        ),
+    ),
+    _Recognizer(
+        "status.singular",
+        QuestionIntentID.ENTITY_STATUS,
+        lambda s: _STATUS_ANCHORS(s.normalized) and s.mention_count >= 1,
+    ),
+)
+
+
+def _cardinality_for(mention_count: int) -> Cardinality:
+    """Derived, never asserted.
+
+    ``DevQuestionIntent`` enforces ``PLURAL_COHORT => >=2 mentions`` and
+    ``ORGANIZATION_WIDE => 0 mentions``, so derivation is the only construction
+    that validates.
+    """
+
+    if mention_count == 0:
+        return Cardinality.ORGANIZATION_WIDE
+    if mention_count == 1:
+        return Cardinality.SINGULAR
+    return Cardinality.PLURAL_COHORT
+
+
+def _comparison_mode(normalized: str, intent: QuestionIntentID) -> str:
+    if _COHORT_COMPARISON_ANCHORS(normalized):
+        return "cohort_relative"
+    if _PERIOD_COMPARISON_ANCHORS(normalized):
+        return "period_over_period"
+    if intent is QuestionIntentID.OBSERVED_CHANGE:
+        return "own_history"
+    return "none"
+
+
+# ---------------------------------------------------------------------------
+# Constrained model fallback
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ClassifierProposal:
+    """What a constrained classifier is allowed to return — and nothing else.
+
+    It cannot mint an ID, cannot choose a scope, cannot request a tool, and
+    cannot clear ``requires_clarification``: those fields simply do not exist
+    on this type. Post-validation additionally rejects any ``text_span`` that
+    is not a literal substring of the question, which is what makes "cannot
+    author entity names" true rather than merely requested.
+    """
+
+    intent_id: str
+    cardinality: str
+    candidates: tuple[tuple[str, str], ...] = ()
+    confidence: float = 0.0
+
+
+class IntentClassifier(Protocol):
+    """A no-tool, no-data classifier over the raw question text alone."""
+
+    async def classify(self, *, question: str) -> ClassifierProposal | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class InterpretedQuestion:
+    intent: DevQuestionIntent
+    mentions: tuple[DevSubjectMention, ...]
+
+    @property
+    def mention_by_id(self) -> dict[str, DevSubjectMention]:
+        return {mention.mention_id: mention for mention in self.mentions}
+
+
+class QuestionInterpreter:
+    """Deterministic recognizers plus an optional constrained model fallback."""
+
+    def __init__(
+        self,
+        *,
+        classifier: IntentClassifier | None = None,
+        mint_id: Callable[[], str] = lambda: str(uuid.uuid4()),
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._classifier = classifier
+        self._mint_id = mint_id
+        self._now = now
+
+    async def interpret(self, request: DevMessageRequest) -> InterpretedQuestion:
+        context_refs = list(request.scope.entity_refs)
+        if request.scope.surface_context is not None:
+            context_refs.extend(request.scope.surface_context.entity_refs)
+        mentions = extract_mentions(
+            request.question, context_refs=context_refs, mint_id=self._mint_id
+        )
+        normalized = _normalize(request.question)
+        signals = _Signals(
+            normalized=normalized,
+            mention_count=len(mentions),
+            has_metric_alias=any(alias in normalized for alias in _METRIC_ALIASES),
+            has_requested_metrics=bool(request.requested_metric_ids),
+        )
+
+        intent_id = QuestionIntentID.BOUNDED_INVESTIGATION
+        reasons: list[str] = ["recognizer.none"]
+        confidence = _UNRECOGNIZED_CONFIDENCE
+        for recognizer in _RECOGNIZERS:
+            if recognizer.matches(signals):
+                intent_id = recognizer.intent
+                reasons = [recognizer.recognizer_id]
+                confidence = _DETERMINISTIC_CONFIDENCE
+                break
+
+        requires_clarification = False
+        clarification_reason: str | None = None
+        if confidence < FALLBACK_CONFIDENCE_FLOOR and self._classifier is not None:
+            (
+                intent_id,
+                mentions,
+                confidence,
+                requires_clarification,
+                clarification_reason,
+                fallback_reason,
+            ) = await self._apply_fallback(
+                request=request,
+                intent_id=intent_id,
+                mentions=mentions,
+                confidence=confidence,
+            )
+            reasons.append(fallback_reason)
+
+        subject_kinds = tuple(
+            sorted(
+                {mention.requested_entity_kind for mention in mentions},
+                key=lambda kind: kind.value,
+            )
+        )[:5]
+        intent = DevQuestionIntent(
+            schema_version="dev_question_intent.v1",
+            intent_id=intent_id,
+            interpreter_version=INTERPRETER_VERSION,
+            cardinality=_cardinality_for(len(mentions)),
+            subject_kinds=subject_kinds,
+            mention_ordinals=tuple(range(len(mentions))),
+            requested_dimensions=(),
+            requested_metric_ids=tuple(request.requested_metric_ids)[:8],
+            comparison_mode=_comparison_mode(normalized, intent_id),
+            ranking_requested=_RANKING_ANCHORS(normalized),
+            confidence=confidence,
+            interpretation_reasons=tuple(reasons[:10]),
+            requires_clarification=requires_clarification,
+            clarification_reason=clarification_reason,
+            # Read, recorded, and never used for planning (TRD v2 §4.1).
+            client_question_class_hint=request.question_class,
+            client_hint_deprecation_warning=CLIENT_HINT_DEPRECATION_WARNING,
+            generated_at=self._now(),
+        )
+        return InterpretedQuestion(intent=intent, mentions=mentions)
+
+    async def _apply_fallback(
+        self,
+        *,
+        request: DevMessageRequest,
+        intent_id: QuestionIntentID,
+        mentions: tuple[DevSubjectMention, ...],
+        confidence: float,
+    ) -> tuple[
+        QuestionIntentID,
+        tuple[DevSubjectMention, ...],
+        float,
+        bool,
+        str | None,
+        str,
+    ]:
+        """One bounded classifier call, then total post-validation.
+
+        On **any** provider error, timeout, malformed output, or post-validation
+        rejection the run never falls back to organization scope. When the
+        question named something, the failure becomes an explicit clarification
+        request; when it named nothing there is no named subject to get wrong,
+        so the run keeps today's bounded-investigation behaviour rather than
+        refusing a question that works in production now.
+        """
+
+        assert self._classifier is not None
+        try:
+            proposal = await self._classifier.classify(question=request.question)
+        except Exception:
+            proposal = None
+        rejected_reason = "fallback.unavailable"
+        if proposal is not None:
+            validated = self._validate_proposal(proposal, question=request.question)
+            if validated is None:
+                rejected_reason = "fallback.rejected"
+            else:
+                proposed_intent, spans, proposed_confidence = validated
+                merged = self._merge_spans(mentions, spans)
+                return (
+                    proposed_intent,
+                    merged,
+                    min(proposed_confidence, _MAX_FALLBACK_CONFIDENCE),
+                    False,
+                    None,
+                    "fallback.model_assisted",
+                )
+        if mentions:
+            reason_key = (
+                "interpreter_unavailable"
+                if rejected_reason == "fallback.unavailable"
+                else "interpreter_rejected_extraction"
+            )
+            return (
+                intent_id,
+                mentions,
+                confidence,
+                True,
+                CLARIFICATION_REASONS[reason_key],
+                rejected_reason,
+            )
+        return (intent_id, mentions, confidence, False, None, rejected_reason)
+
+    @staticmethod
+    def _validate_proposal(
+        proposal: ClassifierProposal, *, question: str
+    ) -> tuple[QuestionIntentID, tuple[tuple[str, EntityKind], ...], float] | None:
+        try:
+            intent = QuestionIntentID(proposal.intent_id)
+        except ValueError:
+            return None
+        try:
+            Cardinality(proposal.cardinality)
+        except ValueError:
+            return None
+        if not 0.0 <= proposal.confidence <= 1.0:
+            return None
+        if len(proposal.candidates) > MAX_MENTIONS:
+            return None
+        spans: list[tuple[str, EntityKind]] = []
+        for raw_span, raw_kind in proposal.candidates:
+            # The literal-substring rule is what makes "the classifier cannot
+            # author an entity name" structural: a name it invented is not in
+            # the user's question, so it cannot survive this check.
+            if not raw_span or raw_span not in question:
+                return None
+            try:
+                kind = EntityKind(raw_kind)
+            except ValueError:
+                return None
+            spans.append((raw_span, kind))
+        return intent, tuple(spans), proposal.confidence
+
+    def _merge_spans(
+        self,
+        mentions: tuple[DevSubjectMention, ...],
+        spans: tuple[tuple[str, EntityKind], ...],
+    ) -> tuple[DevSubjectMention, ...]:
+        merged = list(mentions)
+        seen = {
+            (mention.normalized_lookup_text, mention.requested_entity_kind)
+            for mention in merged
+        }
+        for span, kind in spans:
+            key = (_normalize(span), kind)
+            if key in seen or len(merged) >= MAX_MENTIONS:
+                continue
+            seen.add(key)
+            merged.append(
+                DevSubjectMention(
+                    schema_version="dev_subject_mention.v1",
+                    mention_id=self._mint_id(),
+                    mention_ordinal=len(merged),
+                    original_text_span=span[:2048],
+                    requested_entity_kind=kind,
+                    normalized_lookup_text=_normalize(span)[:2048],
+                )
+            )
+        return tuple(merged)

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -17,6 +17,7 @@ from .orchestrator import (
     ScopeResolver,
 )
 from .prompts import PromptConversationTurn
+from .subject_preflight import SubjectPreflight
 from .tool_registry import AskDevToolRegistry
 
 
@@ -35,6 +36,9 @@ class BoundedDevRuntime:
     registry: AskDevToolRegistry
     scope_resolver: ScopeResolver
     versions: DevContractVersions
+    #: ``None`` when ``ask_dev_wave_3_1`` is off for this organization, which
+    #: is the pre-CHAOS-3292 run path.
+    preflight: SubjectPreflight | None = None
 
     async def run(
         self,
@@ -59,6 +63,7 @@ class BoundedDevRuntime:
             scope_resolver=self.scope_resolver,
             versions=self.versions,
             recorder=recorder,
+            preflight=self.preflight,
         )
         return await orchestrator.run(
             request=request,

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -619,26 +619,28 @@ class ScopeResolutionService:
                 allowed_kinds=SEARCHABLE_ENTITY_KINDS,
             )
         )
-        refs = (
-            tuple(ScopeRef(kind, lookup_text[:512]) for kind in ordered_kinds)
-            if exact
-            else ()
-        )
+        refs = tuple(ScopeRef(kind, lookup_text[:512]) for kind in ordered_kinds)
         try:
-            if search_request is not None:
+            watermark = await self._catalog.watermark(org_id, ordered_kinds)
+            # Exact first, always. The catalog's fuzzy query orders by label and
+            # applies its LIMIT in SQL, so with more than MAX_CANDIDATES
+            # substring matches sorted ahead of it the exactly-named entity
+            # never reaches this code at all — and a legitimate question died
+            # ambiguous with the one thing the user actually named missing from
+            # the candidate list. ``exact()`` matches id or label equality and
+            # is not subject to that page boundary.
+            matches: list[AuthorizedEntity] = []
+            for ref in refs:
+                matches.extend(
+                    await self._catalog.exact(org_id, ref, limit=MAX_CANDIDATES)
+                )
+            candidates = _dedupe_entities(matches)[:MAX_CANDIDATES]
+            if not candidates and search_request is not None:
                 result = await self.search(
                     org_id, permission_fingerprint, search_request
                 )
                 candidates = result.candidates
                 watermark = result.catalog_watermark
-            else:
-                watermark = await self._catalog.watermark(org_id, ordered_kinds)
-                matches: list[AuthorizedEntity] = []
-                for ref in refs:
-                    matches.extend(
-                        await self._catalog.exact(org_id, ref, limit=MAX_CANDIDATES)
-                    )
-                candidates = _dedupe_entities(matches)[:MAX_CANDIDATES]
         except Exception:
             return MentionResolution(
                 outcome=ResolutionOutcome.CATALOG_UNAVAILABLE,

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -31,12 +31,17 @@ from .contracts import (
     EntityType,
     ScopeResolutionOutcome,
 )
+from .contracts_v2 import ResolutionOutcome
 
 QUERY_VERSION = "resolve-scope.v1"
 MAX_REPOSITORIES = 20
 MAX_ENTITY_REFS = 20
 MAX_CANDIDATES = 25
 MAX_REQUEST_CACHE_ENTRIES = 128
+#: ``DevResolutionEntry.query_version`` is a non-empty ``Version``; a failed
+#: catalog read has no watermark to carry, and a content-free placeholder is
+#: honest where an empty string would be unrepresentable.
+_UNAVAILABLE_WATERMARK = "catalog-watermark-unavailable"
 
 
 class EntityKind(StrEnum):
@@ -59,6 +64,21 @@ DIRECT_SCOPE_KINDS = frozenset(
         EntityKind.PULL_REQUEST,
     }
 )
+
+#: The kinds any v1 surface (``resolve_scope.v1``, the GraphQL scope-search
+#: field) may search. Organization is excluded because named-entity resolution
+#: never searches organization scope itself (CHAOS-3256).
+V1_SEARCHABLE_ENTITY_KINDS = frozenset(DIRECT_SCOPE_KINDS - {EntityKind.ORGANIZATION})
+
+#: The **ceiling** on what any caller may search — not a default. CHAOS-3292
+#: adds ``TEAM`` here so the subject preflight can resolve a named team against
+#: the catalog (which has supported teams since ``scope_catalog``'s team
+#: queries landed) and record an honest ``exact_match`` for it. Giving a team
+#: real v1 ``DirectScope``/``DevScope`` semantics is CHAOS-3301's, so every
+#: pre-existing caller keeps ``V1_SEARCHABLE_ENTITY_KINDS`` and a resolved team
+#: terminates the preflight as ``unsupported`` rather than reaching
+#: ``DirectScope(...)``/``EntityType(...)``, which raise for ``team``.
+SEARCHABLE_ENTITY_KINDS = V1_SEARCHABLE_ENTITY_KINDS | {EntityKind.TEAM}
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,6 +198,12 @@ class ScopeSearchRequest:
     query: str
     kinds: tuple[EntityKind, ...]
     limit: int = MAX_CANDIDATES
+    #: Each caller declares the kinds *it* is allowed to search;
+    #: ``SEARCHABLE_ENTITY_KINDS`` is the ceiling, never the default. Widening
+    #: the ceiling for the subject preflight must not implicitly expose team
+    #: search on the GraphQL field or the model-facing ``resolve_scope.v1``
+    #: tool, both of which CHAOS-3301 owns.
+    allowed_kinds: frozenset[EntityKind] = V1_SEARCHABLE_ENTITY_KINDS
 
     def __post_init__(self) -> None:
         query = self.query.strip()
@@ -185,14 +211,32 @@ class ScopeSearchRequest:
             raise ValueError("Search query must contain 1 to 256 characters")
         if not self.kinds:
             raise ValueError("At least one entity kind is required")
-        if any(
-            kind not in DIRECT_SCOPE_KINDS - {EntityKind.ORGANIZATION}
-            for kind in self.kinds
-        ):
+        if not self.allowed_kinds <= SEARCHABLE_ENTITY_KINDS:
+            raise ValueError("Caller allowlist exceeds the searchable entity ceiling")
+        if any(kind not in self.allowed_kinds for kind in self.kinds):
             raise ValueError("Only approved searchable V1 direct scopes are allowed")
         if self.limit < 1 or self.limit > MAX_CANDIDATES:
             raise ValueError(f"Search limit must be between 1 and {MAX_CANDIDATES}")
         object.__setattr__(self, "query", query)
+
+
+@dataclass(frozen=True, slots=True)
+class MentionResolution:
+    """One subject mention's resolution outcome, in the v2 vocabulary.
+
+    Distinct from ``resolve_query_contract``'s ``DevScopeResolution``, whose
+    ``FORBIDDEN_OR_NOT_FOUND`` conflates not-exists, cross-tenant, and (until
+    this module started catching it) a catalog error. Nothing on this path ever
+    constructs that combined outcome — the preflight has no code path that
+    produces it, which is what makes "the internal combined outcome never
+    leaves the server" structural rather than a filter.
+    """
+
+    outcome: ResolutionOutcome
+    entity: AuthorizedEntity | None
+    candidates: tuple[AuthorizedEntity, ...]
+    catalog_watermark: str
+    query_version: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -527,6 +571,160 @@ class ScopeResolutionService:
         self._cache.put(cache_key, result)
         return result
 
+    async def resolve_mention(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        *,
+        lookup_text: str,
+        kinds: tuple[EntityKind, ...],
+        exact: bool = False,
+    ) -> MentionResolution:
+        """Resolve one named subject mention to a per-mention typed outcome.
+
+        The existing service cannot express this: ``resolve()`` collapses every
+        ref to one combined outcome and ``resolve_query_contract`` returns the
+        internal ``FORBIDDEN_OR_NOT_FOUND`` code. Ambiguity is probed against
+        the full ``MAX_CANDIDATES`` page for the same reason
+        ``resolve_query_contract`` documents: truncating first would let an
+        arbitrary one of several real matches be reported as exact.
+
+        **The catalog call is wrapped here deliberately.** ``search()`` has no
+        exception handling of its own — unlike ``resolve()``, which types a
+        catalog failure as ``UNRESOLVED``/``catalog_unavailable`` — so without
+        this wrapper a ClickHouse outage would escape as an exception, surface
+        as ``internal_error``, and make ``CATALOG_UNAVAILABLE`` unreachable.
+        """
+
+        if not org_id or not permission_fingerprint:
+            raise ValueError("Tenant and permission fingerprint are required")
+        if any(kind not in SEARCHABLE_ENTITY_KINDS for kind in kinds) or not kinds:
+            return MentionResolution(
+                outcome=ResolutionOutcome.UNSUPPORTED_KIND,
+                entity=None,
+                candidates=(),
+                catalog_watermark=_UNAVAILABLE_WATERMARK,
+                query_version=QUERY_VERSION,
+            )
+        ordered_kinds = tuple(sorted(set(kinds), key=lambda kind: kind.value))
+        # Built outside the try: a malformed request is a caller defect, not a
+        # catalog outage, and must not be mistyped as one.
+        search_request = (
+            None
+            if exact
+            else ScopeSearchRequest(
+                query=lookup_text[:256],
+                kinds=ordered_kinds,
+                limit=MAX_CANDIDATES,
+                allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+            )
+        )
+        refs = (
+            tuple(ScopeRef(kind, lookup_text[:512]) for kind in ordered_kinds)
+            if exact
+            else ()
+        )
+        try:
+            if search_request is not None:
+                result = await self.search(
+                    org_id, permission_fingerprint, search_request
+                )
+                candidates = result.candidates
+                watermark = result.catalog_watermark
+            else:
+                watermark = await self._catalog.watermark(org_id, ordered_kinds)
+                matches: list[AuthorizedEntity] = []
+                for ref in refs:
+                    matches.extend(
+                        await self._catalog.exact(org_id, ref, limit=MAX_CANDIDATES)
+                    )
+                candidates = _dedupe_entities(matches)[:MAX_CANDIDATES]
+        except Exception:
+            return MentionResolution(
+                outcome=ResolutionOutcome.CATALOG_UNAVAILABLE,
+                entity=None,
+                candidates=(),
+                catalog_watermark=_UNAVAILABLE_WATERMARK,
+                query_version=QUERY_VERSION,
+            )
+        watermark = watermark or _UNAVAILABLE_WATERMARK
+        if not candidates:
+            return MentionResolution(
+                outcome=ResolutionOutcome.NO_AUTHORIZED_MATCH,
+                entity=None,
+                candidates=(),
+                catalog_watermark=watermark,
+                query_version=QUERY_VERSION,
+            )
+        if len(candidates) > 1:
+            return MentionResolution(
+                outcome=ResolutionOutcome.AMBIGUOUS_CANDIDATES,
+                entity=None,
+                candidates=candidates,
+                catalog_watermark=watermark,
+                query_version=QUERY_VERSION,
+            )
+        return MentionResolution(
+            outcome=ResolutionOutcome.EXACT_MATCH,
+            entity=candidates[0],
+            candidates=(),
+            catalog_watermark=watermark,
+            query_version=QUERY_VERSION,
+        )
+
+    def committed_resolution_for(
+        self,
+        entity: AuthorizedEntity,
+        *,
+        org_id: str,
+        base_scope: DevScope,
+        resolved_at: datetime,
+    ) -> DevScopeResolution:
+        """The one construction of an exact-match committed scope.
+
+        Shared by ``resolve_query_contract`` (the legacy ``resolve_scope.v1``
+        path) and the subject preflight, so there is one notion of "committed
+        scope" rather than two that can drift.
+
+        Raises ``ValueError`` for a kind v1 cannot represent (``team``), rather
+        than letting ``DirectScope(...)``/``EntityType(...)`` raise a bare
+        enum error from deep inside scope construction.
+        """
+
+        if entity.kind not in V1_SEARCHABLE_ENTITY_KINDS:
+            raise ValueError(
+                f"{entity.kind.value} has no v1 direct-scope representation"
+            )
+        is_repository = entity.kind is EntityKind.REPOSITORY
+        resolved_scope = DevScope(
+            schema_version="dev_scope.v1",
+            organization_id=org_id,
+            direct_scope=DirectScope(entity.kind.value),
+            repositories=[entity.canonical_id] if is_repository else [],
+            entity_refs=[] if is_repository else [self._contract_entity_ref(entity)],
+            team_ids=[],
+            time_range=base_scope.time_range,
+            comparison_range=base_scope.comparison_range,
+            surface_context=None,
+        )
+        repository_ids = sorted(
+            ({entity.canonical_id} if is_repository else set())
+            | ({entity.repository_id} if entity.repository_id else set())
+        )
+        entity_ids = [] if is_repository else [entity.canonical_id]
+        return DevScopeResolution(
+            schema_version="dev_scope_resolution.v1",
+            requested_scope=base_scope,
+            resolved_scope=resolved_scope,
+            outcome=ScopeResolutionOutcome.EXACT,
+            authorized_repository_ids=repository_ids,
+            authorized_entity_ids=entity_ids,
+            candidates=[],
+            fallbacks=[],
+            warnings=[],
+            resolved_at=resolved_at,
+        )
+
     async def resolve_query_contract(
         self,
         org_id: str,
@@ -553,6 +751,21 @@ class ScopeResolutionService:
         and report it as an exact commit. ``request.limit`` only bounds how
         many typed candidates are returned once the outcome is ambiguous.
         """
+        # A typed guard, not an assumption: ``ScopeSearchRequest``'s allowlist
+        # is now per-caller, so a caller that widened its own allowlist must
+        # not be able to reach ``DirectScope(...)``/``EntityType(...)`` below
+        # with a kind v1 cannot represent and produce a bare enum ValueError
+        # from inside scope construction.
+        unrepresentable = sorted(
+            kind.value
+            for kind in request.kinds
+            if kind not in V1_SEARCHABLE_ENTITY_KINDS
+        )
+        if unrepresentable:
+            raise ValueError(
+                "resolve_scope.v1 cannot represent entity kinds "
+                f"{unrepresentable}; use resolve_mention for those"
+            )
         probe_request = (
             request
             if request.limit == MAX_CANDIDATES
@@ -593,34 +806,10 @@ class ScopeResolutionService:
                 warnings=[],
                 resolved_at=resolved_at,
             )
-        entity = result.candidates[0]
-        is_repository = entity.kind is EntityKind.REPOSITORY
-        resolved_scope = DevScope(
-            schema_version="dev_scope.v1",
-            organization_id=org_id,
-            direct_scope=DirectScope(entity.kind.value),
-            repositories=[entity.canonical_id] if is_repository else [],
-            entity_refs=[] if is_repository else [self._contract_entity_ref(entity)],
-            team_ids=[],
-            time_range=base_scope.time_range,
-            comparison_range=base_scope.comparison_range,
-            surface_context=None,
-        )
-        repository_ids = sorted(
-            ({entity.canonical_id} if is_repository else set())
-            | ({entity.repository_id} if entity.repository_id else set())
-        )
-        entity_ids = [] if is_repository else [entity.canonical_id]
-        return DevScopeResolution(
-            schema_version="dev_scope_resolution.v1",
-            requested_scope=base_scope,
-            resolved_scope=resolved_scope,
-            outcome=ScopeResolutionOutcome.EXACT,
-            authorized_repository_ids=repository_ids,
-            authorized_entity_ids=entity_ids,
-            candidates=[],
-            fallbacks=[],
-            warnings=[],
+        return self.committed_resolution_for(
+            result.candidates[0],
+            org_id=org_id,
+            base_scope=base_scope,
             resolved_at=resolved_at,
         )
 

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -656,18 +656,30 @@ class ScopeResolutionService:
                 catalog_watermark=watermark,
                 query_version=QUERY_VERSION,
             )
-        if len(candidates) > 1:
+        # The catalog's text search is a ``%query%`` LIKE, so a *sole* result is
+        # not the same thing as an exact match: "the Dev project" returns only
+        # "Ask Dev" and would otherwise commit it, answering about an entity
+        # the user did not name. Committing therefore requires the name to
+        # equal a label or canonical id outright; a partial name that matched
+        # something real is offered back as candidates instead.
+        wanted = lookup_text.strip().casefold()
+        exact_matches = tuple(
+            candidate
+            for candidate in candidates
+            if wanted in {candidate.canonical_id.casefold(), candidate.label.casefold()}
+        )
+        if len(exact_matches) == 1:
             return MentionResolution(
-                outcome=ResolutionOutcome.AMBIGUOUS_CANDIDATES,
-                entity=None,
-                candidates=candidates,
+                outcome=ResolutionOutcome.EXACT_MATCH,
+                entity=exact_matches[0],
+                candidates=(),
                 catalog_watermark=watermark,
                 query_version=QUERY_VERSION,
             )
         return MentionResolution(
-            outcome=ResolutionOutcome.EXACT_MATCH,
-            entity=candidates[0],
-            candidates=(),
+            outcome=ResolutionOutcome.AMBIGUOUS_CANDIDATES,
+            entity=None,
+            candidates=exact_matches or candidates,
             catalog_watermark=watermark,
             query_version=QUERY_VERSION,
         )

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -1,0 +1,593 @@
+"""Deny-by-default subject preflight for Ask Dev (CHAOS-3292).
+
+Runs between scope authorization and the first model round, so **no
+evidence-bearing tool executes before an exact, committed subject exists**.
+Every named subject in the question is resolved against the authorized
+catalog first; the resolution is recorded on an append-only
+``dev_resolution_ledger.v1``; and the run either proceeds with a
+server-committed scope or terminates with a public outcome that names nothing
+the catalog did not confirm.
+
+Why the placement matters
+-------------------------
+
+Today the model is *told* to call ``resolve_scope.v1`` before any status tool
+(``prompts/composer``'s ``named_entity_resolution`` section) and is *judged*
+afterwards by a prose-matching backstop. Both are post-hoc. Committing the
+subject here means the model is **given** a project scope in its prompt rather
+than asked to earn one — which is what closes the residual failure rate the
+CHAOS-3289 verification measured.
+
+What this module never does
+---------------------------
+
+* It never constructs ``FORBIDDEN_OR_NOT_FOUND`` — see ``preflight_outcomes``.
+* It never falls back to organization scope for an unresolved named subject.
+* It never lets a later resolution erase an earlier unresolved one: every
+  update appends to the ledger and is checked with ``validate_ledger_extends``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from .contracts import DevContractVersions, DevScope, DevScopeResolution, ToolID
+from .contracts_v2 import (
+    DevAnswerV2,
+    DevEntityRefV2,
+    DevResolutionCandidate,
+    DevResolutionEntry,
+    DevResolutionLedger,
+    DevSubjectMention,
+    PublicOutcome,
+    ResolutionOutcome,
+    validate_ledger_extends,
+)
+from .contracts_v2 import (
+    EntityKind as ContractEntityKind,
+)
+from .contracts_v2.subject import UNRESOLVED_OUTCOMES
+from .orchestrator_states import RunState
+from .preflight_outcomes import (
+    PREFLIGHT_OUTCOME_BY_RESOLUTION,
+    build_preflight_answer,
+)
+from .question_interpreter import InterpretedQuestion, QuestionInterpreter
+from .scope_service import (
+    V1_SEARCHABLE_ENTITY_KINDS,
+    AuthorizedEntity,
+    EntityKind,
+    MentionResolution,
+    ScopeResolutionService,
+)
+
+__all__ = [
+    "SUBJECT_BEARING_TOOLS",
+    "PreflightDecision",
+    "SubjectPreflight",
+    "SubjectPreflightResult",
+]
+
+#: Tools whose results are *about a subject*. None of these may execute while
+#: any mention lacks a committed exact match.
+#:
+#: ``resolve_scope.v1`` and ``list_metrics.v1`` are exempt for different
+#: reasons: the former is how a subject would be resolved at all, and the
+#: latter is an organization catalog answer — CHAOS-3295 states explicitly that
+#: "a correct catalog answer does not fail merely because metric definitions do
+#: not carry material evidence refs".
+SUBJECT_BEARING_TOOLS = frozenset(
+    {
+        ToolID.STATUS_SNAPSHOT,
+        ToolID.CHANGE_SUMMARY,
+        ToolID.QUERY_METRIC,
+        ToolID.WORK_GRAPH_NEIGHBORS,
+        ToolID.SEARCH_EVIDENCE,
+        ToolID.GET_EVIDENCE,
+        ToolID.DATA_HEALTH,
+    }
+)
+
+ALL_TOOLS = frozenset(ToolID)
+
+
+class PreflightDecision(StrEnum):
+    PROCEED = "proceed"
+    TERMINATE = "terminate"
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectPreflightResult:
+    decision: PreflightDecision
+    interpretation: InterpretedQuestion
+    #: ``None`` only when the question named no subject at all.
+    ledger: DevResolutionLedger | None
+    #: The server-committed scope, when exactly one subject resolved exactly.
+    committed_resolution: DevScopeResolution | None
+    #: Present only for ``TERMINATE``.
+    answer: DevAnswerV2 | None
+    outcome: PublicOutcome | None
+    #: The per-run tool allowlist the model round is held to.
+    allowed_tools: frozenset[ToolID]
+    #: Content-free code recorded on the run row. Never question or entity text.
+    diagnostic: str
+
+    @property
+    def all_subjects_committed(self) -> bool:
+        """Whether every mention currently holds an ``exact_match``."""
+
+        if self.ledger is None:
+            return True
+        return all(
+            entry.outcome is ResolutionOutcome.EXACT_MATCH
+            for entry in self.ledger.latest_by_mention().values()
+        )
+
+
+def _entity_ref_v2(entity: AuthorizedEntity) -> DevEntityRefV2:
+    """Build the v2 ref directly from the authorized entity.
+
+    Deliberately **not** via ``_contract_entity_ref`` / ``_resolved_scope`` /
+    ``resolve_query_contract``: all three call ``EntityType(...)`` or
+    ``DirectScope(...)``, which raise for ``team``. ``DevEntityRefV2`` is
+    team-capable at the contract layer, which is what lets a resolved team be
+    recorded honestly as ``exact_match`` before CHAOS-3301 gives it v1 scope
+    semantics.
+    """
+
+    return DevEntityRefV2(
+        entity_kind=ContractEntityKind(entity.kind.value),
+        entity_id=entity.canonical_id,
+        display_label=entity.label,
+        repository_id=entity.repository_id,
+        team_id=entity.canonical_id if entity.kind is EntityKind.TEAM else None,
+    )
+
+
+class SubjectPreflight:
+    """Interpret one question, resolve its subjects, and gate the run."""
+
+    def __init__(
+        self,
+        *,
+        interpreter: QuestionInterpreter,
+        scope_service: ScopeResolutionService,
+        versions: DevContractVersions,
+        mint_id: Callable[[], str] = lambda: str(uuid.uuid4()),
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._interpreter = interpreter
+        self._scope_service = scope_service
+        self._versions = versions
+        self._mint_id = mint_id
+        self._now = now
+
+    async def run(
+        self,
+        *,
+        request,
+        org_id: str,
+        permission_fingerprint: str,
+        authorized_scope: DevScope,
+        run_id: str,
+        answer_id: str,
+        conversation_id: str,
+        on_phase: Callable[[RunState], Awaitable[None]] | None = None,
+    ) -> SubjectPreflightResult:
+        async def phase(state: RunState) -> None:
+            if on_phase is not None:
+                await on_phase(state)
+
+        await phase(RunState.INTERPRETING)
+        interpretation = await self._interpreter.interpret(request)
+        intent = interpretation.intent
+        mentions = interpretation.mentions
+        generated_at = self._now()
+
+        if intent.requires_clarification:
+            return self._terminate(
+                interpretation=interpretation,
+                ledger=None,
+                outcome=PublicOutcome.NEEDS_CLARIFICATION,
+                diagnostic="interpreter_clarification_required",
+                run_id=run_id,
+                answer_id=answer_id,
+                conversation_id=conversation_id,
+                generated_at=generated_at,
+                clarification_key="uninterpretable",
+            )
+
+        if not mentions:
+            # Organization-wide by derivation, not by fallback: the question
+            # named nothing, so there is no subject to get wrong. This is the
+            # branch that keeps org-wide questions working exactly as today.
+            return SubjectPreflightResult(
+                decision=PreflightDecision.PROCEED,
+                interpretation=interpretation,
+                ledger=None,
+                committed_resolution=None,
+                answer=None,
+                outcome=None,
+                allowed_tools=ALL_TOOLS,
+                diagnostic="proceeded_organization_wide",
+            )
+
+        await phase(RunState.RESOLVING_SUBJECTS)
+        context_ref_ids = self._context_ref_ids(request)
+        resolutions = await asyncio.gather(
+            *(
+                self._scope_service.resolve_mention(
+                    org_id,
+                    permission_fingerprint,
+                    lookup_text=mention.normalized_lookup_text,
+                    kinds=(EntityKind(mention.requested_entity_kind.value),),
+                    exact=mention.normalized_lookup_text in context_ref_ids,
+                )
+                for mention in mentions
+            )
+        )
+
+        ledger = self._build_ledger(
+            mentions=mentions, resolutions=resolutions, resolved_at=generated_at
+        )
+        ledger = self._apply_context_tiebreaker(
+            ledger=ledger,
+            mentions=mentions,
+            resolutions=resolutions,
+            context_ref_ids=context_ref_ids,
+            resolved_at=generated_at,
+        )
+        ledger = self._apply_catalog_reuse(
+            ledger=ledger,
+            mentions=mentions,
+            resolutions=resolutions,
+            authorized_scope=authorized_scope,
+            resolved_at=generated_at,
+        )
+
+        latest = ledger.latest_by_mention()
+        # Precedence: the lowest-ordinal unresolved mention wins. Stable and
+        # explainable ("the first thing you named"), and independent of catalog
+        # latency — a severity ordering would let a slow catalog change the
+        # reported outcome between runs, which directly breaks determinism.
+        for mention in mentions:
+            entry = latest[mention.mention_id]
+            if entry.outcome in UNRESOLVED_OUTCOMES:
+                return self._terminate(
+                    interpretation=interpretation,
+                    ledger=ledger,
+                    outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
+                    diagnostic=f"unresolved_{entry.outcome.value}",
+                    run_id=run_id,
+                    answer_id=answer_id,
+                    conversation_id=conversation_id,
+                    generated_at=generated_at,
+                )
+
+        committed = [
+            latest[mention.mention_id].committed_entity_ref for mention in mentions
+        ]
+        kinds = {ref.entity_kind for ref in committed if ref is not None}
+        if any(
+            EntityKind(kind.value) not in V1_SEARCHABLE_ENTITY_KINDS for kind in kinds
+        ):
+            # Interim TEAM semantics (CHAOS-3301 owns the rest): the ledger
+            # already records exact_match with a team ref — the team
+            # demonstrably exists — but no v1 DevScope can carry a team
+            # subject. Never not_found, never organization fallback.
+            return self._terminate(
+                interpretation=interpretation,
+                ledger=ledger,
+                outcome=PublicOutcome.UNSUPPORTED,
+                diagnostic="committed_kind_unsupported_in_v1",
+                run_id=run_id,
+                answer_id=answer_id,
+                conversation_id=conversation_id,
+                generated_at=generated_at,
+            )
+        if len(committed) > 1:
+            # A cohort has no faithful v1 representation either: a v1 DevScope
+            # names one direct subject. The landed v2-to-v1 projector reaches
+            # the same conclusion independently for ``subject_set_ref``
+            # ("Cohort-scoped Ask Dev answers require a newer client"), and
+            # committing only the first of several named subjects is precisely
+            # the fabricated-premise shape this issue exists to close.
+            # CHAOS-3301 owns subject sets and batch execution.
+            return self._terminate(
+                interpretation=interpretation,
+                ledger=ledger,
+                outcome=PublicOutcome.UNSUPPORTED,
+                diagnostic="cohort_unsupported_in_v1",
+                run_id=run_id,
+                answer_id=answer_id,
+                conversation_id=conversation_id,
+                generated_at=generated_at,
+            )
+
+        entry = latest[mentions[0].mention_id]
+        entity = self._authorized_entity_for(entry)
+        committed_resolution = self._scope_service.committed_resolution_for(
+            entity,
+            org_id=org_id,
+            base_scope=authorized_scope,
+            resolved_at=generated_at,
+        )
+        return SubjectPreflightResult(
+            decision=PreflightDecision.PROCEED,
+            interpretation=interpretation,
+            ledger=ledger,
+            committed_resolution=committed_resolution,
+            answer=None,
+            outcome=None,
+            # With a subject already committed there is nothing left for the
+            # model to resolve, so ``resolve_scope.v1`` is withheld — which is
+            # also what makes the ``forbidden_or_not_found`` tool-result leak
+            # channel unreachable on this path, without renaming a token that
+            # five published v1 schemas carry.
+            allowed_tools=ALL_TOOLS - {ToolID.RESOLVE_SCOPE},
+            diagnostic="proceeded_committed_subject",
+        )
+
+    # -- construction helpers -------------------------------------------------
+
+    @staticmethod
+    def _context_ref_ids(request) -> frozenset[str]:
+        refs = list(request.scope.entity_refs)
+        if request.scope.surface_context is not None:
+            refs.extend(request.scope.surface_context.entity_refs)
+        return frozenset(ref.entity_id for ref in refs)
+
+    def _build_ledger(
+        self,
+        *,
+        mentions: Sequence[DevSubjectMention],
+        resolutions: Sequence[MentionResolution],
+        resolved_at: datetime,
+    ) -> DevResolutionLedger:
+        entries = tuple(
+            self._entry(
+                ordinal=ordinal,
+                mention=mention,
+                resolution=resolution,
+                resolved_at=resolved_at,
+            )
+            for ordinal, (mention, resolution) in enumerate(
+                zip(mentions, resolutions, strict=True)
+            )
+        )
+        return DevResolutionLedger(
+            schema_version="dev_resolution_ledger.v1",
+            ledger_id=self._mint_id(),
+            mention_ids=tuple(mention.mention_id for mention in mentions),
+            entries=entries,
+            updated_at=resolved_at,
+        )
+
+    def _entry(
+        self,
+        *,
+        ordinal: int,
+        mention: DevSubjectMention,
+        resolution: MentionResolution,
+        resolved_at: datetime,
+    ) -> DevResolutionEntry:
+        committed = (
+            _entity_ref_v2(resolution.entity) if resolution.entity is not None else None
+        )
+        candidates = tuple(
+            DevResolutionCandidate(
+                entity_ref=_entity_ref_v2(candidate),
+                reason="Multiple authorized entities match this name.",
+            )
+            for candidate in resolution.candidates
+        )
+        return DevResolutionEntry(
+            entry_ordinal=ordinal,
+            mention_id=mention.mention_id,
+            outcome=resolution.outcome,
+            committed_entity_ref=committed,
+            candidates=candidates,
+            repository_attribution=(
+                resolution.entity.repository_id if resolution.entity else None
+            ),
+            team_attribution=(
+                resolution.entity.canonical_id
+                if resolution.entity is not None
+                and resolution.entity.kind is EntityKind.TEAM
+                else None
+            ),
+            resolver_version=resolution.query_version,
+            query_version=resolution.catalog_watermark,
+            resolved_at=resolved_at,
+        )
+
+    def _append(
+        self,
+        ledger: DevResolutionLedger,
+        entries: Sequence[DevResolutionEntry],
+        *,
+        resolved_at: datetime,
+    ) -> DevResolutionLedger:
+        """Append entries and prove the result extends the previous snapshot.
+
+        ``validate_ledger_extends`` is called on every update, not only at the
+        persistence boundary: it is the mechanical proof that a later success
+        cannot erase an earlier unresolved mention, and it is cheap enough to
+        run at the one place that constructs a successor ledger.
+        """
+
+        if not entries:
+            return ledger
+        candidate = DevResolutionLedger(
+            schema_version="dev_resolution_ledger.v1",
+            ledger_id=ledger.ledger_id,
+            mention_ids=ledger.mention_ids,
+            entries=ledger.entries + tuple(entries),
+            updated_at=resolved_at,
+        )
+        validate_ledger_extends(ledger, candidate)
+        return candidate
+
+    def _apply_context_tiebreaker(
+        self,
+        *,
+        ledger: DevResolutionLedger,
+        mentions: Sequence[DevSubjectMention],
+        resolutions: Sequence[MentionResolution],
+        context_ref_ids: frozenset[str],
+        resolved_at: datetime,
+    ) -> DevResolutionLedger:
+        """Break an ambiguity with the page's own typed refs — never override one.
+
+        A context ref may only pick between candidates the catalog itself
+        returned for the name the user typed. It can never introduce an entity
+        the user did not name, and it can never overturn an exact match.
+        """
+
+        appended: list[DevResolutionEntry] = []
+        next_ordinal = len(ledger.entries)
+        for mention, resolution in zip(mentions, resolutions, strict=True):
+            if resolution.outcome is not ResolutionOutcome.AMBIGUOUS_CANDIDATES:
+                continue
+            matches = [
+                candidate
+                for candidate in resolution.candidates
+                if candidate.canonical_id in context_ref_ids
+            ]
+            if len(matches) != 1:
+                continue
+            appended.append(
+                self._entry(
+                    ordinal=next_ordinal,
+                    mention=mention,
+                    resolution=MentionResolution(
+                        outcome=ResolutionOutcome.EXACT_MATCH,
+                        entity=matches[0],
+                        candidates=(),
+                        catalog_watermark=resolution.catalog_watermark,
+                        query_version=resolution.query_version,
+                    ),
+                    resolved_at=resolved_at,
+                )
+            )
+            next_ordinal += 1
+        return self._append(ledger, appended, resolved_at=resolved_at)
+
+    def _apply_catalog_reuse(
+        self,
+        *,
+        ledger: DevResolutionLedger,
+        mentions: Sequence[DevSubjectMention],
+        resolutions: Sequence[MentionResolution],
+        authorized_scope: DevScope,
+        resolved_at: datetime,
+    ) -> DevResolutionLedger:
+        """A catalog outage downgrades to "proceed" only on an exact prior commit.
+
+        The reuse is admissible only when this run already holds a committed,
+        same-kind direct scope whose entity *is* the named one. Anything else
+        stays ``catalog_unavailable`` and terminates as temporarily
+        unavailable — a stale guess about a named subject is the same defect as
+        an unresolved one.
+        """
+
+        appended: list[DevResolutionEntry] = []
+        next_ordinal = len(ledger.entries)
+        for mention, resolution in zip(mentions, resolutions, strict=True):
+            if resolution.outcome is not ResolutionOutcome.CATALOG_UNAVAILABLE:
+                continue
+            reusable = self._reusable_entity(mention, authorized_scope)
+            if reusable is None:
+                continue
+            appended.append(
+                self._entry(
+                    ordinal=next_ordinal,
+                    mention=mention,
+                    resolution=MentionResolution(
+                        outcome=ResolutionOutcome.EXACT_MATCH,
+                        entity=reusable,
+                        candidates=(),
+                        catalog_watermark=resolution.catalog_watermark,
+                        query_version=resolution.query_version,
+                    ),
+                    resolved_at=resolved_at,
+                )
+            )
+            next_ordinal += 1
+        return self._append(ledger, appended, resolved_at=resolved_at)
+
+    @staticmethod
+    def _reusable_entity(
+        mention: DevSubjectMention, authorized_scope: DevScope
+    ) -> AuthorizedEntity | None:
+        wanted = mention.normalized_lookup_text.casefold()
+        if authorized_scope.direct_scope.value != mention.requested_entity_kind.value:
+            return None
+        for ref in authorized_scope.entity_refs:
+            if wanted in {ref.entity_id.casefold(), ref.display_label.casefold()}:
+                return AuthorizedEntity(
+                    kind=EntityKind(ref.entity_type.value),
+                    canonical_id=ref.entity_id,
+                    label=ref.display_label,
+                    repository_id=ref.repository_id,
+                )
+        for repository_id in authorized_scope.repositories:
+            if wanted == repository_id.casefold():
+                return AuthorizedEntity(
+                    kind=EntityKind.REPOSITORY,
+                    canonical_id=repository_id,
+                    label=repository_id,
+                    repository_id=repository_id,
+                )
+        return None
+
+    @staticmethod
+    def _authorized_entity_for(entry: DevResolutionEntry) -> AuthorizedEntity:
+        ref = entry.committed_entity_ref
+        if ref is None:  # pragma: no cover - guarded by the caller
+            raise RuntimeError("an exact match must carry a committed entity ref")
+        return AuthorizedEntity(
+            kind=EntityKind(ref.entity_kind.value),
+            canonical_id=ref.entity_id,
+            label=ref.display_label,
+            repository_id=ref.repository_id,
+        )
+
+    def _terminate(
+        self,
+        *,
+        interpretation: InterpretedQuestion,
+        ledger: DevResolutionLedger | None,
+        outcome: PublicOutcome,
+        diagnostic: str,
+        run_id: str,
+        answer_id: str,
+        conversation_id: str,
+        generated_at: datetime,
+        clarification_key: str = "ambiguous",
+    ) -> SubjectPreflightResult:
+        answer = build_preflight_answer(
+            outcome=outcome,
+            intent_id=interpretation.intent.intent_id,
+            versions=self._versions,
+            run_id=run_id,
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            generated_at=generated_at,
+            clarification_key=clarification_key,
+        )
+        return SubjectPreflightResult(
+            decision=PreflightDecision.TERMINATE,
+            interpretation=interpretation,
+            ledger=ledger,
+            committed_resolution=None,
+            answer=answer,
+            outcome=outcome,
+            allowed_tools=frozenset(),
+            diagnostic=diagnostic,
+        )

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -22,7 +22,12 @@ What this module never does
 ---------------------------
 
 * It never constructs ``FORBIDDEN_OR_NOT_FOUND`` — see ``preflight_outcomes``.
-* It never falls back to organization scope for an unresolved named subject.
+* It never answers about one entity under another's name. A *typed* named
+  subject that does not resolve terminates the run. A **bare** name — one the
+  kind-noun grammar could not type, which may not be a subject at all — widens
+  the run to organization scope instead, precisely so a page-derived subject
+  cannot be narrated as the named one, and re-arms the legacy backstop to catch
+  an answer that narrates the name anyway.
 * It never lets a later resolution erase an earlier unresolved one: every
   update appends to the ledger and is checked with ``validate_ledger_extends``.
 """
@@ -36,7 +41,14 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 
-from .contracts import DevContractVersions, DevScope, DevScopeResolution, ToolID
+from .contracts import (
+    DevContractVersions,
+    DevScope,
+    DevScopeResolution,
+    DirectScope,
+    ScopeResolutionOutcome,
+    ToolID,
+)
 from .contracts_v2 import (
     DevAnswerV2,
     DevEntityRefV2,
@@ -126,6 +138,22 @@ class SubjectPreflightResult:
     #: re-armed as terminal for it: that check judges the model's own answer
     #: text, so it fires only if the answer actually narrates the name.
     legacy_guard_required: bool = False
+    #: The normalized bare names that went unresolved. The legacy backstop's own
+    #: grammar only recognizes a name adjacent to an entity noun, so without
+    #: these it cannot see the very names re-arming it is meant to guard.
+    unresolved_name_spans: frozenset[str] = frozenset()
+
+    @property
+    def has_committed_subject(self) -> bool:
+        """Whether a *named subject* was committed, not merely a scope.
+
+        The unresolved-bare-name path commits an organization scope to strip a
+        page-derived subject, which is a scope but emphatically not a subject:
+        telling the model "resolution is already complete" there would be the
+        same false claim the v1/v2 prompt split exists to prevent.
+        """
+
+        return self.committed_resolution is not None and not self.legacy_guard_required
 
     @property
     def all_subjects_committed(self) -> bool:
@@ -308,16 +336,35 @@ class SubjectPreflight:
             # — with the legacy backstop re-armed as terminal, which judges the
             # model's own answer text and so fires only if the answer actually
             # narrates the unresolved name.
+            #
+            # It must continue **organization-wide specifically**. Simply not
+            # committing anything leaves the run holding whatever scope it
+            # arrived with, and on a page-scoped request that is a concrete
+            # subject: "How is Nightfall doing?" asked from an Ask Dev page
+            # would execute status against Ask Dev and answer under the name
+            # Nightfall — the same misattribution one layer down. Widening to
+            # the organization is not a privilege change (the org is the
+            # authenticated tenant, and every native query is bound by org_id
+            # anyway); it removes the specific entity that would otherwise be
+            # silently narrated as the named one.
             return SubjectPreflightResult(
                 decision=PreflightDecision.PROCEED,
                 interpretation=interpretation,
                 ledger=ledger,
-                committed_resolution=None,
+                committed_resolution=self._organization_resolution(
+                    authorized_scope, resolved_at=generated_at
+                ),
                 answer=None,
                 outcome=None,
                 allowed_tools=ALL_TOOLS,
                 blocking_mention_ids=blocking_ids,
                 legacy_guard_required=True,
+                unresolved_name_spans=frozenset(
+                    mention.normalized_lookup_text
+                    for mention in mentions
+                    if mention.mention_id in untyped_ids
+                    and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+                ),
                 diagnostic="proceeded_unresolved_bare_name",
             )
 
@@ -387,6 +434,41 @@ class SubjectPreflight:
         )
 
     # -- construction helpers -------------------------------------------------
+
+    @staticmethod
+    def _organization_resolution(
+        authorized_scope: DevScope, *, resolved_at: datetime
+    ) -> DevScopeResolution:
+        """The run's own organization, with any page-derived subject removed.
+
+        Keeps the request's time window (the question is still about that
+        period) and drops the entity refs, repositories, team filters and
+        surface context that name a specific subject.
+        """
+
+        scope = DevScope(
+            schema_version="dev_scope.v1",
+            organization_id=authorized_scope.organization_id,
+            direct_scope=DirectScope.ORGANIZATION,
+            repositories=[],
+            entity_refs=[],
+            team_ids=[],
+            time_range=authorized_scope.time_range,
+            comparison_range=authorized_scope.comparison_range,
+            surface_context=None,
+        )
+        return DevScopeResolution(
+            schema_version="dev_scope_resolution.v1",
+            requested_scope=authorized_scope,
+            resolved_scope=scope,
+            outcome=ScopeResolutionOutcome.ORGANIZATION_FALLBACK,
+            authorized_repository_ids=[],
+            authorized_entity_ids=[],
+            candidates=[],
+            fallbacks=["organization"],
+            warnings=[],
+            resolved_at=resolved_at,
+        )
 
     @staticmethod
     def _context_ref_ids(request) -> frozenset[str]:

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -59,6 +59,7 @@ from .preflight_outcomes import (
 )
 from .question_interpreter import InterpretedQuestion, QuestionInterpreter
 from .scope_service import (
+    SEARCHABLE_ENTITY_KINDS,
     V1_SEARCHABLE_ENTITY_KINDS,
     AuthorizedEntity,
     EntityKind,
@@ -116,16 +117,27 @@ class SubjectPreflightResult:
     allowed_tools: frozenset[ToolID]
     #: Content-free code recorded on the run row. Never question or entity text.
     diagnostic: str
+    #: Mention IDs whose lack of a committed subject must block a
+    #: subject-bearing tool. Excludes unresolved *untyped* mentions, which we
+    #: are not confident were subjects at all.
+    blocking_mention_ids: frozenset[str] = frozenset()
+    #: True when a bare name went unresolved. The run proceeds organization-
+    #: wide exactly as it does today, but the legacy CHAOS-3289 backstop is
+    #: re-armed as terminal for it: that check judges the model's own answer
+    #: text, so it fires only if the answer actually narrates the name.
+    legacy_guard_required: bool = False
 
     @property
     def all_subjects_committed(self) -> bool:
-        """Whether every mention currently holds an ``exact_match``."""
+        """Whether every *blocking* mention currently holds an exact match."""
 
-        if self.ledger is None:
+        if self.ledger is None or not self.blocking_mention_ids:
             return True
+        latest = self.ledger.latest_by_mention()
         return all(
-            entry.outcome is ResolutionOutcome.EXACT_MATCH
-            for entry in self.ledger.latest_by_mention().values()
+            latest[mention_id].outcome is ResolutionOutcome.EXACT_MATCH
+            for mention_id in self.blocking_mention_ids
+            if mention_id in latest
         )
 
 
@@ -219,13 +231,21 @@ class SubjectPreflight:
 
         await phase(RunState.RESOLVING_SUBJECTS)
         context_ref_ids = self._context_ref_ids(request)
+        untyped_ids = interpretation.untyped_mention_ids
+        all_kinds = tuple(sorted(SEARCHABLE_ENTITY_KINDS, key=lambda kind: kind.value))
         resolutions = await asyncio.gather(
             *(
                 self._scope_service.resolve_mention(
                     org_id,
                     permission_fingerprint,
                     lookup_text=mention.normalized_lookup_text,
-                    kinds=(EntityKind(mention.requested_entity_kind.value),),
+                    kinds=(
+                        # A bare name states no kind, so every searchable kind
+                        # is a legitimate reading of it.
+                        all_kinds
+                        if mention.mention_id in untyped_ids
+                        else (EntityKind(mention.requested_entity_kind.value),)
+                    ),
                     exact=mention.normalized_lookup_text in context_ref_ids,
                 )
                 for mention in mentions
@@ -251,11 +271,23 @@ class SubjectPreflight:
         )
 
         latest = ledger.latest_by_mention()
+        blocking_ids = frozenset(
+            mention.mention_id
+            for mention in mentions
+            if mention.mention_id not in untyped_ids
+        )
+        unresolved_untyped = any(
+            latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+            for mention in mentions
+            if mention.mention_id in untyped_ids
+        )
         # Precedence: the lowest-ordinal unresolved mention wins. Stable and
         # explainable ("the first thing you named"), and independent of catalog
         # latency — a severity ordering would let a slow catalog change the
         # reported outcome between runs, which directly breaks determinism.
         for mention in mentions:
+            if mention.mention_id not in blocking_ids:
+                continue
             entry = latest[mention.mention_id]
             if entry.outcome in UNRESOLVED_OUTCOMES:
                 return self._terminate(
@@ -268,6 +300,26 @@ class SubjectPreflight:
                     conversation_id=conversation_id,
                     generated_at=generated_at,
                 )
+
+        if unresolved_untyped:
+            # A bare name we could not resolve is not proof of a subject, so
+            # blocking here would break questions like "what is our DORA
+            # score?". The run continues organization-wide — today's behaviour
+            # — with the legacy backstop re-armed as terminal, which judges the
+            # model's own answer text and so fires only if the answer actually
+            # narrates the unresolved name.
+            return SubjectPreflightResult(
+                decision=PreflightDecision.PROCEED,
+                interpretation=interpretation,
+                ledger=ledger,
+                committed_resolution=None,
+                answer=None,
+                outcome=None,
+                allowed_tools=ALL_TOOLS,
+                blocking_mention_ids=blocking_ids,
+                legacy_guard_required=True,
+                diagnostic="proceeded_unresolved_bare_name",
+            )
 
         committed = [
             latest[mention.mention_id].committed_entity_ref for mention in mentions
@@ -330,6 +382,7 @@ class SubjectPreflight:
             # channel unreachable on this path, without renaming a token that
             # five published v1 schemas carry.
             allowed_tools=ALL_TOOLS - {ToolID.RESOLVE_SCOPE},
+            blocking_mention_ids=frozenset(mention.mention_id for mention in mentions),
             diagnostic="proceeded_committed_subject",
         )
 

--- a/src/dev_health_ops/api/dev/tool_registry.py
+++ b/src/dev_health_ops/api/dev/tool_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Collection, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -225,7 +225,23 @@ class AskDevToolRegistry:
             raise UnknownToolError("tool is not registered") from exc
         return self._definitions[canonical]
 
-    def manifest(self) -> dict[str, object]:
+    def manifest(
+        self, *, allowed_tool_ids: Collection[ToolID] | None = None
+    ) -> dict[str, object]:
+        """The registry manifest, optionally narrowed to a per-run allowlist.
+
+        Until CHAOS-3292 there was no per-run tool-availability seam at all:
+        every registered tool was advertised on every round, to every question.
+        ``allowed_tool_ids`` is that seam. ``None`` means "advertise everything",
+        which is both the default and the behaviour when no preflight ran.
+        """
+
+        allowed = set(ToolID) if allowed_tool_ids is None else set(allowed_tool_ids)
+        unknown = sorted(str(item) for item in allowed - set(ToolID))
+        if unknown:
+            raise ToolRegistryError(
+                f"tool allowlist names unregistered tools {unknown}"
+            )
         return {
             "version": TOOL_CONTRACT_VERSION,
             "schemas": {
@@ -239,6 +255,7 @@ class AskDevToolRegistry:
             "tools": [
                 self._definitions[tool_id].manifest()
                 for tool_id in sorted(ToolID, key=lambda item: item.value)
+                if tool_id in allowed
             ],
         }
 

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -16,11 +16,16 @@ STANDARD_FEATURE_ROW = tuple[str, str, FeatureCategory, LicenseTier, str]
 CANONICAL_INCIDENT_INGESTION_FEATURE: Final = "canonical_incident_ingestion"
 ASK_DEV_FEATURE: Final = "ask_dev"
 ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE: Final = "ask_dev_contextual_entrypoints"
+#: Wave 3.1 rollout gate (Amendment TRD v2 §15 Phase A). Off means the run
+#: behaves exactly as it does today: no server-owned interpretation, no subject
+#: preflight, every tool advertised, and the CHAOS-3289 backstop terminating.
+ASK_DEV_WAVE_3_1_FEATURE: Final = "ask_dev_wave_3_1"
 EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset(
     {
         "agent_context_runtime",
         ASK_DEV_FEATURE,
         ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE,
+        ASK_DEV_WAVE_3_1_FEATURE,
     }
 )
 ORG_OVERRIDE_ONLY_FEATURES: frozenset[str] = frozenset()
@@ -188,6 +193,13 @@ STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
         FeatureCategory.ANALYTICS,
         LicenseTier.COMMUNITY,
         "Typed Ask Dev handoffs from approved product surfaces",
+    ),
+    (
+        ASK_DEV_WAVE_3_1_FEATURE,
+        "Ask Dev Wave 3.1",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.COMMUNITY,
+        "Server-owned question intent and named-subject preflight",
     ),
     (
         "scheduled_jobs",

--- a/src/dev_health_ops/models/dev_persistence.py
+++ b/src/dev_health_ops/models/dev_persistence.py
@@ -212,13 +212,21 @@ class DevRun(Base):
         String(32), nullable=True
     )
     safe_error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # CHAOS-3292 content-free run diagnostics. Both are members of closed
+    # server-owned vocabularies (never question or entity text): the subject
+    # preflight's outcome, and the legacy CHAOS-3289 backstop's reason code
+    # when it fires on a run the preflight already governed — which TRD §10
+    # classes as a cutover defect worth alerting on rather than acting on.
+    preflight_outcome: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    legacy_guard_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utc_now
     )
 
     __table_args__ = (
         CheckConstraint(
-            "state IN ('accepted', 'resolving_scope', 'model_decision', "
+            "state IN ('accepted', 'resolving_scope', 'interpreting', "
+            "'resolving_subjects', 'model_decision', "
             "'tool_validation', 'tool_execution', 'answer_validation', "
             "'completed', 'insufficient_evidence', 'refused', 'failed', 'cancelled')",
             name="ck_dev_runs_state",

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -1,0 +1,592 @@
+"""Shared deterministic harness for the CHAOS-3292 preflight suites.
+
+Lives in the ``tests`` package (which has an ``__init__.py``, unlike
+``tests/api/dev``) so both mypy and pytest resolve it the same way, following
+``tests/_helpers``. The leading underscore keeps pytest from collecting it, and
+the named acceptance cases live here too so the mutation suite can reuse them
+without importing a test module.
+
+Determinism is the whole point of this file: identical seeded catalog plus an
+identical scripted-provider *script* must produce a byte-identical outcome
+tuple on every iteration. Two things make that true — ``ScriptedAgentProvider``
+consumes a ``deque``, so every iteration builds a fresh provider from a shared
+script factory, and every server-minted UUID comes from an injected
+counter-based factory rather than ``uuid.uuid4``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevAnswer,
+    DevContractVersions,
+    DevMessageRequest,
+    DevScope,
+    DevScopeResolution,
+    DevToolRequest,
+    DevToolResult,
+    QuestionClass,
+    ToolID,
+)
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator, OrchestratorResult
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ScopeRef,
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentMessage,
+    AgentMessageRole,
+    AgentToolDefinition,
+    AgentToolRequest,
+    AgentUsage,
+    CancellationSignal,
+)
+from dev_health_ops.llm.agent.scripted import ScriptedAgentProvider, ScriptedStep
+
+ORG_ID = "org_fullchaos"
+OTHER_ORG_ID = "org_nightfall_holdings"
+USER_ID = "user_01"
+PERMISSION_FINGERPRINT = "permissions_01"
+RUN_ID = "run_01"
+CONVERSATION_ID = "conversation_01"
+ANSWER_ID = "answer_01"
+
+#: Seeded subjects, by owning organization. Every catalog method filters on
+#: ``org_id`` exactly as every ``scope_catalog`` query does in SQL, so
+#: cross-tenant is modelled as a *populated catalog owned by someone else* —
+#: not as an empty catalog, which cannot distinguish forbidden from not-found.
+ASK_DEV_PROJECT = AuthorizedEntity(EntityKind.PROJECT, "project-ask-dev", "Ask Dev")
+PLATFORM_TEAM = AuthorizedEntity(EntityKind.TEAM, "team-platform", "Platform")
+NIGHTFALL_PROJECT = AuthorizedEntity(
+    EntityKind.PROJECT, "project-nightfall", "Nightfall"
+)
+ATLAS_PROJECT_ONE = AuthorizedEntity(EntityKind.PROJECT, "project-atlas-1", "Atlas")
+ATLAS_PROJECT_TWO = AuthorizedEntity(EntityKind.PROJECT, "project-atlas-2", "Atlas")
+PAGE_PROJECT = AuthorizedEntity(EntityKind.PROJECT, "project-page-ctx", "Beacon")
+
+
+class SeededCatalog:
+    """An ``AuthorizedEntityCatalog`` over a fixed, org-scoped entity list."""
+
+    def __init__(
+        self,
+        entities: Sequence[tuple[str, AuthorizedEntity]],
+        *,
+        fail_search: bool = False,
+        fail_watermark: bool = False,
+    ) -> None:
+        self.entities = list(entities)
+        self.fail_search = fail_search
+        self.fail_watermark = fail_watermark
+        self.search_calls: list[tuple[str, str]] = []
+
+    async def watermark(self, org_id: str, kinds: tuple[EntityKind, ...]) -> str:
+        if self.fail_watermark:
+            raise RuntimeError("catalog watermark unavailable")
+        del kinds
+        return f"{org_id}:watermark-1"
+
+    async def exact(
+        self, org_id: str, ref: ScopeRef, *, limit: int
+    ) -> list[AuthorizedEntity]:
+        if self.fail_search:
+            raise RuntimeError("catalog unavailable")
+        return [
+            entity
+            for owner, entity in self.entities
+            if owner == org_id
+            and entity.kind is ref.kind
+            and ref.value.casefold()
+            in {entity.canonical_id.casefold(), entity.label.casefold()}
+        ][:limit]
+
+    async def search(
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+    ) -> list[AuthorizedEntity]:
+        self.search_calls.append((org_id, query))
+        if self.fail_search:
+            raise RuntimeError("catalog unavailable")
+        needle = query.casefold()
+        return [
+            entity
+            for owner, entity in self.entities
+            if owner == org_id
+            and entity.kind in kinds
+            and (
+                needle == entity.canonical_id.casefold()
+                or needle in entity.label.casefold()
+            )
+        ][:limit]
+
+    async def organization_repository_ids(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[str], int]:
+        del org_id, limit
+        return [], 0
+
+
+def sequential_ids() -> Callable[[], str]:
+    """Deterministic, canonical dashed lowercase UUIDs (CHAOS-3294 grammar)."""
+
+    counter = 0
+
+    def mint() -> str:
+        nonlocal counter
+        counter += 1
+        return str(uuid.UUID(int=counter))
+
+    return mint
+
+
+def fixed_now() -> datetime:
+    return datetime(2026, 7, 31, 12, 0, 0, tzinfo=UTC)
+
+
+def scope_dict(**overrides: Any) -> dict[str, Any]:
+    scope = deepcopy(positive_fixtures()["dev_message_request.v1"]["scope"])
+    scope.update(
+        {
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "team_ids": [],
+            "surface_context": None,
+        }
+    )
+    scope.update(overrides)
+    return scope
+
+
+def request_for(
+    question: str,
+    *,
+    question_class: QuestionClass = QuestionClass.STATUS,
+    scope_overrides: dict[str, Any] | None = None,
+    requested_metric_ids: Sequence[str] = (),
+    organization_id: str = ORG_ID,
+) -> DevMessageRequest:
+    payload = deepcopy(positive_fixtures()["dev_message_request.v1"])
+    scope = scope_dict(**(scope_overrides or {}))
+    scope["organization_id"] = organization_id
+    payload.update(
+        {
+            "question": question,
+            "question_class": question_class.value,
+            "scope": scope,
+            "requested_metric_ids": list(requested_metric_ids),
+        }
+    )
+    return DevMessageRequest.model_validate(payload)
+
+
+def versions() -> DevContractVersions:
+    return DevContractVersions.model_validate(
+        positive_fixtures()["dev_answer.v1"]["versions"]
+    )
+
+
+def organization_resolution(scope: DevScope) -> DevScopeResolution:
+    return DevScopeResolution.model_validate(
+        {
+            "schema_version": "dev_scope_resolution.v1",
+            "requested_scope": scope.model_dump(mode="json"),
+            "resolved_scope": scope.model_dump(mode="json"),
+            "outcome": "inherited",
+            "authorized_repository_ids": [],
+            "authorized_entity_ids": [],
+            "candidates": [],
+            "fallbacks": [],
+            "warnings": [],
+            "resolved_at": fixed_now(),
+        }
+    )
+
+
+def answer_payload(*, script_id: str) -> dict[str, Any]:
+    """The stock answer with claims dropped.
+
+    The fixture claim hardcodes a repository ``validity_scope``; these runs
+    commit a project or organization scope, so keeping it would fail answer
+    validation for a reason unrelated to what is under test. Metrics and
+    evidence still come from the tool results, so the grounding floor is met.
+    """
+
+    import hashlib
+
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload["claims"] = []
+    payload["model"] = {
+        "provider_source": "platform",
+        "provider_family": "scripted",
+        "model_fingerprint": hashlib.sha256(script_id.encode()).hexdigest()[:24],
+    }
+    return payload
+
+
+class RecordingProvider:
+    """Captures the exact tool definitions and messages each round was given."""
+
+    def __init__(self, steps: list[ScriptedStep], *, script_id: str) -> None:
+        self._inner = ScriptedAgentProvider(steps, script_id=script_id)
+        self.tool_ids: list[tuple[str, ...]] = []
+        self.user_texts: list[str] = []
+        self.system_texts: list[str] = []
+
+    @property
+    def capabilities(self) -> Any:
+        return self._inner.capabilities
+
+    @property
+    def provider_fingerprint(self) -> str:
+        return self._inner.provider_fingerprint
+
+    @property
+    def model_fingerprint(self) -> str:
+        return self._inner.model_fingerprint
+
+    async def decide(
+        self,
+        messages: Sequence[AgentMessage],
+        tools: Sequence[AgentToolDefinition],
+        response_schema: Mapping[str, Any],
+        timeout_seconds: float,
+        max_output_tokens: int,
+        signal: CancellationSignal | None = None,
+    ) -> AgentDecisionResult:
+        self.tool_ids.append(tuple(tool.tool_id for tool in tools))
+        for message in messages:
+            if message.role is AgentMessageRole.SYSTEM:
+                self.system_texts.append(message.content)
+            elif message.role is AgentMessageRole.USER:
+                self.user_texts.append(message.content)
+        return await self._inner.decide(
+            messages=messages,
+            tools=tools,
+            response_schema=response_schema,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=max_output_tokens,
+            signal=signal,
+        )
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.transitions: list[RunState] = []
+        self.answers: list[DevAnswer] = []
+        self.terminals: list[RunState] = []
+        self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
+
+    async def transition(self, state: RunState) -> None:
+        self.transitions.append(state)
+
+    async def record_tool(self, **values: Any) -> None:
+        del values
+
+    async def record_answer(self, answer: DevAnswer) -> None:
+        self.answers.append(answer)
+
+    async def record_preflight(
+        self, *, preflight_outcome: str | None, legacy_guard_reason: str | None
+    ) -> None:
+        self.preflight_diagnostics.append((preflight_outcome, legacy_guard_reason))
+
+    async def terminal(self, **values: Any) -> None:
+        self.terminals.append(values["state"])
+
+
+def recording_registry(calls: list[DevToolRequest]) -> AskDevToolRegistry:
+    async def execute(_context: Any, request: DevToolRequest) -> DevToolResult:
+        calls.append(request)
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+
+def status_then_answer(script_id: str) -> list[ScriptedStep]:
+    """The script a well-behaved model runs once a subject is committed."""
+
+    return [
+        ScriptedStep(
+            decision=AgentToolRequest(
+                tool_id="status_snapshot.v1",
+                arguments={"limit": 25, "include_comparison": False},
+                call_id="tool_call_01",
+            ),
+            usage=AgentUsage(input_tokens=100, output_tokens=10),
+        ),
+        ScriptedStep(decision=AgentFinalAnswer(answer_payload(script_id=script_id))),
+    ]
+
+
+@dataclass(slots=True)
+class RunOutput:
+    result: OrchestratorResult
+    calls: list[DevToolRequest] = field(default_factory=list)
+    provider: RecordingProvider | None = None
+    recorder: Recorder | None = None
+
+    def outcome_tuple(self) -> tuple[Any, ...]:
+        """The byte-comparable outcome for the determinism loops.
+
+        Deliberately excludes minted correlation handles and timestamps, and
+        deliberately *includes* the recorded tool-call list: an outcome tuple
+        that only carried the terminal state would report "deterministic" for a
+        run that executed different tools each time.
+
+        The demoted legacy guard's reason code is excluded because it is
+        telemetry, not outcome — A13 compares these tuples with the guard
+        disabled, and a firing that *did* change the tuple would mean the guard
+        was still deciding something.
+        """
+
+        return (
+            self.result.state.value,
+            self.result.error.code if self.result.error is not None else None,
+            self.result.error.retryable if self.result.error is not None else None,
+            self.result.answer is not None,
+            tuple(request.tool_id.value for request in self.calls),
+            self.preflight_outcomes(),
+        )
+
+    def preflight_outcomes(self) -> tuple[str | None, ...]:
+        """Preflight outcomes only.
+
+        The demoted legacy guard re-records the same outcome alongside its own
+        reason code; those rows belong to ``guard_reasons``, not here.
+        """
+
+        if self.recorder is None:
+            return ()
+        return tuple(
+            outcome
+            for outcome, guard in self.recorder.preflight_diagnostics
+            if guard is None
+        )
+
+    def guard_reasons(self) -> tuple[str, ...]:
+        if self.recorder is None:
+            return ()
+        return tuple(
+            guard
+            for _outcome, guard in self.recorder.preflight_diagnostics
+            if guard is not None
+        )
+
+
+async def run_preflight_orchestrator(
+    *,
+    question: str,
+    entities: Sequence[tuple[str, AuthorizedEntity]],
+    script: Callable[[str], list[ScriptedStep]] | None = None,
+    script_id: str = "preflight",
+    question_class: QuestionClass = QuestionClass.STATUS,
+    scope_overrides: dict[str, Any] | None = None,
+    requested_metric_ids: Sequence[str] = (),
+    org_id: str = ORG_ID,
+    fail_search: bool = False,
+    preflight_enabled: bool = True,
+) -> RunOutput:
+    """One full orchestrator run with the preflight wired the way production wires it."""
+
+    catalog = SeededCatalog(entities, fail_search=fail_search)
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    mint = sequential_ids()
+    preflight = (
+        SubjectPreflight(
+            interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+            scope_service=scope_service,
+            versions=versions(),
+            mint_id=mint,
+            now=fixed_now,
+        )
+        if preflight_enabled
+        else None
+    )
+    request = request_for(
+        question,
+        question_class=question_class,
+        scope_overrides=scope_overrides,
+        requested_metric_ids=requested_metric_ids,
+        organization_id=org_id,
+    )
+    resolution = organization_resolution(request.scope)
+
+    async def resolve(**_values: Any) -> DevScopeResolution:
+        return resolution
+
+    calls: list[DevToolRequest] = []
+    provider = RecordingProvider(
+        (script or status_then_answer)(script_id), script_id=script_id
+    )
+    recorder = Recorder()
+    orchestrator = DevOrchestrator(
+        provider=provider,
+        provider_source="platform",
+        provider_family="scripted",
+        registry=recording_registry(calls),
+        scope_resolver=resolve,
+        versions=versions(),
+        recorder=recorder,
+        preflight=preflight,
+    )
+    result = await orchestrator.run(
+        request=request,
+        org_id=org_id,
+        user_id=USER_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        run_id=RUN_ID,
+        conversation_id=CONVERSATION_ID,
+        answer_id=ANSWER_ID,
+        cancellation=asyncio.Event(),
+    )
+    return RunOutput(result=result, calls=calls, provider=provider, recorder=recorder)
+
+
+# ---------------------------------------------------------------------------
+# The named acceptance cases
+# ---------------------------------------------------------------------------
+#
+# The case factories live beside the harness rather than in the acceptance test
+# module so the mutation suite can reuse them without importing a test module
+# (which mypy cannot resolve and pytest would collect twice).
+
+
+async def case_a1() -> RunOutput:
+    """A known real project."""
+
+    return await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a1",
+    )
+
+
+async def case_a2() -> RunOutput:
+    """A target that does not exist in this organization's catalog."""
+
+    return await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a2",
+    )
+
+
+async def case_a3() -> RunOutput:
+    """Two authorized entities share the named label."""
+
+    return await run_preflight_orchestrator(
+        question="What's the status of the Atlas project?",
+        entities=[(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)],
+        script_id="a3",
+    )
+
+
+async def case_a4() -> RunOutput:
+    """An organization-wide question that names nothing."""
+
+    return await run_preflight_orchestrator(
+        question="How are we doing on delivery this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a4",
+    )
+
+
+async def case_a6_real_then_fake() -> RunOutput:
+    return await run_preflight_orchestrator(
+        question="Compare project Ask Dev and project Nightfall",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a6a",
+    )
+
+
+async def case_a6_fake_then_real() -> RunOutput:
+    return await run_preflight_orchestrator(
+        question="Compare project Nightfall and project Ask Dev",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a6b",
+    )
+
+
+async def case_a8() -> RunOutput:
+    """Seeded and real — just owned by another tenant."""
+
+    return await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(OTHER_ORG_ID, NIGHTFALL_PROJECT), (ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a8",
+    )
+
+
+async def case_a9() -> RunOutput:
+    """The catalog raises."""
+
+    return await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        fail_search=True,
+        script_id="a9",
+    )
+
+
+async def case_a10() -> RunOutput:
+    """A context ref pointing at an entity that no longer exists."""
+
+    return await run_preflight_orchestrator(
+        question="What is the current state?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        scope_overrides={
+            "entity_refs": [
+                {
+                    "entity_type": "project",
+                    "entity_id": "project-deleted",
+                    "display_label": "Deleted project",
+                    "repository_id": None,
+                }
+            ],
+            "direct_scope": "project",
+        },
+        script_id="a10",
+    )
+
+
+async def case_a11() -> RunOutput:
+    """A named team, which the catalog can resolve but v1 cannot scope."""
+
+    return await run_preflight_orchestrator(
+        question="What is the status of the Platform team?",
+        entities=[(ORG_ID, PLATFORM_TEAM)],
+        script_id="a11",
+    )

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -129,7 +129,7 @@ class SeededCatalog:
         if self.fail_search:
             raise RuntimeError("catalog unavailable")
         needle = query.casefold()
-        return [
+        matched = [
             entity
             for owner, entity in self.entities
             if owner == org_id
@@ -138,7 +138,12 @@ class SeededCatalog:
                 needle == entity.canonical_id.casefold()
                 or needle in entity.label.casefold()
             )
-        ][:limit]
+        ]
+        # ORDER BY lowerUTF8(label), canonical_id ... LIMIT n — the ordering and
+        # the truncation both happen in SQL, so an exact label sorted past the
+        # page boundary never reaches the caller at all.
+        matched.sort(key=lambda entity: (entity.label.casefold(), entity.canonical_id))
+        return matched[:limit]
 
     async def organization_repository_ids(
         self, org_id: str, *, limit: int
@@ -237,6 +242,31 @@ def answer_payload(*, script_id: str) -> dict[str, Any]:
 
     payload = deepcopy(positive_fixtures()["dev_answer.v1"])
     payload["claims"] = []
+    payload["model"] = {
+        "provider_source": "platform",
+        "provider_family": "scripted",
+        "model_fingerprint": hashlib.sha256(script_id.encode()).hexdigest()[:24],
+    }
+    return payload
+
+
+def grounded_answer_payload(
+    *, script_id: str, summary: str, validity_scope: dict[str, Any]
+) -> dict[str, Any]:
+    """An evidence-backed answer that narrates ``summary``.
+
+    Keeping the fixture's claim (and re-pointing its ``validity_scope`` at the
+    run's own scope) is what makes the CHAOS-3289 narration clause reachable:
+    the claim-count clause short-circuits before it on a claim-free answer, so
+    a claim-free fixture cannot exercise fabricated narration at all.
+    """
+
+    import hashlib
+
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload["direct_summary"] = summary
+    payload["claims"][0]["text"] = summary
+    payload["claims"][0]["validity_scope"] = deepcopy(validity_scope)
     payload["model"] = {
         "provider_source": "platform",
         "provider_family": "scripted",

--- a/tests/api/dev/test_chaos_3292_mutations.py
+++ b/tests/api/dev/test_chaos_3292_mutations.py
@@ -1,0 +1,652 @@
+"""CHAOS-3292 mutation suite M1-M9.
+
+Every test here is a **pair**: it first observes the invariant holding on
+unmutated code, then defeats exactly one named seam and observes the same
+invariant fail. A mutation test that only asserted the mutated behaviour would
+not distinguish a guard that closes a gap from one that merely sits beside it.
+
+Mutations are clause-level, not wholesale: the two enforcement points of the
+deny-by-default gate are defeated separately (M1a/M1b) and then together
+(M1c), because a compound guard mutated as a whole can report KILLED while one
+clause inside it is wrong and unasserted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import QuestionClass, ToolID
+from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome, no_answer_policy
+from dev_health_ops.api.dev.contracts_v2.validators import scan_public_text
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.question_interpreter import (
+    ClassifierProposal,
+    QuestionInterpreter,
+)
+from dev_health_ops.api.dev.scope_service import (
+    MentionResolution,
+    ScopeRequestCache,
+    ScopeResolutionService,
+    ScopeSearchRequest,
+)
+from dev_health_ops.api.dev.subject_preflight import (
+    PreflightDecision,
+    SubjectPreflight,
+    SubjectPreflightResult,
+)
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
+    NIGHTFALL_PROJECT,
+    ORG_ID,
+    OTHER_ORG_ID,
+    RunOutput,
+    SeededCatalog,
+    case_a1,
+    case_a2,
+    case_a4,
+    case_a8,
+    case_a9,
+    fixed_now,
+    request_for,
+    sequential_ids,
+    versions,
+)
+
+
+def _subject_tool_calls(output: RunOutput) -> list[str]:
+    from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
+
+    return [
+        request.tool_id.value
+        for request in output.calls
+        if request.tool_id in SUBJECT_BEARING_TOOLS
+    ]
+
+
+def _preflight_for(entities: Any, **kwargs: Any) -> SubjectPreflight:
+    mint = sequential_ids()
+    return SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog(entities, **kwargs), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# M1 — the two enforcement points of the deny-by-default gate
+# ---------------------------------------------------------------------------
+
+
+def _proceed_anyway(keep_ledger: bool) -> Any:
+    """Defeat the pre-loop gate: every termination becomes "proceed"."""
+
+    original = SubjectPreflight.run
+
+    async def mutated(self: SubjectPreflight, **kwargs: Any) -> SubjectPreflightResult:
+        result = await original(self, **kwargs)
+        if result.decision is PreflightDecision.PROCEED:
+            return result
+        return SubjectPreflightResult(
+            decision=PreflightDecision.PROCEED,
+            interpretation=result.interpretation,
+            ledger=result.ledger if keep_ledger else None,
+            committed_resolution=None,
+            answer=None,
+            outcome=None,
+            allowed_tools=frozenset(ToolID),
+            diagnostic="mutated_proceed",
+        )
+
+    return mutated
+
+
+@pytest.mark.asyncio
+async def test_m1a_pre_loop_gate_defeated_is_still_caught_at_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _subject_tool_calls(await case_a2()) == []
+
+    monkeypatch.setattr(SubjectPreflight, "run", _proceed_anyway(keep_ledger=True))
+    mutated = await case_a2()
+
+    # The run no longer terminates early, but the dispatch gate independently
+    # refuses to execute a subject-bearing tool for an unresolved mention.
+    assert mutated.result.state is not RunState.INSUFFICIENT_EVIDENCE
+    assert _subject_tool_calls(mutated) == []
+
+
+@pytest.mark.asyncio
+async def test_m1b_dispatch_gate_defeated_is_still_caught_before_the_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _subject_tool_calls(await case_a2()) == []
+
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_subject_gate_rejection",
+        staticmethod(lambda **_kwargs: None),
+    )
+    mutated = await case_a2()
+
+    assert mutated.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert _subject_tool_calls(mutated) == []
+
+
+@pytest.mark.asyncio
+async def test_m1c_defeating_both_gates_lets_the_subject_tool_execute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-before observation that makes M1a and M1b non-vacuous.
+
+    If a subject-bearing tool could not execute for this question even with
+    *both* gates removed, neither gate would be proven to be doing anything.
+    """
+
+    assert _subject_tool_calls(await case_a2()) == []
+
+    monkeypatch.setattr(SubjectPreflight, "run", _proceed_anyway(keep_ledger=False))
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_subject_gate_rejection",
+        staticmethod(lambda **_kwargs: None),
+    )
+    mutated = await case_a2()
+
+    assert _subject_tool_calls(mutated) == ["status_snapshot.v1"]
+
+
+# ---------------------------------------------------------------------------
+# M2 — an unresolved subject falling through to organization scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m2_no_authorized_match_must_not_fall_through_to_organization_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = await case_a2()
+    assert baseline.result.error is not None
+    assert baseline.result.error.code == "scope_not_found"
+    assert _subject_tool_calls(baseline) == []
+
+    # The CHAOS-3289 defect, reintroduced: the named subject is unresolved and
+    # the run answers about the organization under that name anyway.
+    monkeypatch.setattr(SubjectPreflight, "run", _proceed_anyway(keep_ledger=False))
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_subject_gate_rejection",
+        staticmethod(lambda **_kwargs: None),
+    )
+    mutated = await case_a2()
+
+    assert _subject_tool_calls(mutated) == ["status_snapshot.v1"]
+    assert mutated.calls[0].scope.direct_scope.value == "organization"
+
+
+@pytest.mark.asyncio
+async def test_m2_multi_mention_fallthrough_is_caught_in_both_orders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests._chaos_3292_preflight import (
+        case_a6_fake_then_real,
+        case_a6_real_then_fake,
+    )
+
+    for case in (case_a6_real_then_fake, case_a6_fake_then_real):
+        assert _subject_tool_calls(await case()) == []
+
+    monkeypatch.setattr(SubjectPreflight, "run", _proceed_anyway(keep_ledger=False))
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_subject_gate_rejection",
+        staticmethod(lambda **_kwargs: None),
+    )
+    for case in (case_a6_real_then_fake, case_a6_fake_then_real):
+        assert _subject_tool_calls(await case()) == ["status_snapshot.v1"]
+
+
+# ---------------------------------------------------------------------------
+# M3 — an internal token reaching public copy
+# ---------------------------------------------------------------------------
+
+
+_LEAKY_COPY = "No matching subject was found (forbidden_or_not_found)."
+
+
+@pytest.mark.asyncio
+async def test_m3a_leaky_canonical_copy_cannot_be_constructed_at_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layer one: the frame refuses to exist.
+
+    Mutating the canonical table also defeats the no-answer *allowlist*
+    projection, because the builder and the allowlist read the same object.
+    Guardrail (a) is independent of it and scans the frame's public copy
+    fields, so the leaked token fails the whole termination closed instead of
+    reaching a client.
+    """
+
+    baseline = await case_a8()
+    assert baseline.result.error is not None
+    assert baseline.result.error.code == "scope_not_found"
+
+    monkeypatch.setitem(
+        no_answer_policy.CANONICAL_NO_ANSWER_COPY,
+        "not_found",
+        _LEAKY_COPY,
+    )
+    mutated = await case_a8()
+
+    assert mutated.result.error is not None
+    assert mutated.result.error.code == "internal_error"
+    assert scan_public_text(mutated.result.error.safe_message) == []
+
+
+@pytest.mark.asyncio
+async def test_m3b_with_the_leakage_guard_also_disabled_a8_is_the_net(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layer two: defeat guardrail (a) as well, and watch A8's scan catch it."""
+
+    from dev_health_ops.api.dev.contracts_v2 import validators as validators_module
+
+    monkeypatch.setitem(
+        no_answer_policy.CANONICAL_NO_ANSWER_COPY,
+        "not_found",
+        _LEAKY_COPY,
+    )
+    monkeypatch.setattr(
+        validators_module, "validate_no_internal_leakage", lambda _frame: None
+    )
+    mutated = await case_a8()
+
+    assert mutated.result.error is not None
+    assert scan_public_text(mutated.result.error.safe_message) == [
+        "forbidden_or_not_found"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# M4 — the ledger overwriting instead of appending
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m4_ledger_overwrite_instead_of_append_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atlas_ref = {
+        "entity_type": "project",
+        "entity_id": ATLAS_PROJECT_TWO.canonical_id,
+        "display_label": "Atlas",
+        "repository_id": None,
+    }
+    request = request_for(
+        "What's the status of the Atlas project?",
+        scope_overrides={
+            "direct_scope": "project",
+            "entity_refs": [atlas_ref],
+            "surface_context": {
+                "route_id": "project_detail",
+                "entity_refs": [atlas_ref],
+                "filter_fingerprint": "filters_01",
+            },
+        },
+    )
+
+    async def run_once() -> Any:
+        preflight = _preflight_for(
+            [(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]
+        )
+        return await preflight.run(
+            request=request,
+            org_id=ORG_ID,
+            permission_fingerprint="permissions_01",
+            authorized_scope=request.scope,
+            run_id="run_01",
+            answer_id="answer_01",
+            conversation_id="conversation_01",
+        )
+
+    baseline = await run_once()
+    assert baseline.ledger is not None
+    assert len(baseline.ledger.entries) == 2
+    assert baseline.ledger.entries[0].outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+
+    from dev_health_ops.api.dev import subject_preflight as preflight_module
+
+    def overwrite_last(
+        self: SubjectPreflight, ledger: Any, entries: Any, *, resolved_at: Any
+    ) -> Any:
+        del self, resolved_at
+        if not entries:
+            return ledger
+        # "Erase the earlier unresolved entry and put the successful one in its
+        # place" — the exact history rewrite the append-only ledger forbids.
+        # ``model_copy`` does not re-validate, so the model's own contiguity
+        # rule cannot see this; the cross-snapshot check is the only guard, and
+        # it is still called here so the mutation isolates that one clause.
+        candidate = ledger.model_copy(update={"entries": tuple(entries)})
+        preflight_module.validate_ledger_extends(ledger, candidate)
+        return candidate
+
+    monkeypatch.setattr(SubjectPreflight, "_append", overwrite_last)
+    with pytest.raises(ValueError, match="cannot shrink|cannot rewrite or erase"):
+        await run_once()
+
+    # ...and with that one guard disabled the erasure goes through unnoticed,
+    # which is what makes the assertion above non-vacuous.
+    monkeypatch.setattr(
+        preflight_module, "validate_ledger_extends", lambda _previous, _candidate: None
+    )
+    erased = await run_once()
+    assert erased.ledger is not None
+    assert len(erased.ledger.entries) == 1
+    assert erased.ledger.entries[0].outcome is ResolutionOutcome.EXACT_MATCH
+
+
+# ---------------------------------------------------------------------------
+# M5 — the legacy guard terminating on the preflight path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m5_legacy_guard_must_not_terminate_a_preflight_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = await case_a4()
+    assert baseline.result.state is RunState.COMPLETED
+    # The guard did fire — it just did not decide anything.
+    assert baseline.guard_reasons() == ("no_evidence_backed_claims",)
+
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_legacy_guard_is_terminal",
+        staticmethod(lambda _preflight: True),
+    )
+    mutated = await case_a4()
+
+    assert mutated.result.state is RunState.INSUFFICIENT_EVIDENCE
+
+
+# ---------------------------------------------------------------------------
+# M6 — the constrained classifier authoring an entity name
+# ---------------------------------------------------------------------------
+
+
+class _FabricatingClassifier:
+    """Proposes a span that is not in the question at all."""
+
+    def __init__(self, span: str) -> None:
+        self.span = span
+
+    async def classify(self, *, question: str) -> ClassifierProposal:
+        del question
+        return ClassifierProposal(
+            intent_id="entity_status",
+            cardinality="singular",
+            candidates=((self.span, "project"),),
+            confidence=0.95,
+        )
+
+
+@pytest.mark.asyncio
+async def test_m6_a_span_absent_from_the_question_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    question = "How are things looking?"
+    interpreter = QuestionInterpreter(
+        classifier=_FabricatingClassifier("Nightfall"),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    )
+    baseline = await interpreter.interpret(request_for(question))
+
+    # Rejected: the model cannot introduce a subject the user never named.
+    assert baseline.mentions == ()
+    assert "fallback.rejected" in baseline.intent.interpretation_reasons
+
+    original = QuestionInterpreter._validate_proposal
+
+    def without_substring_check(proposal: ClassifierProposal, *, question: str) -> Any:
+        return original(proposal, question=question + proposal.candidates[0][0])
+
+    monkeypatch.setattr(
+        QuestionInterpreter,
+        "_validate_proposal",
+        staticmethod(without_substring_check),
+    )
+    mutated = await QuestionInterpreter(
+        classifier=_FabricatingClassifier("Nightfall"),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    ).interpret(request_for(question))
+
+    assert [mention.original_text_span for mention in mutated.mentions] == ["Nightfall"]
+
+
+@pytest.mark.asyncio
+async def test_m6_an_in_question_span_is_accepted() -> None:
+    """Anti-vacuity: the post-validation must not reject everything."""
+
+    question = "How is Nightfall looking?"
+    interpreted = await QuestionInterpreter(
+        classifier=_FabricatingClassifier("Nightfall"),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    ).interpret(request_for(question))
+
+    assert [mention.original_text_span for mention in interpreted.mentions] == [
+        "Nightfall"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# M7 — the interpreter planning from the client's question_class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m7_intent_is_independent_of_the_client_question_class_hint() -> None:
+    question = "What's the status of the Ask Dev project?"
+    intents = set()
+    for question_class in QuestionClass:
+        interpreted = await QuestionInterpreter(
+            mint_id=sequential_ids(), now=fixed_now
+        ).interpret(request_for(question, question_class=question_class))
+        intents.add(interpreted.intent.intent_id)
+        # Recorded for audit, with its mandatory deprecation warning.
+        assert interpreted.intent.client_question_class_hint is question_class
+        assert interpreted.intent.client_hint_deprecation_warning is not None
+
+    assert len(intents) == 1
+
+
+@pytest.mark.asyncio
+async def test_m7_a_hint_reading_interpreter_is_caught_by_that_invariant() -> None:
+    """The fail-before half: the invariant above can actually fail.
+
+    A real interpreter that plans from the client's ``question_class`` — the
+    thing the Wave 3.1 request amendment forbids — is run through the exact
+    same loop, and produces a different intent per hint.
+    """
+
+    from dev_health_ops.api.dev.contracts_v2 import QuestionIntentID
+    from dev_health_ops.api.dev.question_interpreter import InterpretedQuestion
+
+    hint_to_intent = {
+        QuestionClass.STATUS: QuestionIntentID.ENTITY_STATUS,
+        QuestionClass.REMAINING_WORK: QuestionIntentID.REMAINING_WORK,
+        QuestionClass.OBSERVED_CHANGE: QuestionIntentID.OBSERVED_CHANGE,
+        QuestionClass.REGISTERED_STATISTICS: QuestionIntentID.REGISTERED_STATISTICS,
+        QuestionClass.DATA_TRUST: QuestionIntentID.DATA_TRUST,
+        QuestionClass.INVESTIGATION: QuestionIntentID.BOUNDED_INVESTIGATION,
+    }
+
+    class HintPlanningInterpreter(QuestionInterpreter):
+        async def interpret(self, request: Any) -> InterpretedQuestion:
+            interpreted = await super().interpret(request)
+            return InterpretedQuestion(
+                intent=interpreted.intent.model_copy(
+                    update={"intent_id": hint_to_intent[request.question_class]}
+                ),
+                mentions=interpreted.mentions,
+            )
+
+    question = "What's the status of the Ask Dev project?"
+    intents = set()
+    for question_class in QuestionClass:
+        interpreted = await HintPlanningInterpreter(
+            mint_id=sequential_ids(), now=fixed_now
+        ).interpret(request_for(question, question_class=question_class))
+        intents.add(interpreted.intent.intent_id)
+
+    assert len(intents) > 1
+
+
+# ---------------------------------------------------------------------------
+# M8 — the tool-availability seam restoring a withheld tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m8_manifest_ignoring_the_allowlist_readvertises_resolve_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = await case_a1()
+    assert baseline.provider is not None
+    for advertised in baseline.provider.tool_ids:
+        assert ToolID.RESOLVE_SCOPE.value not in advertised
+
+    original = AskDevToolRegistry.manifest
+
+    def unfiltered(
+        self: AskDevToolRegistry, *, allowed_tool_ids: Any = None
+    ) -> dict[str, object]:
+        del allowed_tool_ids
+        return original(self)
+
+    monkeypatch.setattr(AskDevToolRegistry, "manifest", unfiltered)
+    mutated = await case_a1()
+
+    assert mutated.provider is not None
+    assert any(
+        ToolID.RESOLVE_SCOPE.value in advertised
+        for advertised in mutated.provider.tool_ids
+    )
+    # Defense in depth: advertising it does not make it executable.
+    assert "resolve_scope.v1" not in [
+        request.tool_id.value for request in mutated.calls
+    ]
+
+
+# ---------------------------------------------------------------------------
+# M9 — resolve_mention's catalog wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m9_removing_the_catalog_wrapper_turns_an_outage_into_internal_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = await case_a9()
+    assert baseline.result.error is not None
+    assert baseline.result.error.code == "source_unavailable"
+    assert baseline.result.error.retryable is True
+
+    async def unwrapped(
+        self: ScopeResolutionService,
+        org_id: str,
+        permission_fingerprint: str,
+        *,
+        lookup_text: str,
+        kinds: Any,
+        exact: bool = False,
+    ) -> MentionResolution:
+        del exact
+        # The pre-CHAOS-3292 shape: search() has no exception handling of its
+        # own, so a catalog failure escapes to the orchestrator's generic
+        # handler and is reported as an opaque server fault.
+        result = await self.search(
+            org_id,
+            permission_fingerprint,
+            ScopeSearchRequest(query=lookup_text[:256], kinds=tuple(kinds)),
+        )
+        return MentionResolution(
+            outcome=(
+                ResolutionOutcome.EXACT_MATCH
+                if len(result.candidates) == 1
+                else ResolutionOutcome.NO_AUTHORIZED_MATCH
+            ),
+            entity=result.candidates[0] if len(result.candidates) == 1 else None,
+            candidates=(),
+            catalog_watermark=result.catalog_watermark,
+            query_version=result.query_version,
+        )
+
+    monkeypatch.setattr(ScopeResolutionService, "resolve_mention", unwrapped)
+    mutated = await case_a9()
+
+    assert mutated.result.error is not None
+    assert mutated.result.error.code == "internal_error"
+    assert mutated.result.error.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_m9_catalog_unavailable_is_reachable_at_the_service_level() -> None:
+    """Directly, without the orchestrator, so the typing is not inferred."""
+
+    service = ScopeResolutionService(
+        SeededCatalog([(ORG_ID, ASK_DEV_PROJECT)], fail_search=True),
+        cache=ScopeRequestCache(),
+    )
+    from dev_health_ops.api.dev.scope_service import EntityKind
+
+    resolution = await service.resolve_mention(
+        ORG_ID,
+        "permissions_01",
+        lookup_text="Ask Dev",
+        kinds=(EntityKind.PROJECT,),
+    )
+    assert resolution.outcome is ResolutionOutcome.CATALOG_UNAVAILABLE
+
+    healthy = ScopeResolutionService(
+        SeededCatalog([(ORG_ID, ASK_DEV_PROJECT)]), cache=ScopeRequestCache()
+    )
+    assert (
+        await healthy.resolve_mention(
+            ORG_ID,
+            "permissions_01",
+            lookup_text="Ask Dev",
+            kinds=(EntityKind.PROJECT,),
+        )
+    ).outcome is ResolutionOutcome.EXACT_MATCH
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_never_reports_forbidden() -> None:
+    """A8's other half, at the service level: cross-tenant is not-found."""
+
+    from dev_health_ops.api.dev.scope_service import EntityKind
+
+    service = ScopeResolutionService(
+        SeededCatalog([(OTHER_ORG_ID, NIGHTFALL_PROJECT)]), cache=ScopeRequestCache()
+    )
+    resolution = await service.resolve_mention(
+        ORG_ID,
+        "permissions_01",
+        lookup_text="Nightfall",
+        kinds=(EntityKind.PROJECT,),
+    )
+    assert resolution.outcome is ResolutionOutcome.NO_AUTHORIZED_MATCH
+    assert resolution.candidates == ()

--- a/tests/api/dev/test_chaos_3292_mutations.py
+++ b/tests/api/dev/test_chaos_3292_mutations.py
@@ -104,6 +104,16 @@ def _proceed_anyway(keep_ledger: bool) -> Any:
             answer=None,
             outcome=None,
             allowed_tools=frozenset(ToolID),
+            # Defeating the *pre-loop* gate must not also erase what the
+            # dispatch gate reads, or M1a would be testing two mutations.
+            blocking_mention_ids=(
+                result.blocking_mention_ids
+                or frozenset(
+                    mention.mention_id for mention in result.interpretation.mentions
+                )
+                if keep_ledger
+                else frozenset()
+            ),
             diagnostic="mutated_proceed",
         )
 
@@ -372,7 +382,7 @@ async def test_m5_legacy_guard_must_not_terminate_a_preflight_run(
     monkeypatch.setattr(
         DevOrchestrator,
         "_legacy_guard_is_terminal",
-        staticmethod(lambda _preflight: True),
+        staticmethod(lambda _preflight, _reason: True),
     )
     mutated = await case_a4()
 

--- a/tests/api/dev/test_chaos_3292_preflight_acceptance.py
+++ b/tests/api/dev/test_chaos_3292_preflight_acceptance.py
@@ -1,0 +1,857 @@
+"""CHAOS-3292 acceptance harness A1-A13.
+
+Every case asserts the *state the system exists to reach* — which tool actually
+received which scope, and which tools were never called at all — rather than
+that a code path ran. A2/A3/A9 in particular assert against a recorded call
+list, never against the absence of an exception: a run that crashed before
+dispatch would satisfy "no exception" while proving nothing.
+
+Anti-vacuity guards are asserted explicitly (``test_harness_is_not_vacuous``):
+the registry really does register every subject-bearing tool, and every
+determinism loop really did run twenty iterations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import DirectScope, QuestionClass, ToolID
+from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome
+from dev_health_ops.api.dev.contracts_v2.validators import scan_public_text
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
+from dev_health_ops.llm.agent.contracts import (
+    AgentFinalAnswer,
+    AgentToolRequest,
+    AgentUsage,
+)
+from dev_health_ops.llm.agent.scripted import ScriptedStep
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
+    NIGHTFALL_PROJECT,
+    ORG_ID,
+    OTHER_ORG_ID,
+    PAGE_PROJECT,
+    PLATFORM_TEAM,
+    RunOutput,
+    answer_payload,
+    case_a1,
+    case_a2,
+    case_a3,
+    case_a4,
+    case_a6_fake_then_real,
+    case_a6_real_then_fake,
+    case_a8,
+    case_a9,
+    case_a10,
+    case_a11,
+    run_preflight_orchestrator,
+)
+
+DETERMINISM_ITERATIONS = 20
+
+
+def _subject_bearing_calls(output: RunOutput) -> list[str]:
+    return [
+        request.tool_id.value
+        for request in output.calls
+        if request.tool_id in SUBJECT_BEARING_TOOLS
+    ]
+
+
+def _public_strings(output: RunOutput) -> list[str]:
+    values: list[str] = []
+    if output.result.error is not None:
+        values.append(output.result.error.safe_message)
+        values.append(output.result.error.code)
+        values.extend(output.result.error.remediation)
+    if output.result.answer is not None:
+        values.append(output.result.answer.direct_summary)
+        values.extend(claim.text for claim in output.result.answer.claims)
+        values.extend(output.result.answer.warnings)
+    return values
+
+
+async def _twenty(coro_factory: Any) -> list[tuple[Any, ...]]:
+    results = [(await coro_factory()).outcome_tuple() for _ in range(20)]
+    # Rule 4: a measurement that did not happen must fail loudly. An empty or
+    # short list would otherwise make `len(set(results)) == 1` vacuously true.
+    assert len(results) == DETERMINISM_ITERATIONS
+    return results
+
+
+# ---------------------------------------------------------------------------
+# A1 — a known real project commits before any subject-bearing tool runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a1_known_project_commits_scope_before_the_status_tool() -> None:
+    output = await case_a1()
+
+    assert output.result.state is RunState.COMPLETED
+    assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
+    status_call = output.calls[0]
+    assert status_call.scope.direct_scope is DirectScope.PROJECT
+    assert [ref.entity_id for ref in status_call.scope.entity_refs] == [
+        ASK_DEV_PROJECT.canonical_id
+    ]
+    # The commit is recorded before the first tool dispatch, not after it.
+    assert output.preflight_outcomes() == ("proceeded_committed_subject",)
+    assert output.recorder is not None
+    assert output.recorder.transitions.index(
+        RunState.RESOLVING_SUBJECTS
+    ) < output.recorder.transitions.index(RunState.TOOL_EXECUTION)
+
+
+@pytest.mark.asyncio
+async def test_a1_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_a1)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# A2 — a nonexistent target executes nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2_unknown_target_is_not_found_and_runs_no_subject_tool() -> None:
+    output = await case_a2()
+
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert output.result.error.retryable is False
+    assert _subject_bearing_calls(output) == []
+    assert output.calls == []
+    assert output.provider is not None
+    # Not one provider round either: the preflight spends zero model tokens.
+    assert output.provider.tool_ids == []
+
+
+@pytest.mark.asyncio
+async def test_a2_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_a2)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# A3 — an ambiguous target asks for clarification and carries both candidates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a3_ambiguous_target_needs_clarification_with_candidates() -> None:
+    output = await case_a3()
+
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_ambiguous"
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a3_ledger_records_both_authorized_candidates() -> None:
+    from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+    from dev_health_ops.api.dev.scope_service import (
+        ScopeRequestCache,
+        ScopeResolutionService,
+    )
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from tests._chaos_3292_preflight import (
+        SeededCatalog,
+        fixed_now,
+        request_for,
+        sequential_ids,
+        versions,
+    )
+
+    mint = sequential_ids()
+    catalog = SeededCatalog([(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)])
+    preflight = SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(catalog, cache=ScopeRequestCache()),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+    request = request_for("What's the status of the Atlas project?")
+    result = await preflight.run(
+        request=request,
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+    )
+
+    assert result.ledger is not None
+    entry = next(iter(result.ledger.latest_by_mention().values()))
+    assert entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+    assert sorted(candidate.entity_ref.entity_id for candidate in entry.candidates) == [
+        ATLAS_PROJECT_ONE.canonical_id,
+        ATLAS_PROJECT_TWO.canonical_id,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# A4 — an organization-wide question is not blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a4_organization_wide_question_executes_normally() -> None:
+    output = await case_a4()
+
+    assert output.result.state is RunState.COMPLETED
+    assert _subject_bearing_calls(output) == ["status_snapshot.v1"]
+    assert output.calls[0].scope.direct_scope is DirectScope.ORGANIZATION
+    assert output.preflight_outcomes()[0] == "proceeded_organization_wide"
+    # With nothing committed, resolve_scope.v1 stays available: a name the
+    # extractor missed must still be resolvable by the model.
+    assert output.provider is not None
+    assert ToolID.RESOLVE_SCOPE.value in output.provider.tool_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_a4_legacy_guard_fires_as_telemetry_without_changing_the_outcome() -> (
+    None
+):
+    """The demotion, observed rather than asserted in the abstract.
+
+    This claim-free organization-wide answer is exactly the shape the
+    CHAOS-3289 backstop terminates on today. On the preflight path it still
+    *fires* — TRD §10 keeps it as defense in depth — but the run completes and
+    the reason is recorded as a content-free diagnostic instead of becoming
+    public copy.
+    """
+
+    with_preflight = await case_a4()
+    assert with_preflight.guard_reasons() == ("no_evidence_backed_claims",)
+    assert with_preflight.result.state is RunState.COMPLETED
+
+    without_preflight = await run_preflight_orchestrator(
+        question="How are we doing on delivery this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="a4-off",
+        preflight_enabled=False,
+    )
+    # Same guard, same input, opposite consequence: on the flag-off path it is
+    # still the terminating check it is in production today.
+    assert without_preflight.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert without_preflight.result.error is not None
+    assert without_preflight.result.error.code == "insufficient_evidence"
+
+
+@pytest.mark.asyncio
+async def test_a4_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_a4)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# A5 — the guarantee holds for non-status named-target intents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "question_class", "metric_ids"),
+    [
+        ("What's left on the Nightfall project?", QuestionClass.REMAINING_WORK, ()),
+        (
+            "What changed in the Nightfall project since last week?",
+            QuestionClass.OBSERVED_CHANGE,
+            (),
+        ),
+        (
+            "Compare items completed for the Nightfall project against last month",
+            QuestionClass.INVESTIGATION,
+            ("items_completed",),
+        ),
+        ("Is the data for the Nightfall project stale?", QuestionClass.DATA_TRUST, ()),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a5_non_status_named_targets_are_gated_identically(
+    question: str, question_class: QuestionClass, metric_ids: tuple[str, ...]
+) -> None:
+    output = await run_preflight_orchestrator(
+        question=question,
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        question_class=question_class,
+        requested_metric_ids=metric_ids,
+        script_id="a5",
+    )
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a5_non_status_named_target_commits_when_it_resolves() -> None:
+    output = await run_preflight_orchestrator(
+        question="What's left on the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        question_class=QuestionClass.REMAINING_WORK,
+        script_id="a5-ok",
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.calls[0].scope.direct_scope is DirectScope.PROJECT
+
+
+# ---------------------------------------------------------------------------
+# A6 — multi-mention, both orders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case_a6_real_then_fake, case_a6_fake_then_real],
+    ids=["real_first", "fake_first"],
+)
+@pytest.mark.asyncio
+async def test_a6_one_unresolved_mention_blocks_regardless_of_order(
+    case: Any,
+) -> None:
+    output = await case()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a6_ledger_records_every_mention_including_the_resolved_one() -> None:
+    from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+    from dev_health_ops.api.dev.scope_service import (
+        ScopeRequestCache,
+        ScopeResolutionService,
+    )
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from tests._chaos_3292_preflight import (
+        SeededCatalog,
+        fixed_now,
+        request_for,
+        sequential_ids,
+        versions,
+    )
+
+    mint = sequential_ids()
+    preflight = SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog([(ORG_ID, ASK_DEV_PROJECT)]), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+    request = request_for("Compare project Ask Dev and project Nightfall")
+    result = await preflight.run(
+        request=request,
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+    )
+
+    assert result.ledger is not None
+    assert len(result.ledger.entries) >= 2
+    outcomes = {entry.outcome for entry in result.ledger.latest_by_mention().values()}
+    assert outcomes == {
+        ResolutionOutcome.EXACT_MATCH,
+        ResolutionOutcome.NO_AUTHORIZED_MATCH,
+    }
+
+
+# ---------------------------------------------------------------------------
+# A7 — the ledger appends across a retry, never overwrites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a7_ledger_append_across_a_context_tiebreak_extends_the_snapshot() -> (
+    None
+):
+    from dev_health_ops.api.dev.contracts_v2 import (
+        DevResolutionLedger,
+        validate_ledger_extends,
+    )
+    from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+    from dev_health_ops.api.dev.scope_service import (
+        ScopeRequestCache,
+        ScopeResolutionService,
+    )
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from tests._chaos_3292_preflight import (
+        SeededCatalog,
+        fixed_now,
+        request_for,
+        sequential_ids,
+        versions,
+    )
+
+    mint = sequential_ids()
+    preflight = SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog([(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]),
+            cache=ScopeRequestCache(),
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+    # The page context names one of the two Atlas projects, so the ambiguity is
+    # broken by a *second appended entry*, never by rewriting the first.
+    atlas_ref = {
+        "entity_type": "project",
+        "entity_id": ATLAS_PROJECT_TWO.canonical_id,
+        "display_label": "Atlas",
+        "repository_id": None,
+    }
+    request = request_for(
+        "What's the status of the Atlas project?",
+        scope_overrides={
+            "direct_scope": "project",
+            "entity_refs": [atlas_ref],
+            "surface_context": {
+                "route_id": "project_detail",
+                "entity_refs": [atlas_ref],
+                "filter_fingerprint": "filters_01",
+            },
+        },
+    )
+    result = await preflight.run(
+        request=request,
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+    )
+
+    assert result.ledger is not None
+    assert len(result.ledger.entries) == 2
+    assert result.ledger.entries[0].outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+    assert result.ledger.entries[1].outcome is ResolutionOutcome.EXACT_MATCH
+    # The earlier unresolved entry survives verbatim.
+    first_snapshot = DevResolutionLedger(
+        schema_version="dev_resolution_ledger.v1",
+        ledger_id=result.ledger.ledger_id,
+        mention_ids=result.ledger.mention_ids,
+        entries=result.ledger.entries[:1],
+        updated_at=result.ledger.updated_at,
+    )
+    validate_ledger_extends(first_snapshot, result.ledger)
+
+
+@pytest.mark.asyncio
+async def test_a7_a_ledger_that_erases_an_entry_is_rejected() -> None:
+    """The fail-before half: prove the append-only check can actually fail."""
+
+    from dev_health_ops.api.dev.contracts_v2 import (
+        DevResolutionEntry,
+        DevResolutionLedger,
+        validate_ledger_extends,
+    )
+    from tests._chaos_3292_preflight import fixed_now
+
+    def entry(ordinal: int, outcome: ResolutionOutcome) -> DevResolutionEntry:
+        return DevResolutionEntry(
+            entry_ordinal=ordinal,
+            mention_id="00000000-0000-0000-0000-000000000001",
+            outcome=outcome,
+            committed_entity_ref=(
+                {
+                    "entity_kind": "project",
+                    "entity_id": ASK_DEV_PROJECT.canonical_id,
+                    "display_label": "Ask Dev",
+                }
+                if outcome is ResolutionOutcome.EXACT_MATCH
+                else None
+            ),
+            resolver_version="resolve-scope.v1",
+            query_version="watermark-1",
+            resolved_at=fixed_now(),
+        )
+
+    def ledger(*entries: DevResolutionEntry) -> DevResolutionLedger:
+        return DevResolutionLedger(
+            schema_version="dev_resolution_ledger.v1",
+            ledger_id="00000000-0000-0000-0000-0000000000ff",
+            mention_ids=("00000000-0000-0000-0000-000000000001",),
+            entries=entries,
+            updated_at=fixed_now(),
+        )
+
+    previous = ledger(entry(0, ResolutionOutcome.NO_AUTHORIZED_MATCH))
+    erased = ledger(entry(0, ResolutionOutcome.EXACT_MATCH))
+    with pytest.raises(ValueError, match="cannot rewrite or erase"):
+        validate_ledger_extends(previous, erased)
+
+
+# ---------------------------------------------------------------------------
+# A8 — cross-tenant reads as not-found and discloses nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a8_cross_tenant_subject_is_not_found_and_leaks_nothing() -> None:
+    output = await case_a8()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+    for value in _public_strings(output):
+        assert scan_public_text(value) == []
+        assert NIGHTFALL_PROJECT.label.casefold() not in value.casefold()
+        assert NIGHTFALL_PROJECT.canonical_id.casefold() not in value.casefold()
+
+
+@pytest.mark.asyncio
+async def test_a8_the_same_subject_resolves_for_its_own_tenant() -> None:
+    """Anti-vacuity: A8 would pass on a broken catalog that finds nothing."""
+
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(OTHER_ORG_ID, NIGHTFALL_PROJECT)],
+        org_id=OTHER_ORG_ID,
+        script_id="a8-owner",
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.calls[0].scope.direct_scope is DirectScope.PROJECT
+
+
+# ---------------------------------------------------------------------------
+# A9 — a catalog outage is typed, not an internal error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a9_catalog_outage_is_temporarily_unavailable_and_retryable() -> None:
+    output = await case_a9()
+
+    assert output.result.state is RunState.FAILED
+    assert output.result.error is not None
+    # Not internal_error: search() has no try/except of its own, so before
+    # resolve_mention wrapped it a ClickHouse failure escaped as an exception
+    # and this run reported an opaque server fault.
+    assert output.result.error.code == "source_unavailable"
+    assert output.result.error.retryable is True
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a9_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_a9)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# A10 — a stale context ref is not-found, not a silent page-scope fall-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a10_stale_context_ref_is_not_found() -> None:
+    output = await case_a10()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a10_a_live_context_ref_still_commits() -> None:
+    """Anti-vacuity for A10: the context-ref path must be able to succeed."""
+
+    output = await run_preflight_orchestrator(
+        question="What is the current state?",
+        entities=[(ORG_ID, PAGE_PROJECT)],
+        scope_overrides={
+            "entity_refs": [
+                {
+                    "entity_type": "project",
+                    "entity_id": PAGE_PROJECT.canonical_id,
+                    "display_label": PAGE_PROJECT.label,
+                    "repository_id": None,
+                }
+            ],
+            "direct_scope": "project",
+        },
+        script_id="a10-ok",
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert [ref.entity_id for ref in output.calls[0].scope.entity_refs] == [
+        PAGE_PROJECT.canonical_id
+    ]
+
+
+# ---------------------------------------------------------------------------
+# A11 — a TEAM subject resolves, and is honestly unsupported
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a11_resolved_team_is_unsupported_never_not_found() -> None:
+    output = await case_a11()
+
+    assert output.result.state is RunState.FAILED
+    assert output.result.error is not None
+    # The team demonstrably exists, so "not found" would be a lie and an
+    # organization fallback would be the CHAOS-3289 defect on another kind.
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+
+
+@pytest.mark.asyncio
+async def test_a11_team_resolution_records_an_exact_match_without_raising() -> None:
+    from dev_health_ops.api.dev.contracts_v2 import EntityKind as ContractEntityKind
+    from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+    from dev_health_ops.api.dev.scope_service import (
+        ScopeRequestCache,
+        ScopeResolutionService,
+    )
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from tests._chaos_3292_preflight import (
+        SeededCatalog,
+        fixed_now,
+        request_for,
+        sequential_ids,
+        versions,
+    )
+
+    mint = sequential_ids()
+    preflight = SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog([(ORG_ID, PLATFORM_TEAM)]), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+    request = request_for("What is the status of the Platform team?")
+    # No ValueError from DirectScope(...)/EntityType(...), which have no team
+    # member: the preflight builds DevEntityRefV2 straight from the entity.
+    result = await preflight.run(
+        request=request,
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+    )
+
+    assert result.ledger is not None
+    entry = next(iter(result.ledger.latest_by_mention().values()))
+    assert entry.outcome is ResolutionOutcome.EXACT_MATCH
+    assert entry.committed_entity_ref is not None
+    assert entry.committed_entity_ref.entity_kind is ContractEntityKind.TEAM
+    assert result.diagnostic == "committed_kind_unsupported_in_v1"
+
+
+@pytest.mark.asyncio
+async def test_a11_the_graphql_searchable_set_still_rejects_team() -> None:
+    """R1: widening the ceiling must not expose team search on a v1 surface."""
+
+    from dev_health_ops.api.dev.scope_service import (
+        SEARCHABLE_ENTITY_KINDS,
+        EntityKind,
+        ScopeSearchRequest,
+    )
+
+    with pytest.raises(ValueError, match="approved searchable V1 direct scopes"):
+        ScopeSearchRequest(query="Platform", kinds=(EntityKind.TEAM,))
+    # ...and the ceiling itself does admit it, so the rejection above is the
+    # caller allowlist doing the work rather than the kind being unsearchable.
+    assert EntityKind.TEAM in SEARCHABLE_ENTITY_KINDS
+    ScopeSearchRequest(
+        query="Platform",
+        kinds=(EntityKind.TEAM,),
+        allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a11_resolve_query_contract_rejects_an_unrepresentable_kind() -> None:
+    from dev_health_ops.api.dev.scope_service import (
+        SEARCHABLE_ENTITY_KINDS,
+        EntityKind,
+        ScopeRequestCache,
+        ScopeResolutionService,
+        ScopeSearchRequest,
+    )
+    from tests._chaos_3292_preflight import SeededCatalog, request_for
+
+    service = ScopeResolutionService(
+        SeededCatalog([(ORG_ID, PLATFORM_TEAM)]), cache=ScopeRequestCache()
+    )
+    with pytest.raises(ValueError, match="cannot represent entity kinds"):
+        await service.resolve_query_contract(
+            ORG_ID,
+            "permissions_01",
+            ScopeSearchRequest(
+                query="Platform",
+                kinds=(EntityKind.TEAM,),
+                allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+            ),
+            base_scope=request_for("x").scope,
+        )
+
+
+# ---------------------------------------------------------------------------
+# A12 — resolve_scope.v1 is withheld once a subject is committed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a12_resolve_scope_is_withheld_and_its_token_never_reaches_the_model() -> (
+    None
+):
+    output = await case_a1()
+
+    import json
+
+    assert output.provider is not None
+    assert output.provider.tool_ids
+    for advertised in output.provider.tool_ids:
+        assert ToolID.RESOLVE_SCOPE.value not in advertised
+    # The system prompt's own advertised registry must agree with the provider
+    # tool definitions. (Its embedded dev_tool_request.v1 JSON Schema still
+    # enumerates the full closed ToolID enum — that is the wire contract, not
+    # an offer, and narrowing it would be a contract change.)
+    for system_text in output.provider.system_texts:
+        manifest = json.loads(system_text)["tool_registry"]
+        assert ToolID.RESOLVE_SCOPE.value not in {
+            item["tool_id"] for item in manifest["tools"]
+        }
+    # And no tool-result JSON carrying the internal combined outcome reaches
+    # the composed user text.
+    for user_text in output.provider.user_texts:
+        assert "forbidden_or_not_found" not in user_text
+
+
+@pytest.mark.asyncio
+async def test_a12_a_dispatched_withheld_tool_never_reaches_the_executor() -> None:
+    """The second enforcement point, exercised directly.
+
+    A model that ignores the advertised registry and asks for the withheld tool
+    anyway is degraded to one failed tool result, not executed.
+    """
+
+    def script(script_id: str) -> list[ScriptedStep]:
+        payload = answer_payload(script_id=script_id)
+        # The withheld call becomes one failed tool result, which legitimately
+        # makes the run's coverage incomplete — so the answer must not claim
+        # completeness. That is the degrade working, not a workaround.
+        payload["status"] = "degraded"
+        return [
+            ScriptedStep(
+                decision=AgentToolRequest(
+                    tool_id="resolve_scope.v1",
+                    arguments={"query": "Ask Dev", "limit": 25},
+                    call_id="tool_call_01",
+                ),
+                usage=AgentUsage(input_tokens=100, output_tokens=10),
+            ),
+            ScriptedStep(
+                decision=AgentToolRequest(
+                    tool_id="status_snapshot.v1",
+                    arguments={"limit": 25, "include_comparison": False},
+                    call_id="tool_call_02",
+                ),
+                usage=AgentUsage(input_tokens=100, output_tokens=10),
+            ),
+            ScriptedStep(decision=AgentFinalAnswer(payload)),
+        ]
+
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script=script,
+        script_id="a12-dispatch",
+    )
+
+    assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
+    # Degraded per call, not fatal to the run.
+    assert output.result.state is RunState.COMPLETED
+    assert output.provider is not None
+    assert "tool_unavailable" in output.provider.user_texts[-1]
+
+
+# ---------------------------------------------------------------------------
+# A13 — disabling the legacy guard does not reduce the new path's correctness
+# ---------------------------------------------------------------------------
+
+_GUARD_INDEPENDENT_CASES = (
+    ("a1", case_a1),
+    ("a2", case_a2),
+    ("a3", case_a3),
+    ("a4", case_a4),
+    ("a8", case_a8),
+    ("a9", case_a9),
+    ("a10", case_a10),
+    ("a11", case_a11),
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "case"),
+    _GUARD_INDEPENDENT_CASES,
+    ids=[n for n, _ in _GUARD_INDEPENDENT_CASES],
+)
+@pytest.mark.asyncio
+async def test_a13_outcomes_are_unchanged_with_the_legacy_guard_disabled(
+    name: str, case: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What "the 3289 guard can be disabled" means operationally.
+
+    Removal itself is blocked on the cutover issue (TRD §15 Phase D); this is
+    the proof that the preflight path does not depend on it.
+    """
+
+    del name
+    expected = (await case()).outcome_tuple()
+    monkeypatch.setattr(
+        DevOrchestrator,
+        "_legacy_named_entity_guard_reason",
+        staticmethod(lambda **_kwargs: None),
+    )
+    assert (await case()).outcome_tuple() == expected
+
+
+# ---------------------------------------------------------------------------
+# Anti-vacuity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_harness_is_not_vacuous() -> None:
+    """A2/A3/A9 would pass trivially against a registry with no gated tool."""
+
+    from tests._chaos_3292_preflight import recording_registry
+
+    registry = recording_registry([])
+    assert SUBJECT_BEARING_TOOLS <= set(registry._executors)
+    assert SUBJECT_BEARING_TOOLS
+    # And the happy path really does exercise one of them, so "no
+    # subject-bearing call" is a statement about this run, not about the suite.
+    output = await case_a1()
+    assert _subject_bearing_calls(output) == ["status_snapshot.v1"]

--- a/tests/api/dev/test_chaos_3292_review_findings.py
+++ b/tests/api/dev/test_chaos_3292_review_findings.py
@@ -1,0 +1,375 @@
+"""Regressions for the defects adversarial review reproduced (CHAOS-3292).
+
+Each test names the behaviour that was wrong before the fix, so a revert shows
+up as a failing assertion about the *outcome*, not about an implementation
+detail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import DevTranscriptRunState, DirectScope
+from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.prompts import LEGACY_PROMPT_VERSION, PROMPT_VERSION
+from dev_health_ops.api.dev.question_interpreter import (
+    ClassifierProposal,
+    QuestionInterpreter,
+    untyped_name_candidates,
+)
+from dev_health_ops.api.dev.scope_service import (
+    EntityKind,
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    NIGHTFALL_PROJECT,
+    ORG_ID,
+    SeededCatalog,
+    fixed_now,
+    request_for,
+    run_preflight_orchestrator,
+    sequential_ids,
+)
+
+# ---------------------------------------------------------------------------
+# A partial name must not commit a different entity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_partial_name_does_not_commit_the_entity_it_is_a_substring_of() -> None:
+    """The catalog's text search is a ``%query%`` LIKE.
+
+    "the Dev project" returns only "Ask Dev", and treating a sole result as an
+    exact match committed it — answering about an entity the user never named.
+    """
+
+    service = ScopeResolutionService(
+        SeededCatalog([(ORG_ID, ASK_DEV_PROJECT)]), cache=ScopeRequestCache()
+    )
+    partial = await service.resolve_mention(
+        ORG_ID, "permissions_01", lookup_text="Dev", kinds=(EntityKind.PROJECT,)
+    )
+    assert partial.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+    assert partial.entity is None
+    # The real match is still offered back, so a partial name is useful rather
+    # than merely rejected.
+    assert [candidate.canonical_id for candidate in partial.candidates] == [
+        ASK_DEV_PROJECT.canonical_id
+    ]
+
+    exact = await service.resolve_mention(
+        ORG_ID, "permissions_01", lookup_text="Ask Dev", kinds=(EntityKind.PROJECT,)
+    )
+    assert exact.outcome is ResolutionOutcome.EXACT_MATCH
+    assert exact.entity == ASK_DEV_PROJECT
+
+
+@pytest.mark.asyncio
+async def test_a_partial_name_never_reaches_a_subject_bearing_tool() -> None:
+    output = await run_preflight_orchestrator(
+        question="What is the status of the Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="partial",
+    )
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_ambiguous"
+    assert output.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Page context must not stand in for a name we merely failed to type
+# ---------------------------------------------------------------------------
+
+
+def test_page_context_is_not_substituted_for_an_untyped_name() -> None:
+    from dev_health_ops.api.dev.contracts import DevEntityRef, EntityType
+    from dev_health_ops.api.dev.question_interpreter import extract_mentions
+
+    page_ref = DevEntityRef(
+        entity_type=EntityType.PROJECT,
+        entity_id=ASK_DEV_PROJECT.canonical_id,
+        display_label=ASK_DEV_PROJECT.label,
+    )
+    mentions = extract_mentions(
+        "How is Nightfall doing?", context_refs=[page_ref], mint_id=sequential_ids()
+    )
+
+    # Before the fix the kind-noun grammar found nothing, the question looked
+    # subject-free, and the page's own project was committed — so the run
+    # answered about Ask Dev under the name Nightfall.
+    assert [mention.normalized_lookup_text for mention in mentions] != [
+        ASK_DEV_PROJECT.canonical_id
+    ]
+    assert mentions == ()
+
+
+@pytest.mark.asyncio
+async def test_a_page_scoped_run_does_not_answer_under_an_unresolved_name() -> None:
+    project_ref = {
+        "entity_type": "project",
+        "entity_id": ASK_DEV_PROJECT.canonical_id,
+        "display_label": ASK_DEV_PROJECT.label,
+        "repository_id": None,
+    }
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        scope_overrides={"direct_scope": "project", "entity_refs": [project_ref]},
+        script_id="page-ctx",
+    )
+
+    # The bare name is unresolved, so nothing is committed for it and the
+    # legacy backstop is re-armed to judge the answer's own text.
+    assert output.preflight_outcomes() == ("proceeded_unresolved_bare_name",)
+
+
+# ---------------------------------------------------------------------------
+# Bare names without a kind noun
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("How is Nightfall doing?", ("Nightfall",)),
+        ("Anything about Nightfall worth knowing?", ("Nightfall",)),
+        # Sentence-initial single words are capitalized by grammar, not naming.
+        ("What is the current state?", ()),
+        ("How are we doing on delivery this month?", ()),
+        ("Show me the status of everything", ()),
+    ],
+)
+def test_bare_names_are_recognized_without_sentence_initial_false_positives(
+    question: str, expected: tuple[str, ...]
+) -> None:
+    assert untyped_name_candidates(question) == expected
+
+
+@pytest.mark.asyncio
+async def test_a_resolvable_bare_name_commits_a_subject() -> None:
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, NIGHTFALL_PROJECT)],
+        script_id="bare-ok",
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.calls[0].scope.direct_scope is DirectScope.PROJECT
+    assert [ref.entity_id for ref in output.calls[0].scope.entity_refs] == [
+        NIGHTFALL_PROJECT.canonical_id
+    ]
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_bare_name_does_not_block_the_run() -> None:
+    """R4, concretely: "what is our DORA score?" must still answer.
+
+    A bare name we cannot resolve is not proof that it was a subject, so it
+    re-arms the backstop instead of terminating — otherwise an acronym in an
+    ordinary organization-wide question would break a working question.
+    """
+
+    with_acronym = await run_preflight_orchestrator(
+        question="What is our DORA score this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="dora",
+    )
+    without = await run_preflight_orchestrator(
+        question="What is our delivery score this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="dora",
+    )
+
+    # The acronym is recognized as a bare name and resolves to nothing, but the
+    # run reaches exactly the same terminal state, under exactly the same
+    # organization scope, as the same question without it.
+    assert with_acronym.preflight_outcomes() == ("proceeded_unresolved_bare_name",)
+    assert with_acronym.result.state is without.result.state
+    assert [request.tool_id.value for request in with_acronym.calls] == [
+        request.tool_id.value for request in without.calls
+    ]
+    for request in with_acronym.calls:
+        assert request.scope.direct_scope is DirectScope.ORGANIZATION
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_bare_name_rearms_only_the_name_specific_reasons() -> None:
+    """Re-arming the backstop must be narrow.
+
+    Only the reasons that are *evidence about the unresolved name* may
+    terminate: the answer narrating it, or a resolution attempt that came back
+    ambiguous or not-found. ``no_evidence_backed_claims`` describes the shape
+    of the answer, not the name, and terminating on it would fail an ordinary
+    organization-wide question containing a capitalized acronym.
+    """
+
+    from dev_health_ops.api.dev.orchestrator import DevOrchestrator
+    from dev_health_ops.api.dev.subject_preflight import (
+        PreflightDecision,
+        SubjectPreflightResult,
+    )
+
+    def preflight(*, bare_name_unresolved: bool) -> SubjectPreflightResult:
+        return SubjectPreflightResult(
+            decision=PreflightDecision.PROCEED,
+            interpretation=None,  # type: ignore[arg-type]
+            ledger=None,
+            committed_resolution=None,
+            answer=None,
+            outcome=None,
+            allowed_tools=frozenset(),
+            diagnostic="test",
+            legacy_guard_required=bare_name_unresolved,
+        )
+
+    armed = preflight(bare_name_unresolved=True)
+    quiet = preflight(bare_name_unresolved=False)
+
+    assert (
+        DevOrchestrator._legacy_guard_is_terminal(armed, "narrated_unresolved_entity")
+        is True
+    )
+    assert (
+        DevOrchestrator._legacy_guard_is_terminal(armed, "resolve_scope_not_found")
+        is True
+    )
+    assert (
+        DevOrchestrator._legacy_guard_is_terminal(armed, "no_evidence_backed_claims")
+        is False
+    )
+    # A committed-subject run never lets the backstop decide anything...
+    assert (
+        DevOrchestrator._legacy_guard_is_terminal(quiet, "narrated_unresolved_entity")
+        is False
+    )
+    # ...and the flag-off path keeps every reason terminal, as today.
+    for reason in (
+        "narrated_unresolved_entity",
+        "no_evidence_backed_claims",
+        "resolve_scope_ambiguous",
+    ):
+        assert DevOrchestrator._legacy_guard_is_terminal(None, reason) is True
+
+
+# ---------------------------------------------------------------------------
+# The prompt must describe the run it is actually composing for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_committed_subject_prompt_is_only_used_when_one_is_committed() -> (
+    None
+):
+    committed = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="prompt-committed",
+    )
+    assert committed.provider is not None
+    assert '"prompt_version":"' + PROMPT_VERSION in committed.provider.system_texts[0]
+    assert "committed_subject" in committed.provider.system_texts[0]
+
+    organization_wide = await run_preflight_orchestrator(
+        question="How are we doing on delivery this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="prompt-orgwide",
+    )
+    assert organization_wide.provider is not None
+    system_text = organization_wide.provider.system_texts[0]
+    # Telling a run with no committed subject that "resolution is already
+    # complete" would be false, and on the flag-off path it deletes the only
+    # instruction that makes named-entity resolution happen at all.
+    assert '"prompt_version":"' + LEGACY_PROMPT_VERSION in system_text
+    assert "named_entity_resolution" in system_text
+    assert "resolve_scope.v1" in system_text
+
+
+@pytest.mark.asyncio
+async def test_a_flag_off_run_keeps_the_v1_prompt() -> None:
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="prompt-off",
+        preflight_enabled=False,
+    )
+    assert output.provider is not None
+    assert (
+        '"prompt_version":"' + LEGACY_PROMPT_VERSION in output.provider.system_texts[0]
+    )
+
+
+# ---------------------------------------------------------------------------
+# The transcript contract must admit the new in-flight states
+# ---------------------------------------------------------------------------
+
+
+def test_the_transcript_contract_admits_every_run_state() -> None:
+    from typing import get_args
+
+    admitted = set(get_args(DevTranscriptRunState))
+    # A transcript can be fetched while a run is mid-preflight; omitting these
+    # turned an in-progress run into a server error at transcript validation.
+    assert {state.value for state in RunState} <= admitted
+
+
+# ---------------------------------------------------------------------------
+# The constrained classifier cannot point at an arbitrary entity
+# ---------------------------------------------------------------------------
+
+
+class _SpanClassifier:
+    def __init__(self, span: str) -> None:
+        self.span = span
+
+    async def classify(self, *, question: str) -> ClassifierProposal:
+        del question
+        return ClassifierProposal(
+            intent_id="entity_status",
+            cardinality="singular",
+            candidates=((self.span, "project"),),
+            confidence=0.95,
+        )
+
+
+@pytest.mark.parametrize(
+    "span",
+    ["a", "A", "ightfal", "the", " Nightfall"],
+    ids=["one_char", "one_capital", "mid_word_fragment", "stop_word", "unstripped"],
+)
+@pytest.mark.asyncio
+async def test_a_substring_that_is_not_a_whole_name_is_rejected(span: str) -> None:
+    """Literal-substring alone was too weak.
+
+    A single character or a mid-word fragment appears in almost any question,
+    so it satisfied "quoted from the user" while letting the classifier point
+    at an arbitrary catalog entry.
+    """
+
+    interpreted = await QuestionInterpreter(
+        classifier=_SpanClassifier(span), mint_id=sequential_ids(), now=fixed_now
+    ).interpret(request_for("Anything worth a look at Nightfall today?"))
+
+    assert interpreted.intent.interpretation_reasons[-1] == "fallback.rejected"
+
+
+@pytest.mark.asyncio
+async def test_a_whole_word_span_from_the_question_is_still_accepted() -> None:
+    interpreted = await QuestionInterpreter(
+        classifier=_SpanClassifier("Nightfall"), mint_id=sequential_ids(), now=fixed_now
+    ).interpret(request_for("Anything worth a look at Nightfall today?"))
+
+    assert "fallback.model_assisted" in interpreted.intent.interpretation_reasons
+    assert any(
+        mention.original_text_span == "Nightfall" for mention in interpreted.mentions
+    )
+
+
+def _unused(value: Any) -> None:  # pragma: no cover - keeps Any import honest
+    del value

--- a/tests/api/dev/test_chaos_3292_review_findings.py
+++ b/tests/api/dev/test_chaos_3292_review_findings.py
@@ -292,6 +292,25 @@ async def test_the_committed_subject_prompt_is_only_used_when_one_is_committed()
 
 
 @pytest.mark.asyncio
+async def test_an_unresolved_bare_name_run_keeps_the_v1_prompt() -> None:
+    """Widening to organization scope commits a scope, not a subject.
+
+    Claiming "resolution is already complete" there would be the same false
+    statement the v1/v2 prompt split exists to prevent.
+    """
+
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="prompt-bare",
+    )
+    assert output.provider is not None
+    system_text = output.provider.system_texts[0]
+    assert '"prompt_version":"' + LEGACY_PROMPT_VERSION in system_text
+    assert "named_entity_resolution" in system_text
+
+
+@pytest.mark.asyncio
 async def test_a_flag_off_run_keeps_the_v1_prompt() -> None:
     output = await run_preflight_orchestrator(
         question="What's the status of the Ask Dev project?",
@@ -373,3 +392,179 @@ async def test_a_whole_word_span_from_the_question_is_still_accepted() -> None:
 
 def _unused(value: Any) -> None:  # pragma: no cover - keeps Any import honest
     del value
+
+
+# ---------------------------------------------------------------------------
+# Restricted verification round: three defects reproduced by execution probes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_bare_name_never_executes_under_the_page_subject() -> None:
+    """The first regression asserted the *diagnostic*, which was a false pass.
+
+    Proceeding without a commit left the run holding the page's project scope,
+    so ``status_snapshot.v1`` executed against Ask Dev while the user had asked
+    about Nightfall — the same misattribution, one layer down. This asserts the
+    scope the tool actually received.
+    """
+
+    project_ref = {
+        "entity_type": "project",
+        "entity_id": ASK_DEV_PROJECT.canonical_id,
+        "display_label": ASK_DEV_PROJECT.label,
+        "repository_id": None,
+    }
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        scope_overrides={"direct_scope": "project", "entity_refs": [project_ref]},
+        script_id="page-subject",
+    )
+
+    assert output.calls, "the run must reach a tool for this to prove anything"
+    for request in output.calls:
+        assert request.scope.direct_scope is DirectScope.ORGANIZATION
+        assert ASK_DEV_PROJECT.canonical_id not in [
+            ref.entity_id for ref in request.scope.entity_refs
+        ]
+        assert ASK_DEV_PROJECT.canonical_id not in request.scope.repositories
+
+
+@pytest.mark.asyncio
+async def test_a_page_scoped_run_with_a_resolvable_name_still_commits_that_name() -> (
+    None
+):
+    """Anti-vacuity: the page subject is stripped only when nothing resolved."""
+
+    project_ref = {
+        "entity_type": "project",
+        "entity_id": ASK_DEV_PROJECT.canonical_id,
+        "display_label": ASK_DEV_PROJECT.label,
+        "repository_id": None,
+    }
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, NIGHTFALL_PROJECT)],
+        scope_overrides={"direct_scope": "project", "entity_refs": [project_ref]},
+        script_id="page-subject-ok",
+    )
+
+    assert [ref.entity_id for ref in output.calls[0].scope.entity_refs] == [
+        NIGHTFALL_PROJECT.canonical_id
+    ]
+
+
+@pytest.mark.asyncio
+async def test_an_answer_narrating_an_unresolved_bare_name_is_terminated() -> None:
+    """The re-armed backstop must be able to *see* a bare name.
+
+    ``_named_entity_phrases`` only recognizes a name adjacent to an entity
+    noun, so re-arming it for a bare name was inert: a grounded answer
+    narrating "Nightfall" completed with zero guard reasons.
+    """
+
+    from dev_health_ops.llm.agent.contracts import AgentFinalAnswer
+    from dev_health_ops.llm.agent.scripted import ScriptedStep
+    from tests._chaos_3292_preflight import (
+        grounded_answer_payload,
+        scope_dict,
+        status_then_answer,
+    )
+
+    def narrating(script_id: str) -> list[ScriptedStep]:
+        steps = status_then_answer(script_id)
+        steps[-1] = ScriptedStep(
+            decision=AgentFinalAnswer(
+                grounded_answer_payload(
+                    script_id=script_id,
+                    summary="Nightfall completed twelve work items this period.",
+                    validity_scope=scope_dict(),
+                )
+            )
+        )
+        return steps
+
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script=narrating,
+        script_id="narrate-bare",
+    )
+
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "insufficient_evidence"
+
+
+@pytest.mark.asyncio
+async def test_an_answer_that_does_not_narrate_the_bare_name_is_kept() -> None:
+    """Anti-vacuity for the clause above: it must not terminate everything."""
+
+    from dev_health_ops.llm.agent.contracts import AgentFinalAnswer
+    from dev_health_ops.llm.agent.scripted import ScriptedStep
+    from tests._chaos_3292_preflight import (
+        grounded_answer_payload,
+        scope_dict,
+        status_then_answer,
+    )
+
+    def quiet(script_id: str) -> list[ScriptedStep]:
+        steps = status_then_answer(script_id)
+        steps[-1] = ScriptedStep(
+            decision=AgentFinalAnswer(
+                grounded_answer_payload(
+                    script_id=script_id,
+                    summary="Twelve work items completed across the organization.",
+                    validity_scope=scope_dict(),
+                )
+            )
+        )
+        return steps
+
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script=quiet,
+        script_id="quiet-bare",
+    )
+
+    assert output.result.state is RunState.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_an_exact_label_beyond_the_candidate_page_still_commits() -> None:
+    """A bounded fuzzy search can push the exact target off the page.
+
+    ``scope_catalog`` orders by label and applies ``LIMIT`` in SQL, so with
+    more than ``MAX_CANDIDATES`` substring matches sorted ahead of it, the
+    exactly-named project never reaches the caller — and a legitimate run died
+    ``scope_ambiguous`` having executed nothing.
+    """
+
+    from dev_health_ops.api.dev.scope_service import MAX_CANDIDATES, AuthorizedEntity
+
+    crowd = [
+        (
+            ORG_ID,
+            AuthorizedEntity(
+                EntityKind.PROJECT,
+                f"project-dev-{index:02d}",
+                # Sorts *ahead* of the bare "Dev" label, so the LIMIT
+                # drops the exact target rather than the crowd.
+                f"Adjacent Dev {index:02d}",
+            ),
+        )
+        for index in range(MAX_CANDIDATES + 5)
+    ]
+    exact = AuthorizedEntity(EntityKind.PROJECT, "project-dev-exact", "Dev")
+
+    service = ScopeResolutionService(
+        SeededCatalog([*crowd, (ORG_ID, exact)]), cache=ScopeRequestCache()
+    )
+    resolution = await service.resolve_mention(
+        ORG_ID, "permissions_01", lookup_text="Dev", kinds=(EntityKind.PROJECT,)
+    )
+
+    assert resolution.outcome is ResolutionOutcome.EXACT_MATCH
+    assert resolution.entity == exact

--- a/tests/api/dev/test_chaos_3292_run_states.py
+++ b/tests/api/dev/test_chaos_3292_run_states.py
@@ -1,0 +1,94 @@
+"""The run-state vocabulary must agree in four places at once (CHAOS-3292).
+
+``RunState`` is enforced by a database CHECK constraint, not by an import, so
+adding a member without the matching Alembic revision fails at persistence —
+on the one request that happens to hit the new state, in production. These are
+pure-Python drift guards that run in every tier and fail loudly at build time
+instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from sqlalchemy import CheckConstraint, String
+
+from dev_health_ops.api.dev.orchestrator_states import TERMINAL_STATES, RunState
+from dev_health_ops.api.dev.persistence.service import (
+    _RUN_STATES,
+    _TERMINAL_RUN_STATES,
+)
+from dev_health_ops.models.dev_persistence import DevRun
+
+_MIGRATION = importlib.import_module(
+    "dev_health_ops.alembic.versions.0072_widen_dev_run_states"
+)
+
+
+def _check_constraint_text() -> str:
+    for constraint in DevRun.__table_args__:
+        if isinstance(constraint, CheckConstraint) and (
+            constraint.name == "ck_dev_runs_state"
+        ):
+            return str(constraint.sqltext)
+    raise AssertionError("ck_dev_runs_state is not declared on DevRun")
+
+
+def test_model_check_constraint_covers_every_run_state() -> None:
+    sqltext = _check_constraint_text()
+    missing = sorted(
+        state.value for state in RunState if f"'{state.value}'" not in sqltext
+    )
+    assert missing == []
+
+
+def test_persistence_service_vocabulary_matches_the_enum_exactly() -> None:
+    assert _RUN_STATES == {state.value for state in RunState}
+    assert _TERMINAL_RUN_STATES == {state.value for state in TERMINAL_STATES}
+
+
+def test_migration_0072_enumerates_exactly_the_current_run_states() -> None:
+    # Both halves: the migration must not omit a state the model requires, and
+    # must not invent one the enum does not have.
+    migration_states = set(_MIGRATION._PRIOR_STATES) | set(_MIGRATION._NEW_STATES)
+    assert migration_states == {state.value for state in RunState}
+    assert set(_MIGRATION._NEW_STATES) == {"interpreting", "resolving_subjects"}
+    assert _MIGRATION.down_revision == "0071"
+
+
+def test_the_new_preflight_states_are_not_terminal() -> None:
+    """A run parked mid-preflight must read as still running, not as finished.
+
+    The replay path in ``router`` treats any non-terminal state as an in-flight
+    run (409 ``concurrency_limited``); classifying either new state as terminal
+    would make a half-finished run replay as a completed one.
+    """
+
+    assert RunState.INTERPRETING not in TERMINAL_STATES
+    assert RunState.RESOLVING_SUBJECTS not in TERMINAL_STATES
+
+
+def test_router_replay_allowlist_matches_the_terminal_set() -> None:
+    import inspect
+
+    from dev_health_ops.api.dev import router
+
+    source = inspect.getsource(router)
+    marker = "if accepted.run.state not in {"
+    assert marker in source, "the replay allow-list moved; re-point this guard"
+    block = source.split(marker, 1)[1].split("}", 1)[0]
+    listed = {
+        line.strip().rstrip(",").removeprefix("RunState.").removesuffix(".value")
+        for line in block.splitlines()
+        if line.strip()
+    }
+    assert listed == {state.name for state in TERMINAL_STATES}
+
+
+def test_run_diagnostic_columns_are_present_and_bounded() -> None:
+    columns = DevRun.__table__.columns
+    for name, length in (("preflight_outcome", 32), ("legacy_guard_reason", 64)):
+        column_type = columns[name].type
+        assert isinstance(column_type, String)
+        assert column_type.length == length
+        assert columns[name].nullable

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -44,6 +44,7 @@ class Recorder:
         self.executions: list[Any] = []
         self.answers: list[DevAnswer] = []
         self.terminals: list[RunState] = []
+        self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
         self.fail_answer_write = fail_answer_write
 
     async def transition(self, state: RunState) -> None:
@@ -57,6 +58,11 @@ class Recorder:
         if self.fail_answer_write:
             raise RuntimeError("storage unavailable")
         self.answers.append(answer)
+
+    async def record_preflight(
+        self, *, preflight_outcome: str | None, legacy_guard_reason: str | None
+    ) -> None:
+        self.preflight_diagnostics.append((preflight_outcome, legacy_guard_reason))
 
     async def terminal(self, **values) -> None:
         self.terminals.append(values["state"])

--- a/tests/api/dev/test_orchestrator_persistence.py
+++ b/tests/api/dev/test_orchestrator_persistence.py
@@ -12,6 +12,7 @@ from dev_health_ops.api.dev.contracts import DevError, DevToolRequest, DevToolRe
 from dev_health_ops.api.dev.orchestrator import RunState
 from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
 from dev_health_ops.api.dev.persistence.service import DevPersistenceService
+from dev_health_ops.api.dev.prompts import PROMPT_VERSION
 from dev_health_ops.api.dev.tool_registry import ToolExecution
 from dev_health_ops.llm.agent.contracts import AgentUsage
 
@@ -54,7 +55,7 @@ async def test_recorder_persists_only_safe_versioned_terminal_metadata() -> None
     assert service.update_run.await_count == 2
     terminal = service.update_run.await_args_list[-1].kwargs
     assert terminal["state"] == "failed"
-    assert terminal["prompt_version"] == "ask_dev_prompt.v1:sha256:" + "a" * 64
+    assert terminal["prompt_version"] == f"{PROMPT_VERSION}:sha256:" + "a" * 64
     assert terminal["provider_fingerprint"].startswith("sha256:")
     assert terminal["model_fingerprint"].startswith("sha256:")
     assert terminal["safe_error_code"] == "provider_unavailable"

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -1,0 +1,402 @@
+"""Unit coverage for the server-owned question interpreter (CHAOS-3292)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import QuestionClass
+from dev_health_ops.api.dev.contracts_v2 import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+)
+from dev_health_ops.api.dev.question_interpreter import (
+    CLARIFICATION_REASONS,
+    FALLBACK_CONFIDENCE_FLOOR,
+    INTERPRETER_VERSION,
+    MAX_MENTIONS,
+    ClassifierProposal,
+    QuestionInterpreter,
+    extract_mentions,
+)
+from tests._chaos_3292_preflight import fixed_now, request_for, sequential_ids
+
+
+def _interpreter(**kwargs: Any) -> QuestionInterpreter:
+    return QuestionInterpreter(mint_id=sequential_ids(), now=fixed_now, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Recognizers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        (
+            "What's the status of the Ask Dev project?",
+            QuestionIntentID.ENTITY_STATUS,
+        ),
+        (
+            "What's the status across all projects?",
+            QuestionIntentID.PORTFOLIO_STATUS,
+        ),
+        (
+            "What's left on the Ask Dev project?",
+            QuestionIntentID.REMAINING_WORK,
+        ),
+        (
+            "What changed in the Ask Dev project since last week?",
+            QuestionIntentID.OBSERVED_CHANGE,
+        ),
+        ("What metrics can you measure?", QuestionIntentID.REGISTERED_STATISTICS),
+        (
+            "Compare cycle time p50 against last quarter",
+            QuestionIntentID.METRIC_COMPARISON,
+        ),
+        ("Is our deployment data stale?", QuestionIntentID.DATA_TRUST),
+        ("How healthy is the Ask Dev project?", QuestionIntentID.PROJECT_HEALTH),
+        ("Is the Platform team healthy?", QuestionIntentID.TEAM_HEALTH),
+        (
+            "Which team is overburdened right now?",
+            QuestionIntentID.TEAM_WORKLOAD_BALANCE,
+        ),
+        (
+            "List our operational deficiencies",
+            QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY,
+        ),
+        ("Tell me something interesting", QuestionIntentID.BOUNDED_INVESTIGATION),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_launch_intent_has_a_deterministic_recognizer(
+    question: str, expected: QuestionIntentID
+) -> None:
+    interpreted = await _interpreter().interpret(request_for(question))
+    assert interpreted.intent.intent_id is expected
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_question_degrades_rather_than_refusing() -> None:
+    """R4: a recognizer miss must never block a question that works today."""
+
+    interpreted = await _interpreter().interpret(
+        request_for("Tell me something interesting")
+    )
+    assert interpreted.intent.intent_id is QuestionIntentID.BOUNDED_INVESTIGATION
+    assert interpreted.intent.requires_clarification is False
+    assert interpreted.intent.confidence < FALLBACK_CONFIDENCE_FLOOR
+
+
+@pytest.mark.asyncio
+async def test_recognizer_order_is_a_stable_tiebreak() -> None:
+    """A question satisfying two recognizers always resolves the same way."""
+
+    question = "What changed in the status of the Ask Dev project since last week?"
+    seen = {
+        (await _interpreter().interpret(request_for(question))).intent.intent_id
+        for _ in range(5)
+    }
+    assert seen == {QuestionIntentID.OBSERVED_CHANGE}
+
+
+@pytest.mark.asyncio
+async def test_interpretation_reasons_carry_recognizer_ids_never_question_text() -> (
+    None
+):
+    question = "What's the status of the Ask Dev project?"
+    interpreted = await _interpreter().interpret(request_for(question))
+
+    assert interpreted.intent.interpretation_reasons == ("status.singular",)
+    for reason in interpreted.intent.interpretation_reasons:
+        assert "Ask Dev" not in reason
+        assert reason.lower() not in question.lower()
+
+
+@pytest.mark.asyncio
+async def test_interpreter_version_satisfies_the_platform_token_grammar() -> None:
+    from dev_health_ops.api.dev.contracts_v2 import DevFrameVersions
+
+    versions = DevFrameVersions(
+        interpreter_version=INTERPRETER_VERSION,
+        plan_id="status.entity.v2",
+        plan_version="ask_dev_plan.v1",
+        tool_contract_version="ask_dev_tools.v2",
+        metric_definition_version="ask_dev_metrics.v1",
+        query_version="ask_dev_queries.v1",
+    )
+    assert versions.interpreter_version == INTERPRETER_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Mention extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("What's the status of the Ask Dev project?", [("Ask Dev", "project")]),
+        ("Can you check project Ask Dev status?", [("Ask Dev", "project")]),
+        (
+            "Compare project Ask Dev and project Nightfall",
+            [("Ask Dev", "project"), ("Nightfall", "project")],
+        ),
+        ('How is repo "dev-health-ops" doing?', [("dev-health-ops", "repository")]),
+        ("Is the Platform team overloaded?", [("Platform", "team")]),
+        ("How is issue CHAOS-3292 going?", [("CHAOS-3292", "issue")]),
+    ],
+)
+def test_mentions_are_extracted_in_reading_order(
+    question: str, expected: list[tuple[str, str]]
+) -> None:
+    mentions = extract_mentions(question, mint_id=sequential_ids())
+    assert [
+        (mention.original_text_span, mention.requested_entity_kind.value)
+        for mention in mentions
+    ] == expected
+    assert [mention.mention_ordinal for mention in mentions] == list(
+        range(len(expected))
+    )
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Our team is overburdened",
+        "Which team is at risk?",
+        "Show me the status of everything",
+        "What metrics can you measure?",
+    ],
+)
+def test_pronouns_and_interrogatives_are_never_subjects(question: str) -> None:
+    assert extract_mentions(question, mint_id=sequential_ids()) == ()
+
+
+def test_a_noun_bound_to_a_following_name_is_not_also_read_backwards() -> None:
+    """ "Compare project Ask Dev" must not mint a project called "Compare"."""
+
+    mentions = extract_mentions(
+        "Compare project Ask Dev and project Nightfall", mint_id=sequential_ids()
+    )
+    assert [mention.original_text_span for mention in mentions] == [
+        "Ask Dev",
+        "Nightfall",
+    ]
+
+
+def test_extraction_is_bounded_by_the_contract_maximum() -> None:
+    question = " ".join(f"project P{index}" for index in range(40))
+    mentions = extract_mentions(question, mint_id=sequential_ids())
+    assert len(mentions) == MAX_MENTIONS
+    assert mentions[-1].mention_ordinal == MAX_MENTIONS - 1
+
+
+def test_context_refs_are_used_only_when_the_question_names_nothing() -> None:
+    from dev_health_ops.api.dev.contracts import DevEntityRef, EntityType
+
+    page_ref = DevEntityRef(
+        entity_type=EntityType.PROJECT,
+        entity_id="project-page-ctx",
+        display_label="Beacon",
+    )
+
+    named = extract_mentions(
+        "What's the status of the Ask Dev project?",
+        context_refs=[page_ref],
+        mint_id=sequential_ids(),
+    )
+    # The page context never overrides, and never silently joins, a named
+    # subject: substituting page context for a name is the fabrication path in
+    # a different costume.
+    assert [mention.original_text_span for mention in named] == ["Ask Dev"]
+
+    unnamed = extract_mentions(
+        "What is the current state?", context_refs=[page_ref], mint_id=sequential_ids()
+    )
+    assert [mention.normalized_lookup_text for mention in unnamed] == [
+        "project-page-ctx"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cardinality, comparison mode, and the client hint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("How are we doing overall?", Cardinality.ORGANIZATION_WIDE),
+        ("What's the status of the Ask Dev project?", Cardinality.SINGULAR),
+        (
+            "Compare project Ask Dev and project Nightfall",
+            Cardinality.PLURAL_COHORT,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cardinality_is_derived_from_the_mentions(
+    question: str, expected: Cardinality
+) -> None:
+    interpreted = await _interpreter().interpret(request_for(question))
+    assert interpreted.intent.cardinality is expected
+    assert len(interpreted.intent.mention_ordinals) == len(interpreted.mentions)
+
+
+@pytest.mark.asyncio
+async def test_subject_kinds_are_deduplicated_and_sorted() -> None:
+    interpreted = await _interpreter().interpret(
+        request_for("How do project Ask Dev and the Platform team compare?")
+    )
+    assert interpreted.intent.subject_kinds == (EntityKind.PROJECT, EntityKind.TEAM)
+
+
+@pytest.mark.asyncio
+async def test_the_client_hint_is_recorded_with_its_mandatory_warning() -> None:
+    interpreted = await _interpreter().interpret(
+        request_for(
+            "What's the status of the Ask Dev project?",
+            question_class=QuestionClass.INVESTIGATION,
+        )
+    )
+    assert interpreted.intent.client_question_class_hint is QuestionClass.INVESTIGATION
+    assert interpreted.intent.client_hint_deprecation_warning is not None
+    # ...and it did not steer planning.
+    assert interpreted.intent.intent_id is QuestionIntentID.ENTITY_STATUS
+
+
+# ---------------------------------------------------------------------------
+# The constrained model fallback
+# ---------------------------------------------------------------------------
+
+
+class _Classifier:
+    def __init__(self, proposal: ClassifierProposal | Exception | None) -> None:
+        self.proposal = proposal
+        self.calls = 0
+
+    async def classify(self, *, question: str) -> ClassifierProposal | None:
+        del question
+        self.calls += 1
+        if isinstance(self.proposal, Exception):
+            raise self.proposal
+        return self.proposal
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_runs_only_below_the_confidence_floor() -> None:
+    classifier = _Classifier(None)
+    await QuestionInterpreter(
+        classifier=classifier, mint_id=sequential_ids(), now=fixed_now
+    ).interpret(request_for("What's the status of the Ask Dev project?"))
+    assert classifier.calls == 0
+
+    await QuestionInterpreter(
+        classifier=classifier, mint_id=sequential_ids(), now=fixed_now
+    ).interpret(request_for("Tell me something interesting"))
+    assert classifier.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_a_provider_failure_never_falls_back_to_organization_scope() -> None:
+    """A named subject plus an unavailable classifier asks for clarification."""
+
+    interpreted = await QuestionInterpreter(
+        classifier=_Classifier(RuntimeError("provider down")),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    ).interpret(request_for("Anything I should know about the Ask Dev project?"))
+
+    assert interpreted.intent.requires_clarification is True
+    assert (
+        interpreted.intent.clarification_reason
+        == CLARIFICATION_REASONS["interpreter_unavailable"]
+    )
+    assert interpreted.mentions  # the mention is preserved, not discarded
+
+
+@pytest.mark.asyncio
+async def test_a_provider_failure_on_a_subjectless_question_keeps_working() -> None:
+    """With no named subject there is nothing to get wrong.
+
+    Refusing here would regress an organization-wide question that answers
+    correctly in production today.
+    """
+
+    interpreted = await QuestionInterpreter(
+        classifier=_Classifier(RuntimeError("provider down")),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    ).interpret(request_for("Tell me something interesting"))
+
+    assert interpreted.intent.requires_clarification is False
+    assert interpreted.intent.intent_id is QuestionIntentID.BOUNDED_INVESTIGATION
+
+
+@pytest.mark.parametrize(
+    "proposal",
+    [
+        ClassifierProposal(intent_id="not_a_real_intent", cardinality="singular"),
+        ClassifierProposal(intent_id="entity_status", cardinality="not_a_cardinality"),
+        ClassifierProposal(
+            intent_id="entity_status", cardinality="singular", confidence=1.5
+        ),
+        ClassifierProposal(
+            intent_id="entity_status",
+            cardinality="singular",
+            candidates=(("Nightfall", "project"),),
+        ),
+        ClassifierProposal(
+            intent_id="entity_status",
+            cardinality="singular",
+            candidates=(("Something", "galaxy"),),
+        ),
+    ],
+    ids=["bad_intent", "bad_cardinality", "bad_confidence", "absent_span", "bad_kind"],
+)
+@pytest.mark.asyncio
+async def test_post_validation_rejects_every_out_of_contract_proposal(
+    proposal: ClassifierProposal,
+) -> None:
+    interpreted = await QuestionInterpreter(
+        classifier=_Classifier(proposal), mint_id=sequential_ids(), now=fixed_now
+    ).interpret(request_for("Tell me something interesting"))
+
+    assert "fallback.rejected" in interpreted.intent.interpretation_reasons
+    assert interpreted.intent.intent_id is QuestionIntentID.BOUNDED_INVESTIGATION
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_proposal_is_never_trusted_above_a_recognizer() -> None:
+    interpreted = await QuestionInterpreter(
+        classifier=_Classifier(
+            ClassifierProposal(
+                intent_id="project_health",
+                cardinality="singular",
+                candidates=(("Nightfall", "project"),),
+                confidence=1.0,
+            )
+        ),
+        mint_id=sequential_ids(),
+        now=fixed_now,
+    ).interpret(request_for("Anything about Nightfall worth knowing?"))
+
+    assert interpreted.intent.intent_id is QuestionIntentID.PROJECT_HEALTH
+    assert interpreted.intent.confidence < 1.0
+    assert "fallback.model_assisted" in interpreted.intent.interpretation_reasons
+    assert [mention.original_text_span for mention in interpreted.mentions] == [
+        "Nightfall"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_proposal_cannot_clear_a_clarification_requirement() -> None:
+    """There is no field on ``ClassifierProposal`` that could carry it."""
+
+    assert not hasattr(ClassifierProposal, "requires_clarification")
+    assert "requires_clarification" not in ClassifierProposal.__annotations__
+    assert "mention_id" not in ClassifierProposal.__annotations__

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -362,3 +362,43 @@ async def test_a_team_subject_never_reaches_the_v1_scope_constructors() -> None:
     entry = next(iter(result.ledger.latest_by_mention().values()))
     assert entry.outcome is ResolutionOutcome.EXACT_MATCH
     assert entry.team_attribution == PLATFORM_TEAM.canonical_id
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary handlers must be total over their enum
+# ---------------------------------------------------------------------------
+
+
+def test_display_labels_cover_every_public_outcome() -> None:
+    """Derived from the enum, so a new member fails here until it is labelled.
+
+    ``DENIED`` was missing and is unreachable from the preflight today, which
+    is precisely what made it a latent ``KeyError`` rather than a live bug.
+    """
+
+    from dev_health_ops.api.dev.preflight_outcomes import _DISPLAY_LABELS
+
+    assert set(_DISPLAY_LABELS) == set(PublicOutcome)
+
+
+def test_display_labels_match_the_canonical_answer_labels() -> None:
+    """The stronger half: a *wrong* label is as broken as a missing one.
+
+    ``DevAnswerV2`` validates ``outcome_display_label`` against its own
+    canonical table, so a drifted duplicate here would raise on the first
+    answer that used it.
+    """
+
+    from dev_health_ops.api.dev.contracts_v2.answer import _OUTCOME_DISPLAY_LABELS
+    from dev_health_ops.api.dev.preflight_outcomes import _DISPLAY_LABELS
+
+    assert _DISPLAY_LABELS == _OUTCOME_DISPLAY_LABELS
+
+
+@pytest.mark.parametrize("outcome", list(PublicOutcome))
+def test_every_public_outcome_has_a_usable_label(outcome: PublicOutcome) -> None:
+    """Reaching the label must not raise for any member of the vocabulary."""
+
+    from dev_health_ops.api.dev.preflight_outcomes import _DISPLAY_LABELS
+
+    assert _DISPLAY_LABELS[outcome]

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -1,0 +1,364 @@
+"""Unit coverage for the subject preflight and its outcome mapping (CHAOS-3292)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import ToolID
+from dev_health_ops.api.dev.contracts_v2 import (
+    PublicOutcome,
+    QuestionIntentID,
+    ResolutionOutcome,
+)
+from dev_health_ops.api.dev.contracts_v2.plan import PLAN_REGISTRY
+from dev_health_ops.api.dev.contracts_v2.subject import UNRESOLVED_OUTCOMES
+from dev_health_ops.api.dev.orchestrator_states import TERMINAL_STATES
+from dev_health_ops.api.dev.preflight_outcomes import (
+    PLAN_ID_BY_INTENT,
+    PREFLIGHT_OUTCOME_BY_RESOLUTION,
+    TERMINAL_STATE_BY_OUTCOME,
+    build_preflight_answer,
+    project_preflight_error,
+)
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_service import (
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import (
+    SUBJECT_BEARING_TOOLS,
+    PreflightDecision,
+    SubjectPreflight,
+)
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    NIGHTFALL_PROJECT,
+    ORG_ID,
+    PLATFORM_TEAM,
+    SeededCatalog,
+    fixed_now,
+    request_for,
+    sequential_ids,
+    versions,
+)
+
+
+def _preflight(entities: Any, **catalog_kwargs: Any) -> SubjectPreflight:
+    mint = sequential_ids()
+    return SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog(entities, **catalog_kwargs), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+
+async def _run(preflight: SubjectPreflight, request: Any, **kwargs: Any) -> Any:
+    return await preflight.run(
+        request=request,
+        org_id=kwargs.pop("org_id", ORG_ID),
+        permission_fingerprint="permissions_01",
+        authorized_scope=kwargs.pop("authorized_scope", request.scope),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_single_exact_subject_commits_and_withholds_resolve_scope() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of the Ask Dev project?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.committed_resolution is not None
+    assert result.allowed_tools == frozenset(ToolID) - {ToolID.RESOLVE_SCOPE}
+    assert SUBJECT_BEARING_TOOLS <= result.allowed_tools
+    assert result.all_subjects_committed is True
+
+
+@pytest.mark.asyncio
+async def test_an_organization_wide_question_keeps_every_tool() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("How are we doing overall?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.ledger is None
+    assert result.allowed_tools == frozenset(ToolID)
+
+
+@pytest.mark.asyncio
+async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> None:
+    """Two real subjects: v1 ``DevScope`` names one, so neither is guessed.
+
+    Committing only the first of several named subjects is the fabricated
+    premise this issue exists to close; the landed v2-to-v1 projector reaches
+    the same conclusion independently for a ``subject_set_ref`` cohort frame.
+    CHAOS-3301 owns subject sets and batch execution.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, NIGHTFALL_PROJECT)]),
+        request_for("Compare project Ask Dev and project Nightfall"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.UNSUPPORTED
+    assert result.diagnostic == "cohort_unsupported_in_v1"
+    assert result.committed_resolution is None
+    # Both resolved honestly; nothing was discarded to make one fit.
+    assert result.ledger is not None
+    assert all(
+        entry.outcome is ResolutionOutcome.EXACT_MATCH
+        for entry in result.ledger.latest_by_mention().values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_lowest_ordinal_unresolved_mention_decides_the_outcome() -> None:
+    """Stable and explainable — and independent of catalog latency.
+
+    A severity ordering would let a slow catalog change the reported outcome
+    between runs, which breaks the determinism criterion directly.
+    """
+
+    # Ordinal 0 is ambiguous (two Atlas), ordinal 1 does not exist at all.
+    from tests._chaos_3292_preflight import ATLAS_PROJECT_ONE, ATLAS_PROJECT_TWO
+
+    result = await _run(
+        _preflight([(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]),
+        request_for("Compare project Atlas and project Nightfall"),
+    )
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+
+    reversed_result = await _run(
+        _preflight([(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]),
+        request_for("Compare project Nightfall and project Atlas"),
+    )
+    assert reversed_result.outcome is PublicOutcome.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# The catalog-outage reuse rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_catalog_outage_reuses_only_an_exact_prior_commit() -> None:
+    project_ref = {
+        "entity_type": "project",
+        "entity_id": ASK_DEV_PROJECT.canonical_id,
+        "display_label": ASK_DEV_PROJECT.label,
+        "repository_id": None,
+    }
+    request = request_for(
+        "What's the status of the Ask Dev project?",
+        scope_overrides={"direct_scope": "project", "entity_refs": [project_ref]},
+    )
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)], fail_search=True), request
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.committed_resolution is not None
+
+
+@pytest.mark.asyncio
+async def test_a_catalog_outage_without_a_matching_commit_is_unavailable() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)], fail_search=True),
+        request_for("What's the status of the Ask Dev project?"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.TEMPORARILY_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_an_outage_never_reuses_a_scope_for_a_different_subject() -> None:
+    """A stale guess about a *different* named subject is the same defect."""
+
+    other_ref = {
+        "entity_type": "project",
+        "entity_id": NIGHTFALL_PROJECT.canonical_id,
+        "display_label": NIGHTFALL_PROJECT.label,
+        "repository_id": None,
+    }
+    request = request_for(
+        "What's the status of the Ask Dev project?",
+        scope_overrides={"direct_scope": "project", "entity_refs": [other_ref]},
+    )
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)], fail_search=True), request
+    )
+
+    assert result.outcome is PublicOutcome.TEMPORARILY_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Outcome mapping and the emitted v2 objects
+# ---------------------------------------------------------------------------
+
+
+def test_every_unresolved_outcome_has_a_public_mapping() -> None:
+    assert set(PREFLIGHT_OUTCOME_BY_RESOLUTION) == set(UNRESOLVED_OUTCOMES)
+    # EXACT_MATCH is deliberately absent: it is not a termination.
+    assert ResolutionOutcome.EXACT_MATCH not in PREFLIGHT_OUTCOME_BY_RESOLUTION
+
+
+def test_every_public_outcome_maps_to_a_terminal_run_state() -> None:
+    assert set(TERMINAL_STATE_BY_OUTCOME) >= set(
+        PREFLIGHT_OUTCOME_BY_RESOLUTION.values()
+    )
+    for state in TERMINAL_STATE_BY_OUTCOME.values():
+        assert state in TERMINAL_STATES
+
+
+def test_every_launch_intent_maps_to_a_registered_plan() -> None:
+    assert set(PLAN_ID_BY_INTENT) == set(QuestionIntentID)
+    assert set(PLAN_ID_BY_INTENT.values()) <= PLAN_REGISTRY
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_code", "expected_retryable"),
+    [
+        (PublicOutcome.NOT_FOUND, "scope_not_found", False),
+        (PublicOutcome.TEMPORARILY_UNAVAILABLE, "source_unavailable", True),
+        (PublicOutcome.UNSUPPORTED, "feature_not_enabled", False),
+        (PublicOutcome.NEEDS_CLARIFICATION, "scope_ambiguous", False),
+    ],
+)
+def test_each_outcome_projects_to_its_v1_error(
+    outcome: PublicOutcome, expected_code: str, expected_retryable: bool
+) -> None:
+    answer = build_preflight_answer(
+        outcome=outcome,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+    )
+    error = project_preflight_error(answer, request_id="request_01")
+
+    assert error.code == expected_code
+    assert error.retryable is expected_retryable
+    assert error.request_id == "request_01"
+
+
+def test_a_no_answer_frame_carries_no_provenance_block_or_subject() -> None:
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NOT_FOUND,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+    )
+
+    assert answer.frame.versions is None
+    assert answer.frame.subject_ref is None
+    assert answer.frame.subject_set_ref is None
+    assert answer.frame.facts == ()
+    assert answer.narrative is None
+
+
+def test_a_needs_clarification_frame_does_carry_provenance() -> None:
+    """It is not one of ``NO_ANSWER_OUTCOMES``, so the contract requires one."""
+
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NEEDS_CLARIFICATION,
+        intent_id=QuestionIntentID.PROJECT_HEALTH,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+    )
+
+    assert answer.frame.versions is not None
+    assert answer.frame.versions.plan_id == "health.project.v1"
+    assert answer.frame.versions.interpreter_version == "intent_interpreter.v1"
+
+
+def test_correlation_handles_are_canonical_server_handles() -> None:
+    """Non-UUID run ids are folded, never rejected and never rendered as text."""
+
+    import re
+
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NOT_FOUND,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+    )
+    grammar = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    )
+    for handle in (
+        answer.run_id,
+        answer.answer_id,
+        answer.conversation_id,
+        answer.frame.frame_id,
+    ):
+        assert grammar.match(handle)
+    # Deterministic: the same id folds to the same handle every time.
+    again = build_preflight_answer(
+        outcome=PublicOutcome.NOT_FOUND,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+    )
+    assert again.run_id == answer.run_id
+
+
+def test_a_real_uuid_run_id_is_preserved_verbatim() -> None:
+    run_id = "3f2a1c88-9d4e-4b71-8a2f-0c5e7d6b1a90"
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NOT_FOUND,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id=run_id,
+        answer_id=run_id,
+        conversation_id=run_id,
+        generated_at=fixed_now(),
+    )
+    assert answer.run_id == run_id
+
+
+@pytest.mark.asyncio
+async def test_a_team_subject_never_reaches_the_v1_scope_constructors() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, PLATFORM_TEAM)]),
+        request_for("How is the Platform team doing?"),
+    )
+
+    assert result.outcome is PublicOutcome.UNSUPPORTED
+    assert result.committed_resolution is None
+    assert result.ledger is not None
+    entry = next(iter(result.ledger.latest_by_mention().values()))
+    assert entry.outcome is ResolutionOutcome.EXACT_MATCH
+    assert entry.team_attribution == PLATFORM_TEAM.canonical_id

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0071"}
+    assert _revisions(migrated_to_0065.engine) == {"0073"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -231,10 +231,22 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     retargeted the routes. Reapplying the new 0066 sibling is intentionally
     idempotent and restores explicit two-head provenance without another route
     generation change.
+
+    The simulated database is built by upgrading to **0066 and 0071
+    specifically**, not to ``heads``. The stamp below rewinds only the version
+    table, so upgrading to ``heads`` first would leave the schema ahead of the
+    revision it claims to be at — and every application-branch revision after
+    0071 would then be re-applied against objects it had already created
+    (CHAOS-3292's 0072 died with DuplicateColumnError on exactly that). While
+    0071 was the application head the two agreed by coincidence; pinning the
+    upgrade to the revisions this test says it is simulating makes them agree
+    by construction, and makes the assertion below a real proof that a
+    legacy-provenance database migrates forward cleanly.
     """
     migration = _migration()
     monkeypatch.setenv(_CUTOVER_ENV, "1")
-    command.upgrade(_migration_config(), "heads")
+    command.upgrade(_migration_config(), "0066")
+    command.upgrade(_migration_config(), "0071")
     command.stamp(_migration_config(), "0071", purge=True)
     before = _routes(migrated_to_0065.engine, migration)
 
@@ -243,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0071"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0071"}
+    assert set(heads) == {"0066", "0073"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1239,10 +1239,13 @@ class TestGetFeaturesForTier:
         enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
         assert set(community.keys()) == set(team.keys()) == set(enterprise.keys())
 
-    def test_returns_31_features_including_contextual_entrypoints(self):
+    def test_returns_32_features_including_explicit_purchase_ones(self):
         features = get_features_for_tier(LicenseTier.COMMUNITY)
-        assert len(features) == 31
+        assert len(features) == 32
+        # Explicit-purchase features stay denied for every tier until an
+        # organization or license override grants them.
         assert features["ask_dev_contextual_entrypoints"] is False
+        assert features["ask_dev_wave_3_1"] is False
 
     def test_sign_license_uses_canonical_registry(self):
         """sign_license() with no explicit features uses get_features_for_tier."""

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0071"}
+        assert set(heads) == {"0066", "0073"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0071"
+        assert script.get_revision("application_schema@head").revision == "0073"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0071"}
-        assert scripts.get_revision("application_schema@head").revision == "0071"
-        assert _database_has_revision(cfg, ("0071",), "0065")
-        assert not _database_has_revision(cfg, ("0071",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0073"}
+        assert scripts.get_revision("application_schema@head").revision == "0073"
+        assert _database_has_revision(cfg, ("0073",), "0065")
+        assert not _database_has_revision(cfg, ("0073",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## CHAOS-3292 — Server-owned intent interpretation and named-subject preflight

Replaces the CHAOS-3289 regex/late-guard architecture with the Wave 3.1 target lifecycle: the server interprets the question, resolves and commits every named subject **before** the model runs, and the model receives an already-committed scope instead of being asked to earn one. Behind the `ask_dev_wave_3_1` flag (TRD §15 Phase A); flag-off is byte-for-byte today's behavior with the legacy backstop intact.

### What lands

- **`question_interpreter.py`** — deterministic recognizers for the 12 launch intents, typed + bare-name mention extraction, and a constrained-model fallback (no tools, no scope authority, literal-substring + whole-word post-validation). Browser `question_class` is no longer authoritative.
- **`subject_preflight.py`** — deny-by-default gate at the pre-model seam: per-mention resolution through `ScopeResolutionService` with an append-only resolution ledger (`validate_ledger_extends` on every update), exact-equality commit (fuzzy search never commits), `catalog.exact()` before bounded fuzzy search so exact labels can't be starved by the 25-candidate LIMIT, and typed outcomes: ambiguous → clarification, no-match → not_found, catalog outage → temporarily_unavailable (previously surfaced as `internal_error` — `search()` had no exception boundary).
- **Per-run tool availability** — a new registry seam (`manifest(allowed_tool_ids=...)`) plus a dispatch-time check: no evidence-bearing tool can execute before an exact committed subject. Previously all nine tools were advertised every round unconditionally.
- **Preflight outcomes as v2 no-answer frames** projected through the landed compat projector — `forbidden_or_not_found` is unreachable on the preflight path (org-wide residual: CHAOS-3326; v1 candidate delivery: CHAOS-3325).
- **TEAM is searchable** and ledger-recorded (public `unsupported` until CHAOS-3301 makes it a direct scope). Multi-subject (≥2 exact mentions) terminates `unsupported` — committing only the first named subject is the fabrication shape this issue closes; cohorts are CHAOS-3301.
- **Unresolved bare names widen to organization scope** — the page-derived subject is stripped so page context can never be silently substituted for a name the grammar couldn't type; the legacy backstop is re-armed with the preflight's unresolved spans (it was structurally blind to noun-less names). Legacy guard demoted: terminates only when preflight did not run; telemetry-only (content-free diagnostics) when it did.
- **Alembic 0072** (run-state CHECK widening + 2 content-free diagnostic columns) and **0073** (`ask_dev_wave_3_1` flag seed).

### Verification

- 265 new tests (898 green in tests/api/dev + tests/docs): A1–A13 acceptance harness with 20× determinism loops, M1–M9 mutation suite with observed fail-before/pass-after on every seam (incl. layered gate mutations and a ledger-erasure mutation only the guard can see), 44 interpreter + 19 preflight units, run-state drift guards verified by planting the defect.
- Two adversarial review rounds, every finding reproduced by execution before fixing; final round's probes (page-scope inheritance, bare-name narration, exact-label starvation) are permanent end-to-end regressions asserting the **executed tool-request scope**, not diagnostics.
- Full `ci/local_validate.sh` green (ruff, mypy, go, FULL unit suite, live-ClickHouse argMax proof).

### Positive control

The literal "What is the status of the Ask Dev project?" resolves, commits, and executes under the committed project scope deterministically (A-series, 20/20); the nonexistent-project case returns `not_found` with zero status/change/metric/evidence steps (20/20).

SCREENSHOT-WAIVER: backend only.

