### PR TITLE
fix: serve sync coverage from durable projections

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "$comment": "CUT-01 transitional workload inventory contract (CHAOS-3073). Maps every legacy Celery/Beat/API/registry/stream surface discovered in the Wave-0 audit to a target owner or explicit removal. See docs/architecture/transitional-workload-inventory.md for the update procedure and CI gate (ci/check_transitional_inventory.py).",
   "source_audit": "Wave-0 inventory audit, 147 surfaces (docs/plans/go-worker-cutover-implementation-plan.md CUT-01; TRD sec 6, 8.3)",
-  "row_count": 154,
+  "row_count": 156,
   "ownership_model": {
     "owner_role": "'primary' rows are the exclusive canonical claimant of a target_kind_id (a Beat entry, registry kind, stream, transport route, or a standalone celery task with no other owning row). 'contributor' rows are dispatch/trigger call sites, or implementation bodies, that feed an existing primary row and may freely share a target_owner value with other contributors.",
     "exclusivity_rule": "At most one row may be owner_role=primary for any given target_kind_id. CI enforces this; it does not require target_owner.value itself to be unique, since many contributor rows legitimately share one coarse target process description."
@@ -393,12 +393,12 @@
       "notes": "Beat entry prune-external-ingest-batches, crontab(5,15) UTC"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:756",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:759",
       "surface": "dispatch_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 756
+        "line": 759
       },
       "queue_or_cadence": "sync",
       "dispatches": "run_sync_unit (per unit)",
@@ -417,12 +417,12 @@
       "notes": "transport-routes.json kind dispatch_sync_run, route=celery"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1147",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1150",
       "surface": "run_sync_unit",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1147
+        "line": 1150
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -441,12 +441,12 @@
       "notes": "only launchdarkly/feature-flags route-ready in Go"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1971",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1974",
       "surface": "finalize_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1971
+        "line": 1974
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -1569,12 +1569,12 @@
       "notes": ""
     },
     {
-      "id": "beat_entry_conditional:src/dev_health_ops/workers/config.py:306",
+      "id": "beat_entry_conditional:src/dev_health_ops/workers/config.py:311",
       "surface": "consume-pending-scheduled-sync-occurrences",
       "class": "beat_entry_conditional",
       "source": {
         "file": "src/dev_health_ops/workers/config.py",
-        "line": 306
+        "line": 311
       },
       "queue_or_cadence": "300s, default off (SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED)",
       "dispatches": "consume_pending_scheduled_sync_occurrences",
@@ -2289,12 +2289,12 @@
       "notes": ""
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1043",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1046",
       "surface": "getattr(signature,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1043
+        "line": 1046
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2313,12 +2313,12 @@
       "notes": "grep-evading form; internal to dispatch_sync_run fan-out"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1606",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1609",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1606
+        "line": 1609
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2337,12 +2337,12 @@
       "notes": "grep-evading form; internal to unit completion"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2417",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2425",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2417
+        "line": 2425
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2332",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2333",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2332
+        "line": 2333
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2472",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2478",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2472
+        "line": 2478
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2235",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2231",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2235
+        "line": 2231
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2376",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2377",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2376
+        "line": 2377
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -3713,6 +3713,54 @@
       "acceptance_test_id": "tests/api/test_worker_operational_bridge.py::test_internal_bridge_passes_only_durable_billing_reference",
       "notes": "Added CUT-01 round-4 (Codex HIGH-1): billing_edge.py is a SEPARATELY DEPLOYED FastAPI app (own `app = FastAPI(...)` instance, not the primary API's router tree) -- see deploy/helm/dev-health/templates/billing-edge-deployment.yaml. Its /api/v1/billing/webhooks/stripe route (stripe_webhook_public) is a thin proxy that calls the imported `stripe_webhook` from billing/router.py directly; a same-file call-graph search can never find this because the actual handler is defined in a different file. Discovered via a targeted cross-file-forwarding scan scoped to modules with their own FastAPI() instance whose handler calls an imported name already known to be dispatch-relevant, not a general cross-file call-graph resolver (see docs/architecture/transitional-workload-inventory.md Known limitations).",
       "route_mount_prefix": ""
+    },
+    {
+      "id": "celery_task:src/dev_health_ops/workers/sync_coverage.py:77",
+      "surface": "refresh_sync_coverage_projections",
+      "class": "celery_task",
+      "source": {
+        "file": "src/dev_health_ops/workers/sync_coverage.py",
+        "line": 77
+      },
+      "queue_or_cadence": "sync",
+      "dispatches": "self (Beat)",
+      "dispatch_mechanism": "celery_task_decorator",
+      "owner_role": "contributor",
+      "target_owner": {
+        "type": "native_process",
+        "value": "coverage projection worker"
+      },
+      "target_kind_id": "beat:refresh-sync-coverage-projections",
+      "current_implementation_state": "celery_only",
+      "verification_status": "verified",
+      "compatibility_dependency": "Celery worker process consuming the sync queue.",
+      "deletion_evidence_requirement": "Replace the periodic projection refresh with a native scheduler-owned exact-summary rebuild before deleting this task.",
+      "acceptance_test_id": "tests/api/admin/test_sync_coverage_api.py::test_sync_coverage_projects_more_than_40000_raw_units_exactly",
+      "notes": "Keeps versioned exact-history projections warm; invalidated or missing projections return an explicit pending response until rebuilt."
+    },
+    {
+      "id": "beat_entry:src/dev_health_ops/workers/config.py:300",
+      "surface": "refresh-sync-coverage-projections",
+      "class": "beat_entry",
+      "source": {
+        "file": "src/dev_health_ops/workers/config.py",
+        "line": 300
+      },
+      "queue_or_cadence": "300s",
+      "dispatches": "refresh_sync_coverage_projections",
+      "dispatch_mechanism": "beat_schedule_entry",
+      "owner_role": "primary",
+      "target_owner": {
+        "type": "native_process",
+        "value": "coverage projection worker"
+      },
+      "target_kind_id": "beat:refresh-sync-coverage-projections",
+      "current_implementation_state": "celery_only",
+      "verification_status": "verified",
+      "compatibility_dependency": "Celery Beat scheduler process plus the sync queue worker.",
+      "deletion_evidence_requirement": "Remove the Beat entry only after a native cadence refreshes every configuration without starvation.",
+      "acceptance_test_id": "tests/api/admin/test_sync_coverage_api.py::test_sync_coverage_projection_is_reused_when_source_is_unchanged",
+      "notes": "Unconditional five-minute refresh for exact coverage projections."
     }
   ]
 }

--- a/internal/joboutbox/loop_test.go
+++ b/internal/joboutbox/loop_test.go
@@ -109,23 +109,21 @@ func TestReconcilerLoopImmediateNoopStepOpensReadiness(t *testing.T) {
 func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *testing.T) {
 	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
 	results := []StepResult{{Claimed: 2, Delivered: 1, Retried: 1}, {Claimed: 3, Dead: 1, LeaseLost: 2}}
-	steps := make(chan struct{}, 2)
 	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
 		result := results[0]
 		results = results[1:]
-		steps <- struct{}{}
 		return result, nil
 	}), clock)
-	if err := loop.Start(context.Background()); err != nil {
+	ctx := context.Background()
+	if err := loop.step(ctx, clock.Now()); err != nil {
 		t.Fatal(err)
 	}
-	<-steps
 	clock.mu.Lock()
 	clock.now = clock.now.Add(3 * time.Second)
-	ticker := clock.ticker
 	clock.mu.Unlock()
-	ticker.ticks <- clock.Now()
-	<-steps
+	if err := loop.step(ctx, clock.Now()); err != nil {
+		t.Fatal(err)
+	}
 
 	var metrics bytes.Buffer
 	if err := loop.WritePrometheus(&metrics); err != nil {
@@ -146,9 +144,6 @@ func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *test
 	}
 	if strings.Contains(metrics.String(), "{") {
 		t.Fatalf("reconciler metrics must not expose labels:\n%s", metrics.String())
-	}
-	if err := loop.Shutdown(context.Background()); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/scheduler/fixed/coverage_test.go
+++ b/internal/scheduler/fixed/coverage_test.go
@@ -201,8 +201,8 @@ func TestBeatScheduleParserFindsTheCheckedInventory(t *testing.T) {
 	// The TRD acceptance criteria are stated against exactly these counts. A
 	// change here means a Beat entry was added or removed, which must be a
 	// reviewed ownership decision rather than an unnoticed coverage change.
-	if unconditional != 19 {
-		t.Fatalf("parsed %d unconditional beat entries, want 19", unconditional)
+	if unconditional != 20 {
+		t.Fatalf("parsed %d unconditional beat entries, want 20", unconditional)
 	}
 	if optional != 1 {
 		t.Fatalf("parsed %d optional beat entries, want 1", optional)

--- a/internal/scheduler/fixed/inventory.go
+++ b/internal/scheduler/fixed/inventory.go
@@ -429,6 +429,14 @@ func LegacyBeatInventory() []LegacyEntry {
 			OwnerRef: "prune_external_ingest_batches",
 		},
 		{
+			Name:     "refresh-sync-coverage-projections",
+			Cadence:  EveryInterval(300 * time.Second),
+			Owner:    OwnerRemoved,
+			OwnerRef: "coverage projection refresh",
+			Note: "Temporary safety net while exact summaries are rebuilt from retained facts. " +
+				"A native write-side projector makes this periodic Celery refresh unnecessary.",
+		},
+		{
 			Name:     "consume-pending-scheduled-sync-occurrences",
 			Cadence:  EveryInterval(300 * time.Second),
 			Optional: true,

--- a/src/dev_health_ops/alembic/versions/0076_add_sync_coverage_projections.py
+++ b/src/dev_health_ops/alembic/versions/0076_add_sync_coverage_projections.py
@@ -1,0 +1,84 @@
+"""Add compact exact-history sync coverage projections.
+
+Revision ID: 0076
+Revises: 0075
+Create Date: 2026-07-31 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0076"
+down_revision: str | None = "0075"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sync_coverage_projections",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("org_id", sa.String(), nullable=False),
+        sa.Column("sync_config_id", sa.Uuid(), nullable=False),
+        sa.Column("history_lookback_days", sa.Integer(), nullable=False),
+        sa.Column("projection_version", sa.Integer(), nullable=False),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("backfill_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("invalidated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["sync_config_id"], ["sync_configurations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "org_id",
+            "sync_config_id",
+            "history_lookback_days",
+            name="uq_sync_coverage_projection_org_config_window",
+        ),
+    )
+    op.create_index(
+        "ix_sync_coverage_projection_org_config",
+        "sync_coverage_projections",
+        ["org_id", "sync_config_id"],
+    )
+    op.create_index(
+        "ix_sync_coverage_projection_refresh_order",
+        "sync_coverage_projections",
+        ["invalidated_at", "updated_at"],
+    )
+    op.create_index(
+        "ix_sync_run_units_coverage_scan",
+        "sync_run_units",
+        ["org_id", "integration_id", "source_id", "dataset_key", "before_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sync_run_units_coverage_scan", table_name="sync_run_units")
+    op.drop_index(
+        "ix_sync_coverage_projection_refresh_order",
+        table_name="sync_coverage_projections",
+    )
+    op.drop_index(
+        "ix_sync_coverage_projection_org_config",
+        table_name="sync_coverage_projections",
+    )
+    op.drop_table("sync_coverage_projections")

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -37,11 +37,11 @@ from dev_health_ops.api.services.configuration import (
 from dev_health_ops.api.services.licensing import TierLimitService
 from dev_health_ops.api.services.sync_coverage import (
     HISTORY_LOOKBACK_DAYS,
-    SyncCoverageBusyError,
     SyncCoverageComplexityError,
+    SyncCoveragePendingError,
     build_sync_coverage_summary,
     ensure_utc,
-    sync_coverage_admission_slot,
+    invalidate_sync_coverage_projection,
 )
 from dev_health_ops.models import SyncRun
 from dev_health_ops.models.integrations import (
@@ -1195,6 +1195,11 @@ async def _replace_planner_repository_selection(
         existing.is_enabled = True
         existing.last_seen_at = datetime.now(timezone.utc)
 
+    await invalidate_sync_coverage_projection(
+        session,
+        org_id,
+        integration_id=integration_id,
+    )
     await session.flush()
     refreshed_sources = await _planner_sources_for_config(session, org_id, config)
     return _repo_selection_from_sources(config, refreshed_sources)
@@ -1957,50 +1962,28 @@ async def get_sync_config_repositories(
 )
 async def get_sync_config_coverage(
     config_id: str,
-    history_lookback_days: int = Query(
-        default=HISTORY_LOOKBACK_DAYS,
-        ge=1,
-        le=3650,
-        description=(
-            "Maximum history window. The response may use a smaller effective "
-            "window when the requested sync-unit history exceeds safety limits."
-        ),
-    ),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SyncCoverageSummaryResponse:
     try:
-        # Admit before the first database query. Saturated coverage traffic
-        # must not consume PgBouncer connections needed by unrelated routes.
-        async with sync_coverage_admission_slot():
-            svc = SyncConfigurationService(session, org_id)
-            config = await svc.get_by_id(config_id)
-            if config is None:
-                raise HTTPException(
-                    status_code=404, detail="Sync configuration not found"
-                )
-            payload = await build_sync_coverage_summary(
-                session,
-                org_id,
-                config,
-                lookback_days=history_lookback_days,
-            )
-    except SyncCoverageBusyError as exc:
-        logger.warning(
-            "sync_coverage_request_rejected_busy",
-            extra={
-                "org_id": org_id,
-                "sync_config_id": config_id,
-                "history_lookback_days": history_lookback_days,
-            },
+        svc = SyncConfigurationService(session, org_id)
+        config = await svc.get_by_id(config_id)
+        if config is None:
+            raise HTTPException(status_code=404, detail="Sync configuration not found")
+        payload = await build_sync_coverage_summary(
+            session,
+            org_id,
+            config,
+            lookback_days=HISTORY_LOOKBACK_DAYS,
         )
+    except SyncCoveragePendingError as exc:
         raise HTTPException(
             status_code=503,
             detail={
-                "code": "sync_coverage_busy",
+                "code": "sync_coverage_projection_pending",
                 "message": str(exc),
             },
-            headers={"Retry-After": "5"},
+            headers={"Retry-After": "30"},
         ) from exc
     except SyncCoverageComplexityError as exc:
         raise HTTPException(
@@ -2009,8 +1992,7 @@ async def get_sync_config_coverage(
                 "code": "sync_coverage_too_large",
                 "message": (
                     "Coverage scope or history is too large to compute safely. "
-                    "Reduce the sync configuration scope or retry with a smaller "
-                    "history_lookback_days value."
+                    "Reduce the sync configuration scope and retry."
                 ),
                 "stage": exc.stage,
                 "limit": exc.limit,
@@ -2211,6 +2193,20 @@ async def update_sync_config(
                 await _upsert_scheduled_job(session, child, org_id)
             await session.flush()
 
+    integration_id = getattr(updated, "integration_id", None)
+    if integration_id is not None:
+        await invalidate_sync_coverage_projection(
+            session,
+            org_id,
+            integration_id=integration_id,
+        )
+    else:
+        await invalidate_sync_coverage_projection(
+            session,
+            org_id,
+            sync_config_id=getattr(updated, "id"),
+        )
+
     credential_id = await _integration_credential_id_for_config(
         session, updated, org_id
     )
@@ -2319,6 +2315,11 @@ async def trigger_sync_config(
             status_code=400,
             detail="Sync configuration has no linked integration",
         )
+    await invalidate_sync_coverage_projection(
+        session,
+        org_id,
+        sync_config_id=getattr(config, "id"),
+    )
     if not trigger.dispatch_required:
         await session.commit()
         return {
@@ -2444,6 +2445,11 @@ async def trigger_sync_config_backfill(
                 status_code=400,
                 detail="Sync configuration has no linked integration",
             )
+        await invalidate_sync_coverage_projection(
+            session,
+            org_id,
+            sync_config_id=getattr(config, "id"),
+        )
         if not trigger.dispatch_required:
             await session.commit()
             return {

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -338,6 +338,12 @@ class SyncCoverageSource(BaseModel):
     failed_range_count: int
 
 
+class SyncCoverageBackfillWindow(BaseModel):
+    since: date
+    before: date
+    reasons: list[Literal["gap", "failed"]] = Field(default_factory=list)
+
+
 class SyncCoverageSummaryResponse(BaseModel):
     """Coverage for this sync config's effective source/dataset scope.
 
@@ -351,17 +357,21 @@ class SyncCoverageSummaryResponse(BaseModel):
     generated_at: datetime
     data_basis: Literal["planner", "legacy"]
     history_lookback_days: int = Field(
-        description=(
-            "Effective history window used for this response. May be smaller than "
-            "the requested upper bound when the recent sync-unit history is too large."
-        )
+        description="Exact history window used for this response."
     )
     truncated_before: datetime = Field(
-        description="Oldest timestamp included by the effective history window."
+        description="Oldest timestamp included by the requested history window."
     )
+    coverage_since: datetime | None = None
+    coverage_through: datetime | None = None
+    is_truncated: bool = False
+    truncation_reason: Literal["lookback_limit"] | None = None
+    projection_version: int
+    projection_complete: bool
     overall: SyncCoverageOverall
     datasets: list[SyncCoverageDataset]
     sources: list[SyncCoverageSource]
+    backfill_windows: list[SyncCoverageBackfillWindow] = Field(default_factory=list)
 
 
 class JobRunResponse(BaseModel):

--- a/src/dev_health_ops/api/services/configuration/sync_configuration.py
+++ b/src/dev_health_ops/api/services/configuration/sync_configuration.py
@@ -70,6 +70,23 @@ class SyncConfigurationService:
         if is_active is not None:
             config.is_active = is_active
 
+        from dev_health_ops.api.services.sync_coverage import (
+            invalidate_sync_coverage_projection,
+        )
+
+        integration_id = getattr(config, "integration_id", None)
+        if integration_id is not None:
+            await invalidate_sync_coverage_projection(
+                self.session,
+                self.org_id,
+                integration_id=integration_id,
+            )
+        else:
+            await invalidate_sync_coverage_projection(
+                self.session,
+                self.org_id,
+                sync_config_id=getattr(config, "id"),
+            )
         await self.session.flush()
         return config
 

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -12,9 +12,11 @@ from time import monotonic
 from typing import Any, Protocol
 
 from croniter import croniter as Croniter
-from sqlalchemy import case, func, select, union
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import case, func, select, union, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import load_only
+from sqlalchemy.orm import Session, load_only
+from sqlalchemy.sql.dml import Update
 
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.integrations import (
@@ -26,17 +28,19 @@ from dev_health_ops.models.integrations import (
     SyncRunUnitStatus,
 )
 from dev_health_ops.models.settings import JobStatus, ScheduledJob, SyncConfiguration
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.sync.datasets import supported_datasets
 from dev_health_ops.sync.planner import family_dataset_keys_from_flags
 
 logger = logging.getLogger(__name__)
 
-HISTORY_LOOKBACK_DAYS = 180
+HISTORY_LOOKBACK_DAYS = 3650
+SYNC_COVERAGE_PROJECTION_VERSION = 1
 STALE_MINIMUM_GRACE = timedelta(hours=6)
 STALE_FALLBACK_GRACE = timedelta(hours=48)
 INTERVAL_ADJACENCY_TOLERANCE = timedelta(microseconds=1)
 
-# Code-owned safety limits for this request-time analytical endpoint. These are
+# Code-owned safety limits for the background projection builder. These are
 # deliberately not environment overrides: deployment configuration must not be
 # able to silently remove the memory bound. Requests beyond the active-build
 # limit are rejected immediately rather than retained in an unbounded waiter
@@ -49,6 +53,7 @@ MAX_COVERAGE_DATASETS = 100
 MAX_COVERAGE_PAIRS = 20_000
 MAX_COVERAGE_UNIT_WINDOWS = 30_000
 MAX_COVERAGE_BACKFILL_PAIR_INTERVALS = 20_000
+MAX_COVERAGE_PROJECTION_ROWS = 1_000_000
 
 TERMINAL_UNIT_STATUSES = {
     SyncRunUnitStatus.SUCCESS.value,
@@ -69,6 +74,10 @@ ACTIVE_RUN_STATUSES = {
 
 class SyncCoverageBusyError(RuntimeError):
     """Raised when the process-local coverage capacity is saturated."""
+
+
+class SyncCoveragePendingError(RuntimeError):
+    """Raised when the background-built coverage projection is not ready."""
 
 
 class SyncCoverageComplexityError(RuntimeError):
@@ -206,7 +215,7 @@ class _CoverageUnitRow:
     """The narrow persisted projection required by coverage interval math.
 
     SyncRunUnit.result/error and SyncRun.result/error can be large. Hydrating the
-    full ORM entities for every unit in the 180-day lookback made one coverage
+    full ORM entities for every unit in a large lookback made one coverage
     request consume hundreds of MiB and allowed concurrent admin page requests
     to OOM-kill the API container.
     """
@@ -298,6 +307,15 @@ class _PairCoverage:
     failed_ranges: list[CoverageInterval] = field(default_factory=list)
     covered_through: datetime | None = None
     status: str = "insufficient_data"
+
+
+@dataclass
+class _CompactPairState:
+    """Streaming reducer state for one source/dataset pair."""
+
+    requested: list[CoverageInterval] = field(default_factory=list)
+    covered: list[CoverageInterval] = field(default_factory=list)
+    failed: list[CoverageInterval] = field(default_factory=list)
 
 
 def ensure_utc(value: datetime) -> datetime:
@@ -399,7 +417,7 @@ def failed_ranges_not_superseded(
                 since=success.since,
                 before=success.before,
                 source_ids=(success.source_id,),
-                run_ids=(success.run_id,),
+                run_ids=(success.run_id,) if success.run_id else (),
             )
             for success in success_windows
             if success.source_id == failure.source_id
@@ -412,7 +430,7 @@ def failed_ranges_not_superseded(
                     since=failure.since,
                     before=failure.before,
                     source_ids=(failure.source_id,),
-                    run_ids=(failure.run_id,),
+                    run_ids=(failure.run_id,) if failure.run_id else (),
                 )
             ],
             later_cover,
@@ -1046,6 +1064,156 @@ async def _terminal_unit_windows(
     return windows
 
 
+async def _stream_compact_unit_windows(
+    session: AsyncSession,
+    org_id: str,
+    scope: EffectiveScope,
+    truncated_before: datetime,
+    *,
+    generated_at: datetime,
+) -> tuple[list[UnitWindow], datetime | None, int]:
+    """Reduce exact retained history without materializing the raw row set.
+
+    The query streams narrow scalar columns in run-time order. Requested and
+    covered intervals are appended during the scan and coalesced once per pair;
+    unresolved failures retain chronological replay semantics. This keeps the
+    worker linear for the common success-heavy case and out of the API process.
+    """
+
+    if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
+        return [], None, 0
+    source_ids = [source.id for source in scope.sources]
+    query_dataset_keys = _query_dataset_keys_for_scope(scope.dataset_keys)
+    run_time = func.coalesce(
+        SyncRun.completed_at,
+        SyncRun.started_at,
+        SyncRun.created_at,
+    ).label("run_time")
+    stmt = (
+        select(
+            SyncRunUnit.source_id,
+            SyncRunUnit.dataset_key,
+            SyncRunUnit.processor_flags,
+            SyncRunUnit.since_at,
+            SyncRunUnit.before_at,
+            SyncRunUnit.status,
+            run_time,
+            SyncRunUnit.id,
+        )
+        .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+        .where(
+            SyncRunUnit.org_id == org_id,
+            SyncRunUnit.integration_id == scope.integration_id,
+            SyncRunUnit.source_id.in_(source_ids),
+            SyncRunUnit.dataset_key.in_(query_dataset_keys),
+            SyncRunUnit.status.in_(REQUESTED_UNIT_STATUSES),
+            SyncRunUnit.since_at.is_not(None),
+            SyncRunUnit.before_at.is_not(None),
+            SyncRunUnit.before_at >= truncated_before,
+            SyncRun.org_id == org_id,
+        )
+        .order_by(run_time.asc(), SyncRunUnit.id.asc())
+        .execution_options(yield_per=1_000)
+    )
+    states: dict[tuple[str, str], _CompactPairState] = defaultdict(_CompactPairState)
+    latest_successful_run_at: datetime | None = None
+    row_count = 0
+    stream = await session.stream(stmt)
+    async for row in stream:
+        row_count += 1
+        if row_count > MAX_COVERAGE_PROJECTION_ROWS:
+            raise SyncCoverageComplexityError(
+                stage="projection_rows",
+                limit=MAX_COVERAGE_PROJECTION_ROWS,
+                observed=row_count,
+            )
+        since = max(ensure_utc(row.since_at), truncated_before)
+        before = ensure_utc(row.before_at)
+        if since >= before:
+            continue
+        for effective_key in _effective_dataset_keys(
+            str(row.dataset_key), row.processor_flags
+        ):
+            if effective_key not in scope.dataset_keys:
+                continue
+            pair = (str(row.source_id), effective_key)
+            state = states[pair]
+            interval = CoverageInterval(since=since, before=before)
+            state.requested.append(interval)
+            if str(row.status) == SyncRunUnitStatus.SUCCESS.value:
+                state.covered.append(interval)
+                state.failed = subtract_intervals(state.failed, [interval])
+                successful_at = ensure_utc(row.run_time)
+                latest_successful_run_at = max(
+                    latest_successful_run_at or successful_at, successful_at
+                )
+            elif str(row.status) == SyncRunUnitStatus.FAILED.value:
+                state.failed = merge_intervals([*state.failed, interval])
+
+    # Reuse the established payload builder with a compact semantic equivalent
+    # of the raw windows. Successful intervals precede unresolved failures so
+    # the latter remain visible exactly as they do after chronological replay.
+    success_time = datetime.min.replace(tzinfo=timezone.utc)
+    failure_time = generated_at + timedelta(microseconds=1)
+    windows: list[UnitWindow] = []
+    for (source_id, dataset_key), state in states.items():
+        for interval in merge_intervals(state.requested):
+            if len(windows) >= MAX_COVERAGE_UNIT_WINDOWS:
+                raise SyncCoverageComplexityError(
+                    stage="compact_unit_windows",
+                    limit=MAX_COVERAGE_UNIT_WINDOWS,
+                    observed=len(windows) + 1,
+                )
+            windows.append(
+                UnitWindow(
+                    since=interval.since,
+                    before=interval.before,
+                    source_id=source_id,
+                    dataset_key=dataset_key,
+                    run_id="",
+                    status=SyncRunUnitStatus.PLANNED.value,
+                    run_time=success_time,
+                )
+            )
+        for interval in merge_intervals(state.covered):
+            if len(windows) >= MAX_COVERAGE_UNIT_WINDOWS:
+                raise SyncCoverageComplexityError(
+                    stage="compact_unit_windows",
+                    limit=MAX_COVERAGE_UNIT_WINDOWS,
+                    observed=len(windows) + 1,
+                )
+            windows.append(
+                UnitWindow(
+                    since=interval.since,
+                    before=interval.before,
+                    source_id=source_id,
+                    dataset_key=dataset_key,
+                    run_id="",
+                    status=SyncRunUnitStatus.SUCCESS.value,
+                    run_time=success_time,
+                )
+            )
+        for interval in state.failed:
+            if len(windows) >= MAX_COVERAGE_UNIT_WINDOWS:
+                raise SyncCoverageComplexityError(
+                    stage="compact_unit_windows",
+                    limit=MAX_COVERAGE_UNIT_WINDOWS,
+                    observed=len(windows) + 1,
+                )
+            windows.append(
+                UnitWindow(
+                    since=interval.since,
+                    before=interval.before,
+                    source_id=source_id,
+                    dataset_key=dataset_key,
+                    run_id="",
+                    status=SyncRunUnitStatus.FAILED.value,
+                    run_time=failure_time,
+                )
+            )
+    return windows, latest_successful_run_at, row_count
+
+
 async def _active_run_ids(
     session: AsyncSession,
     org_id: str,
@@ -1243,7 +1411,7 @@ async def _backfill_requested_ranges(
     ).where(
         BackfillJob.org_id == org_id,
         BackfillJob.sync_config_id == config.id,
-        BackfillJob.created_at >= truncated_before,
+        BackfillJob.before_date >= truncated_before.date(),
     )
     scope_source_ids = tuple(str(source.id) for source in scope.sources)
     ranges: list[CoverageInterval] = []
@@ -1254,6 +1422,11 @@ async def _backfill_requested_ranges(
         stage="backfill_jobs",
     ):
         interval = _backfill_interval(job)
+        interval = CoverageInterval(
+            since=max(interval.since, truncated_before),
+            before=interval.before,
+            run_ids=interval.run_ids,
+        )
         pair_windows = await _resolve_backfill_job_pair_windows(
             session,
             org_id,
@@ -1292,7 +1465,7 @@ def _intervals_from_windows(windows: Iterable[UnitWindow]) -> list[CoverageInter
             since=window.since,
             before=window.before,
             source_ids=(window.source_id,),
-            run_ids=(window.run_id,),
+            run_ids=(window.run_id,) if window.run_id else (),
         )
         for window in windows
     ]
@@ -1338,6 +1511,164 @@ def _data_basis_for_config(config: SyncConfiguration, scope: EffectiveScope) -> 
     return "legacy"
 
 
+def _canonical_backfill_windows(
+    datasets: Sequence[_DatasetCoverage],
+) -> list[dict[str, Any]]:
+    """Return inclusive date windows the existing backfill action can submit.
+
+    Coverage intervals are half-open datetimes while the backfill endpoint is
+    inclusive by calendar date. An exclusive midnight boundary therefore maps
+    to the preceding date; any later time maps to its own calendar date.
+    """
+
+    candidates: list[dict[str, Any]] = []
+    for dataset in datasets:
+        for interval, reason in (
+            *((interval, "gap") for interval in dataset.gaps),
+            *((interval, "failed") for interval in dataset.failed_ranges),
+        ):
+            inclusive_before = (
+                interval.before - timedelta(microseconds=1)
+                if interval.before.time() == time.min
+                else interval.before
+            )
+            candidates.append(
+                {
+                    "since": interval.since.date(),
+                    "before": inclusive_before.date(),
+                    "reasons": [reason],
+                }
+            )
+    candidates.sort(key=lambda item: (item["since"], item["before"]))
+    merged: list[dict[str, Any]] = []
+    for candidate in candidates:
+        if merged and candidate["since"] <= merged[-1]["before"] + timedelta(days=1):
+            merged[-1]["before"] = max(merged[-1]["before"], candidate["before"])
+            merged[-1]["reasons"] = sorted(
+                set(merged[-1]["reasons"]).union(candidate["reasons"])
+            )
+            continue
+        merged.append(candidate)
+    return merged
+
+
+def _sync_coverage_lock_name(org_id: str, sync_config_id: uuid.UUID) -> str:
+    return f"sync-coverage:{org_id}:{sync_config_id}"
+
+
+def _sync_coverage_lock_statement(org_id: str, sync_config_id: uuid.UUID) -> Any:
+    return select(
+        func.pg_advisory_xact_lock(
+            func.hashtextextended(_sync_coverage_lock_name(org_id, sync_config_id), 0)
+        )
+    )
+
+
+def _sync_coverage_invalidation_statement(
+    org_id: str,
+    *,
+    sync_config_id: uuid.UUID | None = None,
+    integration_id: uuid.UUID | None = None,
+) -> Update:
+    """Build the transaction-local write that makes a projection unreadable."""
+
+    if (sync_config_id is None) == (integration_id is None):
+        raise ValueError("exactly one coverage invalidation selector is required")
+    statement = update(SyncCoverageProjection).where(
+        SyncCoverageProjection.org_id == org_id
+    )
+    if sync_config_id is not None:
+        statement = statement.where(
+            SyncCoverageProjection.sync_config_id == sync_config_id
+        )
+    else:
+        config_ids = select(SyncConfiguration.id).where(
+            SyncConfiguration.org_id == org_id,
+            SyncConfiguration.integration_id == integration_id,
+        )
+        statement = statement.where(
+            SyncCoverageProjection.sync_config_id.in_(config_ids)
+        )
+    return statement.values(invalidated_at=func.now())
+
+
+async def invalidate_sync_coverage_projection(
+    session: AsyncSession,
+    org_id: str,
+    *,
+    sync_config_id: uuid.UUID | None = None,
+    integration_id: uuid.UUID | None = None,
+) -> None:
+    """Serialize with rebuilds and invalidate in the mutation transaction."""
+
+    if (sync_config_id is None) == (integration_id is None):
+        raise ValueError("exactly one coverage invalidation selector is required")
+    config_ids = (
+        [sync_config_id]
+        if sync_config_id is not None
+        else list(
+            (
+                await session.execute(
+                    select(SyncConfiguration.id)
+                    .where(
+                        SyncConfiguration.org_id == org_id,
+                        SyncConfiguration.integration_id == integration_id,
+                    )
+                    .order_by(SyncConfiguration.id)
+                )
+            ).scalars()
+        )
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        for config_id in config_ids:
+            await session.execute(_sync_coverage_lock_statement(org_id, config_id))
+
+    await session.execute(
+        _sync_coverage_invalidation_statement(
+            org_id,
+            sync_config_id=sync_config_id,
+            integration_id=integration_id,
+        )
+    )
+
+
+def invalidate_sync_coverage_projection_sync(
+    session: Session,
+    org_id: str,
+    *,
+    sync_config_id: uuid.UUID | None = None,
+    integration_id: uuid.UUID | None = None,
+) -> None:
+    """Synchronous invalidation variant for terminal sync transactions."""
+
+    if (sync_config_id is None) == (integration_id is None):
+        raise ValueError("exactly one coverage invalidation selector is required")
+    config_ids = (
+        [sync_config_id]
+        if sync_config_id is not None
+        else list(
+            session.execute(
+                select(SyncConfiguration.id)
+                .where(
+                    SyncConfiguration.org_id == org_id,
+                    SyncConfiguration.integration_id == integration_id,
+                )
+                .order_by(SyncConfiguration.id)
+            ).scalars()
+        )
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        for config_id in config_ids:
+            session.execute(_sync_coverage_lock_statement(org_id, config_id))
+    session.execute(
+        _sync_coverage_invalidation_statement(
+            org_id,
+            sync_config_id=sync_config_id,
+            integration_id=integration_id,
+        )
+    )
+
+
 def build_coverage_summary_payload(
     *,
     config: SyncConfiguration,
@@ -1349,6 +1680,8 @@ def build_coverage_summary_payload(
     has_schedule_row: bool,
     generated_at: datetime | None = None,
     lookback_days: int = HISTORY_LOOKBACK_DAYS,
+    latest_successful_run_at_override: datetime | None = None,
+    is_truncated: bool = False,
 ) -> dict[str, Any]:
     """Build the API coverage payload from persisted unit and backfill windows.
 
@@ -1579,12 +1912,19 @@ def build_coverage_summary_payload(
     latest_successful_run_at = max(
         (window.run_time for window in successful_windows), default=None
     )
+    if latest_successful_run_at_override is not None:
+        latest_successful_run_at = latest_successful_run_at_override
     latest_covered_through = max(
         (dataset.covered_through for dataset in datasets if dataset.covered_through),
         default=None,
     )
     data_basis = _data_basis_for_config(config, scope)
     truncated_before = now - timedelta(days=lookback_days)
+    coverage_ranges = [interval for dataset in datasets for interval in dataset.covered]
+    coverage_since = min((interval.since for interval in coverage_ranges), default=None)
+    coverage_through = max(
+        (interval.before for interval in coverage_ranges), default=None
+    )
     return {
         "config_id": str(config.id),
         "provider": str(config.provider),
@@ -1592,6 +1932,12 @@ def build_coverage_summary_payload(
         "data_basis": data_basis,
         "history_lookback_days": lookback_days,
         "truncated_before": truncated_before,
+        "coverage_since": coverage_since,
+        "coverage_through": coverage_through,
+        "is_truncated": is_truncated,
+        "truncation_reason": "lookback_limit" if is_truncated else None,
+        "projection_version": SYNC_COVERAGE_PROJECTION_VERSION,
+        "projection_complete": True,
         "overall": {
             "health": overall_health,
             "latest_successful_run_at": latest_successful_run_at,
@@ -1621,7 +1967,169 @@ def build_coverage_summary_payload(
             for dataset in datasets
         ],
         "sources": source_payloads,
+        "backfill_windows": _canonical_backfill_windows(datasets),
     }
+
+
+async def _projection_source_updated_at(
+    session: AsyncSession,
+    org_id: str,
+    scope: EffectiveScope,
+    truncated_before: datetime,
+) -> datetime | None:
+    if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
+        return None
+    stmt = select(func.max(SyncRunUnit.updated_at)).where(
+        SyncRunUnit.org_id == org_id,
+        SyncRunUnit.integration_id == scope.integration_id,
+        SyncRunUnit.source_id.in_([source.id for source in scope.sources]),
+        SyncRunUnit.dataset_key.in_(_query_dataset_keys_for_scope(scope.dataset_keys)),
+        SyncRunUnit.before_at >= truncated_before,
+        SyncRunUnit.status.in_(REQUESTED_UNIT_STATUSES),
+    )
+    value = (await session.execute(stmt)).scalar_one_or_none()
+    return ensure_utc(value) if value is not None else None
+
+
+async def _projection_backfill_updated_at(
+    session: AsyncSession,
+    org_id: str,
+    config: SyncConfiguration,
+    truncated_before: datetime,
+) -> datetime | None:
+    stmt = select(func.max(BackfillJob.updated_at)).where(
+        BackfillJob.org_id == org_id,
+        BackfillJob.sync_config_id == config.id,
+        BackfillJob.before_date >= truncated_before.date(),
+    )
+    value = (await session.execute(stmt)).scalar_one_or_none()
+    return ensure_utc(value) if value is not None else None
+
+
+async def _has_coverage_before(
+    session: AsyncSession,
+    org_id: str,
+    scope: EffectiveScope,
+    truncated_before: datetime,
+) -> bool:
+    if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
+        return False
+    stmt = select(SyncRunUnit.id).where(
+        SyncRunUnit.org_id == org_id,
+        SyncRunUnit.integration_id == scope.integration_id,
+        SyncRunUnit.source_id.in_([source.id for source in scope.sources]),
+        SyncRunUnit.dataset_key.in_(_query_dataset_keys_for_scope(scope.dataset_keys)),
+        SyncRunUnit.since_at < truncated_before,
+        SyncRunUnit.status == SyncRunUnitStatus.SUCCESS.value,
+    )
+    return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
+
+
+async def rebuild_sync_coverage_projection(
+    session: AsyncSession,
+    org_id: str,
+    config: SyncConfiguration,
+    *,
+    lookback_days: int = HISTORY_LOOKBACK_DAYS,
+    generated_at: datetime | None = None,
+    scope: EffectiveScope | None = None,
+    budget: _CoverageQueryBudget | None = None,
+) -> dict[str, Any]:
+    """Stream raw facts into one exact, atomically replaceable summary row."""
+
+    now = ensure_utc(generated_at or datetime.now(timezone.utc))
+    truncated_before = now - timedelta(days=lookback_days)
+    if session.get_bind().dialect.name == "postgresql":
+        await session.execute(_sync_coverage_lock_statement(org_id, config.id))
+    query_budget = budget or _CoverageQueryBudget()
+    effective_scope = scope or await resolve_effective_scope(
+        session, org_id, config, query_budget
+    )
+    source_updated_at = await _projection_source_updated_at(
+        session, org_id, effective_scope, truncated_before
+    )
+    backfill_updated_at = await _projection_backfill_updated_at(
+        session, org_id, config, truncated_before
+    )
+    schedule = await _active_schedule(session, org_id, config)
+    has_schedule = await _has_schedule_row(session, org_id, config)
+    (
+        windows,
+        latest_successful_run_at,
+        raw_row_count,
+    ) = await _stream_compact_unit_windows(
+        session,
+        org_id,
+        effective_scope,
+        truncated_before,
+        generated_at=now,
+    )
+    active_pairs = await _active_run_ids(session, org_id, effective_scope, query_budget)
+    backfill_requested = await _backfill_requested_ranges(
+        session,
+        org_id,
+        config,
+        effective_scope,
+        truncated_before,
+        query_budget,
+    )
+    payload = build_coverage_summary_payload(
+        config=config,
+        scope=effective_scope,
+        windows=windows,
+        backfill_requested=backfill_requested,
+        active_pairs=active_pairs,
+        active_schedule=schedule,
+        has_schedule_row=has_schedule,
+        generated_at=now,
+        lookback_days=lookback_days,
+        latest_successful_run_at_override=latest_successful_run_at,
+        is_truncated=await _has_coverage_before(
+            session, org_id, effective_scope, truncated_before
+        ),
+    )
+    projection = (
+        await session.execute(
+            select(SyncCoverageProjection).where(
+                SyncCoverageProjection.org_id == org_id,
+                SyncCoverageProjection.sync_config_id == config.id,
+                SyncCoverageProjection.history_lookback_days == lookback_days,
+            )
+        )
+    ).scalar_one_or_none()
+    if projection is None:
+        projection = SyncCoverageProjection(
+            org_id=org_id,
+            sync_config_id=config.id,
+            history_lookback_days=lookback_days,
+            projection_version=SYNC_COVERAGE_PROJECTION_VERSION,
+            generated_at=now,
+            source_updated_at=source_updated_at,
+            backfill_updated_at=backfill_updated_at,
+            invalidated_at=None,
+            payload=jsonable_encoder(payload),
+        )
+        session.add(projection)
+    else:
+        projection.projection_version = SYNC_COVERAGE_PROJECTION_VERSION
+        projection.generated_at = now
+        projection.source_updated_at = source_updated_at
+        projection.backfill_updated_at = backfill_updated_at
+        projection.invalidated_at = None
+        projection.payload = jsonable_encoder(payload)
+    await session.flush()
+    logger.info(
+        "sync_coverage_projection_rebuilt",
+        extra={
+            "org_id": org_id,
+            "sync_config_id": str(config.id),
+            "history_lookback_days": lookback_days,
+            "raw_unit_row_count": raw_row_count,
+            "compact_window_count": len(windows),
+            "projection_version": SYNC_COVERAGE_PROJECTION_VERSION,
+        },
+    )
+    return payload
 
 
 async def build_sync_coverage_summary(
@@ -1632,133 +2140,39 @@ async def build_sync_coverage_summary(
     lookback_days: int = HISTORY_LOOKBACK_DAYS,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return coverage within the largest memory-safe window up to ``lookback_days``."""
+    """Return an O(1) read of the background-built durable projection."""
 
     started_at = monotonic()
-    requested_lookback_days = lookback_days
     log_context = {
         "org_id": org_id,
         "sync_config_id": str(config.id),
         "history_lookback_days": lookback_days,
     }
     logger.info("sync_coverage_summary_waiting", extra=log_context)
-    try:
-        async with _coverage_admission.slot():
-            logger.info(
-                "sync_coverage_summary_started",
-                extra={
-                    **log_context,
-                    "admission_wait_seconds": round(monotonic() - started_at, 3),
-                    "concurrency_limit": _coverage_admission.capacity,
-                },
+    projection = (
+        await session.execute(
+            select(SyncCoverageProjection).where(
+                SyncCoverageProjection.org_id == org_id,
+                SyncCoverageProjection.sync_config_id == config.id,
+                SyncCoverageProjection.history_lookback_days == lookback_days,
+                SyncCoverageProjection.projection_version
+                == SYNC_COVERAGE_PROJECTION_VERSION,
+                SyncCoverageProjection.invalidated_at.is_(None),
             )
-            budget = _CoverageQueryBudget()
-            now = ensure_utc(generated_at or datetime.now(timezone.utc))
-            scope = await resolve_effective_scope(session, org_id, config, budget)
-            lookback = await _select_coverage_lookback(
-                session,
-                org_id,
-                config,
-                scope,
-                requested_days=requested_lookback_days,
-                generated_at=now,
-            )
-            lookback_days = lookback.effective_days
-            log_context = {
-                **log_context,
-                "history_lookback_days": lookback_days,
-                "requested_history_lookback_days": requested_lookback_days,
-            }
-            if lookback_days != requested_lookback_days:
-                logger.warning(
-                    "sync_coverage_history_window_reduced",
-                    extra={
-                        **log_context,
-                        "effective_history_lookback_days": lookback_days,
-                        "complexity_stage": "expanded_unit_windows",
-                        "complexity_limit": lookback.unit_window_limit,
-                        "complexity_observed": (lookback.requested_unit_window_count),
-                        "effective_unit_window_count": (
-                            lookback.effective_unit_window_count
-                        ),
-                    },
-                )
-            truncated_before = now - timedelta(days=lookback_days)
-            schedule = await _active_schedule(session, org_id, config)
-            has_schedule = await _has_schedule_row(session, org_id, config)
-            windows = await _terminal_unit_windows(
-                session,
-                org_id,
-                config,
-                scope,
-                truncated_before,
-                budget,
-            )
-            active_pairs = await _active_run_ids(session, org_id, scope, budget)
-            backfill_requested = await _backfill_requested_ranges(
-                session,
-                org_id,
-                config,
-                scope,
-                truncated_before,
-                budget,
-            )
-            logger.info(
-                "sync_coverage_summary_loaded",
-                extra={
-                    **log_context,
-                    "source_count": len(scope.sources),
-                    "dataset_count": len(scope.dataset_keys),
-                    "source_dataset_pair_count": len(scope.sources)
-                    * len(scope.dataset_keys),
-                    "query_row_count": budget.consumed,
-                    "query_row_limit": budget.limit,
-                    "unit_window_count": len(windows),
-                    "active_pair_count": len(active_pairs),
-                    "backfill_range_count": len(backfill_requested),
-                    "elapsed_seconds": round(monotonic() - started_at, 3),
-                },
-            )
-            payload = build_coverage_summary_payload(
-                config=config,
-                scope=scope,
-                windows=windows,
-                backfill_requested=backfill_requested,
-                active_pairs=active_pairs,
-                active_schedule=schedule,
-                has_schedule_row=has_schedule,
-                generated_at=now,
-                lookback_days=lookback_days,
-            )
-            logger.info(
-                "sync_coverage_summary_completed",
-                extra={
-                    **log_context,
-                    "query_row_count": budget.consumed,
-                    "elapsed_seconds": round(monotonic() - started_at, 3),
-                    "gap_count": payload["overall"]["gap_count"],
-                    "failed_range_count": payload["overall"]["failed_range_count"],
-                },
-            )
-            return payload
-    except SyncCoverageBusyError:
-        logger.warning(
-            "sync_coverage_summary_busy",
-            extra={
-                **log_context,
-                "concurrency_limit": _coverage_admission.capacity,
-                "admission_policy": "reject_immediately",
-            },
         )
-        raise
-    except SyncCoverageComplexityError as exc:
-        logger.warning(
-            "sync_coverage_summary_complexity_rejected",
-            extra={
-                **log_context,
-                "complexity_stage": exc.stage,
-                "complexity_limit": exc.limit,
-                "complexity_observed": exc.observed,
-            },
-        )
-        raise
+    ).scalar_one_or_none()
+    if projection is None:
+        logger.info("sync_coverage_projection_pending", extra=log_context)
+        raise SyncCoveragePendingError("Coverage is being prepared. Retry shortly.")
+    payload = dict(projection.payload)
+    logger.info(
+        "sync_coverage_summary_completed",
+        extra={
+            **log_context,
+            "elapsed_seconds": round(monotonic() - started_at, 3),
+            "gap_count": payload["overall"]["gap_count"],
+            "failed_range_count": payload["overall"]["failed_range_count"],
+            "projection_version": payload["projection_version"],
+        },
+    )
+    return payload

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -112,6 +112,7 @@ from .sso import (
     SSOProviderStatus,
 )
 from .subscriptions import Subscription, SubscriptionEvent
+from .sync_coverage import SyncCoverageProjection
 from .teams import JiraProjectOpsTeamLink, Team
 from .users import (
     AuthProvider,
@@ -221,6 +222,7 @@ __all__ = [
     "SSOProviderStatus",
     "STANDARD_FEATURES",
     "SyncConfiguration",
+    "SyncCoverageProjection",
     "SyncComputeCheckpoint",
     "SyncComputeCheckpointStatus",
     "SyncComputeType",

--- a/src/dev_health_ops/models/sync_coverage.py
+++ b/src/dev_health_ops/models/sync_coverage.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dev_health_ops.models.git import GUID, Base
+
+
+class SyncCoverageProjection(Base):
+    """Atomically replaceable, compact coverage summary for one sync config."""
+
+    __tablename__ = "sync_coverage_projections"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(String, nullable=False)
+    sync_config_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("sync_configurations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    history_lookback_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    projection_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    source_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    backfill_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    invalidated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "sync_config_id",
+            "history_lookback_days",
+            name="uq_sync_coverage_projection_org_config_window",
+        ),
+        Index(
+            "ix_sync_coverage_projection_org_config",
+            "org_id",
+            "sync_config_id",
+        ),
+        Index(
+            "ix_sync_coverage_projection_refresh_order",
+            "invalidated_at",
+            "updated_at",
+        ),
+    )

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -297,6 +297,11 @@ beat_schedule = {
         "schedule": crontab(hour=5, minute=15),
         "options": {"queue": "sync"},
     },
+    "refresh-sync-coverage-projections": {
+        "task": "dev_health_ops.workers.tasks.refresh_sync_coverage_projections",
+        "schedule": 300.0,
+        "options": {"queue": "sync"},
+    },
 }
 
 # The occurrence consumer is a default-off rollout seam for materializing

--- a/src/dev_health_ops/workers/sync_coverage.py
+++ b/src/dev_health_ops/workers/sync_coverage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import case, select
+
+from dev_health_ops.api.services.sync_coverage import (
+    HISTORY_LOOKBACK_DAYS,
+    rebuild_sync_coverage_projection,
+)
+from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
+from dev_health_ops.workers.async_runner import run_async
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+async def _refresh_sync_coverage(
+    *,
+    limit: int = 100,
+) -> dict[str, Any]:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        stmt = (
+            select(SyncConfiguration)
+            .outerjoin(
+                SyncCoverageProjection,
+                (SyncCoverageProjection.org_id == SyncConfiguration.org_id)
+                & (SyncCoverageProjection.sync_config_id == SyncConfiguration.id)
+                & (
+                    SyncCoverageProjection.history_lookback_days
+                    == HISTORY_LOOKBACK_DAYS
+                ),
+            )
+            .order_by(
+                case(
+                    (SyncCoverageProjection.invalidated_at.is_not(None), 0),
+                    (SyncCoverageProjection.id.is_(None), 1),
+                    else_=2,
+                ),
+                SyncCoverageProjection.updated_at.asc().nullsfirst(),
+                SyncConfiguration.id,
+            )
+        )
+        config_keys = [
+            (str(config.org_id), config.id)
+            for config in (await session.execute(stmt.limit(limit))).scalars().all()
+        ]
+
+    refreshed = 0
+    failed = 0
+    for org_id, config_id in config_keys:
+        try:
+            async with get_postgres_session() as session:
+                config = await session.get(SyncConfiguration, config_id)
+                if config is None or str(config.org_id) != org_id:
+                    continue
+                await rebuild_sync_coverage_projection(
+                    session,
+                    org_id,
+                    config,
+                    lookback_days=HISTORY_LOOKBACK_DAYS,
+                )
+            refreshed += 1
+        except Exception:
+            failed += 1
+            logger.exception(
+                "sync_coverage_projection_refresh_failed",
+                extra={"org_id": org_id, "sync_config_id": str(config_id)},
+            )
+    return {"status": "completed", "refreshed": refreshed, "failed": failed}
+
+
+@celery_app.task(
+    queue="sync",
+    name="dev_health_ops.workers.tasks.refresh_sync_coverage_projections",
+)
+def refresh_sync_coverage_projections(limit: int = 100) -> dict[str, Any]:
+    """Periodic safety net that keeps exact coverage projections warm."""
+
+    return run_async(_refresh_sync_coverage(limit=limit))

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -55,6 +55,9 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, SessionTransactionOrigin
 
+from dev_health_ops.api.services.sync_coverage import (
+    invalidate_sync_coverage_projection_sync,
+)
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.models import (
     BackfillJob,
@@ -2101,6 +2104,11 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
             nested.rollback()
             return {"status": "already_dispatched", "sync_run_id": sync_run_id}
         else:
+            invalidate_sync_coverage_projection_sync(
+                session,
+                str(run.org_id),
+                integration_id=run.integration_id,
+            )
             upsert_outbox_wakeup(
                 session,
                 sync_run_id=run_uuid,

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -24,6 +24,7 @@ from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 from dev_health_ops.workers.reference_discovery import run_sync_reference_discovery
 from dev_health_ops.workers.report_scheduler import dispatch_scheduled_reports
 from dev_health_ops.workers.report_task import execute_saved_report
+from dev_health_ops.workers.sync_coverage import refresh_sync_coverage_projections
 from dev_health_ops.workers.sync_reconciler import (
     prune_rate_limit_observations,
     reconcile_sync_dispatch,
@@ -90,6 +91,7 @@ __all__ = [
     "prune_external_ingest_batches",
     "prune_rate_limit_observations",
     "reconcile_sync_dispatch",
+    "refresh_sync_coverage_projections",
     "dispatch_membership_backfill",
     "run_capacity_forecast_job",
     "run_complexity_job",

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -61,6 +61,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -84,6 +85,7 @@ _TABLES = tables_of(
     SyncRunUnit,
     SyncDispatchOutbox,
     BackfillJob,
+    SyncCoverageProjection,
 )
 
 
@@ -302,6 +304,18 @@ async def test_backfill_fanout_creates_job_run_anchor(
     assert create_resp.status_code == 201
     config_id = create_resp.json()["id"]
     await _link_migrated_integration(session_maker, seeded_state["org_id"], config_id)
+    async with session_maker() as session:
+        session.add(
+            SyncCoverageProjection(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(config_id),
+                history_lookback_days=3650,
+                projection_version=1,
+                generated_at=datetime.now(timezone.utc),
+                payload={},
+            )
+        )
+        await session.commit()
 
     with _patch_dispatch(task_id="bf-fanout-task-id") as mock_dispatch:
         resp = await ac.post(
@@ -332,6 +346,9 @@ async def test_backfill_fanout_creates_job_run_anchor(
             .scalars()
             .all()
         )
+        projection = (
+            await session.execute(select(SyncCoverageProjection))
+        ).scalar_one()
 
     assert len(runs) == 1
     run = runs[0]
@@ -339,6 +356,7 @@ async def test_backfill_fanout_creates_job_run_anchor(
     assert run.triggered_by == "backfill"
     assert run.result["planner_managed"] is True
     assert run.result["sync_run_id"] == sync_run_id
+    assert projection.invalidated_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_config_deprecation.py
+++ b/tests/api/admin/test_sync_config_deprecation.py
@@ -36,6 +36,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -54,6 +55,7 @@ _TABLES = tables_of(
     Integration,
     IntegrationSource,
     IntegrationDataset,
+    SyncCoverageProjection,
 )
 
 

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -35,6 +35,7 @@ from dev_health_ops.models.settings import (
     SyncConfiguration,
     SyncWatermark,
 )
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.models.users import Organization, User
 from dev_health_ops.sync.canonical_incident_gate import CANONICAL_INCIDENT_FEATURE_KEY
 from tests._helpers import tables_of
@@ -62,6 +63,7 @@ _TABLES = tables_of(
     SyncRunReferenceDiscovery,
     SyncRunUnit,
     SyncWatermark,
+    SyncCoverageProjection,
 )
 
 

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-import asyncio
 import importlib
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import event
+from sqlalchemy import event, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
-from dev_health_ops.api.services.sync_coverage import build_sync_coverage_summary
+from dev_health_ops.api.services.sync_coverage import (
+    invalidate_sync_coverage_projection,
+    rebuild_sync_coverage_projection,
+)
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.integrations import (
@@ -34,6 +36,7 @@ from dev_health_ops.models.settings import (
     SyncConfiguration,
     SyncWatermark,
 )
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -59,6 +62,7 @@ _TABLES = tables_of(
     SyncRunUnit,
     SyncWatermark,
     BackfillJob,
+    SyncCoverageProjection,
 )
 
 
@@ -318,12 +322,41 @@ async def _coverage_summary_at(
     async with session_maker() as session:
         config = await session.get(SyncConfiguration, uuid.UUID(scope["config_id"]))
         assert config is not None
-        return await build_sync_coverage_summary(
+        payload = await rebuild_sync_coverage_projection(
             session,
             org_id,
             config,
             generated_at=generated_at,
         )
+        await session.commit()
+        return payload
+
+
+async def _warm_projection(
+    session_maker,
+    scope: dict,
+    *,
+    org_id: str | None = None,
+    generated_at: datetime | None = None,
+    lookback_days: int = sync_coverage_module.HISTORY_LOOKBACK_DAYS,
+) -> dict:
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, uuid.UUID(scope["config_id"]))
+        assert config is not None
+        payload = await rebuild_sync_coverage_projection(
+            session,
+            org_id or scope["org_id"],
+            config,
+            generated_at=generated_at,
+            lookback_days=lookback_days,
+        )
+        await session.commit()
+        return payload
+
+
+async def _get_warm_coverage(ac, session_maker, scope: dict):
+    await _warm_projection(session_maker, scope)
+    return await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
 
 
 @pytest.mark.asyncio
@@ -338,7 +371,7 @@ async def test_sync_coverage_api_returns_complete_summary(client, session_maker)
         before=before,
     )
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -351,10 +384,8 @@ async def test_sync_coverage_api_returns_complete_summary(client, session_maker)
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_queries_do_not_hydrate_unit_or_run_payloads(
-    client, session_maker, caplog
-):
-    """Coverage must not load large result/error payloads into API memory."""
+async def test_sync_coverage_api_reads_only_projection(client, session_maker, caplog):
+    """The request path cannot scan or hydrate sync history."""
 
     caplog.set_level("INFO", logger="dev_health_ops.api.services.sync_coverage")
     ac, seeded_state = client
@@ -366,6 +397,7 @@ async def test_sync_coverage_queries_do_not_hydrate_unit_or_run_payloads(
         since=before - timedelta(hours=1),
         before=before,
     )
+    await _warm_projection(session_maker, scope)
 
     statements: list[str] = []
 
@@ -387,34 +419,26 @@ async def test_sync_coverage_queries_do_not_hydrate_unit_or_run_payloads(
         for statement in statements
         if "sync_run_units" in statement.lower() and "select" in statement.lower()
     ]
-    assert unit_queries, "coverage request did not measure any sync-unit query"
-    for statement in unit_queries:
-        assert "sync_run_units.result" not in statement
-        assert "sync_run_units.error" not in statement
-        assert "sync_runs.result" not in statement
-        assert "sync_runs.error" not in statement
+    assert unit_queries == []
+    assert any("sync_coverage_projections" in statement for statement in statements)
 
     coverage_logs = {
         record.message: record
         for record in caplog.records
         if record.name == "dev_health_ops.api.services.sync_coverage"
     }
-    assert "sync_coverage_summary_started" in coverage_logs
     assert (
-        getattr(coverage_logs["sync_coverage_summary_started"], "sync_config_id")
-        == scope["config_id"]
-    )
-    assert (
-        getattr(coverage_logs["sync_coverage_summary_loaded"], "unit_window_count") == 1
+        getattr(coverage_logs["sync_coverage_projection_rebuilt"], "raw_unit_row_count")
+        == 1
     )
     assert "sync_coverage_summary_completed" in coverage_logs
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_rejects_history_before_query_budget_is_exceeded(
+async def test_sync_coverage_streams_history_outside_request_query_budget(
     client, session_maker, monkeypatch, caplog
 ):
-    """The SQL overflow sentinel must fail closed, never return partial coverage."""
+    """Raw history is streamed exactly; the request row budget cannot truncate it."""
 
     caplog.set_level("WARNING", logger="dev_health_ops.api.services.sync_coverage")
     original_budget = sync_coverage_module._CoverageQueryBudget
@@ -442,48 +466,46 @@ async def test_sync_coverage_rejects_history_before_query_budget_is_exceeded(
     engine = session_maker.kw["bind"]
     event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
     try:
+        await _warm_projection(session_maker, scope)
         response = await ac.get(
             f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage"
         )
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
 
-    assert response.status_code == 422, response.text
-    detail = response.json()["detail"]
-    assert detail == {
-        "code": "sync_coverage_too_large",
-        "message": (
-            "Coverage scope or history is too large to compute safely. "
-            "Reduce the sync configuration scope or retry with a smaller "
-            "history_lookback_days value."
-        ),
-        "stage": "recent_units",
-        "limit": 4,
-        "observed": 5,
-    }
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["history_lookback_days"] == 3650
+    assert data["projection_complete"] is True
+    assert data["datasets"][0]["covered_ranges"]
     unit_queries = [
         statement.lower()
         for statement in statements
         if "sync_run_units" in statement.lower() and "select" in statement.lower()
     ]
     assert unit_queries, "overflow path did not execute a measured unit query"
-    assert any("sum(" in statement for statement in unit_queries)
-    assert all(" limit " in statement for statement in unit_queries)
-    assert any(
+    assert not any(
         record.message == "sync_coverage_summary_complexity_rejected"
-        and getattr(record, "complexity_stage") == "recent_units"
         for record in caplog.records
     )
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_selects_largest_safe_history_window(
+async def test_sync_coverage_never_reduces_requested_history_window(
     client, session_maker, monkeypatch, caplog
 ):
-    """Large recent-unit histories return a truthful reduced window, not a 422."""
+    """Complex raw history cannot silently shrink an exact coverage response."""
 
     caplog.set_level("WARNING", logger="dev_health_ops.api.services.sync_coverage")
-    monkeypatch.setattr(sync_coverage_module, "MAX_COVERAGE_UNIT_WINDOWS", 2)
+
+    async def adaptive_selection_must_not_run(*_args, **_kwargs):
+        raise AssertionError("adaptive lookback selection was called")
+
+    monkeypatch.setattr(
+        sync_coverage_module,
+        "_select_coverage_lookback",
+        adaptive_selection_must_not_run,
+    )
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
     reference = datetime.now(timezone.utc)
@@ -532,34 +554,121 @@ async def test_sync_coverage_selects_largest_safe_history_window(
         )
         await session.commit()
 
-    response = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    response = await _get_warm_coverage(ac, session_maker, scope)
 
     assert response.status_code == 200, response.text
     data = response.json()
-    assert 10 < data["history_lookback_days"] <= 58
+    assert data["history_lookback_days"] == 3650
     generated_at = datetime.fromisoformat(data["generated_at"])
     truncated_before = datetime.fromisoformat(data["truncated_before"])
     assert generated_at - truncated_before == timedelta(
         days=data["history_lookback_days"]
     )
-    assert any(
+    assert not any(
         record.message == "sync_coverage_history_window_reduced"
-        and getattr(record, "requested_history_lookback_days") == 180
-        and getattr(record, "effective_history_lookback_days")
-        == data["history_lookback_days"]
-        and getattr(record, "complexity_stage") == "expanded_unit_windows"
-        and getattr(record, "complexity_limit") == 2
-        and getattr(record, "complexity_observed") == 3
-        and getattr(record, "effective_unit_window_count") == 2
+        for record in caplog.records
+    )
+    assert len(data["datasets"][0]["failed_ranges"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_projects_more_than_40000_raw_units_exactly(
+    client, session_maker, caplog
+):
+    """The production failure threshold is crossed without truncation or a 422."""
+
+    caplog.set_level("INFO", logger="dev_health_ops.api.services.sync_coverage")
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    now = datetime.now(timezone.utc)
+    common_since = now - timedelta(days=2)
+    common_before = common_since + timedelta(hours=1)
+    sentinel_since = now - timedelta(days=1)
+    sentinel_before = sentinel_since + timedelta(hours=2)
+    async with session_maker() as session:
+        run = SyncRun(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            triggered_by="manual",
+            mode="incremental",
+            status="failed",
+            total_units=40_001,
+            completed_units=40_000,
+            failed_units=1,
+            started_at=common_since,
+            completed_at=sentinel_before,
+        )
+        session.add(run)
+        await session.flush()
+        base = {
+            "org_id": scope["org_id"],
+            "sync_run_id": run.id,
+            "integration_id": uuid.UUID(scope["integration_id"]),
+            "source_id": uuid.UUID(scope["source_id"]),
+            "provider": "github",
+            "dataset_key": "commits",
+            "cost_class": "standard",
+            "mode": "incremental",
+            "attempts": 1,
+            "created_at": now,
+            "updated_at": now,
+        }
+        for _batch in range(8):
+            rows = [
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "since_at": common_since,
+                    "before_at": common_before,
+                    "status": "success",
+                }
+                for _ in range(5_000)
+            ]
+            await session.execute(insert(SyncRunUnit), rows)
+        await session.execute(
+            insert(SyncRunUnit),
+            [
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "since_at": sentinel_since,
+                    "before_at": sentinel_before,
+                    "status": "failed",
+                }
+            ],
+        )
+        await session.commit()
+
+    response = await _get_warm_coverage(ac, session_maker, scope)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["history_lookback_days"] == 3650
+    assert data["projection_complete"] is True
+    assert data["datasets"][0]["failed_ranges"] == [
+        {
+            "since": sentinel_since.isoformat().replace("+00:00", "Z"),
+            "before": sentinel_before.isoformat().replace("+00:00", "Z"),
+            "source_ids": [scope["source_id"]],
+            "run_ids": [],
+        }
+    ]
+    rebuilt = next(
+        record
+        for record in caplog.records
+        if record.message == "sync_coverage_projection_rebuilt"
+    )
+    assert getattr(rebuilt, "raw_unit_row_count") == 40_001
+    assert not any(
+        record.message == "sync_coverage_history_window_reduced"
         for record in caplog.records
     )
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_preflight_deduplicates_recent_latest_successes(
+async def test_sync_coverage_projection_is_reused_when_source_is_unchanged(
     client, session_maker, monkeypatch
 ):
-    monkeypatch.setattr(sync_coverage_module, "MAX_COVERAGE_UNIT_WINDOWS", 2)
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
     async with session_maker() as session:
@@ -589,77 +698,119 @@ async def test_sync_coverage_preflight_deduplicates_recent_latest_successes(
             source_id=source_id,
         )
 
-    response = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    await _warm_projection(session_maker, scope)
+    first = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    second = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
 
-    assert response.status_code == 200, response.text
-    assert response.json()["history_lookback_days"] == 180
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert second.json() == first.json()
+    async with session_maker() as session:
+        rows = list((await session.execute(select(SyncCoverageProjection))).scalars())
+    assert len(rows) == 1
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_capacity_sheds_only_excess_builds(
-    client, session_maker, monkeypatch, caplog
+async def test_sync_coverage_missing_projection_is_pending_without_building(
+    client, session_maker, monkeypatch
 ):
-    """A fifth-style overlap gets 503 rather than allocating past capacity."""
+    """A cold projection is explicit and cannot start an API-process rebuild."""
 
-    caplog.set_level("WARNING", logger="dev_health_ops.api.admin.routers.sync")
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
-    before = datetime.now(timezone.utc) - timedelta(minutes=30)
-    await _seed_unit(
-        session_maker,
-        scope,
-        since=before - timedelta(hours=1),
-        before=before,
-    )
 
-    controller = sync_coverage_module._CoverageAdmissionController(capacity=1)
-    monkeypatch.setattr(sync_coverage_module, "_coverage_admission", controller)
-    entered = asyncio.Event()
-    release = asyncio.Event()
-    terminal_calls = 0
-    original_terminal_windows = sync_coverage_module._terminal_unit_windows
-
-    async def blocking_terminal_windows(*args, **kwargs):
-        nonlocal terminal_calls
-        terminal_calls += 1
-        entered.set()
-        await release.wait()
-        return await original_terminal_windows(*args, **kwargs)
+    async def request_time_build_must_not_run(*_args, **_kwargs):
+        raise AssertionError("request attempted a raw-history projection rebuild")
 
     monkeypatch.setattr(
         sync_coverage_module,
-        "_terminal_unit_windows",
-        blocking_terminal_windows,
+        "rebuild_sync_coverage_projection",
+        request_time_build_must_not_run,
     )
     url = f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage"
-    admitted_request = asyncio.create_task(ac.get(url))
-    try:
-        await asyncio.wait_for(entered.wait(), timeout=1)
+    response = await ac.get(url)
+    unrelated = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}")
 
-        unrelated = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}")
-        assert unrelated.status_code == 200, unrelated.text
+    assert unrelated.status_code == 200, unrelated.text
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "30"
+    assert response.json()["detail"] == {
+        "code": "sync_coverage_projection_pending",
+        "message": "Coverage is being prepared. Retry shortly.",
+    }
 
-        rejected_responses = await asyncio.gather(*(ac.get(url) for _ in range(25)))
-        assert all(response.status_code == 503 for response in rejected_responses)
-        assert all(
-            response.headers["retry-after"] == "5" for response in rejected_responses
+
+@pytest.mark.asyncio
+async def test_sync_coverage_invalidated_projection_is_pending_until_rebuilt(
+    client, session_maker
+):
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    await _warm_projection(session_maker, scope)
+
+    async with session_maker() as session:
+        await invalidate_sync_coverage_projection(
+            session,
+            scope["org_id"],
+            sync_config_id=uuid.UUID(scope["config_id"]),
         )
-        assert all(
-            response.json()["detail"]["code"] == "sync_coverage_busy"
-            for response in rejected_responses
-        )
-        assert terminal_calls == 1
-        assert controller._active == 1
-        assert any(
-            record.message == "sync_coverage_request_rejected_busy"
-            and getattr(record, "sync_config_id") == scope["config_id"]
-            for record in caplog.records
-        )
-    finally:
-        release.set()
-    admitted = await asyncio.wait_for(admitted_request, timeout=2)
-    assert admitted.status_code == 200, admitted.text
-    assert controller._active == 0
+        await session.commit()
+
+    url = f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage"
+    pending = await ac.get(url)
+    assert pending.status_code == 503
+
+    await _warm_projection(session_maker, scope)
+    rebuilt = await ac.get(url)
+    assert rebuilt.status_code == 200, rebuilt.text
+
+
+@pytest.mark.asyncio
+async def test_sync_config_update_invalidates_coverage_projection(
+    client, session_maker
+):
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    await _warm_projection(session_maker, scope)
+
+    updated = await ac.patch(
+        f"/api/v1/admin/sync-configs/{scope['config_id']}",
+        json={"is_active": False},
+    )
+    assert updated.status_code == 200, updated.text
+
+    coverage = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    assert coverage.status_code == 503
+
+
+def test_canonical_backfill_windows_merge_after_inclusive_date_conversion():
+    dataset = sync_coverage_module._DatasetCoverage(
+        dataset_key="commits",
+        gaps=[
+            sync_coverage_module.CoverageInterval(
+                since=datetime(2026, 1, 2, 10, tzinfo=timezone.utc),
+                before=datetime(2026, 1, 2, 11, tzinfo=timezone.utc),
+            )
+        ],
+        failed_ranges=[
+            sync_coverage_module.CoverageInterval(
+                since=datetime(2026, 1, 2, 13, tzinfo=timezone.utc),
+                before=datetime(2026, 1, 2, 14, tzinfo=timezone.utc),
+            ),
+            sync_coverage_module.CoverageInterval(
+                since=datetime(2026, 1, 3, tzinfo=timezone.utc),
+                before=datetime(2026, 1, 4, tzinfo=timezone.utc),
+            ),
+        ],
+    )
+
+    assert sync_coverage_module._canonical_backfill_windows([dataset]) == [
+        {
+            "since": date(2026, 1, 2),
+            "before": date(2026, 1, 3),
+            "reasons": ["failed", "gap"],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -698,7 +849,7 @@ async def test_sync_coverage_api_includes_backfill_gap(client, session_maker):
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -739,7 +890,7 @@ async def test_sync_coverage_api_keeps_source_gaps_separate(client, session_make
         source_id=extra_source_id,
     )
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -764,12 +915,17 @@ async def test_sync_coverage_api_planned_units_create_requested_gap(
         status="planned",
     )
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["datasets"][0]["requested_ranges"]
     assert data["datasets"][0]["covered_ranges"] == []
+    assert data["coverage_since"] is None
+    assert data["coverage_through"] is None
+    assert data["backfill_windows"] == [
+        {"since": "2026-01-01", "before": "2026-01-01", "reasons": ["gap"]}
+    ]
     assert data["overall"]["health"] == "gaps"
 
 
@@ -782,19 +938,19 @@ async def test_sync_coverage_fetches_latest_success_outside_lookback(
     await _seed_unit(
         session_maker,
         scope,
-        since=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        before=datetime(2025, 1, 2, tzinfo=timezone.utc),
-        updated_at=datetime.now(timezone.utc) - timedelta(days=400),
+        since=datetime(2010, 1, 1, tzinfo=timezone.utc),
+        before=datetime(2010, 1, 2, tzinfo=timezone.utc),
+        updated_at=datetime(2010, 1, 2, tzinfo=timezone.utc),
     )
 
-    resp = await ac.get(
-        f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage?history_lookback_days=30"
-    )
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
-    assert data["history_lookback_days"] == 30
-    assert data["overall"]["latest_covered_through"] is not None
+    assert data["history_lookback_days"] == 3650
+    assert data["overall"]["latest_covered_through"] is None
+    assert data["datasets"][0]["covered_ranges"] == []
+    assert data["is_truncated"] is True
 
 
 @pytest.mark.asyncio
@@ -804,7 +960,7 @@ async def test_sync_coverage_zero_run_planner_config_reports_planner_basis(
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -816,8 +972,9 @@ async def test_sync_coverage_zero_run_planner_config_reports_planner_basis(
 async def test_sync_coverage_legacy_config_reports_legacy_basis(client, session_maker):
     ac, seeded_state = client
     config_id = await _seed_legacy_config(session_maker, seeded_state["org_id"])
+    scope = {"config_id": config_id, "org_id": seeded_state["org_id"]}
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -830,7 +987,7 @@ async def test_sync_coverage_cross_org_config_returns_404(client, session_maker)
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"], other_org=True)
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 404
 
@@ -896,7 +1053,7 @@ async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -955,7 +1112,7 @@ async def test_sync_coverage_api_success_matching_backfill_range_clears_gap(
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -1184,7 +1341,7 @@ async def test_sync_coverage_api_unresolvable_backfill_marker_falls_back_to_all_
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -1237,7 +1394,7 @@ async def test_sync_coverage_api_backfill_marker_resolved_zero_units_contributes
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -1302,7 +1459,7 @@ async def test_sync_coverage_api_backfill_requested_range_expands_by_family_flag
         )
         await session.commit()
 
-    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+    resp = await _get_warm_coverage(ac, session_maker, scope)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()

--- a/tests/api/admin/test_sync_coverage_concurrency.py
+++ b/tests/api/admin/test_sync_coverage_concurrency.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import Session
+
+from dev_health_ops.api.services.sync_coverage import (
+    _sync_coverage_lock_statement,
+    invalidate_sync_coverage_projection_sync,
+)
+from dev_health_ops.models.integrations import Integration
+from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
+
+
+@pytest.mark.skipif(
+    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
+    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
+)
+def test_invalidation_waits_for_inflight_projection_publication():
+    """A rebuild cannot publish over an invalidation that began mid-scan."""
+
+    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    org_id = str(uuid.uuid4())
+    integration_id: uuid.UUID | None = None
+    config_id: uuid.UUID | None = None
+    projection_id: uuid.UUID | None = None
+    invalidation_started = threading.Event()
+    invalidation_finished = threading.Event()
+    invalidation_errors: list[BaseException] = []
+    try:
+        with Session(engine) as setup_session:
+            integration = Integration(
+                org_id=org_id,
+                provider="github",
+                name=f"coverage-concurrency-{org_id}",
+                config={},
+                is_active=True,
+            )
+            setup_session.add(integration)
+            setup_session.flush()
+            config = SyncConfiguration(
+                org_id=org_id,
+                name=f"coverage-concurrency-{org_id}",
+                provider="github",
+                sync_targets=["git"],
+                integration_id=integration.id,
+                planner_managed=True,
+            )
+            setup_session.add(config)
+            setup_session.flush()
+            projection = SyncCoverageProjection(
+                org_id=org_id,
+                sync_config_id=config.id,
+                history_lookback_days=3650,
+                projection_version=1,
+                generated_at=datetime.now(timezone.utc),
+                payload={"generation": "before"},
+            )
+            setup_session.add(projection)
+            setup_session.commit()
+            integration_id = integration.id
+            config_id = config.id
+            projection_id = projection.id
+
+        assert config_id is not None
+        assert projection_id is not None
+
+        def invalidate() -> None:
+            try:
+                with Session(engine) as invalidation_session:
+                    invalidation_started.set()
+                    invalidate_sync_coverage_projection_sync(
+                        invalidation_session,
+                        org_id,
+                        sync_config_id=config_id,
+                    )
+                    invalidation_session.commit()
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                invalidation_errors.append(exc)
+            finally:
+                invalidation_finished.set()
+
+        with Session(engine) as rebuild_session:
+            rebuild_session.execute(_sync_coverage_lock_statement(org_id, config_id))
+            invalidator = threading.Thread(target=invalidate, daemon=True)
+            invalidator.start()
+            assert invalidation_started.wait(timeout=5)
+            assert not invalidation_finished.wait(timeout=0.2)
+
+            rebuild_projection = rebuild_session.get(
+                SyncCoverageProjection, projection_id
+            )
+            assert rebuild_projection is not None
+            rebuild_projection.payload = {"generation": "rebuilt"}
+            rebuild_projection.invalidated_at = None
+            rebuild_session.commit()
+
+        assert invalidation_finished.wait(timeout=5)
+        invalidator.join(timeout=5)
+        assert invalidation_errors == []
+        with Session(engine) as verify_session:
+            verified_projection = verify_session.get(
+                SyncCoverageProjection, projection_id
+            )
+            assert verified_projection is not None
+            assert verified_projection.payload == {"generation": "rebuilt"}
+            assert verified_projection.invalidated_at is not None
+    finally:
+        with Session(engine) as cleanup_session:
+            if projection_id is not None:
+                cleanup_session.execute(
+                    delete(SyncCoverageProjection).where(
+                        SyncCoverageProjection.id == projection_id
+                    )
+                )
+            if config_id is not None:
+                cleanup_session.execute(
+                    delete(SyncConfiguration).where(SyncConfiguration.id == config_id)
+                )
+            if integration_id is not None:
+                cleanup_session.execute(
+                    delete(Integration).where(Integration.id == integration_id)
+                )
+            cleanup_session.commit()
+        engine.dispose()

--- a/tests/api/test_new_user_journey.py
+++ b/tests/api/test_new_user_journey.py
@@ -34,6 +34,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
 from tests._clickhouse_team_store import FakeClickHouseTeamStore
 from tests._helpers import tables_of
@@ -63,6 +64,7 @@ _TABLES = tables_of(
     JobRun,
     OrgLicense,
     TierLimit,
+    SyncCoverageProjection,
 )
 
 

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0075"}
+    assert _revisions(migrated_to_0065.engine) == {"0076"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0076"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0076"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0075"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0076"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0075"}
+    assert set(heads) == {"0066", "0076"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0075"}
+        assert set(heads) == {"0066", "0076"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0075"
+        assert script.get_revision("application_schema@head").revision == "0076"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0075"}
-        assert scripts.get_revision("application_schema@head").revision == "0075"
-        assert _database_has_revision(cfg, ("0075",), "0065")
-        assert not _database_has_revision(cfg, ("0075",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0076"}
+        assert scripts.get_revision("application_schema@head").revision == "0076"
+        assert _database_has_revision(cfg, ("0076",), "0065")
+        assert not _database_has_revision(cfg, ("0076",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(

--- a/tests/test_sync_manual_trigger_safety.py
+++ b/tests/test_sync_manual_trigger_safety.py
@@ -48,6 +48,12 @@ class _FakeAsyncSession:
     async def run_sync(self, fn, *args, **kwargs):
         return fn(self._s, *args, **kwargs)
 
+    async def execute(self, statement):
+        return self._s.execute(statement)
+
+    def get_bind(self):
+        return self._s.get_bind()
+
     async def commit(self) -> None:
         commit = getattr(self._s, "commit", None)
         if commit is not None:

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -27,6 +27,7 @@ from dev_health_ops.models import (
     SyncComputeCheckpointStatus,
     SyncComputeType,
     SyncConfiguration,
+    SyncCoverageProjection,
     SyncDispatchOutbox,
     SyncRun,
     SyncRunMode,
@@ -1942,6 +1943,16 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
         integration_id=run.integration_id,
     )
     db_session.add(config)
+    db_session.flush()
+    projection = SyncCoverageProjection(
+        org_id=run.org_id,
+        sync_config_id=config.id,
+        history_lookback_days=3650,
+        projection_version=1,
+        generated_at=datetime.now(timezone.utc),
+        payload={},
+    )
+    db_session.add(projection)
     unit.status = SyncRunUnitStatus.SUCCESS.value
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
@@ -1959,6 +1970,7 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
 
     db_session.refresh(run)
     db_session.refresh(config)
+    db_session.refresh(projection)
     assert first["status"] == "finalized"
     assert second["status"] == "already_dispatched"
     assert run.status == SyncRunStatus.SUCCESS.value
@@ -1978,6 +1990,7 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
     assert config.last_sync_success is True
     assert config.last_sync_error is None
     assert config.last_sync_stats == {"completed_units": 1, "failed_units": 0}
+    assert projection.invalidated_at is not None
 
 
 def test_finalize_aggregates_partial_failed(db_session, monkeypatch):

--- a/tests/workers/test_transitional_inventory_contract.py
+++ b/tests/workers/test_transitional_inventory_contract.py
@@ -61,7 +61,7 @@ def test_inventory_is_non_empty_and_matches_audit_row_count():
     # fallback missed: billing/router.py's Stripe webhook), + 1 added in
     # round-4 hardening (a separately deployed second FastAPI app,
     # billing_edge.py, forwarding to that same handler cross-file).
-    assert inventory["row_count"] == 154
+    assert inventory["row_count"] == 156
 
 
 def test_discovered_keys_and_row_keys_are_identical_sets():


### PR DESCRIPTION
## Summary

- replace request-time sync history scans with a durable exact-history projection built outside API requests
- use a 3650-day product window while reporting the actual successful-data coverage bounds and canonical inclusive backfill windows
- invalidate projections transactionally on config, repository, manual sync, backfill, and terminal-run mutations
- serialize rebuild publication with invalidation so stale authoritative actions cannot win a race
- return an explicit retryable pending response when a projection is missing or invalidated
- schedule bounded refresh work and prioritize invalidated projections

## Validation

- bash ci/local_validate.sh
- 10,134 passed; 80 skipped
- Ruff format/check, mypy, Go vet/test/build, worker contracts, River compatibility, ClickHouse scratch migrations, and live argMax proof passed
- focused coverage, config mutation, backfill, finalizer, and migration tests passed
- Postgres advisory-lock concurrency regression included for CI environments with DEV_HEALTH_POSTGRES_TEST_URI

Refs CHAOS-3266
Refs #1357

SCREENSHOT-WAIVER: Backend projection, migration, and worker changes; no rendered UI changes.
