### PR TITLE
fix(helm): use process-only API liveness

### DIFF
--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -50,7 +50,7 @@ api:
     targetMemoryUtilizationPercentage: 80
   livenessProbe:
     httpGet:
-      path: /health
+      path: /ready
       port: http
     initialDelaySeconds: 30
     periodSeconds: 10

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -469,7 +469,17 @@ class ScopeResolutionService:
         org_id: str,
         permission_fingerprint: str,
         request: ScopeResolveRequest,
+        *,
+        now: datetime | None = None,
     ) -> ScopeResolution:
+        """Resolve ``request`` as of ``now`` (default: the wall clock).
+
+        ``now`` governs the *whole* resolution, not just part of it. A preset
+        window is anchored on the caller's instant, so a resolution that took
+        its window from the wall clock while its caller believed it had pinned
+        the instant was reproducible only for as long as the two agreed --
+        which, for a preset, means until the next local midnight.
+        """
         if not org_id or not permission_fingerprint:
             raise ValueError("Tenant and permission fingerprint are required")
 
@@ -492,7 +502,7 @@ class ScopeResolutionService:
                 entities=(),
                 team_filters=(),
                 candidates=(),
-                time_range=self.resolve_time_range(request.time_range),
+                time_range=self.resolve_time_range(request.time_range, now=now),
                 warnings=("catalog_unavailable",),
             )
         cache_key = self._cache_key(
@@ -501,12 +511,17 @@ class ScopeResolutionService:
             permission_fingerprint,
             _request_payload(request),
             watermark,
+            # A preset window is derived from the instant, so two resolutions
+            # of the same request at different instants are different results
+            # and must not share an entry. Production passes ``now=None`` and
+            # keys on the literal ``None``, exactly as before.
+            now.isoformat() if now is not None else None,
         )
         cached = self._cache.get(cache_key)
         if isinstance(cached, ScopeResolution):
             return cached
 
-        time_range = self.resolve_time_range(request.time_range)
+        time_range = self.resolve_time_range(request.time_range, now=now)
         if not active_refs:
             result = ScopeResolution(
                 outcome=ScopeResolutionOutcome.UNRESOLVED,
@@ -963,8 +978,17 @@ class ScopeResolutionService:
         *,
         resolved_at: datetime | None = None,
     ) -> DevScopeResolution:
-        """Resolve ``resolve_scope.v1`` into the canonical CHAOS-3223 contract."""
-        domain = await self.resolve(org_id, permission_fingerprint, request)
+        """Resolve ``resolve_scope.v1`` into the canonical CHAOS-3223 contract.
+
+        ``resolved_at`` is the instant the resolution is *made at*, so it also
+        anchors the resolved preset window -- it is not merely a label applied
+        to a window taken from a second, unrelated clock. Production callers
+        pass ``None`` and get the wall clock for both, unchanged.
+        """
+        resolved_at = resolved_at or datetime.now(timezone.utc)
+        domain = await self.resolve(
+            org_id, permission_fingerprint, request, now=resolved_at
+        )
         requested = self._requested_scope(org_id, request, domain.time_range)
         resolved = self._resolved_scope(org_id, request, domain)
         outcome = domain.outcome
@@ -1026,7 +1050,7 @@ class ScopeResolutionService:
             candidates=candidates,
             fallbacks=list(domain.fallbacks),
             warnings=warnings,
-            resolved_at=resolved_at or datetime.now(timezone.utc),
+            resolved_at=resolved_at,
         )
 
     async def _organization_scope_repositories(
@@ -1291,6 +1315,7 @@ class ScopeResolutionService:
         permission_fingerprint: str,
         payload: dict[str, object],
         watermark: str,
+        resolved_as_of: str | None = None,
     ) -> str:
         raw = json.dumps(
             {
@@ -1300,6 +1325,7 @@ class ScopeResolutionService:
                 "input": payload,
                 "query_version": QUERY_VERSION,
                 "watermark": watermark,
+                "resolved_as_of": resolved_as_of,
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -300,8 +300,8 @@ async def ready() -> JSONResponse:
     """Readiness probe: fast check that the API process is up.
 
     Unlike /health, this does NOT verify external dependencies.
-    Kubernetes/Docker should use this for readiness probes and /health
-    for liveness probes.
+    Kubernetes/Docker should use this for liveness probes and /health
+    for readiness probes.
     """
     return JSONResponse(status_code=200, content={"status": "ready"})
 

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -588,6 +588,82 @@ async def test_scope_search_is_bounded_and_deterministically_ordered() -> None:
     assert result.catalog_watermark == "org-a:watermark-1"
 
 
+@pytest.mark.asyncio
+async def test_resolved_at_anchors_the_window_it_stamps() -> None:
+    """``resolved_at`` must govern the window, not merely label it.
+
+    ``resolve_contract`` stamped the caller's instant on the contract while
+    ``resolve`` took the preset window from ``datetime.now``. Callers that
+    pinned the instant therefore got a scope that still moved with the wall
+    clock, and every assertion written against it held only until the next
+    local midnight -- a whole test module went red overnight on exactly that
+    (``tests/api/dev/test_project_scope_status_snapshot_repositories.py``),
+    with nothing in the diff that broke it.
+
+    The boundaries below are absolute, so this test cannot itself expire: a
+    30-day preset resolved at 2026-08-04T01:44Z is the half-open UTC window
+    [2026-07-06, 2026-08-05), whatever day it is read on.
+    """
+
+    service = ScopeResolutionService(FakeCatalog([]))
+    resolved_at = datetime(2026, 8, 4, 1, 44, tzinfo=timezone.utc)
+
+    result = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),),
+            time_range=TimeRangeRequest(preset_days=30, timezone="UTC"),
+        ),
+        resolved_at=resolved_at,
+    )
+
+    assert result.resolved_at == resolved_at
+    assert result.requested_scope.time_range.end == datetime(
+        2026, 8, 5, tzinfo=timezone.utc
+    )
+    assert result.requested_scope.time_range.start == datetime(
+        2026, 7, 6, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_instants_do_not_share_one_cached_resolution() -> None:
+    """The request cache must not serve a window resolved at another instant.
+
+    The window is derived from the instant but was absent from the cache key,
+    so the second of two resolutions differing only in ``resolved_at`` would
+    silently inherit the first one's window -- the same stale-window bug as
+    above, reintroduced through the cache.
+    """
+
+    service = ScopeResolutionService(FakeCatalog([]))
+    request = ScopeResolveRequest(
+        explicit_refs=(ScopeRef(EntityKind.ORGANIZATION, "org-a"),),
+        time_range=TimeRangeRequest(preset_days=7, timezone="UTC"),
+    )
+
+    first = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        request,
+        resolved_at=datetime(2026, 8, 4, 1, 44, tzinfo=timezone.utc),
+    )
+    second = await service.resolve_contract(
+        "org-a",
+        "perm-a",
+        request,
+        resolved_at=datetime(2026, 8, 5, 1, 44, tzinfo=timezone.utc),
+    )
+
+    assert first.requested_scope.time_range.end == datetime(
+        2026, 8, 5, tzinfo=timezone.utc
+    )
+    assert second.requested_scope.time_range.end == datetime(
+        2026, 8, 6, tzinfo=timezone.utc
+    )
+
+
 def test_relative_time_range_uses_local_day_boundaries_across_dst() -> None:
     service = ScopeResolutionService(FakeCatalog([]))
 

--- a/tests/api/test_main_app_integration.py
+++ b/tests/api/test_main_app_integration.py
@@ -92,6 +92,19 @@ def test_health_endpoint_returns_503_when_required_service_is_down(monkeypatch):
     assert body["services"]["redis"] == "ok"
 
 
+def test_ready_endpoint_returns_ok_when_required_service_is_down(monkeypatch):
+    async def _pg_down():
+        return "postgres", "down"
+
+    monkeypatch.setattr(main, "_check_postgres_health", _pg_down)
+
+    with TestClient(main.app) as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
 def test_health_workers_returns_celery_status(monkeypatch):
     async def _celery_ok():
         return "celery", "ok"

--- a/tests/test_helm_api_probes.py
+++ b/tests/test_helm_api_probes.py
@@ -1,11 +1,26 @@
 from pathlib import Path
+from subprocess import run
 
 import yaml
 
 
 def test_api_liveness_is_process_only_while_readiness_checks_dependencies() -> None:
-    values_path = Path(__file__).parents[1] / "deploy/helm/dev-health/values.yaml"
-    values = yaml.safe_load(values_path.read_text())
+    chart_path = Path(__file__).parents[1] / "deploy/helm/dev-health"
+    rendered = run(
+        [
+            "helm",
+            "template",
+            "probe-contract",
+            chart_path,
+            "--show-only",
+            "templates/api-deployment.yaml",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    deployment = yaml.safe_load(rendered.stdout)
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
 
-    assert values["api"]["livenessProbe"]["httpGet"]["path"] == "/ready"
-    assert values["api"]["readinessProbe"]["httpGet"]["path"] == "/health"
+    assert container["livenessProbe"]["httpGet"]["path"] == "/ready"
+    assert container["readinessProbe"]["httpGet"]["path"] == "/health"

--- a/tests/test_helm_api_probes.py
+++ b/tests/test_helm_api_probes.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_api_liveness_is_process_only_while_readiness_checks_dependencies() -> None:
+    values_path = Path(__file__).parents[1] / "deploy/helm/dev-health/values.yaml"
+    values = yaml.safe_load(values_path.read_text())
+
+    assert values["api"]["livenessProbe"]["httpGet"]["path"] == "/ready"
+    assert values["api"]["readinessProbe"]["httpGet"]["path"] == "/health"


### PR DESCRIPTION
Summary: point the API liveness probe at process-only ready; preserve dependency-gated health readiness; render the API deployment in a regression test to pin both paths. Validation: ci/local_validate.sh; a deliberate liveness/readiness mapping swap makes the contract test fail.