### PR TITLE
feat(helm): support bundled PostgreSQL install migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ index.txt
 .codegraph/
 .build/
 .wrangler/
+
+# Agent tool scratch output (browser automation, session memory). These are
+# per-run artifacts and must never enter a commit.
+.playwright-mcp/
+.remember/

--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,7 @@ services:
         condition: service_healthy
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:latest@sha256:d7556a3841027651307b5aa08d72b5c467d0241d3db5b67d9e158ef3975626f5
     container_name: clickhouse
     restart: on-failure
     environment:
@@ -134,7 +134,7 @@ services:
       start_period: 30s
 
   valkey:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey:9-alpine@sha256:ee91f7a174ac4d6a6b0685b3a60e321f0a9dbbb691f9b0e285be2ba1d1be8328
     container_name: valkey
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:latest@sha256:d7556a3841027651307b5aa08d72b5c467d0241d3db5b67d9e158ef3975626f5
     container_name: dev-health-clickhouse
     restart: unless-stopped
     environment:
@@ -27,7 +27,7 @@ services:
       - dev-health
 
   valkey:
-    image: valkey/valkey:8-alpine
+    image: valkey/valkey:9-alpine@sha256:ee91f7a174ac4d6a6b0685b3a60e321f0a9dbbb691f9b0e285be2ba1d1be8328
     container_name: dev-health-valkey
     restart: unless-stopped
     command: >

--- a/deploy/helm/dev-health/templates/migrate-job.yaml
+++ b/deploy/helm/dev-health/templates/migrate-job.yaml
@@ -84,7 +84,10 @@ spec:
       initContainers:
         - name: wait-for-postgresql
           image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The PostgreSQL image's own policy, never image.pullPolicy: this
+          # container runs a registry image, not the application image a local
+          # profile side-loads and marks Never.
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: 70

--- a/deploy/helm/dev-health/templates/migrate-job.yaml
+++ b/deploy/helm/dev-health/templates/migrate-job.yaml
@@ -1,13 +1,25 @@
 {{- if .Values.migrations.hook.enabled }}
+{{- $hookEvents := .Values.migrations.hook.events }}
+{{- $localBundledPostgres := .Values.migrations.hook.localBundledPostgres }}
+{{- if and (has "post-install" $hookEvents) (not $localBundledPostgres) }}
+{{- fail "migrations.hook.events may use post-install only when migrations.hook.localBundledPostgres=true" }}
+{{- end }}
+{{- if and $localBundledPostgres (not .Values.postgresql.enabled) }}
+{{- fail "migrations.hook.localBundledPostgres=true requires postgresql.enabled=true" }}
+{{- end }}
+{{- if and $localBundledPostgres (not (has "post-install" $hookEvents)) }}
+{{- fail "migrations.hook.localBundledPostgres=true requires migrations.hook.events to include post-install" }}
+{{- end }}
 {{- /*
 Database migration hook (CHAOS-2304).
 
-Runs PostgreSQL (Alembic plus opt-in River) + ClickHouse migrations as a
-pre-install/pre-upgrade hook so schema changes complete before any workload
-from the release is
-(re)deployed. App pods run with AUTO_RUN_MIGRATIONS=false (see configmap.yaml)
-and never ambient-migrate — shadow-table rebuild migrations are not safe to
-run concurrently from workers.
+Runs PostgreSQL (Alembic plus opt-in River) + ClickHouse migrations as configured
+by migrations.hook.events. Production defaults remain pre-install/pre-upgrade so
+schema changes complete before workloads deploy. The explicit local bundled
+PostgreSQL mode uses post-install/pre-upgrade and waits for the bundled database.
+App pods run with AUTO_RUN_MIGRATIONS=false (see configmap.yaml) and never
+ambient-migrate — shadow-table rebuild migrations are not safe to run concurrently
+from workers.
 
 The hook ships its own ConfigMap/Secret copies: pre-install hooks run before
 the chart's regular resources exist, so the Job cannot reference them on a
@@ -22,7 +34,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: {{ join "," $hookEvents }}
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 data:
@@ -37,7 +49,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: {{ join "," $hookEvents }}
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 type: Opaque
@@ -53,7 +65,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: {{ join "," $hookEvents }}
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
@@ -68,6 +80,24 @@ spec:
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true
+      {{- if $localBundledPostgres }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 70
+            runAsGroup: 70
+          command:
+            - sh
+            - -ec
+            - >-
+              until pg_isready --host {{ include "dev-health.fullname" . }}-postgresql
+              --port 5432 --username {{ .Values.postgresql.credentials.user | quote }}
+              --dbname {{ .Values.postgresql.credentials.database | quote }};
+              do sleep 2; done
+      {{- end }}
       containers:
         - name: migrate
           image: {{ include "dev-health.image" . }}

--- a/deploy/helm/dev-health/templates/postgresql.yaml
+++ b/deploy/helm/dev-health/templates/postgresql.yaml
@@ -30,12 +30,24 @@ spec:
               value: {{ .Values.postgresql.credentials.password | quote }}
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.credentials.database | quote }}
+            # Must match the compose stack exactly: the volume is mounted at the
+            # parent /var/lib/postgresql and PGDATA is a subdirectory of it,
+            # never the mount root (which holds lost+found and other reserved
+            # entries) and never the image's own default (which moves between
+            # majors). Leaving PGDATA unset only ever worked by coincidence:
+            # through 17 the image default was /var/lib/postgresql/data, which
+            # happened to equal the old mount path, and 18 relocated it to
+            # /var/lib/postgresql/<major>/docker, at which point the entrypoint
+            # refuses to start against an "unused" mount. See
+            # https://github.com/docker-library/postgres/pull/1259.
+            - name: PGDATA
+              value: /var/lib/postgresql/pgdata
           resources:
             {{- toYaml .Values.postgresql.resources | nindent 12 }}
           {{- if .Values.postgresql.persistence.enabled }}
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
           {{- end }}
           livenessProbe:
             exec:

--- a/deploy/helm/dev-health/values-quickstart.yaml
+++ b/deploy/helm/dev-health/values-quickstart.yaml
@@ -12,6 +12,13 @@ postgresql:
     password: devhealth
     database: devhealth
 
+migrations:
+  hook:
+    localBundledPostgres: true
+    events:
+      - post-install
+      - pre-upgrade
+
 clickhouse:
   enabled: true
   credentials:

--- a/deploy/helm/dev-health/values.schema.json
+++ b/deploy/helm/dev-health/values.schema.json
@@ -2,6 +2,24 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "migrations": {
+      "type": "object",
+      "properties": {
+        "hook": {
+          "type": "object",
+          "properties": {
+            "events": {
+              "type": "array",
+              "oneOf": [
+                { "const": ["pre-install", "pre-upgrade"] },
+                { "const": ["post-install", "pre-upgrade"] }
+              ]
+            },
+            "localBundledPostgres": { "type": "boolean" }
+          }
+        }
+      }
+    },
     "secrets": {
       "type": "object",
       "properties": {
@@ -21,5 +39,46 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "migrations": {
+            "properties": {
+              "hook": {
+                "properties": {
+                  "events": { "const": ["post-install", "pre-upgrade"] }
+                },
+                "required": ["events"]
+              }
+            },
+            "required": ["hook"]
+          }
+        },
+        "required": ["migrations"]
+      },
+      "then": {
+        "properties": {
+          "migrations": {
+            "properties": {
+              "hook": {
+                "properties": {
+                  "localBundledPostgres": { "const": true }
+                },
+                "required": ["localBundledPostgres"]
+              }
+            }
+          },
+          "postgresql": {
+            "properties": {
+              "enabled": { "const": true }
+            },
+            "required": ["enabled"]
+          }
+        },
+        "required": ["postgresql"]
+      }
+    }
+  ]
 }

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -331,11 +331,13 @@ web:
 # =============================================================================
 # Database migrations (CHAOS-2304)
 # =============================================================================
-# When enabled, a pre-install/pre-upgrade Helm hook Job applies PostgreSQL
-# (Alembic) + ClickHouse migrations before the release's workloads are
-# (re)deployed, and the shared ConfigMap sets AUTO_RUN_MIGRATIONS=false so
-# api/worker/beat never ambient-migrate. Set config.AUTO_RUN_MIGRATIONS
-# explicitly to override the computed value.
+# When enabled, the default pre-install/pre-upgrade Helm hook Job applies
+# PostgreSQL (Alembic) + ClickHouse migrations before the release's workloads
+# are (re)deployed. For local evaluation with bundled PostgreSQL only, opt into
+# localBundledPostgres and replace pre-install with post-install; the Job waits
+# for PostgreSQL before migrating. The shared ConfigMap sets
+# AUTO_RUN_MIGRATIONS=false so api/worker/beat never ambient-migrate. Set
+# config.AUTO_RUN_MIGRATIONS explicitly to override the computed value.
 #
 # The preferred MIGRATION_DATABASE_URI used for Alembic plus River must point
 # DIRECTLY at Postgres. Legacy POSTGRES_URI / DATABASE_URI values remain
@@ -345,6 +347,14 @@ web:
 migrations:
   hook:
     enabled: true
+    # -- Hook lifecycle events. Production keeps pre-install/pre-upgrade. The
+    #    post-install option is fail-closed unless localBundledPostgres=true.
+    events:
+      - pre-install
+      - pre-upgrade
+    # -- Explicit local/evaluation-only acknowledgement for post-install with
+    #    the chart's bundled PostgreSQL. Requires postgresql.enabled=true.
+    localBundledPostgres: false
     backoffLimit: 2
     activeDeadlineSeconds: 1800
     resources:

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -578,11 +578,16 @@ secrets:
 # =============================================================================
 # In-cluster Valkey (optional — disable for managed Valkey/Redis)
 # =============================================================================
+# Bundled datastore tags carry their digest so a Helm deploy and a compose
+# deploy cannot silently diverge: a bare tag is exactly how this chart sat on
+# postgres:16 while every compose file and the test suite ran 18. The digests
+# below are the same ones compose.yml, deploy/docker-compose/compose.production.yml
+# and the ACR pin allowlist use; refresh all of them together.
 valkey:
   enabled: true
   image:
     repository: valkey/valkey
-    tag: "8-alpine"
+    tag: "9-alpine@sha256:ee91f7a174ac4d6a6b0685b3a60e321f0a9dbbb691f9b0e285be2ba1d1be8328"
   resources:
     requests:
       memory: "64Mi"
@@ -603,7 +608,7 @@ clickhouse:
   enabled: true
   image:
     repository: clickhouse/clickhouse-server
-    tag: "latest"
+    tag: "latest@sha256:d7556a3841027651307b5aa08d72b5c467d0241d3db5b67d9e158ef3975626f5"
   resources:
     requests:
       memory: "512Mi"
@@ -627,7 +632,14 @@ postgresql:
   enabled: false
   image:
     repository: postgres
-    tag: "16-alpine"
+    tag: "18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"
+    # -- Pull policy for the PostgreSQL image specifically. This is a registry
+    #    image, so it must NOT inherit image.pullPolicy, which local profiles
+    #    set to Never for the commit-tagged application image they side-load
+    #    into the cluster. Applying Never here fails a fresh cluster with
+    #    ErrImageNeverPull on the migration hook's wait-for-postgresql init
+    #    container, which has no way to obtain the image.
+    pullPolicy: IfNotPresent
   resources:
     requests:
       memory: "256Mi"

--- a/scripts/acceptance/wave31_manifest.py
+++ b/scripts/acceptance/wave31_manifest.py
@@ -1951,7 +1951,51 @@ PROVEN_E2E_CLAIM_LIMITS = (
 #:
 #: Whether a stale row is ACCEPTABLE is a wave-close decision, not a CI
 #: one. CI's only job here is that nobody can be surprised by one.
-DECLARED_STALE_ARTIFACTS: Mapping[str, Mapping[str, str]] = {}
+#:
+#: ``compose.yml`` at the datastore reconciliation (CHAOS-3312). The bundled
+#: datastore versions were converged onto the ones the Helm chart and the
+#: production compose stack already ran, so every scenario below recorded its
+#: evidence against the PREVIOUS pair:
+#:
+#:     valkey/valkey:8-alpine            -> valkey/valkey:9-alpine@sha256:ee91f7a1...
+#:     clickhouse/clickhouse-server:latest -> ...:latest@sha256:d7556a38...
+#:
+#: The Valkey change is a major version, not a repin, so this is a real
+#: runtime difference and not a formality: these rows are evidence about
+#: Valkey 8. The ClickHouse change binds a previously floating ``latest``,
+#: which is why the digest could not have been what any earlier run resolved
+#: it to either. Ask Dev's read path uses Valkey only as a cache in front of
+#: the ClickHouse/Postgres reads these scenarios assert on, which is the
+#: reason this is declarable rather than blocking -- but it is an
+#: acknowledgement, not a claim that the runs were re-verified.
+#:
+#: All fourteen bind the SAME hash because they drifted on the same file for
+#: the same reason. That does not weaken the gate: the hash is still bound,
+#: so the next edit to ``compose.yml`` produces a different digest and reds
+#: every one of these again.
+_COMPOSE_AT_DATASTORE_RECONCILIATION = (
+    "0beb7626fb984d736b0e65feb72209779c6b258e22c13f57b3cda10b946a8ceb"
+)
+
+DECLARED_STALE_ARTIFACTS: Mapping[str, Mapping[str, str]] = {
+    item_id: {"compose.yml": _COMPOSE_AT_DATASTORE_RECONCILIATION}
+    for item_id in (
+        "attack.team-attribution.e2e-blocked-by-live-defect",
+        "attack.unrelated-evidence.e2e-live-validated",
+        "defect.ask-dev-exact-commit.e2e-live-validated",
+        "defect.ask-dev-not-found.e2e-live-validated",
+        "gate.plan-registry-gap-is-loud.e2e-live-validated",
+        "matrix.data-trust-organization-wide",
+        "matrix.exact-project-complete",
+        "matrix.multi-metric-comparison-organization-wide",
+        "matrix.operational-deficiency.e2e-live-validated",
+        "matrix.registered-metric-catalog",
+        "matrix.remaining-work-exact-project",
+        "matrix.team-health.e2e-live-validated",
+        "matrix.team-workload-balance.e2e-live-validated",
+        "positive-control.real-project-status",
+    )
+}
 
 #: A sha256 hex digest, the only shape a recorded dependency hash may take.
 _SHA256_HEX = re.compile(r"\A[0-9a-f]{64}\Z")

--- a/tests/acceptance/test_wave31_manifest.py
+++ b/tests/acceptance/test_wave31_manifest.py
@@ -504,13 +504,21 @@ def test_every_blocked_item_reason_matches_independent_snapshot() -> None:
         assert by_id[item_id].blocked_reason == blocked_snapshot[item_id], item_id
 
 
-def test_blocked_reason_mutation_is_actually_caught() -> None:
+def test_blocked_reason_mutation_is_actually_caught(monkeypatch) -> None:
     """RED-then-GREEN proof for the fix above: plant codex's exact
     demonstrated bypass (a reason that is 'fabricated but nonempty') on a
     real blocked item and confirm the independent-snapshot check -- not
     validate_manifest's non-empty check -- is what catches it.
+
+    The declaration set is emptied because this validates a SYNTHETIC
+    one-item manifest: every real ``DECLARED_STALE_ARTIFACTS`` entry names a
+    row that manifest does not contain, and the cross-check would rightly
+    report each as acknowledging nothing. That is a different assertion than
+    the one this test makes, and letting it fire here would turn a targeted
+    RED-then-GREEN proof into a test that fails for an unrelated reason.
     """
 
+    monkeypatch.setattr(wave31_manifest, "DECLARED_STALE_ARTIFACTS", {})
     fabricated = ManifestItem(
         id="matrix.organization-portfolio-status",
         category="blocking_matrix",
@@ -630,7 +638,13 @@ def test_validate_manifest_catches_unknown_status() -> None:
 
 def test_validate_manifest_is_clean_over_a_single_well_formed_item(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
+    # Synthetic one-item manifest: see the note on the same monkeypatch in
+    # test_blocked_reason_mutation_is_actually_caught. "Clean" here means
+    # this item is well formed, not that the repository's real declaration
+    # set happens to be empty.
+    monkeypatch.setattr(wave31_manifest, "DECLARED_STALE_ARTIFACTS", {})
     commit_sha = _init_throwaway_git_repo(tmp_path)
     artifact_path = _write_valid_artifact(
         tmp_path,

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -607,7 +607,7 @@ def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:
     template = (_HELM_DIR / "templates" / "migrate-job.yaml").read_text(
         encoding="utf-8"
     )
-    assert "helm.sh/hook: pre-install,pre-upgrade" in template
+    assert 'helm.sh/hook: {{ join "," $hookEvents }}' in template
     assert "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded" in template
     assert "dev-hops migrate clickhouse" in template
     assert "dev-hops admin features seed" in template
@@ -620,6 +620,11 @@ def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:
 
     values = _load_yaml(_HELM_DIR / "values.yaml")
     assert values["migrations"]["hook"]["enabled"] is True
+    assert values["migrations"]["hook"]["events"] == [
+        "pre-install",
+        "pre-upgrade",
+    ]
+    assert values["migrations"]["hook"]["localBundledPostgres"] is False
 
 
 def test_deploy_stacks_keep_celery_beat_singleton() -> None:

--- a/tests/test_helm_migration_hook.py
+++ b/tests/test_helm_migration_hook.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from subprocess import run
+
+import yaml
+
+CHART_PATH = Path(__file__).parents[1] / "deploy/helm/dev-health"
+QUICKSTART_VALUES = CHART_PATH / "values-quickstart.yaml"
+
+
+def _render(*args: str):
+    return run(
+        ["helm", "template", "migration-contract", CHART_PATH, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _migration_job(rendered: str) -> dict:
+    resources = yaml.safe_load_all(rendered)
+    return next(
+        resource
+        for resource in resources
+        if resource
+        and resource["kind"] == "Job"
+        and resource["metadata"]["labels"]["app.kubernetes.io/component"] == "migrate"
+    )
+
+
+def test_default_migration_hook_stays_pre_install_and_pre_upgrade() -> None:
+    rendered = _render()
+
+    assert rendered.returncode == 0, rendered.stderr
+    job = _migration_job(rendered.stdout)
+    assert job["metadata"]["annotations"]["helm.sh/hook"] == "pre-install,pre-upgrade"
+    assert "initContainers" not in job["spec"]["template"]["spec"]
+
+
+def test_quickstart_uses_post_install_and_waits_for_bundled_postgres() -> None:
+    rendered = _render("-f", str(QUICKSTART_VALUES))
+
+    assert rendered.returncode == 0, rendered.stderr
+    job = _migration_job(rendered.stdout)
+    assert job["metadata"]["annotations"]["helm.sh/hook"] == "post-install,pre-upgrade"
+    init_container = job["spec"]["template"]["spec"]["initContainers"][0]
+    assert init_container["name"] == "wait-for-postgresql"
+    assert init_container["securityContext"]["runAsUser"] == 70
+    assert init_container["securityContext"]["runAsGroup"] == 70
+    assert "pg_isready" in init_container["command"][-1]
+
+
+def test_post_install_is_rejected_without_explicit_local_bundled_mode() -> None:
+    rendered = _render(
+        "--set-json",
+        'migrations.hook.events=["post-install","pre-upgrade"]',
+        "--set",
+        "postgresql.enabled=true",
+    )
+
+    assert rendered.returncode != 0
+    assert "localBundledPostgres" in rendered.stderr
+
+
+def test_local_post_install_requires_bundled_postgres() -> None:
+    rendered = _render(
+        "--set",
+        "migrations.hook.localBundledPostgres=true",
+        "--set-json",
+        'migrations.hook.events=["post-install","pre-upgrade"]',
+    )
+
+    assert rendered.returncode != 0
+    assert "/postgresql/enabled" in rendered.stderr


### PR DESCRIPTION
## Summary
- add fail-closed configurable migration hook events while retaining production pre-install/pre-upgrade defaults
- enable the explicit local bundled-PostgreSQL post-install mode in quickstart and wait for PostgreSQL as UID/GID 70
- cover default/local rendering plus invalid configuration rejection

## Validation
- bash ci/local_validate.sh
- helm lint deploy/helm/dev-health -f deploy/helm/dev-health/values-quickstart.yaml

Stacked on #1367.