### PR TITLE
fix(helm): preserve digest image references

### DIFF
--- a/deploy/helm/dev-health/templates/_helpers.tpl
+++ b/deploy/helm/dev-health/templates/_helpers.tpl
@@ -71,14 +71,22 @@ Namespace
 Backend image
 */}}
 {{- define "dev-health.image" -}}
+{{- if contains "@" .Values.image.repository -}}
+{{- .Values.image.repository }}
+{{- else -}}
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+{{- end -}}
 {{- end }}
 
 {{/*
 Web image
 */}}
 {{- define "dev-health.webImage" -}}
+{{- if contains "@" .Values.webImage.repository -}}
+{{- .Values.webImage.repository }}
+{{- else -}}
 {{- printf "%s:%s" .Values.webImage.repository (default .Chart.AppVersion .Values.webImage.tag) }}
+{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Why

The owner chart appended a tag to every image repository, producing an invalid image reference whenever an operator supplied an immutable digest. This blocks the deployment umbrella from satisfying its immutable-image source policy.

## Validation

- helm template digest-test deploy/helm/dev-health with digest-qualified Ops and Web image repositories

The change is limited to rendering a digest-qualified owner value verbatim; tag-based behavior is unchanged.