### PR TITLE
feat(ask-dev): Wave 3.1 v2 persistence — intent, resolution, plans, frames, safe replay (CHAOS-3299)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0072_add_ask_dev_v2_persistence.py
+++ b/src/dev_health_ops/alembic/versions/0072_add_ask_dev_v2_persistence.py
@@ -1,0 +1,445 @@
+"""Add Ask Dev Wave 3.1 v2 persistence (intent, resolution, plans, frames, replay).
+
+Revision ID: 0072
+Revises: 0071
+Create Date: 2026-07-31 00:00:00
+
+Additive only. Adds five nullable/defaulted columns to the existing, actively
+written ``dev_runs`` table plus eight new tables FK'd to it. The two new
+``dev_runs`` CHECK constraints are installed ``NOT VALID`` on PostgreSQL (a
+metadata-only operation that does not scan the table) and validated in
+0073, so this migration never holds an ``ACCESS EXCLUSIVE`` lock for the
+duration of a full-table scan on a hot table. The new tables are created
+empty, so their own CHECK constraints need no such split.
+
+Downgrade exists for isolated pre-release rehearsal only, matching 0068's
+posture: it refuses (raises) if any v2 data is present, rather than silently
+dropping it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0072"
+down_revision: str | None = "0071"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_UUID = postgresql.UUID(as_uuid=True)
+_JSON = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+_CONTRACT_GENERATION_CK = "ck_dev_runs_contract_generation"
+_PUBLIC_OUTCOME_CK = "ck_dev_runs_public_outcome"
+
+_PUBLIC_OUTCOME_VALUES = (
+    "'answered', 'answered_with_gaps', 'needs_clarification', 'not_found', "
+    "'temporarily_unavailable', 'unsupported', 'denied', 'failed'"
+)
+
+
+def _owner_fk(table: str) -> sa.ForeignKeyConstraint:
+    return sa.ForeignKeyConstraint(
+        ["run_id", "org_id", "user_id"],
+        ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+        name=f"fk_{table}_run_owner",
+        ondelete="CASCADE",
+    )
+
+
+def _owner_columns() -> list[sa.Column]:
+    return [
+        sa.Column("id", _UUID, nullable=False),
+        sa.Column("run_id", _UUID, nullable=False),
+        sa.Column("org_id", _UUID, nullable=False),
+        sa.Column("user_id", _UUID, nullable=False),
+    ]
+
+
+def _created_at_column() -> sa.Column:
+    return sa.Column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # -- dev_runs additive columns -------------------------------------
+    op.add_column(
+        "dev_runs",
+        sa.Column(
+            "contract_generation",
+            sa.String(length=4),
+            nullable=False,
+            server_default="v1",
+        ),
+    )
+    op.add_column(
+        "dev_runs", sa.Column("public_outcome", sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        "dev_runs",
+        sa.Column(
+            "compatibility_projection_version", sa.String(length=128), nullable=True
+        ),
+    )
+    op.add_column(
+        "dev_runs", sa.Column("plan_id", sa.String(length=128), nullable=True)
+    )
+    op.add_column(
+        "dev_runs", sa.Column("plan_version", sa.String(length=128), nullable=True)
+    )
+
+    if is_postgres:
+        op.execute(
+            f"ALTER TABLE dev_runs ADD CONSTRAINT {_CONTRACT_GENERATION_CK} "
+            "CHECK (contract_generation IN ('v1', 'v2')) NOT VALID"
+        )
+        op.execute(
+            f"ALTER TABLE dev_runs ADD CONSTRAINT {_PUBLIC_OUTCOME_CK} "
+            f"CHECK (public_outcome IS NULL OR public_outcome IN "
+            f"({_PUBLIC_OUTCOME_VALUES})) NOT VALID"
+        )
+    else:
+        with op.batch_alter_table("dev_runs") as batch:
+            batch.create_check_constraint(
+                _CONTRACT_GENERATION_CK, "contract_generation IN ('v1', 'v2')"
+            )
+            batch.create_check_constraint(
+                _PUBLIC_OUTCOME_CK,
+                f"public_outcome IS NULL OR public_outcome IN "
+                f"({_PUBLIC_OUTCOME_VALUES})",
+            )
+
+    # -- dev_run_intents -------------------------------------------------
+    op.create_table(
+        "dev_run_intents",
+        *_owner_columns(),
+        sa.Column("intent_id", sa.String(length=48), nullable=False),
+        sa.Column("cardinality", sa.String(length=24), nullable=False),
+        sa.Column("requires_clarification", sa.Boolean(), nullable=False),
+        sa.Column("interpreter_version", sa.String(length=128), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "intent_id IN ('entity_status', 'portfolio_status', 'remaining_work', "
+            "'observed_change', 'registered_statistics', 'metric_comparison', "
+            "'data_trust', 'project_health', 'team_health', "
+            "'team_workload_balance', 'operational_deficiency_inventory', "
+            "'bounded_investigation')",
+            name="ck_dev_run_intents_intent_id",
+        ),
+        sa.CheckConstraint(
+            "cardinality IN ('singular', 'plural_cohort', 'organization_wide')",
+            name="ck_dev_run_intents_cardinality",
+        ),
+        _owner_fk("dev_run_intents"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_run_intents_run"),
+    )
+    op.create_index(
+        "ix_dev_run_intents_owner_run",
+        "dev_run_intents",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_resolutions (append-only ledger entries) -----------------
+    op.create_table(
+        "dev_run_resolutions",
+        *_owner_columns(),
+        sa.Column("entry_ordinal", sa.SmallInteger(), nullable=False),
+        sa.Column("mention_id", _UUID, nullable=False),
+        sa.Column("outcome", sa.String(length=32), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "entry_ordinal >= 0 AND entry_ordinal <= 99",
+            name="ck_dev_run_resolutions_entry_ordinal",
+        ),
+        sa.CheckConstraint(
+            "outcome IN ('exact_match', 'ambiguous_candidates', "
+            "'no_authorized_match', 'catalog_unavailable', 'unsupported_kind')",
+            name="ck_dev_run_resolutions_outcome",
+        ),
+        _owner_fk("dev_run_resolutions"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_id", "entry_ordinal", name="uq_dev_run_resolutions_run_ordinal"
+        ),
+    )
+    op.create_index(
+        "ix_dev_run_resolutions_owner_run",
+        "dev_run_resolutions",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_subject_sets ---------------------------------------------
+    op.create_table(
+        "dev_run_subject_sets",
+        *_owner_columns(),
+        sa.Column("set_id", _UUID, nullable=False),
+        sa.Column("entity_kind", sa.String(length=32), nullable=False),
+        sa.Column("cohort_complete", sa.Boolean(), nullable=False),
+        sa.Column("fingerprint", sa.String(length=128), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "entity_kind IN ('repository', 'project', 'work_unit', 'issue', "
+            "'pull_request', 'team')",
+            name="ck_dev_run_subject_sets_entity_kind",
+        ),
+        _owner_fk("dev_run_subject_sets"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_run_subject_sets_run"),
+    )
+    op.create_index(
+        "ix_dev_run_subject_sets_owner_run",
+        "dev_run_subject_sets",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_source_observations ---------------------------------------
+    op.create_table(
+        "dev_run_source_observations",
+        *_owner_columns(),
+        sa.Column("ordinal", sa.SmallInteger(), nullable=False),
+        sa.Column("observation_id", _UUID, nullable=False),
+        sa.Column("source_class", sa.String(length=32), nullable=False),
+        sa.Column("requirement_level", sa.String(length=16), nullable=False),
+        sa.Column("observed_state", sa.String(length=32), nullable=False),
+        sa.Column("data_semantics", sa.String(length=16), nullable=False),
+        sa.Column("usable_fact_count", sa.Integer(), nullable=False),
+        sa.Column("sample_count", sa.Integer(), nullable=True),
+        sa.Column("subject_coverage", sa.Float(), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "ordinal >= 0 AND ordinal <= 24",
+            name="ck_dev_run_source_observations_ordinal",
+        ),
+        sa.CheckConstraint(
+            "source_class IN ('status_change', 'work_item', 'work_graph', "
+            "'pull_request', 'code_change', 'review', 'ci_run', 'test_report', "
+            "'deployment', 'incident', 'operational_control', 'source_health')",
+            name="ck_dev_run_source_observations_source_class",
+        ),
+        sa.CheckConstraint(
+            "requirement_level IN ('mandatory', 'conditional', 'optional', "
+            "'not_applicable')",
+            name="ck_dev_run_source_observations_requirement_level",
+        ),
+        sa.CheckConstraint(
+            "observed_state IN ('available_current', 'available_stale', "
+            "'available_unknown', 'unconfigured', 'unavailable', "
+            "'unauthorized_or_not_visible', 'not_applicable', 'truncated')",
+            name="ck_dev_run_source_observations_observed_state",
+        ),
+        sa.CheckConstraint(
+            "data_semantics IN ('measured_zero', 'no_data', 'not_measured')",
+            name="ck_dev_run_source_observations_data_semantics",
+        ),
+        sa.CheckConstraint(
+            "usable_fact_count >= 0 AND (sample_count IS NULL OR sample_count >= 0)",
+            name="ck_dev_run_source_observations_counts_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "subject_coverage >= 0 AND subject_coverage <= 1",
+            name="ck_dev_run_source_observations_coverage_range",
+        ),
+        _owner_fk("dev_run_source_observations"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_id", "ordinal", name="uq_dev_run_source_observations_run_ordinal"
+        ),
+    )
+    op.create_index(
+        "ix_dev_run_source_observations_owner_run",
+        "dev_run_source_observations",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_investigation_results (reconciliation delta) -------------
+    op.create_table(
+        "dev_run_investigation_results",
+        *_owner_columns(),
+        sa.Column("result_id", _UUID, nullable=False),
+        sa.Column("relationship_closure_verified", sa.Boolean(), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=False),
+        _created_at_column(),
+        _owner_fk("dev_run_investigation_results"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_run_investigation_results_run"),
+    )
+    op.create_index(
+        "ix_dev_run_investigation_results_owner_run",
+        "dev_run_investigation_results",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_answer_frames --------------------------------------------------
+    op.create_table(
+        "dev_answer_frames",
+        *_owner_columns(),
+        sa.Column("frame_id", _UUID, nullable=False),
+        sa.Column("public_outcome", sa.String(length=32), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            f"public_outcome IN ({_PUBLIC_OUTCOME_VALUES})",
+            name="ck_dev_answer_frames_public_outcome",
+        ),
+        _owner_fk("dev_answer_frames"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_answer_frames_run"),
+    )
+    op.create_index(
+        "ix_dev_answer_frames_owner_run",
+        "dev_answer_frames",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_narratives ---------------------------------------------
+    op.create_table(
+        "dev_run_narratives",
+        *_owner_columns(),
+        sa.Column("narrative_id", _UUID, nullable=False),
+        sa.Column("frame_id", _UUID, nullable=False),
+        sa.Column("mode", sa.String(length=24), nullable=False),
+        sa.Column("provider_fingerprint", sa.String(length=71), nullable=True),
+        sa.Column("narrative_text", sa.Text(), nullable=False),
+        sa.Column("payload", _JSON, nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "mode IN ('provider', 'deterministic_fallback')",
+            name="ck_dev_run_narratives_mode",
+        ),
+        sa.CheckConstraint(
+            "provider_fingerprint IS NULL OR "
+            "(length(provider_fingerprint) = 71 "
+            "AND provider_fingerprint LIKE 'sha256:%')",
+            name="ck_dev_run_narratives_provider_fingerprint",
+        ),
+        _owner_fk("dev_run_narratives"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_run_narratives_run"),
+    )
+    op.create_index(
+        "ix_dev_run_narratives_owner_run",
+        "dev_run_narratives",
+        ["org_id", "user_id", "run_id"],
+    )
+
+    # -- dev_run_stage_diagnostics -----------------------------------------
+    op.create_table(
+        "dev_run_stage_diagnostics",
+        *_owner_columns(),
+        sa.Column("ordinal", sa.SmallInteger(), nullable=False),
+        sa.Column("stage_id", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("counts", _JSON, nullable=False),
+        _created_at_column(),
+        sa.CheckConstraint(
+            "ordinal >= 0 AND ordinal <= 9",
+            name="ck_dev_run_stage_diagnostics_ordinal",
+        ),
+        sa.CheckConstraint(
+            "stage_id IN ('interpreting', 'resolving_subjects', 'planning', "
+            "'collecting', 'synthesizing_frame', 'narrating_optional', "
+            "'projecting_answer')",
+            name="ck_dev_run_stage_diagnostics_stage_id",
+        ),
+        sa.CheckConstraint(
+            "status IN ('started', 'completed', 'failed', 'skipped')",
+            name="ck_dev_run_stage_diagnostics_status",
+        ),
+        sa.CheckConstraint(
+            "latency_ms IS NULL OR latency_ms >= 0",
+            name="ck_dev_run_stage_diagnostics_latency_nonnegative",
+        ),
+        _owner_fk("dev_run_stage_diagnostics"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_id", "ordinal", name="uq_dev_run_stage_diagnostics_run_ordinal"
+        ),
+    )
+    op.create_index(
+        "ix_dev_run_stage_diagnostics_owner_run",
+        "dev_run_stage_diagnostics",
+        ["org_id", "user_id", "run_id"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # Pre-release rehearsal only (matching 0068's posture): refuse rather
+    # than silently discard v2 data. Checked before dropping anything.
+    if bind.dialect.has_table(bind, "dev_runs"):
+        v2_rows = bind.execute(
+            sa.text("SELECT count(*) FROM dev_runs WHERE contract_generation = 'v2'")
+        ).scalar()
+        if v2_rows:
+            raise RuntimeError(
+                "refusing to downgrade 0072: dev_runs has "
+                f"{v2_rows} row(s) with contract_generation = 'v2'; this "
+                "downgrade is for pre-release rehearsal only"
+            )
+        for table in (
+            "dev_run_intents",
+            "dev_run_resolutions",
+            "dev_run_subject_sets",
+            "dev_run_source_observations",
+            "dev_run_investigation_results",
+            "dev_answer_frames",
+            "dev_run_narratives",
+            "dev_run_stage_diagnostics",
+        ):
+            if bind.dialect.has_table(bind, table):
+                for_v2_rows = bind.execute(
+                    sa.text(f"SELECT count(*) FROM {table}")
+                ).scalar()
+                if for_v2_rows:
+                    raise RuntimeError(
+                        f"refusing to downgrade 0072: {table} has "
+                        f"{for_v2_rows} row(s); this downgrade is for "
+                        "pre-release rehearsal only"
+                    )
+
+    op.drop_table("dev_run_stage_diagnostics")
+    op.drop_table("dev_run_narratives")
+    op.drop_table("dev_answer_frames")
+    op.drop_table("dev_run_investigation_results")
+    op.drop_table("dev_run_source_observations")
+    op.drop_table("dev_run_subject_sets")
+    op.drop_table("dev_run_resolutions")
+    op.drop_table("dev_run_intents")
+
+    if bind.dialect.name == "postgresql":
+        op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_PUBLIC_OUTCOME_CK}")
+        op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_CONTRACT_GENERATION_CK}")
+        op.drop_column("dev_runs", "plan_version")
+        op.drop_column("dev_runs", "plan_id")
+        op.drop_column("dev_runs", "compatibility_projection_version")
+        op.drop_column("dev_runs", "public_outcome")
+        op.drop_column("dev_runs", "contract_generation")
+    else:
+        with op.batch_alter_table("dev_runs") as batch:
+            batch.drop_constraint(_PUBLIC_OUTCOME_CK, type_="check")
+            batch.drop_constraint(_CONTRACT_GENERATION_CK, type_="check")
+            batch.drop_column("plan_version")
+            batch.drop_column("plan_id")
+            batch.drop_column("compatibility_projection_version")
+            batch.drop_column("public_outcome")
+            batch.drop_column("contract_generation")

--- a/src/dev_health_ops/alembic/versions/0073_validate_ask_dev_v2_constraints.py
+++ b/src/dev_health_ops/alembic/versions/0073_validate_ask_dev_v2_constraints.py
@@ -1,0 +1,47 @@
+"""Validate the NOT VALID dev_runs CHECK constraints added in 0072.
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-07-31 00:00:01
+
+``VALIDATE CONSTRAINT`` takes only a ``SHARE UPDATE EXCLUSIVE`` lock (does not
+block concurrent reads/writes) while it scans existing rows. Both
+constraints are trivially satisfiable by every pre-existing row: 0072's
+``ADD COLUMN ... DEFAULT 'v1'`` makes every row already ``contract_generation
+= 'v1'``, and ``public_outcome`` is NULL on every pre-existing row (the
+constraint explicitly allows NULL). This step is therefore expected to be
+fast, but is kept as its own migration -- rather than folded into 0072 -- so
+a slow validation on an unexpectedly large table cannot block table
+creation, matching the 0068/0069 schema-then-index precedent.
+
+No-op on non-PostgreSQL backends: SQLite's ``batch_alter_table`` already
+fully validates a CHECK constraint at creation time in 0072.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0073"
+down_revision: str | None = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONTRACT_GENERATION_CK = "ck_dev_runs_contract_generation"
+_PUBLIC_OUTCOME_CK = "ck_dev_runs_public_outcome"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute(f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_CONTRACT_GENERATION_CK}")
+    op.execute(f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_PUBLIC_OUTCOME_CK}")
+
+
+def downgrade() -> None:
+    # VALIDATE CONSTRAINT has no reversible state: the constraint remains
+    # installed (and valid) from 0072 either way. Nothing to undo here.
+    pass

--- a/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
+++ b/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
@@ -391,6 +391,29 @@ def downgrade() -> None:
                 f"{v2_rows} row(s) with contract_generation = 'v2'; this "
                 "downgrade is for pre-release rehearsal only"
             )
+        # Independent sweep, not just belt-and-suspenders with the tagging
+        # check above: DevPersistenceService.record_investigation_result
+        # can populate these two folded columns (Codex-review CHAOS-3299
+        # fold) before a run ever reaches record_frame -- the call that
+        # tags contract_generation = 'v2' -- e.g. a failure between the
+        # investigation and frame-synthesis stages. A run in that state is
+        # still tagged 'v1' and would silently pass the check above while
+        # carrying real v2 data.
+        folded_column_rows = bind.execute(
+            sa.text(
+                "SELECT count(*) FROM dev_runs WHERE "
+                "plan_step_partition IS NOT NULL "
+                "OR relationship_closure_verified IS NOT NULL"
+            )
+        ).scalar()
+        if folded_column_rows:
+            raise RuntimeError(
+                "refusing to downgrade 0074: dev_runs has "
+                f"{folded_column_rows} row(s) with plan_step_partition or "
+                "relationship_closure_verified populated (independent of "
+                "contract_generation tagging); this downgrade is for "
+                "pre-release rehearsal only"
+            )
         for table in (
             "dev_run_intents",
             "dev_run_resolutions",

--- a/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
+++ b/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
@@ -25,8 +25,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "0072"
-down_revision: str | None = "0071"
+revision: str = "0074"
+down_revision: str | None = "0073"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
+++ b/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
@@ -1,16 +1,25 @@
 """Add Ask Dev Wave 3.1 v2 persistence (intent, resolution, plans, frames, replay).
 
-Revision ID: 0072
-Revises: 0071
+Revision ID: 0074
+Revises: 0073
 Create Date: 2026-07-31 00:00:00
 
-Additive only. Adds five nullable/defaulted columns to the existing, actively
-written ``dev_runs`` table plus eight new tables FK'd to it. The two new
-``dev_runs`` CHECK constraints are installed ``NOT VALID`` on PostgreSQL (a
-metadata-only operation that does not scan the table) and validated in
-0073, so this migration never holds an ``ACCESS EXCLUSIVE`` lock for the
-duration of a full-table scan on a hot table. The new tables are created
-empty, so their own CHECK constraints need no such split.
+Additive only. Adds seven nullable/defaulted columns to the existing,
+actively written ``dev_runs`` table plus seven new tables FK'd to it. The
+two new ``dev_runs`` CHECK constraints are installed ``NOT VALID`` on
+PostgreSQL (a metadata-only operation that does not scan the table) and
+validated in 0075, so this migration never holds an ``ACCESS EXCLUSIVE``
+lock for the duration of a full-table scan on a hot table. The new tables
+are created empty, so their own CHECK constraints need no such split.
+
+``plan_step_partition``/``relationship_closure_verified`` fold what an
+earlier revision of this branch modeled as a dedicated
+``dev_run_investigation_results`` table: observations are already
+persisted 1:N in ``dev_run_source_observations`` and ``dev_answer_frames``
+is the replay source of truth, so the only post-terminal
+``dev_investigation_result.v1`` facts nothing else reconstructs -- which
+plan steps ran, and the closure bit -- are persisted directly on
+``dev_runs`` instead of a ninth table.
 
 Downgrade exists for isolated pre-release rehearsal only, matching 0068's
 posture: it refuses (raises) if any v2 data is present, rather than silently
@@ -97,6 +106,11 @@ def upgrade() -> None:
     )
     op.add_column(
         "dev_runs", sa.Column("plan_version", sa.String(length=128), nullable=True)
+    )
+    op.add_column("dev_runs", sa.Column("plan_step_partition", _JSON, nullable=True))
+    op.add_column(
+        "dev_runs",
+        sa.Column("relationship_closure_verified", sa.Boolean(), nullable=True),
     )
 
     if is_postgres:
@@ -269,25 +283,6 @@ def upgrade() -> None:
         ["org_id", "user_id", "run_id"],
     )
 
-    # -- dev_run_investigation_results (reconciliation delta) -------------
-    op.create_table(
-        "dev_run_investigation_results",
-        *_owner_columns(),
-        sa.Column("result_id", _UUID, nullable=False),
-        sa.Column("relationship_closure_verified", sa.Boolean(), nullable=False),
-        sa.Column("payload", _JSON, nullable=False),
-        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=False),
-        _created_at_column(),
-        _owner_fk("dev_run_investigation_results"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("run_id", name="uq_dev_run_investigation_results_run"),
-    )
-    op.create_index(
-        "ix_dev_run_investigation_results_owner_run",
-        "dev_run_investigation_results",
-        ["org_id", "user_id", "run_id"],
-    )
-
     # -- dev_answer_frames --------------------------------------------------
     op.create_table(
         "dev_answer_frames",
@@ -392,7 +387,7 @@ def downgrade() -> None:
         ).scalar()
         if v2_rows:
             raise RuntimeError(
-                "refusing to downgrade 0072: dev_runs has "
+                "refusing to downgrade 0074: dev_runs has "
                 f"{v2_rows} row(s) with contract_generation = 'v2'; this "
                 "downgrade is for pre-release rehearsal only"
             )
@@ -401,7 +396,6 @@ def downgrade() -> None:
             "dev_run_resolutions",
             "dev_run_subject_sets",
             "dev_run_source_observations",
-            "dev_run_investigation_results",
             "dev_answer_frames",
             "dev_run_narratives",
             "dev_run_stage_diagnostics",
@@ -412,7 +406,7 @@ def downgrade() -> None:
                 ).scalar()
                 if for_v2_rows:
                     raise RuntimeError(
-                        f"refusing to downgrade 0072: {table} has "
+                        f"refusing to downgrade 0074: {table} has "
                         f"{for_v2_rows} row(s); this downgrade is for "
                         "pre-release rehearsal only"
                     )
@@ -420,7 +414,6 @@ def downgrade() -> None:
     op.drop_table("dev_run_stage_diagnostics")
     op.drop_table("dev_run_narratives")
     op.drop_table("dev_answer_frames")
-    op.drop_table("dev_run_investigation_results")
     op.drop_table("dev_run_source_observations")
     op.drop_table("dev_run_subject_sets")
     op.drop_table("dev_run_resolutions")
@@ -429,6 +422,8 @@ def downgrade() -> None:
     if bind.dialect.name == "postgresql":
         op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_PUBLIC_OUTCOME_CK}")
         op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_CONTRACT_GENERATION_CK}")
+        op.drop_column("dev_runs", "relationship_closure_verified")
+        op.drop_column("dev_runs", "plan_step_partition")
         op.drop_column("dev_runs", "plan_version")
         op.drop_column("dev_runs", "plan_id")
         op.drop_column("dev_runs", "compatibility_projection_version")
@@ -438,6 +433,8 @@ def downgrade() -> None:
         with op.batch_alter_table("dev_runs") as batch:
             batch.drop_constraint(_PUBLIC_OUTCOME_CK, type_="check")
             batch.drop_constraint(_CONTRACT_GENERATION_CK, type_="check")
+            batch.drop_column("relationship_closure_verified")
+            batch.drop_column("plan_step_partition")
             batch.drop_column("plan_version")
             batch.drop_column("plan_id")
             batch.drop_column("compatibility_projection_version")

--- a/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
+++ b/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
@@ -24,8 +24,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0073"
-down_revision: str | None = "0072"
+revision: str = "0075"
+down_revision: str | None = "0074"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
+++ b/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
@@ -1,21 +1,21 @@
-"""Validate the NOT VALID dev_runs CHECK constraints added in 0072.
+"""Validate the NOT VALID dev_runs CHECK constraints added in 0074.
 
-Revision ID: 0073
-Revises: 0072
+Revision ID: 0075
+Revises: 0074
 Create Date: 2026-07-31 00:00:01
 
 ``VALIDATE CONSTRAINT`` takes only a ``SHARE UPDATE EXCLUSIVE`` lock (does not
 block concurrent reads/writes) while it scans existing rows. Both
-constraints are trivially satisfiable by every pre-existing row: 0072's
+constraints are trivially satisfiable by every pre-existing row: 0074's
 ``ADD COLUMN ... DEFAULT 'v1'`` makes every row already ``contract_generation
 = 'v1'``, and ``public_outcome`` is NULL on every pre-existing row (the
 constraint explicitly allows NULL). This step is therefore expected to be
-fast, but is kept as its own migration -- rather than folded into 0072 -- so
+fast, but is kept as its own migration -- rather than folded into 0074 -- so
 a slow validation on an unexpectedly large table cannot block table
 creation, matching the 0068/0069 schema-then-index precedent.
 
 No-op on non-PostgreSQL backends: SQLite's ``batch_alter_table`` already
-fully validates a CHECK constraint at creation time in 0072.
+fully validates a CHECK constraint at creation time in 0074.
 """
 
 from __future__ import annotations
@@ -43,5 +43,5 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # VALIDATE CONSTRAINT has no reversible state: the constraint remains
-    # installed (and valid) from 0072 either way. Nothing to undo here.
+    # installed (and valid) from 0074 either way. Nothing to undo here.
     pass

--- a/src/dev_health_ops/api/_health.py
+++ b/src/dev_health_ops/api/_health.py
@@ -101,7 +101,16 @@ def _dsn_uses_async_driver(dsn: str) -> bool:
 
 
 async def _check_postgres_health() -> tuple[str, str]:
-    """Check Postgres connectivity. Returns ``("postgres", status)``."""
+    """Check Postgres connectivity and required schema revision.
+
+    Returns ``("postgres", status)``. ``status`` is ``"down"`` both for raw
+    connectivity failure and for a reachable database missing the required
+    application schema revision (CHAOS-3299) -- this closes the window the
+    one-time ``_lifespan`` startup check cannot: multi-replica rollouts where
+    one replica boots successfully before a migration completes elsewhere, or
+    an operator manually rolling the database back without restarting the
+    process. Re-checked on every probe.
+    """
     if not _postgres_url():
         return "postgres", "not_configured"
     uri = get_postgres_uri()
@@ -111,7 +120,15 @@ async def _check_postgres_health() -> tuple[str, str]:
         ok = await _check_sqlalchemy_health_async(uri)
     else:
         ok = await asyncio.to_thread(_check_sqlalchemy_health, uri)
-    return "postgres", "ok" if ok else "down"
+    if not ok:
+        return "postgres", "down"
+    from dev_health_ops.migrate import application_schema_status
+
+    try:
+        satisfied, _current_heads = await application_schema_status(uri)
+    except Exception:
+        return "postgres", "down"
+    return "postgres", "ok" if satisfied else "down"
 
 
 async def _check_clickhouse_health() -> tuple[str, str]:

--- a/src/dev_health_ops/api/_lifespan.py
+++ b/src/dev_health_ops/api/_lifespan.py
@@ -34,6 +34,14 @@ async def lifespan(app: FastAPI):
          feature keys when a Postgres URL is configured. Re-raise integrity
          errors so the process refuses to start with a corrupt registry; tolerate
          other failures (e.g. DB not yet ready in tests / containers).
+      3. Verify PostgreSQL satisfies the required application schema revision
+         (CHAOS-3299). Re-raise when the database is reachable but missing the
+         revision, so the process refuses to start against an unmigrated
+         schema (converting the failure mode from a runtime
+         ``UndefinedTable``/``ProgrammingError`` on the first Ask Dev v2
+         request to a controlled startup failure). Tolerate connection
+         failures (DB not yet ready) the same way the FeatureBundle check
+         does.
 
     Shutdown:
       * Close the global ClickHouse client.
@@ -75,6 +83,26 @@ async def lifespan(app: FastAPI):
             logger.warning(
                 "FeatureBundle key validation skipped (DB not ready): %s", _exc
             )
+
+        from dev_health_ops.migrate import (
+            application_schema_status,
+            required_application_schema_revision,
+        )
+
+        try:
+            satisfied, current_heads = await application_schema_status(postgres_uri)
+        except Exception as _exc:
+            logger.warning(
+                "Application schema revision check skipped (DB not ready): %s", _exc
+            )
+        else:
+            if not satisfied:
+                raise RuntimeError(
+                    "PostgreSQL is missing required application schema "
+                    f"revision {required_application_schema_revision()} "
+                    f"(current heads: {', '.join(current_heads) or '(base)'}); "
+                    "run `dev-hops migrate postgres` before starting the API"
+                )
 
     yield
     await close_global_client()

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -6,9 +6,15 @@ import hashlib
 import json
 import time
 import uuid
-from typing import Literal
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from .contracts import DevAnswer, DevError, DevToolRequest
+from .contracts_v2.frame import DevAnswerFrame
+from .contracts_v2.intent import DevQuestionIntent
+from .contracts_v2.narrative import DevNarrative
+from .contracts_v2.result import DevInvestigationResult, DevSourceObservation
+from .contracts_v2.subject import DevResolutionEntry, DevSubjectSet
 from .orchestrator import RunState
 from .persistence.service import DevPersistenceService
 from .prompts import PROMPT_VERSION
@@ -117,6 +123,154 @@ class PersistenceRunRecorder:
                 + len(execution.result.data_health)
             ),
             byte_count=execution.serialized_bytes,
+        )
+
+    # -- Wave 3.1 (CHAOS-3299) v2 recorder adapters --------------------------
+    # Thin adapters from a validated contracts_v2 object to the
+    # DevPersistenceService recorder methods. The v2 orchestrator that
+    # produces these objects (TRD v2 Section 10's server-owned stage
+    # machine) is a separate lane's deliverable; these methods are the
+    # interface it calls into, all pre-terminal, mirroring `record_tool`'s
+    # existing placement ahead of `terminal()`.
+
+    async def record_intent(self, intent: DevQuestionIntent) -> None:
+        await self._service.record_intent(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            intent_id=intent.intent_id.value,
+            cardinality=intent.cardinality.value,
+            requires_clarification=intent.requires_clarification,
+            interpreter_version=intent.interpreter_version,
+            payload=intent.model_dump(mode="json"),
+        )
+
+    async def append_resolution(self, entry: DevResolutionEntry) -> None:
+        await self._service.append_resolution(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            entry_ordinal=entry.entry_ordinal,
+            mention_id=uuid.UUID(entry.mention_id),
+            outcome=entry.outcome.value,
+            resolved_at=entry.resolved_at,
+            payload=entry.model_dump(mode="json"),
+        )
+
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        await self._service.record_subject_set(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            set_id=uuid.UUID(subject_set.set_id),
+            entity_kind=subject_set.entity_kind.value,
+            cohort_complete=subject_set.cohort_complete,
+            fingerprint=subject_set.fingerprint,
+            payload=subject_set.model_dump(mode="json"),
+        )
+
+    async def append_source_observation(
+        self, ordinal: int, observation: DevSourceObservation
+    ) -> None:
+        await self._service.append_source_observation(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            ordinal=ordinal,
+            observation_id=uuid.UUID(observation.observation_id),
+            source_class=observation.source_class.value,
+            requirement_level=observation.requirement_level,
+            observed_state=observation.observed_state.value,
+            data_semantics=observation.data_semantics,
+            usable_fact_count=observation.usable_fact_count,
+            sample_count=observation.sample_count,
+            subject_coverage=observation.subject_coverage,
+            observed_at=observation.observed_at,
+            payload=observation.model_dump(mode="json"),
+        )
+
+    async def record_investigation_result(self, result: DevInvestigationResult) -> None:
+        """Persist every observation, then the wrapper's own bookkeeping.
+
+        Reconciliation delta (see ``DevRunInvestigationResult`` docstring):
+        the landed contract has ``DevInvestigationResult`` as a distinct
+        top-level object wrapping ``observations`` plus step-completion
+        bookkeeping the observations alone cannot reconstruct.
+        """
+
+        for ordinal, observation in enumerate(result.observations):
+            await self.append_source_observation(ordinal, observation)
+        await self._service.record_investigation_result(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            result_id=uuid.UUID(result.result_id),
+            relationship_closure_verified=result.relationship_closure_verified,
+            completed_at=result.completed_at,
+            payload={
+                "schema_version": result.schema_version,
+                "result_id": result.result_id,
+                "plan_id": result.plan_id,
+                "plan_version": result.plan_version,
+                "run_id": result.run_id,
+                "subject_set_fingerprint": result.subject_set_fingerprint,
+                "subject_entity_id": result.subject_entity_id,
+                "completed_steps": list(result.completed_steps),
+                "skipped_steps": list(result.skipped_steps),
+                "failed_steps": list(result.failed_steps),
+                "relationship_closure_verified": result.relationship_closure_verified,
+                "completed_at": result.completed_at.isoformat(),
+            },
+        )
+
+    async def record_frame(self, frame: DevAnswerFrame) -> None:
+        await self._service.record_frame(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            frame_id=uuid.UUID(frame.frame_id),
+            public_outcome=frame.public_outcome.value,
+            payload=frame.model_dump(mode="json"),
+        )
+
+    async def record_narrative(self, narrative: DevNarrative) -> None:
+        provider_fingerprint = None
+        if narrative.provider_metadata is not None:
+            provider_fingerprint = _digest(
+                narrative.provider_metadata.model_fingerprint
+            )
+        await self._service.record_narrative(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            narrative_id=uuid.UUID(narrative.narrative_id),
+            frame_id=uuid.UUID(narrative.frame_id),
+            mode=narrative.mode,
+            provider_fingerprint=provider_fingerprint,
+            narrative_text=narrative.body,
+            # `body` is stored separately as `narrative_text`; excluded here
+            # to avoid duplicating it inside the JSONB payload.
+            payload=narrative.model_dump(mode="json", exclude={"body"}),
+        )
+
+    async def append_stage_diagnostic(
+        self,
+        *,
+        ordinal: int,
+        stage_id: str,
+        status: Literal["started", "completed", "failed", "skipped"],
+        latency_ms: int | None = None,
+        counts: Mapping[str, Any] | None = None,
+    ) -> None:
+        await self._service.append_stage_diagnostic(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            ordinal=ordinal,
+            stage_id=stage_id,
+            status=status,
+            latency_ms=latency_ms,
+            counts=dict(counts or {}),
         )
 
     async def record_answer(self, answer: DevAnswer) -> None:

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -190,12 +190,13 @@ class PersistenceRunRecorder:
         )
 
     async def record_investigation_result(self, result: DevInvestigationResult) -> None:
-        """Persist every observation, then the wrapper's own bookkeeping.
+        """Persist every observation, then the plan-step partition + closure bit.
 
-        Reconciliation delta (see ``DevRunInvestigationResult`` docstring):
-        the landed contract has ``DevInvestigationResult`` as a distinct
-        top-level object wrapping ``observations`` plus step-completion
-        bookkeeping the observations alone cannot reconstruct.
+        Folded (orchestrator decision, CHAOS-3299): see
+        ``DevPersistenceService.record_investigation_result`` -- observations
+        are still recorded 1:N as before; the wrapper's own bookkeeping
+        (which plan steps ran, and relationship-closure verification) is now
+        set directly on ``dev_runs`` instead of a dedicated ninth table.
         """
 
         for ordinal, observation in enumerate(result.observations):
@@ -204,23 +205,10 @@ class PersistenceRunRecorder:
             org_id=self._org_id,
             user_id=self._user_id,
             run_id=self._run_id,
-            result_id=uuid.UUID(result.result_id),
+            completed_steps=list(result.completed_steps),
+            skipped_steps=list(result.skipped_steps),
+            failed_steps=list(result.failed_steps),
             relationship_closure_verified=result.relationship_closure_verified,
-            completed_at=result.completed_at,
-            payload={
-                "schema_version": result.schema_version,
-                "result_id": result.result_id,
-                "plan_id": result.plan_id,
-                "plan_version": result.plan_version,
-                "run_id": result.run_id,
-                "subject_set_fingerprint": result.subject_set_fingerprint,
-                "subject_entity_id": result.subject_entity_id,
-                "completed_steps": list(result.completed_steps),
-                "skipped_steps": list(result.skipped_steps),
-                "failed_steps": list(result.failed_steps),
-                "relationship_closure_verified": result.relationship_closure_verified,
-                "completed_at": result.completed_at.isoformat(),
-            },
         )
 
     async def record_frame(self, frame: DevAnswerFrame) -> None:

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -31,7 +31,6 @@ from dev_health_ops.models.dev_persistence import (
     DevMessage,
     DevRun,
     DevRunIntent,
-    DevRunInvestigationResult,
     DevRunNarrative,
     DevRunResolution,
     DevRunSourceObservation,
@@ -200,7 +199,8 @@ _INTENT_PAYLOAD_MAX_BYTES = 16 * 1024
 _RESOLUTION_PAYLOAD_MAX_BYTES = 8 * 1024
 _SUBJECT_SET_PAYLOAD_MAX_BYTES = 16 * 1024
 _SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES = 16 * 1024
-_INVESTIGATION_RESULT_PAYLOAD_MAX_BYTES = 8 * 1024
+_PLAN_STEP_PARTITION_MAX_BYTES = 8 * 1024
+_PLAN_STEP_LIST_MAX_ITEMS = 25
 _FRAME_PAYLOAD_MAX_BYTES = 128 * 1024
 _NARRATIVE_TEXT_MAX_BYTES = 8 * 1024
 _NARRATIVE_PAYLOAD_MAX_BYTES = 16 * 1024
@@ -386,6 +386,29 @@ def _bounded_json(
     if len(encoded.encode("utf-8")) > max_bytes:
         raise DevPersistenceValidationError(f"{field} exceeds {max_bytes} bytes")
     return copied
+
+
+def _bounded_step_list(values: Sequence[str], *, field: str) -> list[str]:
+    """Bound one ``plan_step_partition`` list: at most 25 non-empty entries.
+
+    Mirrors the contract's own ``ShortText`` tuple ``max_length=25`` bound
+    (``DevInvestigationResult.completed_steps`` etc.) as a service-layer
+    double-check, the same posture as every other Wave 3.1 closed-vocabulary
+    re-check.
+    """
+
+    if len(values) > _PLAN_STEP_LIST_MAX_ITEMS:
+        raise DevPersistenceValidationError(
+            f"{field} exceeds {_PLAN_STEP_LIST_MAX_ITEMS} entries"
+        )
+    bounded: list[str] = []
+    for item in values:
+        if not isinstance(item, str) or not item:
+            raise DevPersistenceValidationError(
+                f"{field} entries must be non-empty text"
+            )
+        bounded.append(item)
+    return bounded
 
 
 def _safe_count_summary(value: Mapping[str, Any], *, field: str) -> dict[str, Any]:
@@ -1423,40 +1446,47 @@ class DevPersistenceService:
         org_id: uuid.UUID,
         user_id: uuid.UUID,
         run_id: uuid.UUID,
-        result_id: uuid.UUID,
+        completed_steps: Sequence[str],
+        skipped_steps: Sequence[str],
+        failed_steps: Sequence[str],
         relationship_closure_verified: bool,
-        completed_at: datetime,
-        payload: Mapping[str, Any],
-    ) -> DevRunInvestigationResult:
-        """Persist the ``dev_investigation_result.v1`` wrapper for one run.
+    ) -> DevRun:
+        """Persist the ``dev_investigation_result.v1`` step partition + closure bit.
 
-        Reconciliation delta: not one of the 7 tables in the
-        pre-implementation plan, added because the landed contract has this
-        as a distinct top-level object (completed/skipped/failed plan steps
-        plus relationship-closure verification) that the per-observation
-        ``dev_run_source_observations`` rows alone cannot reconstruct.
+        Folded (orchestrator decision, CHAOS-3299): an earlier revision of
+        this branch modeled this as a dedicated
+        ``dev_run_investigation_results`` table wrapping
+        (result_id, relationship_closure_verified, payload, completed_at).
+        Observations are already persisted 1:N via
+        ``append_source_observation``, and ``dev_answer_frames`` is the
+        replay source of truth -- the only post-terminal facts nothing else
+        reconstructs are which plan steps ran (a step can be skipped without
+        ever producing an observation) and the closure bit, so those two
+        facts are set directly on ``dev_runs`` instead of a ninth table.
         """
 
         run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
         if run is None:
             raise DevPersistenceNotFound("run not found")
-        record = DevRunInvestigationResult(
-            run_id=run.id,
-            org_id=org_id,
-            user_id=user_id,
-            result_id=result_id,
-            relationship_closure_verified=relationship_closure_verified,
-            payload=_bounded_json(
-                payload,
-                field="investigation_result_payload",
-                max_bytes=_INVESTIGATION_RESULT_PAYLOAD_MAX_BYTES,
-            ),
-            completed_at=completed_at,
-            created_at=self._now(),
+        completed = _bounded_step_list(completed_steps, field="completed_steps")
+        skipped = _bounded_step_list(skipped_steps, field="skipped_steps")
+        failed = _bounded_step_list(failed_steps, field="failed_steps")
+        if (
+            (set(completed) & set(skipped))
+            or (set(completed) & set(failed))
+            or (set(skipped) & set(failed))
+        ):
+            raise DevPersistenceValidationError(
+                "a plan step cannot be in more than one of completed/skipped/failed"
+            )
+        run.plan_step_partition = _bounded_json(
+            {"completed": completed, "skipped": skipped, "failed": failed},
+            field="plan_step_partition",
+            max_bytes=_PLAN_STEP_PARTITION_MAX_BYTES,
         )
-        self.session.add(record)
+        run.relationship_closure_verified = relationship_closure_verified
         await self.session.flush()
-        return record
+        return run
 
     async def record_frame(
         self,
@@ -1472,8 +1502,8 @@ class DevPersistenceService:
 
         One row per terminal run regardless of public outcome -- including
         ``needs_clarification``/``not_found``/``unsupported``/``denied``,
-        confirmed by the landed no-answer field policy (see
-        ``DevRunInvestigationResult`` and the frame model docstring).
+        confirmed by the landed no-answer field policy (see the frame model
+        docstring and ``DevRun.plan_step_partition``).
         """
 
         run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -24,11 +24,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dev_health_ops.api.dev.org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from dev_health_ops.models.dev_persistence import (
     DEV_RETENTION_DAYS,
+    DevAnswerFrame,
     DevConversation,
     DevConversationTombstone,
     DevFeedback,
     DevMessage,
     DevRun,
+    DevRunIntent,
+    DevRunInvestigationResult,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
     DevToolCall,
 )
 from dev_health_ops.models.users import Organization, User
@@ -93,6 +101,109 @@ _FORBIDDEN_METADATA_KEYS = frozenset(
     }
 )
 _SAFE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+# -- Wave 3.1 (CHAOS-3299) closed vocabularies -------------------------------
+# Mirrors the CHECK constraints on the corresponding tables (defense in
+# depth, matching the existing double-check pattern in append_tool_call /
+# update_run: the DB CHECK is the hard backstop, this is the friendly error).
+_QUESTION_INTENT_IDS = frozenset(
+    {
+        "entity_status",
+        "portfolio_status",
+        "remaining_work",
+        "observed_change",
+        "registered_statistics",
+        "metric_comparison",
+        "data_trust",
+        "project_health",
+        "team_health",
+        "team_workload_balance",
+        "operational_deficiency_inventory",
+        "bounded_investigation",
+    }
+)
+_CARDINALITIES = frozenset({"singular", "plural_cohort", "organization_wide"})
+_RESOLUTION_OUTCOMES = frozenset(
+    {
+        "exact_match",
+        "ambiguous_candidates",
+        "no_authorized_match",
+        "catalog_unavailable",
+        "unsupported_kind",
+    }
+)
+_ENTITY_KINDS = frozenset(
+    {"repository", "project", "work_unit", "issue", "pull_request", "team"}
+)
+_SOURCE_CLASSES = frozenset(
+    {
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+    }
+)
+_REQUIREMENT_LEVELS = frozenset(
+    {"mandatory", "conditional", "optional", "not_applicable"}
+)
+_SOURCE_OBSERVED_STATES = frozenset(
+    {
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated",
+    }
+)
+_DATA_SEMANTICS = frozenset({"measured_zero", "no_data", "not_measured"})
+_PUBLIC_OUTCOMES = frozenset(
+    {
+        "answered",
+        "answered_with_gaps",
+        "needs_clarification",
+        "not_found",
+        "temporarily_unavailable",
+        "unsupported",
+        "denied",
+        "failed",
+    }
+)
+_NARRATIVE_MODES = frozenset({"provider", "deterministic_fallback"})
+_STAGE_IDS = frozenset(
+    {
+        "interpreting",
+        "resolving_subjects",
+        "planning",
+        "collecting",
+        "synthesizing_frame",
+        "narrating_optional",
+        "projecting_answer",
+    }
+)
+_STAGE_STATUSES = frozenset({"started", "completed", "failed", "skipped"})
+
+# Bounds on the opaque JSONB payload each Wave 3.1 artifact carries. These are
+# defense-in-depth (SQLite test targets have no DB-level byte-length CHECK);
+# the contract's own bounded collection max_lengths are the primary bound.
+_INTENT_PAYLOAD_MAX_BYTES = 16 * 1024
+_RESOLUTION_PAYLOAD_MAX_BYTES = 8 * 1024
+_SUBJECT_SET_PAYLOAD_MAX_BYTES = 16 * 1024
+_SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES = 16 * 1024
+_INVESTIGATION_RESULT_PAYLOAD_MAX_BYTES = 8 * 1024
+_FRAME_PAYLOAD_MAX_BYTES = 128 * 1024
+_NARRATIVE_TEXT_MAX_BYTES = 8 * 1024
+_NARRATIVE_PAYLOAD_MAX_BYTES = 16 * 1024
 
 
 class DevPersistenceNotFound(LookupError):
@@ -256,6 +367,25 @@ def _safe_token(value: str | None, *, field: str, max_bytes: int) -> str | None:
     if value is not None and _SAFE_TOKEN.fullmatch(value) is None:
         raise DevPersistenceValidationError(f"{field} must be a safe identifier")
     return value
+
+
+def _bounded_json(
+    value: Mapping[str, Any], *, field: str, max_bytes: int
+) -> dict[str, Any]:
+    """A sensitive-key-checked, byte-bounded JSONB payload copy.
+
+    Used for every Wave 3.1 (CHAOS-3299) opaque ``payload`` column: the
+    contract's own pydantic validators already bound each collection's
+    ``max_length``, but persistence re-checks byte size and forbidden keys
+    independently rather than trusting the contract validator alone (the
+    established double-check posture, e.g. ``append_tool_call``).
+    """
+
+    copied = _json_copy(dict(value), field=field)
+    encoded = json.dumps(copied, separators=(",", ":"), sort_keys=True)
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise DevPersistenceValidationError(f"{field} exceeds {max_bytes} bytes")
+    return copied
 
 
 def _safe_count_summary(value: Mapping[str, Any], *, field: str) -> dict[str, Any]:
@@ -572,6 +702,29 @@ class DevPersistenceService:
             raise DevPersistenceNotFound("message run not found")
         return result
 
+    async def get_answer_frame(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+    ) -> DevAnswerFrame | None:
+        """Return the tenant-owned answer frame for one run, if any.
+
+        Used by the replay path (``router._replayed_result``) to reconstruct
+        a no-answer-payload outcome (``needs_clarification``/``not_found``/
+        etc.) from the stored frame rather than a generic error, without
+        rerunning any provider or tool (TRD v2 Section 12).
+        """
+
+        return await self.session.scalar(
+            select(DevAnswerFrame).where(
+                DevAnswerFrame.run_id == run_id,
+                DevAnswerFrame.org_id == org_id,
+                DevAnswerFrame.user_id == user_id,
+            )
+        )
+
     async def get_answer_message(
         self,
         *,
@@ -785,9 +938,9 @@ class DevPersistenceService:
             dict(validated),
             field="answer_payload",
         )
-        if payload.get("schema_version") != "dev_answer.v1":
+        if payload.get("schema_version") not in {"dev_answer.v1", "dev_answer.v2"}:
             raise DevPersistenceValidationError(
-                "validated answer payload must use dev_answer.v1"
+                "validated answer payload must use dev_answer.v1 or dev_answer.v2"
             )
         try:
             answer_id = uuid.UUID(str(payload["answer_id"]))
@@ -1068,6 +1221,374 @@ class DevPersistenceService:
         self.session.add(tool_call)
         await self.session.flush()
         return tool_call
+
+    # -- Wave 3.1 (CHAOS-3299) recorder methods ------------------------------
+    # Each of these persists one bounded, validated artifact of the server-
+    # owned intent -> resolution -> plan -> investigation -> frame ->
+    # narrative lifecycle. All are called from PersistenceRunRecorder on the
+    # live (non-replay) run branch only, before the terminal update_run
+    # transition -- the same ordering `append_tool_call` already relies on
+    # for 0-day ephemeral retention to cascade through fully-written rows
+    # rather than orphaning a write after the conversation is already purged.
+
+    async def record_intent(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        intent_id: str,
+        cardinality: str,
+        requires_clarification: bool,
+        interpreter_version: str,
+        payload: Mapping[str, Any],
+    ) -> DevRunIntent:
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if intent_id not in _QUESTION_INTENT_IDS:
+            raise DevPersistenceValidationError("invalid intent_id")
+        if cardinality not in _CARDINALITIES:
+            raise DevPersistenceValidationError("invalid cardinality")
+        record = DevRunIntent(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            intent_id=intent_id,
+            cardinality=cardinality,
+            requires_clarification=requires_clarification,
+            interpreter_version=_safe_token(
+                interpreter_version, field="interpreter_version", max_bytes=128
+            )
+            or "",
+            payload=_bounded_json(
+                payload, field="intent_payload", max_bytes=_INTENT_PAYLOAD_MAX_BYTES
+            ),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def append_resolution(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        entry_ordinal: int,
+        mention_id: uuid.UUID,
+        outcome: str,
+        resolved_at: datetime,
+        payload: Mapping[str, Any],
+    ) -> DevRunResolution:
+        """Append one immutable entity-resolution ledger entry.
+
+        INSERT-only by construction: no update method for an existing
+        ``(run_id, entry_ordinal)`` row is exposed, and a second insert for
+        an already-used ordinal fails via the unique constraint rather than
+        upserting.
+        """
+
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if entry_ordinal < 0 or entry_ordinal > 99:
+            raise DevPersistenceValidationError("resolution entry_ordinal out of range")
+        if outcome not in _RESOLUTION_OUTCOMES:
+            raise DevPersistenceValidationError("invalid resolution outcome")
+        record = DevRunResolution(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            entry_ordinal=entry_ordinal,
+            mention_id=mention_id,
+            outcome=outcome,
+            payload=_bounded_json(
+                payload,
+                field="resolution_payload",
+                max_bytes=_RESOLUTION_PAYLOAD_MAX_BYTES,
+            ),
+            resolved_at=resolved_at,
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def record_subject_set(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        set_id: uuid.UUID,
+        entity_kind: str,
+        cohort_complete: bool,
+        fingerprint: str,
+        payload: Mapping[str, Any],
+    ) -> DevRunSubjectSet:
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if entity_kind not in _ENTITY_KINDS:
+            raise DevPersistenceValidationError("invalid entity_kind")
+        record = DevRunSubjectSet(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            set_id=set_id,
+            entity_kind=entity_kind,
+            cohort_complete=cohort_complete,
+            fingerprint=_safe_token(fingerprint, field="fingerprint", max_bytes=128)
+            or "",
+            payload=_bounded_json(
+                payload,
+                field="subject_set_payload",
+                max_bytes=_SUBJECT_SET_PAYLOAD_MAX_BYTES,
+            ),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def append_source_observation(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        ordinal: int,
+        observation_id: uuid.UUID,
+        source_class: str,
+        requirement_level: str,
+        observed_state: str,
+        data_semantics: str,
+        usable_fact_count: int,
+        sample_count: int | None,
+        subject_coverage: float,
+        observed_at: datetime,
+        payload: Mapping[str, Any],
+    ) -> DevRunSourceObservation:
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if ordinal < 0 or ordinal > 24:
+            raise DevPersistenceValidationError(
+                "source observation ordinal out of range"
+            )
+        if source_class not in _SOURCE_CLASSES:
+            raise DevPersistenceValidationError("invalid source_class")
+        if requirement_level not in _REQUIREMENT_LEVELS:
+            raise DevPersistenceValidationError("invalid requirement_level")
+        if observed_state not in _SOURCE_OBSERVED_STATES:
+            raise DevPersistenceValidationError("invalid observed_state")
+        if data_semantics not in _DATA_SEMANTICS:
+            raise DevPersistenceValidationError("invalid data_semantics")
+        if usable_fact_count < 0:
+            raise DevPersistenceValidationError("usable_fact_count must be nonnegative")
+        if sample_count is not None and sample_count < 0:
+            raise DevPersistenceValidationError("sample_count must be nonnegative")
+        if not (0.0 <= subject_coverage <= 1.0):
+            raise DevPersistenceValidationError("subject_coverage must be in [0, 1]")
+        record = DevRunSourceObservation(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            ordinal=ordinal,
+            observation_id=observation_id,
+            source_class=source_class,
+            requirement_level=requirement_level,
+            observed_state=observed_state,
+            data_semantics=data_semantics,
+            usable_fact_count=usable_fact_count,
+            sample_count=sample_count,
+            subject_coverage=subject_coverage,
+            payload=_bounded_json(
+                payload,
+                field="source_observation_payload",
+                max_bytes=_SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES,
+            ),
+            observed_at=observed_at,
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def record_investigation_result(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        result_id: uuid.UUID,
+        relationship_closure_verified: bool,
+        completed_at: datetime,
+        payload: Mapping[str, Any],
+    ) -> DevRunInvestigationResult:
+        """Persist the ``dev_investigation_result.v1`` wrapper for one run.
+
+        Reconciliation delta: not one of the 7 tables in the
+        pre-implementation plan, added because the landed contract has this
+        as a distinct top-level object (completed/skipped/failed plan steps
+        plus relationship-closure verification) that the per-observation
+        ``dev_run_source_observations`` rows alone cannot reconstruct.
+        """
+
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        record = DevRunInvestigationResult(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            result_id=result_id,
+            relationship_closure_verified=relationship_closure_verified,
+            payload=_bounded_json(
+                payload,
+                field="investigation_result_payload",
+                max_bytes=_INVESTIGATION_RESULT_PAYLOAD_MAX_BYTES,
+            ),
+            completed_at=completed_at,
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def record_frame(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        frame_id: uuid.UUID,
+        public_outcome: str,
+        payload: Mapping[str, Any],
+    ) -> DevAnswerFrame:
+        """Persist the canonical ``dev_answer_frame.v1`` for one run.
+
+        One row per terminal run regardless of public outcome -- including
+        ``needs_clarification``/``not_found``/``unsupported``/``denied``,
+        confirmed by the landed no-answer field policy (see
+        ``DevRunInvestigationResult`` and the frame model docstring).
+        """
+
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if public_outcome not in _PUBLIC_OUTCOMES:
+            raise DevPersistenceValidationError("invalid public_outcome")
+        record = DevAnswerFrame(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            frame_id=frame_id,
+            public_outcome=public_outcome,
+            payload=_bounded_json(
+                payload, field="frame_payload", max_bytes=_FRAME_PAYLOAD_MAX_BYTES
+            ),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def record_narrative(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        narrative_id: uuid.UUID,
+        frame_id: uuid.UUID,
+        mode: str,
+        provider_fingerprint: str | None,
+        narrative_text: str,
+        payload: Mapping[str, Any],
+    ) -> DevRunNarrative:
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if mode not in _NARRATIVE_MODES:
+            raise DevPersistenceValidationError("invalid narrative mode")
+        frame = await self.session.scalar(
+            select(DevAnswerFrame).where(
+                DevAnswerFrame.run_id == run.id,
+                DevAnswerFrame.org_id == org_id,
+                DevAnswerFrame.user_id == user_id,
+            )
+        )
+        if frame is None or frame.frame_id != frame_id:
+            raise DevPersistenceValidationError(
+                "narrative frame_id must match the run's recorded answer frame"
+            )
+        text = _bounded_text(
+            narrative_text, field="narrative_text", max_bytes=_NARRATIVE_TEXT_MAX_BYTES
+        )
+        if not text:
+            raise DevPersistenceValidationError("narrative_text must not be empty")
+        record = DevRunNarrative(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            narrative_id=narrative_id,
+            frame_id=frame_id,
+            mode=mode,
+            provider_fingerprint=_digest(
+                provider_fingerprint, field="provider_fingerprint"
+            ),
+            narrative_text=text,
+            payload=_bounded_json(
+                payload,
+                field="narrative_payload",
+                max_bytes=_NARRATIVE_PAYLOAD_MAX_BYTES,
+            ),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def append_stage_diagnostic(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        ordinal: int,
+        stage_id: str,
+        status: str,
+        latency_ms: int | None,
+        counts: Mapping[str, Any],
+    ) -> DevRunStageDiagnostic:
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if ordinal < 0 or ordinal > 9:
+            raise DevPersistenceValidationError("stage diagnostic ordinal out of range")
+        if stage_id not in _STAGE_IDS:
+            raise DevPersistenceValidationError("invalid stage_id")
+        if status not in _STAGE_STATUSES:
+            raise DevPersistenceValidationError("invalid stage status")
+        if latency_ms is not None and latency_ms < 0:
+            raise DevPersistenceValidationError("latency_ms must be nonnegative")
+        record = DevRunStageDiagnostic(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            ordinal=ordinal,
+            stage_id=stage_id,
+            status=status,
+            latency_ms=latency_ms,
+            counts=_safe_count_summary(counts, field="stage_diagnostic_counts"),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
 
     async def record_feedback(
         self,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -1504,6 +1504,21 @@ class DevPersistenceService:
         ``needs_clarification``/``not_found``/``unsupported``/``denied``,
         confirmed by the landed no-answer field policy (see the frame model
         docstring and ``DevRun.plan_step_partition``).
+
+        Atomically tags the owned run ``contract_generation = 'v2'`` and
+        ``public_outcome`` in the same flush as the frame write. Writing a
+        frame is the definitive, structural signal that a run is v2 --
+        recording it without tagging the run left ``contract_generation``
+        stuck at its 'v1' default forever, which made
+        ``router._replayed_result``'s ``contract_generation == "v2"`` replay
+        gate permanently unreachable for every real v2 run (a Codex review
+        finding on this branch). This closure also structurally narrows the
+        window for CHAOS-3299's downgrade guard (0074) to see folded
+        ``dev_runs`` columns on a run still tagged 'v1' -- the guard still
+        sweeps those columns directly as defense in depth, since a run can
+        carry ``plan_step_partition``/``relationship_closure_verified`` from
+        ``record_investigation_result`` without ever reaching this method
+        (e.g. a failure between investigation and frame synthesis).
         """
 
         run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
@@ -1523,6 +1538,8 @@ class DevPersistenceService:
             created_at=self._now(),
         )
         self.session.add(record)
+        run.contract_generation = "v2"
+        run.public_outcome = public_outcome
         await self.session.flush()
         return record
 

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -52,6 +52,7 @@ from .contracts import (
     DevFeedback,
     DevMessageRequest,
     DevScope,
+    DevTimeRange,
     DevTranscriptEntry,
     dev_error_remediation,
 )
@@ -569,13 +570,53 @@ def _permission_fingerprint(user: AuthenticatedUser) -> str:
 
 
 def _replayed_result(
-    *, run: Any, answer_payload: dict[str, Any] | None
+    *,
+    run: Any,
+    answer_payload: dict[str, Any] | None,
+    frame_payload: dict[str, Any] | None = None,
+    organization_id: str | None = None,
+    time_range: DevTimeRange | None = None,
 ) -> OrchestratorResult:
     state = RunState(run.state)
     answer = None
     error = None
     if answer_payload is not None:
         answer = DevAnswer.model_validate(answer_payload)
+    elif (
+        frame_payload is not None
+        and organization_id is not None
+        and time_range is not None
+    ):
+        # CHAOS-3299 / TRD v2 Section 12: a v2 run with no answer message
+        # (needs_clarification/not_found/temporarily_unavailable/unsupported/
+        # denied/failed -- no assistant DevMessage is ever recorded for these)
+        # renders from the stored frame rather than degrading to a generic
+        # "did not complete" error. Reuses the one backend v2-to-v1
+        # projector (CHAOS-3294 guardrail) so this never becomes a second,
+        # divergent mapping.
+        from .contracts_v2.answer import _OUTCOME_DISPLAY_LABELS, DevAnswerV2
+        from .contracts_v2.compat import project_answer_v2_to_v1
+        from .contracts_v2.frame import DevAnswerFrame as _DevAnswerFrameV2
+
+        frame_obj = _DevAnswerFrameV2.model_validate(frame_payload)
+        answer_v2 = DevAnswerV2(
+            schema_version="dev_answer.v2",
+            answer_id=str(run.id),
+            conversation_id=str(run.conversation_id),
+            run_id=str(run.id),
+            generated_at=run.ended_at or run.started_at,
+            public_outcome=frame_obj.public_outcome,
+            outcome_display_label=_OUTCOME_DISPLAY_LABELS[frame_obj.public_outcome],
+            frame=frame_obj,
+            narrative=None,
+        )
+        projected = project_answer_v2_to_v1(
+            answer_v2, organization_id=organization_id, time_range=time_range
+        )
+        if isinstance(projected, DevAnswer):
+            answer = projected
+        else:
+            error = projected
     else:
         code = run.safe_error_code or "internal_error"
         try:
@@ -1109,6 +1150,7 @@ async def create_message(
                 retryable=True,
             )
         answer_payload = None
+        frame_payload = None
         if accepted.run.answer_id is not None:
             try:
                 answer_message = await service.get_answer_message(
@@ -1120,9 +1162,20 @@ async def create_message(
             except Exception as exc:
                 _raise_persistence(exc, request_id)
                 raise AssertionError("unreachable")
+        elif accepted.run.contract_generation == "v2":
+            frame = await service.get_answer_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=accepted.run.id,
+            )
+            if frame is not None:
+                frame_payload = frame.payload
         replayed = _replayed_result(
             run=accepted.run,
             answer_payload=answer_payload,
+            frame_payload=frame_payload,
+            organization_id=str(org_id),
+            time_range=body.scope.time_range,
         )
 
         async def replay(_sink) -> OrchestratorResult:

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -591,12 +591,22 @@ def _replayed_result(
         # (needs_clarification/not_found/temporarily_unavailable/unsupported/
         # denied/failed -- no assistant DevMessage is ever recorded for these)
         # renders from the stored frame rather than degrading to a generic
-        # "did not complete" error. Reuses the one backend v2-to-v1
-        # projector (CHAOS-3294 guardrail) so this never becomes a second,
-        # divergent mapping.
+        # "did not complete" error. Every outcome reachable in this branch is
+        # a no-answer outcome by construction (an answer_id would have taken
+        # the branch above instead), so the projection is always a DevError
+        # -- and it must be the *same* DevError a live run would have
+        # streamed. ``preflight_outcomes.project_preflight_error`` is that
+        # terminal projection (CHAOS-3292's ratified design): it special-
+        # cases ``needs_clarification`` to the ``scope_ambiguous`` shape the
+        # router and web client already handle, rather than the generic
+        # compat projector's fabricated-candidate ``DevAnswer`` (which is a
+        # different response shape from what the live run actually sent).
+        # For the other four outcomes it delegates to the same one backend
+        # v2-to-v1 projector (CHAOS-3294 guardrail) live preflight uses, so
+        # this is never a second, divergent mapping.
         from .contracts_v2.answer import _OUTCOME_DISPLAY_LABELS, DevAnswerV2
-        from .contracts_v2.compat import project_answer_v2_to_v1
         from .contracts_v2.frame import DevAnswerFrame as _DevAnswerFrameV2
+        from .preflight_outcomes import project_preflight_error
 
         frame_obj = _DevAnswerFrameV2.model_validate(frame_payload)
         answer_v2 = DevAnswerV2(
@@ -604,19 +614,17 @@ def _replayed_result(
             answer_id=str(run.id),
             conversation_id=str(run.conversation_id),
             run_id=str(run.id),
-            generated_at=run.ended_at or run.started_at,
+            # SQLite (test fixtures only) does not round-trip tz-aware
+            # datetimes through DateTime(timezone=True); PostgreSQL does, so
+            # this was unobserved until CHAOS-3299 Codex finding 1's fix made
+            # this branch reachable for the first time.
+            generated_at=_aware_required(run.ended_at or run.started_at),
             public_outcome=frame_obj.public_outcome,
             outcome_display_label=_OUTCOME_DISPLAY_LABELS[frame_obj.public_outcome],
             frame=frame_obj,
             narrative=None,
         )
-        projected = project_answer_v2_to_v1(
-            answer_v2, organization_id=organization_id, time_range=time_range
-        )
-        if isinstance(projected, DevAnswer):
-            answer = projected
-        else:
-            error = projected
+        error = project_preflight_error(answer_v2, request_id=str(run.request_id))
     else:
         code = run.safe_error_code or "internal_error"
         try:

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -118,6 +118,35 @@ def _current_postgres_heads(cfg) -> tuple[str, ...]:
     return asyncio.run(_read_current_postgres_heads(cfg))
 
 
+async def application_schema_status(
+    db_url: str | None = None,
+) -> tuple[bool, tuple[str, ...]]:
+    """Return ``(satisfied, current_heads)`` for the required schema revision.
+
+    Async-native (unlike ``_current_postgres_heads``, which wraps
+    ``asyncio.run`` and therefore cannot be called from within an already
+    running event loop, e.g. FastAPI's ``lifespan``). Promoted to a public
+    function — rather than duplicated — so the API process startup gate
+    (``api/_lifespan.py``) and ``/health`` (``api/_health.py``) share the
+    exact fail-closed ancestor-walk semantics as ``dev-hops migrate
+    postgres-status`` / ``_run_upgrade``'s post-upgrade check: "database has
+    at least ``_APPLICATION_SCHEMA_MINIMUM_REVISION``" (ancestor-walk, not
+    exact-head-equality), so a rolling deploy where an old-generation pod is
+    still healthy against an already-migrated database is not treated as a
+    startup failure.
+    """
+    cfg = _make_alembic_config(db_url)
+    current = await _read_current_postgres_heads(cfg)
+    satisfied = _database_has_revision(
+        cfg, current, _APPLICATION_SCHEMA_MINIMUM_REVISION
+    )
+    return satisfied, current
+
+
+def required_application_schema_revision() -> str:
+    return _APPLICATION_SCHEMA_MINIMUM_REVISION
+
+
 def _database_has_revision(
     cfg, current_heads: tuple[str, ...], target_revision: str
 ) -> bool:

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -32,7 +32,7 @@ _ALEMBIC_DIR = Path(__file__).resolve().parent / "alembic"
 _CELERY_RIVER_CUTOVER_ENV = "DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER"
 _CELERY_RIVER_CUTOVER_REVISION = "0066"
 _APPLICATION_SCHEMA_BRANCH = "application_schema"
-_APPLICATION_SCHEMA_MINIMUM_REVISION = "0073"
+_APPLICATION_SCHEMA_MINIMUM_REVISION = "0075"
 
 # Revision 0066 changes worker execution ownership and remains an explicit
 # operator action. Application schema migrations branch from 0065 separately,

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -32,7 +32,7 @@ _ALEMBIC_DIR = Path(__file__).resolve().parent / "alembic"
 _CELERY_RIVER_CUTOVER_ENV = "DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER"
 _CELERY_RIVER_CUTOVER_REVISION = "0066"
 _APPLICATION_SCHEMA_BRANCH = "application_schema"
-_APPLICATION_SCHEMA_MINIMUM_REVISION = "0071"
+_APPLICATION_SCHEMA_MINIMUM_REVISION = "0073"
 
 # Revision 0066 changes worker execution ownership and remains an explicit
 # operator action. Application schema migrations branch from 0065 separately,

--- a/src/dev_health_ops/models/dev_persistence.py
+++ b/src/dev_health_ops/models/dev_persistence.py
@@ -222,6 +222,23 @@ class DevRun(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utc_now
     )
+    # -- Wave 3.1 (CHAOS-3299) additive columns -----------------------------
+    # contract_generation defaults 'v1' at the DB level so every pre-existing
+    # row is correctly marked legacy the instant the column exists -- no
+    # backfill UPDATE required.
+    contract_generation: Mapped[str] = mapped_column(
+        String(4), nullable=False, default="v1"
+    )
+    # Orthogonal to `state` (the internal admission/lifecycle FSM above):
+    # public_outcome is the TRD v2 §10 dev_answer.v2 outcome vocabulary, set
+    # once at terminal transition. Widening `state`/`ck_dev_runs_state` to the
+    # §10 orchestrator stage names is out of this ticket's scope.
+    public_outcome: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    compatibility_projection_version: Mapped[str | None] = mapped_column(
+        String(128), nullable=True
+    )
+    plan_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    plan_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     __table_args__ = (
         CheckConstraint(
@@ -230,6 +247,16 @@ class DevRun(Base):
             "'tool_validation', 'tool_execution', 'answer_validation', "
             "'completed', 'insufficient_evidence', 'refused', 'failed', 'cancelled')",
             name="ck_dev_runs_state",
+        ),
+        CheckConstraint(
+            "contract_generation IN ('v1', 'v2')",
+            name="ck_dev_runs_contract_generation",
+        ),
+        CheckConstraint(
+            "public_outcome IS NULL OR public_outcome IN ('answered', "
+            "'answered_with_gaps', 'needs_clarification', 'not_found', "
+            "'temporarily_unavailable', 'unsupported', 'denied', 'failed')",
+            name="ck_dev_runs_public_outcome",
         ),
         ForeignKeyConstraint(
             ["conversation_id", "org_id", "user_id"],
@@ -374,6 +401,414 @@ class DevToolCall(Base):
             "run_id",
             "ordinal",
         ),
+    )
+
+
+class DevRunIntent(Base):
+    """Wave 3.1 (CHAOS-3299): the authoritative, server-owned interpretation.
+
+    One row per run (``dev_question_intent.v1``). ``payload`` is the full
+    validated contract dump (bounded, sensitive-key-checked at the service
+    layer); the columns below duplicate only the fields that need CHECK
+    discipline or direct querying.
+    """
+
+    __tablename__ = "dev_run_intents"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    intent_id: Mapped[str] = mapped_column(String(48), nullable=False)
+    cardinality: Mapped[str] = mapped_column(String(24), nullable=False)
+    requires_clarification: Mapped[bool] = mapped_column(nullable=False)
+    interpreter_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "intent_id IN ('entity_status', 'portfolio_status', 'remaining_work', "
+            "'observed_change', 'registered_statistics', 'metric_comparison', "
+            "'data_trust', 'project_health', 'team_health', "
+            "'team_workload_balance', 'operational_deficiency_inventory', "
+            "'bounded_investigation')",
+            name="ck_dev_run_intents_intent_id",
+        ),
+        CheckConstraint(
+            "cardinality IN ('singular', 'plural_cohort', 'organization_wide')",
+            name="ck_dev_run_intents_cardinality",
+        ),
+        UniqueConstraint("run_id", name="uq_dev_run_intents_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_intents_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_intents_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
+class DevRunResolution(Base):
+    """Wave 3.1: one append-only entity-resolution ledger entry per run.
+
+    ``dev_resolution_ledger.v1``'s ``entries`` are contiguous, strictly
+    increasing, and never rewritten -- the service exposes no UPDATE path for
+    an existing row, only INSERT of the next ``entry_ordinal``.
+    """
+
+    __tablename__ = "dev_run_resolutions"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    entry_ordinal: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    mention_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    resolved_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "entry_ordinal >= 0 AND entry_ordinal <= 99",
+            name="ck_dev_run_resolutions_entry_ordinal",
+        ),
+        CheckConstraint(
+            "outcome IN ('exact_match', 'ambiguous_candidates', "
+            "'no_authorized_match', 'catalog_unavailable', 'unsupported_kind')",
+            name="ck_dev_run_resolutions_outcome",
+        ),
+        UniqueConstraint(
+            "run_id", "entry_ordinal", name="uq_dev_run_resolutions_run_ordinal"
+        ),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_resolutions_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_resolutions_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
+class DevRunSubjectSet(Base):
+    """Wave 3.1: the committed plural/cohort subject set for one run.
+
+    ``dev_subject_set.v1``. Present only for plural/cohort intents (0..1 per
+    run).
+    """
+
+    __tablename__ = "dev_run_subject_sets"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    set_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    entity_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    cohort_complete: Mapped[bool] = mapped_column(nullable=False)
+    fingerprint: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "entity_kind IN ('repository', 'project', 'work_unit', 'issue', "
+            "'pull_request', 'team')",
+            name="ck_dev_run_subject_sets_entity_kind",
+        ),
+        UniqueConstraint("run_id", name="uq_dev_run_subject_sets_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_subject_sets_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_subject_sets_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
+class DevRunSourceObservation(Base):
+    """Wave 3.1: one ``dev_source_observation.v1`` deterministic-plan-step row.
+
+    Kept separate from ``dev_tool_calls`` (model-issued tool-call audit)
+    deliberately -- this is the deterministic source-adapter analogue with a
+    different CHECK shape. One row per observation, ordinal-keyed.
+    """
+
+    __tablename__ = "dev_run_source_observations"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    ordinal: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    observation_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    source_class: Mapped[str] = mapped_column(String(32), nullable=False)
+    requirement_level: Mapped[str] = mapped_column(String(16), nullable=False)
+    observed_state: Mapped[str] = mapped_column(String(32), nullable=False)
+    data_semantics: Mapped[str] = mapped_column(String(16), nullable=False)
+    usable_fact_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    sample_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    subject_coverage: Mapped[float] = mapped_column(nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    observed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "ordinal >= 0 AND ordinal <= 24",
+            name="ck_dev_run_source_observations_ordinal",
+        ),
+        CheckConstraint(
+            "source_class IN ('status_change', 'work_item', 'work_graph', "
+            "'pull_request', 'code_change', 'review', 'ci_run', 'test_report', "
+            "'deployment', 'incident', 'operational_control', 'source_health')",
+            name="ck_dev_run_source_observations_source_class",
+        ),
+        CheckConstraint(
+            "requirement_level IN ('mandatory', 'conditional', 'optional', "
+            "'not_applicable')",
+            name="ck_dev_run_source_observations_requirement_level",
+        ),
+        CheckConstraint(
+            "observed_state IN ('available_current', 'available_stale', "
+            "'available_unknown', 'unconfigured', 'unavailable', "
+            "'unauthorized_or_not_visible', 'not_applicable', 'truncated')",
+            name="ck_dev_run_source_observations_observed_state",
+        ),
+        CheckConstraint(
+            "data_semantics IN ('measured_zero', 'no_data', 'not_measured')",
+            name="ck_dev_run_source_observations_data_semantics",
+        ),
+        CheckConstraint(
+            "usable_fact_count >= 0 AND (sample_count IS NULL OR sample_count >= 0)",
+            name="ck_dev_run_source_observations_counts_nonnegative",
+        ),
+        CheckConstraint(
+            "subject_coverage >= 0 AND subject_coverage <= 1",
+            name="ck_dev_run_source_observations_coverage_range",
+        ),
+        UniqueConstraint(
+            "run_id", "ordinal", name="uq_dev_run_source_observations_run_ordinal"
+        ),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_source_observations_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index(
+            "ix_dev_run_source_observations_owner_run", "org_id", "user_id", "run_id"
+        ),
+    )
+
+
+class DevRunInvestigationResult(Base):
+    """Wave 3.1: the ``dev_investigation_result.v1`` wrapper for one run.
+
+    Reconciliation delta (not in the original pre-implementation plan): the
+    landed CHAOS-3294 contract has ``dev_investigation_result.v1`` as a
+    distinct top-level object wrapping ``observations`` (persisted 1:N in
+    ``dev_run_source_observations``) plus step-completion bookkeeping
+    (``completed_steps``/``skipped_steps``/``failed_steps`` -- which *plan
+    steps* ran, distinct from which *source observations* exist, since a step
+    can be skipped without ever producing an observation) and
+    ``relationship_closure_verified``. One row per run.
+    """
+
+    __tablename__ = "dev_run_investigation_results"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    result_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    relationship_closure_verified: Mapped[bool] = mapped_column(nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    completed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("run_id", name="uq_dev_run_investigation_results_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_investigation_results_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index(
+            "ix_dev_run_investigation_results_owner_run",
+            "org_id",
+            "user_id",
+            "run_id",
+        ),
+    )
+
+
+class DevAnswerFrame(Base):
+    """Wave 3.1: the canonical, server-owned ``dev_answer_frame.v1``.
+
+    One row per terminal run, regardless of public outcome -- a
+    ``needs_clarification``/``not_found``/``unsupported``/``denied`` run still
+    produces a (minimal) frame, confirmed by the landed no-answer field
+    policy (``NO_ANSWER_FRAME_FIELD_POLICY`` classifies every frame field,
+    including ``frame_id``/``run_id`` as IDENTIFIER-shaped, rather than
+    omitting the frame entirely).
+    """
+
+    __tablename__ = "dev_answer_frames"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    frame_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    public_outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "public_outcome IN ('answered', 'answered_with_gaps', "
+            "'needs_clarification', 'not_found', 'temporarily_unavailable', "
+            "'unsupported', 'denied', 'failed')",
+            name="ck_dev_answer_frames_public_outcome",
+        ),
+        UniqueConstraint("run_id", name="uq_dev_answer_frames_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_answer_frames_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_answer_frames_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
+class DevRunNarrative(Base):
+    """Wave 3.1: the optional ``dev_narrative.v1`` presentation text for one run.
+
+    0..1 per run, present only when narrative_mode != 'none'. Text is stored
+    verbatim (not a digest) because the contract guarantees it is
+    presentation-only text mapped to existing frame section/fact IDs -- it
+    cannot introduce new facts, numbers, or subjects (TRD v2 §4.5), so it is
+    not raw provider output, prompt, or chain-of-thought.
+    """
+
+    __tablename__ = "dev_run_narratives"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    narrative_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    frame_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    mode: Mapped[str] = mapped_column(String(24), nullable=False)
+    provider_fingerprint: Mapped[str | None] = mapped_column(String(71), nullable=True)
+    narrative_text: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "mode IN ('provider', 'deterministic_fallback')",
+            name="ck_dev_run_narratives_mode",
+        ),
+        CheckConstraint(
+            "provider_fingerprint IS NULL OR "
+            "(length(provider_fingerprint) = 71 "
+            "AND provider_fingerprint LIKE 'sha256:%')",
+            name="ck_dev_run_narratives_provider_fingerprint",
+        ),
+        UniqueConstraint("run_id", name="uq_dev_run_narratives_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_narratives_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_narratives_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
+class DevRunStageDiagnostic(Base):
+    """Wave 3.1: content-free per-stage timing/count/status diagnostics.
+
+    One row per orchestrator stage (TRD v2 §10:
+    interpreting/resolving_subjects/planning/collecting/synthesizing_frame/
+    narrating_optional/projecting_answer) per run. ``counts`` reuses the
+    existing ``_safe_count_summary`` bounded-keys/nonnegative discipline
+    already built for ``dev_tool_calls.safe_scope_summary``.
+    """
+
+    __tablename__ = "dev_run_stage_diagnostics"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    ordinal: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    stage_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    counts: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "ordinal >= 0 AND ordinal <= 9",
+            name="ck_dev_run_stage_diagnostics_ordinal",
+        ),
+        CheckConstraint(
+            "stage_id IN ('interpreting', 'resolving_subjects', 'planning', "
+            "'collecting', 'synthesizing_frame', 'narrating_optional', "
+            "'projecting_answer')",
+            name="ck_dev_run_stage_diagnostics_stage_id",
+        ),
+        CheckConstraint(
+            "status IN ('started', 'completed', 'failed', 'skipped')",
+            name="ck_dev_run_stage_diagnostics_status",
+        ),
+        CheckConstraint(
+            "latency_ms IS NULL OR latency_ms >= 0",
+            name="ck_dev_run_stage_diagnostics_latency_nonnegative",
+        ),
+        UniqueConstraint(
+            "run_id", "ordinal", name="uq_dev_run_stage_diagnostics_run_ordinal"
+        ),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_stage_diagnostics_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_stage_diagnostics_owner_run", "org_id", "user_id", "run_id"),
     )
 
 

--- a/src/dev_health_ops/models/dev_persistence.py
+++ b/src/dev_health_ops/models/dev_persistence.py
@@ -239,6 +239,20 @@ class DevRun(Base):
     )
     plan_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     plan_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Folded (orchestrator decision, CHAOS-3299): a dedicated
+    # dev_run_investigation_results table would have duplicated what's
+    # already owned elsewhere -- observations are persisted 1:N in
+    # dev_run_source_observations, and dev_answer_frames is the replay
+    # source of truth. The only post-terminal dev_investigation_result.v1
+    # facts nothing else can reconstruct are which plan steps ran (a step
+    # can be skipped without ever producing an observation) and whether
+    # relationship closure was verified, so those two facts are persisted
+    # directly here instead of a ninth table. NULL for v1 runs and for v2
+    # runs before the investigation stage completes.
+    plan_step_partition: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    relationship_closure_verified: Mapped[bool | None] = mapped_column(nullable=True)
 
     __table_args__ = (
         CheckConstraint(
@@ -619,52 +633,6 @@ class DevRunSourceObservation(Base):
     )
 
 
-class DevRunInvestigationResult(Base):
-    """Wave 3.1: the ``dev_investigation_result.v1`` wrapper for one run.
-
-    Reconciliation delta (not in the original pre-implementation plan): the
-    landed CHAOS-3294 contract has ``dev_investigation_result.v1`` as a
-    distinct top-level object wrapping ``observations`` (persisted 1:N in
-    ``dev_run_source_observations``) plus step-completion bookkeeping
-    (``completed_steps``/``skipped_steps``/``failed_steps`` -- which *plan
-    steps* ran, distinct from which *source observations* exist, since a step
-    can be skipped without ever producing an observation) and
-    ``relationship_closure_verified``. One row per run.
-    """
-
-    __tablename__ = "dev_run_investigation_results"
-
-    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
-    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
-    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
-    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
-    result_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
-    relationship_closure_verified: Mapped[bool] = mapped_column(nullable=False)
-    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
-    completed_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=_utc_now
-    )
-
-    __table_args__ = (
-        UniqueConstraint("run_id", name="uq_dev_run_investigation_results_run"),
-        ForeignKeyConstraint(
-            ["run_id", "org_id", "user_id"],
-            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
-            name="fk_dev_run_investigation_results_run_owner",
-            ondelete="CASCADE",
-        ),
-        Index(
-            "ix_dev_run_investigation_results_owner_run",
-            "org_id",
-            "user_id",
-            "run_id",
-        ),
-    )
-
-
 class DevAnswerFrame(Base):
     """Wave 3.1: the canonical, server-owned ``dev_answer_frame.v1``.
 
@@ -673,7 +641,8 @@ class DevAnswerFrame(Base):
     produces a (minimal) frame, confirmed by the landed no-answer field
     policy (``NO_ANSWER_FRAME_FIELD_POLICY`` classifies every frame field,
     including ``frame_id``/``run_id`` as IDENTIFIER-shaped, rather than
-    omitting the frame entirely).
+    omitting the frame entirely). See ``DevRun.plan_step_partition`` for the
+    related investigation-result step-completion bookkeeping.
     """
 
     __tablename__ = "dev_answer_frames"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for ``tests/api/`` (cascades into ``tests/api/**``).
+
+CI's "test" job provides a real, reachable PostgreSQL service container
+(``POSTGRES_URI`` set at the job level) that is deliberately left
+unmigrated for the general unit-test tier -- almost every test uses an
+ephemeral in-memory SQLite fixture instead, and only opt-in
+``DEV_HEALTH_POSTGRES_TEST_URI``-gated modules apply migrations to a real
+database. ``ci/local_validate.sh`` never sets ``POSTGRES_URI`` at all, so
+this gap is invisible locally.
+
+Any test under here that boots the real app via
+``with TestClient(main.app) as client:`` runs the real ``lifespan()``
+startup sequence, which (CHAOS-3299) hard-aborts when PostgreSQL is
+reachable but missing the required application schema revision -- exactly
+CI's situation. That's a false negative unrelated to whatever the test is
+actually checking (health-endpoint shape, webhook wiring, work-unit-explain
+validation, ...), so the schema-revision check is stubbed satisfied here by
+default. See ``test_main_app_integration.py``'s
+``test_lifespan_aborts_startup_when_schema_status_is_unsatisfied`` for the
+companion proof that overriding this stub still aborts startup -- this
+fixture narrows *what* is exercised, not *whether* the guard still works.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_application_schema_status_satisfied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _satisfied(dsn: str | None = None) -> tuple[bool, tuple[str, ...]]:
+        return True, ()
+
+    monkeypatch.setattr(
+        "dev_health_ops.migrate.application_schema_status",
+        _satisfied,
+    )

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -1,0 +1,809 @@
+"""Unit proofs for the Wave 3.1 v2 persistence recorder methods (CHAOS-3299).
+
+Mirrors ``test_persistence.py``'s SQLite in-memory + FK-cascade-enabled
+fixture pattern. Each new artifact table gets: a happy path, closed-
+vocabulary rejection, and (where the table has a genuine bound) an
+off-by-one pair proving the bound itself, not just that a large value
+fails.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.persistence import (
+    DevPersistenceNotFound,
+    DevPersistenceService,
+    DevPersistenceValidationError,
+)
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunIntent,
+    DevRunInvestigationResult,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
+    DevRunInvestigationResult,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunStageDiagnostic,
+)
+_ALL_V2_MODELS = (
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
+    DevRunInvestigationResult,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunStageDiagnostic,
+)
+
+
+@pytest_asyncio.fixture
+async def persistence(tmp_path: Path):
+    database = tmp_path / "ask-dev-v2-persistence.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, other_org_id, user_id, other_user_id = (
+        uuid.uuid4(),
+        uuid.uuid4(),
+        uuid.uuid4(),
+        uuid.uuid4(),
+    )
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev-v2", name="Ask Dev v2"),
+                Organization(id=other_org_id, slug="other-v2", name="Other v2"),
+                User(id=user_id, email="ask-dev-v2@example.com"),
+                User(id=other_user_id, email="other-v2@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, other_org_id, user_id, other_user_id
+    finally:
+        await engine.dispose()
+
+
+async def _accepted_run(
+    service: DevPersistenceService, *, org_id: uuid.UUID, user_id: uuid.UUID
+) -> tuple[uuid.UUID, uuid.UUID]:
+    conversation = await service.create_conversation(
+        org_id=org_id, user_id=user_id, current_scope={}
+    )
+    accepted = await service.append_user_message_and_run(
+        org_id=org_id,
+        user_id=user_id,
+        conversation_id=conversation.id,
+        client_message_id=uuid.uuid4(),
+        question="What is the status of this project?",
+        scope_snapshot={},
+    )
+    return conversation.id, accepted.run.id
+
+
+# -- dev_run_intents ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_intent_happy_path_and_closed_vocabulary(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        record = await service.record_intent(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            intent_id="entity_status",
+            cardinality="singular",
+            requires_clarification=False,
+            interpreter_version="intent_interpreter.v1",
+            payload={"schema_version": "dev_question_intent.v1", "confidence": 0.9},
+        )
+        assert record.intent_id == "entity_status"
+        assert record.payload["confidence"] == 0.9
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_intent(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                intent_id="not_a_real_intent",
+                cardinality="singular",
+                requires_clarification=False,
+                interpreter_version="intent_interpreter.v1",
+                payload={},
+            )
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_intent(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                intent_id="entity_status",
+                cardinality="plural",  # not 'plural_cohort'
+                requires_clarification=False,
+                interpreter_version="intent_interpreter.v1",
+                payload={},
+            )
+
+
+@pytest.mark.asyncio
+async def test_record_intent_payload_bound_off_by_one(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        # Just at the bound: passes.
+        padding = "x" * 16_100
+        await service.record_intent(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            intent_id="entity_status",
+            cardinality="singular",
+            requires_clarification=False,
+            interpreter_version="intent_interpreter.v1",
+            payload={"note": padding},
+        )
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id2, run_id2 = await _accepted_run(
+            service, org_id=org_id, user_id=user_id
+        )
+        # One unit past the bound: rejected.
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_intent(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id2,
+                intent_id="entity_status",
+                cardinality="singular",
+                requires_clarification=False,
+                interpreter_version="intent_interpreter.v1",
+                payload={"note": "x" * 20_000},
+            )
+
+
+@pytest.mark.asyncio
+async def test_record_intent_rejects_sensitive_metadata_keys(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_intent(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                intent_id="entity_status",
+                cardinality="singular",
+                requires_clarification=False,
+                interpreter_version="intent_interpreter.v1",
+                payload={"nested": {"deeper": {"raw_prompt": "leaked"}}},
+            )
+
+
+# -- dev_run_resolutions (append-only) -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_resolution_is_append_only_and_insert_only(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        mention_id = uuid.uuid4()
+
+        first = await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload={"candidates": []},
+        )
+        assert first.entry_ordinal == 0
+
+        # A later resolution appends at the next ordinal -- never overwrites.
+        second = await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            entry_ordinal=1,
+            mention_id=mention_id,
+            outcome="exact_match",
+            resolved_at=datetime.now(UTC),
+            payload={"committed_entity_ref": {"entity_id": "repo/x"}},
+        )
+        assert second.entry_ordinal == 1
+
+        # No update path is exposed; re-inserting an already-used ordinal
+        # fails via the unique constraint rather than upserting.
+        with pytest.raises(Exception):  # noqa: B017 - IntegrityError, dialect-specific
+            async with session.begin_nested():
+                await service.append_resolution(
+                    org_id=org_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    entry_ordinal=0,
+                    mention_id=mention_id,
+                    outcome="no_authorized_match",
+                    resolved_at=datetime.now(UTC),
+                    payload={},
+                )
+
+        count = await session.scalar(select(func.count()).select_from(DevRunResolution))
+        assert count == 2
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_resolution(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                entry_ordinal=2,
+                mention_id=mention_id,
+                outcome="not_a_real_outcome",
+                resolved_at=datetime.now(UTC),
+                payload={},
+            )
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_resolution(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                entry_ordinal=100,  # bound is 0..99
+                mention_id=mention_id,
+                outcome="exact_match",
+                resolved_at=datetime.now(UTC),
+                payload={},
+            )
+
+
+# -- dev_run_subject_sets --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_subject_set_happy_path_and_invalid_entity_kind(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        record = await service.record_subject_set(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            set_id=uuid.uuid4(),
+            entity_kind="team",
+            cohort_complete=True,
+            fingerprint="sha256:" + "a" * 64,
+            payload={"committed_entity_refs": []},
+        )
+        assert record.entity_kind == "team"
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_subject_set(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                set_id=uuid.uuid4(),
+                entity_kind="not_a_real_kind",
+                cohort_complete=True,
+                fingerprint="fp",
+                payload={},
+            )
+
+
+# -- dev_run_source_observations ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_source_observation_bounds_and_closed_vocabulary(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        record = await service.append_source_observation(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=24,  # top of the 0..24 bound
+            observation_id=uuid.uuid4(),
+            source_class="status_change",
+            requirement_level="mandatory",
+            observed_state="available_current",
+            data_semantics="measured_zero",
+            usable_fact_count=0,
+            sample_count=0,
+            subject_coverage=1.0,
+            observed_at=datetime.now(UTC),
+            payload={"relationship_paths": []},
+        )
+        assert record.ordinal == 24
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_source_observation(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=25,  # one past the bound
+                observation_id=uuid.uuid4(),
+                source_class="status_change",
+                requirement_level="mandatory",
+                observed_state="available_current",
+                data_semantics="measured_zero",
+                usable_fact_count=0,
+                sample_count=0,
+                subject_coverage=1.0,
+                observed_at=datetime.now(UTC),
+                payload={},
+            )
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_source_observation(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=1,
+                observation_id=uuid.uuid4(),
+                source_class="not_a_real_source",
+                requirement_level="mandatory",
+                observed_state="available_current",
+                data_semantics="measured_zero",
+                usable_fact_count=0,
+                sample_count=0,
+                subject_coverage=1.0,
+                observed_at=datetime.now(UTC),
+                payload={},
+            )
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_source_observation(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=1,
+                observation_id=uuid.uuid4(),
+                source_class="status_change",
+                requirement_level="mandatory",
+                observed_state="available_current",
+                data_semantics="measured_zero",
+                usable_fact_count=0,
+                sample_count=0,
+                subject_coverage=1.5,  # out of [0, 1]
+                observed_at=datetime.now(UTC),
+                payload={},
+            )
+
+
+# -- dev_answer_frames / dev_run_narratives -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_frame_every_public_outcome_and_invalid_outcome(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    outcomes = (
+        "answered",
+        "answered_with_gaps",
+        "needs_clarification",
+        "not_found",
+        "temporarily_unavailable",
+        "unsupported",
+        "denied",
+        "failed",
+    )
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        for outcome in outcomes:
+            _conv_id, run_id = await _accepted_run(
+                service, org_id=org_id, user_id=user_id
+            )
+            record = await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.uuid4(),
+                public_outcome=outcome,
+                payload={"schema_version": "dev_answer_frame.v1"},
+            )
+            assert record.public_outcome == outcome
+
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.uuid4(),
+                public_outcome="bogus_outcome",
+                payload={},
+            )
+
+
+@pytest.mark.asyncio
+async def test_record_narrative_requires_matching_recorded_frame(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        real_frame_id = uuid.uuid4()
+        await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=real_frame_id,
+            public_outcome="answered",
+            payload={},
+        )
+
+        # A mutated frame_id -- not matching the run's actual recorded frame
+        # -- is rejected (same posture as append_assistant_answer's
+        # payload_conversation_id != conversation_id check).
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_narrative(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                narrative_id=uuid.uuid4(),
+                frame_id=uuid.uuid4(),  # mismatched
+                mode="deterministic_fallback",
+                provider_fingerprint=None,
+                narrative_text="Here is a safe presentation summary.",
+                payload={},
+            )
+
+        record = await service.record_narrative(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            narrative_id=uuid.uuid4(),
+            frame_id=real_frame_id,
+            mode="deterministic_fallback",
+            provider_fingerprint=None,
+            narrative_text="Here is a safe presentation summary.",
+            payload={},
+        )
+        assert record.frame_id == real_frame_id
+
+
+@pytest.mark.asyncio
+async def test_record_narrative_before_any_frame_is_rejected(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_narrative(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                narrative_id=uuid.uuid4(),
+                frame_id=uuid.uuid4(),
+                mode="provider",
+                provider_fingerprint=None,
+                narrative_text="text",
+                payload={},
+            )
+
+
+# -- dev_run_stage_diagnostics ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_stage_diagnostic_bounds_and_closed_vocabulary(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        record = await service.append_stage_diagnostic(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=0,
+            stage_id="interpreting",
+            status="completed",
+            latency_ms=12,
+            counts={"mention_count": 2},
+        )
+        assert record.stage_id == "interpreting"
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_stage_diagnostic(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=1,
+                stage_id="not_a_real_stage",
+                status="completed",
+                latency_ms=None,
+                counts={},
+            )
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_stage_diagnostic(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=1,
+                stage_id="planning",
+                status="not_a_real_status",
+                latency_ms=None,
+                counts={},
+            )
+
+
+# -- cross-org / cross-run association rejection --------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_run_association_is_rejected_for_every_recorder(persistence):
+    """A run_id that exists, but under a different org, must fail via the
+    composite ownership lookup -- not via an application check that could be
+    bypassed for one artifact but not another."""
+
+    maker, org_id, other_org_id, user_id, other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        with pytest.raises(DevPersistenceNotFound):
+            await service.record_intent(
+                org_id=other_org_id,
+                user_id=other_user_id,
+                run_id=run_id,
+                intent_id="entity_status",
+                cardinality="singular",
+                requires_clarification=False,
+                interpreter_version="intent_interpreter.v1",
+                payload={},
+            )
+        with pytest.raises(DevPersistenceNotFound):
+            await service.record_frame(
+                org_id=other_org_id,
+                user_id=other_user_id,
+                run_id=run_id,
+                frame_id=uuid.uuid4(),
+                public_outcome="answered",
+                payload={},
+            )
+        with pytest.raises(DevPersistenceNotFound):
+            await service.append_stage_diagnostic(
+                org_id=other_org_id,
+                user_id=other_user_id,
+                run_id=run_id,
+                ordinal=0,
+                stage_id="interpreting",
+                status="started",
+                latency_ms=None,
+                counts={},
+            )
+
+
+# -- purge/retention parity across all 8 new artifact tables ---------------
+
+
+async def _record_every_v2_artifact(
+    service: DevPersistenceService,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    run_id: uuid.UUID,
+) -> None:
+    await service.record_intent(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        intent_id="entity_status",
+        cardinality="singular",
+        requires_clarification=False,
+        interpreter_version="intent_interpreter.v1",
+        payload={},
+    )
+    await service.append_resolution(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        entry_ordinal=0,
+        mention_id=uuid.uuid4(),
+        outcome="exact_match",
+        resolved_at=datetime.now(UTC),
+        payload={},
+    )
+    await service.record_subject_set(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        set_id=uuid.uuid4(),
+        entity_kind="repository",
+        cohort_complete=True,
+        fingerprint="fp",
+        payload={},
+    )
+    await service.append_source_observation(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        ordinal=0,
+        observation_id=uuid.uuid4(),
+        source_class="status_change",
+        requirement_level="mandatory",
+        observed_state="available_current",
+        data_semantics="measured_zero",
+        usable_fact_count=0,
+        sample_count=0,
+        subject_coverage=1.0,
+        observed_at=datetime.now(UTC),
+        payload={},
+    )
+    await service.record_investigation_result(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        result_id=uuid.uuid4(),
+        relationship_closure_verified=True,
+        completed_at=datetime.now(UTC),
+        payload={},
+    )
+    frame_id = uuid.uuid4()
+    await service.record_frame(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        frame_id=frame_id,
+        public_outcome="answered",
+        payload={},
+    )
+    await service.record_narrative(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        narrative_id=uuid.uuid4(),
+        frame_id=frame_id,
+        mode="deterministic_fallback",
+        provider_fingerprint=None,
+        narrative_text="Safe presentation text.",
+        payload={},
+    )
+    await service.append_stage_diagnostic(
+        org_id=org_id,
+        user_id=user_id,
+        run_id=run_id,
+        ordinal=0,
+        stage_id="interpreting",
+        status="completed",
+        latency_ms=5,
+        counts={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_purges_every_new_artifact_table(persistence):
+    """Fail-before/pass-after for the cascade itself: this is the exact test
+    that would fail loudly (table not found / row not purged) if any of the
+    8 new FKs were wired wrong -- one INSERT per table, one DELETE, and a
+    direct count(*) per table, not just 'no exception was raised'."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        await _record_every_v2_artifact(
+            service, org_id=org_id, user_id=user_id, run_id=run_id
+        )
+        for model in _ALL_V2_MODELS:
+            count = await session.scalar(select(func.count()).select_from(model))
+            assert count == 1, f"{model.__tablename__} was not seeded"
+
+        deleted = await service.delete_conversation(
+            org_id=org_id, user_id=user_id, conversation_id=conv_id
+        )
+        assert deleted is True
+
+        for model in _ALL_V2_MODELS:
+            count = await session.scalar(select(func.count()).select_from(model))
+            assert count == 0, f"{model.__tablename__} was not purged"
+
+
+@pytest.mark.asyncio
+async def test_zero_day_immediate_purge_covers_every_new_artifact_and_orphan_write_fails(
+    persistence,
+):
+    """The 0-day path: record every artifact *before* the terminal
+    update_run transition, then confirm the immediate purge removes all of
+    them, and that writing to an already-purged run fails loudly (a
+    DevPersistenceNotFound from the owned-run lookup, not a silent no-op or
+    an orphaned row surviving the purge)."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Is this project healthy?",
+            scope_snapshot={},
+        )
+        run_id = accepted.run.id
+        await _record_every_v2_artifact(
+            service, org_id=org_id, user_id=user_id, run_id=run_id
+        )
+
+        result = await service.update_run(
+            org_id=org_id, user_id=user_id, run_id=run_id, state="completed"
+        )
+        assert result is None  # signals the ephemeral purge fired
+        assert await session.get(DevConversation, conversation.id) is None
+
+        for model in _ALL_V2_MODELS:
+            count = await session.scalar(select(func.count()).select_from(model))
+            assert count == 0, f"{model.__tablename__} was left orphaned"
+
+        # Writing to the now-purged run fails loudly, not silently.
+        with pytest.raises(DevPersistenceNotFound):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.uuid4(),
+                public_outcome="answered",
+                payload={},
+            )

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -32,7 +32,6 @@ from dev_health_ops.models.dev_persistence import (
     DevMessage,
     DevRun,
     DevRunIntent,
-    DevRunInvestigationResult,
     DevRunNarrative,
     DevRunResolution,
     DevRunSourceObservation,
@@ -57,7 +56,6 @@ _TABLES = tables_of(
     DevRunResolution,
     DevRunSubjectSet,
     DevRunSourceObservation,
-    DevRunInvestigationResult,
     DevAnswerFrame,
     DevRunNarrative,
     DevRunStageDiagnostic,
@@ -67,7 +65,6 @@ _ALL_V2_MODELS = (
     DevRunResolution,
     DevRunSubjectSet,
     DevRunSourceObservation,
-    DevRunInvestigationResult,
     DevAnswerFrame,
     DevRunNarrative,
     DevRunStageDiagnostic,
@@ -430,6 +427,96 @@ async def test_append_source_observation_bounds_and_closed_vocabulary(persistenc
             )
 
 
+# -- dev_runs.plan_step_partition / relationship_closure_verified ---------
+# Folded from a dedicated dev_run_investigation_results table (orchestrator
+# decision, CHAOS-3299): these two facts are set directly on the owned
+# dev_runs row instead.
+
+
+@pytest.mark.asyncio
+async def test_record_investigation_result_sets_partition_and_closure_bit(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        run = await service.record_investigation_result(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            completed_steps=["collect_status_changes", "collect_pull_requests"],
+            skipped_steps=["collect_ci_runs"],
+            failed_steps=[],
+            relationship_closure_verified=False,
+        )
+        assert run.plan_step_partition == {
+            "completed": ["collect_status_changes", "collect_pull_requests"],
+            "skipped": ["collect_ci_runs"],
+            "failed": [],
+        }
+        assert run.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_record_investigation_result_rejects_a_step_in_more_than_one_list(
+    persistence,
+):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_investigation_result(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                completed_steps=["collect_status_changes"],
+                skipped_steps=["collect_status_changes"],  # also completed
+                failed_steps=[],
+                relationship_closure_verified=True,
+            )
+
+
+@pytest.mark.asyncio
+async def test_record_investigation_result_step_list_bound_off_by_one(persistence):
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        # Exactly at the bound: passes.
+        run = await service.record_investigation_result(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            completed_steps=[f"step_{i}" for i in range(25)],
+            skipped_steps=[],
+            failed_steps=[],
+            relationship_closure_verified=True,
+        )
+        partition = run.plan_step_partition
+        assert partition is not None
+        assert len(partition["completed"]) == 25
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id2, run_id2 = await _accepted_run(
+            service, org_id=org_id, user_id=user_id
+        )
+        # One entry past the bound: rejected.
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_investigation_result(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id2,
+                completed_steps=[f"step_{i}" for i in range(26)],
+                skipped_steps=[],
+                failed_steps=[],
+                relationship_closure_verified=True,
+            )
+
+
 # -- dev_answer_frames / dev_run_narratives -------------------------------
 
 
@@ -612,6 +699,16 @@ async def test_cross_org_run_association_is_rejected_for_every_recorder(persiste
                 payload={},
             )
         with pytest.raises(DevPersistenceNotFound):
+            await service.record_investigation_result(
+                org_id=other_org_id,
+                user_id=other_user_id,
+                run_id=run_id,
+                completed_steps=[],
+                skipped_steps=[],
+                failed_steps=[],
+                relationship_closure_verified=True,
+            )
+        with pytest.raises(DevPersistenceNotFound):
             await service.record_frame(
                 org_id=other_org_id,
                 user_id=other_user_id,
@@ -633,7 +730,7 @@ async def test_cross_org_run_association_is_rejected_for_every_recorder(persiste
             )
 
 
-# -- purge/retention parity across all 8 new artifact tables ---------------
+# -- purge/retention parity across all 7 new artifact tables ---------------
 
 
 async def _record_every_v2_artifact(
@@ -693,10 +790,10 @@ async def _record_every_v2_artifact(
         org_id=org_id,
         user_id=user_id,
         run_id=run_id,
-        result_id=uuid.uuid4(),
+        completed_steps=["collect_status_changes"],
+        skipped_steps=[],
+        failed_steps=[],
         relationship_closure_verified=True,
-        completed_at=datetime.now(UTC),
-        payload={},
     )
     frame_id = uuid.uuid4()
     await service.record_frame(
@@ -734,8 +831,13 @@ async def _record_every_v2_artifact(
 async def test_delete_conversation_purges_every_new_artifact_table(persistence):
     """Fail-before/pass-after for the cascade itself: this is the exact test
     that would fail loudly (table not found / row not purged) if any of the
-    8 new FKs were wired wrong -- one INSERT per table, one DELETE, and a
-    direct count(*) per table, not just 'no exception was raised'."""
+    7 new FKs were wired wrong -- one INSERT per table, one DELETE, and a
+    direct count(*) per table, not just 'no exception was raised'.
+
+    ``plan_step_partition``/``relationship_closure_verified`` are not
+    separate FK'd tables -- they're columns folded onto ``dev_runs`` -- so
+    their purge parity is proven by the ``dev_runs`` row itself vanishing,
+    asserted explicitly rather than assumed."""
 
     maker, org_id, _other_org, user_id, _other_user = persistence
     async with maker() as session:
@@ -747,6 +849,14 @@ async def test_delete_conversation_purges_every_new_artifact_table(persistence):
         for model in _ALL_V2_MODELS:
             count = await session.scalar(select(func.count()).select_from(model))
             assert count == 1, f"{model.__tablename__} was not seeded"
+        seeded_run = await session.get(DevRun, run_id)
+        assert seeded_run is not None
+        assert seeded_run.plan_step_partition == {
+            "completed": ["collect_status_changes"],
+            "skipped": [],
+            "failed": [],
+        }
+        assert seeded_run.relationship_closure_verified is True
 
         deleted = await service.delete_conversation(
             org_id=org_id, user_id=user_id, conversation_id=conv_id
@@ -756,6 +866,10 @@ async def test_delete_conversation_purges_every_new_artifact_table(persistence):
         for model in _ALL_V2_MODELS:
             count = await session.scalar(select(func.count()).select_from(model))
             assert count == 0, f"{model.__tablename__} was not purged"
+        # session.get() would return the stale identity-mapped instance
+        # from the seed check above without re-querying; a fresh select
+        # is required to observe the cascade-deleted row.
+        assert await session.scalar(select(DevRun).where(DevRun.id == run_id)) is None
 
 
 @pytest.mark.asyncio
@@ -786,6 +900,10 @@ async def test_zero_day_immediate_purge_covers_every_new_artifact_and_orphan_wri
         await _record_every_v2_artifact(
             service, org_id=org_id, user_id=user_id, run_id=run_id
         )
+        seeded_run = await session.get(DevRun, run_id)
+        assert seeded_run is not None
+        assert seeded_run.plan_step_partition is not None
+        assert seeded_run.relationship_closure_verified is True
 
         result = await service.update_run(
             org_id=org_id, user_id=user_id, run_id=run_id, state="completed"
@@ -796,6 +914,11 @@ async def test_zero_day_immediate_purge_covers_every_new_artifact_and_orphan_wri
         for model in _ALL_V2_MODELS:
             count = await session.scalar(select(func.count()).select_from(model))
             assert count == 0, f"{model.__tablename__} was left orphaned"
+        # The columns are folded onto dev_runs, not a separate table --
+        # purge parity means the row (and therefore the columns) is gone.
+        # (select(), not get(): get() would return the stale
+        # identity-mapped instance from the seed check above.)
+        assert await session.scalar(select(DevRun).where(DevRun.id == run_id)) is None
 
         # Writing to the now-purged run fails loudly, not silently.
         with pytest.raises(DevPersistenceNotFound):

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -549,6 +549,16 @@ async def test_record_frame_every_public_outcome_and_invalid_outcome(persistence
             )
             assert record.public_outcome == outcome
 
+            # Codex-review finding (CHAOS-3299): record_frame must
+            # atomically tag the owned run v2 -- writing a frame without
+            # tagging left contract_generation stuck at 'v1' forever, which
+            # made router._replayed_result's "== 'v2'" replay gate
+            # permanently unreachable for every real v2 run.
+            run = await session.get(DevRun, run_id)
+            assert run is not None
+            assert run.contract_generation == "v2"
+            assert run.public_outcome == outcome
+
         _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
         with pytest.raises(DevPersistenceValidationError):
             await service.record_frame(

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -648,17 +648,8 @@ async def test_dev_message_stream_is_bounded_persisted_and_idempotent(
         PublicOutcome.NOT_FOUND,
         PublicOutcome.TEMPORARILY_UNAVAILABLE,
         PublicOutcome.UNSUPPORTED,
+        PublicOutcome.DENIED,
         PublicOutcome.FAILED,
-        # PublicOutcome.DENIED intentionally excluded: it is unreachable
-        # from real preflight today (PREFLIGHT_OUTCOME_BY_RESOLUTION has no
-        # entry that maps to it, matching FORBIDDEN_OR_NOT_FOUND's own
-        # documented unreachability), and preflight_outcomes.py's own
-        # _DISPLAY_LABELS table has no "denied" entry -- calling
-        # build_preflight_answer(outcome=DENIED, ...) raises KeyError. A
-        # real but separate, pre-existing completeness gap in CHAOS-3292's
-        # landed preflight_outcomes.py, out of scope for this CHAOS-3299
-        # replay-parity fix; flagged for follow-up rather than silently
-        # dropped from this parametrization.
     ],
 )
 async def test_no_answer_replay_matches_live_terminal_projection(

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass
@@ -19,10 +20,12 @@ from dev_health_ops.api.dev import router as dev_router_module
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import (
     DevAnswer,
+    DevContractVersions,
     DevScope,
     DevScopeResolution,
     ScopeResolutionOutcome,
 )
+from dev_health_ops.api.dev.contracts_v2.base import PublicOutcome, QuestionIntentID
 from dev_health_ops.api.dev.evidence_service import (
     EvidenceAvailability,
     EvidenceExpansion,
@@ -38,12 +41,18 @@ from dev_health_ops.api.dev.org_policy import (
     ASK_DEV_RETENTION_KEY,
 )
 from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.api.dev.preflight_outcomes import (
+    TERMINAL_STATE_BY_OUTCOME,
+    build_preflight_answer,
+    project_preflight_error,
+)
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.licensing import FeatureDecisionReason
 from dev_health_ops.licensing.registry import ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE
 from dev_health_ops.llm.agent.contracts import AgentUsage
 from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
     DevConversation,
     DevConversationTombstone,
     DevFeedback,
@@ -65,6 +74,7 @@ _TABLES = tables_of(
     DevToolCall,
     DevFeedback,
     DevConversationTombstone,
+    DevAnswerFrame,
     Setting,
 )
 
@@ -184,6 +194,99 @@ class HistoryCapturingRuntime(FakeBoundedRuntime):
     async def run(self, **kwargs) -> OrchestratorResult:
         self.prior_turns.append(tuple(kwargs.get("prior_turns", ())))
         return await super().run(**kwargs)
+
+
+_TEST_VERSIONS = DevContractVersions(
+    prompt_version="ask_dev_prompt.v1",
+    tool_contract_version="ask_dev_tools.v1",
+    metric_definition_version="ask_dev_metrics.v1",
+    query_version="ask_dev_queries.v1",
+)
+
+
+class PreflightNoAnswerRuntime(FakeBoundedRuntime):
+    """A CHAOS-3292 preflight termination for one no-answer public outcome.
+
+    Records the v2 frame the same way real preflight would (tagging the run
+    ``contract_generation = 'v2'``, CHAOS-3299 Codex finding 1) and streams
+    exactly the ``DevError`` ``preflight_outcomes.project_preflight_error``
+    builds live -- the same terminal projection a real orchestrator run
+    would use, so a router-level idempotent replay of this run can be
+    checked against it (CHAOS-3299 Codex finding 2).
+    """
+
+    def __init__(self, outcome: PublicOutcome) -> None:
+        self.outcome = outcome
+
+    async def run(
+        self,
+        *,
+        request,
+        run_id,
+        conversation_id,
+        answer_id,
+        recorder,
+        event_sink,
+        **_kwargs,
+    ) -> OrchestratorResult:
+        await recorder.transition(RunState.RESOLVING_SCOPE)
+        await event_sink(OrchestratorEvent(RunState.RESOLVING_SCOPE))
+
+        answer_v2 = build_preflight_answer(
+            outcome=self.outcome,
+            intent_id=QuestionIntentID.ENTITY_STATUS,
+            versions=_TEST_VERSIONS,
+            run_id=run_id,
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            generated_at=datetime.now(UTC),
+        )
+        await recorder.record_frame(answer_v2.frame)
+        error = project_preflight_error(answer_v2, request_id=request.request_id)
+        terminal_state = TERMINAL_STATE_BY_OUTCOME.get(self.outcome, RunState.FAILED)
+
+        await recorder.terminal(
+            state=terminal_state,
+            answer=None,
+            error=error,
+            usage=AgentUsage(input_tokens=0, output_tokens=0),
+            tool_call_count=0,
+            provider_fingerprint=None,
+            model_fingerprint=None,
+            prompt_checksum=None,
+        )
+        await event_sink(OrchestratorEvent(terminal_state, error.code))
+        return OrchestratorResult(
+            run_id=run_id,
+            state=terminal_state,
+            answer=None,
+            error=error,
+            events=(OrchestratorEvent(terminal_state, error.code),),
+            usage=AgentUsage(input_tokens=0, output_tokens=0),
+            tool_call_count=0,
+            provider_fingerprint=None,
+            model_fingerprint=None,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _parse_sse_events(text: str) -> list[tuple[str, dict[str, Any]]]:
+    events: list[tuple[str, dict[str, Any]]] = []
+    for block in text.strip().split("\n\n"):
+        if not block:
+            continue
+        event_name = None
+        data: dict[str, Any] | None = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event_name = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                data = json.loads(line.removeprefix("data: "))
+        if event_name is not None and data is not None:
+            events.append((event_name, data))
+    return events
 
 
 @pytest.mark.asyncio
@@ -535,6 +638,119 @@ async def test_dev_message_stream_is_bounded_persisted_and_idempotent(
     async with dev_api_context.maker() as session:
         assert await session.scalar(select(func.count()).select_from(DevRun)) == 2
         assert await session.scalar(select(func.count()).select_from(DevMessage)) == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        PublicOutcome.NEEDS_CLARIFICATION,
+        PublicOutcome.NOT_FOUND,
+        PublicOutcome.TEMPORARILY_UNAVAILABLE,
+        PublicOutcome.UNSUPPORTED,
+        PublicOutcome.FAILED,
+        # PublicOutcome.DENIED intentionally excluded: it is unreachable
+        # from real preflight today (PREFLIGHT_OUTCOME_BY_RESOLUTION has no
+        # entry that maps to it, matching FORBIDDEN_OR_NOT_FOUND's own
+        # documented unreachability), and preflight_outcomes.py's own
+        # _DISPLAY_LABELS table has no "denied" entry -- calling
+        # build_preflight_answer(outcome=DENIED, ...) raises KeyError. A
+        # real but separate, pre-existing completeness gap in CHAOS-3292's
+        # landed preflight_outcomes.py, out of scope for this CHAOS-3299
+        # replay-parity fix; flagged for follow-up rather than silently
+        # dropped from this parametrization.
+    ],
+)
+async def test_no_answer_replay_matches_live_terminal_projection(
+    dev_api_context, outcome: PublicOutcome
+) -> None:
+    """Endpoint-level idempotent-replay proof for every no-answer outcome
+    (CHAOS-3299 Codex review findings 1+2).
+
+    Before both fixes: ``record_frame`` never tagged the run
+    ``contract_generation = 'v2'`` (finding 1), so
+    ``router._replayed_result``'s ``== "v2"`` gate never took the
+    frame-reconstruction branch at all -- the replay fell through to the
+    generic "did not complete" error, a different shape from what the live
+    run streamed. And even with tagging fixed, the frame-reconstruction
+    branch called the generic v1-compat projector directly instead of
+    ``preflight_outcomes.project_preflight_error`` -- for
+    ``needs_clarification`` specifically that fabricated a disambiguation
+    candidate and returned a v1 ``DevAnswer`` (status
+    ``insufficient_evidence``) where live streams a ``DevError`` with code
+    ``scope_ambiguous`` (finding 2). This test drives the real endpoint
+    twice with the identical ``client_message_id`` -- the first call is
+    live, the second is the idempotent replay -- and asserts they carry the
+    same error code/message/retryable/remediation and, critically, the same
+    *event type*. ``request_id`` is intentionally excluded: live builds it
+    from the raw client-supplied request id (``request.request_id``) while
+    replay reads the persisted, UUID-folded ``dev_runs.request_id`` -- a
+    pre-existing, separate divergence in the "no frame at all" replay
+    branch too, out of scope for this fix.
+    """
+
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=cast(Any, PreflightNoAnswerRuntime(outcome))
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(dev_api_context.org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = {
+        "schema_version": "dev_message_request.v1",
+        "request_id": f"request_no_answer_{outcome.value}",
+        "client_message_id": f"client_no_answer_{outcome.value}",
+        "conversation_id": conversation_id,
+        "question": "What is the status of the thing I mean?",
+        "question_class": "status",
+        "scope": _scope_payload(dev_api_context.org_id),
+    }
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200
+    replay = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert replay.status_code == 200
+
+    live_events = dict(_parse_sse_events(live.text))
+    replay_events = dict(_parse_sse_events(replay.text))
+
+    assert "answer.completed" not in live_events, "live must not fabricate an answer"
+    assert "answer.completed" not in replay_events, (
+        "replay must not fabricate an answer either"
+    )
+    assert "error" in live_events
+    assert "error" in replay_events
+
+    live_error = live_events["error"]["error"]
+    replay_error = replay_events["error"]["error"]
+
+    def _comparable(error: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in error.items() if k != "request_id"}
+
+    assert _comparable(live_error) == _comparable(replay_error)
+    if outcome is PublicOutcome.NEEDS_CLARIFICATION:
+        assert live_error["code"] == "scope_ambiguous"
+
+    async with dev_api_context.maker() as session:
+        runs = (
+            await session.scalars(
+                select(DevRun).where(
+                    DevRun.conversation_id == uuid.UUID(conversation_id)
+                )
+            )
+        ).all()
+        assert len(runs) == 1, "the replay must not have created a second run"
+        assert runs[0].contract_generation == "v2"
+        assert runs[0].public_outcome == outcome.value
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_main_app_integration.py
+++ b/tests/api/test_main_app_integration.py
@@ -1,8 +1,45 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from dev_health_ops.api import main
+
+
+def test_lifespan_aborts_startup_when_schema_status_is_unsatisfied(monkeypatch):
+    """Companion proof for ``tests/api/conftest.py``'s autouse stub.
+
+    That fixture stubs ``application_schema_status`` satisfied for every
+    test in this package so CI's real-but-deliberately-unmigrated Postgres
+    service doesn't fail tests unrelated to schema-revision checking (see
+    the conftest docstring). This test overrides the stub back to
+    unsatisfied and confirms ``lifespan()`` still aborts startup through
+    the real ``with TestClient(main.app)`` seam -- proving the fixture
+    narrows what's exercised without disabling the guard itself. The
+    live-PostgreSQL-gated ancestor-walk proof lives in
+    ``tests/test_ask_dev_v2_persistence_startup_gate.py``; this is the fast,
+    CI-default companion at the mocked level.
+    """
+
+    async def _unsatisfied(dsn: str | None = None) -> tuple[bool, tuple[str, ...]]:
+        return False, ("0071",)
+
+    monkeypatch.setattr(
+        "dev_health_ops.migrate.application_schema_status", _unsatisfied
+    )
+    # A real (but unreachable) DSN so _lifespan.py's `if postgres_uri:` gate
+    # is entered -- the FeatureBundle validation step that runs first
+    # tolerates the resulting connection failure as "DB not ready" and
+    # continues on to the schema-revision check, which is stubbed above
+    # and needs no real connection of its own.
+    monkeypatch.setenv(
+        "POSTGRES_URI",
+        "postgresql+asyncpg://unreachable:unreachable@localhost:1/unreachable",
+    )
+
+    with pytest.raises(RuntimeError, match="application schema"):
+        with TestClient(main.app):
+            pytest.fail("lifespan must abort before yielding")
 
 
 def test_health_endpoint_returns_ok_when_required_services_ok(monkeypatch):

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0073"}
+    assert _revisions(migrated_to_0065.engine) == {"0075"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0073"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -3,22 +3,53 @@ from sqlalchemy.engine import make_url
 
 from dev_health_ops.api import _health
 
+_FAKE_ASYNC_URI = (
+    "postgresql+asyncpg://u:p@pooler.example.com/db"
+    "?sslmode=require&channel_binding=require"
+)
 
-@pytest.mark.asyncio
-async def test_postgres_health_uses_normalized_async_uri(monkeypatch):
-    captured: dict[str, str] = {}
+
+def _stub_connectivity(monkeypatch, *, captured: dict[str, str]):
+    """Stub the connectivity ping to always succeed and record the DSN it saw."""
 
     async def check(dsn: str) -> bool:
         captured["dsn"] = dsn
         return True
 
-    monkeypatch.setenv(
-        "POSTGRES_URI",
-        "postgresql+asyncpg://u:p@pooler.example.com/db?sslmode=require&channel_binding=require",
-    )
+    monkeypatch.setenv("POSTGRES_URI", _FAKE_ASYNC_URI)
     monkeypatch.delenv("DATABASE_URI", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setattr(_health, "_check_sqlalchemy_health_async", check)
+
+
+def _stub_schema_status(monkeypatch, *, satisfied: bool, captured: dict[str, str]):
+    """Stub the schema-revision check (CHAOS-3299) without touching a real DB.
+
+    ``_check_postgres_health`` imports ``application_schema_status`` from
+    ``dev_health_ops.migrate`` inside its own body on every call, so the
+    patch target is the source module's attribute, not ``_health``'s.
+    """
+
+    async def status(dsn: str | None = None) -> tuple[bool, tuple[str, ...]]:
+        captured["schema_status_dsn"] = dsn or ""
+        return satisfied, ()
+
+    monkeypatch.setattr("dev_health_ops.migrate.application_schema_status", status)
+
+
+@pytest.mark.asyncio
+async def test_postgres_health_uses_normalized_async_uri(monkeypatch):
+    """URI normalization only -- the schema-revision check (CHAOS-3299) is
+    stubbed satisfied so this stays decoupled from that separate concern
+    (see ``test_postgres_health_reports_down_when_schema_revision_behind``
+    for the fail-closed case, and the live-PostgreSQL-gated
+    ``test_health_postgres_check_reports_down_below_required_revision`` in
+    ``tests/test_ask_dev_v2_persistence_startup_gate.py`` for the real
+    ancestor-walk proof)."""
+
+    captured: dict[str, str] = {}
+    _stub_connectivity(monkeypatch, captured=captured)
+    _stub_schema_status(monkeypatch, satisfied=True, captured=captured)
 
     service, status = await _health._check_postgres_health()
 
@@ -29,3 +60,24 @@ async def test_postgres_health_uses_normalized_async_uri(monkeypatch):
     assert url.query["ssl"] == "require"
     assert "sslmode" not in url.query
     assert "channel_binding" not in url.query
+    # The schema-revision check reuses the exact same normalized DSN as the
+    # connectivity ping -- not a second, independently-resolved URI.
+    assert captured["schema_status_dsn"] == captured["dsn"]
+
+
+@pytest.mark.asyncio
+async def test_postgres_health_reports_down_when_schema_revision_behind(monkeypatch):
+    """Fail-closed by design (CHAOS-3299): a reachable database missing the
+    required application schema revision is ``"down"``, not ``"ok"`` --
+    closing the rolling-deploy window a one-time startup check can't. Fast
+    mock-level companion to the live-PostgreSQL-gated ancestor-walk proof in
+    ``tests/test_ask_dev_v2_persistence_startup_gate.py``."""
+
+    captured: dict[str, str] = {}
+    _stub_connectivity(monkeypatch, captured=captured)
+    _stub_schema_status(monkeypatch, satisfied=False, captured=captured)
+
+    service, status = await _health._check_postgres_health()
+
+    assert service == "postgres"
+    assert status == "down"

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -1,0 +1,421 @@
+"""Migration proofs for the Wave 3.1 v2 persistence schema (CHAOS-3299).
+
+SQLite covers the fast, CI-default upgrade/downgrade/re-upgrade rehearsal.
+CHECK constraint *enforcement*, JSONB, and NOT VALID/VALIDATE CONSTRAINT
+semantics don't exist in SQLite at all, so a live-PostgreSQL-gated variant
+(``DEV_HEALTH_POSTGRES_TEST_URI``, matching ``test_persistence_postgres.py``'s
+skipif pattern) proves the CHECK constraints themselves, not just that the
+migration runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+_NEW_TABLES = {
+    "dev_run_intents",
+    "dev_run_resolutions",
+    "dev_run_subject_sets",
+    "dev_run_source_observations",
+    "dev_run_investigation_results",
+    "dev_answer_frames",
+    "dev_run_narratives",
+    "dev_run_stage_diagnostics",
+}
+
+
+def _parent_and_v1_tables(connection: sa.Connection) -> None:
+    metadata = sa.MetaData()
+    sa.Table(
+        "organizations",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.Text(), nullable=False),
+    )
+    sa.Table(
+        "users",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("email", sa.Text(), nullable=False),
+    )
+    metadata.create_all(connection)
+
+
+def _load(revision_module: str):
+    return importlib.import_module(f"dev_health_ops.alembic.versions.{revision_module}")
+
+
+def test_0072_and_0073_module_metadata() -> None:
+    m72 = _load("0072_add_ask_dev_v2_persistence")
+    m73 = _load("0073_validate_ask_dev_v2_constraints")
+    assert m72.revision == "0072"
+    assert m72.down_revision == "0071"
+    assert m73.revision == "0073"
+    assert m73.down_revision == "0072"
+
+
+def test_0072_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() -> None:
+    m68 = _load("0068_add_ask_dev_persistence")
+    m69 = _load("0069_add_ask_dev_admission_indexes")
+    m72 = _load("0072_add_ask_dev_v2_persistence")
+    m73 = _load("0073_validate_ask_dev_v2_constraints")
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _parent_and_v1_tables(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                m68.upgrade()
+                m69.upgrade()
+                m72.upgrade()
+                m73.upgrade()
+
+                tables = set(sa.inspect(connection).get_table_names())
+                assert _NEW_TABLES.issubset(tables)
+                columns = {
+                    c["name"] for c in sa.inspect(connection).get_columns("dev_runs")
+                }
+                assert {
+                    "contract_generation",
+                    "public_outcome",
+                    "compatibility_projection_version",
+                    "plan_id",
+                    "plan_version",
+                }.issubset(columns)
+
+                m73.downgrade()
+                m72.downgrade()
+                tables = set(sa.inspect(connection).get_table_names())
+                assert not (_NEW_TABLES & tables)
+                columns = {
+                    c["name"] for c in sa.inspect(connection).get_columns("dev_runs")
+                }
+                assert "contract_generation" not in columns
+                assert "dev_runs" in tables  # 0068's tables are untouched
+
+                m72.upgrade()
+                m73.upgrade()
+                tables = set(sa.inspect(connection).get_table_names())
+                assert _NEW_TABLES.issubset(tables)
+    finally:
+        engine.dispose()
+
+
+def test_0072_dev_runs_contract_generation_defaults_v1_without_backfill() -> None:
+    """Every pre-existing row is legacy the instant the column exists."""
+
+    m68 = _load("0068_add_ask_dev_persistence")
+    m69 = _load("0069_add_ask_dev_admission_indexes")
+    m72 = _load("0072_add_ask_dev_v2_persistence")
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _parent_and_v1_tables(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                m68.upgrade()
+                m69.upgrade()
+
+            org_id, user_id, conv_id, run_id = (str(uuid.uuid4()) for _ in range(4))
+            connection.execute(
+                sa.text("INSERT INTO organizations (id, name) VALUES (:id, 'o')"),
+                {"id": org_id},
+            )
+            connection.execute(
+                sa.text("INSERT INTO users (id, email) VALUES (:id, 'u@example.com')"),
+                {"id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_conversations "
+                    "(id, org_id, user_id, current_scope, retention_days, "
+                    "created_at, updated_at) VALUES "
+                    "(:id, :org_id, :user_id, '{}', 30, CURRENT_TIMESTAMP, "
+                    "CURRENT_TIMESTAMP)"
+                ),
+                {"id": conv_id, "org_id": org_id, "user_id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_runs "
+                    "(id, request_id, conversation_id, org_id, user_id, state, "
+                    "started_at, created_at) VALUES "
+                    "(:id, :req, :conv, :org_id, :user_id, 'accepted', "
+                    "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                {
+                    "id": run_id,
+                    "req": str(uuid.uuid4()),
+                    "conv": conv_id,
+                    "org_id": org_id,
+                    "user_id": user_id,
+                },
+            )
+            connection.commit()
+
+            with Operations.context(context):
+                m72.upgrade()
+            row = connection.execute(
+                sa.text(
+                    "SELECT contract_generation, public_outcome FROM dev_runs "
+                    "WHERE id = :id"
+                ),
+                {"id": run_id},
+            ).one()
+            assert row.contract_generation == "v1"
+            assert row.public_outcome is None
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.skipif(
+    not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
+)
+def test_live_postgres_check_constraints_and_not_valid_validate_split() -> None:
+    """CHECK-constraint enforcement and the NOT VALID/VALIDATE split, live.
+
+    SQLite silently accepts anything through the ``ck_dev_runs_*`` string
+    checks (they're not enforced at all without STRICT tables); only a live
+    engine proves the constraint text is real and installed correctly.
+    """
+
+    from sqlalchemy.engine import make_url
+
+    configured = make_url(os.environ[_POSTGRES_URI_ENV])
+    if configured.get_backend_name() != "postgresql":
+        pytest.fail(f"{_POSTGRES_URI_ENV} must use PostgreSQL")
+    sync_url = configured.set(drivername="postgresql+psycopg2")
+    schema = f"ask_dev_v2_migration_{uuid.uuid4().hex}"
+
+    admin_engine = sa.create_engine(sync_url)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        engine = sa.create_engine(
+            sync_url, connect_args={"options": f"-csearch_path={schema}"}
+        )
+        try:
+            m68 = _load("0068_add_ask_dev_persistence")
+            m69 = _load("0069_add_ask_dev_admission_indexes")
+            m72 = _load("0072_add_ask_dev_v2_persistence")
+            m73 = _load("0073_validate_ask_dev_v2_constraints")
+            with engine.connect() as connection:
+                with connection.begin():
+                    _parent_and_v1_tables(connection)
+                    context = MigrationContext.configure(connection)
+                    with Operations.context(context):
+                        m68.upgrade()
+                        m69.upgrade()
+                        m72.upgrade()
+                        m73.upgrade()
+
+                        # Constraints are marked VALID after 0073.
+                        validated = connection.execute(
+                            sa.text(
+                                "SELECT conname, convalidated FROM pg_constraint "
+                                f"WHERE conrelid = '{schema}.dev_runs'::regclass "
+                                "AND conname IN "
+                                "('ck_dev_runs_contract_generation', "
+                                "'ck_dev_runs_public_outcome')"
+                            )
+                        ).fetchall()
+                        assert {
+                            (row.conname, row.convalidated) for row in validated
+                        } == {
+                            ("ck_dev_runs_contract_generation", True),
+                            ("ck_dev_runs_public_outcome", True),
+                        }
+
+                        # New-table CHECK constraints reject an
+                        # out-of-vocabulary source_class.
+                        org_id = connection.execute(
+                            sa.text(
+                                "INSERT INTO organizations (id, name) "
+                                "VALUES (gen_random_uuid(), 'o') RETURNING id"
+                            )
+                        ).scalar()
+                        user_id = connection.execute(
+                            sa.text(
+                                "INSERT INTO users (id, email) VALUES "
+                                "(gen_random_uuid(), 'u@example.com') "
+                                "RETURNING id"
+                            )
+                        ).scalar()
+                        conv_id = connection.execute(
+                            sa.text(
+                                "INSERT INTO dev_conversations (id, org_id, "
+                                "user_id, current_scope, retention_days, "
+                                "created_at, updated_at) VALUES "
+                                "(gen_random_uuid(), :org_id, :user_id, "
+                                "'{}', 30, now(), now()) RETURNING id"
+                            ),
+                            {"org_id": org_id, "user_id": user_id},
+                        ).scalar()
+                        run_id = connection.execute(
+                            sa.text(
+                                "INSERT INTO dev_runs (id, request_id, "
+                                "conversation_id, org_id, user_id, state, "
+                                "started_at, created_at) VALUES "
+                                "(gen_random_uuid(), gen_random_uuid(), "
+                                ":conv_id, :org_id, :user_id, 'accepted', "
+                                "now(), now()) RETURNING id"
+                            ),
+                            {
+                                "conv_id": conv_id,
+                                "org_id": org_id,
+                                "user_id": user_id,
+                            },
+                        ).scalar()
+
+                        # CHECK constraints reject an out-of-vocabulary value.
+                        with pytest.raises(sa.exc.IntegrityError):
+                            with connection.begin_nested():
+                                connection.execute(
+                                    sa.text(
+                                        "UPDATE dev_runs SET "
+                                        "contract_generation = 'v3' "
+                                        "WHERE id = :run_id"
+                                    ),
+                                    {"run_id": run_id},
+                                )
+                        with pytest.raises(sa.exc.IntegrityError):
+                            with connection.begin_nested():
+                                connection.execute(
+                                    sa.text(
+                                        "UPDATE dev_runs SET "
+                                        "public_outcome = 'bogus_outcome' "
+                                        "WHERE id = :run_id"
+                                    ),
+                                    {"run_id": run_id},
+                                )
+
+                        with pytest.raises(sa.exc.IntegrityError):
+                            with connection.begin_nested():
+                                connection.execute(
+                                    sa.text(
+                                        "INSERT INTO dev_run_source_observations "
+                                        "(id, run_id, org_id, user_id, ordinal, "
+                                        "observation_id, source_class, "
+                                        "requirement_level, observed_state, "
+                                        "data_semantics, usable_fact_count, "
+                                        "subject_coverage, payload, "
+                                        "observed_at) VALUES "
+                                        "(gen_random_uuid(), :run_id, :org_id, "
+                                        ":user_id, 0, gen_random_uuid(), "
+                                        "'not_a_real_source_class', "
+                                        "'mandatory', 'available_current', "
+                                        "'measured_zero', 0, 1.0, '{}', now())"
+                                    ),
+                                    {
+                                        "run_id": run_id,
+                                        "org_id": org_id,
+                                        "user_id": user_id,
+                                    },
+                                )
+
+                        m73.downgrade()
+                        m72.downgrade()
+                    tables = set(sa.inspect(connection).get_table_names(schema=schema))
+                    assert not (_NEW_TABLES & tables)
+        finally:
+            engine.dispose()
+    finally:
+        with admin_engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        admin_engine.dispose()
+
+
+@pytest.mark.skipif(
+    not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
+)
+def test_live_postgres_downgrade_refuses_when_v2_data_present() -> None:
+    """Observe the pre-release-rehearsal-only guard fail, then pass.
+
+    fail-before/pass-after pair for the safety check itself: a plain
+    ``op.drop_table`` sequence (no guard) would silently discard the row;
+    the guard must raise instead.
+    """
+
+    from sqlalchemy.engine import make_url
+
+    configured = make_url(os.environ[_POSTGRES_URI_ENV])
+    if configured.get_backend_name() != "postgresql":
+        pytest.fail(f"{_POSTGRES_URI_ENV} must use PostgreSQL")
+    sync_url = configured.set(drivername="postgresql+psycopg2")
+    schema = f"ask_dev_v2_downgrade_guard_{uuid.uuid4().hex}"
+
+    admin_engine = sa.create_engine(sync_url)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        engine = sa.create_engine(
+            sync_url, connect_args={"options": f"-csearch_path={schema}"}
+        )
+        try:
+            m68 = _load("0068_add_ask_dev_persistence")
+            m69 = _load("0069_add_ask_dev_admission_indexes")
+            m72 = _load("0072_add_ask_dev_v2_persistence")
+            with engine.connect() as connection:
+                with connection.begin():
+                    _parent_and_v1_tables(connection)
+                    context = MigrationContext.configure(connection)
+                    with Operations.context(context):
+                        m68.upgrade()
+                        m69.upgrade()
+                        m72.upgrade()
+                with connection.begin():
+                    org_id = connection.execute(
+                        sa.text(
+                            "INSERT INTO organizations (id, name) VALUES "
+                            "(gen_random_uuid(), 'o') RETURNING id"
+                        )
+                    ).scalar()
+                    user_id = connection.execute(
+                        sa.text(
+                            "INSERT INTO users (id, email) VALUES "
+                            "(gen_random_uuid(), 'u@example.com') RETURNING id"
+                        )
+                    ).scalar()
+                    conv_id = connection.execute(
+                        sa.text(
+                            "INSERT INTO dev_conversations (id, org_id, "
+                            "user_id, current_scope, retention_days, "
+                            "created_at, updated_at) VALUES "
+                            "(gen_random_uuid(), :org_id, :user_id, '{}', "
+                            "30, now(), now()) RETURNING id"
+                        ),
+                        {"org_id": org_id, "user_id": user_id},
+                    ).scalar()
+                    connection.execute(
+                        sa.text(
+                            "INSERT INTO dev_runs (id, request_id, "
+                            "conversation_id, org_id, user_id, state, "
+                            "contract_generation, started_at, created_at) "
+                            "VALUES (gen_random_uuid(), gen_random_uuid(), "
+                            ":conv_id, :org_id, :user_id, 'accepted', 'v2', "
+                            "now(), now())"
+                        ),
+                        {"conv_id": conv_id, "org_id": org_id, "user_id": user_id},
+                    )
+                with connection.begin():
+                    context = MigrationContext.configure(connection)
+                    with Operations.context(context):
+                        with pytest.raises(RuntimeError, match="contract_generation"):
+                            m72.downgrade()
+        finally:
+            engine.dispose()
+    finally:
+        with admin_engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        admin_engine.dispose()

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -54,20 +54,22 @@ def _load(revision_module: str):
     return importlib.import_module(f"dev_health_ops.alembic.versions.{revision_module}")
 
 
-def test_0072_and_0073_module_metadata() -> None:
-    m72 = _load("0072_add_ask_dev_v2_persistence")
-    m73 = _load("0073_validate_ask_dev_v2_constraints")
-    assert m72.revision == "0072"
-    assert m72.down_revision == "0071"
-    assert m73.revision == "0073"
-    assert m73.down_revision == "0072"
+def test_0074_and_0075_module_metadata() -> None:
+    m74 = _load("0074_add_ask_dev_v2_persistence")
+    m75 = _load("0075_validate_ask_dev_v2_constraints")
+    assert m74.revision == "0074"
+    # "0073" is CHAOS-3292's flag-seed migration; this branch stacks on
+    # feat/chaos-3292-interpret-preflight, where 0072/0073 exist.
+    assert m74.down_revision == "0073"
+    assert m75.revision == "0075"
+    assert m75.down_revision == "0074"
 
 
-def test_0072_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() -> None:
+def test_0074_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() -> None:
     m68 = _load("0068_add_ask_dev_persistence")
     m69 = _load("0069_add_ask_dev_admission_indexes")
-    m72 = _load("0072_add_ask_dev_v2_persistence")
-    m73 = _load("0073_validate_ask_dev_v2_constraints")
+    m74 = _load("0074_add_ask_dev_v2_persistence")
+    m75 = _load("0075_validate_ask_dev_v2_constraints")
 
     engine = sa.create_engine("sqlite:///:memory:")
     try:
@@ -77,8 +79,8 @@ def test_0072_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() 
             with Operations.context(context):
                 m68.upgrade()
                 m69.upgrade()
-                m72.upgrade()
-                m73.upgrade()
+                m74.upgrade()
+                m75.upgrade()
 
                 tables = set(sa.inspect(connection).get_table_names())
                 assert _NEW_TABLES.issubset(tables)
@@ -93,8 +95,8 @@ def test_0072_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() 
                     "plan_version",
                 }.issubset(columns)
 
-                m73.downgrade()
-                m72.downgrade()
+                m75.downgrade()
+                m74.downgrade()
                 tables = set(sa.inspect(connection).get_table_names())
                 assert not (_NEW_TABLES & tables)
                 columns = {
@@ -103,20 +105,20 @@ def test_0072_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() 
                 assert "contract_generation" not in columns
                 assert "dev_runs" in tables  # 0068's tables are untouched
 
-                m72.upgrade()
-                m73.upgrade()
+                m74.upgrade()
+                m75.upgrade()
                 tables = set(sa.inspect(connection).get_table_names())
                 assert _NEW_TABLES.issubset(tables)
     finally:
         engine.dispose()
 
 
-def test_0072_dev_runs_contract_generation_defaults_v1_without_backfill() -> None:
+def test_0074_dev_runs_contract_generation_defaults_v1_without_backfill() -> None:
     """Every pre-existing row is legacy the instant the column exists."""
 
     m68 = _load("0068_add_ask_dev_persistence")
     m69 = _load("0069_add_ask_dev_admission_indexes")
-    m72 = _load("0072_add_ask_dev_v2_persistence")
+    m74 = _load("0074_add_ask_dev_v2_persistence")
 
     engine = sa.create_engine("sqlite:///:memory:")
     try:
@@ -165,7 +167,7 @@ def test_0072_dev_runs_contract_generation_defaults_v1_without_backfill() -> Non
             connection.commit()
 
             with Operations.context(context):
-                m72.upgrade()
+                m74.upgrade()
             row = connection.execute(
                 sa.text(
                     "SELECT contract_generation, public_outcome FROM dev_runs "
@@ -208,8 +210,8 @@ def test_live_postgres_check_constraints_and_not_valid_validate_split() -> None:
         try:
             m68 = _load("0068_add_ask_dev_persistence")
             m69 = _load("0069_add_ask_dev_admission_indexes")
-            m72 = _load("0072_add_ask_dev_v2_persistence")
-            m73 = _load("0073_validate_ask_dev_v2_constraints")
+            m74 = _load("0074_add_ask_dev_v2_persistence")
+            m75 = _load("0075_validate_ask_dev_v2_constraints")
             with engine.connect() as connection:
                 with connection.begin():
                     _parent_and_v1_tables(connection)
@@ -217,10 +219,10 @@ def test_live_postgres_check_constraints_and_not_valid_validate_split() -> None:
                     with Operations.context(context):
                         m68.upgrade()
                         m69.upgrade()
-                        m72.upgrade()
-                        m73.upgrade()
+                        m74.upgrade()
+                        m75.upgrade()
 
-                        # Constraints are marked VALID after 0073.
+                        # Constraints are marked VALID after 0075.
                         validated = connection.execute(
                             sa.text(
                                 "SELECT conname, convalidated FROM pg_constraint "
@@ -324,8 +326,8 @@ def test_live_postgres_check_constraints_and_not_valid_validate_split() -> None:
                                     },
                                 )
 
-                        m73.downgrade()
-                        m72.downgrade()
+                        m75.downgrade()
+                        m74.downgrade()
                     tables = set(sa.inspect(connection).get_table_names(schema=schema))
                     assert not (_NEW_TABLES & tables)
         finally:
@@ -365,7 +367,7 @@ def test_live_postgres_downgrade_refuses_when_v2_data_present() -> None:
         try:
             m68 = _load("0068_add_ask_dev_persistence")
             m69 = _load("0069_add_ask_dev_admission_indexes")
-            m72 = _load("0072_add_ask_dev_v2_persistence")
+            m74 = _load("0074_add_ask_dev_v2_persistence")
             with engine.connect() as connection:
                 with connection.begin():
                     _parent_and_v1_tables(connection)
@@ -373,7 +375,7 @@ def test_live_postgres_downgrade_refuses_when_v2_data_present() -> None:
                     with Operations.context(context):
                         m68.upgrade()
                         m69.upgrade()
-                        m72.upgrade()
+                        m74.upgrade()
                 with connection.begin():
                     org_id = connection.execute(
                         sa.text(
@@ -412,7 +414,7 @@ def test_live_postgres_downgrade_refuses_when_v2_data_present() -> None:
                     context = MigrationContext.configure(connection)
                     with Operations.context(context):
                         with pytest.raises(RuntimeError, match="contract_generation"):
-                            m72.downgrade()
+                            m74.downgrade()
         finally:
             engine.dispose()
     finally:

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -187,6 +187,116 @@ def test_0074_dev_runs_contract_generation_defaults_v1_without_backfill() -> Non
         engine.dispose()
 
 
+def test_0074_downgrade_refuses_with_folded_column_only_data() -> None:
+    """Codex-review finding (CHAOS-3299): the downgrade guard must sweep
+    ``plan_step_partition``/``relationship_closure_verified`` independently
+    of ``contract_generation`` tagging.
+
+    ``DevPersistenceService.record_investigation_result`` can populate these
+    two folded ``dev_runs`` columns before a run ever reaches
+    ``record_frame`` -- the call that tags ``contract_generation = 'v2'`` --
+    e.g. a failure between the investigation and frame-synthesis stages. A
+    run in that state is still tagged 'v1' and would otherwise silently
+    pass the existing ``contract_generation = 'v2'`` guard while carrying
+    real v2 data. Fail-before/pass-after: the guard must raise while the
+    column is populated, and the same downgrade must then succeed once it is
+    cleared.
+    """
+
+    m68 = _load("0068_add_ask_dev_persistence")
+    m69 = _load("0069_add_ask_dev_admission_indexes")
+    m74 = _load("0074_add_ask_dev_v2_persistence")
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _parent_and_v1_tables(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                m68.upgrade()
+                m69.upgrade()
+
+            org_id, user_id, conv_id, run_id = (str(uuid.uuid4()) for _ in range(4))
+            connection.execute(
+                sa.text("INSERT INTO organizations (id, name) VALUES (:id, 'o')"),
+                {"id": org_id},
+            )
+            connection.execute(
+                sa.text("INSERT INTO users (id, email) VALUES (:id, 'u@example.com')"),
+                {"id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_conversations "
+                    "(id, org_id, user_id, current_scope, retention_days, "
+                    "created_at, updated_at) VALUES "
+                    "(:id, :org_id, :user_id, '{}', 30, CURRENT_TIMESTAMP, "
+                    "CURRENT_TIMESTAMP)"
+                ),
+                {"id": conv_id, "org_id": org_id, "user_id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_runs "
+                    "(id, request_id, conversation_id, org_id, user_id, state, "
+                    "started_at, created_at) VALUES "
+                    "(:id, :req, :conv, :org_id, :user_id, 'accepted', "
+                    "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                {
+                    "id": run_id,
+                    "req": str(uuid.uuid4()),
+                    "conv": conv_id,
+                    "org_id": org_id,
+                    "user_id": user_id,
+                },
+            )
+            connection.commit()
+
+            with Operations.context(context):
+                m74.upgrade()
+
+            # The run is still tagged 'v1' (the default) but carries a
+            # folded-column fact -- exactly the record_investigation_result-
+            # without-record_frame scenario the guard exists to catch.
+            connection.execute(
+                sa.text(
+                    "UPDATE dev_runs SET plan_step_partition = "
+                    '\'{"completed":["step_a"],"skipped":[],"failed":[]}\' '
+                    "WHERE id = :id"
+                ),
+                {"id": run_id},
+            )
+            connection.commit()
+            row = connection.execute(
+                sa.text(
+                    "SELECT contract_generation, plan_step_partition "
+                    "FROM dev_runs WHERE id = :id"
+                ),
+                {"id": run_id},
+            ).one()
+            assert row.contract_generation == "v1"
+            assert row.plan_step_partition is not None
+
+            with Operations.context(context):
+                with pytest.raises(RuntimeError, match="plan_step_partition"):
+                    m74.downgrade()
+
+            connection.execute(
+                sa.text(
+                    "UPDATE dev_runs SET plan_step_partition = NULL WHERE id = :id"
+                ),
+                {"id": run_id},
+            )
+            connection.commit()
+            with Operations.context(context):
+                m74.downgrade()  # now succeeds
+            tables = set(sa.inspect(connection).get_table_names())
+            assert not (_NEW_TABLES & tables)
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.skipif(
     not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
 )

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -26,7 +26,6 @@ _NEW_TABLES = {
     "dev_run_resolutions",
     "dev_run_subject_sets",
     "dev_run_source_observations",
-    "dev_run_investigation_results",
     "dev_answer_frames",
     "dev_run_narratives",
     "dev_run_stage_diagnostics",
@@ -93,6 +92,8 @@ def test_0074_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() 
                     "compatibility_projection_version",
                     "plan_id",
                     "plan_version",
+                    "plan_step_partition",
+                    "relationship_closure_verified",
                 }.issubset(columns)
 
                 m75.downgrade()
@@ -103,6 +104,8 @@ def test_0074_clean_install_upgrade_and_pre_release_downgrade_are_rehearsable() 
                     c["name"] for c in sa.inspect(connection).get_columns("dev_runs")
                 }
                 assert "contract_generation" not in columns
+                assert "plan_step_partition" not in columns
+                assert "relationship_closure_verified" not in columns
                 assert "dev_runs" in tables  # 0068's tables are untouched
 
                 m74.upgrade()
@@ -170,13 +173,16 @@ def test_0074_dev_runs_contract_generation_defaults_v1_without_backfill() -> Non
                 m74.upgrade()
             row = connection.execute(
                 sa.text(
-                    "SELECT contract_generation, public_outcome FROM dev_runs "
-                    "WHERE id = :id"
+                    "SELECT contract_generation, public_outcome, "
+                    "plan_step_partition, relationship_closure_verified "
+                    "FROM dev_runs WHERE id = :id"
                 ),
                 {"id": run_id},
             ).one()
             assert row.contract_generation == "v1"
             assert row.public_outcome is None
+            assert row.plan_step_partition is None
+            assert row.relationship_closure_verified is None
     finally:
         engine.dispose()
 

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -100,14 +100,14 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is False, "0071 predates the CHAOS-3299 revisions"
 
-    await asyncio.to_thread(_upgrade_to, sync_url, "0072")
+    await asyncio.to_thread(_upgrade_to, sync_url, "0074")
     satisfied, heads = await application_schema_status(async_url)
-    assert satisfied is False, "0073 (VALIDATE CONSTRAINT) is still missing"
+    assert satisfied is False, "0075 (VALIDATE CONSTRAINT) is still missing"
 
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0073",)
+    assert heads == ("0075",)
 
 
 @pytest.mark.asyncio
@@ -167,7 +167,7 @@ async def test_health_postgres_check_reports_down_below_required_revision(
     from dev_health_ops.api._health import _check_postgres_health
 
     sync_url, async_url = scratch_database
-    await asyncio.to_thread(_upgrade_to, sync_url, "0072")  # 0073 still missing
+    await asyncio.to_thread(_upgrade_to, sync_url, "0074")  # 0075 still missing
 
     with patch.dict(os.environ, {"POSTGRES_URI": async_url}):
         name, status_value = await _check_postgres_health()

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -1,0 +1,187 @@
+"""Startup/health schema-revision gate proofs (CHAOS-3299).
+
+Before this ticket, nothing checked the application schema revision at API
+process startup or in ``/health`` -- a missing migration surfaced as a raw
+``UndefinedTable``/``ProgrammingError`` on the first request that touched an
+unmigrated table. This is a live-PostgreSQL-gated test (schema revision
+tracking has no meaning against SQLite) proving the gate fires correctly at
+each stage of the real alembic chain, and that ``api._lifespan.lifespan``
+itself raises/aborts against an unmigrated database and starts cleanly
+against a migrated one -- the acceptance clause is "controlled
+startup/readiness failure", so the test must exercise ``lifespan()``, not
+just the underlying primitive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import make_url
+
+_POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
+)
+
+
+@pytest.fixture
+def scratch_database():
+    """A throwaway PostgreSQL database (own alembic_version), auto-dropped."""
+
+    configured = make_url(os.environ[_POSTGRES_URI_ENV])
+    if configured.get_backend_name() != "postgresql":
+        pytest.fail(f"{_POSTGRES_URI_ENV} must use PostgreSQL")
+    admin_url = configured.set(drivername="postgresql+psycopg2")
+    dbname = f"ask_dev_v2_gate_{uuid.uuid4().hex[:16]}"
+
+    admin_engine = sa.create_engine(admin_url, isolation_level="AUTOCOMMIT")
+    with admin_engine.connect() as connection:
+        connection.execute(sa.text(f'CREATE DATABASE "{dbname}"'))
+    host = configured.host or "localhost"
+    port = configured.port or 5432
+    user = configured.username or ""
+    password = configured.password or ""
+    try:
+        sync_url = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
+        async_url = f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{dbname}"
+        yield sync_url, async_url
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sa.text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{dbname}'"
+                )
+            )
+            connection.execute(sa.text(f'DROP DATABASE IF EXISTS "{dbname}"'))
+        admin_engine.dispose()
+
+
+def _upgrade_to(sync_url: str, revision: str) -> None:
+    from dev_health_ops.migrate import _make_alembic_config
+
+    # env.py always builds an async engine regardless of the configured URL
+    # scheme, so the config URL must itself be async-capable. env.py also
+    # re-resolves get_postgres_uri() at import time and overwrites whatever
+    # _make_alembic_config already set, so POSTGRES_URI must be set too --
+    # the autouse conftest fixture otherwise forces DATABASE_URI to an
+    # in-memory sqlite for every test.
+    async_url = sync_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    cfg = _make_alembic_config(async_url)
+    previous = os.environ.get("POSTGRES_URI")
+    os.environ["POSTGRES_URI"] = async_url
+    try:
+        command.upgrade(cfg, revision)
+    finally:
+        if previous is None:
+            os.environ.pop("POSTGRES_URI", None)
+        else:
+            os.environ["POSTGRES_URI"] = previous
+
+
+@pytest.mark.asyncio
+async def test_application_schema_status_ancestor_walk(scratch_database) -> None:
+    from dev_health_ops.migrate import application_schema_status
+
+    sync_url, async_url = scratch_database
+
+    satisfied, heads = await application_schema_status(async_url)
+    assert satisfied is False
+    assert heads == ()
+
+    await asyncio.to_thread(_upgrade_to, sync_url, "0071")
+    satisfied, heads = await application_schema_status(async_url)
+    assert satisfied is False, "0071 predates the CHAOS-3299 revisions"
+
+    await asyncio.to_thread(_upgrade_to, sync_url, "0072")
+    satisfied, heads = await application_schema_status(async_url)
+    assert satisfied is False, "0073 (VALIDATE CONSTRAINT) is still missing"
+
+    await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
+    satisfied, heads = await application_schema_status(async_url)
+    assert satisfied is True
+    assert heads == ("0073",)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_aborts_startup_when_schema_revision_missing(
+    scratch_database,
+) -> None:
+    """The acceptance clause verbatim: a controlled startup failure, not a
+    runtime ``UndefinedTable``. Exercises the real ``lifespan()`` context
+    manager against a database pinned at 0071 (pre-CHAOS-3299)."""
+
+    from dev_health_ops.api._lifespan import lifespan
+
+    sync_url, async_url = scratch_database
+    await asyncio.to_thread(_upgrade_to, sync_url, "0071")
+
+    with (
+        patch.dict(os.environ, {"POSTGRES_URI": async_url}),
+        patch(
+            "dev_health_ops.api.middleware.rate_limit.verify_rate_limit_config",
+            return_value=None,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="application schema"):
+            async with lifespan(_fake_app()):
+                pytest.fail("lifespan must abort before yielding")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_cleanly_at_required_revision(
+    scratch_database,
+) -> None:
+    from dev_health_ops.api._lifespan import lifespan
+
+    sync_url, async_url = scratch_database
+    await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
+
+    with (
+        patch.dict(os.environ, {"POSTGRES_URI": async_url}),
+        patch(
+            "dev_health_ops.api.middleware.rate_limit.verify_rate_limit_config",
+            return_value=None,
+        ),
+    ):
+        async with lifespan(_fake_app()):
+            pass  # started cleanly
+
+
+@pytest.mark.asyncio
+async def test_health_postgres_check_reports_down_below_required_revision(
+    scratch_database,
+) -> None:
+    """`/health` re-verifies on every probe -- covers the rolling-deploy
+    window a one-time startup check cannot (a replica that booted before a
+    migration completed elsewhere, or a manual DB rollback without a
+    process restart)."""
+
+    from dev_health_ops.api._health import _check_postgres_health
+
+    sync_url, async_url = scratch_database
+    await asyncio.to_thread(_upgrade_to, sync_url, "0072")  # 0073 still missing
+
+    with patch.dict(os.environ, {"POSTGRES_URI": async_url}):
+        name, status_value = await _check_postgres_health()
+    assert name == "postgres"
+    assert status_value == "down"
+
+    await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
+    with patch.dict(os.environ, {"POSTGRES_URI": async_url}):
+        name, status_value = await _check_postgres_health()
+    assert status_value == "ok"
+
+
+def _fake_app():
+    class _FakeApp:
+        pass
+
+    return _FakeApp()

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0073"}
+    assert set(heads) == {"0066", "0075"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0073"}
+        assert set(heads) == {"0066", "0075"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0073"
+        assert script.get_revision("application_schema@head").revision == "0075"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0073"}
-        assert scripts.get_revision("application_schema@head").revision == "0073"
-        assert _database_has_revision(cfg, ("0073",), "0065")
-        assert not _database_has_revision(cfg, ("0073",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0075"}
+        assert scripts.get_revision("application_schema@head").revision == "0075"
+        assert _database_has_revision(cfg, ("0075",), "0065")
+        assert not _database_has_revision(cfg, ("0075",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## CHAOS-3299 — Persist intent, resolution, plans, frames, and safe replay state

**Stacked on #1360** (`feat/chaos-3292-interpret-preflight`) — merge that first; GitHub will retarget this to `main`. Migrations chain 0072/0073 (3292) → **0074/0075** (this PR).

### What lands

- **Additive v2 persistence** for the full Wave 3.1 lifecycle, all FK-cascaded under `dev_runs` so 0/30-day retention, tombstoned purge, and org deletion cover every new artifact with the same DELETE: `dev_run_intents`, `dev_run_resolutions` (INSERT-only, per-mention), `dev_run_subject_sets`, `dev_run_source_observations`, `dev_answer_frames`, `dev_run_narratives`, `dev_run_stage_diagnostics`, plus `dev_runs` columns (`contract_generation` defaulting `'v1'` — every existing row is legacy the instant the column exists; `public_outcome`; `plan_id`/`plan_version`; `plan_step_partition` + `relationship_closure_verified` — the investigation-result facts folded onto the run row instead of a redundant payload table).
- **Migrations 0074 (NOT VALID) + 0075 (VALIDATE)** on the `application_schema` branch, with upgrade/downgrade/re-upgrade rehearsal on SQLite **and live Postgres**, old-head convergence with seeded v1 rows, and a downgrade that refuses when any v2 data exists — including folded-column-only data on runs still tagged v1.
- **Startup/health schema gate** (new coverage — previously zero anywhere): the API hard-fails startup when Postgres is reachable but missing the required revision, and `/health` re-verifies per probe (ancestor-walk semantics, rolling-deploy safe). Fail-closed reachable-but-behind = down.
- **Recorder + replay wiring**: `DevPersistenceService` v2 record methods called pre-terminal (0-day purge ordering proven — a write after purge fails loudly); `record_frame` atomically tags the run v2 with its public outcome; `router._replayed_result` renders no-answer replays through **live's own terminal projection** (`project_preflight_error`), with endpoint-level live-vs-replay equivalence tests across all 6 no-answer outcomes.

### Verification

Full `ci/local_validate.sh` green on the stacked tree (10,118 passed / 0 failed). Codex adversarial review: 3 findings, all execution-reproduced, all fixed with fail-before/pass-after pairs (v2 tagging unreachability, replay-projection parity — which also surfaced a latent naive-datetime bug on the previously unreachable branch — and the folded-column downgrade guard). Sensitive-key rejection at depth, off-by-one bounds pairs, cross-org FK enforcement, resolution immutability, and CHECK-constraint per-member mutation coverage per the four verification rules.

Reconciliation deltas vs the pre-implementation plan (documented on the issue): enum literals taken from the landed contracts (not TRD reconstructions), `plural_cohort`, GUID correlation-ID columns per the `ServerHandle` grammar, and the investigation-result fold.

SCREENSHOT-WAIVER: backend only.

