### PR TITLE
fix(migrations): satisfy Semgrep on 0074/0075 identifier literals (CHAOS-3299)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
+++ b/src/dev_health_ops/alembic/versions/0074_add_ask_dev_v2_persistence.py
@@ -425,7 +425,7 @@ def downgrade() -> None:
         ):
             if bind.dialect.has_table(bind, table):
                 for_v2_rows = bind.execute(
-                    sa.text(f"SELECT count(*) FROM {table}")
+                    sa.select(sa.func.count()).select_from(sa.table(table))
                 ).scalar()
                 if for_v2_rows:
                     raise RuntimeError(
@@ -443,8 +443,13 @@ def downgrade() -> None:
     op.drop_table("dev_run_intents")
 
     if bind.dialect.name == "postgresql":
-        op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_PUBLIC_OUTCOME_CK}")
-        op.execute(f"ALTER TABLE dev_runs DROP CONSTRAINT {_CONTRACT_GENERATION_CK}")
+        # Constraint name is a module-level literal; DDL identifiers cannot be bound parameters.
+        op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            f"ALTER TABLE dev_runs DROP CONSTRAINT {_PUBLIC_OUTCOME_CK}"
+        )
+        op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            f"ALTER TABLE dev_runs DROP CONSTRAINT {_CONTRACT_GENERATION_CK}"
+        )
         op.drop_column("dev_runs", "relationship_closure_verified")
         op.drop_column("dev_runs", "plan_step_partition")
         op.drop_column("dev_runs", "plan_version")

--- a/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
+++ b/src/dev_health_ops/alembic/versions/0075_validate_ask_dev_v2_constraints.py
@@ -37,8 +37,13 @@ def upgrade() -> None:
     bind = op.get_bind()
     if bind.dialect.name != "postgresql":
         return
-    op.execute(f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_CONTRACT_GENERATION_CK}")
-    op.execute(f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_PUBLIC_OUTCOME_CK}")
+    # Constraint name is a module-level literal; DDL identifiers cannot be bound parameters.
+    op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_CONTRACT_GENERATION_CK}"
+    )
+    op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        f"ALTER TABLE dev_runs VALIDATE CONSTRAINT {_PUBLIC_OUTCOME_CK}"
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## What / why
- After #1361 (CHAOS-3299) merged, Semgrep OSS flagged 5 errors + 4 warnings on `main` in the two v2-persistence migrations, `0074_add_ask_dev_v2_persistence.py` and `0075_validate_ask_dev_v2_constraints.py`, for building SQL/DDL via f-string interpolation.
- All 5 are verified false positives: the interpolated values are either a literal tuple of table names or module-level constraint-name constants (`_PUBLIC_OUTCOME_CK`, `_CONTRACT_GENERATION_CK`) — never external/user input.
- `0074`'s row-count check is genuine dynamic SQL that SQLAlchemy Core can express directly, so the count query is moved to `sa.select(sa.func.count()).select_from(sa.table(table))` — the rule is satisfied, not suppressed.
- The four `DROP CONSTRAINT`/`VALIDATE CONSTRAINT` DDL statements keep their f-strings (SQLAlchemy has no bind-parameter syntax for DDL identifiers) and get a scoped `nosemgrep` naming only the exact rule ids that fired on that line, plus a one-line comment explaining why.

SCREENSHOT-WAIVER: backend only

TEST-EVIDENCE:
- `.venv/bin/python -m pytest tests/test_ask_dev_v2_persistence_migration.py -q` — 4 passed, 2 skipped
- Live-Postgres proof against a fresh scratch DB, exercising the edited downgrade/validate paths directly: `DEV_HEALTH_POSTGRES_TEST_URI=postgresql://postgres:postgres@localhost:5555/scratch_3299_ci .venv/bin/python -m pytest tests/test_0066_celery_river_cutover_postgres.py tests/api/test_main_app_integration.py tests/api/test_work_unit_explain_hardening.py -q` — 22 passed

RISK-NOTES: No behavior change — the 0074 rewrite is semantically identical SQL (SELECT count(*) FROM <table>) expressed via SQLAlchemy Core instead of sa.text(); the nosemgrep lines suppress only the two named rule ids on the four DDL statements that must stay f-strings. Blast radius limited to two already-merged, not-yet-run-in-production migration files (0074/0075, part of the CHAOS-3299 stack). No rollback needed beyond reverting this commit; no follow-up required.