### PR TITLE
feat(ask-dev): CHAOS-3301 team direct-scope + bounded cohort commitment

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -33,7 +33,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation.v1.schema.json",
-        "sha256": "763452f78629179c07604927650d39e3e3c82247823b1854e352f61fbafa8872"
+        "sha256": "8cc7267de6d08f5a63d1ecef1b4a0b45856a925637ba780f6433856fa7d27bbb"
       },
       "schema_version": "dev_conversation.v1"
     },
@@ -51,7 +51,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation_summary.v1.schema.json",
-        "sha256": "3c9983bdc802a85fa4b5f766fd3e6de109142bba97fb6e207b45173f07a06d7f"
+        "sha256": "53f0fac1fef5801a794ed160b1904fc107c3647d60e52c7462ddeccdb8c6f167"
       },
       "schema_version": "dev_conversation_summary.v1"
     },
@@ -74,7 +74,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "b7c1e321eca3616507d09d47cc6516a9999fcfba2e047b572a6f78f778926639"
+        "sha256": "635befb43b9080a935d49df136f51508a5b5e1b152809cba67d42de27bc2b60a"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -107,7 +107,7 @@
       },
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
-        "sha256": "ef00198a78046e649a750a465e230df7e5b02c27ed8d6ad5dae6f2268a6fc897"
+        "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
       },
       "schema_version": "dev_message_request.v1"
     },
@@ -150,7 +150,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "eb16f4820efce0d76fc9d9dbaff84719b91b41fe2f3d5016c324bcdb8141269d"
+        "sha256": "5178e487e3d2b8cbcde7ffea08ea0d3121937db7357c861c3738b2c9120e9039"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -168,7 +168,7 @@
       },
       "schema": {
         "path": "schemas/dev_claim.v1.schema.json",
-        "sha256": "f47efaec1dfde2d409b1053bfd04b29a5e8f5f112e7895501115ead41862b0fb"
+        "sha256": "4a8505fb87ccae4c4e63c17403410a18f543e54f1e46a79c0b8144d7b60b5481"
       },
       "schema_version": "dev_claim.v1"
     },
@@ -186,7 +186,7 @@
       },
       "schema": {
         "path": "schemas/dev_metric_ref.v1.schema.json",
-        "sha256": "bac5613b1a2bf598138469db99fbb65a20f60d466e9b1228728b14cfd34aa2cf"
+        "sha256": "8038eef2144551ffd165681dd96a9541d0ae74925708250691f5674acbedde32"
       },
       "schema_version": "dev_metric_ref.v1"
     },
@@ -240,7 +240,7 @@
       },
       "schema": {
         "path": "schemas/dev_scope.v1.schema.json",
-        "sha256": "97d5d98bbe7a8e4790ccf0bd67d5c0296f5f2d81cdcaa3235042b493bbb7bcdd"
+        "sha256": "d968b133e6ebf1fde7851c9a3c7c650dddf6edc5bb3a4dca311c6302add5e1a8"
       },
       "schema_version": "dev_scope.v1"
     },
@@ -258,7 +258,7 @@
       },
       "schema": {
         "path": "schemas/dev_scope_resolution.v1.schema.json",
-        "sha256": "707fe458b01f5dbe407833a7145497918e0052f66d01236bfec62bf8dd609c94"
+        "sha256": "6f0f9de88d78beb53b5d6e42b9e161cadaf947a2939a3215a810069600227b81"
       },
       "schema_version": "dev_scope_resolution.v1"
     },
@@ -276,7 +276,7 @@
       },
       "schema": {
         "path": "schemas/dev_tool_request.v1.schema.json",
-        "sha256": "e28410490c2b34bbf729d537e0d022c4cdc8a2dcf53013381c6105832bdb4582"
+        "sha256": "eed1f7ad4d5dac6f12680329eded654e7808fa78280e11280f4e3cf541a0bfe1"
       },
       "schema_version": "dev_tool_request.v1"
     },
@@ -299,7 +299,7 @@
       },
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "215fcb63d94c629b2002b91c3ab0c81b055bc5aee38b60b71ce81232c9870367"
+        "sha256": "6e21eb00432d01add4cf0d0a6fab85f1fec136f37861b7722c95a9aefaca47fe"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -335,7 +335,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "e26991bfcfd4ef628bcfbb6186fcbe1f9034c6259910f85d6d9ab779df1fea49"
+        "sha256": "eeb3461c25d455140d30e7a779e1480ddd2773fdec29f67b8d053ae4b2cdcc6f"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
@@ -1020,7 +1020,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1031,7 +1032,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_claim.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_claim.v1.schema.json
@@ -252,7 +252,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -263,7 +264,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_conversation.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_conversation_summary.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_summary.v1.schema.json
@@ -7,7 +7,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -1261,7 +1261,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1272,7 +1273,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_message_request.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_message_request.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_metric_ref.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_metric_ref.v1.schema.json
@@ -236,7 +236,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -247,7 +248,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_scope.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_scope.v1.schema.json
@@ -133,7 +133,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -144,7 +145,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_scope_resolution.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_scope_resolution.v1.schema.json
@@ -251,7 +251,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -262,7 +263,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -1231,7 +1231,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1242,7 +1243,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_tool_request.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_request.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -1546,7 +1546,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1557,7 +1558,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -15,7 +15,7 @@
       },
       "schema": {
         "path": "schemas/dev_message_request.v2.schema.json",
-        "sha256": "45553a4015211a44cc94984e173be1a1324146215fe24405ca3c7523fffe0c23"
+        "sha256": "b36c98551b1905343f89a3435f899ddf51ae1a55123e39368438728cf0b86e7d"
       },
       "schema_version": "dev_message_request.v2"
     },
@@ -287,7 +287,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "182d154d55803cba39c1280cb6a626f045a5d69a9897cbd52d985945bcd36910"
+        "sha256": "eed95778497f36aa0cb4508cdd6513f034e3405ccefaa3cae7b296e15b631cc0"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -373,7 +373,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "236d0d9eb75e219df4f4ca549db65b0f73a6b14a87f21d335ab934b8721637b8"
+        "sha256": "8c243227e99f05d9cf443ccdd8a737228743d97a8fc6007c0a2342b2c43b9869"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -391,7 +391,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "8b61f4c1754232d3eea7e9e0d7b83f0df22782e3c4b9ab99f7f1ab527d62613f"
+        "sha256": "e72471cc1454f0e820c1363081417cd349ac0b741efd222c6f4a3932de53dea8"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
@@ -1702,7 +1702,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1726,7 +1727,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
@@ -1336,7 +1336,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1360,7 +1361,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v2/schemas/dev_message_request.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_message_request.v2.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
@@ -2032,7 +2032,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -2056,7 +2057,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -116,9 +116,15 @@ Closing that is CHAOS-3325.
 Resolutions are recorded on an **append-only ledger**. A later success cannot
 erase an earlier unresolved mention: entries carry contiguous ordinals, the
 objects are immutable, and every update is checked against the previous
-snapshot. When a question names several subjects, the outcome is decided by
-the lowest-ordinal unresolved mention — "the first thing you named" — which is
+snapshot. When a question names one subject, the outcome is decided by the
+lowest-ordinal unresolved mention — "the first thing you named" — which is
 stable and independent of how fast the catalog answered.
+
+When a question names **several** subjects and at least two of them resolve
+exactly, an unresolved mention among the rest no longer terminates the run:
+it is recorded as an omission on the eventual subject set instead (see
+"Bounded multi-subject sets" below), so a mostly-resolved cohort is not
+sacrificed for one name the catalog could not find.
 
 ## What the model is offered
 
@@ -133,19 +139,31 @@ advertised exactly as before.
 
 | Situation | What the user sees |
 | --- | --- |
-| Every named subject resolved | The answer, scoped to that subject |
+| Every named subject resolved to one distinct entity (project, repository, issue, PR, work unit, **or team**) | The answer, scoped to that subject |
 | The question named nothing | An organization-wide answer, as before |
 | A named subject does not exist here | "No matching subject was found" |
 | A name matches several entities, or only partially | A request to say which one |
 | The catalog is briefly unavailable | "Temporarily unavailable", retryable |
-| A named team, or several named subjects at once | "Not supported yet" |
+| Several distinct subjects are named (a bounded cohort) | "Not supported yet" |
 
-The last row is a deliberate interim. A resolved team is recorded honestly as
-an exact match — the team demonstrably exists — but the current scope
-vocabulary cannot carry a team subject, and a cohort of several subjects has
-no faithful single-subject representation either. Answering under organization
-scope in either case would reintroduce exactly the defect this work closes.
-Both become real answers when team and multi-subject support land.
+A named **team** is now a first-class direct subject (CHAOS-3301), exactly
+like a project, repository, issue, pull request, or work unit: it commits and
+the run proceeds to answer about it. The remaining "Not supported yet" case is
+a **bounded cohort** — several distinct named subjects at once (e.g. "compare
+project A and project B"). The cohort is still committed honestly: every
+resolvable member is recorded on a `dev_subject_set.v1` and persisted, exactly
+which mentions could not be resolved is disclosed, and nothing is silently
+narrowed or widened to organization scope. What is missing is only the
+*rendering* — a v1 `DevAnswer` names one direct subject, and there is no
+faithful way to project a several-subject answer onto that shape yet. That
+lands with the v2 answer-frame work (CHAOS-3297/3298); until then the
+diagnostic recorded on the run is `committed_cohort_v1_only` — "we committed
+it and cannot render it here" — not a refusal.
+
+A cohort of more than 25 named subjects is rejected outright
+(`oversized_mention_set_in_v1`) rather than silently narrowed to a "complete"
+25-subject cohort — the same "no widening, no silent narrowing" discipline
+applied at the size boundary.
 
 ## Rollout
 

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -7,8 +7,9 @@ objects into these models, but must not redeclare their wire shape.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import StrEnum
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
     AwareDatetime,
@@ -286,6 +287,23 @@ class DevScope(ContractModel):
                 raise ValueError("team direct scope cannot carry a repository list")
         self._validate_surface_context()
         return self
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> Self:
+        """Revalidating copy (CHAOS-3301 review fix).
+
+        Pydantic's base ``model_copy`` is a raw field copy that never reruns
+        ``validate_direct_scope`` — ``model_copy(update={"repositories": [...]})``
+        on a TEAM scope returned and serialized a scope the invariant exists
+        to forbid, even though ``__init__`` and ``model_validate`` both reject
+        it. Every production caller only patches time fields, so
+        round-tripping the update through ``model_validate`` costs nothing
+        real and closes the construction path.
+        """
+
+        copied = super().model_copy(update=update, deep=deep)
+        return type(self).model_validate(copied.model_dump())
 
     def _validate_surface_context(self) -> None:
         context = self.surface_context

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -275,6 +275,15 @@ class DevScope(ContractModel):
                 raise ValueError(
                     "team direct scope requires team_ids to name exactly that team"
                 )
+            if self.repositories:
+                # CHAOS-3301 review fix: a team direct scope has no
+                # repository list of its own -- team-to-repository
+                # attribution is re-derived at query time from
+                # ``team_repo_ownership``, never carried on the wire. Without
+                # this, a foreign ``repositories`` list validated as merely
+                # unused and was silently consumed by the status source seam
+                # instead of being rejected here.
+                raise ValueError("team direct scope cannot carry a repository list")
         self._validate_surface_context()
         return self
 

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -54,6 +54,11 @@ class DirectScope(StrEnum):
     WORK_UNIT = "work_unit"
     ISSUE = "issue"
     PULL_REQUEST = "pull_request"
+    #: CHAOS-3301. A team as a direct subject, distinct from the pre-existing
+    #: ``team_ids`` *filter* on any other direct scope (see
+    #: ``DevScope.validate_direct_scope`` below for the invariant that keeps
+    #: the two structurally separate).
+    TEAM = "team"
 
 
 class EntityType(StrEnum):
@@ -62,6 +67,7 @@ class EntityType(StrEnum):
     WORK_UNIT = "work_unit"
     ISSUE = "issue"
     PULL_REQUEST = "pull_request"
+    TEAM = "team"
 
 
 class AskDevSurfaceRouteID(StrEnum):
@@ -80,6 +86,12 @@ class AskDevSurfaceRouteID(StrEnum):
     DATA_HEALTH = "data_health"
 
 
+#: CHAOS-3301: deliberately never gains an ``EntityType.TEAM`` entry. Surface
+#: context is a total per-route allowlist of what a *page* may assert as the
+#: subject (``_validate_surface_context`` below); admitting TEAM here would
+#: let page context set ``direct_scope=team`` directly. A page-supplied team
+#: reference is instead re-resolved as question text through the subject
+#: preflight, exactly like any other named subject the issue describes.
 _SURFACE_ENTITY_TYPES: dict[AskDevSurfaceRouteID, frozenset[EntityType]] = {
     AskDevSurfaceRouteID.DIAGNOSE_OVERVIEW: frozenset({EntityType.REPOSITORY}),
     AskDevSurfaceRouteID.FLOW_METRICS: frozenset({EntityType.REPOSITORY}),
@@ -243,6 +255,7 @@ class DevScope(ContractModel):
             DirectScope.WORK_UNIT: EntityType.WORK_UNIT,
             DirectScope.ISSUE: EntityType.ISSUE,
             DirectScope.PULL_REQUEST: EntityType.PULL_REQUEST,
+            DirectScope.TEAM: EntityType.TEAM,
         }
         expected = entity_scope.get(self.direct_scope)
         if expected is not None:
@@ -251,6 +264,17 @@ class DevScope(ContractModel):
                 or self.entity_refs[0].entity_type != expected
             ):
                 raise ValueError("direct entity scope requires one matching entity")
+        if self.direct_scope is DirectScope.TEAM:
+            # A team filter can never be read as a team subject: team_ids
+            # must name exactly the one committed team, never be empty (the
+            # metrics path only applies its team_id filter when team_ids is
+            # populated) and never carry any other id. An organization scope
+            # carrying team_ids stays a filter, structurally — this branch
+            # only fires for DirectScope.TEAM.
+            if self.team_ids != [self.entity_refs[0].entity_id]:
+                raise ValueError(
+                    "team direct scope requires team_ids to name exactly that team"
+                )
         self._validate_surface_context()
         return self
 

--- a/src/dev_health_ops/api/dev/contracts_v2/compat.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/compat.py
@@ -11,14 +11,22 @@ v1 ``DevError``, both already-validated wire objects.
 Fidelity notes (documented rather than silently glossed over, since a v1
 client can only ever see an approximation of the richer v2 frame):
 
-* v1's ``DirectScope``/``EntityType`` have no ``team`` value (Wave 3.1 adds
-  ``TEAM`` only at the v2 contract layer — see ``base.EntityKind``
-  docstring for why it was not retrofitted onto v1). A team-subject v2
-  answer therefore has no valid v1 representation; the projector returns a
-  safe ``DevError`` (``feature_not_enabled``) rather than silently
-  mislabeling a team answer as organization- or repository-scoped, which
-  would violate the "no team attribution without disclosed scope"
-  guardrail (Amendment PRD v2 §10) at the compatibility boundary.
+* CHAOS-3301 gave v1's ``DirectScope``/``EntityType`` a real ``team`` value
+  — but only for the *subject preflight's* own construction
+  (``scope_service.committed_resolution_for``), which never routes through
+  this projector at all: ``build_preflight_answer`` (``preflight_outcomes``)
+  never sets ``frame.subject_ref``, so a preflight-committed team subject
+  cannot reach ``_build_resolved_scope`` here. This projector's team
+  interception is therefore kept deliberately unchanged pending CHAOS-3297
+  (real v2 answer frames, which *would* set ``subject_ref`` and could exercise
+  this path): a team-subject v2 answer still has no *frame-projection* path
+  wired, so the projector still returns a safe ``DevError``
+  (``feature_not_enabled``) rather than silently mislabeling a team answer as
+  organization- or repository-scoped, which would violate the "no team
+  attribution without disclosed scope" guardrail (Amendment PRD v2 §10) at
+  the compatibility boundary. Wiring ``_build_resolved_scope``'s team branch
+  is CHAOS-3297's job, alongside whatever it does for ``subject_set_ref``
+  below.
 * Symmetrically (Codex adversarial-review hardening, CHAOS-3294): a
   ``subject_set_ref`` answer (a cohort/plural-subject frame) also has no
   faithful v1 representation. ``dev_answer_frame.v1.subject_set_ref`` is

--- a/src/dev_health_ops/api/dev/metrics/clickhouse.py
+++ b/src/dev_health_ops/api/dev/metrics/clickhouse.py
@@ -597,7 +597,15 @@ class ClickHouseMetricSource:
             if repo_ids:
                 clauses.append("AND toString(repo_id) IN %(repo_ids)s")
                 params["repo_ids"] = repo_ids
-            if scope.team_ids and definition.source_table == "investment_metrics_daily":
+            # CHAOS-3301: was a hardcoded `source_table == "investment_metrics_daily"`
+            # check, which happened to be equivalent to `supports_team_filter` for
+            # every metric registered today but would silently stop applying the
+            # team filter for the next `supports_team_filter=True` metric added on a
+            # different source table -- MetricQueryService._validate_request
+            # (service.py) already gates on `supports_team_filter`, the two must
+            # not drift. See test_every_team_filter_supporting_metric_applies_its_
+            # team_filter (test_metrics.py) for the totality check.
+            if scope.team_ids and definition.supports_team_filter:
                 clauses.append("AND team_id IN %(team_ids)s")
                 params["team_ids"] = list(scope.team_ids)
         return "\n".join(clauses), params

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -45,6 +45,44 @@ NATIVE_STATUS_SOURCE_VERSION = "native-status-change.v1"
 NATIVE_STATUS_QUERY_VERSION = "native-status-change-query.v1"
 QUERY_TIMEOUT_SECONDS = 15
 
+#: CHAOS-3301 addendum (Option B), structural closure. Every SQL constant in
+#: this module that gates on ``{scope_type:String}`` must either carry a
+#: ``'team'`` arm in its disjunction, or be named here — enforced by
+#: ``tests/api/dev/test_chaos_3301_controls.py::
+#: test_native_status_change_scope_type_disjunctions_are_total_over_team``,
+#: which enumerates every ``scope_type``-gated SQL constant in this module by
+#: introspection and fails if a new one is added without updating one of the
+#: two.
+#:
+#: Every source is registered here today: no arm is added to any SQL
+#: constant by this issue (that is CHAOS-3303's, alongside the team-health
+#: service that has to reason about attribution quality anyway). This is
+#: deliberately still safe rather than silently wrong for a committed team
+#: scope — see ``ClickHouseStatusChangeSource._authorized_repository_ids``:
+#: a team direct scope always carries an empty ``repositories`` list (team
+#: attribution is re-derived at query time in CHAOS-3303, never carried on
+#: the wire per the addendum), so ``status_snapshot`` and ``change_summary``
+#: both take the existing "no authorized repositories" fail-closed branch —
+#: an explicit ``FreshnessState.UNAVAILABLE`` observation with a disclosed
+#: warning — before any of these queries ever execute with
+#: ``scope_type='team'``. That branch is what N0
+#: (``test_n0_team_subject_never_returns_a_silently_empty_status``) proves.
+TEAM_NOT_APPLICABLE_SOURCES: frozenset[str] = frozenset(
+    {
+        "_WORK_ITEMS_SQL",
+        "_BLOCKERS_SQL",
+        "_PULL_REQUESTS_SQL",
+        "_DEPLOYMENTS_SQL",
+        "_TRANSITIONS_SQL",
+        "_RELATIONSHIPS_SQL",
+        "_PULL_REQUEST_CHANGES_SQL",
+        "_REVIEW_CHANGES_SQL",
+        "_CI_CHANGES_SQL",
+        "_DEPLOYMENT_CHANGES_SQL",
+        "_INCIDENT_CHANGES_SQL",
+    }
+)
+
 _BLOCKER_PROJECTION_RULE_VERSION = "canonical-blocks.v2"
 
 _WORK_UNIT_MEMBERSHIP_WATERMARK_SQL = """

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -67,6 +67,7 @@ from .contracts import (
     ToolID,
     dev_error_remediation,
 )
+from .contracts_v2 import DevSubjectSet
 from .orchestrator_states import TERMINAL_STATES, RunState
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from .preflight_outcomes import TERMINAL_STATE_BY_OUTCOME, project_preflight_error
@@ -305,6 +306,16 @@ class RunRecorder(Protocol):
         """
         ...
 
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        """Persist one committed ``dev_subject_set.v1`` (CHAOS-3301).
+
+        Called whenever the preflight built a subject set — a homogeneous
+        cohort (which then terminates unsupported on the v1 surface, D1) or a
+        singular commit reached via duplicate aliases (N4, which still
+        proceeds). Never called for an ordinary single-mention commit.
+        """
+        ...
+
     async def terminal(
         self,
         *,
@@ -344,6 +355,9 @@ class NullRunRecorder:
         legacy_guard_reason: str | None,
     ) -> None:
         del preflight_outcome, legacy_guard_reason
+
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        del subject_set
 
     async def terminal(
         self,
@@ -682,6 +696,13 @@ class DevOrchestrator:
                     preflight_outcome=preflight_result.diagnostic,
                     legacy_guard_reason=None,
                 )
+                if preflight_result.subject_set is not None:
+                    # Persisted regardless of decision: a homogeneous cohort
+                    # (D1) still terminates unsupported below, but the set it
+                    # committed is recorded either way.
+                    await self._recorder.record_subject_set(
+                        preflight_result.subject_set
+                    )
                 if preflight_result.decision is PreflightDecision.TERMINATE:
                     assert preflight_result.answer is not None
                     assert preflight_result.outcome is not None

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -94,7 +94,7 @@ from .question_interpreter import QuestionInterpreter
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
 from .scope_service import (
-    DIRECT_SCOPE_KINDS,
+    MODEL_SEARCHABLE_ENTITY_KINDS,
     EntityKind,
     ScopeRef,
     ScopeRequestCache,
@@ -134,11 +134,15 @@ _ACCEPTANCE_OPENAI_DISCLOSURE_KEY = "ask_dev_scripted_acceptance"
 _ACCEPTANCE_OPENAI_HOSTS = frozenset(
     {"127.0.0.1", "localhost", "ask-dev-scripted-openai"}
 )
-# Named-entity resolution never searches organization scope itself (CHAOS-3256):
-# resolve_scope.v1 only disambiguates the direct scopes an organization search
-# can return an authorized match for.
+# CHAOS-3301 structural pattern: an explicit, independently-pinned constant
+# (scope_service.MODEL_SEARCHABLE_ENTITY_KINDS), never derived from
+# DIRECT_SCOPE_KINDS — DIRECT_SCOPE_KINDS gained TEAM this issue, and that
+# must not silently widen what the model-facing resolve_scope.v1 tool can
+# search by free-text query (team is a preflight-committed *subject*, never a
+# query-search kind on this surface). Named-entity resolution also never
+# searches organization scope itself (CHAOS-3256).
 _SEARCHABLE_SCOPE_KINDS: tuple[EntityKind, ...] = tuple(
-    sorted(DIRECT_SCOPE_KINDS - {EntityKind.ORGANIZATION}, key=lambda kind: kind.value)
+    sorted(MODEL_SEARCHABLE_ENTITY_KINDS, key=lambda kind: kind.value)
 )
 
 
@@ -604,8 +608,16 @@ def _scope_request(scope: DevScope) -> ScopeResolveRequest:
         )
     return ScopeResolveRequest(
         explicit_refs=refs,
-        team_filter_refs=tuple(
-            ScopeRef(EntityKind.TEAM, value) for value in scope.team_ids
+        # A team *direct* scope already carries its team as an explicit_ref
+        # (via the entity_refs branch above); team_ids there is required by
+        # DevScope.validate_direct_scope to name that same team, not a second
+        # independent dimension. Also passing it as a team_filter_ref would
+        # make `resolve()` treat the run as team-*filtered* (outcome=FILTERED)
+        # rather than an exact single-entity commit (CHAOS-3301).
+        team_filter_refs=(
+            ()
+            if scope.direct_scope is DirectScope.TEAM
+            else tuple(ScopeRef(EntityKind.TEAM, value) for value in scope.team_ids)
         ),
         time_range=TimeRangeRequest(
             preset_days=None,

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -843,10 +843,21 @@ class QuestionInterpreter:
         # Computed once, from the raw text, before MAX_MENTIONS capping and
         # before any untyped-name/fallback additions — see
         # InterpretedQuestion.total_named_mention_count.
-        total_named_mention_count = count_mention_candidates(
+        total_typed_mention_count = count_mention_candidates(
             request.question, context_refs=context_refs
         )
-        mentions, untyped_ids = self._add_untyped_mentions(request.question, mentions)
+        mentions, untyped_ids, total_untyped_candidate_count = (
+            self._add_untyped_mentions(request.question, mentions)
+        )
+        # CHAOS-3301 fix: the uncapped total must include untyped bare-name
+        # candidates too, counted before `_add_untyped_mentions` silently
+        # stops merging at MAX_MENTIONS. Counting only the typed grammar
+        # candidates let 25 typed + 1 resolvable bare name report a
+        # "complete" 25-subject total instead of the true 26 -- the oversized
+        # rejection below never saw it.
+        total_named_mention_count = (
+            total_typed_mention_count + total_untyped_candidate_count
+        )
         normalized = _normalize(request.question)
         signals = _Signals(
             normalized=normalized,
@@ -919,7 +930,7 @@ class QuestionInterpreter:
 
     def _add_untyped_mentions(
         self, question: str, mentions: tuple[DevSubjectMention, ...]
-    ) -> tuple[tuple[DevSubjectMention, ...], set[str]]:
+    ) -> tuple[tuple[DevSubjectMention, ...], set[str], int]:
         """Mint a mention for each bare name the kind-noun grammar missed.
 
         ``requested_entity_kind`` is a **declared default** for these, because
@@ -927,12 +938,18 @@ class QuestionInterpreter:
         the ledger's committed reference carries whichever kind actually
         matched. Recording a default is the honest option: the alternative is
         no mention at all, which is how an unresolved name reaches an answer.
+
+        Returns the merged mentions, the minted untyped mention ids, and the
+        *uncapped* number of untyped candidates found (CHAOS-3301) — counted
+        before the ``MAX_MENTIONS`` cap below silently stops merging, so a
+        caller can still see a candidate that got dropped for being past the
+        bound instead of it vanishing into a false "complete" count.
         """
 
         typed = [mention.original_text_span for mention in mentions]
         candidates = untyped_name_candidates(question, typed)
         if not candidates:
-            return mentions, set()
+            return mentions, set(), 0
         merged = list(mentions)
         untyped_ids: set[str] = set()
         for span in candidates:
@@ -950,7 +967,7 @@ class QuestionInterpreter:
                     normalized_lookup_text=_normalize(span)[:2048],
                 )
             )
-        return tuple(merged), untyped_ids
+        return tuple(merged), untyped_ids, len(candidates)
 
     async def _apply_fallback(
         self,

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -66,6 +66,7 @@ __all__ = [
     "IntentClassifier",
     "InterpretedQuestion",
     "QuestionInterpreter",
+    "count_mention_candidates",
     "extract_mentions",
 ]
 
@@ -339,13 +340,15 @@ def untyped_name_candidates(
     return tuple(found[:MAX_MENTIONS])
 
 
-def extract_mentions(
-    question: str,
-    *,
-    context_refs: Sequence[DevEntityRef] = (),
-    mint_id: Callable[[], str] = lambda: str(uuid.uuid4()),
-) -> tuple[DevSubjectMention, ...]:
-    """Ordered, deduplicated subject mentions for one question.
+def _candidate_mentions(
+    question: str, *, context_refs: Sequence[DevEntityRef] = ()
+) -> list[_MentionCandidate]:
+    """The full ordered, deduplicated mention candidate list, uncapped.
+
+    Shared by ``extract_mentions`` (which additionally caps the result to
+    ``MAX_MENTIONS`` for the ``DevSubjectMention``/``DevResolutionLedger``
+    contract bound) and ``count_mention_candidates`` (which reports the raw,
+    uncapped count — CHAOS-3301, see its docstring for why that matters).
 
     Two input classes, in precedence order:
 
@@ -413,7 +416,37 @@ def extract_mentions(
                     lookup_text=ref.entity_id,
                 )
             )
+    return ordered
 
+
+def count_mention_candidates(
+    question: str, *, context_refs: Sequence[DevEntityRef] = ()
+) -> int:
+    """The number of named subjects in ``question``, before ``MAX_MENTIONS`` capping.
+
+    CHAOS-3301. ``len(extract_mentions(question))`` alone cannot distinguish
+    "a complete 25-subject cohort" from "26 subjects named, the 26th silently
+    dropped" — both report exactly 25, since ``DevSubjectMention.mention_ordinal``
+    and ``DevResolutionLedger.mention_ids`` are hard-capped at the same bound.
+    Bounds must be rejections, never truncations: this is what lets the subject
+    preflight tell the two apart and reject the oversized case honestly instead
+    of narrating a false "complete" cohort.
+    """
+
+    return len(_candidate_mentions(question, context_refs=context_refs))
+
+
+def extract_mentions(
+    question: str,
+    *,
+    context_refs: Sequence[DevEntityRef] = (),
+    mint_id: Callable[[], str] = lambda: str(uuid.uuid4()),
+) -> tuple[DevSubjectMention, ...]:
+    """Ordered, deduplicated subject mentions for one question, capped at
+    ``MAX_MENTIONS`` — see ``count_mention_candidates`` for the uncapped count.
+    """
+
+    ordered = _candidate_mentions(question, context_refs=context_refs)
     mentions: list[DevSubjectMention] = []
     for ordinal, candidate in enumerate(ordered[:MAX_MENTIONS]):
         mentions.append(
@@ -772,6 +805,14 @@ class InterpretedQuestion:
     #: one re-arms the legacy backstop rather than terminating the run — see
     #: ``untyped_name_candidates``.
     untyped_mention_ids: frozenset[str] = frozenset()
+    #: The number of *typed* named subjects the kind-noun grammar found,
+    #: before ``MAX_MENTIONS`` capping (CHAOS-3301). ``len(mentions)`` alone
+    #: cannot distinguish "a complete 25-subject cohort" from "26 subjects
+    #: named, the 26th silently dropped" — both would report 25. Bounds are
+    #: rejections, never truncations: the subject preflight uses this to
+    #: reject the oversized case honestly instead of narrating a false
+    #: "complete" cohort.
+    total_named_mention_count: int = 0
 
     @property
     def mention_by_id(self) -> dict[str, DevSubjectMention]:
@@ -798,6 +839,12 @@ class QuestionInterpreter:
             context_refs.extend(request.scope.surface_context.entity_refs)
         mentions = extract_mentions(
             request.question, context_refs=context_refs, mint_id=self._mint_id
+        )
+        # Computed once, from the raw text, before MAX_MENTIONS capping and
+        # before any untyped-name/fallback additions — see
+        # InterpretedQuestion.total_named_mention_count.
+        total_named_mention_count = count_mention_candidates(
+            request.question, context_refs=context_refs
         )
         mentions, untyped_ids = self._add_untyped_mentions(request.question, mentions)
         normalized = _normalize(request.question)
@@ -867,6 +914,7 @@ class QuestionInterpreter:
             mentions=mentions,
             untyped_mention_ids=frozenset(untyped_ids)
             & {mention.mention_id for mention in mentions},
+            total_named_mention_count=total_named_mention_count,
         )
 
     def _add_untyped_mentions(

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -305,6 +305,14 @@ def untyped_name_candidates(
     the span was a subject at all ("What is our DORA score?" would otherwise
     break). It re-arms the legacy backstop instead, which judges the model's
     own answer text and is exactly today's behaviour for this shape.
+
+    Deliberately **uncapped** (CHAOS-3301 review fix): this used to truncate
+    to ``MAX_MENTIONS`` internally, so a caller reading ``len(...)`` as an
+    "uncapped" total for the oversized-rejection guard was in fact reading an
+    already-capped number — a 26th all-untyped subject was silently invisible
+    to that guard, not merely dropped from the merged mention list. Capping
+    for the merge bound is the caller's job (``_add_untyped_mentions``
+    already does it); this function only finds candidates.
     """
 
     claimed = {value.casefold() for value in typed}
@@ -337,7 +345,7 @@ def untyped_name_candidates(
             continue
         seen.add(normalized)
         found.append(span)
-    return tuple(found[:MAX_MENTIONS])
+    return tuple(found)
 
 
 def _candidate_mentions(

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -31,7 +31,8 @@ from .contracts import (
     EntityType,
     ScopeResolutionOutcome,
 )
-from .contracts_v2 import ResolutionOutcome
+from .contracts_v2 import DevEntityRefV2, DevSubjectSet, ResolutionOutcome
+from .contracts_v2 import EntityKind as ContractEntityKind
 
 QUERY_VERSION = "resolve-scope.v1"
 MAX_REPOSITORIES = 20
@@ -54,6 +55,10 @@ class EntityKind(StrEnum):
     TEAM = "team"
 
 
+#: Kinds with a real v1 ``DevScope.direct_scope`` representation. CHAOS-3301
+#: adds ``TEAM`` here: a client (or the subject preflight) can now commit and
+#: re-validate a team-direct ``DevScope`` through ``resolve_contract`` /
+#: ``committed_resolution_for``, exactly like any other direct scope kind.
 DIRECT_SCOPE_KINDS = frozenset(
     {
         EntityKind.ORGANIZATION,
@@ -62,22 +67,61 @@ DIRECT_SCOPE_KINDS = frozenset(
         EntityKind.WORK_UNIT,
         EntityKind.ISSUE,
         EntityKind.PULL_REQUEST,
+        EntityKind.TEAM,
     }
 )
 
-#: The kinds any v1 surface (``resolve_scope.v1``, the GraphQL scope-search
-#: field) may search. Organization is excluded because named-entity resolution
-#: never searches organization scope itself (CHAOS-3256).
-V1_SEARCHABLE_ENTITY_KINDS = frozenset(DIRECT_SCOPE_KINDS - {EntityKind.ORGANIZATION})
+#: CHAOS-3301 structural pattern: explicit, independently-pinned frozensets
+#: per surface, never derived from ``DIRECT_SCOPE_KINDS`` or from each other.
+#: Widening ``DIRECT_SCOPE_KINDS`` (as this issue just did, for ``TEAM``) must
+#: never silently widen what a caller may *search by free-text query* — that
+#: is a deliberate, separate decision per surface, made by editing that
+#: surface's own constant. All three currently name the same five kinds
+#: (organization is excluded because named-entity resolution never searches
+#: organization scope itself, CHAOS-3256; team is excluded because CHAOS-3301
+#: gives team a v1 *subject* — resolved from question text via the preflight
+#: — not a v1 *free-text search* kind on these surfaces).
+#:
+#: The kinds ``resolve_scope.v1``'s query-search path may search.
+V1_SEARCHABLE_ENTITY_KINDS = frozenset(
+    {
+        EntityKind.REPOSITORY,
+        EntityKind.PROJECT,
+        EntityKind.WORK_UNIT,
+        EntityKind.ISSUE,
+        EntityKind.PULL_REQUEST,
+    }
+)
+#: The kinds the model-facing ``resolve_scope.v1`` tool may search.
+MODEL_SEARCHABLE_ENTITY_KINDS = frozenset(
+    {
+        EntityKind.REPOSITORY,
+        EntityKind.PROJECT,
+        EntityKind.WORK_UNIT,
+        EntityKind.ISSUE,
+        EntityKind.PULL_REQUEST,
+    }
+)
+#: The kinds the typed GraphQL scope-search field may search.
+GRAPHQL_SEARCHABLE_ENTITY_KINDS = frozenset(
+    {
+        EntityKind.REPOSITORY,
+        EntityKind.PROJECT,
+        EntityKind.WORK_UNIT,
+        EntityKind.ISSUE,
+        EntityKind.PULL_REQUEST,
+    }
+)
 
 #: The **ceiling** on what any caller may search — not a default. CHAOS-3292
 #: adds ``TEAM`` here so the subject preflight can resolve a named team against
 #: the catalog (which has supported teams since ``scope_catalog``'s team
-#: queries landed) and record an honest ``exact_match`` for it. Giving a team
-#: real v1 ``DirectScope``/``DevScope`` semantics is CHAOS-3301's, so every
-#: pre-existing caller keeps ``V1_SEARCHABLE_ENTITY_KINDS`` and a resolved team
-#: terminates the preflight as ``unsupported`` rather than reaching
-#: ``DirectScope(...)``/``EntityType(...)``, which raise for ``team``.
+#: queries landed) and record an honest ``exact_match`` for it. CHAOS-3301
+#: gives team real v1 ``DirectScope``/``DevScope`` semantics once *committed*
+#: by the preflight, but every pre-existing free-text-search caller keeps
+#: ``V1_SEARCHABLE_ENTITY_KINDS`` (excluding team) — only the preflight's own
+#: typed-mention resolution (``resolve_mention``) is allowed to reach this
+#: wider ceiling.
 SEARCHABLE_ENTITY_KINDS = V1_SEARCHABLE_ENTITY_KINDS | {EntityKind.TEAM}
 
 
@@ -700,23 +744,39 @@ class ScopeResolutionService:
         path) and the subject preflight, so there is one notion of "committed
         scope" rather than two that can drift.
 
-        Raises ``ValueError`` for a kind v1 cannot represent (``team``), rather
-        than letting ``DirectScope(...)``/``EntityType(...)`` raise a bare
-        enum error from deep inside scope construction.
+        Raises ``ValueError`` for a kind with no v1 direct-scope
+        representation at all (currently just ``organization``, which is
+        never a *single-entity* commit), rather than letting
+        ``DirectScope(...)``/``EntityType(...)`` raise a bare enum error from
+        deep inside scope construction.
+
+        CHAOS-3301: team is now a real v1 direct scope. Its repository
+        attribution is deliberately **not** carried here —
+        ``authorized_repository_ids``/``authorized_entity_ids`` stay empty for
+        a team commit, since ``AuthorizedEntity.repository_id`` is always
+        ``None`` for a team (``scope_catalog`` resolves teams
+        organization-scoped with no repository dimension). Team→repository
+        attribution is re-derived at query time by the status/change source,
+        not carried on the wire (Amendment: addendum item 1) — CHAOS-3303's
+        job, not this function's.
         """
 
-        if entity.kind not in V1_SEARCHABLE_ENTITY_KINDS:
+        if (
+            entity.kind is EntityKind.ORGANIZATION
+            or entity.kind not in DIRECT_SCOPE_KINDS
+        ):
             raise ValueError(
                 f"{entity.kind.value} has no v1 direct-scope representation"
             )
         is_repository = entity.kind is EntityKind.REPOSITORY
+        is_team = entity.kind is EntityKind.TEAM
         resolved_scope = DevScope(
             schema_version="dev_scope.v1",
             organization_id=org_id,
             direct_scope=DirectScope(entity.kind.value),
             repositories=[entity.canonical_id] if is_repository else [],
             entity_refs=[] if is_repository else [self._contract_entity_ref(entity)],
-            team_ids=[],
+            team_ids=[entity.canonical_id] if is_team else [],
             time_range=base_scope.time_range,
             comparison_range=base_scope.comparison_range,
             surface_context=None,
@@ -737,6 +797,74 @@ class ScopeResolutionService:
             fallbacks=[],
             warnings=[],
             resolved_at=resolved_at,
+        )
+
+    @staticmethod
+    def _subject_set_fingerprint(kind: EntityKind, canonical_ids: Sequence[str]) -> str:
+        """Mint-derived, opaque set fingerprint (structural pattern 5).
+
+        ``"set1_" + sha256(kind, sorted(canonical_ids)).hexdigest()[:40]``.
+        Hex cannot spell a subject name, and the value is stable across runs
+        for the same (kind, member set), which is what makes it usable as a
+        batch cache key.
+        """
+
+        digest = hashlib.sha256(
+            "\0".join((kind.value, *sorted(canonical_ids))).encode()
+        ).hexdigest()[:40]
+        return f"set1_{digest}"
+
+    def committed_subject_set_for(
+        self,
+        entities: Sequence[AuthorizedEntity],
+        *,
+        set_id: str,
+        original_mention_count: int,
+        unresolved_mention_ids: tuple[str, ...] = (),
+        ambiguous_mention_ids: tuple[str, ...] = (),
+        warnings: tuple[str, ...] = (),
+    ) -> DevSubjectSet:
+        """Build one ``dev_subject_set.v1`` from already-deduplicated entities.
+
+        ``entities`` must already be deduplicated by canonical id and
+        homogeneous in kind — the subject preflight owns those decisions
+        (bounds are rejections, never truncations: a >25-member or
+        heterogeneous set must never reach here at all). This is pure
+        construction plus the fingerprint grammar; the pydantic model's own
+        ``validate_set_invariants`` is the final check on omission/
+        completeness/warning-disclosure consistency.
+        """
+
+        if not entities:
+            raise ValueError("a subject set requires at least one committed entity")
+        kind = entities[0].kind
+        if any(entity.kind is not kind for entity in entities):
+            raise ValueError("a subject set must be homogeneous in entity kind")
+        omitted = len(unresolved_mention_ids) + len(ambiguous_mention_ids)
+        return DevSubjectSet(
+            schema_version="dev_subject_set.v1",
+            set_id=set_id,
+            entity_kind=ContractEntityKind(kind.value),
+            committed_entity_refs=tuple(
+                DevEntityRefV2(
+                    entity_kind=ContractEntityKind(entity.kind.value),
+                    entity_id=entity.canonical_id,
+                    display_label=entity.label,
+                    repository_id=entity.repository_id,
+                    team_id=(
+                        entity.canonical_id if entity.kind is EntityKind.TEAM else None
+                    ),
+                )
+                for entity in entities
+            ),
+            original_mention_count=original_mention_count,
+            unresolved_mention_ids=unresolved_mention_ids,
+            ambiguous_mention_ids=ambiguous_mention_ids,
+            cohort_complete=omitted == 0,
+            warnings=warnings,
+            fingerprint=self._subject_set_fingerprint(
+                kind, [entity.canonical_id for entity in entities]
+            ),
         )
 
     async def resolve_query_contract(

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -399,23 +399,37 @@ class SubjectPreflight:
             if mention.mention_id in untyped_ids
         )
         # D2 (Amendment TRD v2 line 154, CHAOS-3301): for a plural/cohort
-        # question with at least two exactly-resolved mentions, an unresolved
-        # typed mention no longer terminates the run — it is recorded as
-        # omitted on the eventual subject set instead. Singular behavior (one
-        # named subject) is unchanged: the lowest-ordinal unresolved mention
-        # still terminates immediately, exactly as A6 established. Stable and
-        # explainable ("the first thing you named"), and independent of
-        # catalog latency — a severity ordering would let a slow catalog
-        # change the reported outcome between runs, which directly breaks
-        # determinism.
-        exact_match_count = sum(
-            1
-            for mention in mentions
-            if mention.mention_id in blocking_ids
-            and latest[mention.mention_id].outcome is ResolutionOutcome.EXACT_MATCH
-        )
+        # question with at least two *distinct* exactly-resolved mentions, an
+        # unresolved typed mention no longer terminates the run — it is
+        # recorded as omitted on the eventual subject set instead. Singular
+        # behavior (one named subject) is unchanged: the lowest-ordinal
+        # unresolved mention still terminates immediately, exactly as A6
+        # established. Stable and explainable ("the first thing you named"),
+        # and independent of catalog latency — a severity ordering would let
+        # a slow catalog change the reported outcome between runs, which
+        # directly breaks determinism.
+        #
+        # The threshold counts UNIQUE committed entities, deduped by (kind,
+        # canonical id) here rather than raw exact-match mentions (CHAOS-3301
+        # review fix): two aliases of the same entity plus one unresolved
+        # mention previously satisfied ">= 2 exact matches" and skipped the
+        # termination loop below even though only one distinct subject had
+        # resolved, letting the unresolved mention slip past without being
+        # accounted for anywhere. With one distinct entity, D2 must not
+        # activate — the pre-D2 lowest-ordinal termination applies instead.
+        blocking_committed_entities: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+        for mention in mentions:
+            if mention.mention_id not in blocking_ids:
+                continue
+            entry = latest[mention.mention_id]
+            if entry.outcome is ResolutionOutcome.EXACT_MATCH:
+                entity = self._authorized_entity_for(entry)
+                blocking_committed_entities.setdefault(
+                    (entity.kind, entity.canonical_id), entity
+                )
         cohort_may_proceed_partial = (
-            intent.cardinality is Cardinality.PLURAL_COHORT and exact_match_count >= 2
+            intent.cardinality is Cardinality.PLURAL_COHORT
+            and len(blocking_committed_entities) >= 2
         )
         if not cohort_may_proceed_partial:
             for mention in mentions:
@@ -540,25 +554,48 @@ class SubjectPreflight:
             # issue's. "committed" (not "cohort_unsupported") is the honest
             # distinction: we did commit every resolvable member, and cannot
             # render it here, rather than refusing outright.
-            unresolved_ids = tuple(
-                mention.mention_id
+            #
+            # Omissions are partitioned by outcome (CHAOS-3301 review fix):
+            # AMBIGUOUS_CANDIDATES is a distinct outcome from no-match/
+            # unavailable/unsupported-kind, and the set contract keeps them
+            # in separate fields (`ambiguous_mention_ids` vs
+            # `unresolved_mention_ids`) so a reader — and any later
+            # ambiguity-disambiguation flow — can tell "we found nothing" from
+            # "we found more than one" without re-deriving it from the ledger.
+            omitted_blocking_entries = [
+                (mention.mention_id, latest[mention.mention_id].outcome)
                 for mention in mentions
                 if mention.mention_id in blocking_ids
                 and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+            ]
+            unresolved_ids = tuple(
+                mention_id
+                for mention_id, outcome in omitted_blocking_entries
+                if outcome is not ResolutionOutcome.AMBIGUOUS_CANDIDATES
             )
+            ambiguous_ids = tuple(
+                mention_id
+                for mention_id, outcome in omitted_blocking_entries
+                if outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+            )
+            warnings: tuple[str, ...] = ()
+            if unresolved_ids:
+                warnings += (
+                    "one or more named subjects could not be resolved and "
+                    "were omitted from this set",
+                )
+            if ambiguous_ids:
+                warnings += (
+                    "one or more named subjects were ambiguous and were "
+                    "omitted from this set",
+                )
             subject_set = self._scope_service.committed_subject_set_for(
                 unique_entities,
                 set_id=self._mint_id(),
                 original_mention_count=len(mentions),
                 unresolved_mention_ids=unresolved_ids,
-                warnings=(
-                    (
-                        "one or more named subjects could not be resolved and "
-                        "were omitted from this set",
-                    )
-                    if unresolved_ids
-                    else ()
-                ),
+                ambiguous_mention_ids=ambiguous_ids,
+                warnings=warnings,
             )
             return self._terminate(
                 interpretation=interpretation,

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -50,12 +50,14 @@ from .contracts import (
     ToolID,
 )
 from .contracts_v2 import (
+    Cardinality,
     DevAnswerV2,
     DevEntityRefV2,
     DevResolutionCandidate,
     DevResolutionEntry,
     DevResolutionLedger,
     DevSubjectMention,
+    DevSubjectSet,
     PublicOutcome,
     ResolutionOutcome,
     validate_ledger_extends,
@@ -69,10 +71,10 @@ from .preflight_outcomes import (
     PREFLIGHT_OUTCOME_BY_RESOLUTION,
     build_preflight_answer,
 )
-from .question_interpreter import InterpretedQuestion, QuestionInterpreter
+from .question_interpreter import MAX_MENTIONS, InterpretedQuestion, QuestionInterpreter
 from .scope_service import (
+    DIRECT_SCOPE_KINDS,
     SEARCHABLE_ENTITY_KINDS,
-    V1_SEARCHABLE_ENTITY_KINDS,
     AuthorizedEntity,
     EntityKind,
     MentionResolution,
@@ -80,7 +82,9 @@ from .scope_service import (
 )
 
 __all__ = [
+    "PREFLIGHT_DIAGNOSTICS",
     "SUBJECT_BEARING_TOOLS",
+    "CommittedSubjects",
     "PreflightDecision",
     "SubjectPreflight",
     "SubjectPreflightResult",
@@ -114,21 +118,82 @@ class PreflightDecision(StrEnum):
     TERMINATE = "terminate"
 
 
+#: Every diagnostic this module can emit — content-free codes recorded on
+#: ``dev_runs.preflight_outcome``, a ``String(32)`` column with no CHECK
+#: constraint. A diagnostic over 32 characters is a real insert-time failure
+#: in production and passes every unit test that never persists a run
+#: (CHAOS-3292's "interpreter_clarification_required", 34 chars, was exactly
+#: that — fixed alongside this closed tuple). Kept literal, not derived from
+#: an f-string template, so a new diagnostic is always visible here and the
+#: length test below is exhaustive.
+PREFLIGHT_DIAGNOSTICS: tuple[str, ...] = (
+    "clarification_required",
+    "proceeded_organization_wide",
+    "unresolved_ambiguous_candidates",
+    "unresolved_no_authorized_match",
+    "unresolved_catalog_unavailable",
+    "unresolved_unsupported_kind",
+    "proceeded_unresolved_bare_name",
+    "committed_kind_unsupported_in_v1",
+    "oversized_mention_set_in_v1",
+    "cohort_unsupported_in_v1",
+    "committed_cohort_v1_only",
+    "proceeded_committed_subject",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedSubjects:
+    """What the preflight committed for one run: a scope, a subject set, or both.
+
+    CHAOS-3301. Exactly one of ``resolution``/``subject_set`` is set for a
+    singular commit or a cohort respectively, except the "duplicate aliases
+    collapse to one subject" case (N4), where both are set: the run proceeds
+    on ``resolution`` (there is only one *distinct* committed entity), and
+    ``subject_set`` still records that the question named it more than once
+    (``original_mention_count`` on the persisted ``dev_subject_set.v1``).
+    """
+
+    resolution: DevScopeResolution | None
+    subject_set: DevSubjectSet | None
+
+    def __post_init__(self) -> None:
+        if self.resolution is None and self.subject_set is None:
+            raise ValueError(
+                "CommittedSubjects requires a resolution, a subject set, or both"
+            )
+
+
 @dataclass(frozen=True, slots=True)
 class SubjectPreflightResult:
     decision: PreflightDecision
     interpretation: InterpretedQuestion
     #: ``None`` only when the question named no subject at all.
     ledger: DevResolutionLedger | None
-    #: The server-committed scope, when exactly one subject resolved exactly.
+    #: The server-committed scope, when exactly one *distinct* subject
+    #: resolved exactly. ``None`` for a cohort (CHAOS-3301, D1): a committed
+    #: cohort never proceeds to tool execution on the v1 surface, so it never
+    #: has a single scope to bind — see ``subject_set`` and
+    #: ``committed_subjects`` instead.
     committed_resolution: DevScopeResolution | None
+    #: CHAOS-3301: the full committed-subject outcome (scope and/or subject
+    #: set). ``committed_resolution``/``subject_set`` are equivalent
+    #: shorthands over this, kept as separate fields because the orchestrator
+    #: and persistence each only need one half.
+    committed_subjects: CommittedSubjects | None = None
+    #: The persisted ``dev_subject_set.v1``, present whenever the question
+    #: named more than one mention (a cohort, complete or partial; or
+    #: duplicate aliases of one entity) — regardless of whether the run then
+    #: proceeds (N4) or terminates unsupported (D1).
+    subject_set: DevSubjectSet | None = None
     #: Present only for ``TERMINATE``.
-    answer: DevAnswerV2 | None
-    outcome: PublicOutcome | None
+    answer: DevAnswerV2 | None = None
+    outcome: PublicOutcome | None = None
     #: The per-run tool allowlist the model round is held to.
-    allowed_tools: frozenset[ToolID]
-    #: Content-free code recorded on the run row. Never question or entity text.
-    diagnostic: str
+    allowed_tools: frozenset[ToolID] = frozenset()
+    #: Content-free code recorded on the run row. Never question or entity
+    #: text. Always a member of ``PREFLIGHT_DIAGNOSTICS``.
+    diagnostic: str = ""
     #: Mention IDs whose lack of a committed subject must block a
     #: subject-bearing tool. Excludes unresolved *untyped* mentions, which we
     #: are not confident were subjects at all.
@@ -234,7 +299,13 @@ class SubjectPreflight:
                 interpretation=interpretation,
                 ledger=None,
                 outcome=PublicOutcome.NEEDS_CLARIFICATION,
-                diagnostic="interpreter_clarification_required",
+                # CHAOS-3301 fix, pre-existing CHAOS-3292 bug: the previous
+                # value ("interpreter_clarification_required", 34 chars)
+                # exceeded dev_runs.preflight_outcome's String(32) column
+                # with no CHECK constraint -- a real insert-time failure for
+                # every clarification-required run, caught by the new closed
+                # PREFLIGHT_DIAGNOSTICS length test below.
+                diagnostic="clarification_required",
                 run_id=run_id,
                 answer_id=answer_id,
                 conversation_id=conversation_id,
@@ -255,6 +326,24 @@ class SubjectPreflight:
                 outcome=None,
                 allowed_tools=ALL_TOOLS,
                 diagnostic="proceeded_organization_wide",
+            )
+
+        if interpretation.total_named_mention_count > MAX_MENTIONS:
+            # Bounds are rejections, never truncations (CHAOS-3301). Without
+            # this check, `mentions` (already capped by extract_mentions) is
+            # indistinguishable from a genuinely complete cohort at exactly
+            # the bound -- a 26-subject question would silently narrate the
+            # first 25 as though nothing were omitted. Rejected before any
+            # catalog round trip.
+            return self._terminate(
+                interpretation=interpretation,
+                ledger=None,
+                outcome=PublicOutcome.UNSUPPORTED,
+                diagnostic="oversized_mention_set_in_v1",
+                run_id=run_id,
+                answer_id=answer_id,
+                conversation_id=conversation_id,
+                generated_at=generated_at,
             )
 
         await phase(RunState.RESOLVING_SUBJECTS)
@@ -309,25 +398,41 @@ class SubjectPreflight:
             for mention in mentions
             if mention.mention_id in untyped_ids
         )
-        # Precedence: the lowest-ordinal unresolved mention wins. Stable and
-        # explainable ("the first thing you named"), and independent of catalog
-        # latency — a severity ordering would let a slow catalog change the
-        # reported outcome between runs, which directly breaks determinism.
-        for mention in mentions:
-            if mention.mention_id not in blocking_ids:
-                continue
-            entry = latest[mention.mention_id]
-            if entry.outcome in UNRESOLVED_OUTCOMES:
-                return self._terminate(
-                    interpretation=interpretation,
-                    ledger=ledger,
-                    outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
-                    diagnostic=f"unresolved_{entry.outcome.value}",
-                    run_id=run_id,
-                    answer_id=answer_id,
-                    conversation_id=conversation_id,
-                    generated_at=generated_at,
-                )
+        # D2 (Amendment TRD v2 line 154, CHAOS-3301): for a plural/cohort
+        # question with at least two exactly-resolved mentions, an unresolved
+        # typed mention no longer terminates the run — it is recorded as
+        # omitted on the eventual subject set instead. Singular behavior (one
+        # named subject) is unchanged: the lowest-ordinal unresolved mention
+        # still terminates immediately, exactly as A6 established. Stable and
+        # explainable ("the first thing you named"), and independent of
+        # catalog latency — a severity ordering would let a slow catalog
+        # change the reported outcome between runs, which directly breaks
+        # determinism.
+        exact_match_count = sum(
+            1
+            for mention in mentions
+            if mention.mention_id in blocking_ids
+            and latest[mention.mention_id].outcome is ResolutionOutcome.EXACT_MATCH
+        )
+        cohort_may_proceed_partial = (
+            intent.cardinality is Cardinality.PLURAL_COHORT and exact_match_count >= 2
+        )
+        if not cohort_may_proceed_partial:
+            for mention in mentions:
+                if mention.mention_id not in blocking_ids:
+                    continue
+                entry = latest[mention.mention_id]
+                if entry.outcome in UNRESOLVED_OUTCOMES:
+                    return self._terminate(
+                        interpretation=interpretation,
+                        ledger=ledger,
+                        outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
+                        diagnostic=f"unresolved_{entry.outcome.value}",
+                        run_id=run_id,
+                        answer_id=answer_id,
+                        conversation_id=conversation_id,
+                        generated_at=generated_at,
+                    )
 
         if unresolved_untyped:
             # A bare name we could not resolve is not proof of a subject, so
@@ -368,17 +473,26 @@ class SubjectPreflight:
                 diagnostic="proceeded_unresolved_bare_name",
             )
 
-        committed = [
-            latest[mention.mention_id].committed_entity_ref for mention in mentions
+        # All exactly-resolved mentions, not only blocking (typed) ones: by
+        # this point any untyped mention is either exact_match or absent
+        # entirely (`unresolved_untyped` already returned above otherwise),
+        # so a resolved bare name commits exactly as a resolved typed one
+        # does — matching pre-CHAOS-3301 behavior (A-series "resolvable bare
+        # name commits a subject").
+        committed_entries = [
+            (mention, latest[mention.mention_id])
+            for mention in mentions
+            if latest[mention.mention_id].outcome is ResolutionOutcome.EXACT_MATCH
         ]
-        kinds = {ref.entity_kind for ref in committed if ref is not None}
-        if any(
-            EntityKind(kind.value) not in V1_SEARCHABLE_ENTITY_KINDS for kind in kinds
-        ):
-            # Interim TEAM semantics (CHAOS-3301 owns the rest): the ledger
-            # already records exact_match with a team ref — the team
-            # demonstrably exists — but no v1 DevScope can carry a team
-            # subject. Never not_found, never organization fallback.
+        kinds: set[ContractEntityKind] = set()
+        for _mention, entry in committed_entries:
+            assert entry.committed_entity_ref is not None  # exact_match guarantees this
+            kinds.add(entry.committed_entity_ref.entity_kind)
+        if any(EntityKind(kind.value) not in DIRECT_SCOPE_KINDS for kind in kinds):
+            # A defensive totality check, not a live branch today: every
+            # SEARCHABLE_ENTITY_KINDS member (including TEAM, CHAOS-3301) has
+            # a v1 DevScope representation. Guards against a future v2-only
+            # kind reaching here before it gets one.
             return self._terminate(
                 interpretation=interpretation,
                 ledger=ledger,
@@ -389,38 +503,106 @@ class SubjectPreflight:
                 conversation_id=conversation_id,
                 generated_at=generated_at,
             )
-        if len(committed) > 1:
-            # A cohort has no faithful v1 representation either: a v1 DevScope
-            # names one direct subject. The landed v2-to-v1 projector reaches
-            # the same conclusion independently for ``subject_set_ref``
-            # ("Cohort-scoped Ask Dev answers require a newer client"), and
-            # committing only the first of several named subjects is precisely
-            # the fabricated-premise shape this issue exists to close.
-            # CHAOS-3301 owns subject sets and batch execution.
+
+        # Dedup by (kind, canonical id): duplicate aliases of the same entity
+        # collapse to one committed subject (N4) — the *distinct* subject
+        # count is what determines singular-vs-cohort, not the raw mention
+        # count. Insertion order is preserved (first-seen entity wins the
+        # position), which keeps this deterministic across runs.
+        unique_by_id: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+        for _mention, entry in committed_entries:
+            entity = self._authorized_entity_for(entry)
+            unique_by_id.setdefault((entity.kind, entity.canonical_id), entity)
+        unique_entities = list(unique_by_id.values())
+        unique_kinds = {entity.kind for entity in unique_entities}
+
+        if len(unique_entities) > 1:
+            if len(unique_kinds) > 1:
+                # A heterogeneous set has no faithful v1 representation and
+                # is a non-goal outright (never even a committed set): a
+                # ``dev_subject_set.v1`` must be homogeneous in entity kind.
+                # The landed v2-to-v1 projector reaches the same conclusion
+                # independently for ``subject_set_ref`` ("Cohort-scoped Ask
+                # Dev answers require a newer client").
+                return self._terminate(
+                    interpretation=interpretation,
+                    ledger=ledger,
+                    outcome=PublicOutcome.UNSUPPORTED,
+                    diagnostic="cohort_unsupported_in_v1",
+                    run_id=run_id,
+                    answer_id=answer_id,
+                    conversation_id=conversation_id,
+                    generated_at=generated_at,
+                )
+            # A homogeneous, bounded cohort: commit and persist the subject
+            # set, but the v1 surface still returns unsupported (D1) —
+            # rendering a cohort answer is CHAOS-3297/3298's job, not this
+            # issue's. "committed" (not "cohort_unsupported") is the honest
+            # distinction: we did commit every resolvable member, and cannot
+            # render it here, rather than refusing outright.
+            unresolved_ids = tuple(
+                mention.mention_id
+                for mention in mentions
+                if mention.mention_id in blocking_ids
+                and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+            )
+            subject_set = self._scope_service.committed_subject_set_for(
+                unique_entities,
+                set_id=self._mint_id(),
+                original_mention_count=len(mentions),
+                unresolved_mention_ids=unresolved_ids,
+                warnings=(
+                    (
+                        "one or more named subjects could not be resolved and "
+                        "were omitted from this set",
+                    )
+                    if unresolved_ids
+                    else ()
+                ),
+            )
             return self._terminate(
                 interpretation=interpretation,
                 ledger=ledger,
                 outcome=PublicOutcome.UNSUPPORTED,
-                diagnostic="cohort_unsupported_in_v1",
+                diagnostic="committed_cohort_v1_only",
                 run_id=run_id,
                 answer_id=answer_id,
                 conversation_id=conversation_id,
                 generated_at=generated_at,
+                subject_set=subject_set,
             )
 
-        entry = latest[mentions[0].mention_id]
-        entity = self._authorized_entity_for(entry)
+        # Exactly one *distinct* committed subject — a singular commit, even
+        # if the question named it more than once (N4: duplicate aliases).
+        entity = unique_entities[0]
         committed_resolution = self._scope_service.committed_resolution_for(
             entity,
             org_id=org_id,
             base_scope=authorized_scope,
             resolved_at=generated_at,
         )
+        # The subject set here is audit-only: it exists so a duplicate-alias
+        # question's original mention count is not lost, not because this run
+        # is a cohort — it never blocks execution, unlike the >1-distinct
+        # branch above.
+        audit_subject_set: DevSubjectSet | None = (
+            self._scope_service.committed_subject_set_for(
+                unique_entities,
+                set_id=self._mint_id(),
+                original_mention_count=len(mentions),
+            )
+            if len(mentions) > 1
+            else None
+        )
         return SubjectPreflightResult(
             decision=PreflightDecision.PROCEED,
             interpretation=interpretation,
             ledger=ledger,
             committed_resolution=committed_resolution,
+            committed_subjects=CommittedSubjects(
+                resolution=committed_resolution, subject_set=audit_subject_set
+            ),
+            subject_set=audit_subject_set,
             answer=None,
             outcome=None,
             # With a subject already committed there is nothing left for the
@@ -705,6 +887,7 @@ class SubjectPreflight:
         conversation_id: str,
         generated_at: datetime,
         clarification_key: str = "ambiguous",
+        subject_set: DevSubjectSet | None = None,
     ) -> SubjectPreflightResult:
         answer = build_preflight_answer(
             outcome=outcome,
@@ -721,6 +904,12 @@ class SubjectPreflight:
             interpretation=interpretation,
             ledger=ledger,
             committed_resolution=None,
+            committed_subjects=(
+                CommittedSubjects(resolution=None, subject_set=subject_set)
+                if subject_set is not None
+                else None
+            ),
+            subject_set=subject_set,
             answer=answer,
             outcome=outcome,
             allowed_tools=frozenset(),

--- a/src/dev_health_ops/api/graphql/resolvers/dev_scope.py
+++ b/src/dev_health_ops/api/graphql/resolvers/dev_scope.py
@@ -9,6 +9,7 @@ import strawberry
 
 from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
 from dev_health_ops.api.dev.scope_service import (
+    GRAPHQL_SEARCHABLE_ENTITY_KINDS,
     EntityKind,
     ScopeRequestCache,
     ScopeResolutionService,
@@ -75,6 +76,11 @@ async def resolve_dev_scope_search(
             query=input.query,
             kinds=tuple(EntityKind(kind.value) for kind in input.kinds),
             limit=input.limit,
+            # Pinned explicitly (CHAOS-3301 review fix) rather than riding
+            # ScopeSearchRequest's V1 default: this is the GraphQL surface's
+            # own policy, and it must stay independently pinned even if the
+            # V1/model/GraphQL searchable sets later diverge.
+            allowed_kinds=GRAPHQL_SEARCHABLE_ENTITY_KINDS,
         ),
     )
     return DevScopeSearchResult(

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -448,8 +448,14 @@ async def run_preflight_orchestrator(
     org_id: str = ORG_ID,
     fail_search: bool = False,
     preflight_enabled: bool = True,
+    recorder_factory: Callable[[], Recorder] = Recorder,
 ) -> RunOutput:
-    """One full orchestrator run with the preflight wired the way production wires it."""
+    """One full orchestrator run with the preflight wired the way production wires it.
+
+    ``recorder_factory`` defaults to the plain ``Recorder`` above; CHAOS-3301's
+    harness passes a subclass that also captures ``record_subject_set`` calls,
+    without duplicating this whole function for one extra capture point.
+    """
 
     catalog = SeededCatalog(entities, fail_search=fail_search)
     scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
@@ -481,7 +487,7 @@ async def run_preflight_orchestrator(
     provider = RecordingProvider(
         (script or status_then_answer)(script_id), script_id=script_id
     )
-    recorder = Recorder()
+    recorder = recorder_factory()
     orchestrator = DevOrchestrator(
         provider=provider,
         provider_source="platform",

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -36,6 +36,7 @@ from dev_health_ops.api.dev.contracts import (
     QuestionClass,
     ToolID,
 )
+from dev_health_ops.api.dev.contracts_v2 import DevSubjectSet
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator, OrchestratorResult
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
@@ -344,6 +345,10 @@ class Recorder:
         self, *, preflight_outcome: str | None, legacy_guard_reason: str | None
     ) -> None:
         self.preflight_diagnostics.append((preflight_outcome, legacy_guard_reason))
+
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        """No-op here; CHAOS-3301's SubjectSetRecorder subclass captures this."""
+        del subject_set
 
     async def terminal(self, **values: Any) -> None:
         self.terminals.append(values["state"])

--- a/tests/_chaos_3301_subjects.py
+++ b/tests/_chaos_3301_subjects.py
@@ -19,6 +19,8 @@ from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
 from tests._chaos_3292_preflight import (
     ANSWER_ID,
     ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
     CONVERSATION_ID,
     ORG_ID,
     OTHER_ORG_ID,
@@ -71,6 +73,9 @@ __all__ = [
     "case_p1_known_team_singular",
     "case_p2_two_project_cohort",
     "case_p3_partial_project_cohort",
+    "case_r1_duplicate_alias_with_unresolved_mention",
+    "case_r2_twentyfive_typed_plus_resolvable_bare_name",
+    "case_r3_ambiguous_mention_in_cohort",
     "fixed_now",
     "organization_resolution",
     "recording_registry",
@@ -241,4 +246,82 @@ async def case_n0_team_facts_or_typed_not_applicable() -> RunOutput:
         question="What is the status of the Platform team?",
         entities=[(ORG_ID, PLATFORM_TEAM)],
         script_id="n0",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial-review regression cases (CHAOS-3301 review findings)
+# ---------------------------------------------------------------------------
+
+
+async def case_r1_duplicate_alias_with_unresolved_mention() -> RunOutput:
+    """Two aliases of one entity, plus a third mention that never resolves.
+
+    Regression for the review's HIGH finding: D2's ">=2" threshold counted
+    raw exact-match *mentions*, not distinct committed *entities*, so the two
+    Halo aliases alone satisfied it and let the run skip past the unresolved
+    ``Vesta`` mention instead of terminating on it -- then the post-dedup
+    singular branch (only one distinct entity survives dedup) committed Halo
+    as though nothing had been omitted. With exactly one distinct entity
+    here, D2 must not activate at all; the pre-D2 lowest-ordinal termination
+    rule applies, exactly as it would with no aliasing.
+    """
+
+    return await run_preflight_orchestrator(
+        question=(
+            'Compare project Halo and project "project-halo" and project '
+            f"{VESTA_PROJECT_NAME}"
+        ),
+        entities=[(ORG_ID, HALO_PROJECT)],
+        script_id="r1",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_r2_twentyfive_typed_plus_resolvable_bare_name() -> RunOutput:
+    """25 typed subjects plus one resolvable bare name -- 26 total.
+
+    Regression for the review's HIGH finding: the uncapped mention count only
+    summed the *typed* grammar candidates, so ``_add_untyped_mentions``
+    silently dropping the 26th (bare-name) candidate at the ``MAX_MENTIONS``
+    merge cap left the oversized-rejection check looking at 25, not 26, and
+    the run reported a "complete" 25-subject cohort instead of rejecting an
+    oversized one.
+    """
+
+    entities = _oversized_project_entities(25)
+    entities.append(
+        (ORG_ID, AuthorizedEntity(EntityKind.PROJECT, "project-nightfall", "Nightfall"))
+    )
+    names = [f"project Alpha{index:02d}" for index in range(25)]
+    question = "Compare " + " and ".join(names) + " and Nightfall"
+    return await run_preflight_orchestrator(
+        question=question,
+        entities=entities,
+        script_id="r2",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_r3_ambiguous_mention_in_cohort() -> RunOutput:
+    """A cohort with one committed pair and one ambiguous (not unresolved) mention.
+
+    Regression for the review's MEDIUM finding: every ``UNRESOLVED_OUTCOMES``
+    member (including ``AMBIGUOUS_CANDIDATES``) was copied into the set's
+    ``unresolved_mention_ids`` with the generic "could not be resolved"
+    warning. Ambiguity is a distinct, separately-fielded outcome
+    (``ambiguous_mention_ids`` plus its own warning) that this must not
+    collapse into.
+    """
+
+    return await run_preflight_orchestrator(
+        question="Compare project Halo and project Nova and project Atlas",
+        entities=[
+            (ORG_ID, HALO_PROJECT),
+            (ORG_ID, NOVA_PROJECT),
+            (ORG_ID, ATLAS_PROJECT_ONE),
+            (ORG_ID, ATLAS_PROJECT_TWO),
+        ],
+        script_id="r3",
+        recorder_factory=SubjectSetRecorder,
     )

--- a/tests/_chaos_3301_subjects.py
+++ b/tests/_chaos_3301_subjects.py
@@ -1,0 +1,244 @@
+"""Shared deterministic harness for the CHAOS-3301 team-scope/cohort suites.
+
+Clones the shape of ``tests/_chaos_3292_preflight`` (same underscore-prefixed
+placement, same ``SeededCatalog``/``RecordingProvider``/``recording_registry``/
+``run_preflight_orchestrator`` primitives) and imports the org/user/catalog
+constants from it directly rather than redefining them, so both suites stay
+consistent about what "the organization" and "the catalog" mean.
+
+New entities and case factories here are specific to CHAOS-3301: a named team
+as a direct subject, bounded multi-subject (cohort) sets, and the structural
+regression that a legacy ``team_ids`` filter must never become a committed
+subject.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.api.dev.contracts_v2 import DevSubjectSet
+from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
+from tests._chaos_3292_preflight import (
+    ANSWER_ID,
+    ASK_DEV_PROJECT,
+    CONVERSATION_ID,
+    ORG_ID,
+    OTHER_ORG_ID,
+    PERMISSION_FINGERPRINT,
+    PLATFORM_TEAM,
+    RUN_ID,
+    USER_ID,
+    Recorder,
+    RecordingProvider,
+    RunOutput,
+    SeededCatalog,
+    answer_payload,
+    fixed_now,
+    organization_resolution,
+    recording_registry,
+    request_for,
+    run_preflight_orchestrator,
+    scope_dict,
+    sequential_ids,
+    status_then_answer,
+    versions,
+)
+
+__all__ = [
+    "ANSWER_ID",
+    "ASK_DEV_PROJECT",
+    "CONVERSATION_ID",
+    "HALO_PROJECT",
+    "NOVA_PROJECT",
+    "ORG_ID",
+    "OTHER_ORG_ID",
+    "PERMISSION_FINGERPRINT",
+    "PLATFORM_TEAM",
+    "RIVAL_TEAM",
+    "RUN_ID",
+    "USER_ID",
+    "VESTA_PROJECT_NAME",
+    "Recorder",
+    "RecordingProvider",
+    "RunOutput",
+    "SeededCatalog",
+    "SubjectSetRecorder",
+    "answer_payload",
+    "case_n0_team_facts_or_typed_not_applicable",
+    "case_n1_cross_tenant_team",
+    "case_n2_mixed_kind_set",
+    "case_n3_oversized_project_set",
+    "case_n4_duplicate_aliases_one_entity",
+    "case_n5_team_filter_is_not_a_subject",
+    "case_p1_known_team_singular",
+    "case_p2_two_project_cohort",
+    "case_p3_partial_project_cohort",
+    "fixed_now",
+    "organization_resolution",
+    "recording_registry",
+    "request_for",
+    "run_preflight_orchestrator",
+    "scope_dict",
+    "sequential_ids",
+    "status_then_answer",
+    "versions",
+]
+
+#: Owned by ORG_ID. Two homogeneous projects for the bounded-cohort controls.
+HALO_PROJECT = AuthorizedEntity(EntityKind.PROJECT, "project-halo", "Halo")
+NOVA_PROJECT = AuthorizedEntity(EntityKind.PROJECT, "project-nova", "Nova")
+#: Named in a question but never seeded for ORG_ID — the partial cohort's
+#: unresolved third mention.
+VESTA_PROJECT_NAME = "Vesta"
+
+#: Owned by OTHER_ORG_ID only — the cross-tenant team control (N1). Distinct
+#: from PLATFORM_TEAM (which lives under ORG_ID) so a catalog bug that leaked
+#: cross-tenant would be caught by name, not just by id.
+RIVAL_TEAM = AuthorizedEntity(EntityKind.TEAM, "team-rival", "Rival")
+
+
+class SubjectSetRecorder(Recorder):
+    """``Recorder`` plus a capture point for ``record_subject_set``.
+
+    The orchestrator does not call this today (CHAOS-3301 wires it); the
+    capture list stays empty until that wiring lands, which is itself part of
+    what the cohort controls (P2/P3/N4) are RED against.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.subject_sets: list[DevSubjectSet] = []
+
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        self.subject_sets.append(subject_set)
+
+
+def _oversized_project_question(count: int) -> str:
+    """A question naming ``count`` distinct capitalized project mentions.
+
+    Each ``project AlphaNN`` is an independent noun-leading match in the
+    question-interpreter grammar (see ``question_interpreter._NOUN_LEADING``),
+    so this reliably produces ``count`` candidate mentions before any
+    extraction-time cap is applied.
+    """
+
+    names = [f"project Alpha{index:02d}" for index in range(count)]
+    return "What is the status of " + " and ".join(names) + "?"
+
+
+def _oversized_project_entities(
+    count: int,
+) -> list[tuple[str, AuthorizedEntity]]:
+    return [
+        (
+            ORG_ID,
+            AuthorizedEntity(
+                EntityKind.PROJECT, f"project-alpha-{index:02d}", f"Alpha{index:02d}"
+            ),
+        )
+        for index in range(count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The named CHAOS-3301 case factories
+# ---------------------------------------------------------------------------
+
+
+async def case_p1_known_team_singular() -> RunOutput:
+    """A known team, asked about on its own — a direct singular subject."""
+
+    return await run_preflight_orchestrator(
+        question="How is the Platform team doing?",
+        entities=[(ORG_ID, PLATFORM_TEAM)],
+        script_id="p1",
+    )
+
+
+async def case_n1_cross_tenant_team() -> RunOutput:
+    """A real team that exists, but only for a different tenant."""
+
+    return await run_preflight_orchestrator(
+        question="How is the Rival team doing?",
+        entities=[(OTHER_ORG_ID, RIVAL_TEAM), (ORG_ID, PLATFORM_TEAM)],
+        script_id="n1",
+    )
+
+
+async def case_p2_two_project_cohort() -> RunOutput:
+    """Two known projects, named together — a complete bounded cohort."""
+
+    return await run_preflight_orchestrator(
+        question="Compare project Halo and project Nova",
+        entities=[(ORG_ID, HALO_PROJECT), (ORG_ID, NOVA_PROJECT)],
+        script_id="p2",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_p3_partial_project_cohort() -> RunOutput:
+    """Two resolve, one does not — a partial cohort, disclosed not widened."""
+
+    return await run_preflight_orchestrator(
+        question=(
+            f"Compare project Halo and project Nova and project {VESTA_PROJECT_NAME}"
+        ),
+        entities=[(ORG_ID, HALO_PROJECT), (ORG_ID, NOVA_PROJECT)],
+        script_id="p3",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_n2_mixed_kind_set() -> RunOutput:
+    """One project and one team, named together — never a supported set."""
+
+    return await run_preflight_orchestrator(
+        question="Compare project Halo and the Platform team",
+        entities=[(ORG_ID, HALO_PROJECT), (ORG_ID, PLATFORM_TEAM)],
+        script_id="n2",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_n3_oversized_project_set(count: int = 26) -> RunOutput:
+    """More projects than the ``dev_subject_set.v1`` bound admits."""
+
+    return await run_preflight_orchestrator(
+        question=_oversized_project_question(count),
+        entities=_oversized_project_entities(count),
+        script_id="n3",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_n4_duplicate_aliases_one_entity() -> RunOutput:
+    """The same project named twice, by two different spans."""
+
+    return await run_preflight_orchestrator(
+        question='Compare project Halo and project "project-halo"',
+        entities=[(ORG_ID, HALO_PROJECT)],
+        script_id="n4",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_n5_team_filter_is_not_a_subject() -> RunOutput:
+    """A legacy ``team_ids`` filter alongside an organization-wide question."""
+
+    return await run_preflight_orchestrator(
+        question="How are we doing on delivery this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, PLATFORM_TEAM)],
+        scope_overrides={
+            "direct_scope": "organization",
+            "team_ids": [PLATFORM_TEAM.canonical_id],
+        },
+        script_id="n5",
+    )
+
+
+async def case_n0_team_facts_or_typed_not_applicable() -> RunOutput:
+    """A committed team subject must never answer from silent zero rows."""
+
+    return await run_preflight_orchestrator(
+        question="What is the status of the Platform team?",
+        entities=[(ORG_ID, PLATFORM_TEAM)],
+        script_id="n0",
+    )

--- a/tests/_chaos_3301_subjects.py
+++ b/tests/_chaos_3301_subjects.py
@@ -76,6 +76,8 @@ __all__ = [
     "case_r1_duplicate_alias_with_unresolved_mention",
     "case_r2_twentyfive_typed_plus_resolvable_bare_name",
     "case_r3_ambiguous_mention_in_cohort",
+    "case_r4a_twentyfive_all_untyped_names",
+    "case_r4b_twentysix_all_untyped_names",
     "fixed_now",
     "organization_resolution",
     "recording_registry",
@@ -127,6 +129,33 @@ def _oversized_project_question(count: int) -> str:
 
     names = [f"project Alpha{index:02d}" for index in range(count)]
     return "What is the status of " + " and ".join(names) + "?"
+
+
+def _all_untyped_question(count: int) -> str:
+    """A question naming ``count`` distinct subjects with no kind noun at all.
+
+    Each name is quoted, so it is found only by ``untyped_name_candidates``
+    (the kind-noun grammar never matches it) -- this is the review's
+    all-untyped repro shape, where the uncapped candidate count used to be
+    silently truncated inside ``untyped_name_candidates`` itself (CHAOS-3301
+    review fix), not merely inside the merge step that caps mentions at
+    ``MAX_MENTIONS``.
+    """
+
+    names = [f'"Bravo{index:02d}"' for index in range(count)]
+    return "Compare " + " and ".join(names)
+
+
+def _all_untyped_entities(count: int) -> list[tuple[str, AuthorizedEntity]]:
+    return [
+        (
+            ORG_ID,
+            AuthorizedEntity(
+                EntityKind.PROJECT, f"project-bravo-{index:02d}", f"Bravo{index:02d}"
+            ),
+        )
+        for index in range(count)
+    ]
 
 
 def _oversized_project_entities(
@@ -323,5 +352,42 @@ async def case_r3_ambiguous_mention_in_cohort() -> RunOutput:
             (ORG_ID, ATLAS_PROJECT_TWO),
         ],
         script_id="r3",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_r4a_twentyfive_all_untyped_names() -> RunOutput:
+    """25 subjects, none typed by the kind-noun grammar -- a complete cohort.
+
+    Companion boundary case for R4b: proves the fix does not regress the
+    in-bound side once ``untyped_name_candidates`` stops truncating its own
+    result. All 25 must still commit as a complete cohort.
+    """
+
+    return await run_preflight_orchestrator(
+        question=_all_untyped_question(25),
+        entities=_all_untyped_entities(25),
+        script_id="r4a",
+        recorder_factory=SubjectSetRecorder,
+    )
+
+
+async def case_r4b_twentysix_all_untyped_names() -> RunOutput:
+    """26 subjects, none typed by the kind-noun grammar -- must be rejected.
+
+    Regression for the review verify round's HIGH finding: ``untyped_name_
+    candidates()`` truncated its own return value to ``MAX_MENTIONS`` (25)
+    *before* ``_add_untyped_mentions`` reported ``len(candidates)`` as the
+    "uncapped" total, so an all-untyped 26th subject was invisible to the
+    oversized-rejection guard even after the first fix (which only addressed
+    a *mixed* typed+untyped 26th subject). The guard must see 26, not a
+    pre-truncated 25, and reject the request instead of silently answering
+    about the first 25.
+    """
+
+    return await run_preflight_orchestrator(
+        question=_all_untyped_question(26),
+        entities=_all_untyped_entities(26),
+        script_id="r4b",
         recorder_factory=SubjectSetRecorder,
     )

--- a/tests/api/dev/test_chaos_3292_preflight_acceptance.py
+++ b/tests/api/dev/test_chaos_3292_preflight_acceptance.py
@@ -603,24 +603,31 @@ async def test_a10_a_live_context_ref_still_commits() -> None:
 
 
 # ---------------------------------------------------------------------------
-# A11 — a TEAM subject resolves, and is honestly unsupported
+# A11 — a TEAM subject resolves and commits (CHAOS-3301 superseded this
+# section: team is now a real v1 direct scope, not an interim "resolved but
+# unsupported" kind — see tests/api/dev/test_chaos_3301_controls.py's P1/N1
+# for the full CHAOS-3301 control set this A11 pair now defers to).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_a11_resolved_team_is_unsupported_never_not_found() -> None:
+async def test_a11_resolved_team_is_a_committed_subject_end_to_end() -> None:
+    from dev_health_ops.api.dev.contracts import DirectScope
+
     output = await case_a11()
 
-    assert output.result.state is RunState.FAILED
-    assert output.result.error is not None
-    # The team demonstrably exists, so "not found" would be a lie and an
-    # organization fallback would be the CHAOS-3289 defect on another kind.
-    assert output.result.error.code == "feature_not_enabled"
-    assert _subject_bearing_calls(output) == []
+    assert output.result.state is RunState.COMPLETED
+    assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
+    status_call = output.calls[0]
+    assert status_call.scope.direct_scope is DirectScope.TEAM
+    assert [ref.entity_id for ref in status_call.scope.entity_refs] == [
+        PLATFORM_TEAM.canonical_id
+    ]
 
 
 @pytest.mark.asyncio
-async def test_a11_team_resolution_records_an_exact_match_without_raising() -> None:
+async def test_a11_team_resolution_records_an_exact_match_and_commits() -> None:
+    from dev_health_ops.api.dev.contracts import DirectScope
     from dev_health_ops.api.dev.contracts_v2 import EntityKind as ContractEntityKind
     from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
     from dev_health_ops.api.dev.scope_service import (
@@ -647,8 +654,10 @@ async def test_a11_team_resolution_records_an_exact_match_without_raising() -> N
         now=fixed_now,
     )
     request = request_for("What is the status of the Platform team?")
-    # No ValueError from DirectScope(...)/EntityType(...), which have no team
-    # member: the preflight builds DevEntityRefV2 straight from the entity.
+    # No ValueError from DirectScope(...)/EntityType(...): CHAOS-3301 gave
+    # both a real TEAM member, so the preflight's committed_resolution_for
+    # now builds a genuine v1 DevScope(direct_scope=TEAM, ...) rather than
+    # only recording the exact_match ledger entry.
     result = await preflight.run(
         request=request,
         org_id=ORG_ID,
@@ -664,7 +673,12 @@ async def test_a11_team_resolution_records_an_exact_match_without_raising() -> N
     assert entry.outcome is ResolutionOutcome.EXACT_MATCH
     assert entry.committed_entity_ref is not None
     assert entry.committed_entity_ref.entity_kind is ContractEntityKind.TEAM
-    assert result.diagnostic == "committed_kind_unsupported_in_v1"
+    assert result.diagnostic == "proceeded_committed_subject"
+    assert result.committed_resolution is not None
+    committed_scope = result.committed_resolution.resolved_scope
+    assert committed_scope is not None
+    assert committed_scope.direct_scope is DirectScope.TEAM
+    assert committed_scope.team_ids == [PLATFORM_TEAM.canonical_id]
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3301_controls.py
+++ b/tests/api/dev/test_chaos_3301_controls.py
@@ -1,0 +1,670 @@
+"""CHAOS-3301 RED control battery — TEAM as a direct scope, bounded cohorts.
+
+Written and observed RED before any ``src/`` edit, per the ratified plan
+(`.claude/jobs/.../chaos-3301-plan.md`, its addendum, and Amendment 2). Every
+control asserts the *executed tool-request scope* and/or the *persisted/
+serialized state* — never a diagnostic string alone — following
+``test_chaos_3292_preflight_acceptance.py``'s style.
+
+Ratified decisions this file encodes (layered on top of the original plan
+table, per the team-lead brief):
+
+* **Addendum option (B)**: no team arm is added to ``native_status_change.py``
+  SQL. Instead a totality test/registry (``TEAM_NOT_APPLICABLE_SOURCES``) and
+  N0 prove a committed team subject is answered as typed not-applicable,
+  never silently empty.
+* **D1**: a committed *cohort* (>=2 distinct committed entities) still
+  returns ``unsupported`` on the v1 surface — diagnostic
+  ``committed_cohort_v1_only`` for a homogeneous set, unchanged
+  ``cohort_unsupported_in_v1`` for a heterogeneous one. This supersedes the
+  original plan table's P2/P3 wording ("both member scopes execute"): no
+  cohort ever reaches a subject-bearing tool in this issue. What CHAOS-3301
+  adds for a cohort is *commitment, ledger accounting, and persistence* of
+  the ``dev_subject_set.v1``, not multi-scope execution.
+* **D2**: for ``PLURAL_COHORT`` intents only, an unresolved typed mention no
+  longer terminates the run while >=2 committed refs remain; it is recorded
+  as omitted (``unresolved_mention_ids`` + ``warnings``,
+  ``cohort_complete=False``) rather than blocking.
+
+N3 (oversized set) has one further, unavoidable adjustment: both
+``DevSubjectMention.mention_ordinal`` (``le=24``) and
+``DevResolutionLedger.mention_ids`` (``max_length=25``) are contract-capped
+at 25. A ledger literally cannot carry a 26th mention id, so this suite
+cannot assert "ledger mention_ids length is 26" as the original plan text
+states. It instead asserts the *externally observable* property the plan
+cares about: a question naming more than 25 subjects is rejected as
+unsupported and discloses that it was too large, and is never silently
+narrowed to a "complete" 25-member cohort. See the test docstring for the
+exact reasoning; this is flagged as a known deviation in the implementation
+report.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.validators import scan_public_text
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
+from tests._chaos_3301_subjects import (
+    HALO_PROJECT,
+    NOVA_PROJECT,
+    ORG_ID,
+    PERMISSION_FINGERPRINT,
+    PLATFORM_TEAM,
+    RunOutput,
+    SubjectSetRecorder,
+    case_n1_cross_tenant_team,
+    case_n2_mixed_kind_set,
+    case_n3_oversized_project_set,
+    case_n4_duplicate_aliases_one_entity,
+    case_n5_team_filter_is_not_a_subject,
+    case_p1_known_team_singular,
+    case_p2_two_project_cohort,
+    case_p3_partial_project_cohort,
+)
+from tests.api.dev.test_router import dev_api_context  # noqa: F401 - pytest fixture
+
+DETERMINISM_ITERATIONS = 20
+#: build_production_runtime's flag check parses org_id as a UUID
+#: (production_runtime._wave_3_1_enabled -> uuid.UUID(org_id)); the shared
+#: harness's ORG_ID ("org_fullchaos") is not one, so G2 needs its own.
+_G2_ORG_ID = str(uuid.uuid4())
+
+
+def _subject_bearing_calls(output: RunOutput) -> list[str]:
+    return [
+        request.tool_id.value
+        for request in output.calls
+        if request.tool_id in SUBJECT_BEARING_TOOLS
+    ]
+
+
+def _public_strings(output: RunOutput) -> list[str]:
+    values: list[str] = []
+    if output.result.error is not None:
+        values.append(output.result.error.safe_message)
+        values.append(output.result.error.code)
+        values.extend(output.result.error.remediation)
+    if output.result.answer is not None:
+        values.append(output.result.answer.direct_summary)
+        values.extend(claim.text for claim in output.result.answer.claims)
+        values.extend(output.result.answer.warnings)
+    return values
+
+
+async def _twenty(coro_factory: Any) -> list[tuple[Any, ...]]:
+    results = [(await coro_factory()).outcome_tuple() for _ in range(20)]
+    # Rule 4: a measurement that did not happen must fail loudly.
+    assert len(results) == DETERMINISM_ITERATIONS
+    return results
+
+
+# ---------------------------------------------------------------------------
+# P1 — a known team is a committed direct subject end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p1_team_commits_and_status_executes_team_scope() -> None:
+    from dev_health_ops.api.dev.contracts import DirectScope
+
+    output = await case_p1_known_team_singular()
+
+    assert output.result.state is RunState.COMPLETED
+    assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
+    status_call = output.calls[0]
+    # RED: DirectScope.TEAM does not exist yet (CHAOS-3301 adds it).
+    assert status_call.scope.direct_scope is DirectScope.TEAM  # type: ignore[attr-defined]
+    assert [ref.entity_id for ref in status_call.scope.entity_refs] == [
+        PLATFORM_TEAM.canonical_id
+    ]
+    assert output.recorder is not None
+    assert output.recorder.transitions.index(
+        RunState.RESOLVING_SUBJECTS
+    ) < output.recorder.transitions.index(RunState.TOOL_EXECUTION)
+
+
+@pytest.mark.asyncio
+async def test_p1_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_p1_known_team_singular)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# P1w / G1 — the whole request path, endpoint to executed tool scope
+#
+# Amendment 2 correction: a router-level assertion alone would prove nothing
+# about the real path, since every existing router test injects
+# FakeBoundedRuntime and every orchestrator-seam test bypasses the router
+# entirely. This constructs a REAL BoundedDevRuntime (real SubjectPreflight,
+# real ScopeResolutionService over a seeded catalog, a scripted-but-real
+# provider, a recording tool registry) and drives one HTTP request through
+# the real FastAPI app.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p1w_endpoint_to_executed_tool_scope_is_team(
+    dev_api_context: Any,  # noqa: F811 - pytest fixture, imported above for reuse
+) -> None:
+    from dev_health_ops.api.dev import router as dev_router_module
+    from dev_health_ops.api.dev.contracts import DevToolRequest, DirectScope
+    from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+    from dev_health_ops.api.dev.runtime import BoundedDevRuntime
+    from dev_health_ops.api.dev.scope_service import (
+        AuthorizedEntity,
+        EntityKind,
+        ScopeRequestCache,
+        ScopeResolutionService,
+    )
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from tests._chaos_3292_preflight import (
+        RecordingProvider,
+        SeededCatalog,
+        fixed_now,
+        recording_registry,
+        sequential_ids,
+        status_then_answer,
+        versions,
+    )
+    from tests.api.dev.test_router import FakeBoundedRuntime, _parse_sse_events
+
+    org_id = str(dev_api_context.org_id)
+    team = AuthorizedEntity(EntityKind.TEAM, "team-platform", "Platform")
+    mint = sequential_ids()
+    calls: list[DevToolRequest] = []
+
+    async def resolve(**_values: Any):
+        # Mirrors run_preflight_orchestrator's stand-in resolver: the request's
+        # own (organization-wide) scope, unchanged. The preflight is what
+        # narrows this to the team once the question names one.
+        raise AssertionError(
+            "scope_resolver must not be reached once preflight owns the run"
+        )
+
+    real_runtime = BoundedDevRuntime(
+        provider=cast(
+            Any,
+            RecordingProvider(status_then_answer("p1w"), script_id="p1w"),
+        ),
+        provider_source="platform",
+        provider_family="scripted",
+        registry=recording_registry(calls),
+        scope_resolver=resolve,
+        versions=versions(),
+        preflight=SubjectPreflight(
+            interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+            scope_service=ScopeResolutionService(
+                SeededCatalog([(org_id, team)]), cache=ScopeRequestCache()
+            ),
+            versions=versions(),
+            mint_id=mint,
+            now=fixed_now,
+        ),
+    )
+    # Anti-vacuity: a wiring mistake that silently reinstated the router's
+    # default fake runtime must not read as a pass.
+    assert not isinstance(real_runtime, FakeBoundedRuntime)
+
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(runtime=real_runtime)
+
+    scope_payload = {
+        "schema_version": "dev_scope.v1",
+        "organization_id": org_id,
+        "direct_scope": "organization",
+        "repositories": [],
+        "entity_refs": [],
+        "team_ids": [],
+        "time_range": {
+            "start": "2026-07-28T12:00:00+00:00",
+            "end": "2026-07-28T13:00:00+00:00",
+            "timezone": "UTC",
+        },
+    }
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations", json={"current_scope": scope_payload}
+    )
+    assert created.status_code == 200
+    conversation_id = created.json()["conversation_id"]
+
+    response = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages",
+        json={
+            "schema_version": "dev_message_request.v1",
+            "request_id": "request_p1w_01",
+            "client_message_id": "client_p1w_01",
+            "conversation_id": conversation_id,
+            "question": "How is the Platform team doing?",
+            "question_class": "status",
+            "scope": scope_payload,
+            "requested_metric_ids": [],
+        },
+    )
+    assert response.status_code == 200
+    events = _parse_sse_events(response.text)
+    completed = [data for name, data in events if name == "answer.completed"]
+    assert len(completed) == 1, "exactly one terminal answer.completed event"
+
+    # Both ends of the join in one run: the tool actually executed against a
+    # team scope, and the wire response says so too.
+    assert calls, "the recording registry must have recorded a real tool call"
+    # RED: DirectScope.TEAM does not exist yet (CHAOS-3301 adds it).
+    assert calls[0].scope.direct_scope is DirectScope.TEAM  # type: ignore[attr-defined]
+    assert completed[0]["answer"]["resolved_scope"]["direct_scope"] == "team"
+
+
+# ---------------------------------------------------------------------------
+# N1 — a real team, but for a different tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n1_cross_tenant_team_is_not_found_and_leaks_nothing() -> None:
+    output = await case_n1_cross_tenant_team()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+    for text in _public_strings(output):
+        assert scan_public_text(text) == []
+
+
+@pytest.mark.asyncio
+async def test_n1_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_n1_cross_tenant_team)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# P2 — a complete two-project cohort commits and persists, never executes
+#
+# Superseded per D1 from the original plan table's "both member scopes
+# execute": a committed cohort still returns unsupported on the v1 surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p2_two_project_cohort_commits_and_persists_without_executing() -> None:
+    output = await case_p2_two_project_cohort()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.preflight_outcomes() == ("committed_cohort_v1_only",)
+
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert len(output.recorder.subject_sets) == 1
+    subject_set = output.recorder.subject_sets[0]
+    assert subject_set.original_mention_count == 2
+    assert subject_set.cohort_complete is True
+    assert subject_set.unresolved_mention_ids == ()
+    assert subject_set.warnings == ()
+    committed_ids = {ref.entity_id for ref in subject_set.committed_entity_refs}
+    assert committed_ids == {HALO_PROJECT.canonical_id, NOVA_PROJECT.canonical_id}
+    import re
+
+    assert re.fullmatch(r"set1_[0-9a-f]{40}", subject_set.fingerprint)
+
+
+@pytest.mark.asyncio
+async def test_p2_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_p2_two_project_cohort)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# P3 — a partial cohort discloses omissions and never widens to org
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p3_partial_cohort_discloses_and_does_not_widen() -> None:
+    output = await case_p3_partial_project_cohort()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.preflight_outcomes() == ("committed_cohort_v1_only",)
+
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert len(output.recorder.subject_sets) == 1
+    subject_set = output.recorder.subject_sets[0]
+    assert subject_set.original_mention_count == 3
+    assert subject_set.cohort_complete is False
+    assert len(subject_set.unresolved_mention_ids) == 1
+    assert subject_set.warnings != ()
+    committed_ids = {ref.entity_id for ref in subject_set.committed_entity_refs}
+    assert committed_ids == {HALO_PROJECT.canonical_id, NOVA_PROJECT.canonical_id}
+
+    # The ledger keeps all three mentions, including the unresolved one.
+    assert output.recorder is not None
+
+
+@pytest.mark.asyncio
+async def test_p3_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_p3_partial_project_cohort)
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# N2 — a heterogeneous set never forms; both mentions still ledgered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n2_mixed_kind_set_is_unsupported_with_full_ledger() -> None:
+    output = await case_n2_mixed_kind_set()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    # Heterogeneous kinds never form a dev_subject_set.v1 at all (a non-goal).
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert output.recorder.subject_sets == []
+
+
+# ---------------------------------------------------------------------------
+# N3 — oversized sets are rejected, never silently trimmed to 25
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n3_oversized_set_is_rejected_not_trimmed() -> None:
+    """26 named subjects must never silently become a 'complete' 25-set.
+
+    Both ``DevSubjectMention.mention_ordinal`` (le=24) and
+    ``DevResolutionLedger.mention_ids`` (max_length=25) are hard contract
+    bounds — a ledger cannot literally carry 26 entries. The property this
+    test protects is therefore not "the ledger has 26 entries" (impossible)
+    but "the run does not silently answer about the first 25 and drop the
+    26th without disclosure": today's ``extract_mentions`` does exactly that
+    (truncates at ``MAX_MENTIONS`` with no signal), so this is RED against
+    the *silent-truncation* defect, not only against team/cohort support.
+    """
+
+    output = await case_n3_oversized_project_set(26)
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    # No 25-member set may be silently persisted as though it were complete.
+    assert output.recorder.subject_sets == []
+    # Today this reaches the ordinary >1-committed cohort branch and reports
+    # the same diagnostic P2 does — which is exactly the silent-truncation
+    # defect: 26 named subjects is indistinguishable from a normal 2-name
+    # cohort once extraction has already dropped the 26th. An oversized
+    # question must be diagnosed distinctly.
+    assert output.preflight_outcomes() != ("cohort_unsupported_in_v1",)
+
+
+@pytest.mark.asyncio
+async def test_n3_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(lambda: case_n3_oversized_project_set(26))
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# N4 — duplicate aliases collapse to one committed subject, and it executes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n4_duplicate_aliases_commit_once_and_execute_once() -> None:
+    from dev_health_ops.api.dev.contracts import DirectScope
+
+    output = await case_n4_duplicate_aliases_one_entity()
+
+    # Only one *distinct* subject was ever named — this is not a cohort, so
+    # it proceeds and executes exactly one scope, unlike P2/P3/N2.
+    assert output.result.state is RunState.COMPLETED
+    assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
+    assert output.calls[0].scope.direct_scope is DirectScope.PROJECT
+    assert [ref.entity_id for ref in output.calls[0].scope.entity_refs] == [
+        HALO_PROJECT.canonical_id
+    ]
+
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert len(output.recorder.subject_sets) == 1
+    subject_set = output.recorder.subject_sets[0]
+    assert subject_set.original_mention_count == 2
+    assert subject_set.cohort_complete is True
+    assert [ref.entity_id for ref in subject_set.committed_entity_refs] == [
+        HALO_PROJECT.canonical_id
+    ]
+
+
+# ---------------------------------------------------------------------------
+# N5 — a legacy team_ids filter is not a team subject (regression control)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n5_team_filter_is_not_a_team_subject() -> None:
+    output = await case_n5_team_filter_is_not_a_subject()
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.calls, "the org-wide question must still execute"
+    for call in output.calls:
+        assert call.scope.direct_scope.value == "organization"
+        assert call.scope.team_ids == [PLATFORM_TEAM.canonical_id]
+    assert output.recorder is not None
+    if isinstance(output.recorder, SubjectSetRecorder):
+        assert output.recorder.subject_sets == []
+
+
+# ---------------------------------------------------------------------------
+# N0 — a committed team subject never yields a silently empty answer
+#
+# Addendum item 4. Exercised at the real status-source seam directly (the
+# orchestrator harness's recording_registry is a fixture stub and would
+# mask the defect the addendum describes), with a fake ClickHouse client:
+# a team scope carries no repositories (Option B — attribution is
+# re-derived at query time in CHAOS-3303, not this issue), so the existing
+# "no authorized repositories" fail-closed branch is reached before any SQL
+# executes, and it already returns a typed FreshnessState.UNAVAILABLE
+# observation rather than empty rows. This control is what proves that stays
+# true once TEAM becomes a real DirectScope.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n0_team_subject_never_returns_a_silently_empty_status() -> None:
+    from datetime import UTC, datetime
+
+    from dev_health_ops.api.dev.contracts import (
+        DevEntityRef,
+        DevScope,
+        DevTimeRange,
+        DirectScope,
+        EntityType,
+        FreshnessState,
+    )
+    from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
+
+    # RED: DirectScope.TEAM / EntityType.TEAM do not exist yet (CHAOS-3301 adds them).
+    scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.TEAM,  # type: ignore[attr-defined]
+        repositories=[],
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM,  # type: ignore[attr-defined]
+                entity_id=PLATFORM_TEAM.canonical_id,
+                display_label=PLATFORM_TEAM.label,
+            )
+        ],
+        team_ids=[PLATFORM_TEAM.canonical_id],
+        time_range=DevTimeRange(
+            start=datetime(2026, 7, 1, tzinfo=UTC),
+            end=datetime(2026, 7, 31, tzinfo=UTC),
+            timezone="UTC",
+        ),
+    )
+    source = ClickHouseStatusChangeSource(cast(Any, object()))
+    snapshot = await source.status_snapshot(
+        org_id=ORG_ID, scope=scope, as_of=datetime(2026, 7, 31, tzinfo=UTC), limit=25
+    )
+
+    assert snapshot.declared is None
+    assert snapshot.source_refs, (
+        "a committed team subject must carry an explicit typed observation, "
+        "never silent zero rows"
+    )
+    assert all(
+        ref.freshness is FreshnessState.UNAVAILABLE for ref in snapshot.source_refs
+    )
+    assert snapshot.warnings, "an empty-facts team answer must disclose why"
+
+
+def test_native_status_change_scope_type_disjunctions_are_total_over_team() -> None:
+    """Structural closure: every scope_type disjunction has a team arm, or is
+    listed in TEAM_NOT_APPLICABLE_SOURCES. Without this, the next SQL constant
+    added re-opens the silent-empty-team-answer hole the addendum describes.
+    """
+
+    from dev_health_ops.api.dev import native_status_change as nsc
+
+    scope_type_constants = {
+        name: value
+        for name, value in vars(nsc).items()
+        if name.startswith("_")
+        and name.endswith("_SQL")
+        and isinstance(value, str)
+        and "scope_type" in value
+    }
+    assert scope_type_constants, "sanity: native_status_change defines scope_type SQL"
+
+    missing_team_arm = {
+        name for name, sql in scope_type_constants.items() if "'team'" not in sql
+    }
+    registry = frozenset(getattr(nsc, "TEAM_NOT_APPLICABLE_SOURCES", ()))
+    unregistered = missing_team_arm - registry
+    assert not unregistered, (
+        "every scope_type disjunction must either gate on 'team' or be listed "
+        f"in TEAM_NOT_APPLICABLE_SOURCES: {sorted(unregistered)}"
+    )
+    # And the registry itself must not claim sources that do not exist.
+    assert registry <= set(scope_type_constants), (
+        "TEAM_NOT_APPLICABLE_SOURCES names a source that is not a real "
+        "scope_type-gated SQL constant"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2 — the production flag gate that constructs the preflight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g2_flag_off_production_runtime_has_no_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.dev import production_runtime
+    from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+    from dev_health_ops.llm.agent.policy import AgentProviderSource
+
+    class _FakeProvider:
+        async def decide(self, **_values: Any) -> Any:
+            raise AssertionError("no provider call expected for a construction test")
+
+        async def aclose(self) -> None:
+            return None
+
+    async def resolve_provider(_session: Any, *, org_id: str) -> Any:
+        return ProductionProviderResolution(
+            provider=cast(Any, _FakeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes")
+
+    runtime = await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id=_G2_ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        clickhouse=cast(Any, object()),
+    )
+    try:
+        assert runtime.preflight is None
+    finally:
+        await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_g2_flag_on_production_runtime_constructs_the_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paired with the flag-off control above so the pair proves the gate
+    discriminates, rather than proving only that one side happens to work.
+    """
+
+    from dev_health_ops.api.dev import production_runtime
+    from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+    from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+    from dev_health_ops.licensing.feature_policy import (
+        FeatureDecision,
+        FeatureDecisionReason,
+    )
+    from dev_health_ops.licensing.registry import ASK_DEV_WAVE_3_1_FEATURE
+    from dev_health_ops.llm.agent.policy import AgentProviderSource
+    from tests._chaos_3292_preflight import RecordingProvider, status_then_answer
+
+    async def resolve_provider(_session: Any, *, org_id: str) -> Any:
+        return ProductionProviderResolution(
+            provider=cast(
+                Any, RecordingProvider(status_then_answer("g2"), script_id="g2")
+            ),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    async def feature_allowed(_session: Any, _org_id: Any, _key: str) -> Any:
+        return FeatureDecision(
+            feature_key=ASK_DEV_WAVE_3_1_FEATURE,
+            allowed=True,
+            reason=FeatureDecisionReason.ENABLED_BY_ORG_OVERRIDE,
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setattr(
+        production_runtime, "evaluate_org_feature_async", feature_allowed
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes")
+
+    runtime = await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id=_G2_ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        clickhouse=cast(Any, object()),
+    )
+    try:
+        assert runtime.preflight is not None
+        assert isinstance(runtime.preflight, SubjectPreflight)
+    finally:
+        await runtime.aclose()

--- a/tests/api/dev/test_chaos_3301_controls.py
+++ b/tests/api/dev/test_chaos_3301_controls.py
@@ -117,8 +117,7 @@ async def test_p1_team_commits_and_status_executes_team_scope() -> None:
     assert output.result.state is RunState.COMPLETED
     assert [request.tool_id.value for request in output.calls] == ["status_snapshot.v1"]
     status_call = output.calls[0]
-    # RED: DirectScope.TEAM does not exist yet (CHAOS-3301 adds it).
-    assert status_call.scope.direct_scope is DirectScope.TEAM  # type: ignore[attr-defined]
+    assert status_call.scope.direct_scope is DirectScope.TEAM
     assert [ref.entity_id for ref in status_call.scope.entity_refs] == [
         PLATFORM_TEAM.canonical_id
     ]
@@ -166,6 +165,7 @@ async def test_p1w_endpoint_to_executed_tool_scope_is_team(
         RecordingProvider,
         SeededCatalog,
         fixed_now,
+        organization_resolution,
         recording_registry,
         sequential_ids,
         status_then_answer,
@@ -178,13 +178,13 @@ async def test_p1w_endpoint_to_executed_tool_scope_is_team(
     mint = sequential_ids()
     calls: list[DevToolRequest] = []
 
-    async def resolve(**_values: Any):
-        # Mirrors run_preflight_orchestrator's stand-in resolver: the request's
-        # own (organization-wide) scope, unchanged. The preflight is what
-        # narrows this to the team once the question names one.
-        raise AssertionError(
-            "scope_resolver must not be reached once preflight owns the run"
-        )
+    async def resolve(*, requested_scope: Any, **_values: Any) -> Any:
+        # Mirrors run_preflight_orchestrator's stand-in resolver: authorizes
+        # the request's own (organization-wide) scope, unchanged. This is the
+        # orchestrator's *initial* authorization step, which always runs
+        # before the preflight; the preflight is what narrows the run to the
+        # team once the question names one.
+        return organization_resolution(requested_scope)
 
     real_runtime = BoundedDevRuntime(
         provider=cast(
@@ -231,7 +231,7 @@ async def test_p1w_endpoint_to_executed_tool_scope_is_team(
     created = await client.post(
         "/api/v1/dev/conversations", json={"current_scope": scope_payload}
     )
-    assert created.status_code == 200
+    assert created.status_code == 201
     conversation_id = created.json()["conversation_id"]
 
     response = await client.post(
@@ -255,9 +255,13 @@ async def test_p1w_endpoint_to_executed_tool_scope_is_team(
     # Both ends of the join in one run: the tool actually executed against a
     # team scope, and the wire response says so too.
     assert calls, "the recording registry must have recorded a real tool call"
-    # RED: DirectScope.TEAM does not exist yet (CHAOS-3301 adds it).
-    assert calls[0].scope.direct_scope is DirectScope.TEAM  # type: ignore[attr-defined]
-    assert completed[0]["answer"]["resolved_scope"]["direct_scope"] == "team"
+    assert calls[0].scope.direct_scope is DirectScope.TEAM
+    # DevAnswer.resolved_scope is a DevScopeResolution; the actual DevScope
+    # lives one level down, at .resolved_scope.
+    assert (
+        completed[0]["answer"]["resolved_scope"]["resolved_scope"]["direct_scope"]
+        == "team"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -494,15 +498,14 @@ async def test_n0_team_subject_never_returns_a_silently_empty_status() -> None:
     )
     from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
 
-    # RED: DirectScope.TEAM / EntityType.TEAM do not exist yet (CHAOS-3301 adds them).
     scope = DevScope(
         schema_version="dev_scope.v1",
         organization_id=ORG_ID,
-        direct_scope=DirectScope.TEAM,  # type: ignore[attr-defined]
+        direct_scope=DirectScope.TEAM,
         repositories=[],
         entity_refs=[
             DevEntityRef(
-                entity_type=EntityType.TEAM,  # type: ignore[attr-defined]
+                entity_type=EntityType.TEAM,
                 entity_id=PLATFORM_TEAM.canonical_id,
                 display_label=PLATFORM_TEAM.label,
             )

--- a/tests/api/dev/test_chaos_3301_review_findings.py
+++ b/tests/api/dev/test_chaos_3301_review_findings.py
@@ -1,35 +1,51 @@
 """CHAOS-3301 codex adversarial-review findings, converted to permanent tests.
 
-Three findings were confirmed by execution against the merged CHAOS-3301
-branch (report: `.claude/jobs/.../codex-review-chaos-3301.md`). Each was
-reproduced fail-before against the pre-fix code (observed to match the
-report's own recorded output byte-for-byte), fixed in ``src/``, and observed
-pass-after. This file pins the pass-after state as a permanent regression
-fence, following ``test_chaos_3301_controls.py``'s style: assert the real
-seam (executed calls, persisted subject set), never a diagnostic string
-alone.
+Five findings across two review rounds were confirmed by execution against
+the CHAOS-3301 branch (reports: `.claude/jobs/.../codex-review-chaos-3301.md`
+for R1-R3, `.claude/jobs/.../codex-verify-3301.md` for R4-R5). Each was
+reproduced fail-before against the pre-fix code, fixed in ``src/``, and
+observed pass-after. This file pins the pass-after state as a permanent
+regression fence, following ``test_chaos_3301_controls.py``'s style: assert
+the real seam (executed calls, persisted subject set), never a diagnostic
+string alone.
 
-* **HIGH** -- duplicate aliases of one entity falsely satisfied D2's
+* **HIGH (R1)** -- duplicate aliases of one entity falsely satisfied D2's
   ``>=2``-exact-match threshold (raw mention count, not distinct entities),
   letting an unresolved third mention slip past termination and the entity
   commit as a false-complete singular. Fixed in
   ``subject_preflight.py``'s D2 gate (dedup by ``(kind, canonical_id)``
   before comparing against 2).
-* **HIGH** -- the uncapped mention-count check only summed typed grammar
+* **HIGH (R2)** -- the uncapped mention-count check only summed typed grammar
   candidates, so 25 typed + 1 resolvable bare name silently truncated to a
   "complete" 25-subject set instead of a 26-subject oversized rejection.
   Fixed in ``question_interpreter.py``'s ``_add_untyped_mentions`` /
   ``interpret`` (uncapped total now includes untyped candidates).
-* **MEDIUM** -- every unresolved outcome, including ``AMBIGUOUS_CANDIDATES``,
-  was filed under ``unresolved_mention_ids`` with a generic warning. Fixed in
-  ``subject_preflight.py``'s cohort-branch omission accounting (partitioned
-  by outcome into ``unresolved_mention_ids`` vs ``ambiguous_mention_ids``).
+* **MEDIUM (R3)** -- every unresolved outcome, including
+  ``AMBIGUOUS_CANDIDATES``, was filed under ``unresolved_mention_ids`` with a
+  generic warning. Fixed in ``subject_preflight.py``'s cohort-branch
+  omission accounting (partitioned by outcome into
+  ``unresolved_mention_ids`` vs ``ambiguous_mention_ids``).
+* **HIGH (R4)** -- the R2 fix was one layer too shallow:
+  ``untyped_name_candidates()`` truncated its own return value to
+  ``MAX_MENTIONS`` internally, so an all-untyped 26th subject (no typed
+  mentions at all) was invisible to the oversized-rejection guard even after
+  R2 landed. Fixed by making ``untyped_name_candidates`` genuinely uncapped;
+  capping for the merge bound stays the caller's job.
+* **MEDIUM (R5)** -- ``DevScope.model_copy(update=...)`` bypassed
+  ``validate_direct_scope`` entirely (pydantic's base ``model_copy`` never
+  reruns validators), so a TEAM-scoped copy with a tampered ``repositories``
+  or ``team_ids`` list would construct and serialize cleanly despite the
+  invariant every other construction path (``__init__``, ``model_validate``)
+  enforces. Fixed with a revalidating ``DevScope.model_copy`` override.
 """
 
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import DevScope
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
 from tests._chaos_3301_subjects import (
@@ -40,6 +56,8 @@ from tests._chaos_3301_subjects import (
     case_r1_duplicate_alias_with_unresolved_mention,
     case_r2_twentyfive_typed_plus_resolvable_bare_name,
     case_r3_ambiguous_mention_in_cohort,
+    case_r4a_twentyfive_all_untyped_names,
+    case_r4b_twentysix_all_untyped_names,
 )
 
 DETERMINISM_ITERATIONS = 20
@@ -165,3 +183,109 @@ async def test_r3_is_deterministic_across_twenty_runs() -> None:
     ]
     assert len(results) == DETERMINISM_ITERATIONS
     assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# R4 -- an all-untyped 26th subject must be rejected as oversized (HIGH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r4a_twentyfive_all_untyped_names_commit_as_a_complete_cohort() -> None:
+    """Boundary control: 25 all-untyped subjects must still proceed."""
+
+    output = await case_r4a_twentyfive_all_untyped_names()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert output.preflight_outcomes() == ("committed_cohort_v1_only",)
+
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert len(output.recorder.subject_sets) == 1
+    subject_set = output.recorder.subject_sets[0]
+    assert len(subject_set.committed_entity_refs) == 25
+    assert subject_set.cohort_complete is True
+
+
+@pytest.mark.asyncio
+async def test_r4b_twentysix_all_untyped_names_is_rejected_as_oversized() -> None:
+    output = await case_r4b_twentysix_all_untyped_names()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.preflight_outcomes() == ("oversized_mention_set_in_v1",)
+
+    # No 25-member set may be silently persisted as a "complete" cohort --
+    # exactly the class of failure R2 fixed for a mixed typed+untyped 26th
+    # subject, reproduced here for an all-untyped 26th subject that R2 alone
+    # did not close.
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert output.recorder.subject_sets == []
+
+
+@pytest.mark.asyncio
+async def test_r4b_is_deterministic_across_twenty_runs() -> None:
+    results = [
+        (await case_r4b_twentysix_all_untyped_names()).outcome_tuple()
+        for _ in range(DETERMINISM_ITERATIONS)
+    ]
+    assert len(results) == DETERMINISM_ITERATIONS
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# R5 -- DevScope.model_copy must not bypass the TEAM invariant (MEDIUM)
+# ---------------------------------------------------------------------------
+
+
+def _team_scope_fixture() -> dict:
+    fixture = dict(positive_fixtures()["dev_scope.v1"])
+    fixture["direct_scope"] = "team"
+    fixture["repositories"] = []
+    fixture["entity_refs"] = [
+        {
+            "entity_type": "team",
+            "entity_id": "team_platform",
+            "display_label": "Platform",
+        }
+    ]
+    fixture["team_ids"] = ["team_platform"]
+    fixture["surface_context"] = None
+    return fixture
+
+
+def test_r5_model_copy_cannot_attach_a_repository_list_to_a_team_scope() -> None:
+    scope = DevScope.model_validate(_team_scope_fixture())
+
+    # Direct construction and model_validate both reject this; model_copy
+    # (pydantic's raw field copy, which never reruns validators) must too.
+    with pytest.raises(ValidationError, match="cannot carry a repository list"):
+        scope.model_copy(update={"repositories": ["repo-1"]})
+
+
+def test_r5_model_copy_cannot_widen_team_ids_on_a_team_scope() -> None:
+    scope = DevScope.model_validate(_team_scope_fixture())
+
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        scope.model_copy(update={"team_ids": ["team_platform", "team_other"]})
+
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        scope.model_copy(update={"team_ids": []})
+
+
+def test_r5_model_copy_still_supports_the_legitimate_time_range_update() -> None:
+    """Control: the two production ``model_copy`` callers only ever patch
+    time fields with an already-built ``DevTimeRange`` instance (never a raw
+    dict) -- the revalidating override must not break that path."""
+
+    scope = DevScope.model_validate(_team_scope_fixture())
+    patched_range = scope.time_range.model_copy(update={"timezone": "America/New_York"})
+
+    copied = scope.model_copy(update={"time_range": patched_range})
+
+    assert copied.time_range.timezone == "America/New_York"
+    assert copied.direct_scope == scope.direct_scope
+    assert copied.team_ids == scope.team_ids

--- a/tests/api/dev/test_chaos_3301_review_findings.py
+++ b/tests/api/dev/test_chaos_3301_review_findings.py
@@ -1,0 +1,167 @@
+"""CHAOS-3301 codex adversarial-review findings, converted to permanent tests.
+
+Three findings were confirmed by execution against the merged CHAOS-3301
+branch (report: `.claude/jobs/.../codex-review-chaos-3301.md`). Each was
+reproduced fail-before against the pre-fix code (observed to match the
+report's own recorded output byte-for-byte), fixed in ``src/``, and observed
+pass-after. This file pins the pass-after state as a permanent regression
+fence, following ``test_chaos_3301_controls.py``'s style: assert the real
+seam (executed calls, persisted subject set), never a diagnostic string
+alone.
+
+* **HIGH** -- duplicate aliases of one entity falsely satisfied D2's
+  ``>=2``-exact-match threshold (raw mention count, not distinct entities),
+  letting an unresolved third mention slip past termination and the entity
+  commit as a false-complete singular. Fixed in
+  ``subject_preflight.py``'s D2 gate (dedup by ``(kind, canonical_id)``
+  before comparing against 2).
+* **HIGH** -- the uncapped mention-count check only summed typed grammar
+  candidates, so 25 typed + 1 resolvable bare name silently truncated to a
+  "complete" 25-subject set instead of a 26-subject oversized rejection.
+  Fixed in ``question_interpreter.py``'s ``_add_untyped_mentions`` /
+  ``interpret`` (uncapped total now includes untyped candidates).
+* **MEDIUM** -- every unresolved outcome, including ``AMBIGUOUS_CANDIDATES``,
+  was filed under ``unresolved_mention_ids`` with a generic warning. Fixed in
+  ``subject_preflight.py``'s cohort-branch omission accounting (partitioned
+  by outcome into ``unresolved_mention_ids`` vs ``ambiguous_mention_ids``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
+from tests._chaos_3301_subjects import (
+    HALO_PROJECT,
+    NOVA_PROJECT,
+    RunOutput,
+    SubjectSetRecorder,
+    case_r1_duplicate_alias_with_unresolved_mention,
+    case_r2_twentyfive_typed_plus_resolvable_bare_name,
+    case_r3_ambiguous_mention_in_cohort,
+)
+
+DETERMINISM_ITERATIONS = 20
+
+
+def _subject_bearing_calls(output: RunOutput) -> list[str]:
+    return [
+        request.tool_id.value
+        for request in output.calls
+        if request.tool_id in SUBJECT_BEARING_TOOLS
+    ]
+
+
+# ---------------------------------------------------------------------------
+# R1 -- duplicate aliases must not falsely activate D2 (HIGH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r1_duplicate_alias_does_not_falsely_activate_d2() -> None:
+    output = await case_r1_duplicate_alias_with_unresolved_mention()
+
+    # The pre-D2 lowest-ordinal termination applies: with only one distinct
+    # committed entity, the unresolved "Vesta" mention must terminate the
+    # run rather than being silently omitted from a committed singular.
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert _subject_bearing_calls(output) == []
+    assert output.calls == []
+    assert output.preflight_outcomes() == ("unresolved_no_authorized_match",)
+
+    # No committed-subject state -- singular or cohort -- may be persisted
+    # for a run that terminated instead of proceeding.
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert output.recorder.subject_sets == []
+
+
+@pytest.mark.asyncio
+async def test_r1_is_deterministic_across_twenty_runs() -> None:
+    results = [
+        (await case_r1_duplicate_alias_with_unresolved_mention()).outcome_tuple()
+        for _ in range(DETERMINISM_ITERATIONS)
+    ]
+    assert len(results) == DETERMINISM_ITERATIONS
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# R2 -- 25 typed + 1 resolvable bare name is 26, and must be rejected (HIGH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r2_25_typed_plus_bare_name_is_rejected_as_oversized() -> None:
+    output = await case_r2_twentyfive_typed_plus_resolvable_bare_name()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.preflight_outcomes() == ("oversized_mention_set_in_v1",)
+
+    # No 25-member set may be silently persisted as a "complete" cohort --
+    # the whole point of the finding is that the 26th subject must never be
+    # allowed to vanish into an apparently-complete smaller set.
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert output.recorder.subject_sets == []
+
+
+@pytest.mark.asyncio
+async def test_r2_is_deterministic_across_twenty_runs() -> None:
+    results = [
+        (await case_r2_twentyfive_typed_plus_resolvable_bare_name()).outcome_tuple()
+        for _ in range(DETERMINISM_ITERATIONS)
+    ]
+    assert len(results) == DETERMINISM_ITERATIONS
+    assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# R3 -- ambiguity is filed separately from no-match/unresolved (MEDIUM)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r3_ambiguous_mention_is_filed_as_ambiguous_not_unresolved() -> None:
+    output = await case_r3_ambiguous_mention_in_cohort()
+
+    assert output.result.error is not None
+    assert output.result.error.code == "feature_not_enabled"
+    assert _subject_bearing_calls(output) == []
+    assert output.preflight_outcomes() == ("committed_cohort_v1_only",)
+
+    assert output.recorder is not None
+    assert isinstance(output.recorder, SubjectSetRecorder)
+    assert len(output.recorder.subject_sets) == 1
+    subject_set = output.recorder.subject_sets[0]
+
+    committed_ids = {ref.entity_id for ref in subject_set.committed_entity_refs}
+    assert committed_ids == {HALO_PROJECT.canonical_id, NOVA_PROJECT.canonical_id}
+    assert subject_set.cohort_complete is False
+
+    # The ambiguous "Atlas" mention must land in ambiguous_mention_ids, never
+    # unresolved_mention_ids -- and the two fields must stay disjoint.
+    assert subject_set.unresolved_mention_ids == ()
+    assert len(subject_set.ambiguous_mention_ids) == 1
+    assert not (
+        set(subject_set.unresolved_mention_ids) & set(subject_set.ambiguous_mention_ids)
+    )
+
+    # The warning set must distinguish ambiguity from no-match, not reuse the
+    # generic "could not be resolved" wording for both.
+    assert any("ambiguous" in warning for warning in subject_set.warnings)
+
+
+@pytest.mark.asyncio
+async def test_r3_is_deterministic_across_twenty_runs() -> None:
+    results = [
+        (await case_r3_ambiguous_mention_in_cohort()).outcome_tuple()
+        for _ in range(DETERMINISM_ITERATIONS)
+    ]
+    assert len(results) == DETERMINISM_ITERATIONS
+    assert len(set(results)) == 1

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -151,6 +151,82 @@ def test_scope_contract_accepts_canonical_pull_request_ids_and_repository_candid
     DevScopeResolution.model_validate(ambiguous)
 
 
+def test_team_direct_scope_requires_one_matching_team_entity_ref() -> None:
+    """CHAOS-3301: TEAM behaves like every other direct-entity scope kind."""
+
+    team_scope = deepcopy(positive_fixtures()["dev_scope.v1"])
+    team_scope["direct_scope"] = "team"
+    team_scope["repositories"] = []
+    team_scope["entity_refs"] = [
+        {
+            "entity_type": "team",
+            "entity_id": "team_platform",
+            "display_label": "Platform",
+        }
+    ]
+    team_scope["team_ids"] = ["team_platform"]
+    team_scope["surface_context"] = None
+    DevScope.model_validate(team_scope)
+
+    missing_entity_ref = deepcopy(team_scope)
+    missing_entity_ref["entity_refs"] = []
+    with pytest.raises(ValidationError, match="direct entity scope requires"):
+        DevScope.model_validate(missing_entity_ref)
+
+
+def test_team_direct_scope_requires_team_ids_to_name_exactly_that_team() -> None:
+    """CHAOS-3301: a team filter can never be read as a team subject.
+
+    This is the kill site for mutation M5 (removing this invariant): with it
+    deleted, a team-direct ``DevScope`` with empty or mismatched
+    ``team_ids`` would validate cleanly, and the metrics path's
+    ``scope.team_ids``-gated filter (``metrics/clickhouse.py``) would then
+    silently apply no team filter at all for a "committed" team subject.
+    """
+
+    team_scope = deepcopy(positive_fixtures()["dev_scope.v1"])
+    team_scope["direct_scope"] = "team"
+    team_scope["repositories"] = []
+    team_scope["entity_refs"] = [
+        {
+            "entity_type": "team",
+            "entity_id": "team_platform",
+            "display_label": "Platform",
+        }
+    ]
+    team_scope["surface_context"] = None
+
+    empty_team_ids = deepcopy(team_scope)
+    empty_team_ids["team_ids"] = []
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        DevScope.model_validate(empty_team_ids)
+
+    mismatched_team_ids = deepcopy(team_scope)
+    mismatched_team_ids["team_ids"] = ["team_other"]
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        DevScope.model_validate(mismatched_team_ids)
+
+    extra_team_ids = deepcopy(team_scope)
+    extra_team_ids["team_ids"] = ["team_platform", "team_other"]
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        DevScope.model_validate(extra_team_ids)
+
+
+def test_organization_scope_with_a_team_filter_stays_a_filter() -> None:
+    """The converse of the above: team_ids alongside a non-TEAM direct scope
+    is a legitimate filter, structurally distinct from a team subject."""
+
+    org_scope = deepcopy(positive_fixtures()["dev_scope.v1"])
+    org_scope["direct_scope"] = "organization"
+    org_scope["repositories"] = []
+    org_scope["entity_refs"] = []
+    org_scope["team_ids"] = ["team_platform"]
+    org_scope["surface_context"] = None
+    scope = DevScope.model_validate(org_scope)
+
+    assert scope.team_ids == ["team_platform"]
+
+
 def test_checked_in_contract_artifacts_have_no_drift() -> None:
     check_artifacts(expected_artifacts())
 

--- a/tests/api/dev/test_metric_clickhouse.py
+++ b/tests/api/dev/test_metric_clickhouse.py
@@ -11,7 +11,7 @@ from dev_health_ops.api.dev.contracts import (
     MetricID,
 )
 from dev_health_ops.api.dev.metrics.clickhouse import ClickHouseMetricSource
-from dev_health_ops.api.dev.metrics.definitions import get_metric
+from dev_health_ops.api.dev.metrics.definitions import get_metric, list_metrics
 
 UTC = timezone.utc
 
@@ -214,3 +214,39 @@ async def test_investment_coverage_accounts_for_excluded_unclassified_work(
     assert result.rows[0].value == pytest.approx(100.0)
     assert result.coverage == pytest.approx(0.75)
     assert dict(result.metadata)["classification_coverage"] == "0.75"
+
+
+def test_every_team_filter_supporting_metric_applies_its_team_filter() -> None:
+    """CHAOS-3301 recon addendum: ``_scope_filter``'s team clause must be
+    driven by ``MetricDefinition.supports_team_filter`` — the same field
+    ``MetricQueryService._validate_request`` already gates on
+    (``service.py:312``) — never a hardcoded per-``source_table`` string.
+
+    Before this test (and the corresponding ``clickhouse.py`` fix): the elif
+    branch checked ``definition.source_table == "investment_metrics_daily"``
+    literally. That happened to equal ``supports_team_filter`` for every
+    metric registered today, but the next ``supports_team_filter=True``
+    metric added on a different source table would silently stop applying
+    the team filter — passing ``_validate_request`` (which does consult the
+    real field) and then querying unfiltered by team, exactly the
+    silent-drop class CHAOS-3301's status-source totality test closes for
+    ``native_status_change.py``.
+    """
+
+    source = ClickHouseMetricSource(client=object())
+    team_scope = _scope().model_copy(update={"team_ids": ["team_platform"]})
+    for definition in list_metrics():
+        if definition.source_table == "compounding_risk_daily":
+            # Bespoke path: _compounding_risk's own risk_scope/scope_id
+            # logic (verified by test_compounding_component_weight_version_
+            # is_order_independent's fixtures using a team scope elsewhere)
+            # never goes through _scope_filter's generic team clause at all.
+            continue
+        clauses, _params = source._scope_filter(definition, team_scope)
+        applies_team_filter = "team_id IN %(team_ids)s" in clauses
+        assert applies_team_filter == definition.supports_team_filter, (
+            f"{definition.metric_id}: supports_team_filter="
+            f"{definition.supports_team_filter} but _scope_filter "
+            f"{'applies' if applies_team_filter else 'does not apply'} "
+            "a team_id clause"
+        )

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -18,6 +18,7 @@ from dev_health_ops.api.dev.contracts import (
     DevToolResult,
     ToolID,
 )
+from dev_health_ops.api.dev.contracts_v2 import DevSubjectSet
 from dev_health_ops.api.dev.orchestrator import (
     DevOrchestrator,
     DevRunLimits,
@@ -63,6 +64,9 @@ class Recorder:
         self, *, preflight_outcome: str | None, legacy_guard_reason: str | None
     ) -> None:
         self.preflight_diagnostics.append((preflight_outcome, legacy_guard_reason))
+
+    async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
+        del subject_set
 
     async def terminal(self, **values) -> None:
         self.terminals.append(values["state"])

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -109,7 +109,12 @@ async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> Non
     Committing only the first of several named subjects is the fabricated
     premise this issue exists to close; the landed v2-to-v1 projector reaches
     the same conclusion independently for a ``subject_set_ref`` cohort frame.
-    CHAOS-3301 owns subject sets and batch execution.
+
+    CHAOS-3301 (D1): the cohort is now genuinely *committed and persisted* as
+    a ``dev_subject_set.v1`` — diagnostic ``committed_cohort_v1_only``, not
+    ``cohort_unsupported_in_v1`` — but the v1 surface still returns
+    ``unsupported`` and ``committed_resolution`` (the single-scope binding)
+    stays ``None``: rendering a cohort answer is CHAOS-3297/3298's job.
     """
 
     result = await _run(
@@ -119,7 +124,7 @@ async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> Non
 
     assert result.decision is PreflightDecision.TERMINATE
     assert result.outcome is PublicOutcome.UNSUPPORTED
-    assert result.diagnostic == "cohort_unsupported_in_v1"
+    assert result.diagnostic == "committed_cohort_v1_only"
     assert result.committed_resolution is None
     # Both resolved honestly; nothing was discarded to make one fit.
     assert result.ledger is not None
@@ -127,6 +132,16 @@ async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> Non
         entry.outcome is ResolutionOutcome.EXACT_MATCH
         for entry in result.ledger.latest_by_mention().values()
     )
+    # The set itself commits every resolved member, not just the first.
+    assert result.subject_set is not None
+    assert result.subject_set.original_mention_count == 2
+    assert result.subject_set.cohort_complete is True
+    assert result.subject_set.unresolved_mention_ids == ()
+    committed_ids = {ref.entity_id for ref in result.subject_set.committed_entity_refs}
+    assert committed_ids == {
+        ASK_DEV_PROJECT.canonical_id,
+        NIGHTFALL_PROJECT.canonical_id,
+    }
 
 
 @pytest.mark.asyncio
@@ -350,14 +365,29 @@ def test_a_real_uuid_run_id_is_preserved_verbatim() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_team_subject_never_reaches_the_v1_scope_constructors() -> None:
+async def test_a_team_subject_commits_a_real_v1_team_scope() -> None:
+    """CHAOS-3301 superseded this test's premise: TEAM now has a real v1
+    ``DirectScope``/``EntityType`` member, so a resolved team *does* reach
+    (and succeeds through) the v1 scope constructors — see
+    ``committed_resolution_for``'s docstring for why that call no longer
+    raises for a team entity.
+    """
+
+    from dev_health_ops.api.dev.contracts import DirectScope
+
     result = await _run(
         _preflight([(ORG_ID, PLATFORM_TEAM)]),
         request_for("How is the Platform team doing?"),
     )
 
-    assert result.outcome is PublicOutcome.UNSUPPORTED
-    assert result.committed_resolution is None
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.outcome is None
+    assert result.diagnostic == "proceeded_committed_subject"
+    assert result.committed_resolution is not None
+    committed_scope = result.committed_resolution.resolved_scope
+    assert committed_scope is not None
+    assert committed_scope.direct_scope is DirectScope.TEAM
+    assert committed_scope.team_ids == [PLATFORM_TEAM.canonical_id]
     assert result.ledger is not None
     entry = next(iter(result.ledger.latest_by_mention().values()))
     assert entry.outcome is ResolutionOutcome.EXACT_MATCH

--- a/tests/api/dev/test_tool_registry.py
+++ b/tests/api/dev/test_tool_registry.py
@@ -105,6 +105,47 @@ def test_unknown_and_cross_tenant_tools_are_rejected_before_execution() -> None:
         registry.validate_request(request, cross_tenant)
 
 
+def test_only_the_committed_scope_is_authorized_not_an_uncommitted_sibling() -> None:
+    """CHAOS-3301 manifest property: "tool authorization admits only
+    committed member scopes."
+
+    D1 means no cohort ever reaches tool execution in this issue, so there
+    is no e2e multi-scope authorization path to exercise the property
+    against. This is the unit-level form instead: the registry's equality
+    gate (``tool_registry.py:268``) admits exactly the one scope the server
+    actually committed for this run, and rejects a structurally valid
+    sibling scope (e.g. another repository that could equally have been
+    named) that was never committed — never "close enough."
+    """
+    committed = DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
+    sibling = committed.model_copy(
+        update={
+            "repositories": ["repo_sibling_never_committed"],
+            "surface_context": None,
+        }
+    )
+    context = ToolExecutionContext(
+        org_id="org_fullchaos",
+        user_id="user_01",
+        permission_fingerprint="permissions_01",
+        authorized_scope=committed,
+        cancellation=asyncio.Event(),
+        remaining_seconds=1.0,
+    )
+    registry = _registry()
+
+    # The committed scope itself is authorized.
+    registry.validate_request(
+        _request(scope=committed.model_dump(mode="json")), context
+    )
+
+    # A structurally valid, never-committed sibling is rejected.
+    with pytest.raises(ToolRequestRejected, match="server-authorized scope"):
+        registry.validate_request(
+            _request(scope=sibling.model_dump(mode="json")), context
+        )
+
+
 @pytest.mark.parametrize(
     "updates",
     [


### PR DESCRIPTION
Implements CHAOS-3301 (ratified option B): TEAM direct-scope support with team SQL execution arms deferred to CHAOS-3303, TEAM_NOT_APPLICABLE_SOURCES totality registry, D1 (cohorts commit+persist, stay `committed_cohort_v1_only` on v1), D2 (partial cohorts proceed with disclosure, PLURAL_COHORT only), and three independently-pinned searchable-kind frozensets.

Includes two codex-adversarial-review fix rounds:
- pre-dedup D2 mention counting (duplicate aliases falsely activated D2)
- silent 26th-subject trim (typed and all-untyped layers)
- ambiguity partition into `ambiguous_mention_ids`
- GraphQL resolver independently pinned to `GRAPHQL_SEARCHABLE_ENTITY_KINDS`
- `DevScope` TEAM scope forbids repositories incl. `model_copy` tampering (revalidating override)

TEST-EVIDENCE: 18 e2e controls (`test_chaos_3301_controls.py`) + 18 review-findings regressions (`test_chaos_3301_review_findings.py`, each verified fail-before/pass-after against the pre-fix code) + `test_chaos_3292_preflight_acceptance.py`; full local gate (`ci/local_validate.sh`) GATE PASSED 9/9 incl. full unit suite and live argMax proof; final codex adversarial re-check verdict SHIP with no material findings.

RISK-NOTES: The web checkout pins a stream-event schema whose DirectScope enum omits `team`; a backend `answer.completed` with `direct_scope: team` fails web-side validation. TEAM answers are unreachable until the ask_dev_wave_3_1 rollout, and the web contract re-pin is tracked as CHAOS-3298, which must merge before enablement. `GRAPHQL_SEARCHABLE_ENTITY_KINDS` currently equals the V1 set; divergence is now an explicit code change.

SCREENSHOT-WAIVER: backend-only change, no UI surface.