### PR TITLE
fix(clickhouse): pass authenticated URI options explicitly

### DIFF
--- a/src/dev_health_ops/api/queries/client.py
+++ b/src/dev_health_ops/api/queries/client.py
@@ -12,6 +12,10 @@ import clickhouse_connect
 from dev_health_ops.api.services.auth import get_current_org_id
 from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.metrics.sinks.clickhouse.connection import (
+    clickhouse_client_kwargs,
+    redact_clickhouse_uri,
+)
 from dev_health_ops.metrics.sinks.factory import create_sink
 
 logger = logging.getLogger(__name__)
@@ -30,7 +34,9 @@ async def get_global_sink(dsn: str) -> BaseMetricsSink:
         _SHARED_SINK = None
 
     if _SHARED_SINK is None:
-        logger.info("Initializing global metrics sink for %s", dsn)
+        logger.info(
+            "Initializing global metrics sink for %s", redact_clickhouse_uri(dsn)
+        )
         _SHARED_SINK = create_sink(dsn)
         _SHARED_DSN = dsn
         logger.info("Metrics sink initialized")
@@ -155,7 +161,9 @@ async def query_dicts(
 
         def _thread_query() -> list[dict[str, Any]]:
             client = clickhouse_connect.get_client(
-                dsn=dsn, settings={"max_query_size": 1 * 1024 * 1024}
+                **clickhouse_client_kwargs(
+                    dsn, settings={"max_query_size": 1 * 1024 * 1024}
+                )
             )
             try:
                 result = client.query(query, parameters=params)

--- a/src/dev_health_ops/metrics/sinks/clickhouse/connection.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/connection.py
@@ -1,0 +1,160 @@
+"""Typed ClickHouse connection URI parsing for clickhouse-connect."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+from urllib.parse import SplitResult, parse_qsl, unquote, urlsplit
+
+
+class ClickHouseClientKwargs(TypedDict):
+    """Explicit clickhouse-connect client construction options."""
+
+    host: str
+    port: int
+    username: str
+    password: str
+    database: str
+    interface: Literal["http", "https"]
+    secure: bool
+    settings: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class ClickHouseConnectionUriError(ValueError):
+    """A ClickHouse URI that cannot safely create a driver connection."""
+
+    reason: str
+
+    def __str__(self) -> str:
+        return f"Invalid ClickHouse connection URI: {self.reason}"
+
+
+_SUPPORTED_SCHEMES = frozenset(
+    {"clickhouse", "clickhouse+http", "clickhouse+https", "clickhouse+native"}
+)
+
+
+def clickhouse_client_kwargs(
+    dsn: str, *, settings: dict[str, int]
+) -> ClickHouseClientKwargs:
+    """Build explicit clickhouse-connect options from a supported URI.
+
+    URI credentials are decoded here and never retained in error messages or logs.
+    """
+    parsed = _parse_clickhouse_uri(dsn)
+    host = parsed.hostname
+    if host is None:
+        raise ClickHouseConnectionUriError(reason="host is required")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ClickHouseConnectionUriError(
+            reason="port must be a valid integer"
+        ) from exc
+
+    interface, secure = _interface_and_security(parsed, port)
+
+    return {
+        "host": host,
+        "port": port if port is not None else 8443 if secure else 8123,
+        "username": unquote(parsed.username)
+        if parsed.username is not None
+        else "default",
+        "password": unquote(parsed.password) if parsed.password is not None else "",
+        "database": _database_name(parsed),
+        "interface": interface,
+        "secure": secure,
+        "settings": settings,
+    }
+
+
+def redact_clickhouse_uri(dsn: str) -> str:
+    """Return a log-safe URI display that never includes userinfo or query data."""
+    try:
+        parsed = urlsplit(dsn)
+        host = parsed.hostname
+    except ValueError:
+        return "clickhouse://<invalid>"
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _SUPPORTED_SCHEMES or host is None:
+        return "clickhouse://<invalid>"
+    try:
+        port = f":{parsed.port}" if parsed.port is not None else ""
+    except ValueError:
+        return "clickhouse://<invalid>"
+    database = parsed.path.lstrip("/")
+    return (
+        f"{scheme}://{host}{port}/{database}"
+        if database
+        else f"{scheme}://{host}{port}"
+    )
+
+
+def _parse_clickhouse_uri(dsn: str) -> SplitResult:
+    try:
+        parsed = urlsplit(dsn)
+    except ValueError as exc:
+        raise ClickHouseConnectionUriError(reason="URI is malformed") from exc
+
+    if parsed.scheme.lower() not in _SUPPORTED_SCHEMES:
+        raise ClickHouseConnectionUriError(reason="scheme is unsupported")
+    if not parsed.netloc:
+        raise ClickHouseConnectionUriError(reason="host is required")
+    if parsed.fragment:
+        raise ClickHouseConnectionUriError(reason="fragments are unsupported")
+    return parsed
+
+
+def _database_name(parsed: SplitResult) -> str:
+    database = unquote(parsed.path.lstrip("/"))
+    if "/" in database:
+        raise ClickHouseConnectionUriError(
+            reason="database path must contain one segment"
+        )
+    return database or "default"
+
+
+def _interface_and_security(
+    parsed: SplitResult, port: int | None
+) -> tuple[Literal["http", "https"], bool]:
+    scheme = parsed.scheme.lower()
+    requested_secure = _query_secure(parsed)
+    if scheme == "clickhouse+https":
+        if requested_secure is False:
+            raise ClickHouseConnectionUriError(
+                reason="secure=false conflicts with clickhouse+https"
+            )
+        return "https", True
+    if scheme == "clickhouse+http":
+        if requested_secure is True:
+            raise ClickHouseConnectionUriError(
+                reason="secure=true conflicts with clickhouse+http"
+            )
+        return "http", False
+    secure = requested_secure if requested_secure is not None else port in {443, 8443}
+    return ("https", True) if secure else ("http", False)
+
+
+def _query_secure(parsed: SplitResult) -> bool | None:
+    try:
+        options = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True)
+    except ValueError as exc:
+        raise ClickHouseConnectionUriError(reason="query string is malformed") from exc
+    if not options:
+        return None
+    if len(options) != 1 or options[0][0] != "secure":
+        raise ClickHouseConnectionUriError(
+            reason="only secure is supported in the query"
+        )
+    match options[0][1].lower():
+        case "true":
+            return True
+        case "false":
+            return False
+        case _:
+            raise ClickHouseConnectionUriError(
+                reason="secure query parameter must be true or false"
+            )

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -36,6 +36,7 @@ from dev_health_ops.metrics.sinks.clickhouse._insert import (
     _chunked,
     _dt_to_clickhouse_datetime,
 )
+from dev_health_ops.metrics.sinks.clickhouse.connection import clickhouse_client_kwargs
 from dev_health_ops.metrics.sinks.factory import detect_backend
 from dev_health_ops.models.work_items import Sprint
 
@@ -87,7 +88,9 @@ class ClickHouseCore(BaseMetricsSink):
             settings = {
                 "max_query_size": 1 * 1024 * 1024,  # 1MB
             }
-            self.client = clickhouse_connect.get_client(dsn=dsn, settings=settings)
+            self.client = clickhouse_connect.get_client(
+                **clickhouse_client_kwargs(dsn, settings=settings)
+            )
 
     def close(self) -> None:
         try:

--- a/tests/metrics/test_clickhouse_connection.py
+++ b/tests/metrics/test_clickhouse_connection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.metrics.sinks.clickhouse.connection import (
+    ClickHouseConnectionUriError,
+    clickhouse_client_kwargs,
+)
+
+AUTHENTICATED_HTTPS_DSN = "clickhouse+https://reader%40service:secret%2Fword@clickhouse.example:8443/analytics"
+EXPECTED_CLIENT_KWARGS = {
+    "host": "clickhouse.example",
+    "port": 8443,
+    "username": "reader@service",
+    "password": "secret/word",
+    "database": "analytics",
+    "interface": "https",
+    "secure": True,
+    "settings": {"max_query_size": 1024 * 1024},
+}
+
+
+def test_clickhouse_client_kwargs_decodes_uri_and_explicitly_sets_tls() -> None:
+    # Given: an authenticated ClickHouse HTTPS URI with encoded userinfo.
+    # When: the connection kwargs are built.
+    # Then: clickhouse-connect receives decoded, explicit connection fields.
+    assert (
+        clickhouse_client_kwargs(
+            AUTHENTICATED_HTTPS_DSN,
+            settings={"max_query_size": 1024 * 1024},
+        )
+        == EXPECTED_CLIENT_KWARGS
+    )
+
+
+@pytest.mark.parametrize(
+    ("dsn", "port"),
+    [
+        ("clickhouse://clickhouse.example:443/analytics", 443),
+        ("clickhouse://clickhouse.example:8443/analytics", 8443),
+        ("clickhouse://clickhouse.example:8123/analytics?secure=true", 8123),
+    ],
+)
+def test_clickhouse_client_kwargs_preserves_tls_uri_variants(
+    dsn: str, port: int
+) -> None:
+    # Given: a generic URI that selects TLS by port or secure query option.
+    # When: the connection kwargs are built.
+    # Then: the driver receives explicit HTTPS settings.
+    kwargs = clickhouse_client_kwargs(dsn, settings={})
+
+    assert kwargs["port"] == port
+    assert kwargs["interface"] == "https"
+    assert kwargs["secure"] is True
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://reader:secret@clickhouse.example/analytics",
+        "clickhouse://reader:secret@/analytics",
+        "clickhouse://reader:secret@clickhouse.example/analytics/extra",
+    ],
+)
+def test_clickhouse_client_kwargs_rejects_invalid_connection_uris(dsn: str) -> None:
+    # Given: a malformed or unsupported connection URI.
+    # When: the connection kwargs are built.
+    # Then: a typed error excludes raw credentials from its message.
+    with pytest.raises(ClickHouseConnectionUriError) as exc_info:
+        clickhouse_client_kwargs(dsn, settings={})
+
+    assert "secret" not in str(exc_info.value)
+    assert dsn not in str(exc_info.value)

--- a/tests/metrics/test_clickhouse_connection_seams.py
+++ b/tests/metrics/test_clickhouse_connection_seams.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import anyio
+import pytest
+
+from dev_health_ops.api.queries import client as query_client
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+AUTHENTICATED_HTTPS_DSN = "clickhouse+https://reader%40service:secret%2Fword@clickhouse.example:8443/analytics"
+EXPECTED_CLIENT_KWARGS = {
+    "host": "clickhouse.example",
+    "port": 8443,
+    "username": "reader@service",
+    "password": "secret/word",
+    "database": "analytics",
+    "interface": "https",
+    "secure": True,
+    "settings": {"max_query_size": 1024 * 1024},
+}
+
+
+def test_clickhouse_core_passes_explicit_authenticated_client_kwargs() -> None:
+    # Given: an authenticated HTTPS ClickHouse URI.
+    # When: the core sink constructs its client.
+    # Then: the driver receives explicit, decoded connection kwargs.
+    raw_client = MagicMock()
+    with patch(
+        "clickhouse_connect.get_client",
+        side_effect=lambda **kwargs: _client_without_dsn(raw_client, kwargs),
+    ) as get_client:
+        sink = ClickHouseMetricsSink(AUTHENTICATED_HTTPS_DSN)
+
+    assert sink.client is raw_client
+    get_client.assert_called_once_with(**EXPECTED_CLIENT_KWARGS)
+
+
+def test_thread_query_passes_explicit_authenticated_client_kwargs() -> None:
+    # Given: a sink retaining an authenticated HTTPS ClickHouse URI.
+    # When: an API query creates its thread-local client.
+    # Then: the driver receives explicit, decoded connection kwargs.
+    result = MagicMock(column_names=["answer"], result_rows=[(42,)])
+    raw_client = MagicMock()
+    raw_client.query.return_value = result
+    sink = MagicMock(dsn=AUTHENTICATED_HTTPS_DSN)
+
+    with patch(
+        "clickhouse_connect.get_client",
+        side_effect=lambda **kwargs: _client_without_dsn(raw_client, kwargs),
+    ) as get_client:
+        rows = anyio.run(query_client.query_dicts, sink, "SELECT 42 AS answer", {})
+
+    assert rows == [{"answer": 42}]
+    get_client.assert_called_once_with(**EXPECTED_CLIENT_KWARGS)
+    raw_client.close.assert_called_once_with()
+
+
+def test_global_sink_log_redacts_clickhouse_userinfo(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Given: a newly initialized global sink using authenticated userinfo.
+    # When: the sink is created.
+    # Then: an operational log is present without the URI or password.
+    sink = MagicMock()
+    with (
+        patch.object(query_client, "_SHARED_SINK", None),
+        patch.object(query_client, "_SHARED_DSN", None),
+        patch.object(query_client, "create_sink", return_value=sink),
+        caplog.at_level(logging.INFO, logger="dev_health_ops.api.queries.client"),
+    ):
+        assert anyio.run(query_client.get_global_sink, AUTHENTICATED_HTTPS_DSN) is sink
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Initializing global metrics sink" in messages
+    assert AUTHENTICATED_HTTPS_DSN not in messages
+    assert "reader@service" not in messages
+    assert "secret/word" not in messages
+
+
+def _client_without_dsn(client: MagicMock, kwargs: dict[str, object]) -> MagicMock:
+    assert "dsn" not in kwargs, "raw DSN passed to driver"
+    return client


### PR DESCRIPTION
## Summary
- parse supported ClickHouse URIs once into explicit clickhouse-connect options
- percent-decode userinfo and redact it from global-sink logs
- cover both client factory seams and preserved TLS URI variants

## Verification
- uv run pytest -q tests/metrics/test_clickhouse_connection.py tests/metrics/test_clickhouse_connection_seams.py
- bash ci/local_validate.sh