### PR TITLE
fix(ask-dev): CHAOS-3297 C0 — persist preflight-termination frames, harden replay

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -329,6 +329,22 @@ class RunRecorder(Protocol):
         ...
 
 
+    async def rollback(self) -> None:
+        """Discard pending writes after a failed record_frame flush (CHAOS-3297).
+
+        A database-level failure during ``record_frame``'s flush (a
+        constraint violation, a dropped connection) marks the underlying
+        session rollback-only: the next write on it raises
+        ``PendingRollbackError`` instead of succeeding. A caller that catches
+        a ``record_frame`` failure must call this before any further
+        recorder write (``terminal()`` in particular) on the same run, or a
+        recoverable frame-write failure strands the run as a nonterminal
+        ``accepted``/v1 row that every idempotent retry then 409s against
+        forever.
+        """
+        ...
+
+
     async def terminal(
         self,
         *,
@@ -374,6 +390,10 @@ class NullRunRecorder:
 
     async def record_frame(self, frame: DevAnswerFrame) -> None:
         del frame
+
+
+    async def rollback(self) -> None:
+        return None
 
 
     async def terminal(
@@ -728,7 +748,20 @@ class DevOrchestrator:
                     # state and the frame's contract_generation='v2' tag
                     # land together -- mirrors record_answer's placement
                     # ahead of terminal() on the completed-answer path.
-                    await self._recorder.record_frame(preflight_result.answer.frame)
+                    try:
+                        await self._recorder.record_frame(preflight_result.answer.frame)
+                    except Exception:
+                        # A database-layer failure here (constraint
+                        # violation, dropped connection) marks the
+                        # recorder's session rollback-only; the terminal()
+                        # write below would then raise PendingRollbackError
+                        # and strand this run as a nonterminal accepted/v1
+                        # row that every idempotent retry 409s against
+                        # forever (Codex review finding, CHAOS-3297). Roll
+                        # back and finish as a coherent v1 terminal run
+                        # instead -- a dropped frame is recoverable, a
+                        # stranded run is not.
+                        await self._recorder.rollback()
                     return await finish(
                         TERMINAL_STATE_BY_OUTCOME[preflight_result.outcome],
                         error=project_preflight_error(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -762,6 +762,19 @@ class DevOrchestrator:
                         # instead -- a dropped frame is recoverable, a
                         # stranded run is not.
                         await self._recorder.rollback()
+                        # The rollback above discards every unflushed write
+                        # on this session, not just the poisoned frame --
+                        # including the record_preflight() diagnostic
+                        # flushed a few lines above, which shares this same
+                        # transaction. Re-persist it before finish() writes
+                        # the terminal row, or the run lands with
+                        # preflight_outcome=None and silently loses the
+                        # closed-vocabulary explanation of why it
+                        # terminated (Codex review finding, CHAOS-3297).
+                        await self._recorder.record_preflight(
+                            preflight_outcome=preflight_result.diagnostic,
+                            legacy_guard_reason=None,
+                        )
                     return await finish(
                         TERMINAL_STATE_BY_OUTCOME[preflight_result.outcome],
                         error=project_preflight_error(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -328,7 +328,6 @@ class RunRecorder(Protocol):
         """
         ...
 
-
     async def rollback(self) -> None:
         """Discard pending writes after a failed record_frame flush (CHAOS-3297).
 
@@ -343,7 +342,6 @@ class RunRecorder(Protocol):
         forever.
         """
         ...
-
 
     async def terminal(
         self,
@@ -391,10 +389,8 @@ class NullRunRecorder:
     async def record_frame(self, frame: DevAnswerFrame) -> None:
         del frame
 
-
     async def rollback(self) -> None:
         return None
-
 
     async def terminal(
         self,

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -68,6 +68,7 @@ from .contracts import (
     dev_error_remediation,
 )
 from .contracts_v2 import DevSubjectSet
+from .contracts_v2.frame import DevAnswerFrame
 from .orchestrator_states import TERMINAL_STATES, RunState
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from .preflight_outcomes import TERMINAL_STATE_BY_OUTCOME, project_preflight_error
@@ -316,6 +317,18 @@ class RunRecorder(Protocol):
         """
         ...
 
+    async def record_frame(self, frame: DevAnswerFrame) -> None:
+        """Persist one already-built ``dev_answer_frame.v1`` (CHAOS-3297).
+
+        Called from the preflight TERMINATE branch with the frame
+        ``preflight_outcomes.build_preflight_answer`` already validated, so
+        the run tags ``contract_generation = 'v2'`` and the CHAOS-3299 v2
+        replay branch (``router._replayed_result``) becomes reachable for a
+        preflight-terminated run, not just a full model-round completion.
+        """
+        ...
+
+
     async def terminal(
         self,
         *,
@@ -358,6 +371,10 @@ class NullRunRecorder:
 
     async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
         del subject_set
+
+    async def record_frame(self, frame: DevAnswerFrame) -> None:
+        del frame
+
 
     async def terminal(
         self,
@@ -706,6 +723,12 @@ class DevOrchestrator:
                 if preflight_result.decision is PreflightDecision.TERMINATE:
                     assert preflight_result.answer is not None
                     assert preflight_result.outcome is not None
+                    # CHAOS-3297: persist the frame the preflight already
+                    # built *before* finishing the run, so the terminal
+                    # state and the frame's contract_generation='v2' tag
+                    # land together -- mirrors record_answer's placement
+                    # ahead of terminal() on the completed-answer path.
+                    await self._recorder.record_frame(preflight_result.answer.frame)
                     return await finish(
                         TERMINAL_STATE_BY_OUTCOME[preflight_result.outcome],
                         error=project_preflight_error(

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -221,6 +221,17 @@ class PersistenceRunRecorder:
             payload=frame.model_dump(mode="json"),
         )
 
+    async def rollback(self) -> None:
+        """Discard pending writes on this request's session (CHAOS-3297).
+
+        Called by the orchestrator after a failed ``record_frame`` flush,
+        before any further write on this same recorder -- a session
+        SQLAlchemy has marked rollback-only raises ``PendingRollbackError``
+        on the next flush otherwise, which is exactly the failure mode this
+        exists to prevent.
+        """
+        await self._service.session.rollback()
+
     async def record_narrative(self, narrative: DevNarrative) -> None:
         provider_fingerprint = None
         if narrative.provider_metadata is not None:

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -639,28 +639,55 @@ def _replayed_result(
         # v2-to-v1 projector (CHAOS-3294 guardrail) live preflight uses, so
         # this is never a second, divergent mapping.
         from .contracts_v2.answer import _OUTCOME_DISPLAY_LABELS, DevAnswerV2
+        from .contracts_v2.base import PublicOutcome
         from .contracts_v2.frame import DevAnswerFrame as _DevAnswerFrameV2
+        from .contracts_v2.no_answer_policy import NO_ANSWER_OUTCOMES
         from .preflight_outcomes import project_preflight_error
 
+        # project_preflight_error is only total over the no-answer outcomes
+        # plus needs_clarification (CHAOS-3292's ratified vocabulary for a
+        # preflight termination) -- ANSWERED/ANSWERED_WITH_GAPS raise
+        # RuntimeError there by design, since a preflight never terminates
+        # with an answer. A row reachable through this branch (no
+        # answer_payload) is only trustworthy if the frame agrees: it must
+        # both carry one of those outcomes *and* match the run's own
+        # `public_outcome` column, which is written from the same frame at
+        # persist time (CHAOS-3297 Codex review MEDIUM #2). A corrupted or
+        # schema-skewed row that still happens to validate must not project
+        # false public semantics or crash the replay -- degrade to the same
+        # safe fallback used for a missing frame.
+        _REPLAYABLE_PREFLIGHT_OUTCOMES = NO_ANSWER_OUTCOMES | {
+            PublicOutcome.NEEDS_CLARIFICATION.value
+        }
         try:
             frame_obj = _DevAnswerFrameV2.model_validate(frame_payload)
-            answer_v2 = DevAnswerV2(
-                schema_version="dev_answer.v2",
-                answer_id=str(run.id),
-                conversation_id=str(run.conversation_id),
-                run_id=str(run.id),
-                # SQLite (test fixtures only) does not round-trip tz-aware
-                # datetimes through DateTime(timezone=True); PostgreSQL
-                # does, so this was unobserved until CHAOS-3299 Codex
-                # finding 1's fix made this branch reachable for the first
-                # time.
-                generated_at=_aware_required(run.ended_at or run.started_at),
-                public_outcome=frame_obj.public_outcome,
-                outcome_display_label=_OUTCOME_DISPLAY_LABELS[frame_obj.public_outcome],
-                frame=frame_obj,
-                narrative=None,
-            )
-            error = project_preflight_error(answer_v2, request_id=str(run.request_id))
+            if (
+                frame_obj.public_outcome.value not in _REPLAYABLE_PREFLIGHT_OUTCOMES
+                or run.public_outcome != frame_obj.public_outcome.value
+            ):
+                error = _replay_fallback_error(run)
+            else:
+                answer_v2 = DevAnswerV2(
+                    schema_version="dev_answer.v2",
+                    answer_id=str(run.id),
+                    conversation_id=str(run.conversation_id),
+                    run_id=str(run.id),
+                    # SQLite (test fixtures only) does not round-trip
+                    # tz-aware datetimes through DateTime(timezone=True);
+                    # PostgreSQL does, so this was unobserved until
+                    # CHAOS-3299 Codex finding 1's fix made this branch
+                    # reachable for the first time.
+                    generated_at=_aware_required(run.ended_at or run.started_at),
+                    public_outcome=frame_obj.public_outcome,
+                    outcome_display_label=_OUTCOME_DISPLAY_LABELS[
+                        frame_obj.public_outcome
+                    ],
+                    frame=frame_obj,
+                    narrative=None,
+                )
+                error = project_preflight_error(
+                    answer_v2, request_id=str(run.request_id)
+                )
         except ValidationError:
             error = _replay_fallback_error(run)
     else:

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -26,7 +26,7 @@ from fastapi import (
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api._health import _analytics_db_url
@@ -569,6 +569,40 @@ def _permission_fingerprint(user: AuthenticatedUser) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+def _replay_fallback_error(run: Any) -> DevError:
+    """The generic "did not complete" shape for a run with nothing to replay.
+
+    Used both when no answer/frame was ever persisted for a terminal run,
+    and (CHAOS-3297 Codex review MEDIUM) when a persisted v2 frame payload
+    fails to validate -- a corrupted or legacy-shaped row must degrade to
+    this safe public shape rather than 500 every future replay of the same
+    idempotency key.
+    """
+
+    code = run.safe_error_code or "internal_error"
+    try:
+        return DevError(
+            schema_version="dev_error.v1",
+            request_id=str(run.request_id),
+            code=code,
+            safe_message=("The prior Ask Dev request did not complete with an answer."),
+            retryable=code in {"provider_unavailable", "source_unavailable"},
+            # A replayed run must carry the same corrective guidance a
+            # live failure with this code would (CHAOS-3254) -- never
+            # silently drop remediation just because the client is
+            # reading back an idempotent replay instead of a fresh run.
+            remediation=dev_error_remediation(code),
+        )
+    except ValueError:
+        return DevError(
+            schema_version="dev_error.v1",
+            request_id=str(run.request_id),
+            code="internal_error",
+            safe_message=("The prior Ask Dev request did not complete with an answer."),
+            retryable=True,
+        )
+
+
 def _replayed_result(
     *,
     run: Any,
@@ -608,50 +642,29 @@ def _replayed_result(
         from .contracts_v2.frame import DevAnswerFrame as _DevAnswerFrameV2
         from .preflight_outcomes import project_preflight_error
 
-        frame_obj = _DevAnswerFrameV2.model_validate(frame_payload)
-        answer_v2 = DevAnswerV2(
-            schema_version="dev_answer.v2",
-            answer_id=str(run.id),
-            conversation_id=str(run.conversation_id),
-            run_id=str(run.id),
-            # SQLite (test fixtures only) does not round-trip tz-aware
-            # datetimes through DateTime(timezone=True); PostgreSQL does, so
-            # this was unobserved until CHAOS-3299 Codex finding 1's fix made
-            # this branch reachable for the first time.
-            generated_at=_aware_required(run.ended_at or run.started_at),
-            public_outcome=frame_obj.public_outcome,
-            outcome_display_label=_OUTCOME_DISPLAY_LABELS[frame_obj.public_outcome],
-            frame=frame_obj,
-            narrative=None,
-        )
-        error = project_preflight_error(answer_v2, request_id=str(run.request_id))
-    else:
-        code = run.safe_error_code or "internal_error"
         try:
-            error = DevError(
-                schema_version="dev_error.v1",
-                request_id=str(run.request_id),
-                code=code,
-                safe_message=(
-                    "The prior Ask Dev request did not complete with an answer."
-                ),
-                retryable=code in {"provider_unavailable", "source_unavailable"},
-                # A replayed run must carry the same corrective guidance a
-                # live failure with this code would (CHAOS-3254) -- never
-                # silently drop remediation just because the client is
-                # reading back an idempotent replay instead of a fresh run.
-                remediation=dev_error_remediation(code),
+            frame_obj = _DevAnswerFrameV2.model_validate(frame_payload)
+            answer_v2 = DevAnswerV2(
+                schema_version="dev_answer.v2",
+                answer_id=str(run.id),
+                conversation_id=str(run.conversation_id),
+                run_id=str(run.id),
+                # SQLite (test fixtures only) does not round-trip tz-aware
+                # datetimes through DateTime(timezone=True); PostgreSQL
+                # does, so this was unobserved until CHAOS-3299 Codex
+                # finding 1's fix made this branch reachable for the first
+                # time.
+                generated_at=_aware_required(run.ended_at or run.started_at),
+                public_outcome=frame_obj.public_outcome,
+                outcome_display_label=_OUTCOME_DISPLAY_LABELS[frame_obj.public_outcome],
+                frame=frame_obj,
+                narrative=None,
             )
-        except ValueError:
-            error = DevError(
-                schema_version="dev_error.v1",
-                request_id=str(run.request_id),
-                code="internal_error",
-                safe_message=(
-                    "The prior Ask Dev request did not complete with an answer."
-                ),
-                retryable=True,
-            )
+            error = project_preflight_error(answer_v2, request_id=str(run.request_id))
+        except ValidationError:
+            error = _replay_fallback_error(run)
+    else:
+        error = _replay_fallback_error(run)
     return OrchestratorResult(
         run_id=str(run.id),
         state=state,

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -354,10 +354,8 @@ class Recorder:
     async def record_frame(self, frame: Any) -> None:
         self.frames.append(frame)
 
-
     async def rollback(self) -> None:
         pass
-
 
     async def terminal(self, **values: Any) -> None:
         self.terminals.append(values["state"])

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -331,6 +331,7 @@ class Recorder:
         self.answers: list[DevAnswer] = []
         self.terminals: list[RunState] = []
         self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
+        self.frames: list[Any] = []
 
     async def transition(self, state: RunState) -> None:
         self.transitions.append(state)
@@ -349,6 +350,10 @@ class Recorder:
     async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
         """No-op here; CHAOS-3301's SubjectSetRecorder subclass captures this."""
         del subject_set
+
+    async def record_frame(self, frame: Any) -> None:
+        self.frames.append(frame)
+
 
     async def terminal(self, **values: Any) -> None:
         self.terminals.append(values["state"])

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -355,6 +355,10 @@ class Recorder:
         self.frames.append(frame)
 
 
+    async def rollback(self) -> None:
+        pass
+
+
     async def terminal(self, **values: Any) -> None:
         self.terminals.append(values["state"])
 

--- a/tests/api/dev/test_chaos_3297_frame_reachability.py
+++ b/tests/api/dev/test_chaos_3297_frame_reachability.py
@@ -30,6 +30,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.dev import router as dev_router_module
+from dev_health_ops.api.dev.contract_fixtures_v2 import (
+    no_answer_answer_fixture,
+    positive_fixtures,
+)
 from dev_health_ops.api.dev.contracts import (
     DevContractVersions,
     DevScope,
@@ -375,6 +379,17 @@ async def test_preflight_frame_flush_failure_reaches_terminal_state_not_stranded
             select(DevAnswerFrame).where(DevAnswerFrame.run_id == run.id)
         )
         assert frame_row is None, "the poisoned frame insert must have been rolled back"
+        # Codex review MEDIUM #2: record_preflight()'s diagnostic flush
+        # happens before record_frame() on this same session/transaction, so
+        # the session.rollback() above -- necessary to clear the poisoned
+        # frame's rollback-only state -- would also erase it unless the
+        # orchestrator re-persists it. A run that terminated for a reason
+        # must not silently lose the reason.
+        assert run.preflight_outcome == "unresolved_no_authorized_match", (
+            "the record_preflight() diagnostic must survive the post-poison "
+            "rollback, not be silently erased along with the bad frame write "
+            f"(got {run.preflight_outcome!r})"
+        )
 
     # The duplicate POST must replay, not 409 -- proving the run actually
     # reached a terminal state the router's not-created branch can see.
@@ -451,3 +466,151 @@ async def test_replay_with_corrupted_frame_payload_falls_back_safely(
     # fallback -- otherwise this test could not distinguish "used the real
     # frame" from "always falls back".
     assert live_message != fallback_message
+
+
+async def test_replay_with_mismatched_frame_outcome_falls_back_safely(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+) -> None:
+    """Codex re-review MEDIUM: a self-consistent but wrong-outcome frame must
+    not project its own semantics over the run's persisted outcome.
+
+    Persists a real preflight-terminated ``not_found`` frame, then swaps the
+    stored payload for a *different*, independently valid no-answer frame (a
+    ``denied`` fixture built by the real fixture producer --
+    ``DevAnswerFrame.model_validate`` accepts it on its own). Before this fix
+    ``_replayed_result`` trusted the frame's own ``public_outcome`` with no
+    cross-check against ``dev_runs.public_outcome``, so a stale or corrupted
+    row could replay a ``forbidden``/"You do not have access" error for a run
+    that actually terminated ``not_found`` -- false public semantics.
+    """
+
+    org_id = dev_api_context.org_id
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=_preflight_runtime(org_id=org_id)
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = _preflight_terminating_payload(conversation_id, org_id)
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        assert run.public_outcome == "not_found"
+        frame_row = await session.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run.id)
+        )
+        assert frame_row is not None
+        # A fully valid frame, produced by the real fixture builder -- just
+        # for a different outcome than the run itself recorded.
+        denied_frame = no_answer_answer_fixture("denied")["frame"]
+        # The frame's own run_id must match the real run's id -- DevAnswerV2
+        # independently enforces that consistency, and this test's target
+        # (the run/frame *outcome* cross-check) must fail on its own merits,
+        # not be masked by an unrelated run_id mismatch.
+        denied_frame["run_id"] = str(run.id)
+        FrameContract.model_validate(denied_frame)  # sanity: valid on its own
+        frame_row.payload = denied_frame
+        await session.commit()
+
+    replay = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert replay.status_code == 200, (
+        f"a mismatched-but-valid frame outcome must degrade to a safe "
+        f"error, not project the frame's own outcome: "
+        f"{replay.status_code} {replay.text}"
+    )
+    replay_events = dict(_parse_sse_events(replay.text))
+    assert "answer.completed" not in replay_events
+    assert "error" in replay_events
+    fallback_message = "The prior Ask Dev request did not complete with an answer."
+    assert replay_events["error"]["error"]["safe_message"] == fallback_message
+    # "forbidden" is the code the (wrong) denied frame would have projected
+    # -- proving the replay did not adopt the mismatched frame's semantics.
+    assert replay_events["error"]["error"]["code"] != "forbidden"
+
+
+async def test_replay_with_answered_frame_falls_back_safely(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+) -> None:
+    """Codex re-review MEDIUM: an out-of-vocabulary ``answered`` frame must
+    not crash the replay.
+
+    ``project_preflight_error`` is only total over the no-answer outcomes
+    plus ``needs_clarification`` (CHAOS-3292's ratified preflight-
+    termination vocabulary) -- a preflight itself never terminates with
+    ``answered``. Swaps the stored payload for the canonical ``answered``
+    positive fixture, which validates cleanly as a ``DevAnswerFrame`` but
+    hits ``project_preflight_error``'s own defensive
+    ``isinstance(projected, DevError)`` assertion. Before this fix that
+    raised an uncaught ``RuntimeError``, turning every future replay of the
+    idempotency key into a 500.
+    """
+
+    org_id = dev_api_context.org_id
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=_preflight_runtime(org_id=org_id)
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = _preflight_terminating_payload(conversation_id, org_id)
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        frame_row = await session.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run.id)
+        )
+        assert frame_row is not None
+        # positive_fixtures()'s canonical "answered" frame: fully valid,
+        # produced by the real fixture builder, not a shape this run ever
+        # actually persisted.
+        answered_frame = positive_fixtures()["dev_answer_frame.v1"]
+        # See the mismatched-outcome test above: the frame's run_id must
+        # match the real run so this test's target (the answered-outcome
+        # totality gap) fails on its own merits.
+        answered_frame["run_id"] = str(run.id)
+        FrameContract.model_validate(answered_frame)  # sanity: valid on its own
+        frame_row.payload = answered_frame
+        await session.commit()
+
+    replay = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert replay.status_code == 200, (
+        f"an answered-outcome frame on a preflight-terminated run must "
+        f"degrade to a safe error, not 500: {replay.status_code} {replay.text}"
+    )
+    replay_events = dict(_parse_sse_events(replay.text))
+    assert "answer.completed" not in replay_events
+    assert "error" in replay_events
+    fallback_message = "The prior Ask Dev request did not complete with an answer."
+    assert replay_events["error"]["error"]["safe_message"] == fallback_message

--- a/tests/api/dev/test_chaos_3297_frame_reachability.py
+++ b/tests/api/dev/test_chaos_3297_frame_reachability.py
@@ -37,6 +37,7 @@ from dev_health_ops.api.dev.contracts import (
     ScopeResolutionOutcome,
 )
 from dev_health_ops.api.dev.contracts_v2.frame import DevAnswerFrame as FrameContract
+from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
 from dev_health_ops.api.dev.runtime import BoundedDevRuntime
 from dev_health_ops.api.dev.scope_service import (
@@ -289,3 +290,164 @@ async def test_preflight_termination_persists_frame_and_replays(
         ).all()
         assert len(runs) == 1, "the replay must not have created a second run"
         assert runs[0].contract_generation == "v2"
+
+
+async def test_preflight_frame_flush_failure_reaches_terminal_state_not_stranded(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review HIGH: a record_frame flush failure must not strand the run.
+
+    Before the fix, a database-layer failure while flushing the preflight's
+    frame write (a constraint violation, a dropped connection) marks the
+    request's session rollback-only; the terminal() write that follows then
+    raises PendingRollbackError instead of completing, so the run is never
+    written past 'accepted'/'v1'. Every retry with the same
+    client_message_id then hits router.py's not-created branch, sees a
+    non-terminal state, and 409s forever.
+
+    Poisons the session with a genuine CHECK-constraint violation on
+    record_frame -- an ``IntegrityError`` raised by the real flush, not a
+    bare Python raise -- so the session is actually marked rollback-only the
+    way the Codex repro's SQLAlchemy script demonstrated, and asserts the
+    run still reaches a terminal state with a safe error, and that a
+    duplicate POST replays (200) instead of 409ing.
+    """
+
+    org_id = dev_api_context.org_id
+
+    async def poisoned_record_frame(self: PersistenceRunRecorder, frame: Any) -> None:
+        del frame
+        # A real DB-layer failure: violates dev_answer_frames' public_outcome
+        # CHECK constraint at flush time, exactly the failure class the
+        # review confirmed (not a synthetic raise -- the session must
+        # actually become rollback-only).
+        bad = DevAnswerFrame(
+            run_id=self._run_id,
+            org_id=self._org_id,
+            user_id=self._user_id,
+            frame_id=uuid.uuid4(),
+            public_outcome="not_a_real_public_outcome",
+            payload={},
+        )
+        self._service.session.add(bad)
+        await self._service.session.flush()
+
+    monkeypatch.setattr(PersistenceRunRecorder, "record_frame", poisoned_record_frame)
+
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=_preflight_runtime(org_id=org_id)
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = _preflight_terminating_payload(conversation_id, org_id)
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200, live.text
+    live_events = dict(_parse_sse_events(live.text))
+    assert "answer.completed" not in live_events
+    assert "error" in live_events, (
+        "a poisoned frame write must still reach a terminal error, not hang or 500"
+    )
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        assert run.state != "accepted", (
+            "the run must not be stranded nonterminal after the frame flush failed"
+        )
+        assert run.contract_generation == "v1", (
+            "the poisoned frame write must have been rolled back, not left "
+            "half-tagged v2 with no frame to back it"
+        )
+        frame_row = await session.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run.id)
+        )
+        assert frame_row is None, "the poisoned frame insert must have been rolled back"
+
+    # The duplicate POST must replay, not 409 -- proving the run actually
+    # reached a terminal state the router's not-created branch can see.
+    duplicate = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert duplicate.status_code == 200, duplicate.text
+    duplicate_events = dict(_parse_sse_events(duplicate.text))
+    assert "error" in duplicate_events
+
+
+async def test_replay_with_corrupted_frame_payload_falls_back_safely(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+) -> None:
+    """Codex review MEDIUM: a corrupted v2 frame payload must not 500 every replay.
+
+    Persists a real preflight-terminated frame, then corrupts the stored
+    payload directly (simulating a damaged row or a since-changed schema)
+    and asserts the idempotent replay degrades to the same generic "did not
+    complete" shape used when the frame row is missing outright, instead of
+    a 500 that would repeat on every future replay of the same
+    client_message_id.
+    """
+
+    org_id = dev_api_context.org_id
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=_preflight_runtime(org_id=org_id)
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = _preflight_terminating_payload(conversation_id, org_id)
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200
+    live_events = dict(_parse_sse_events(live.text))
+    live_message = live_events["error"]["error"]["safe_message"]
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        frame_row = await session.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run.id)
+        )
+        assert frame_row is not None
+        # Missing every field DevAnswerFrame.model_validate requires beyond
+        # schema_version -- a damaged/legacy row, not a well-formed one.
+        frame_row.payload = {"schema_version": "dev_answer_frame.v1"}
+        await session.commit()
+
+    replay = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert replay.status_code == 200, (
+        f"a corrupted frame payload must degrade to a safe error, not 500: "
+        f"{replay.status_code} {replay.text}"
+    )
+    replay_events = dict(_parse_sse_events(replay.text))
+    assert "answer.completed" not in replay_events
+    assert "error" in replay_events
+    fallback_message = "The prior Ask Dev request did not complete with an answer."
+    assert replay_events["error"]["error"]["safe_message"] == fallback_message
+    # The live run's own preflight-specific copy must differ from the
+    # fallback -- otherwise this test could not distinguish "used the real
+    # frame" from "always falls back".
+    assert live_message != fallback_message

--- a/tests/api/dev/test_chaos_3297_frame_reachability.py
+++ b/tests/api/dev/test_chaos_3297_frame_reachability.py
@@ -1,0 +1,291 @@
+"""RED-first reachability proof for CHAOS-3297 C0.
+
+CHAOS-3299's v2 replay branch (``router._replayed_result`` /
+``router.py`` ``contract_generation == "v2"`` gate) can only ever be
+exercised by a run that actually persisted a ``dev_answer_frame.v1`` row via
+``PersistenceRunRecorder.record_frame``. Today the subject preflight (CHAOS-
+3292) builds a fully validated ``DevAnswerV2`` no-answer frame in
+``preflight_outcomes.build_preflight_answer`` and the orchestrator's
+TERMINATE branch (``orchestrator.py`` around the ``project_preflight_error``
+call) discards it -- only the projected v1 ``DevError`` is used. No
+production code path ever calls ``record_frame`` for a preflight
+termination, so ``dev_runs.contract_generation`` never becomes ``'v2'`` and
+the v2 replay branch is unreachable dead code.
+
+This module drives the *real* ``DevOrchestrator`` + real ``SubjectPreflight``
+through the real ``/api/v1/dev/conversations/{id}/messages`` endpoint (not
+the hand-rolled ``PreflightNoAnswerRuntime`` fake in ``test_router.py``,
+which manually calls ``recorder.record_frame`` and therefore cannot catch
+this gap) and asserts the frame the preflight already built lands in
+Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.dev import router as dev_router_module
+from dev_health_ops.api.dev.contracts import (
+    DevContractVersions,
+    DevScope,
+    DevScopeResolution,
+    ScopeResolutionOutcome,
+)
+from dev_health_ops.api.dev.contracts_v2.frame import DevAnswerFrame as FrameContract
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.runtime import BoundedDevRuntime
+from dev_health_ops.api.dev.scope_service import (
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+from dev_health_ops.llm.agent.scripted import ScriptedAgentProvider
+from dev_health_ops.models.dev_persistence import DevAnswerFrame, DevRun
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    SeededCatalog,
+    fixed_now,
+    recording_registry,
+    sequential_ids,
+)
+from tests.api.dev.test_router import (  # noqa: F401
+    _parse_sse_events,
+    _scope_payload,
+    dev_api_context,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _test_versions() -> DevContractVersions:
+    return DevContractVersions(
+        prompt_version="ask_dev_prompt.v1",
+        tool_contract_version="ask_dev_tools.v1",
+        metric_definition_version="ask_dev_metrics.v1",
+        query_version="ask_dev_queries.v1",
+    )
+
+
+async def assert_frame_persisted(session: AsyncSession, run_id: uuid.UUID) -> None:
+    """N0: prove one terminal run actually reached the CHAOS-3299 v2 replay path.
+
+    A run that only streamed a correct v1 error is not enough -- the frame
+    row, the run's ``contract_generation`` tag, and the run's own
+    ``public_outcome`` must all agree, and the persisted payload must still
+    validate as a ``dev_answer_frame.v1``. Any one of those missing means
+    ``router._replayed_result``'s ``== "v2"`` branch stays unreachable for
+    this run, silently falling back to the "did not complete" replay shape.
+    """
+
+    frame = await session.scalar(
+        select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
+    )
+    assert frame is not None, f"no dev_answer_frames row was persisted for run {run_id}"
+
+    run = await session.get(DevRun, run_id)
+    assert run is not None, f"no dev_runs row for run {run_id}"
+    assert run.contract_generation == "v2", (
+        f"dev_runs.contract_generation was {run.contract_generation!r}, expected 'v2' "
+        "-- record_frame was never called, or was called without the "
+        "run.contract_generation write-through"
+    )
+    assert run.public_outcome == frame.payload.get("public_outcome"), (
+        "dev_runs.public_outcome must match the persisted frame's own "
+        f"public_outcome; got run={run.public_outcome!r} "
+        f"frame={frame.payload.get('public_outcome')!r}"
+    )
+    # Round-trips the exact bytes written to Postgres back through the
+    # contract model -- a stored payload that fails validation would still
+    # satisfy every assertion above while being useless to a v2 replay.
+    FrameContract.model_validate(frame.payload)
+
+
+def _preflight_runtime(*, org_id: uuid.UUID) -> BoundedDevRuntime:
+    """The production runtime seam, wired with a real preflight and catalog.
+
+    Mirrors ``tests/_chaos_3292_preflight.py``'s ``run_preflight_orchestrator``
+    construction, but returns the ``BoundedDevRuntime`` the router's
+    ``get_dev_execution_runtime`` dependency normally builds -- so the test
+    drives the same orchestrator code path production does, through the real
+    HTTP endpoint, instead of calling ``DevOrchestrator`` directly.
+    """
+
+    catalog = SeededCatalog([(str(org_id), ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    mint = sequential_ids()
+    preflight = SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=scope_service,
+        versions=_test_versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+    async def scope_resolver(
+        *, org_id: str, user_id: str, requested_scope: DevScope
+    ) -> DevScopeResolution:
+        del user_id
+        assert requested_scope.organization_id == org_id
+        return DevScopeResolution(
+            schema_version="dev_scope_resolution.v1",
+            outcome=ScopeResolutionOutcome.EXACT,
+            requested_scope=requested_scope,
+            resolved_scope=requested_scope,
+            authorized_repository_ids=list(requested_scope.repositories),
+            authorized_entity_ids=[
+                item.entity_id for item in requested_scope.entity_refs
+            ],
+            candidates=[],
+            fallbacks=[],
+            warnings=[],
+            resolved_at=fixed_now(),
+        )
+
+    return BoundedDevRuntime(
+        # Never called: the preflight terminates before the first model
+        # round, and an empty script raises loudly (AgentProviderError) if
+        # it ever were -- a silent no-op provider would let a broken test
+        # setup masquerade as a passing one.
+        provider=cast(Any, ScriptedAgentProvider([], script_id="chaos_3297_c0")),
+        provider_source="platform",
+        provider_family="scripted",
+        registry=recording_registry([]),
+        scope_resolver=scope_resolver,
+        versions=_test_versions(),
+        preflight=preflight,
+    )
+
+
+def _preflight_terminating_payload(
+    conversation_id: str, org_id: uuid.UUID
+) -> dict[str, Any]:
+    return {
+        "schema_version": "dev_message_request.v1",
+        "request_id": "request_chaos_3297_c0",
+        "client_message_id": "client_chaos_3297_c0",
+        "conversation_id": conversation_id,
+        "question": "What's the status of the Nightfall project?",
+        "question_class": "status",
+        "scope": _scope_payload(org_id),
+    }
+
+
+async def test_assert_frame_persisted_fails_loudly_when_frame_missing(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+) -> None:
+    """N0 self-proof: the helper must fail, not silently pass, on a frameless run.
+
+    Drives a normal completed run through the stock ``FakeBoundedRuntime``
+    fixture (which records an answer, never a frame) and asserts
+    ``assert_frame_persisted`` raises rather than passing vacuously -- proving
+    the helper is actually load-bearing before C0 relies on it.
+    """
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(dev_api_context.org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = {
+        "schema_version": "dev_message_request.v1",
+        "request_id": "request_chaos_3297_n0",
+        "client_message_id": "client_chaos_3297_n0",
+        "conversation_id": conversation_id,
+        "question": "What changed?",
+        "question_class": "observed_change",
+        "scope": _scope_payload(dev_api_context.org_id),
+    }
+    response = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert response.status_code == 200
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        with pytest.raises(AssertionError, match="no dev_answer_frames row"):
+            await assert_frame_persisted(session, run.id)
+
+
+async def test_preflight_termination_persists_frame_and_replays(
+    dev_api_context,  # noqa: F811 -- pytest fixture imported from test_router
+) -> None:
+    """C0: a real preflight-terminated run must persist its frame and replay it.
+
+    Drives a question naming a project absent from the authorized catalog
+    through the real ``DevOrchestrator`` + real ``SubjectPreflight`` (not a
+    fake runtime), so the orchestrator's TERMINATE branch runs exactly as it
+    does in production. Before the fix this is RED: the frame the preflight
+    built is discarded, so ``assert_frame_persisted`` fails on
+    ``dev_runs.contract_generation`` never becoming 'v2'.
+    """
+
+    org_id = dev_api_context.org_id
+    dev_api_context.app.dependency_overrides[
+        dev_router_module.get_dev_execution_runtime
+    ] = lambda: dev_router_module.DevExecutionRuntimeResolution(
+        runtime=_preflight_runtime(org_id=org_id)
+    )
+
+    client = dev_api_context.client
+    created = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    conversation_id = created.json()["conversation_id"]
+    payload = _preflight_terminating_payload(conversation_id, org_id)
+
+    live = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert live.status_code == 200
+    live_events = dict(_parse_sse_events(live.text))
+    assert "answer.completed" not in live_events, (
+        "a not-found subject must not fabricate an answer"
+    )
+    assert "error" in live_events
+
+    async with dev_api_context.maker() as session:
+        run = await session.scalar(
+            select(DevRun).where(DevRun.conversation_id == uuid.UUID(conversation_id))
+        )
+        assert run is not None
+        await assert_frame_persisted(session, run.id)
+
+    # Replay reachability: the same client_message_id must now take the v2
+    # frame-reconstruction branch in router._replayed_result and stream the
+    # identical terminal error -- proving the persisted frame is not just
+    # written but actually consumable.
+    replay = await client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages", json=payload
+    )
+    assert replay.status_code == 200
+    replay_events = dict(_parse_sse_events(replay.text))
+    assert "answer.completed" not in replay_events
+    assert "error" in replay_events
+
+    def _comparable(error: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in error.items() if k != "request_id"}
+
+    assert _comparable(live_events["error"]["error"]) == _comparable(
+        replay_events["error"]["error"]
+    )
+
+    async with dev_api_context.maker() as session:
+        runs = (
+            await session.scalars(
+                select(DevRun).where(
+                    DevRun.conversation_id == uuid.UUID(conversation_id)
+                )
+            )
+        ).all()
+        assert len(runs) == 1, "the replay must not have created a second run"
+        assert runs[0].contract_generation == "v2"

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -72,6 +72,10 @@ class Recorder:
         del frame
 
 
+    async def rollback(self) -> None:
+        pass
+
+
     async def terminal(self, **values) -> None:
         self.terminals.append(values["state"])
 

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -71,10 +71,8 @@ class Recorder:
     async def record_frame(self, frame: Any) -> None:
         del frame
 
-
     async def rollback(self) -> None:
         pass
-
 
     async def terminal(self, **values) -> None:
         self.terminals.append(values["state"])

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -68,6 +68,10 @@ class Recorder:
     async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
         del subject_set
 
+    async def record_frame(self, frame: Any) -> None:
+        del frame
+
+
     async def terminal(self, **values) -> None:
         self.terminals.append(values["state"])
 


### PR DESCRIPTION
CHAOS-3297 C0 quick-win: preflight terminations now persist their `dev_answer_frame.v1`, making the dormant v2 replay gate (router `contract_generation=='v2'`) production-reachable, plus hardening from two codex adversarial rounds:

- `record_frame` flush failure: rollback-then-terminalize via a new `RunRecorder.rollback()` seam — a poisoned session can no longer strand a run nonterminal (permanent 409); the preflight diagnostic is re-persisted after rollback so terminal state keeps its explanation.
- Replay: `_replayed_result` requires frame outcome ∈ the replayable no-answer set AND equality with `run.public_outcome` before projection; any invalid, mismatched, or corrupted frame degrades to the safe generic fallback instead of 500ing or replaying false semantics.

TEST-EVIDENCE: `test_chaos_3297_frame_reachability.py` (6 tests: RED-batch reachability controls plus flush-failure, corrupted-frame, mismatched-frame, answered-frame regressions, each verified fail-before/pass-after); duplicate-POST race control passed; full local gate GATE PASSED 9/9 (10138 unit tests); two codex adversarial rounds, final verdict SHIP with no material findings.

RISK-NOTES: Frame persistence shares the run transaction; a flush failure now downgrades that run to v1 replay semantics (safe fallback) rather than v2 — disclosed by the preserved preflight diagnostic. No schema migration in this PR.

SCREENSHOT-WAIVER: backend-only change, no UI surface.