### PR TITLE
feat(ask-dev): CHAOS-3303 canonical project/team health + portfolio status services

### DIFF
--- a/src/dev_health_ops/api/dev/dimension_observation_adapters.py
+++ b/src/dev_health_ops/api/dev/dimension_observation_adapters.py
@@ -1,0 +1,284 @@
+"""Typed ``dimension_observation.v1`` adapters (CHAOS-3303).
+
+Pure functions that turn an already-computed canonical service result
+(:class:`~.data_health_service.DataHealthResult`,
+:class:`~.status_change_service.StatusSnapshotResult`,
+:class:`~.metrics.service.MetricQueryResult`) into a
+:class:`~.contracts_v2.health_rules.DimensionObservation` for exactly one
+:class:`~.contracts_v2.health_rules.HealthRuleDefinition`. No adapter here
+computes a NEW metric, ratio, or threshold -- each one only re-expresses a
+value the canonical service already produced in the shape
+``evaluate_rule`` requires. A rule whose ``comparison_unit`` has no
+canonical, scope-safe source yet (see ``health_profile_synthesis``'s
+``UNBOUND_RULE_LIMITATIONS``) is never approximated by a different unit's
+value here -- it is reported honestly via :func:`unavailable_observation`
+instead, matching "No missing data as zero" and "No model-created
+dimension, severity, percentage, or finding".
+
+Reuses ``investigation_plans.state_mapping`` for every canonical
+service-state -> ``SourceRequirementState`` mapping rather than
+re-deriving it (CHAOS-3295's own module, already exhaustive/mypy-proven).
+``DimensionObservation.validate_zero_semantics`` enforces one invariant
+this module leans on throughout: whenever ``current_value`` is not
+``None``, ``data_semantics`` must be ``"measured_zero"`` -- *regardless* of
+whether the value itself happens to be numerically zero. ``"measured_zero"``
+therefore means "this dimension carries a real, queried value", not "the
+value is literally 0"; :func:`_value_semantics` below is the one place that
+distinction is applied so every adapter agrees on it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .contracts_v2.base import SourceRequirementState
+from .contracts_v2.health_rules import (
+    DataSemantics,
+    DimensionObservation,
+    RuleApplicability,
+)
+from .data_health_service import DataHealthResult
+from .investigation_plans.state_mapping import (
+    UNMEASURED_REQUIREMENT_STATES,
+    data_health_state_to_requirement_state,
+    metric_data_state_to_requirement_state,
+    status_result_state_to_requirement_state,
+)
+from .metrics.service import MetricDataState, MetricQueryResult
+from .status_change_service import StatusSnapshotResult
+
+__all__ = [
+    "change_failure_rate_observation",
+    "data_trust_observation",
+    "incident_load_observation",
+    "unavailable_observation",
+]
+
+#: Severity order (least to most available) for picking the worst mapped
+#: state across several required data-health sources -- mirrors
+#: ``investigation_plans.builtin_steps._data_health_outcome``'s own table
+#: (that helper is module-private, so this is a deliberate, small,
+#: independently-testable re-derivation over the same public
+#: ``state_mapping`` output, not a duplicate of its business logic).
+_STATE_SEVERITY: dict[SourceRequirementState, int] = {
+    SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE: 0,
+    SourceRequirementState.UNAVAILABLE: 1,
+    SourceRequirementState.UNCONFIGURED: 2,
+    SourceRequirementState.AVAILABLE_STALE: 3,
+    SourceRequirementState.AVAILABLE_UNKNOWN: 4,
+    SourceRequirementState.AVAILABLE_CURRENT: 5,
+    SourceRequirementState.NOT_APPLICABLE: 6,
+    SourceRequirementState.TRUNCATED: 3,
+}
+
+
+def _value_semantics(current_value: float | None) -> DataSemantics:
+    """``measured_zero`` iff a real value is present -- see module docstring."""
+
+    return "measured_zero" if current_value is not None else "no_data"
+
+
+def unavailable_observation(
+    *,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    window_index: int,
+    observed_at: datetime,
+    state: SourceRequirementState = SourceRequirementState.UNAVAILABLE,
+) -> DimensionObservation:
+    """An honest, structural gap: no canonical source is wired for this rule yet.
+
+    Never a stand-in for a real zero -- ``evaluate_rule`` maps every
+    ``not_measured`` observation straight to ``DimensionState.UNKNOWN``
+    (never ``healthy``), so a caller cannot mistake this for "measured and
+    fine".
+    """
+
+    if state not in UNMEASURED_REQUIREMENT_STATES:
+        raise ValueError(f"{state!r} is not an unmeasured SourceRequirementState")
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        cohort_size=cohort_size,
+        observed_states=(state,),
+        data_semantics="not_measured",
+        sample_count=None,
+        coverage=0.0,
+        current_value=None,
+        comparison_value=None,
+        denominator_present=False,
+        attribution_present=False,
+        window_index=window_index,
+        observed_at=observed_at,
+    )
+
+
+def data_trust_observation(
+    result: DataHealthResult,
+    *,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    window_index: int,
+    observed_at: datetime,
+) -> DimensionObservation:
+    """``health_rule.data_trust_broken.v1``: deterministic, from ``complete_eligible``.
+
+    ``current_value`` is ``1.0`` (broken -- triggers the deterministic
+    condition) when ``complete_eligible`` is ``False``, else ``0.0``. The
+    worst individually-mapped source state across ``result.sources`` decides
+    whether the dimension was measured at all: if every required source is
+    itself unmeasured (unconfigured/unavailable/unauthorized), the whole
+    dimension is honestly unmeasured too, never a fabricated "not broken".
+    """
+
+    if not result.sources:
+        return DimensionObservation(
+            schema_version="dimension_observation.v1",
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            observed_states=(SourceRequirementState.AVAILABLE_CURRENT,),
+            data_semantics="no_data",
+            sample_count=0,
+            coverage=0.0,
+            current_value=None,
+            comparison_value=None,
+            denominator_present=False,
+            attribution_present=False,
+            window_index=window_index,
+            observed_at=observed_at,
+        )
+    mapped = [data_health_state_to_requirement_state(s.state) for s in result.sources]
+    worst = min(mapped, key=lambda state: _STATE_SEVERITY[state])
+    coverage = sum(s.coverage for s in result.sources) / len(result.sources)
+    if worst in UNMEASURED_REQUIREMENT_STATES:
+        return unavailable_observation(
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=window_index,
+            observed_at=observed_at,
+            state=worst,
+        )
+    current_value = 0.0 if result.complete_eligible else 1.0
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        cohort_size=cohort_size,
+        observed_states=(worst,),
+        data_semantics=_value_semantics(current_value),
+        sample_count=len(result.sources),
+        coverage=coverage,
+        current_value=current_value,
+        comparison_value=None,
+        denominator_present=False,
+        attribution_present=False,
+        window_index=window_index,
+        observed_at=observed_at,
+    )
+
+
+def incident_load_observation(
+    snapshot: StatusSnapshotResult,
+    *,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    window_index: int,
+    observed_at: datetime,
+) -> DimensionObservation:
+    """``health_rule.incident_load.v1``: the raw incident count from a status snapshot.
+
+    ``StatusSnapshotResult.incidents`` is a real, already-queried fact list
+    (CHAOS-3295's mandatory ``status_snapshot`` step); its length is exactly
+    the rule's ``incident_count`` comparison unit -- no derived ratio, no
+    invented threshold. A snapshot whose overall state never queried
+    anything (``INSUFFICIENT_EVIDENCE`` -> ``UNAVAILABLE``) is reported
+    unmeasured rather than a fabricated zero-incident count.
+    """
+
+    mapped = status_result_state_to_requirement_state(snapshot.state)
+    if mapped in UNMEASURED_REQUIREMENT_STATES:
+        return unavailable_observation(
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=window_index,
+            observed_at=observed_at,
+            state=mapped,
+        )
+    current_value = float(len(snapshot.incidents))
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        cohort_size=cohort_size,
+        observed_states=(mapped,),
+        data_semantics=_value_semantics(current_value),
+        sample_count=len(snapshot.incidents),
+        coverage=1.0,
+        current_value=current_value,
+        comparison_value=None,
+        denominator_present=False,
+        attribution_present=False,
+        window_index=window_index,
+        observed_at=observed_at,
+    )
+
+
+def change_failure_rate_observation(
+    result: MetricQueryResult,
+    *,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    window_index: int,
+    observed_at: datetime,
+) -> DimensionObservation:
+    """``health_rule.change_failure_rate.v1``: the canonical ``CHANGE_FAILURE_RATE`` metric.
+
+    Reuses ``MetricQueryService``'s own ``change_failure_rate`` computation
+    verbatim -- this adapter only re-expresses ``MetricQueryResult`` as a
+    ``DimensionObservation``, it never recomputes the ratio. A zero
+    denominator (``MetricDataState.INSUFFICIENT_EVIDENCE``, the metric
+    service's own "no denominator" projection) is reported with
+    ``denominator_present=False``, never as a healthy zero rate.
+    """
+
+    mapped = metric_data_state_to_requirement_state(result.state)
+    if mapped in UNMEASURED_REQUIREMENT_STATES:
+        return unavailable_observation(
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=window_index,
+            observed_at=observed_at,
+            state=mapped,
+        )
+    value = result.values[0] if result.values else None
+    current_value = value.value if value is not None else None
+    comparison_value = value.comparison_value if value is not None else None
+    denominator_present = (
+        result.state is not MetricDataState.INSUFFICIENT_EVIDENCE
+        and current_value is not None
+    )
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        cohort_size=cohort_size,
+        observed_states=(mapped,),
+        data_semantics=_value_semantics(current_value),
+        sample_count=None,
+        coverage=result.coverage,
+        current_value=current_value,
+        comparison_value=comparison_value,
+        denominator_present=denominator_present,
+        attribution_present=False,
+        window_index=window_index,
+        observed_at=observed_at,
+    )

--- a/src/dev_health_ops/api/dev/health_profile_synthesis.py
+++ b/src/dev_health_ops/api/dev/health_profile_synthesis.py
@@ -1,0 +1,262 @@
+"""Shared rule-application engine for CHAOS-3303's project/team health profiles.
+
+Builds one :class:`~.contracts_v2.health_rules.DimensionObservation` per
+applicable :data:`~.health_rule_registry.HEALTH_RULE_REGISTRY` rule for a
+subject, evaluates the whole batch through
+:func:`~.health_rule_registry.evaluate_registry` (CHAOS-3302's production
+seam, hard-bound to the canonical registry), and returns every finding --
+launch, shadow, and suppressed -- as ``HealthRuleFinding`` tuples. No
+composite score is ever computed; a caller reads dimension-by-dimension, per
+the CHAOS-3302/3303 "no default composite health score" guardrail.
+
+Every rule shipped in ``HEALTH_RULE_REGISTRY`` today is ``provisional``
+(CHAOS-3302's own ``test_no_shipped_rule_is_launch_authorized`` totality
+test), so every finding this module produces today is ``shadow_only``. That
+is expected, not a defect: calibration has not yet approved any rule for
+launch. The moment a future calibration review promotes a rule, the exact
+same synthesis code produces a launch finding with no changes required
+here.
+
+``_UNBOUND_RULE_LIMITATIONS`` is a closed, exhaustive table (checked at
+import time against every rule currently in the registry): a rule whose
+``comparison_unit`` has no canonical, scope-safe source wired yet is
+reported as an honest, unmeasured gap -- never approximated with a
+different unit's value, and never silently skipped. Adding a rule to
+``HEALTH_RULE_REGISTRY`` without either binding it in
+``_observation_for_rule`` or documenting it here fails construction of this
+module loudly, rather than silently producing no observation for it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+from .contracts_v2.base import SourceRequirementState
+from .contracts_v2.health_rules import (
+    DimensionObservation,
+    HealthRuleDefinition,
+    HealthRuleFinding,
+    RuleApplicability,
+)
+from .data_health_service import DataHealthResult
+from .dimension_observation_adapters import (
+    change_failure_rate_observation,
+    data_trust_observation,
+    incident_load_observation,
+    unavailable_observation,
+)
+from .health_rule_registry import HEALTH_RULE_REGISTRY, evaluate_registry
+from .metrics.service import MetricQueryResult
+from .status_change_service import StatusSnapshotResult
+
+__all__ = [
+    "HealthEvaluationSources",
+    "HealthProfileResult",
+    "synthesize_health_profile",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class HealthEvaluationSources:
+    """Already-fetched canonical results this module composes -- never fetched here.
+
+    Callers (``ProjectHealthService``/``TeamHealthService``) own every
+    ``PlanExecutorRuntime`` call; this module only maps results it is
+    handed.
+    """
+
+    data_health: DataHealthResult | None = None
+    status_snapshot: StatusSnapshotResult | None = None
+    change_failure_rate_metric: MetricQueryResult | None = None
+    #: True when the change-failure-rate metric is structurally
+    #: inapplicable to this subject's direct scope (e.g. TEAM --
+    #: ``CHANGE_FAILURE_RATE``'s ``supported_scopes`` excludes
+    #: ``DirectScope.TEAM`` and ``supports_team_filter`` is ``False``), as
+    #: opposed to merely unqueried. Distinct so the resulting observation
+    #: reports ``NOT_APPLICABLE`` rather than ``UNAVAILABLE``.
+    change_failure_rate_not_applicable: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class HealthProfileResult:
+    subject_kind: RuleApplicability
+    subject_id: str
+    observations: tuple[DimensionObservation, ...]
+    findings: tuple[HealthRuleFinding, ...]
+
+
+#: Rules with a bound canonical source, handled directly in
+#: ``_observation_for_rule``. Every other registry rule id must appear in
+#: ``_UNBOUND_RULE_LIMITATIONS`` below (enforced at import time).
+_BOUND_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "health_rule.data_trust_broken.v1",
+        "health_rule.incident_load.v1",
+        "health_rule.change_failure_rate.v1",
+    }
+)
+
+#: Every other CHAOS-3302 rule id, and why it has no canonical, scope-safe
+#: source wired yet -- see ``dimension_observation_adapters``'s module
+#: docstring. A limitation string here is never surfaced as a percentage or
+#: finding; it only labels why the dimension is honestly ``unavailable``.
+_UNBOUND_RULE_LIMITATIONS: Mapping[str, str] = {
+    "health_rule.completion_stalled.v1": "no_canonical_stalled_work_item_ratio_source",
+    "health_rule.review_latency_sustained.v1": "no_canonical_review_latency_source",
+    "health_rule.wip_congestion.v1": "no_canonical_wip_congestion_ratio_source",
+    "health_rule.review_bottleneck_hours.v1": "no_canonical_review_latency_source",
+    "health_rule.flaky_test_rate.v1": "no_canonical_test_report_source",
+    "health_rule.high_churn.v1": "no_canonical_rework_churn_ratio_source",
+}
+
+_undocumented_rule_ids = (
+    frozenset(HEALTH_RULE_REGISTRY)
+    - _BOUND_RULE_IDS
+    - frozenset(_UNBOUND_RULE_LIMITATIONS)
+)
+if _undocumented_rule_ids:
+    raise RuntimeError(
+        "health_profile_synthesis has no source binding or documented "
+        f"limitation for rule id(s): {sorted(_undocumented_rule_ids)} -- add "
+        "a binding in _observation_for_rule or an entry in "
+        "_UNBOUND_RULE_LIMITATIONS"
+    )
+
+
+def _observation_for_rule(
+    rule: HealthRuleDefinition,
+    sources: HealthEvaluationSources,
+    *,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    observed_at: datetime,
+) -> DimensionObservation:
+    if rule.rule_id == "health_rule.data_trust_broken.v1":
+        if sources.data_health is None:
+            return unavailable_observation(
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                cohort_size=cohort_size,
+                window_index=0,
+                observed_at=observed_at,
+            )
+        return data_trust_observation(
+            sources.data_health,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=0,
+            observed_at=observed_at,
+        )
+    if rule.rule_id == "health_rule.incident_load.v1":
+        if sources.status_snapshot is None:
+            return unavailable_observation(
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                cohort_size=cohort_size,
+                window_index=0,
+                observed_at=observed_at,
+            )
+        return incident_load_observation(
+            sources.status_snapshot,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=0,
+            observed_at=observed_at,
+        )
+    if rule.rule_id == "health_rule.change_failure_rate.v1":
+        if sources.change_failure_rate_not_applicable:
+            return unavailable_observation(
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                cohort_size=cohort_size,
+                window_index=0,
+                observed_at=observed_at,
+                state=SourceRequirementState.NOT_APPLICABLE,
+            )
+        if sources.change_failure_rate_metric is None:
+            return unavailable_observation(
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                cohort_size=cohort_size,
+                window_index=0,
+                observed_at=observed_at,
+            )
+        return change_failure_rate_observation(
+            sources.change_failure_rate_metric,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            window_index=0,
+            observed_at=observed_at,
+        )
+    if rule.rule_id not in _UNBOUND_RULE_LIMITATIONS:
+        # Unreachable given the module-level totality check above; kept as a
+        # loud failure rather than a silent fallthrough if that check is
+        # ever weakened.
+        raise AssertionError(
+            f"rule {rule.rule_id!r} has no source binding or documented limitation"
+        )
+    return unavailable_observation(
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        cohort_size=cohort_size,
+        window_index=0,
+        observed_at=observed_at,
+    )
+
+
+def synthesize_health_profile(
+    *,
+    applicability: RuleApplicability,
+    subject_id: str,
+    cohort_size: int | None,
+    sources: HealthEvaluationSources,
+    org_id: str,
+    observed_at: datetime,
+) -> HealthProfileResult:
+    """Evaluate every ``HEALTH_RULE_REGISTRY`` rule applicable to ``applicability``.
+
+    Returns every finding -- launch, shadow, and suppressed -- sorted
+    deterministically by ``(dimension, rule_id)`` so two evaluations of the
+    same inputs always produce the same ordering.
+    """
+
+    applicable_rules = tuple(
+        rule
+        for rule in HEALTH_RULE_REGISTRY.values()
+        if applicability in rule.applicability
+    )
+    observations_by_rule: dict[str, list[DimensionObservation]] = {}
+    ordered_observations: list[DimensionObservation] = []
+    for rule in applicable_rules:
+        observation = _observation_for_rule(
+            rule,
+            sources,
+            subject_kind=applicability,
+            subject_id=subject_id,
+            cohort_size=cohort_size,
+            observed_at=observed_at,
+        )
+        observations_by_rule[rule.rule_id] = [observation]
+        ordered_observations.append(observation)
+
+    evaluation = evaluate_registry(observations_by_rule, org_id=org_id)
+    findings = sorted(
+        (
+            *evaluation.launch_findings,
+            *evaluation.shadow_findings,
+            *evaluation.suppressed_findings,
+        ),
+        key=lambda finding: (finding.dimension.value, finding.rule_id),
+    )
+    return HealthProfileResult(
+        subject_kind=applicability,
+        subject_id=subject_id,
+        observations=tuple(ordered_observations),
+        findings=tuple(findings),
+    )

--- a/src/dev_health_ops/api/dev/health_profile_synthesis.py
+++ b/src/dev_health_ops/api/dev/health_profile_synthesis.py
@@ -4,18 +4,25 @@ Builds one :class:`~.contracts_v2.health_rules.DimensionObservation` per
 applicable :data:`~.health_rule_registry.HEALTH_RULE_REGISTRY` rule for a
 subject, evaluates the whole batch through
 :func:`~.health_rule_registry.evaluate_registry` (CHAOS-3302's production
-seam, hard-bound to the canonical registry), and returns every finding --
-launch, shadow, and suppressed -- as ``HealthRuleFinding`` tuples. No
-composite score is ever computed; a caller reads dimension-by-dimension, per
-the CHAOS-3302/3303 "no default composite health score" guardrail.
+seam, hard-bound to the canonical registry), and returns
+:class:`HealthProfileResult` with the SAME three-way split
+``evaluate_registry`` itself returns (``launch_findings``/
+``shadow_findings``/``suppressed_findings``), never collapsed into one
+tuple. No composite score is ever computed; a caller reads
+dimension-by-dimension, per the CHAOS-3302/3303 "no default composite
+health score" guardrail.
 
 Every rule shipped in ``HEALTH_RULE_REGISTRY`` today is ``provisional``
 (CHAOS-3302's own ``test_no_shipped_rule_is_launch_authorized`` totality
-test), so every finding this module produces today is ``shadow_only``. That
-is expected, not a defect: calibration has not yet approved any rule for
-launch. The moment a future calibration review promotes a rule, the exact
-same synthesis code produces a launch finding with no changes required
-here.
+test), so ``launch_findings`` is empty and every finding this module
+produces today lands in ``shadow_findings``. That is expected, not a
+defect: calibration has not yet approved any rule for launch. A caller
+(e.g. ``PortfolioStatusService``) that computed status/ordering from a
+merged bucket would therefore be treating pure calibration data as launch
+authority -- ``launch_findings`` staying separate is what keeps that
+distinction available at every call site, not just this one. The moment a
+future calibration review promotes a rule, the exact same synthesis code
+starts populating ``launch_findings`` with no changes required here.
 
 ``_UNBOUND_RULE_LIMITATIONS`` is a closed, exhaustive table (checked at
 import time against every rule currently in the registry): a rule whose
@@ -29,7 +36,7 @@ module loudly, rather than silently producing no observation for it.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -81,10 +88,17 @@ class HealthEvaluationSources:
 
 @dataclass(frozen=True, slots=True)
 class HealthProfileResult:
+    """Mirrors ``HealthRuleEvaluationResult``'s own three-way split exactly --
+    see the module docstring for why a caller must never merge these back
+    into one bucket.
+    """
+
     subject_kind: RuleApplicability
     subject_id: str
     observations: tuple[DimensionObservation, ...]
-    findings: tuple[HealthRuleFinding, ...]
+    launch_findings: tuple[HealthRuleFinding, ...]
+    shadow_findings: tuple[HealthRuleFinding, ...]
+    suppressed_findings: tuple[HealthRuleFinding, ...]
 
 
 #: Rules with a bound canonical source, handled directly in
@@ -221,9 +235,10 @@ def synthesize_health_profile(
 ) -> HealthProfileResult:
     """Evaluate every ``HEALTH_RULE_REGISTRY`` rule applicable to ``applicability``.
 
-    Returns every finding -- launch, shadow, and suppressed -- sorted
-    deterministically by ``(dimension, rule_id)`` so two evaluations of the
-    same inputs always produce the same ordering.
+    Each of ``launch_findings``/``shadow_findings``/``suppressed_findings``
+    is independently sorted deterministically by ``(dimension, rule_id)`` so
+    two evaluations of the same inputs always produce the same ordering
+    within each bucket.
     """
 
     applicable_rules = tuple(
@@ -246,17 +261,22 @@ def synthesize_health_profile(
         ordered_observations.append(observation)
 
     evaluation = evaluate_registry(observations_by_rule, org_id=org_id)
-    findings = sorted(
-        (
-            *evaluation.launch_findings,
-            *evaluation.shadow_findings,
-            *evaluation.suppressed_findings,
-        ),
-        key=lambda finding: (finding.dimension.value, finding.rule_id),
-    )
+
+    def _ordered(
+        findings: Sequence[HealthRuleFinding],
+    ) -> tuple[HealthRuleFinding, ...]:
+        return tuple(
+            sorted(
+                findings,
+                key=lambda finding: (finding.dimension.value, finding.rule_id),
+            )
+        )
+
     return HealthProfileResult(
         subject_kind=applicability,
         subject_id=subject_id,
         observations=tuple(ordered_observations),
-        findings=tuple(findings),
+        launch_findings=_ordered(evaluation.launch_findings),
+        shadow_findings=_ordered(evaluation.shadow_findings),
+        suppressed_findings=_ordered(evaluation.suppressed_findings),
     )

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -125,6 +125,7 @@ _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY = """
           SELECT work_item_id, max(computed_at)
           FROM work_item_team_attributions
           WHERE org_id = {org_id:String}
+            AND computed_at <= {as_of:DateTime64(3, 'UTC')}
           GROUP BY work_item_id
       )
 """
@@ -388,6 +389,33 @@ _ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL = """
 SELECT toString(id) AS repository_id
 FROM repos FINAL
 WHERE org_id = {org_id:String}
+"""
+
+#: CHAOS-3303 round 3 (Codex MEDIUM, 2026-08-02): a bare repository-level
+#: existence check -- deliberately bypasses canonical work-item attribution
+#: entirely (unlike every fact-level team arm above). Used ONLY to detect
+#: "this team's accessible repositories are not actually empty" when every
+#: canonically-attributed team read came back with nothing, so
+#: status_snapshot can tell "insufficient attribution coverage" (repo-level
+#: activity exists, none of it canonically assignable to this team) apart
+#: from "this team genuinely has no activity in scope" -- the exclusion
+#: itself (repo co-location != ownership) stays correct either way; only the
+#: silent-completeness gap is being closed. Checks pull requests and
+#: deployments only (the two root categories every other delivery fact --
+#: CI, reviews, incidents -- derives from), so a genuinely empty root
+#: category set implies the derived categories are empty too.
+_TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL = """
+SELECT 1 AS found
+FROM git_pull_requests FINAL
+WHERE org_id = {org_id:String}
+  AND toString(repo_id) IN {repository_ids:Array(String)}
+LIMIT 1
+UNION ALL
+SELECT 1 AS found
+FROM deployments FINAL
+WHERE org_id = {org_id:String}
+  AND toString(repo_id) IN {repository_ids:Array(String)}
+LIMIT 1
 """
 
 #: CHAOS-3303: re-derive a committed team subject's authorized repositories
@@ -1108,6 +1136,37 @@ class ClickHouseStatusChangeSource:
         source_refs.append(deployment_ref)
         if warning:
             warnings.append(warning)
+        if (
+            scope.direct_scope not in {DirectScope.ORGANIZATION, DirectScope.REPOSITORY}
+            and pr_ref.freshness is not FreshnessState.UNAVAILABLE
+        ):
+            # Codex finding (HIGH, 2026-08-02): _DEPLOYMENTS_SQL's
+            # ifNull(pull_request_number, 0) IN {pr_numbers} arm matches on
+            # a bare, cross-repository-flattened PR NUMBER list -- with
+            # multiple repositories in scope (team, and in principle
+            # organization/repository), a deployment in repo B for its own
+            # unrelated PR #77 is wrongly admitted merely because repo A's
+            # PR #77 (a genuinely different pull request) was. Re-derive
+            # admission by the exact (repository_id, pr_number) PAIR,
+            # mirroring the pair-filter ci_rows/ci_acceptance_rows already
+            # apply just above. Organization/repository scope is exempt: its
+            # own SQL arm legitimately admits every deployment regardless of
+            # PR linkage (an unlinked scheduled/manual deploy has
+            # pr_number=0, which would never match a real pair) -- for every
+            # other scope, admission is entirely through PR linkage already,
+            # so the pair check only ever tightens a real collision, never
+            # excludes a legitimately-unlinked deployment. Also exempt when
+            # the pull-request read itself failed (pr_ref UNAVAILABLE): an
+            # empty pr_pairs from a genuine failure is not the same claim as
+            # "this scope has zero pull requests", and applying the stricter
+            # pair check there would wrongly strip deployments the SQL's own
+            # (already-executed) pr_numbers filter had legitimately admitted.
+            deployment_rows = [
+                row
+                for row in deployment_rows
+                if (str(row.get("repository_id") or ""), int(row.get("pr_number") or 0))
+                in pr_pairs
+            ]
         deployment_ids = [str(row.get("entity_id") or "") for row in deployment_rows]
 
         incident_rows: list[dict[str, Any]] = []
@@ -1159,6 +1218,39 @@ class ClickHouseStatusChangeSource:
             )
 
         gap_refs: list[SourceReference] = []
+        if (
+            scope.direct_scope is DirectScope.TEAM
+            and not pull_requests
+            and not deployment_rows
+        ):
+            # Codex finding (MEDIUM, 2026-08-02): the exclusion of
+            # repository-co-located-but-not-canonically-owned facts is
+            # correct (see the round-2 fix above), but a team whose
+            # accessible repositories contain ONLY such unlinked activity
+            # would otherwise resolve a clean READY/COMPLETE with zero
+            # attributed facts and no disclosure -- indistinguishable from
+            # a team with genuinely nothing happening. Distinguish the two:
+            # if the team's repos have ANY pull-request or deployment
+            # activity at all (checked here with NO attribution join, only
+            # bare repository membership), the coverage gap must be
+            # disclosed and the result must not read as a clean pass.
+            try:
+                async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
+                    unlinked_activity_rows = await query_dicts(
+                        self._client, _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL, common
+                    )
+            except Exception:
+                unlinked_activity_rows = []
+            if unlinked_activity_rows:
+                gap_refs.append(
+                    self._unavailable_ref("team_attribution_coverage", scope)
+                )
+                warnings.append(
+                    "team-accessible repositories contain pull-request or "
+                    "deployment activity that could not be canonically "
+                    "attributed to this team; reporting insufficient "
+                    "attribution coverage rather than a genuinely empty team"
+                )
         acceptance_run_ids = {
             (str(row.get("repository_id") or ""), str(row.get("run_id") or ""))
             for row in ci_acceptance_rows
@@ -1304,6 +1396,12 @@ class ClickHouseStatusChangeSource:
             "team_id": scope.team_ids[0]
             if scope.direct_scope is DirectScope.TEAM
             else "",
+            # CHAOS-3303 round 3 (Codex HIGH): _TEAM_OWNED_WORK_ITEM_IDS_
+            # SUBQUERY bounds its "latest compute" by as_of -- the natural
+            # as_of for a change-summary window is its own end, the same
+            # instant _authorized_repository_ids already resolved
+            # `repositories` at (see the as_of=current.end call above).
+            "as_of": current.end.astimezone(UTC),
         }
         transitions, transition_ref, transition_warning = await self._read(
             "work_items", _TRANSITIONS_SQL, params, scope

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -54,32 +54,36 @@ QUERY_TIMEOUT_SECONDS = 15
 #: introspection and fails if a new one is added without updating one of the
 #: two.
 #:
-#: Every source is registered here today: no arm is added to any SQL
-#: constant by this issue (that is CHAOS-3303's, alongside the team-health
-#: service that has to reason about attribution quality anyway). This is
-#: deliberately still safe rather than silently wrong for a committed team
-#: scope — see ``ClickHouseStatusChangeSource._authorized_repository_ids``:
-#: a team direct scope always carries an empty ``repositories`` list (team
-#: attribution is re-derived at query time in CHAOS-3303, never carried on
-#: the wire per the addendum), so ``status_snapshot`` and ``change_summary``
-#: both take the existing "no authorized repositories" fail-closed branch —
-#: an explicit ``FreshnessState.UNAVAILABLE`` observation with a disclosed
-#: warning — before any of these queries ever execute with
-#: ``scope_type='team'``. That branch is what N0
-#: (``test_n0_team_subject_never_returns_a_silently_empty_status``) proves.
+#: CHAOS-3303 lands real team arms for the nine sources whose org/repo arm
+#: already meant "everything within ``repository_ids``, no further entity
+#: filter" (``_PULL_REQUESTS_SQL``, ``_DEPLOYMENTS_SQL``, ``_TRANSITIONS_SQL``,
+#: ``_RELATIONSHIPS_SQL``, and the five ``_*_CHANGES_SQL`` delivery
+#: projections): once ``_authorized_repository_ids`` re-derives a team's
+#: owned repositories from ``team_repo_ownership`` at query time (never
+#: carried on the wire, per the addendum), that arm's existing semantics --
+#: "no single named entity, just the repository set" -- is exactly what a
+#: team subject wants, so adding ``'team'`` to the same disjunction member is
+#: sufficient; no new join or control-flow branch is required. ``_CI_SQL``,
+#: ``_CI_ACCEPTANCE_SQL``, and ``_INCIDENTS_SQL`` are not ``scope_type``-gated
+#: at all (they filter by ``pr_numbers``/``deployment_ids`` derived from the
+#: above), so they already work correctly for team scope once those upstream
+#: sources do.
+#:
+#: The remaining two sources stay not-applicable to a team subject, for the
+#: same structural reason organization/repository scope never reaches them
+#: either (see ``status_snapshot``'s own guard: both are only ever queried
+#: when ``scope.direct_scope in {ISSUE, PROJECT}`` or a work-unit's member
+#: issues): ``_WORK_ITEMS_SQL`` produces a single declared/children
+#: completion tree, and ``_BLOCKERS_SQL`` blocks a single target entity --
+#: neither concept maps onto a team cohort of repositories. A team's overall
+#: ``StatusResultState`` no longer requires a declared status either (see
+#: ``StatusChangeService.status_snapshot``'s ``declared_optional`` set),
+#: exactly mirroring how PROJECT/WORK_UNIT scope already treats "no single
+#: declared item" as expected, not a gap.
 TEAM_NOT_APPLICABLE_SOURCES: frozenset[str] = frozenset(
     {
         "_WORK_ITEMS_SQL",
         "_BLOCKERS_SQL",
-        "_PULL_REQUESTS_SQL",
-        "_DEPLOYMENTS_SQL",
-        "_TRANSITIONS_SQL",
-        "_RELATIONSHIPS_SQL",
-        "_PULL_REQUEST_CHANGES_SQL",
-        "_REVIEW_CHANGES_SQL",
-        "_CI_CHANGES_SQL",
-        "_DEPLOYMENT_CHANGES_SQL",
-        "_INCIDENT_CHANGES_SQL",
     }
 )
 
@@ -246,7 +250,7 @@ WHERE pr.org_id = {org_id:String}
         OR concat(toString(pr.repo_id), '#pr', toString(pr.number))
           IN {member_pr_ids:Array(String)}
       ))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
@@ -294,7 +298,7 @@ FROM deployments FINAL
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
   AND (
-    ({scope_type:String} IN ('organization', 'repository'))
+    ({scope_type:String} IN ('organization', 'repository', 'team'))
     OR ifNull(pull_request_number, 0) IN {pr_numbers:Array(UInt32)}
   )
   AND coalesce(deployed_at, finished_at, started_at, last_synced)
@@ -328,6 +332,36 @@ FROM repos FINAL
 WHERE org_id = {org_id:String}
 """
 
+#: CHAOS-3303: re-derive a committed team subject's authorized repositories
+#: from ``team_repo_ownership`` at query time (CHAOS-3301 addendum, Option
+#: B -- never carried on the wire; ``DevScope.validate_direct_scope`` forbids
+#: a team direct scope from carrying its own ``repositories`` list). Mirrors
+#: the exact reviewed ``argMax(..., (updated_at, valid_from))`` /
+#: ``valid_from``/``valid_to`` windowing pattern already used by
+#: ``metrics.loaders.clickhouse.ClickHouseDataLoader.load_team_attribution_
+#: context`` for the same table, scoped further to one ``team_id`` and
+#: excluding pattern-matched-but-unresolved ownership rows (``repo_id IS
+#: NULL`` -- a ``match_type='pattern'`` row that has not yet resolved to a
+#: concrete repository contributes no queryable repository id).
+_TEAM_REPOSITORIES_SQL = """
+SELECT toString(g.repo_id) AS repository_id
+FROM (
+  SELECT
+    org_id,
+    provider,
+    repo_full_name,
+    team_id,
+    argMax(repo_id, (updated_at, valid_from)) AS repo_id
+  FROM team_repo_ownership
+  WHERE org_id = {org_id:String}
+    AND team_id = {team_id:String}
+    AND valid_from <= {as_of:DateTime64(3, 'UTC')}
+    AND (valid_to IS NULL OR valid_to > {as_of:DateTime64(3, 'UTC')})
+  GROUP BY org_id, provider, repo_full_name, team_id
+) AS g
+WHERE g.repo_id IS NOT NULL
+"""
+
 _TRANSITIONS_SQL = """
 SELECT transition.work_item_id AS entity_id, item.title AS display_label,
        transition.from_status, transition.to_status,
@@ -346,7 +380,7 @@ WHERE transition.org_id = {org_id:String}
     ({scope_type:String} = 'issue' AND transition.work_item_id = {entity_id:String})
     OR ({scope_type:String} = 'project'
       AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, from_status, to_status
 LIMIT {limit:UInt32}
@@ -378,7 +412,7 @@ WHERE org_id = {org_id:String}
           AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
       )
     ))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, source_type, source_id, edge_type, target_type, target_id
 LIMIT {limit:UInt32}
@@ -422,7 +456,7 @@ WHERE pr.org_id = {org_id:String}
     OR ({scope_type:String} IN ('issue', 'project')
       AND (toString(pr.repo_id), pr.number) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
@@ -463,7 +497,7 @@ WHERE review.org_id = {org_id:String}
     OR ({scope_type:String} IN ('issue', 'project')
       AND (toString(review.repo_id), review.number) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
@@ -503,7 +537,7 @@ WHERE run.org_id = {org_id:String}
     OR ({scope_type:String} IN ('issue', 'project')
       AND (toString(run.repo_id), ifNull(run.pr_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
@@ -546,7 +580,7 @@ WHERE deployment.org_id = {org_id:String}
     OR ({scope_type:String} IN ('issue', 'project')
       AND (toString(deployment.repo_id), ifNull(deployment.pull_request_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
@@ -601,7 +635,7 @@ WHERE incident.org_id = {org_id:String}
     OR ({scope_type:String} IN ('issue', 'project')
       AND (toString(deployment.repo_id), ifNull(deployment.pull_request_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository'))
+    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
@@ -623,7 +657,7 @@ class ClickHouseStatusChangeSource:
         self._now = now
 
     async def _authorized_repository_ids(
-        self, org_id: str, scope: DevScope
+        self, org_id: str, scope: DevScope, *, as_of: datetime
     ) -> list[str]:
         """Bound status/change reads to the server-owned repository set.
 
@@ -635,13 +669,41 @@ class ClickHouseStatusChangeSource:
         truncation or widening. Every other direct scope keeps using the
         scope's own bounded repository/entity refs.
 
-        A team-filtered organization scope (``scope.team_ids``) is excluded
-        from organization-native enumeration: no native query here applies a
-        team filter, so deriving the full org repository set would silently
-        widen a team-scoped request to every repository in the organization.
+        A team-filtered organization scope (``scope.team_ids`` set alongside
+        ``direct_scope=ORGANIZATION``, a *filter*) is excluded from
+        organization-native enumeration: no native query here applies a team
+        filter, so deriving the full org repository set would silently widen
+        a team-filtered request to every repository in the organization.
         Falling through to the caller's own (empty) bounded fields keeps the
         prior fail-closed "authorized repository set" behavior instead.
+
+        A committed team *subject* (``direct_scope=TEAM``, checked first --
+        distinct from the filter case above) instead re-derives its owned
+        repositories from ``team_repo_ownership`` (CHAOS-3303, CHAOS-3301
+        addendum Option B): a team direct scope can never carry its own
+        ``repositories`` list (``DevScope.validate_direct_scope`` forbids
+        it), so without this branch every team subject would always resolve
+        to an empty repository set and take the fail-closed path below,
+        regardless of real ownership data.
         """
+        if scope.direct_scope is DirectScope.TEAM:
+            team_id = scope.team_ids[0]
+            try:
+                async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
+                    rows = await query_dicts(
+                        self._client,
+                        _TEAM_REPOSITORIES_SQL,
+                        {
+                            "org_id": org_id,
+                            "team_id": team_id,
+                            "as_of": as_of.astimezone(UTC),
+                        },
+                    )
+            except Exception:
+                return []
+            return sorted(
+                {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+            )
         if scope.direct_scope is not DirectScope.ORGANIZATION or scope.team_ids:
             return self._repository_ids(scope)
         try:
@@ -660,7 +722,7 @@ class ClickHouseStatusChangeSource:
     async def status_snapshot(
         self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
     ) -> RawStatusSnapshot:
-        repositories = await self._authorized_repository_ids(org_id, scope)
+        repositories = await self._authorized_repository_ids(org_id, scope, as_of=as_of)
         entity_id = self._entity_id(scope)
         scope_type = scope.direct_scope.value
         warnings: list[str] = []
@@ -1017,7 +1079,9 @@ class ClickHouseStatusChangeSource:
         limit: int,
     ) -> RawChangeSummary:
         del comparison
-        repositories = await self._authorized_repository_ids(org_id, scope)
+        repositories = await self._authorized_repository_ids(
+            org_id, scope, as_of=current.end
+        )
         if not repositories:
             return RawChangeSummary(
                 changes=(),

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -366,6 +366,18 @@ ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """
 
+#: CHAOS-3303 round 4 (Codex HIGH, 2026-08-02): ``deployment_id`` is only
+#: unique PER REPO in the schema -- filtering incident edges by a bare
+#: ``edge.deployment_id IN {deployment_ids}`` list (even after the round-3
+#: (repository_id, pr_number) pair filter correctly excludes a deployment
+#: from ``deployments``) still matches ANY edge with that deployment_id in
+#: ANY of the team's authorized repos, including one whose OWN deployment
+#: happens to share the same id string as an admitted deployment in a
+#: different repo. Admission must therefore be scoped by the exact
+#: (repository_id, deployment_id) PAIR, mirroring the
+#: work_unit_investments.py ``(work_unit_id, categorization_run_id) IN
+#: {pairs:Array(Tuple(String, String))}`` idiom already used elsewhere in
+#: this codebase for the same reason.
 _INCIDENTS_SQL = """
 SELECT incident.id AS entity_id, incident.title AS display_label,
        ifNull(incident.normalized_status, 'unknown') AS status,
@@ -377,8 +389,8 @@ INNER JOIN work_graph_deployment_incident_edges AS edge FINAL
   ON edge.org_id = toUUIDOrZero(incident.org_id)
  AND edge.incident_id = incident.id
 WHERE incident.org_id = {org_id:String}
-  AND edge.deployment_id IN {deployment_ids:Array(String)}
-  AND toString(edge.repo_id) IN {repository_ids:Array(String)}
+  AND (toString(edge.repo_id), edge.deployment_id)
+      IN {deployment_pairs:Array(Tuple(String, String))}
   AND coalesce(incident.source_event_at, incident.observed_at)
       <= {as_of:DateTime64(3, 'UTC')}
 ORDER BY observed_at DESC, entity_id
@@ -404,17 +416,25 @@ WHERE org_id = {org_id:String}
 #: deployments only (the two root categories every other delivery fact --
 #: CI, reviews, incidents -- derives from), so a genuinely empty root
 #: category set implies the derived categories are empty too.
+#: CHAOS-3303 round 4 (Codex MEDIUM, 2026-08-02): bounded by as_of, mirroring
+#: the root _PULL_REQUESTS_SQL / _DEPLOYMENTS_SQL bounds exactly -- without
+#: this, a pull request or deployment created strictly AFTER the snapshot's
+#: as_of would still trip the probe, falsely degrading a historical
+#: (as_of=t1) snapshot with activity that had not happened yet at t1.
 _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL = """
 SELECT 1 AS found
 FROM git_pull_requests FINAL
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
+  AND created_at <= {as_of:DateTime64(3, 'UTC')}
 LIMIT 1
 UNION ALL
 SELECT 1 AS found
 FROM deployments FINAL
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
+  AND coalesce(deployed_at, finished_at, started_at, last_synced)
+      <= {as_of:DateTime64(3, 'UTC')}
 LIMIT 1
 """
 
@@ -1167,14 +1187,19 @@ class ClickHouseStatusChangeSource:
                 if (str(row.get("repository_id") or ""), int(row.get("pr_number") or 0))
                 in pr_pairs
             ]
-        deployment_ids = [str(row.get("entity_id") or "") for row in deployment_rows]
+        # Codex round 4 (HIGH): pairs, not bare ids -- deployment_id alone
+        # collides across repos (see _INCIDENTS_SQL's docstring above).
+        deployment_pairs = [
+            (str(row.get("repository_id") or ""), str(row.get("entity_id") or ""))
+            for row in deployment_rows
+        ]
 
         incident_rows: list[dict[str, Any]] = []
-        if deployment_ids:
+        if deployment_pairs:
             incident_rows, incident_ref, warning = await self._read(
                 "incidents",
                 _INCIDENTS_SQL,
-                {**common, "org_id": org_id, "deployment_ids": deployment_ids},
+                {**common, "org_id": org_id, "deployment_pairs": deployment_pairs},
                 scope,
             )
             source_refs.append(incident_ref)
@@ -1240,17 +1265,32 @@ class ClickHouseStatusChangeSource:
                         self._client, _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL, common
                     )
             except Exception:
-                unlinked_activity_rows = []
-            if unlinked_activity_rows:
+                # Codex round 4 (HIGH): a probe FAILURE must not collapse to
+                # the same empty shape as "genuinely nothing found" -- that
+                # silently restores the exact false-confidence
+                # READY/COMPLETE state this probe exists to prevent. Treat
+                # failure as unknown coverage, not clean coverage.
                 gap_refs.append(
                     self._unavailable_ref("team_attribution_coverage", scope)
                 )
                 warnings.append(
-                    "team-accessible repositories contain pull-request or "
-                    "deployment activity that could not be canonically "
-                    "attributed to this team; reporting insufficient "
-                    "attribution coverage rather than a genuinely empty team"
+                    "team attribution coverage probe failed; cannot rule "
+                    "out unattributed repository activity, reporting "
+                    "insufficient attribution coverage rather than a "
+                    "genuinely empty team"
                 )
+            else:
+                if unlinked_activity_rows:
+                    gap_refs.append(
+                        self._unavailable_ref("team_attribution_coverage", scope)
+                    )
+                    warnings.append(
+                        "team-accessible repositories contain pull-request "
+                        "or deployment activity that could not be "
+                        "canonically attributed to this team; reporting "
+                        "insufficient attribution coverage rather than a "
+                        "genuinely empty team"
+                    )
         acceptance_run_ids = {
             (str(row.get("repository_id") or ""), str(row.get("run_id") or ""))
             for row in ci_acceptance_rows

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -656,6 +656,46 @@ class ClickHouseStatusChangeSource:
         self._policies = dict(policies or default_native_freshness_policies())
         self._now = now
 
+    async def team_repository_ids(
+        self, org_id: str, team_id: str, *, as_of: datetime
+    ) -> list[str]:
+        """Re-derive one team's owned repositories from ``team_repo_ownership``.
+
+        Public (CHAOS-3303, Codex finding HIGH 2026-08-02): this is the
+        canonical, verified team-attribution source -- the ONLY place a
+        real cohort-size count for a team subject may come from. Exposed so
+        ``TeamHealthService`` can resolve its own ``cohort_size`` from this
+        exact query instead of trusting a caller-asserted integer (which
+        could claim "cohort_size=25" for a team with zero real
+        ``team_repo_ownership`` rows and get a fabricated healthy finding
+        out of a fail-closed status source). ``_authorized_repository_ids``
+        also delegates here for its own TEAM branch -- one source of truth
+        for "what repositories does this team own right now", never two
+        independently-drifting queries.
+
+        A genuinely failing lookup or zero-row result both return ``[]``,
+        by design indistinguishable to a caller other than "no verified
+        attribution" -- exactly what the fail-closed floor (N0) already
+        requires downstream.
+        """
+
+        try:
+            async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
+                rows = await query_dicts(
+                    self._client,
+                    _TEAM_REPOSITORIES_SQL,
+                    {
+                        "org_id": org_id,
+                        "team_id": team_id,
+                        "as_of": as_of.astimezone(UTC),
+                    },
+                )
+        except Exception:
+            return []
+        return sorted(
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+        )
+
     async def _authorized_repository_ids(
         self, org_id: str, scope: DevScope, *, as_of: datetime
     ) -> list[str]:
@@ -687,22 +727,8 @@ class ClickHouseStatusChangeSource:
         regardless of real ownership data.
         """
         if scope.direct_scope is DirectScope.TEAM:
-            team_id = scope.team_ids[0]
-            try:
-                async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
-                    rows = await query_dicts(
-                        self._client,
-                        _TEAM_REPOSITORIES_SQL,
-                        {
-                            "org_id": org_id,
-                            "team_id": team_id,
-                            "as_of": as_of.astimezone(UTC),
-                        },
-                    )
-            except Exception:
-                return []
-            return sorted(
-                {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+            return await self.team_repository_ids(
+                org_id, scope.team_ids[0], as_of=as_of
             )
         if scope.direct_scope is not DirectScope.ORGANIZATION or scope.team_ids:
             return self._repository_ids(scope)

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from collections import OrderedDict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -88,6 +90,44 @@ TEAM_NOT_APPLICABLE_SOURCES: frozenset[str] = frozenset(
 )
 
 _BLOCKER_PROJECTION_RULE_VERSION = "canonical-blocks.v2"
+
+#: CHAOS-3303 round 2 (Codex HIGH, 2026-08-02): ``team_repo_ownership`` rows
+#: can represent mere *provider_access* to a repository -- a parent team can
+#: have access to a repo whose canonical primary work-item attribution
+#: belongs to a *different* (e.g. child) team. Repository co-location is not
+#: team ownership. Every fact-level team arm below joins through this exact
+#: canonical-primary snapshot instead of the coarser ``repository_ids``
+#: bound, so a parent team with broader repo access never inherits a child
+#: team's canonically-owned facts. Mirrors
+#: ``api/graphql/resolvers/team_attribution.py``'s own ``is_primary = 1`` +
+#: latest-``computed_at``-snapshot pattern verbatim (not re-derived): a work
+#: item's *latest compute* is scoped by ``(work_item_id, computed_at) IN
+#: (SELECT work_item_id, max(computed_at) ... GROUP BY work_item_id)``
+#: because ``compute_work_item_team_attributions`` appends every candidate
+#: of one compute run and never deletes prior ones -- without this bound, a
+#: retired candidate from an earlier compute could survive ``FINAL`` (its
+#: RMT key includes ``source``, so a superseded row is a distinct key, not
+#: replaced) and reappear as a stale extra ``is_primary`` row.
+#:
+#: Plain (non-f-string) text spliced into each query with ``+`` at the exact
+#: point it's needed -- every ``{name:Type}`` placeholder here is
+#: interpreted by clickhouse-connect server-side, never by Python string
+#: formatting (see ``api/queries/client.py``'s server-placeholder detection),
+#: so verbatim splicing is safe and avoids doubling every brace an f-string
+#: embedding would require across ~500 lines of surrounding SQL.
+_TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY = """
+    SELECT work_item_id
+    FROM work_item_team_attributions FINAL
+    WHERE org_id = {org_id:String}
+      AND team_id = {team_id:String}
+      AND is_primary = 1
+      AND (work_item_id, computed_at) IN (
+          SELECT work_item_id, max(computed_at)
+          FROM work_item_team_attributions
+          WHERE org_id = {org_id:String}
+          GROUP BY work_item_id
+      )
+"""
 
 _WORK_UNIT_MEMBERSHIP_WATERMARK_SQL = """
 SELECT max(completed_at) AS last_synced
@@ -186,7 +226,8 @@ ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """
 
-_PULL_REQUESTS_SQL = """
+_PULL_REQUESTS_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -201,6 +242,11 @@ WITH linked AS (
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
       OR ({scope_type:String} = 'work_unit'
         AND link.work_item_id IN {member_issue_ids:Array(String)})
+      OR ({scope_type:String} = 'team'
+        AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+        ))
     )
 ), latest_reviews AS (
   SELECT toString(repo_id) AS repository_id, number, reviewer,
@@ -240,7 +286,7 @@ WHERE pr.org_id = {org_id:String}
   AND pr.created_at <= {as_of:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'pull_request' AND pr.number = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(pr.repo_id), pr.number) IN
           (SELECT repository_id, pr_number FROM linked))
     OR ({scope_type:String} = 'work_unit'
@@ -250,11 +296,12 @@ WHERE pr.org_id = {org_id:String}
         OR concat(toString(pr.repo_id), '#pr', toString(pr.number))
           IN {member_pr_ids:Array(String)}
       ))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """
+)
 
 _CI_SQL = """
 SELECT toString(repo_id) AS repository_id, run_id,
@@ -298,7 +345,18 @@ FROM deployments FINAL
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
   AND (
-    ({scope_type:String} IN ('organization', 'repository', 'team'))
+    ({scope_type:String} IN ('organization', 'repository'))
+    -- CHAOS-3303 round 2 (Codex HIGH): a bare repository-membership arm
+    -- would admit every deployment in the team's team_repo_ownership
+    -- repos, including ones belonging to a different (e.g. child) team
+    -- that merely shares the repo. A team-scoped deployment is admitted
+    -- ONLY through an already team-owned PR (pr_numbers is derived from
+    -- the now canonically-filtered _PULL_REQUESTS_SQL rows) -- the same
+    -- rule every other scope narrower than organization/repository
+    -- already follows via the unconditional arm below, made explicit here
+    -- for 'team' rather than left implicit.
+    OR ({scope_type:String} = 'team'
+      AND ifNull(pull_request_number, 0) IN {pr_numbers:Array(UInt32)})
     OR ifNull(pull_request_number, 0) IN {pr_numbers:Array(UInt32)}
   )
   AND coalesce(deployed_at, finished_at, started_at, last_synced)
@@ -362,7 +420,8 @@ FROM (
 WHERE g.repo_id IS NOT NULL
 """
 
-_TRANSITIONS_SQL = """
+_TRANSITIONS_SQL = (
+    """
 SELECT transition.work_item_id AS entity_id, item.title AS display_label,
        transition.from_status, transition.to_status,
        transition.occurred_at AS observed_at, transition.last_synced
@@ -380,13 +439,19 @@ WHERE transition.org_id = {org_id:String}
     ({scope_type:String} = 'issue' AND transition.work_item_id = {entity_id:String})
     OR ({scope_type:String} = 'project'
       AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} = 'team' AND transition.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+    ))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, from_status, to_status
 LIMIT {limit:UInt32}
 """
+)
 
-_RELATIONSHIPS_SQL = """
+_RELATIONSHIPS_SQL = (
+    """
 SELECT edge_id AS change_id, source_type, source_id, edge_type,
        target_type, target_id, provenance, confidence,
        discovered_at AS observed_at, last_synced
@@ -412,13 +477,25 @@ WHERE org_id = {org_id:String}
           AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
       )
     ))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} = 'team' AND (
+      source_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      )
+      OR target_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      )
+    ))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, source_type, source_id, edge_type, target_type, target_id
 LIMIT {limit:UInt32}
 """
+)
 
-_PULL_REQUEST_CHANGES_SQL = """
+_PULL_REQUEST_CHANGES_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -433,6 +510,10 @@ WITH linked AS (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
       OR ({scope_type:String} = 'project'
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
     )
 )
 SELECT concat(toString(pr.repo_id), '#pr', toString(pr.number), '#state#',
@@ -453,16 +534,18 @@ WHERE pr.org_id = {org_id:String}
   AND observed_at < {end:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'pull_request' AND pr.number = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(pr.repo_id), pr.number) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
 """
+)
 
-_REVIEW_CHANGES_SQL = """
+_REVIEW_CHANGES_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -477,6 +560,10 @@ WITH linked AS (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
       OR ({scope_type:String} = 'project'
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
     )
 )
 SELECT concat(toString(review.repo_id), '#pr', toString(review.number),
@@ -494,16 +581,18 @@ WHERE review.org_id = {org_id:String}
   AND review.submitted_at < {end:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'pull_request' AND review.number = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(review.repo_id), review.number) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
 """
+)
 
-_CI_CHANGES_SQL = """
+_CI_CHANGES_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -518,6 +607,10 @@ WITH linked AS (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
       OR ({scope_type:String} = 'project'
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
     )
 )
 SELECT concat(toString(run.repo_id), '#ci#', run.run_id) AS change_id,
@@ -534,16 +627,18 @@ WHERE run.org_id = {org_id:String}
   AND observed_at < {end:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'pull_request' AND ifNull(run.pr_number, 0) = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(run.repo_id), ifNull(run.pr_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
 """
+)
 
-_DEPLOYMENT_CHANGES_SQL = """
+_DEPLOYMENT_CHANGES_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -558,6 +653,10 @@ WITH linked AS (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
       OR ({scope_type:String} = 'project'
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
     )
 )
 SELECT concat(toString(deployment.repo_id), '#deployment#',
@@ -577,16 +676,18 @@ WHERE deployment.org_id = {org_id:String}
   AND (
     ({scope_type:String} = 'pull_request'
       AND ifNull(deployment.pull_request_number, 0) = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(deployment.repo_id), ifNull(deployment.pull_request_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
 """
+)
 
-_INCIDENT_CHANGES_SQL = """
+_INCIDENT_CHANGES_SQL = (
+    """
 WITH linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
@@ -601,6 +702,10 @@ WITH linked AS (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
       OR ({scope_type:String} = 'project'
         AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
     )
 )
 SELECT concat(incident.id, '#state#',
@@ -632,14 +737,40 @@ WHERE incident.org_id = {org_id:String}
   AND (
     ({scope_type:String} = 'pull_request'
       AND ifNull(deployment.pull_request_number, 0) = {pr_number:UInt32})
-    OR ({scope_type:String} IN ('issue', 'project')
+    OR ({scope_type:String} IN ('issue', 'project', 'team')
       AND (toString(deployment.repo_id), ifNull(deployment.pull_request_number, 0)) IN
           (SELECT repository_id, pr_number FROM linked))
-    OR ({scope_type:String} IN ('organization', 'repository', 'team'))
+    OR ({scope_type:String} IN ('organization', 'repository'))
   )
 ORDER BY observed_at, entity_id, change_id
 LIMIT {limit:UInt32}
 """
+)
+
+
+#: Bounded so a long-lived ``ClickHouseStatusChangeSource`` (e.g. a worker
+#: process serving many orgs/teams over time) cannot accumulate an unbounded
+#: cache -- mirrors ``metrics.service.MetricRequestCache``'s reviewed
+#: bounded-``OrderedDict`` pattern.
+_TEAM_REPOSITORY_CACHE_MAX_ENTRIES = 64
+
+
+@dataclass(frozen=True, slots=True)
+class TeamAttributionResult:
+    """Distinguishes a genuinely empty cohort from a failed lookup.
+
+    Codex finding (MEDIUM, 2026-08-02): the two must never collapse to the
+    same caller-visible outcome. ``measured=False`` means the lookup itself
+    failed (client/query error) -- cohort_size is UNKNOWABLE, not zero, and
+    a caller must report every dimension unmeasured rather than suppress
+    them as ``insufficient_cohort`` (which claims a real, measured zero).
+    ``measured=True`` with an empty ``repository_ids`` is the genuine
+    zero-cohort case, which correctly does suppress as
+    ``insufficient_cohort``.
+    """
+
+    measured: bool
+    repository_ids: tuple[str, ...] = ()
 
 
 class ClickHouseStatusChangeSource:
@@ -655,10 +786,23 @@ class ClickHouseStatusChangeSource:
         self._client = client
         self._policies = dict(policies or default_native_freshness_policies())
         self._now = now
+        # Codex finding (MEDIUM, 2026-08-02): TeamHealthService resolves its
+        # own cohort attribution snapshot, and status_snapshot/change_summary
+        # independently re-derive the same team's repositories internally
+        # (via _authorized_repository_ids). When both calls share this same
+        # ClickHouseStatusChangeSource instance (the natural production
+        # wiring) and the SAME as_of, this cache turns the second lookup
+        # into a hit instead of a second ClickHouse round trip -- "one
+        # immutable attribution snapshot, reused" without changing
+        # PlanExecutorRuntime's wire contract (a team DevScope cannot carry
+        # its own repository list -- CHAOS-3301 addendum, ratified).
+        self._team_repository_cache: OrderedDict[
+            tuple[str, str, datetime], TeamAttributionResult
+        ] = OrderedDict()
 
     async def team_repository_ids(
         self, org_id: str, team_id: str, *, as_of: datetime
-    ) -> list[str]:
+    ) -> TeamAttributionResult:
         """Re-derive one team's owned repositories from ``team_repo_ownership``.
 
         Public (CHAOS-3303, Codex finding HIGH 2026-08-02): this is the
@@ -673,12 +817,19 @@ class ClickHouseStatusChangeSource:
         for "what repositories does this team own right now", never two
         independently-drifting queries.
 
-        A genuinely failing lookup or zero-row result both return ``[]``,
-        by design indistinguishable to a caller other than "no verified
-        attribution" -- exactly what the fail-closed floor (N0) already
-        requires downstream.
+        A genuine query failure is never cached (a transient outage must
+        not poison a later, successful call within the same evaluation);
+        a successful (possibly empty) result is cached by the exact
+        ``(org_id, team_id, as_of)`` key -- safe because the underlying
+        predicate (``valid_from <= as_of AND (valid_to IS NULL OR valid_to
+        > as_of)``) is a pure function of that key, not of wall-clock time.
         """
 
+        cache_key = (org_id, team_id, as_of)
+        cached = self._team_repository_cache.get(cache_key)
+        if cached is not None:
+            self._team_repository_cache.move_to_end(cache_key)
+            return cached
         try:
             async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
                 rows = await query_dicts(
@@ -691,10 +842,23 @@ class ClickHouseStatusChangeSource:
                     },
                 )
         except Exception:
-            return []
-        return sorted(
-            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+            return TeamAttributionResult(measured=False)
+        result = TeamAttributionResult(
+            measured=True,
+            repository_ids=tuple(
+                sorted(
+                    {
+                        str(row["repository_id"])
+                        for row in rows
+                        if row.get("repository_id")
+                    }
+                )
+            ),
         )
+        self._team_repository_cache[cache_key] = result
+        while len(self._team_repository_cache) > _TEAM_REPOSITORY_CACHE_MAX_ENTRIES:
+            self._team_repository_cache.popitem(last=False)
+        return result
 
     async def _authorized_repository_ids(
         self, org_id: str, scope: DevScope, *, as_of: datetime
@@ -727,9 +891,15 @@ class ClickHouseStatusChangeSource:
         regardless of real ownership data.
         """
         if scope.direct_scope is DirectScope.TEAM:
-            return await self.team_repository_ids(
+            # Unmeasured (failed lookup) and measured-but-empty both fall
+            # through to the existing empty-repositories fail-closed branch
+            # below -- N0's guarantee holds either way; the measured/failed
+            # distinction matters to TeamHealthService's own cohort_size
+            # resolution, not to this read-bounding helper.
+            result = await self.team_repository_ids(
                 org_id, scope.team_ids[0], as_of=as_of
             )
+            return list(result.repository_ids)
         if scope.direct_scope is not DirectScope.ORGANIZATION or scope.team_ids:
             return self._repository_ids(scope)
         try:
@@ -772,6 +942,13 @@ class ClickHouseStatusChangeSource:
             "limit": min(limit, MAX_STATUS_ASSESSMENT_ITEMS),
             "member_issue_ids": [],
             "member_pr_ids": [],
+            # CHAOS-3303 round 2: the canonical-primary-attribution team arms
+            # (_PULL_REQUESTS_SQL, _TRANSITIONS_SQL, _RELATIONSHIPS_SQL, and
+            # the five _*_CHANGES_SQL delivery projections) bind this
+            # directly; harmless/unused for every other scope_type.
+            "team_id": scope.team_ids[0]
+            if scope.direct_scope is DirectScope.TEAM
+            else "",
         }
         if scope.direct_scope is DirectScope.WORK_UNIT:
             marker_rows, membership_ref, warning = await self._read(
@@ -1124,6 +1301,9 @@ class ClickHouseStatusChangeSource:
             "start": current.start.astimezone(UTC),
             "end": current.end.astimezone(UTC),
             "limit": min(limit, 100),
+            "team_id": scope.team_ids[0]
+            if scope.direct_scope is DirectScope.TEAM
+            else "",
         }
         transitions, transition_ref, transition_warning = await self._read(
             "work_items", _TRANSITIONS_SQL, params, scope

--- a/src/dev_health_ops/api/dev/portfolio_status_service.py
+++ b/src/dev_health_ops/api/dev/portfolio_status_service.py
@@ -1,18 +1,20 @@
 """``PortfolioStatusService`` (CHAOS-3303): bounded multi-project status.
 
-Batches ``ProjectHealthService.evaluate_project`` across a bounded set of
-committed project subjects (``status.portfolio.v1`` / ``PROJECT_STATUS``
-intent) via ``asyncio.gather`` -- one bounded fan-out, never a per-project
-model loop. Never averages completion percentages or dimension states
-across projects (CHAOS-3303's own guardrail: "Do not average incompatible
-project completion percentages or treat unknown denominators as
-complete") -- every project's own findings stay independent; only the
-*ordering* and *counts* are computed here.
+Batches ``ProjectHealthService.evaluate_project`` across a bounded (<=25)
+set of committed project subjects (``status.portfolio.v1`` /
+``PROJECT_STATUS`` intent) -- never a per-project *model* loop, though
+evaluation itself is sequential (see ``evaluate_portfolio``'s own comment
+for why concurrent fan-out is unsafe over the shared production runtime).
+Never averages completion percentages or dimension states across projects
+(CHAOS-3303's own guardrail: "Do not average incompatible project
+completion percentages or treat unknown denominators as complete") --
+every project's own findings stay independent; only the *ordering* and
+*counts* are computed here, and only from launch-eligible findings (see
+``PortfolioStatusResult``).
 """
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -56,10 +58,22 @@ class PortfolioProjectScope:
     ``DevScope`` (subject resolution and cohort bounding are CHAOS-3301's
     territory, not this service's) -- this service performs no further
     subject resolution of its own.
+
+    Codex finding (HIGH, 2026-08-02): this used to carry its own
+    caller-supplied ``project_id`` field, independent of ``scope`` -- the
+    same committed scope submitted twice under two different asserted
+    labels minted two "different" portfolio subjects with identical data.
+    ``project_id`` is now a read-only view of the scope's own (validator-
+    guaranteed, unique) entity ref, so there is no longer a second value a
+    caller can assert; batch dedup (``evaluate_portfolio``'s duplicate
+    check) is therefore dedup by validated scope identity, not by label.
     """
 
-    project_id: str
     scope: DevScope
+
+    @property
+    def project_id(self) -> str:
+        return self.scope.entity_refs[0].entity_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,8 +91,20 @@ class PortfolioProjectFailure:
 
 @dataclass(frozen=True, slots=True)
 class PortfolioStatusResult:
-    #: Worst-severity-first, then ``project_id`` for stability -- see
-    #: ``_sort_key``.
+    """``projects`` is worst-severity-first, then ``project_id`` for
+    stability (see ``_sort_key``) -- and that severity is computed ONLY
+    from each project's ``HealthProfileResult.launch_findings`` (Codex
+    finding, HIGH, 2026-08-02): every rule in ``HEALTH_RULE_REGISTRY`` is
+    still provisional today, so ``launch_findings`` is empty for every
+    project and ``counts_by_worst_state`` correctly reports no elevated
+    state anywhere, rather than treating shadow (calibration-only)
+    findings as if they were launch authority. Each project's own
+    ``shadow_findings``/``suppressed_findings`` remain fully available on
+    ``HealthProfileResult`` -- that IS the separately-labeled calibration
+    payload; nothing here discards or merges it, it is simply never
+    consulted for status/ordering/counts.
+    """
+
     projects: tuple[HealthProfileResult, ...]
     counts_by_worst_state: Mapping[DimensionState, int]
     failures: tuple[PortfolioProjectFailure, ...]
@@ -89,10 +115,12 @@ class PortfolioStatusResult:
 
 
 def _worst_state(result: HealthProfileResult) -> DimensionState:
-    if not result.findings:
+    """Launch-eligible findings only -- see ``PortfolioStatusResult``'s docstring."""
+
+    if not result.launch_findings:
         return DimensionState.UNKNOWN
     return min(
-        (finding.state for finding in result.findings),
+        (finding.state for finding in result.launch_findings),
         key=lambda state: _DIMENSION_STATE_SEVERITY[state],
     )
 
@@ -129,31 +157,34 @@ class PortfolioStatusService:
         if len(set(project_ids)) != len(project_ids):
             raise ValueError("duplicate project_id in portfolio batch")
 
-        outcomes = await asyncio.gather(
-            *(
-                self._project_health_service.evaluate_project(
+        # Codex finding (HIGH, 2026-08-02): the production PlanExecutorRuntime
+        # (production_runtime._ProductionPlanExecutorRuntime) is backed by a
+        # single request-scoped SQLAlchemy AsyncSession (entitlement checks,
+        # NativeDataHealthReader) that forbids concurrent use -- fanning this
+        # loop out with asyncio.gather over one shared runtime risks false
+        # entitlement denials or a genuine query racing another and getting
+        # swallowed as "unavailable". Evaluation is bounded to
+        # MAX_PORTFOLIO_PROJECTS (<=25) and every finding is already required
+        # to be deterministic regardless of evaluation order, so sequential
+        # execution costs determinism nothing and removes the concurrency
+        # hazard outright, rather than introducing a second, parallel
+        # per-task-session lifecycle this service does not own.
+        results: list[HealthProfileResult] = []
+        failures: list[PortfolioProjectFailure] = []
+        for item in projects:
+            try:
+                result = await self._project_health_service.evaluate_project(
                     org_id=org_id,
                     permission_fingerprint=permission_fingerprint,
                     scope=item.scope,
-                    project_id=item.project_id,
                     now=now,
                 )
-                for item in projects
-            ),
-            return_exceptions=True,
-        )
-
-        results: list[HealthProfileResult] = []
-        failures: list[PortfolioProjectFailure] = []
-        for item, outcome in zip(projects, outcomes, strict=True):
-            if isinstance(outcome, BaseException):
+            except Exception as exc:  # noqa: BLE001 - isolate, never crash the batch
                 failures.append(
-                    PortfolioProjectFailure(
-                        project_id=item.project_id, error=repr(outcome)
-                    )
+                    PortfolioProjectFailure(project_id=item.project_id, error=repr(exc))
                 )
                 continue
-            results.append(outcome)
+            results.append(result)
 
         ordered = tuple(sorted(results, key=_sort_key))
         counts: dict[DimensionState, int] = {state: 0 for state in DimensionState}

--- a/src/dev_health_ops/api/dev/portfolio_status_service.py
+++ b/src/dev_health_ops/api/dev/portfolio_status_service.py
@@ -1,0 +1,171 @@
+"""``PortfolioStatusService`` (CHAOS-3303): bounded multi-project status.
+
+Batches ``ProjectHealthService.evaluate_project`` across a bounded set of
+committed project subjects (``status.portfolio.v1`` / ``PROJECT_STATUS``
+intent) via ``asyncio.gather`` -- one bounded fan-out, never a per-project
+model loop. Never averages completion percentages or dimension states
+across projects (CHAOS-3303's own guardrail: "Do not average incompatible
+project completion percentages or treat unknown denominators as
+complete") -- every project's own findings stay independent; only the
+*ordering* and *counts* are computed here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from .contracts import DevScope
+from .contracts_v2.health_rules import DimensionState
+from .health_profile_synthesis import HealthProfileResult
+from .project_health_service import ProjectHealthService
+
+__all__ = [
+    "MAX_PORTFOLIO_PROJECTS",
+    "PortfolioProjectScope",
+    "PortfolioStatusResult",
+    "PortfolioStatusService",
+]
+
+#: Mirrors ``DevSubjectSet``'s own bound (``contracts_v2.subject``:
+#: ``committed_entity_refs`` is ``Field(min_length=1, max_length=25)``) --
+#: a portfolio batch is exactly a subject set's worth of projects, never
+#: unbounded.
+MAX_PORTFOLIO_PROJECTS = 25
+
+#: Worst-to-best ordering for deterministic portfolio ranking. Lower sorts
+#: first (worst-first), matching "prioritized findings"/"ordered by
+#: deterministic severity and evidence quality".
+_DIMENSION_STATE_SEVERITY: Mapping[DimensionState, int] = {
+    DimensionState.CRITICAL: 0,
+    DimensionState.AT_RISK: 1,
+    DimensionState.WATCH: 2,
+    DimensionState.UNKNOWN: 3,
+    DimensionState.NOT_APPLICABLE: 4,
+    DimensionState.HEALTHY: 5,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioProjectScope:
+    """One resolved project subject to include in a portfolio batch.
+
+    ``scope`` must already be a committed, validated ``DirectScope.PROJECT``
+    ``DevScope`` (subject resolution and cohort bounding are CHAOS-3301's
+    territory, not this service's) -- this service performs no further
+    subject resolution of its own.
+    """
+
+    project_id: str
+    scope: DevScope
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioProjectFailure:
+    """A project whose canonical-service calls raised, isolated from the batch.
+
+    Never a silently-dropped project: it still appears in
+    ``PortfolioStatusResult.failures``, and its ``project_id`` is excluded
+    from ``projects`` rather than reported with fabricated findings.
+    """
+
+    project_id: str
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioStatusResult:
+    #: Worst-severity-first, then ``project_id`` for stability -- see
+    #: ``_sort_key``.
+    projects: tuple[HealthProfileResult, ...]
+    counts_by_worst_state: Mapping[DimensionState, int]
+    failures: tuple[PortfolioProjectFailure, ...]
+    unresolved_mention_ids: tuple[str, ...]
+    ambiguous_mention_ids: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evaluated_at: datetime
+
+
+def _worst_state(result: HealthProfileResult) -> DimensionState:
+    if not result.findings:
+        return DimensionState.UNKNOWN
+    return min(
+        (finding.state for finding in result.findings),
+        key=lambda state: _DIMENSION_STATE_SEVERITY[state],
+    )
+
+
+def _sort_key(result: HealthProfileResult) -> tuple[int, str]:
+    return (_DIMENSION_STATE_SEVERITY[_worst_state(result)], result.subject_id)
+
+
+class PortfolioStatusService:
+    """Batch-evaluate a bounded set of committed project subjects."""
+
+    def __init__(self, project_health_service: ProjectHealthService) -> None:
+        self._project_health_service = project_health_service
+
+    async def evaluate_portfolio(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        projects: Sequence[PortfolioProjectScope],
+        now: datetime,
+        unresolved_mention_ids: Sequence[str] = (),
+        ambiguous_mention_ids: Sequence[str] = (),
+        warnings: Sequence[str] = (),
+    ) -> PortfolioStatusResult:
+        if not projects:
+            raise ValueError("evaluate_portfolio requires at least one project")
+        if len(projects) > MAX_PORTFOLIO_PROJECTS:
+            raise ValueError(
+                f"portfolio batch exceeds the bounded maximum of "
+                f"{MAX_PORTFOLIO_PROJECTS} projects"
+            )
+        project_ids = [item.project_id for item in projects]
+        if len(set(project_ids)) != len(project_ids):
+            raise ValueError("duplicate project_id in portfolio batch")
+
+        outcomes = await asyncio.gather(
+            *(
+                self._project_health_service.evaluate_project(
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                    scope=item.scope,
+                    project_id=item.project_id,
+                    now=now,
+                )
+                for item in projects
+            ),
+            return_exceptions=True,
+        )
+
+        results: list[HealthProfileResult] = []
+        failures: list[PortfolioProjectFailure] = []
+        for item, outcome in zip(projects, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                failures.append(
+                    PortfolioProjectFailure(
+                        project_id=item.project_id, error=repr(outcome)
+                    )
+                )
+                continue
+            results.append(outcome)
+
+        ordered = tuple(sorted(results, key=_sort_key))
+        counts: dict[DimensionState, int] = {state: 0 for state in DimensionState}
+        for result in ordered:
+            counts[_worst_state(result)] += 1
+
+        return PortfolioStatusResult(
+            projects=ordered,
+            counts_by_worst_state=counts,
+            failures=tuple(sorted(failures, key=lambda failure: failure.project_id)),
+            unresolved_mention_ids=tuple(unresolved_mention_ids),
+            ambiguous_mention_ids=tuple(ambiguous_mention_ids),
+            warnings=tuple(warnings),
+            evaluated_at=now,
+        )

--- a/src/dev_health_ops/api/dev/project_health_service.py
+++ b/src/dev_health_ops/api/dev/project_health_service.py
@@ -55,11 +55,21 @@ class ProjectHealthService:
         org_id: str,
         permission_fingerprint: str,
         scope: DevScope,
-        project_id: str,
         now: datetime,
     ) -> HealthProfileResult:
         if scope.direct_scope is not DirectScope.PROJECT:
             raise ValueError("ProjectHealthService requires a project direct scope")
+        # Codex finding (HIGH, 2026-08-02): project_id used to be a caller-
+        # supplied label independent of `scope`, so the SAME committed
+        # DevScope submitted under two different asserted labels ("alias-a",
+        # "alias-b") minted two portfolio "subjects" with identical
+        # underlying data -- dedup (and the resulting findings' subject_id)
+        # tracked the label, never the validated scope identity. DevScope's
+        # own validator already guarantees a PROJECT direct scope carries
+        # exactly one matching entity_ref, so its entity_id is the only
+        # subject identity this service ever uses -- there is no longer a
+        # separate value a caller can assert.
+        project_id = scope.entity_refs[0].entity_id
         if scope.comparison_range is None:
             # health_rule.change_failure_rate.v1's comparison_value and every
             # future trend-aware rule need a resolved comparison window;

--- a/src/dev_health_ops/api/dev/project_health_service.py
+++ b/src/dev_health_ops/api/dev/project_health_service.py
@@ -1,0 +1,107 @@
+"""``ProjectHealthService`` (CHAOS-3303): canonical project health synthesis.
+
+Composes ``StatusChangeService``/``DataHealthService``/``MetricQueryService``
+through the exact ``PlanExecutorRuntime`` seam CHAOS-3295 already built and
+``production_runtime.py`` already wires for the six core plans -- never a
+second, parallel query path. Every dimension is reported independently
+(``health_profile_synthesis``'s ``no default composite health score``); this
+service only resolves *which* canonical calls a project subject needs and
+hands their results to the shared synthesis engine.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .contracts import DevScope, DirectScope, MetricID
+from .contracts_v2.health_rules import RuleApplicability
+from .health_profile_synthesis import (
+    HealthEvaluationSources,
+    HealthProfileResult,
+    synthesize_health_profile,
+)
+from .investigation_plans.builtin_steps import PlanExecutorRuntime
+
+__all__ = ["CHANGE_FAILURE_RATE_SUPPORTED_SCOPES", "ProjectHealthService"]
+
+#: ``MetricID.CHANGE_FAILURE_RATE``'s own ``supported_scopes``
+#: (``metrics/definitions.py``'s ``_ALL_REPO_SCOPES``) -- every direct scope
+#: for which ``MetricQueryService`` will actually accept a query. Named here
+#: rather than re-imported from that module's private tuple so a caller can
+#: decide "not applicable" *before* calling the metric service, instead of
+#: catching the ``ValueError`` its own ``_validate_request`` would raise for
+#: an unsupported scope.
+CHANGE_FAILURE_RATE_SUPPORTED_SCOPES: frozenset[DirectScope] = frozenset(
+    {
+        DirectScope.ORGANIZATION,
+        DirectScope.REPOSITORY,
+        DirectScope.PROJECT,
+        DirectScope.WORK_UNIT,
+        DirectScope.ISSUE,
+        DirectScope.PULL_REQUEST,
+    }
+)
+
+
+class ProjectHealthService:
+    """Evaluate CHAOS-3302 health rules for one committed project subject."""
+
+    def __init__(self, runtime: PlanExecutorRuntime) -> None:
+        self._runtime = runtime
+
+    async def evaluate_project(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        project_id: str,
+        now: datetime,
+    ) -> HealthProfileResult:
+        if scope.direct_scope is not DirectScope.PROJECT:
+            raise ValueError("ProjectHealthService requires a project direct scope")
+        if scope.comparison_range is None:
+            # health_rule.change_failure_rate.v1's comparison_value and every
+            # future trend-aware rule need a resolved comparison window;
+            # PlanExecutorRuntime.query_metric always requests one (mirrors
+            # production_runtime._ProductionPlanExecutorRuntime.query_metric),
+            # so failing here is clearer than the ValueError
+            # MetricQueryService._validate_request would raise deeper in the
+            # call.
+            raise ValueError(
+                "ProjectHealthService requires scope.comparison_range to be "
+                "resolved for trend/comparison observations"
+            )
+
+        status_snapshot = await self._runtime.status_snapshot(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        data_health = await self._runtime.data_health(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        change_failure_rate_not_applicable = (
+            scope.direct_scope not in CHANGE_FAILURE_RATE_SUPPORTED_SCOPES
+        )
+        change_failure_rate_metric = None
+        if not change_failure_rate_not_applicable:
+            change_failure_rate_metric = await self._runtime.query_metric(
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                metric_id=MetricID.CHANGE_FAILURE_RATE,
+                scope=scope,
+            )
+
+        sources = HealthEvaluationSources(
+            data_health=data_health,
+            status_snapshot=status_snapshot,
+            change_failure_rate_metric=change_failure_rate_metric,
+            change_failure_rate_not_applicable=change_failure_rate_not_applicable,
+        )
+        return synthesize_health_profile(
+            applicability=RuleApplicability.PROJECT,
+            subject_id=project_id,
+            cohort_size=None,
+            sources=sources,
+            org_id=org_id,
+            observed_at=now,
+        )

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -357,8 +357,16 @@ class StatusChangeService:
         actual = self._assess(
             raw,
             assessment_source_limit_reached=assessment_source_limit_reached,
+            # CHAOS-3303: a team subject has no single declared/children
+            # completion tree (_WORK_ITEMS_SQL is never queried for team
+            # scope -- see native_status_change.TEAM_NOT_APPLICABLE_SOURCES),
+            # exactly like PROJECT/WORK_UNIT already. Without TEAM here,
+            # every team snapshot would report declared_status_missing ->
+            # CompletionState.INDETERMINATE -> StatusResultState.
+            # INSUFFICIENT_EVIDENCE regardless of how much real pull-request/
+            # CI/deployment/incident evidence the team's SQL arms return.
             declared_optional=request.scope.direct_scope
-            in {DirectScope.PROJECT, DirectScope.WORK_UNIT},
+            in {DirectScope.PROJECT, DirectScope.WORK_UNIT, DirectScope.TEAM},
             release_evidence_required=request.scope.direct_scope
             in {
                 DirectScope.ISSUE,

--- a/src/dev_health_ops/api/dev/team_health_service.py
+++ b/src/dev_health_ops/api/dev/team_health_service.py
@@ -15,11 +15,36 @@ person-level output" requirements:
   report a fabricated healthy finding for an unattributed team. There is no
   parameter left for a caller to assert a cohort size through -- it is
   always the length of the *verified* repository set this service itself
-  queries for the exact ``team_id``/``as_of`` the evaluation uses. Every
-  CHAOS-3302 rule applicable to ``team`` carries a ``minimum_cohort_size``
-  (``HealthRuleDefinition.validate_cohort_requirement``), so a team with no
-  resolved attribution (``cohort_size=0``) still has every applicable rule
-  honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN``.
+  queries. Every CHAOS-3302 rule applicable to ``team`` carries a
+  ``minimum_cohort_size`` (``HealthRuleDefinition.validate_cohort_
+  requirement``), so a team with no resolved attribution (``cohort_size=0``)
+  still has every applicable rule honestly suppressed as
+  ``insufficient_cohort`` -> ``UNKNOWN``.
+
+  Codex finding (MEDIUM, 2026-08-02): the attribution snapshot is resolved
+  at ``scope.time_range.end`` -- the SAME instant
+  ``StatusSnapshotRequest.as_of`` defaults to inside
+  ``StatusChangeService.status_snapshot`` (and therefore the same instant
+  the runtime's own internal ``team_repository_ids`` call, made through
+  ``_authorized_repository_ids``, uses) -- never wall-clock ``now``. An
+  ownership row valid at scope-end but since expired by ``now`` would
+  otherwise pair real, historical, in-window facts with a wrongly-zeroed
+  cohort_size, misreporting a genuinely attributed team as
+  ``insufficient_cohort``. ``ClickHouseStatusChangeSource`` additionally
+  caches by the exact ``(org_id, team_id, as_of)`` key, so when this
+  service and the wrapped runtime share one source instance (the natural
+  production wiring), the internal call is a cache hit rather than a
+  second round trip -- one resolved attribution snapshot, reused, without
+  changing ``PlanExecutorRuntime``'s wire contract (a team ``DevScope``
+  cannot carry its own repository list -- CHAOS-3301 addendum, ratified).
+
+  A genuine attribution-lookup FAILURE (``measured=False``) is never
+  treated as a zero cohort: cohort_size is UNKNOWABLE, not zero, so this
+  service reports every dimension honestly unmeasured (routing through
+  ``health_profile_synthesis``'s existing unbound/unavailable path) rather
+  than the misleading ``insufficient_cohort`` suppression a measured-zero
+  cohort would produce. The runtime is not even called in that case --
+  nothing meaningful could be reported regardless of what it returns.
 * ``health_rule.change_failure_rate.v1`` is unconditionally reported
   ``not_applicable`` for a team subject: ``MetricID.CHANGE_FAILURE_RATE``'s
   own ``supported_scopes`` (``metrics/definitions.py``) does not include
@@ -27,14 +52,15 @@ person-level output" requirements:
   structurally inapplicable, not merely unqueried.
 
 ``native_status_change.py``'s ``ClickHouseStatusChangeSource`` re-derives a
-team's owned repositories from ``team_repo_ownership`` at query time and
-executes real team-scoped pull-request/CI/deployment/incident reads (see
-``TEAM_NOT_APPLICABLE_SOURCES``, limited to the two sources -- declared/
-children work items and their blockers -- that structurally describe a
-single entity's completion tree, not a team cohort). A team with no
-resolved ``team_repo_ownership`` rows (or a genuinely failing lookup) still
-falls back to the same explicit ``FreshnessState.UNAVAILABLE`` observation
-as before -- never a silently empty answer.
+team's owned repositories from ``team_repo_ownership`` at query time,
+filtered through canonical-primary work-item attribution (CHAOS-3303 round
+2), and executes real team-scoped pull-request/CI/deployment/incident
+reads (see ``TEAM_NOT_APPLICABLE_SOURCES``, limited to the two sources --
+declared/children work items and their blockers -- that structurally
+describe a single entity's completion tree, not a team cohort). A team
+with no resolved ``team_repo_ownership`` rows (or a genuinely failing
+lookup) still falls back to the same explicit ``FreshnessState.UNAVAILABLE``
+observation as before -- never a silently empty answer.
 """
 
 from __future__ import annotations
@@ -50,6 +76,7 @@ from .health_profile_synthesis import (
     synthesize_health_profile,
 )
 from .investigation_plans.builtin_steps import PlanExecutorRuntime
+from .native_status_change import TeamAttributionResult
 
 __all__ = ["TeamAttributionSource", "TeamHealthService"]
 
@@ -63,7 +90,7 @@ class TeamAttributionSource(Protocol):
 
     async def team_repository_ids(
         self, org_id: str, team_id: str, *, as_of: datetime
-    ) -> list[str]: ...
+    ) -> TeamAttributionResult: ...
 
 
 class TeamHealthService:
@@ -91,10 +118,27 @@ class TeamHealthService:
 
         # The ONLY source of cohort_size: verified, queried at evaluation
         # time, never a caller-supplied assertion -- see module docstring.
-        owned_repository_ids = await self._attribution.team_repository_ids(
-            org_id, team_id, as_of=now
+        # as_of=scope.time_range.end (not `now`) matches the instant the
+        # runtime's own internal team-repository lookup uses.
+        attribution = await self._attribution.team_repository_ids(
+            org_id, team_id, as_of=scope.time_range.end
         )
-        cohort_size = len(owned_repository_ids)
+        if not attribution.measured:
+            # The lookup itself failed -- cohort_size is unknowable, not a
+            # measured zero. Every dimension must be honestly unmeasured;
+            # calling the runtime would produce facts we cannot responsibly
+            # attach a trustworthy cohort to.
+            return synthesize_health_profile(
+                applicability=RuleApplicability.TEAM,
+                subject_id=team_id,
+                cohort_size=None,
+                sources=HealthEvaluationSources(
+                    change_failure_rate_not_applicable=True
+                ),
+                org_id=org_id,
+                observed_at=now,
+            )
+        cohort_size = len(attribution.repository_ids)
 
         status_snapshot = await self._runtime.status_snapshot(
             org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope

--- a/src/dev_health_ops/api/dev/team_health_service.py
+++ b/src/dev_health_ops/api/dev/team_health_service.py
@@ -7,28 +7,32 @@ person-level output" requirements:
 
 * ``cohort_size`` is a caller-supplied, already-resolved count of the
   team's attributed repositories/projects (CHAOS-3301's
-  ``team_repo_ownership``/``team_project_ownership`` -- re-deriving that
-  attribution is explicitly CHAOS-3303's still-open SQL-arm work, not this
-  service's). Every CHAOS-3302 rule applicable to ``team`` carries a
+  ``team_repo_ownership``/``team_project_ownership``). This service never
+  computes that count itself -- ``native_status_change.py``'s
+  ``_authorized_repository_ids`` re-derives the *query-time* repository set
+  for the same team independently (never carried on the wire), but a
+  cohort size is a caller-level attribution-quality judgment, not a byproduct
+  of one query. Every CHAOS-3302 rule applicable to ``team`` carries a
   ``minimum_cohort_size`` (``HealthRuleDefinition.validate_cohort_
-  requirement``), so a caller that cannot establish real attribution
-  passes ``cohort_size=0`` (or leaves it unresolved) and every applicable
-  rule is honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN`` --
-  never a fabricated healthy/zero for a team with no valid attribution.
+  requirement``), so a caller that cannot establish real attribution passes
+  ``cohort_size=0`` (or leaves it unresolved) and every applicable rule is
+  honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN`` -- never a
+  fabricated healthy/zero for a team with no valid attribution.
 * ``health_rule.change_failure_rate.v1`` is unconditionally reported
   ``not_applicable`` for a team subject: ``MetricID.CHANGE_FAILURE_RATE``'s
   own ``supported_scopes`` (``metrics/definitions.py``) does not include
   ``DirectScope.TEAM`` and ``supports_team_filter`` is ``False`` --
   structurally inapplicable, not merely unqueried.
 
-As of this issue, ``native_status_change.py``'s ``ClickHouseStatusChangeSource``
-takes its existing fail-closed branch for every team direct scope (every
-SQL source it reads is still in ``TEAM_NOT_APPLICABLE_SOURCES`` -- landing
-real team-attributed query arms is separate, tracked work, deliberately not
-done in this changeset). This service therefore honestly reports every
-status/data-health-derived dimension as unmeasured for a team subject
-today; the moment those arms land, this exact code path starts reporting
-real findings with no changes required here.
+``native_status_change.py``'s ``ClickHouseStatusChangeSource`` now re-derives
+a team's owned repositories from ``team_repo_ownership`` at query time and
+executes real team-scoped pull-request/CI/deployment/incident reads (see
+``TEAM_NOT_APPLICABLE_SOURCES``, now limited to the two sources -- declared/
+children work items and their blockers -- that structurally describe a
+single entity's completion tree, not a team cohort). A team with no
+resolved ``team_repo_ownership`` rows (or a genuinely failing lookup) still
+falls back to the same explicit ``FreshnessState.UNAVAILABLE`` observation
+as before -- never a silently empty answer.
 """
 
 from __future__ import annotations

--- a/src/dev_health_ops/api/dev/team_health_service.py
+++ b/src/dev_health_ops/api/dev/team_health_service.py
@@ -5,29 +5,31 @@ subject instead of ``DirectScope.PROJECT``. Two structural differences
 carry the ticket's "use only team-attributed observations" and "no
 person-level output" requirements:
 
-* ``cohort_size`` is a caller-supplied, already-resolved count of the
-  team's attributed repositories/projects (CHAOS-3301's
-  ``team_repo_ownership``/``team_project_ownership``). This service never
-  computes that count itself -- ``native_status_change.py``'s
-  ``_authorized_repository_ids`` re-derives the *query-time* repository set
-  for the same team independently (never carried on the wire), but a
-  cohort size is a caller-level attribution-quality judgment, not a byproduct
-  of one query. Every CHAOS-3302 rule applicable to ``team`` carries a
-  ``minimum_cohort_size`` (``HealthRuleDefinition.validate_cohort_
-  requirement``), so a caller that cannot establish real attribution passes
-  ``cohort_size=0`` (or leaves it unresolved) and every applicable rule is
-  honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN`` -- never a
-  fabricated healthy/zero for a team with no valid attribution.
+* ``cohort_size`` is resolved by this service itself, from
+  :class:`TeamAttributionSource` -- the canonical ``team_repo_ownership``
+  read ``native_status_change.ClickHouseStatusChangeSource.
+  team_repository_ids`` exposes (CHAOS-3303's own team SQL arms). Codex
+  finding (HIGH, 2026-08-02): a caller-asserted naked ``cohort_size: int``
+  could claim e.g. ``25`` for a team with zero real ``team_repo_ownership``
+  rows, and a runtime returning otherwise-complete sources would then
+  report a fabricated healthy finding for an unattributed team. There is no
+  parameter left for a caller to assert a cohort size through -- it is
+  always the length of the *verified* repository set this service itself
+  queries for the exact ``team_id``/``as_of`` the evaluation uses. Every
+  CHAOS-3302 rule applicable to ``team`` carries a ``minimum_cohort_size``
+  (``HealthRuleDefinition.validate_cohort_requirement``), so a team with no
+  resolved attribution (``cohort_size=0``) still has every applicable rule
+  honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN``.
 * ``health_rule.change_failure_rate.v1`` is unconditionally reported
   ``not_applicable`` for a team subject: ``MetricID.CHANGE_FAILURE_RATE``'s
   own ``supported_scopes`` (``metrics/definitions.py``) does not include
   ``DirectScope.TEAM`` and ``supports_team_filter`` is ``False`` --
   structurally inapplicable, not merely unqueried.
 
-``native_status_change.py``'s ``ClickHouseStatusChangeSource`` now re-derives
-a team's owned repositories from ``team_repo_ownership`` at query time and
+``native_status_change.py``'s ``ClickHouseStatusChangeSource`` re-derives a
+team's owned repositories from ``team_repo_ownership`` at query time and
 executes real team-scoped pull-request/CI/deployment/incident reads (see
-``TEAM_NOT_APPLICABLE_SOURCES``, now limited to the two sources -- declared/
+``TEAM_NOT_APPLICABLE_SOURCES``, limited to the two sources -- declared/
 children work items and their blockers -- that structurally describe a
 single entity's completion tree, not a team cohort). A team with no
 resolved ``team_repo_ownership`` rows (or a genuinely failing lookup) still
@@ -38,6 +40,7 @@ as before -- never a silently empty answer.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Protocol
 
 from .contracts import DevScope, DirectScope
 from .contracts_v2.health_rules import RuleApplicability
@@ -48,14 +51,29 @@ from .health_profile_synthesis import (
 )
 from .investigation_plans.builtin_steps import PlanExecutorRuntime
 
-__all__ = ["TeamHealthService"]
+__all__ = ["TeamAttributionSource", "TeamHealthService"]
+
+
+class TeamAttributionSource(Protocol):
+    """The exact seam ``ClickHouseStatusChangeSource.team_repository_ids``
+    satisfies -- a narrow protocol (not the full status-change source) so a
+    test double only has to implement what ``TeamHealthService`` actually
+    calls.
+    """
+
+    async def team_repository_ids(
+        self, org_id: str, team_id: str, *, as_of: datetime
+    ) -> list[str]: ...
 
 
 class TeamHealthService:
     """Evaluate CHAOS-3302 health rules for one committed team subject."""
 
-    def __init__(self, runtime: PlanExecutorRuntime) -> None:
+    def __init__(
+        self, runtime: PlanExecutorRuntime, attribution: TeamAttributionSource
+    ) -> None:
         self._runtime = runtime
+        self._attribution = attribution
 
     async def evaluate_team(
         self,
@@ -64,13 +82,19 @@ class TeamHealthService:
         permission_fingerprint: str,
         scope: DevScope,
         team_id: str,
-        cohort_size: int | None,
         now: datetime,
     ) -> HealthProfileResult:
         if scope.direct_scope is not DirectScope.TEAM:
             raise ValueError("TeamHealthService requires a team direct scope")
         if scope.team_ids != [team_id]:
             raise ValueError("scope.team_ids must name exactly this team subject")
+
+        # The ONLY source of cohort_size: verified, queried at evaluation
+        # time, never a caller-supplied assertion -- see module docstring.
+        owned_repository_ids = await self._attribution.team_repository_ids(
+            org_id, team_id, as_of=now
+        )
+        cohort_size = len(owned_repository_ids)
 
         status_snapshot = await self._runtime.status_snapshot(
             org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope

--- a/src/dev_health_ops/api/dev/team_health_service.py
+++ b/src/dev_health_ops/api/dev/team_health_service.py
@@ -1,0 +1,91 @@
+"""``TeamHealthService`` (CHAOS-3303): canonical team health synthesis.
+
+Mirrors ``ProjectHealthService`` exactly, over a ``DirectScope.TEAM``
+subject instead of ``DirectScope.PROJECT``. Two structural differences
+carry the ticket's "use only team-attributed observations" and "no
+person-level output" requirements:
+
+* ``cohort_size`` is a caller-supplied, already-resolved count of the
+  team's attributed repositories/projects (CHAOS-3301's
+  ``team_repo_ownership``/``team_project_ownership`` -- re-deriving that
+  attribution is explicitly CHAOS-3303's still-open SQL-arm work, not this
+  service's). Every CHAOS-3302 rule applicable to ``team`` carries a
+  ``minimum_cohort_size`` (``HealthRuleDefinition.validate_cohort_
+  requirement``), so a caller that cannot establish real attribution
+  passes ``cohort_size=0`` (or leaves it unresolved) and every applicable
+  rule is honestly suppressed as ``insufficient_cohort`` -> ``UNKNOWN`` --
+  never a fabricated healthy/zero for a team with no valid attribution.
+* ``health_rule.change_failure_rate.v1`` is unconditionally reported
+  ``not_applicable`` for a team subject: ``MetricID.CHANGE_FAILURE_RATE``'s
+  own ``supported_scopes`` (``metrics/definitions.py``) does not include
+  ``DirectScope.TEAM`` and ``supports_team_filter`` is ``False`` --
+  structurally inapplicable, not merely unqueried.
+
+As of this issue, ``native_status_change.py``'s ``ClickHouseStatusChangeSource``
+takes its existing fail-closed branch for every team direct scope (every
+SQL source it reads is still in ``TEAM_NOT_APPLICABLE_SOURCES`` -- landing
+real team-attributed query arms is separate, tracked work, deliberately not
+done in this changeset). This service therefore honestly reports every
+status/data-health-derived dimension as unmeasured for a team subject
+today; the moment those arms land, this exact code path starts reporting
+real findings with no changes required here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .contracts import DevScope, DirectScope
+from .contracts_v2.health_rules import RuleApplicability
+from .health_profile_synthesis import (
+    HealthEvaluationSources,
+    HealthProfileResult,
+    synthesize_health_profile,
+)
+from .investigation_plans.builtin_steps import PlanExecutorRuntime
+
+__all__ = ["TeamHealthService"]
+
+
+class TeamHealthService:
+    """Evaluate CHAOS-3302 health rules for one committed team subject."""
+
+    def __init__(self, runtime: PlanExecutorRuntime) -> None:
+        self._runtime = runtime
+
+    async def evaluate_team(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        team_id: str,
+        cohort_size: int | None,
+        now: datetime,
+    ) -> HealthProfileResult:
+        if scope.direct_scope is not DirectScope.TEAM:
+            raise ValueError("TeamHealthService requires a team direct scope")
+        if scope.team_ids != [team_id]:
+            raise ValueError("scope.team_ids must name exactly this team subject")
+
+        status_snapshot = await self._runtime.status_snapshot(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        data_health = await self._runtime.data_health(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+
+        sources = HealthEvaluationSources(
+            data_health=data_health,
+            status_snapshot=status_snapshot,
+            change_failure_rate_metric=None,
+            change_failure_rate_not_applicable=True,
+        )
+        return synthesize_health_profile(
+            applicability=RuleApplicability.TEAM,
+            subject_id=team_id,
+            cohort_size=cohort_size,
+            sources=sources,
+            org_id=org_id,
+            observed_at=now,
+        )

--- a/tests/api/dev/test_chaos_3303_dimension_observation_adapters.py
+++ b/tests/api/dev/test_chaos_3303_dimension_observation_adapters.py
@@ -1,0 +1,331 @@
+"""Clause-level tests for CHAOS-3303's ``dimension_observation_adapters``.
+
+Mirrors the mutation discipline already used by ``contracts_v2.validators``
+and ``health_rule_registry``: each test names the exact zero-vs-no-data or
+stale/unavailable boundary it proves, not just "the happy path returns
+something".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import FreshnessState, MetricID
+from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
+from dev_health_ops.api.dev.contracts_v2.health_rules import RuleApplicability
+from dev_health_ops.api.dev.data_health_service import (
+    DataHealthResult,
+    DataHealthSource,
+    DataHealthState,
+)
+from dev_health_ops.api.dev.dimension_observation_adapters import (
+    change_failure_rate_observation,
+    data_trust_observation,
+    incident_load_observation,
+    unavailable_observation,
+)
+from dev_health_ops.api.dev.metrics.definitions import get_metric
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    IncidentFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_COMMON: dict[str, Any] = dict(
+    subject_kind=RuleApplicability.PROJECT,
+    subject_id="proj-1",
+    cohort_size=None,
+    window_index=0,
+    observed_at=_NOW,
+)
+
+
+def _data_health_source(
+    *, state: DataHealthState, coverage: float = 1.0
+) -> DataHealthSource:
+    return DataHealthSource(
+        source_system="work_items",
+        state=state,
+        required=True,
+        last_successful_at=_NOW,
+        watermark=_NOW,
+        missing_repository_ids=(),
+        missing_entity_ids=(),
+        coverage=coverage,
+        confidence_impact=None,
+        freshness_policy_version="v1",
+    )
+
+
+def _actual_completion(
+    state: CompletionState = CompletionState.READY,
+) -> ActualCompletion:
+    return ActualCompletion(
+        state=state,
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=(),
+        required_children=(),
+        conflicts=(),
+        source_ref_ids=(),
+        evidence_ref_ids=(),
+    )
+
+
+def _snapshot(
+    *, state: StatusResultState, incidents: tuple[IncidentFact, ...] = ()
+) -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=state,
+        scope=None,  # type: ignore[arg-type]  # unread by the adapter
+        as_of=_NOW,
+        declared=None,
+        actual=_actual_completion(),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=incidents,
+        source_refs=(),
+        warnings=(),
+    )
+
+
+def _incident(entity_id: str) -> IncidentFact:
+    return IncidentFact(
+        entity_id=entity_id,
+        display_label=entity_id,
+        status="open",
+        active=True,
+        blocking=False,
+        observed_at=_NOW,
+        source_ref_id="ref-1",
+        evidence_ref_ids=(),
+    )
+
+
+def _metric_result(
+    *,
+    state: MetricDataState,
+    values: tuple[MetricQueryValue, ...] = (),
+    coverage: float = 1.0,
+    metadata: tuple[tuple[str, str], ...] = (),
+) -> MetricQueryResult:
+    return MetricQueryResult(
+        definition=get_metric(MetricID.CHANGE_FAILURE_RATE),
+        state=state,
+        freshness=FreshnessState.FRESH,
+        values=values,
+        coverage=coverage,
+        current_window_start=_NOW,
+        current_window_end=_NOW,
+        comparison_window_start=_NOW,
+        comparison_window_end=_NOW,
+        watermark=_NOW,
+        source_refs=(),
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# unavailable_observation
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_observation_rejects_a_queried_state() -> None:
+    """Kill site: the unmeasured-state guard dropped from unavailable_observation."""
+
+    with pytest.raises(ValueError, match="not an unmeasured"):
+        unavailable_observation(
+            **_COMMON, state=SourceRequirementState.AVAILABLE_CURRENT
+        )
+
+
+def test_unavailable_observation_reports_not_measured() -> None:
+    observation = unavailable_observation(**_COMMON)
+    assert observation.data_semantics == "not_measured"
+    assert observation.current_value is None
+
+
+# ---------------------------------------------------------------------------
+# data_trust_observation
+# ---------------------------------------------------------------------------
+
+
+def test_data_trust_complete_eligible_is_measured_healthy_value() -> None:
+    """Kill site: complete_eligible=True must map to current_value=0.0, not None/1.0."""
+
+    result = DataHealthResult(
+        sources=(_data_health_source(state=DataHealthState.COMPLETE),),
+        complete_eligible=True,
+    )
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.current_value == 0.0
+    assert observation.data_semantics == "measured_zero"
+    assert observation.observed_states == (SourceRequirementState.AVAILABLE_CURRENT,)
+
+
+def test_data_trust_not_complete_eligible_is_measured_broken_value() -> None:
+    """Kill site: complete_eligible=False must map to current_value=1.0 (triggers)."""
+
+    result = DataHealthResult(
+        sources=(_data_health_source(state=DataHealthState.COMPLETE),),
+        complete_eligible=False,
+    )
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.current_value == 1.0
+
+
+def test_data_trust_stale_source_reports_available_stale() -> None:
+    result = DataHealthResult(
+        sources=(_data_health_source(state=DataHealthState.STALE),),
+        complete_eligible=False,
+    )
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.observed_states == (SourceRequirementState.AVAILABLE_STALE,)
+    assert observation.current_value == 1.0
+
+
+def test_data_trust_unavailable_source_is_honestly_unmeasured() -> None:
+    """Kill site: an unmeasured worst source must never be reported as a measured value."""
+
+    result = DataHealthResult(
+        sources=(_data_health_source(state=DataHealthState.UNAVAILABLE),),
+        complete_eligible=False,
+    )
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.data_semantics == "not_measured"
+    assert observation.current_value is None
+
+
+def test_data_trust_no_sources_is_no_data_not_measured_zero() -> None:
+    result = DataHealthResult(sources=(), complete_eligible=True)
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.data_semantics == "no_data"
+    assert observation.current_value is None
+
+
+def test_data_trust_worst_source_wins_across_mixed_states() -> None:
+    """Kill site: severity selection must pick UNAVAILABLE over COMPLETE, not the first row."""
+
+    result = DataHealthResult(
+        sources=(
+            _data_health_source(state=DataHealthState.COMPLETE),
+            _data_health_source(state=DataHealthState.UNAVAILABLE),
+        ),
+        complete_eligible=False,
+    )
+    observation = data_trust_observation(result, **_COMMON)
+    assert observation.data_semantics == "not_measured"
+
+
+# ---------------------------------------------------------------------------
+# incident_load_observation
+# ---------------------------------------------------------------------------
+
+
+def test_incident_load_zero_incidents_is_a_measured_zero_not_no_data() -> None:
+    """Kill site: a genuinely queried zero-incident count is measured_zero, not no_data."""
+
+    snapshot = _snapshot(state=StatusResultState.COMPLETE, incidents=())
+    observation = incident_load_observation(snapshot, **_COMMON)
+    assert observation.current_value == 0.0
+    assert observation.data_semantics == "measured_zero"
+
+
+def test_incident_load_counts_real_incidents() -> None:
+    snapshot = _snapshot(
+        state=StatusResultState.COMPLETE,
+        incidents=(_incident("inc-1"), _incident("inc-2")),
+    )
+    observation = incident_load_observation(snapshot, **_COMMON)
+    assert observation.current_value == 2.0
+    assert observation.sample_count == 2
+
+
+def test_incident_load_insufficient_evidence_is_unmeasured() -> None:
+    """Kill site: INSUFFICIENT_EVIDENCE maps to UNAVAILABLE, must stay not_measured."""
+
+    snapshot = _snapshot(
+        state=StatusResultState.INSUFFICIENT_EVIDENCE,
+        incidents=(_incident("inc-1"),),
+    )
+    observation = incident_load_observation(snapshot, **_COMMON)
+    assert observation.data_semantics == "not_measured"
+    assert observation.current_value is None
+
+
+def test_incident_load_degraded_reports_available_unknown() -> None:
+    snapshot = _snapshot(
+        state=StatusResultState.DEGRADED, incidents=(_incident("inc-1"),)
+    )
+    observation = incident_load_observation(snapshot, **_COMMON)
+    assert observation.observed_states == (SourceRequirementState.AVAILABLE_UNKNOWN,)
+    assert observation.current_value == 1.0
+
+
+# ---------------------------------------------------------------------------
+# change_failure_rate_observation
+# ---------------------------------------------------------------------------
+
+
+def test_change_failure_rate_measured_value_passes_through() -> None:
+    result = _metric_result(
+        state=MetricDataState.VALUE,
+        values=(
+            MetricQueryValue(dimensions=(), value=0.2, comparison_value=0.1, series=()),
+        ),
+        coverage=0.9,
+    )
+    observation = change_failure_rate_observation(result, **_COMMON)
+    assert observation.current_value == 0.2
+    assert observation.comparison_value == 0.1
+    assert observation.coverage == 0.9
+    assert observation.denominator_present is True
+
+
+def test_change_failure_rate_zero_denominator_reports_denominator_absent() -> None:
+    """Kill site: INSUFFICIENT_EVIDENCE (zero-denominator) must not claim a denominator."""
+
+    result = _metric_result(
+        state=MetricDataState.INSUFFICIENT_EVIDENCE,
+        values=(),
+        metadata=(("empty_reason", "zero_denominator"),),
+    )
+    observation = change_failure_rate_observation(result, **_COMMON)
+    assert observation.denominator_present is False
+    assert observation.current_value is None
+
+
+def test_change_failure_rate_unconfigured_is_unmeasured() -> None:
+    result = _metric_result(state=MetricDataState.UNCONFIGURED, values=())
+    observation = change_failure_rate_observation(result, **_COMMON)
+    assert observation.data_semantics == "not_measured"
+
+
+def test_change_failure_rate_stale_state_reports_available_stale() -> None:
+    result = _metric_result(
+        state=MetricDataState.STALE,
+        values=(
+            MetricQueryValue(
+                dimensions=(), value=0.0, comparison_value=None, series=()
+            ),
+        ),
+    )
+    observation = change_failure_rate_observation(result, **_COMMON)
+    assert observation.observed_states == (SourceRequirementState.AVAILABLE_STALE,)
+    assert observation.current_value == 0.0
+    assert observation.data_semantics == "measured_zero"

--- a/tests/api/dev/test_chaos_3303_health_profile_synthesis.py
+++ b/tests/api/dev/test_chaos_3303_health_profile_synthesis.py
@@ -1,0 +1,284 @@
+"""Tests for CHAOS-3303's ``health_profile_synthesis`` shared rule-application engine.
+
+Covers the required-implementation test list from the CHAOS-3303 issue that
+applies at this layer: complete/mixed/unknown/not-applicable dimensions,
+measured-zero vs. absent, deterministic ordering, and no composite score.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from dev_health_ops.api.dev.contracts_v2.health_rules import (
+    DimensionState,
+    RuleApplicability,
+)
+from dev_health_ops.api.dev.data_health_service import (
+    DataHealthResult,
+    DataHealthSource,
+    DataHealthState,
+)
+from dev_health_ops.api.dev.health_profile_synthesis import (
+    HealthEvaluationSources,
+    synthesize_health_profile,
+)
+from dev_health_ops.api.dev.health_rule_registry import HEALTH_RULE_REGISTRY
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    IncidentFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _actual_completion() -> ActualCompletion:
+    return ActualCompletion(
+        state=CompletionState.READY,
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=(),
+        required_children=(),
+        conflicts=(),
+        source_ref_ids=(),
+        evidence_ref_ids=(),
+    )
+
+
+def _snapshot(
+    *, state: StatusResultState, incidents: tuple[IncidentFact, ...] = ()
+) -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=state,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=_actual_completion(),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=incidents,
+        source_refs=(),
+        warnings=(),
+    )
+
+
+def _incident(entity_id: str) -> IncidentFact:
+    return IncidentFact(
+        entity_id=entity_id,
+        display_label=entity_id,
+        status="open",
+        active=True,
+        blocking=False,
+        observed_at=_NOW,
+        source_ref_id="ref-1",
+        evidence_ref_ids=(),
+    )
+
+
+def _data_health(*, complete_eligible: bool) -> DataHealthResult:
+    return DataHealthResult(
+        sources=(
+            DataHealthSource(
+                source_system="work_items",
+                state=DataHealthState.COMPLETE,
+                required=True,
+                last_successful_at=_NOW,
+                watermark=_NOW,
+                missing_repository_ids=(),
+                missing_entity_ids=(),
+                coverage=1.0,
+                confidence_impact=None,
+                freshness_policy_version="v1",
+            ),
+        ),
+        complete_eligible=complete_eligible,
+    )
+
+
+def test_registry_totality_covers_every_rule() -> None:
+    """The module-level totality check must already have passed at import time
+    for every rule currently shipped in HEALTH_RULE_REGISTRY -- this test
+    just re-derives that same set to catch a future rule silently excluded
+    from the check itself (not just from the binding table).
+    """
+
+    from dev_health_ops.api.dev import health_profile_synthesis as synthesis
+
+    covered = synthesis._BOUND_RULE_IDS | frozenset(synthesis._UNBOUND_RULE_LIMITATIONS)
+    assert frozenset(HEALTH_RULE_REGISTRY) <= covered
+
+
+def test_project_profile_has_no_composite_score_field() -> None:
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=HealthEvaluationSources(),
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    assert not hasattr(profile, "score")
+    assert not hasattr(profile, "composite_score")
+
+
+def test_project_profile_covers_every_project_applicable_rule() -> None:
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=HealthEvaluationSources(),
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    expected_rule_ids = {
+        rule.rule_id
+        for rule in HEALTH_RULE_REGISTRY.values()
+        if RuleApplicability.PROJECT in rule.applicability
+    }
+    assert {finding.rule_id for finding in profile.findings} == expected_rule_ids
+
+
+def test_mixed_profile_reports_complete_unknown_and_not_applicable_dimensions() -> None:
+    """Complete (data_trust: measured), unknown (change_failure_rate: never
+    queried because sources is None), not_applicable (unbound rules like
+    completion_stalled reported as UNAVAILABLE -> UNKNOWN) all coexist in one
+    profile, independently -- no dimension's state leaks into another's.
+    """
+
+    sources = HealthEvaluationSources(
+        data_health=_data_health(complete_eligible=True),
+        status_snapshot=_snapshot(
+            state=StatusResultState.COMPLETE,
+            incidents=(_incident("inc-1"),),
+        ),
+        change_failure_rate_metric=None,
+        change_failure_rate_not_applicable=False,
+    )
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    findings_by_rule = {finding.rule_id: finding for finding in profile.findings}
+
+    # data_trust_broken: measured healthy (complete_eligible=True -> current_value=0.0).
+    assert findings_by_rule["health_rule.data_trust_broken.v1"].state == (
+        DimensionState.HEALTHY
+    )
+    # incident_load: 1 incident, sample_count=1 clears minimum_sample=1,
+    # value 1.0 < threshold 10.0 -> healthy.
+    assert findings_by_rule["health_rule.incident_load.v1"].state == (
+        DimensionState.HEALTHY
+    )
+    # change_failure_rate: metric never supplied -> unknown, never zero/healthy.
+    assert findings_by_rule["health_rule.change_failure_rate.v1"].state == (
+        DimensionState.UNKNOWN
+    )
+    # An unbound rule (no canonical source wired) is honestly unknown too.
+    assert findings_by_rule["health_rule.completion_stalled.v1"].state == (
+        DimensionState.UNKNOWN
+    )
+
+
+def test_change_failure_rate_not_applicable_flag_is_honored() -> None:
+    sources = HealthEvaluationSources(
+        change_failure_rate_metric=None, change_failure_rate_not_applicable=True
+    )
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    finding = next(
+        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+    )
+    assert finding.state == DimensionState.UNKNOWN
+
+
+def test_team_profile_without_cohort_suppresses_every_applicable_rule() -> None:
+    """A team subject with no resolved attribution (cohort_size=None) must
+    never surface a healthy/at-risk finding -- every applicable rule
+    requires minimum_cohort_size, so every one suppresses as
+    insufficient_cohort -> unknown.
+    """
+
+    sources = HealthEvaluationSources(
+        data_health=_data_health(complete_eligible=True),
+        status_snapshot=_snapshot(state=StatusResultState.COMPLETE, incidents=()),
+        change_failure_rate_metric=None,
+        change_failure_rate_not_applicable=True,
+    )
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.TEAM,
+        subject_id="team-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    assert profile.findings
+    for finding in profile.findings:
+        assert finding.state in (DimensionState.UNKNOWN, DimensionState.NOT_APPLICABLE)
+
+
+def test_findings_are_deterministically_ordered() -> None:
+    sources = HealthEvaluationSources(
+        data_health=_data_health(complete_eligible=True),
+        status_snapshot=_snapshot(state=StatusResultState.COMPLETE, incidents=()),
+    )
+    profile_a = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    profile_b = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    ordering_a = [f.rule_id for f in profile_a.findings]
+    ordering_b = [f.rule_id for f in profile_b.findings]
+    assert ordering_a == ordering_b
+
+    expected = sorted(profile_a.findings, key=lambda f: (f.dimension.value, f.rule_id))
+    assert list(profile_a.findings) == expected
+
+
+def test_every_shipped_finding_is_shadow_only_today() -> None:
+    """Every HEALTH_RULE_REGISTRY rule is provisional (CHAOS-3302's own
+    totality test) -- every finding this synthesis produces today must be
+    shadow_only, never a launch finding surfaced as authoritative.
+    """
+
+    sources = HealthEvaluationSources(
+        data_health=_data_health(complete_eligible=True),
+        status_snapshot=_snapshot(state=StatusResultState.COMPLETE, incidents=()),
+    )
+    profile = synthesize_health_profile(
+        applicability=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        cohort_size=None,
+        sources=sources,
+        org_id=_ORG_ID,
+        observed_at=_NOW,
+    )
+    assert all(finding.shadow_only for finding in profile.findings)

--- a/tests/api/dev/test_chaos_3303_health_profile_synthesis.py
+++ b/tests/api/dev/test_chaos_3303_health_profile_synthesis.py
@@ -142,7 +142,11 @@ def test_project_profile_covers_every_project_applicable_rule() -> None:
         for rule in HEALTH_RULE_REGISTRY.values()
         if RuleApplicability.PROJECT in rule.applicability
     }
-    assert {finding.rule_id for finding in profile.findings} == expected_rule_ids
+    # Every shipped rule is provisional (test_every_shipped_finding_is_
+    # shadow_only_today), so every finding lands in shadow_findings today.
+    assert profile.launch_findings == ()
+    assert profile.suppressed_findings == ()
+    assert {finding.rule_id for finding in profile.shadow_findings} == expected_rule_ids
 
 
 def test_mixed_profile_reports_complete_unknown_and_not_applicable_dimensions() -> None:
@@ -169,7 +173,9 @@ def test_mixed_profile_reports_complete_unknown_and_not_applicable_dimensions() 
         org_id=_ORG_ID,
         observed_at=_NOW,
     )
-    findings_by_rule = {finding.rule_id: finding for finding in profile.findings}
+    # Every rule is provisional today, so every finding is shadow -- see
+    # test_every_shipped_finding_is_shadow_only_today.
+    findings_by_rule = {finding.rule_id: finding for finding in profile.shadow_findings}
 
     # data_trust_broken: measured healthy (complete_eligible=True -> current_value=0.0).
     assert findings_by_rule["health_rule.data_trust_broken.v1"].state == (
@@ -203,7 +209,9 @@ def test_change_failure_rate_not_applicable_flag_is_honored() -> None:
         observed_at=_NOW,
     )
     finding = next(
-        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.change_failure_rate.v1"
     )
     assert finding.state == DimensionState.UNKNOWN
 
@@ -229,8 +237,10 @@ def test_team_profile_without_cohort_suppresses_every_applicable_rule() -> None:
         org_id=_ORG_ID,
         observed_at=_NOW,
     )
-    assert profile.findings
-    for finding in profile.findings:
+    assert profile.launch_findings == ()
+    assert profile.suppressed_findings == ()
+    assert profile.shadow_findings
+    for finding in profile.shadow_findings:
         assert finding.state in (DimensionState.UNKNOWN, DimensionState.NOT_APPLICABLE)
 
 
@@ -255,18 +265,23 @@ def test_findings_are_deterministically_ordered() -> None:
         org_id=_ORG_ID,
         observed_at=_NOW,
     )
-    ordering_a = [f.rule_id for f in profile_a.findings]
-    ordering_b = [f.rule_id for f in profile_b.findings]
+    ordering_a = [f.rule_id for f in profile_a.shadow_findings]
+    ordering_b = [f.rule_id for f in profile_b.shadow_findings]
     assert ordering_a == ordering_b
 
-    expected = sorted(profile_a.findings, key=lambda f: (f.dimension.value, f.rule_id))
-    assert list(profile_a.findings) == expected
+    expected = sorted(
+        profile_a.shadow_findings, key=lambda f: (f.dimension.value, f.rule_id)
+    )
+    assert list(profile_a.shadow_findings) == expected
 
 
 def test_every_shipped_finding_is_shadow_only_today() -> None:
     """Every HEALTH_RULE_REGISTRY rule is provisional (CHAOS-3302's own
-    totality test) -- every finding this synthesis produces today must be
-    shadow_only, never a launch finding surfaced as authoritative.
+    totality test) -- every finding this synthesis produces today must land
+    in ``shadow_findings`` (never ``launch_findings``/``suppressed_findings``,
+    both of which require a non-provisional rule per ``health_rule_
+    registry._evaluate_with_registry``), and every one of those findings
+    must itself report ``shadow_only=True``.
     """
 
     sources = HealthEvaluationSources(
@@ -281,4 +296,7 @@ def test_every_shipped_finding_is_shadow_only_today() -> None:
         org_id=_ORG_ID,
         observed_at=_NOW,
     )
-    assert all(finding.shadow_only for finding in profile.findings)
+    assert profile.launch_findings == ()
+    assert profile.suppressed_findings == ()
+    assert profile.shadow_findings
+    assert all(finding.shadow_only for finding in profile.shadow_findings)

--- a/tests/api/dev/test_chaos_3303_portfolio_status_service.py
+++ b/tests/api/dev/test_chaos_3303_portfolio_status_service.py
@@ -8,6 +8,7 @@ preserved unresolved/ambiguous mention disclosure.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
@@ -172,8 +173,8 @@ async def test_evaluate_portfolio_two_projects_returns_both() -> None:
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         projects=(
-            PortfolioProjectScope("proj-a", _scope("proj-a")),
-            PortfolioProjectScope("proj-b", _scope("proj-b")),
+            PortfolioProjectScope(_scope("proj-a")),
+            PortfolioProjectScope(_scope("proj-b")),
         ),
         now=_NOW,
     )
@@ -189,7 +190,7 @@ async def test_evaluate_portfolio_organization_scale_batch() -> None:
     result = await service.evaluate_portfolio(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
-        projects=tuple(PortfolioProjectScope(pid, _scope(pid)) for pid in project_ids),
+        projects=tuple(PortfolioProjectScope(_scope(pid)) for pid in project_ids),
         now=_NOW,
     )
     assert len(result.projects) == MAX_PORTFOLIO_PROJECTS
@@ -204,9 +205,7 @@ async def test_evaluate_portfolio_rejects_over_bound_batch() -> None:
         await service.evaluate_portfolio(
             org_id=_ORG_ID,
             permission_fingerprint="fp",
-            projects=tuple(
-                PortfolioProjectScope(pid, _scope(pid)) for pid in project_ids
-            ),
+            projects=tuple(PortfolioProjectScope(_scope(pid)) for pid in project_ids),
             now=_NOW,
         )
 
@@ -220,8 +219,37 @@ async def test_evaluate_portfolio_rejects_duplicate_project_ids() -> None:
             org_id=_ORG_ID,
             permission_fingerprint="fp",
             projects=(
-                PortfolioProjectScope("proj-a", _scope("proj-a")),
-                PortfolioProjectScope("proj-a", _scope("proj-a")),
+                PortfolioProjectScope(_scope("proj-a")),
+                PortfolioProjectScope(_scope("proj-a")),
+            ),
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_rejects_duplicate_scope_under_different_labels() -> (
+    None
+):
+    """Codex finding (HIGH, 2026-08-02): project_id used to be a caller-
+    asserted label independent of scope, so the SAME committed DevScope
+    submitted as two ``PortfolioProjectScope`` entries with different
+    asserted ids minted two "different" portfolio subjects with identical
+    data. ``project_id`` is now always ``scope.entity_refs[0].entity_id``,
+    so there is no label left to vary -- the exact same scope object under
+    two entries collides on the duplicate check regardless of how it is
+    constructed.
+    """
+
+    runtime = FakePortfolioRuntime(incident_counts={"proj-a": 1})
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    same_scope = _scope("proj-a")
+    with pytest.raises(ValueError, match="duplicate project_id"):
+        await service.evaluate_portfolio(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            projects=(
+                PortfolioProjectScope(same_scope),
+                PortfolioProjectScope(same_scope),
             ),
             now=_NOW,
         )
@@ -241,8 +269,8 @@ async def test_evaluate_portfolio_isolates_a_failing_project() -> None:
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         projects=(
-            PortfolioProjectScope("proj-a", _scope("proj-a")),
-            PortfolioProjectScope("proj-b", _scope("proj-b")),
+            PortfolioProjectScope(_scope("proj-a")),
+            PortfolioProjectScope(_scope("proj-b")),
         ),
         now=_NOW,
     )
@@ -257,7 +285,7 @@ async def test_evaluate_portfolio_preserves_unresolved_and_ambiguous_mentions() 
     result = await service.evaluate_portfolio(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
-        projects=(PortfolioProjectScope("proj-a", _scope("proj-a")),),
+        projects=(PortfolioProjectScope(_scope("proj-a")),),
         now=_NOW,
         unresolved_mention_ids=("mention-1",),
         ambiguous_mention_ids=("mention-2",),
@@ -269,11 +297,17 @@ async def test_evaluate_portfolio_preserves_unresolved_and_ambiguous_mentions() 
 
 
 @pytest.mark.asyncio
-async def test_evaluate_portfolio_orders_worst_severity_first() -> None:
-    """Kill site: sort key must rank by worst-dimension severity, not by
-    input order or project_id alone. A project with 15 incidents (past the
-    incident_load threshold of 10.0, sustained_periods_required=1,
-    triggered_state=WATCH) must sort ahead of a healthy one.
+async def test_evaluate_portfolio_all_provisional_registry_reports_no_elevated_state() -> (
+    None
+):
+    """Codex finding (HIGH, 2026-08-02): every HEALTH_RULE_REGISTRY rule is
+    provisional today, so ``launch_findings`` is empty for every project --
+    status/ordering/counts_by_worst_state must report no elevated state
+    anywhere (never promote calibration-only shadow findings into launch
+    authority). The underlying WATCH-level signal for the "risky" project
+    (15 incidents, past the incident_load threshold) is NOT lost -- it is
+    exactly the separately-labeled calibration payload, still readable off
+    each project's own ``shadow_findings``.
     """
 
     runtime = FakePortfolioRuntime(
@@ -284,18 +318,29 @@ async def test_evaluate_portfolio_orders_worst_severity_first() -> None:
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         projects=(
-            PortfolioProjectScope("proj-healthy", _scope("proj-healthy")),
-            PortfolioProjectScope("proj-risky", _scope("proj-risky")),
+            PortfolioProjectScope(_scope("proj-healthy")),
+            PortfolioProjectScope(_scope("proj-risky")),
         ),
         now=_NOW,
     )
-    assert [p.subject_id for p in result.projects] == ["proj-risky", "proj-healthy"]
+
+    # No elevated state anywhere: both projects tie at UNKNOWN (no launch
+    # findings), so ordering falls back to project_id alphabetically.
+    assert [p.subject_id for p in result.projects] == ["proj-healthy", "proj-risky"]
+    assert result.counts_by_worst_state[DimensionState.CRITICAL] == 0
+    assert result.counts_by_worst_state[DimensionState.AT_RISK] == 0
+    assert result.counts_by_worst_state[DimensionState.WATCH] == 0
+    assert result.counts_by_worst_state[DimensionState.UNKNOWN] == 2
+    for project in result.projects:
+        assert project.launch_findings == ()
+
+    # The calibration payload is still fully present, separately labeled.
+    risky = next(p for p in result.projects if p.subject_id == "proj-risky")
     risky_incident_finding = next(
-        f
-        for f in result.projects[0].findings
-        if f.rule_id == "health_rule.incident_load.v1"
+        f for f in risky.shadow_findings if f.rule_id == "health_rule.incident_load.v1"
     )
     assert risky_incident_finding.state == DimensionState.WATCH
+    assert risky_incident_finding.shadow_only is True
 
 
 @pytest.mark.asyncio
@@ -306,3 +351,93 @@ async def test_evaluate_portfolio_requires_at_least_one_project() -> None:
         await service.evaluate_portfolio(
             org_id=_ORG_ID, permission_fingerprint="fp", projects=(), now=_NOW
         )
+
+
+@dataclass
+class SingleFlightPortfolioRuntime:
+    """Trips ``RuntimeError`` if any two of its methods are ever in flight at
+    once -- a production-shaped stand-in for the request-scoped SQLAlchemy
+    AsyncSession the real ``_ProductionPlanExecutorRuntime`` shares across
+    every canonical-service call it makes (Codex finding, HIGH,
+    2026-08-02). ``asyncio.sleep(0)`` is a real yield point (mirroring a
+    genuine I/O await), so a concurrent caller (e.g. ``asyncio.gather``)
+    interleaves two calls and the second observes ``_in_flight=True`` before
+    the first resets it; a strictly sequential caller never does.
+    """
+
+    incident_counts: dict[str, int]
+    _in_flight: bool = False
+
+    async def _guarded(self):
+        if self._in_flight:
+            raise RuntimeError(
+                "concurrent single-session use detected -- two calls were "
+                "in flight against the same request-scoped runtime at once"
+            )
+        self._in_flight = True
+        try:
+            await asyncio.sleep(0)
+        finally:
+            self._in_flight = False
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        await self._guarded()
+        project_id = scope.entity_refs[0].entity_id
+        return _snapshot(incident_count=self.incident_counts.get(project_id, 1))
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        await self._guarded()
+        return MetricQueryResult(
+            definition=get_metric(MetricID.CHANGE_FAILURE_RATE),
+            state=MetricDataState.ZERO,
+            freshness=FreshnessState.FRESH,
+            values=(
+                MetricQueryValue(
+                    dimensions=(), value=0.0, comparison_value=0.0, series=()
+                ),
+            ),
+            coverage=1.0,
+            current_window_start=_NOW,
+            current_window_end=_NOW,
+            comparison_window_start=_NOW,
+            comparison_window_end=_NOW,
+            watermark=_NOW,
+            source_refs=(),
+        )
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        await self._guarded()
+        return DataHealthResult(sources=(), complete_eligible=True)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_never_overlaps_single_session_runtime_calls() -> None:
+    """The regression proof for the concurrency fix: a runtime that raises
+    on overlapping in-flight calls must complete cleanly under
+    ``evaluate_portfolio``'s sequential evaluation, across enough projects
+    that a concurrent (``asyncio.gather``) implementation would reliably
+    interleave and trip the guard.
+    """
+
+    project_ids = [f"proj-{i}" for i in range(10)]
+    runtime = SingleFlightPortfolioRuntime(
+        incident_counts=dict.fromkeys(project_ids, 1)
+    )
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=tuple(PortfolioProjectScope(_scope(pid)) for pid in project_ids),
+        now=_NOW,
+    )
+    assert len(result.projects) == len(project_ids)
+    assert not result.failures

--- a/tests/api/dev/test_chaos_3303_portfolio_status_service.py
+++ b/tests/api/dev/test_chaos_3303_portfolio_status_service.py
@@ -1,0 +1,308 @@
+"""Tests for CHAOS-3303's ``PortfolioStatusService``.
+
+Covers the required-implementation test list that applies at this layer:
+two-project and organization-scale portfolio batching, deterministic
+severity ordering, bounded output, isolated per-project failure, and
+preserved unresolved/ambiguous mention disclosure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import DimensionState
+from dev_health_ops.api.dev.data_health_service import DataHealthResult
+from dev_health_ops.api.dev.metrics.definitions import get_metric
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+)
+from dev_health_ops.api.dev.portfolio_status_service import (
+    MAX_PORTFOLIO_PROJECTS,
+    PortfolioProjectScope,
+    PortfolioStatusService,
+)
+from dev_health_ops.api.dev.project_health_service import ProjectHealthService
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    IncidentFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _scope(project_id: str) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.PROJECT,
+                entity_id=project_id,
+                display_label=project_id,
+            )
+        ],
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+        comparison_range=DevTimeRange(
+            start=_NOW - timedelta(days=28),
+            end=_NOW - timedelta(days=14),
+            timezone="UTC",
+        ),
+    )
+
+
+def _actual() -> ActualCompletion:
+    return ActualCompletion(
+        state=CompletionState.READY,
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=(),
+        required_children=(),
+        conflicts=(),
+        source_ref_ids=(),
+        evidence_ref_ids=(),
+    )
+
+
+def _incident(entity_id: str) -> IncidentFact:
+    return IncidentFact(
+        entity_id=entity_id,
+        display_label=entity_id,
+        status="open",
+        active=True,
+        blocking=False,
+        observed_at=_NOW,
+        source_ref_id="ref-1",
+        evidence_ref_ids=(),
+    )
+
+
+def _snapshot(*, incident_count: int) -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.COMPLETE,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=_actual(),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=tuple(_incident(f"inc-{i}") for i in range(incident_count)),
+        source_refs=(),
+        warnings=(),
+    )
+
+
+@dataclass
+class FakePortfolioRuntime:
+    """Per-project-id incident counts drive deterministic severity ordering:
+    a project with more incidents (closer to the incident_load threshold of
+    10.0) sorts as more severe.
+    """
+
+    incident_counts: dict[str, int]
+    raises_for: frozenset[str] = frozenset()
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        project_id = scope.entity_refs[0].entity_id
+        if project_id in self.raises_for:
+            raise RuntimeError(f"simulated status_snapshot failure for {project_id}")
+        return _snapshot(incident_count=self.incident_counts.get(project_id, 1))
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        return MetricQueryResult(
+            definition=get_metric(MetricID.CHANGE_FAILURE_RATE),
+            state=MetricDataState.ZERO,
+            freshness=FreshnessState.FRESH,
+            values=(
+                MetricQueryValue(
+                    dimensions=(), value=0.0, comparison_value=0.0, series=()
+                ),
+            ),
+            coverage=1.0,
+            current_window_start=_NOW,
+            current_window_end=_NOW,
+            comparison_window_start=_NOW,
+            comparison_window_end=_NOW,
+            watermark=_NOW,
+            source_refs=(),
+        )
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        return DataHealthResult(sources=(), complete_eligible=True)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_two_projects_returns_both() -> None:
+    runtime = FakePortfolioRuntime(incident_counts={"proj-a": 1, "proj-b": 1})
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=(
+            PortfolioProjectScope("proj-a", _scope("proj-a")),
+            PortfolioProjectScope("proj-b", _scope("proj-b")),
+        ),
+        now=_NOW,
+    )
+    assert {p.subject_id for p in result.projects} == {"proj-a", "proj-b"}
+    assert not result.failures
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_organization_scale_batch() -> None:
+    project_ids = [f"proj-{i}" for i in range(MAX_PORTFOLIO_PROJECTS)]
+    runtime = FakePortfolioRuntime(incident_counts=dict.fromkeys(project_ids, 1))
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=tuple(PortfolioProjectScope(pid, _scope(pid)) for pid in project_ids),
+        now=_NOW,
+    )
+    assert len(result.projects) == MAX_PORTFOLIO_PROJECTS
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_rejects_over_bound_batch() -> None:
+    project_ids = [f"proj-{i}" for i in range(MAX_PORTFOLIO_PROJECTS + 1)]
+    runtime = FakePortfolioRuntime(incident_counts=dict.fromkeys(project_ids, 1))
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    with pytest.raises(ValueError, match="bounded maximum"):
+        await service.evaluate_portfolio(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            projects=tuple(
+                PortfolioProjectScope(pid, _scope(pid)) for pid in project_ids
+            ),
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_rejects_duplicate_project_ids() -> None:
+    runtime = FakePortfolioRuntime(incident_counts={"proj-a": 1})
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    with pytest.raises(ValueError, match="duplicate project_id"):
+        await service.evaluate_portfolio(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            projects=(
+                PortfolioProjectScope("proj-a", _scope("proj-a")),
+                PortfolioProjectScope("proj-a", _scope("proj-a")),
+            ),
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_isolates_a_failing_project() -> None:
+    """A canonical-service exception for one project must not crash the
+    batch or silently drop the project -- it appears in ``failures``.
+    """
+
+    runtime = FakePortfolioRuntime(
+        incident_counts={"proj-a": 1, "proj-b": 1}, raises_for=frozenset({"proj-b"})
+    )
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=(
+            PortfolioProjectScope("proj-a", _scope("proj-a")),
+            PortfolioProjectScope("proj-b", _scope("proj-b")),
+        ),
+        now=_NOW,
+    )
+    assert {p.subject_id for p in result.projects} == {"proj-a"}
+    assert [f.project_id for f in result.failures] == ["proj-b"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_preserves_unresolved_and_ambiguous_mentions() -> None:
+    runtime = FakePortfolioRuntime(incident_counts={"proj-a": 1})
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=(PortfolioProjectScope("proj-a", _scope("proj-a")),),
+        now=_NOW,
+        unresolved_mention_ids=("mention-1",),
+        ambiguous_mention_ids=("mention-2",),
+        warnings=("cohort_truncated",),
+    )
+    assert result.unresolved_mention_ids == ("mention-1",)
+    assert result.ambiguous_mention_ids == ("mention-2",)
+    assert result.warnings == ("cohort_truncated",)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_orders_worst_severity_first() -> None:
+    """Kill site: sort key must rank by worst-dimension severity, not by
+    input order or project_id alone. A project with 15 incidents (past the
+    incident_load threshold of 10.0, sustained_periods_required=1,
+    triggered_state=WATCH) must sort ahead of a healthy one.
+    """
+
+    runtime = FakePortfolioRuntime(
+        incident_counts={"proj-healthy": 1, "proj-risky": 15}
+    )
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    result = await service.evaluate_portfolio(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        projects=(
+            PortfolioProjectScope("proj-healthy", _scope("proj-healthy")),
+            PortfolioProjectScope("proj-risky", _scope("proj-risky")),
+        ),
+        now=_NOW,
+    )
+    assert [p.subject_id for p in result.projects] == ["proj-risky", "proj-healthy"]
+    risky_incident_finding = next(
+        f
+        for f in result.projects[0].findings
+        if f.rule_id == "health_rule.incident_load.v1"
+    )
+    assert risky_incident_finding.state == DimensionState.WATCH
+
+
+@pytest.mark.asyncio
+async def test_evaluate_portfolio_requires_at_least_one_project() -> None:
+    runtime = FakePortfolioRuntime(incident_counts={})
+    service = PortfolioStatusService(ProjectHealthService(runtime))
+    with pytest.raises(ValueError, match="at least one project"):
+        await service.evaluate_portfolio(
+            org_id=_ORG_ID, permission_fingerprint="fp", projects=(), now=_NOW
+        )

--- a/tests/api/dev/test_chaos_3303_project_health_service.py
+++ b/tests/api/dev/test_chaos_3303_project_health_service.py
@@ -1,0 +1,230 @@
+"""Tests for CHAOS-3303's ``ProjectHealthService``.
+
+A fake ``PlanExecutorRuntime`` double stands in for the exact seam
+CHAOS-3295 built and ``production_runtime.py`` already wires -- this
+service is proven against that protocol, not against a second bespoke
+query path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import DimensionState
+from dev_health_ops.api.dev.data_health_service import DataHealthResult
+from dev_health_ops.api.dev.metrics.definitions import get_metric
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+)
+from dev_health_ops.api.dev.project_health_service import (
+    CHANGE_FAILURE_RATE_SUPPORTED_SCOPES,
+    ProjectHealthService,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _project_scope(*, with_comparison: bool = True) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.PROJECT,
+                entity_id="proj-1",
+                display_label="Project 1",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+        comparison_range=(
+            DevTimeRange(
+                start=_NOW - timedelta(days=28),
+                end=_NOW - timedelta(days=14),
+                timezone="UTC",
+            )
+            if with_comparison
+            else None
+        ),
+    )
+
+
+def _snapshot() -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.COMPLETE,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=ActualCompletion(
+            state=CompletionState.READY,
+            rule_id="actual-completion",
+            rule_version="actual-completion.v4",
+            reason_codes=(),
+            required_children=(),
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=(),
+        source_refs=(),
+        warnings=(),
+    )
+
+
+def _data_health() -> DataHealthResult:
+    return DataHealthResult(sources=(), complete_eligible=True)
+
+
+def _metric_result() -> MetricQueryResult:
+    return MetricQueryResult(
+        definition=get_metric(MetricID.CHANGE_FAILURE_RATE),
+        state=MetricDataState.ZERO,
+        freshness=FreshnessState.FRESH,
+        values=(
+            MetricQueryValue(dimensions=(), value=0.0, comparison_value=0.0, series=()),
+        ),
+        coverage=1.0,
+        current_window_start=_NOW,
+        current_window_end=_NOW,
+        comparison_window_start=_NOW,
+        comparison_window_end=_NOW,
+        watermark=_NOW,
+        source_refs=(),
+    )
+
+
+@dataclass
+class FakeRuntime:
+    query_metric_calls: int = 0
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return _snapshot()
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        self.query_metric_calls += 1
+        return _metric_result()
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        return _data_health()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_rejects_non_project_scope() -> None:
+    runtime = FakeRuntime()
+    service = ProjectHealthService(runtime)
+    non_project_scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.ORGANIZATION,
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+    )
+    with pytest.raises(ValueError, match="project direct scope"):
+        await service.evaluate_project(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=non_project_scope,
+            project_id="proj-1",
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_requires_comparison_range() -> None:
+    runtime = FakeRuntime()
+    service = ProjectHealthService(runtime)
+    with pytest.raises(ValueError, match="comparison_range"):
+        await service.evaluate_project(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=_project_scope(with_comparison=False),
+            project_id="proj-1",
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_queries_the_change_failure_rate_metric() -> None:
+    runtime = FakeRuntime()
+    service = ProjectHealthService(runtime)
+    profile = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        project_id="proj-1",
+        now=_NOW,
+    )
+    assert runtime.query_metric_calls == 1
+    finding = next(
+        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+    )
+    # ZERO state maps to a genuinely measured 0.0 -> healthy, not unknown.
+    assert finding.state == DimensionState.HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_change_failure_rate_supported_scopes_excludes_team() -> None:
+    assert DirectScope.TEAM not in CHANGE_FAILURE_RATE_SUPPORTED_SCOPES
+    assert DirectScope.PROJECT in CHANGE_FAILURE_RATE_SUPPORTED_SCOPES
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_is_deterministic_across_repeated_calls() -> None:
+    runtime = FakeRuntime()
+    service = ProjectHealthService(runtime)
+    profile_a = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        project_id="proj-1",
+        now=_NOW,
+    )
+    profile_b = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        project_id="proj-1",
+        now=_NOW,
+    )
+    assert [f.finding_id for f in profile_a.findings] == [
+        f.finding_id for f in profile_b.findings
+    ]

--- a/tests/api/dev/test_chaos_3303_project_health_service.py
+++ b/tests/api/dev/test_chaos_3303_project_health_service.py
@@ -163,7 +163,6 @@ async def test_evaluate_project_rejects_non_project_scope() -> None:
             org_id=_ORG_ID,
             permission_fingerprint="fp",
             scope=non_project_scope,
-            project_id="proj-1",
             now=_NOW,
         )
 
@@ -177,7 +176,6 @@ async def test_evaluate_project_requires_comparison_range() -> None:
             org_id=_ORG_ID,
             permission_fingerprint="fp",
             scope=_project_scope(with_comparison=False),
-            project_id="proj-1",
             now=_NOW,
         )
 
@@ -190,12 +188,14 @@ async def test_evaluate_project_queries_the_change_failure_rate_metric() -> None
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_project_scope(),
-        project_id="proj-1",
         now=_NOW,
     )
     assert runtime.query_metric_calls == 1
+    # Every shipped rule is provisional today, so the finding is shadow.
     finding = next(
-        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.change_failure_rate.v1"
     )
     # ZERO state maps to a genuinely measured 0.0 -> healthy, not unknown.
     assert finding.state == DimensionState.HEALTHY
@@ -215,16 +215,52 @@ async def test_evaluate_project_is_deterministic_across_repeated_calls() -> None
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_project_scope(),
-        project_id="proj-1",
         now=_NOW,
     )
     profile_b = await service.evaluate_project(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_project_scope(),
-        project_id="proj-1",
         now=_NOW,
     )
-    assert [f.finding_id for f in profile_a.findings] == [
-        f.finding_id for f in profile_b.findings
+    assert [f.finding_id for f in profile_a.shadow_findings] == [
+        f.finding_id for f in profile_b.shadow_findings
     ]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_derives_subject_id_from_scope_not_a_label() -> None:
+    """Codex finding (HIGH, 2026-08-02): project_id used to be a caller-
+    supplied label independent of `scope` -- the exact same committed
+    DevScope submitted as two different asserted labels ("alias-a",
+    "alias-b") minted two portfolio "subjects" with identical underlying
+    data. There is no longer a project_id parameter to assert through:
+    the subject id is always the scope's own (validator-guaranteed unique)
+    entity_ref id, proven here for two scopes that are identical except for
+    entity_id.
+    """
+
+    runtime = FakeRuntime()
+    service = ProjectHealthService(runtime)
+    scope_a = _project_scope()
+    scope_b = scope_a.model_copy(
+        update={
+            "entity_refs": [
+                DevEntityRef(
+                    entity_type=EntityType.PROJECT,
+                    entity_id="proj-2",
+                    display_label="Project 2",
+                )
+            ]
+        }
+    )
+
+    profile_a = await service.evaluate_project(
+        org_id=_ORG_ID, permission_fingerprint="fp", scope=scope_a, now=_NOW
+    )
+    profile_b = await service.evaluate_project(
+        org_id=_ORG_ID, permission_fingerprint="fp", scope=scope_b, now=_NOW
+    )
+
+    assert profile_a.subject_id == "proj-1"
+    assert profile_b.subject_id == "proj-2"

--- a/tests/api/dev/test_chaos_3303_team_health_service.py
+++ b/tests/api/dev/test_chaos_3303_team_health_service.py
@@ -33,6 +33,7 @@ from dev_health_ops.api.dev.contracts import (
 )
 from dev_health_ops.api.dev.contracts_v2.health_rules import DimensionState
 from dev_health_ops.api.dev.data_health_service import DataHealthResult
+from dev_health_ops.api.dev.native_status_change import TeamAttributionResult
 from dev_health_ops.api.dev.status_change_service import (
     ActualCompletion,
     CompletionState,
@@ -124,24 +125,30 @@ class FakeAttributionSource:
     """A configurable ``TeamAttributionSource`` double -- ``repository_ids``
     is the ONLY thing that determines ``cohort_size`` (see
     ``TeamHealthService.evaluate_team``); there is no other lever a test
-    (or a caller) has to influence it.
+    (or a caller) has to influence it. ``measured=False`` simulates a
+    genuine lookup failure, distinct from a measured-empty cohort (Codex
+    finding, MEDIUM, 2026-08-02).
     """
 
     repository_ids: tuple[str, ...] = ()
-    calls: list[tuple[str, str]] | None = None
+    measured: bool = True
+    calls: list[tuple[str, str, datetime]] | None = None
 
     async def team_repository_ids(
         self, org_id: str, team_id: str, *, as_of: datetime
-    ) -> list[str]:
+    ) -> TeamAttributionResult:
         if self.calls is not None:
-            self.calls.append((org_id, team_id))
-        return list(self.repository_ids)
+            self.calls.append((org_id, team_id, as_of))
+        return TeamAttributionResult(
+            measured=self.measured, repository_ids=self.repository_ids
+        )
 
 
 _NO_ATTRIBUTION = FakeAttributionSource(repository_ids=())
 _FULL_ATTRIBUTION = FakeAttributionSource(
     repository_ids=tuple(f"repo-{i}" for i in range(25))
 )
+_FAILED_ATTRIBUTION = FakeAttributionSource(measured=False)
 
 
 @pytest.mark.asyncio
@@ -382,3 +389,96 @@ async def test_evaluate_team_with_attribution_and_real_facts_reports_real_findin
     # threshold 10.0 -- a real, measured healthy finding.
     assert incident_finding.state == DimensionState.HEALTHY
     assert incident_finding.suppressed_reason is None
+
+
+@dataclass
+class _UncallableRuntime:
+    """A runtime that fails the test immediately if any method is called --
+    proves ``evaluate_team`` short-circuits on a failed attribution lookup
+    rather than proceeding to fetch facts it cannot responsibly attach a
+    cohort to.
+    """
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError(
+            "the runtime must never be called when attribution measurement "
+            "itself failed -- cohort_size is unknowable, not merely small"
+        )
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("unexpected call")
+
+    def list_metrics(self, scope):
+        raise AssertionError("unexpected call")
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("unexpected call")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("unexpected call")
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("unexpected call")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_attribution_failure_is_unmeasured_not_insufficient_cohort() -> (
+    None
+):
+    """Codex finding (MEDIUM, 2026-08-02): a genuine attribution-lookup
+    FAILURE must be distinct from a measured-empty cohort. Both currently
+    suppress via the same UNKNOWN state (evaluate_rule's own no_data/
+    not_measured short-circuit fires before the cohort guard even runs --
+    see health_rule_registry.evaluate_rule), but a failure must never carry
+    ``suppressed_reason="insufficient_cohort"`` (a claim that a real,
+    measured zero was found) and the runtime must never even be called.
+    """
+
+    service = TeamHealthService(_UncallableRuntime(), _FAILED_ATTRIBUTION)
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    assert profile.launch_findings == ()
+    assert profile.suppressed_findings == ()
+    assert profile.shadow_findings
+    for finding in profile.shadow_findings:
+        assert finding.state in (DimensionState.UNKNOWN, DimensionState.NOT_APPLICABLE)
+        assert finding.suppressed_reason != "insufficient_cohort"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_resolves_attribution_at_scope_end_not_wall_clock_now() -> (
+    None
+):
+    """Codex finding (MEDIUM, 2026-08-02), the exact repro shape: an
+    ownership row valid at ``scope.time_range.end`` but since expired by
+    wall-clock ``now`` must not wrongly zero the cohort. This service must
+    resolve attribution at ``scope.time_range.end``, never ``now`` -- proven
+    here with a ``now`` far past the scope window.
+    """
+
+    recorded_calls: list[tuple[str, str, datetime]] = []
+    attribution = FakeAttributionSource(
+        repository_ids=("repo-a",), calls=recorded_calls
+    )
+    scope = _team_scope()
+    much_later_now = scope.time_range.end + timedelta(days=90)
+    assert much_later_now != scope.time_range.end
+
+    service = TeamHealthService(FakeAttributedTeamRuntime(), attribution)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=scope,
+        team_id="team-1",
+        now=much_later_now,
+    )
+
+    assert len(recorded_calls) == 1
+    _org_id, _team_id, as_of = recorded_calls[0]
+    assert as_of == scope.time_range.end
+    assert as_of != much_later_now

--- a/tests/api/dev/test_chaos_3303_team_health_service.py
+++ b/tests/api/dev/test_chaos_3303_team_health_service.py
@@ -1,15 +1,20 @@
 """Tests for CHAOS-3303's ``TeamHealthService``.
 
-Proven against a fake ``PlanExecutorRuntime`` in both directions, not by
-special-casing team scope inside the service itself:
+Proven against a fake ``PlanExecutorRuntime`` AND a fake
+``TeamAttributionSource`` independently, not by special-casing team scope
+inside the service itself:
 
 * a runtime that returns real, fresh team-scoped facts (mirroring
   ``native_status_change.py``'s now-landed ``team_repo_ownership``
-  re-derivation and its real 'team' SQL arms) produces real findings;
-* a runtime that returns the fail-closed shape (a team with no resolved
-  attribution, or a source genuinely unavailable) must never fabricate a
-  healthy/zero finding out of it, regardless of whether a cohort size is
-  supplied.
+  re-derivation and its real 'team' SQL arms) produces real findings, but
+  ONLY when the attribution source also reports real owned repositories;
+* a runtime that returns the fail-closed shape (a source genuinely
+  unavailable) must never fabricate a healthy/zero finding out of it;
+* an attribution source reporting zero owned repositories must suppress
+  every applicable rule as insufficient_cohort, even when the runtime
+  itself returns otherwise-complete facts -- there is no caller-supplied
+  cohort_size left to assert around this (Codex finding, HIGH,
+  2026-08-02): cohort_size is always ``len(team_repository_ids(...))``.
 """
 
 from __future__ import annotations
@@ -114,9 +119,34 @@ class FakeTeamRuntime:
         return DataHealthResult(sources=(), complete_eligible=False)
 
 
+@dataclass
+class FakeAttributionSource:
+    """A configurable ``TeamAttributionSource`` double -- ``repository_ids``
+    is the ONLY thing that determines ``cohort_size`` (see
+    ``TeamHealthService.evaluate_team``); there is no other lever a test
+    (or a caller) has to influence it.
+    """
+
+    repository_ids: tuple[str, ...] = ()
+    calls: list[tuple[str, str]] | None = None
+
+    async def team_repository_ids(
+        self, org_id: str, team_id: str, *, as_of: datetime
+    ) -> list[str]:
+        if self.calls is not None:
+            self.calls.append((org_id, team_id))
+        return list(self.repository_ids)
+
+
+_NO_ATTRIBUTION = FakeAttributionSource(repository_ids=())
+_FULL_ATTRIBUTION = FakeAttributionSource(
+    repository_ids=tuple(f"repo-{i}" for i in range(25))
+)
+
+
 @pytest.mark.asyncio
 async def test_evaluate_team_rejects_non_team_scope() -> None:
-    service = TeamHealthService(FakeTeamRuntime())
+    service = TeamHealthService(FakeTeamRuntime(), _NO_ATTRIBUTION)
     project_scope = DevScope(
         schema_version="dev_scope.v1",
         organization_id=_ORG_ID,
@@ -138,21 +168,19 @@ async def test_evaluate_team_rejects_non_team_scope() -> None:
             permission_fingerprint="fp",
             scope=project_scope,
             team_id="team-1",
-            cohort_size=5,
             now=_NOW,
         )
 
 
 @pytest.mark.asyncio
 async def test_evaluate_team_rejects_mismatched_team_id() -> None:
-    service = TeamHealthService(FakeTeamRuntime())
+    service = TeamHealthService(FakeTeamRuntime(), _NO_ATTRIBUTION)
     with pytest.raises(ValueError, match="team_ids must name exactly"):
         await service.evaluate_team(
             org_id=_ORG_ID,
             permission_fingerprint="fp",
             scope=_team_scope(team_id="team-1"),
             team_id="team-2",
-            cohort_size=5,
             now=_NOW,
         )
 
@@ -163,40 +191,68 @@ async def test_evaluate_team_never_queries_change_failure_rate_metric() -> None:
     must be a structural not_applicable, never an attempted, failing call.
     """
 
-    service = TeamHealthService(FakeTeamRuntime())
+    service = TeamHealthService(FakeTeamRuntime(), _FULL_ATTRIBUTION)
     profile = await service.evaluate_team(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_team_scope(),
         team_id="team-1",
-        cohort_size=5,
         now=_NOW,
     )
     finding = next(
-        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.change_failure_rate.v1"
     )
     assert finding.state == DimensionState.UNKNOWN
 
 
 @pytest.mark.asyncio
 async def test_evaluate_team_without_attribution_never_reports_healthy() -> None:
-    """With cohort_size=0 (no resolved team_repo_ownership attribution),
-    every applicable rule requiring a minimum cohort must suppress -- never
-    a fabricated healthy/at-risk finding for an unattributed team.
+    """With zero resolved ``team_repo_ownership`` rows (cohort_size derives
+    to 0), every applicable rule requiring a minimum cohort must suppress --
+    never a fabricated healthy/at-risk finding for an unattributed team.
     """
 
-    service = TeamHealthService(FakeTeamRuntime())
+    service = TeamHealthService(FakeTeamRuntime(), _NO_ATTRIBUTION)
     profile = await service.evaluate_team(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_team_scope(),
         team_id="team-1",
-        cohort_size=0,
         now=_NOW,
     )
-    assert profile.findings
-    for finding in profile.findings:
+    assert profile.launch_findings == ()
+    assert profile.suppressed_findings == ()
+    assert profile.shadow_findings
+    for finding in profile.shadow_findings:
         assert finding.state in (DimensionState.UNKNOWN, DimensionState.NOT_APPLICABLE)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_zero_attribution_suppresses_even_with_real_facts() -> None:
+    """Codex finding (HIGH, 2026-08-02), the exact repro shape: an
+    unattributed team (zero owned repositories) must stay suppressed even
+    when the runtime itself returns otherwise-complete, real facts --
+    proving cohort_size is genuinely derived from the attribution source,
+    never inferable from "the sources look fine" or any other signal.
+    """
+
+    service = TeamHealthService(FakeAttributedTeamRuntime(), _NO_ATTRIBUTION)
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    incident_finding = next(
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.incident_load.v1"
+    )
+    assert incident_finding.state == DimensionState.UNKNOWN
+    assert incident_finding.suppressed_reason == "insufficient_cohort"
 
 
 @pytest.mark.asyncio
@@ -205,22 +261,23 @@ async def test_evaluate_team_with_attribution_stays_honest_when_runtime_fails_cl
 ):
     """Even with real attribution (cohort_size >= minimum), a runtime that
     hands back the fail-closed shape (e.g. a genuinely unresolved
-    ``team_repo_ownership`` lookup) must keep every status-derived dimension
-    unknown -- the service must never treat "cohort size is fine" as
-    license to assume the underlying facts are too.
+    ``team_repo_ownership``-derived read) must keep every status-derived
+    dimension unknown -- the service must never treat "cohort size is fine"
+    as license to assume the underlying facts are too.
     """
 
-    service = TeamHealthService(FakeTeamRuntime())
+    service = TeamHealthService(FakeTeamRuntime(), _FULL_ATTRIBUTION)
     profile = await service.evaluate_team(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_team_scope(),
         team_id="team-1",
-        cohort_size=25,
         now=_NOW,
     )
     incident_finding = next(
-        f for f in profile.findings if f.rule_id == "health_rule.incident_load.v1"
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.incident_load.v1"
     )
     assert incident_finding.state == DimensionState.UNKNOWN
 
@@ -302,22 +359,24 @@ async def test_evaluate_team_with_attribution_and_real_facts_reports_real_findin
 ):
     """The positive control: once the runtime returns real team-scoped
     facts (mirroring the now-landed native_status_change.py team arms) and
-    the caller supplies a cohort size that clears every applicable rule's
-    minimum, the incident_load dimension is a genuinely measured finding --
-    not honestly-unknown-by-construction like the fail-closed tests above.
+    the attribution source reports real owned repositories clearing every
+    applicable rule's minimum cohort, the incident_load dimension is a
+    genuinely measured finding -- not honestly-unknown-by-construction like
+    the fail-closed/unattributed tests above.
     """
 
-    service = TeamHealthService(FakeAttributedTeamRuntime())
+    service = TeamHealthService(FakeAttributedTeamRuntime(), _FULL_ATTRIBUTION)
     profile = await service.evaluate_team(
         org_id=_ORG_ID,
         permission_fingerprint="fp",
         scope=_team_scope(),
         team_id="team-1",
-        cohort_size=25,
         now=_NOW,
     )
     incident_finding = next(
-        f for f in profile.findings if f.rule_id == "health_rule.incident_load.v1"
+        f
+        for f in profile.shadow_findings
+        if f.rule_id == "health_rule.incident_load.v1"
     )
     # 1 incident, sample_count=1 clears minimum_sample=1, value 1.0 <
     # threshold 10.0 -- a real, measured healthy finding.

--- a/tests/api/dev/test_chaos_3303_team_health_service.py
+++ b/tests/api/dev/test_chaos_3303_team_health_service.py
@@ -1,0 +1,221 @@
+"""Tests for CHAOS-3303's ``TeamHealthService``.
+
+The load-bearing behavior today: ``native_status_change.py`` fails closed
+for every team direct scope (every source it reads is still in
+``TEAM_NOT_APPLICABLE_SOURCES``), so a team health evaluation must never
+fabricate a healthy/zero finding out of that fail-closed response --
+regardless of whether a cohort size is supplied. This is proven with a
+fake runtime that mirrors the real fail-closed shape, not by special-casing
+team scope inside the service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import DimensionState
+from dev_health_ops.api.dev.data_health_service import DataHealthResult
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+from dev_health_ops.api.dev.team_health_service import TeamHealthService
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _team_scope(*, team_id: str = "team-1") -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.TEAM,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM, entity_id=team_id, display_label="Team 1"
+            )
+        ],
+        team_ids=[team_id],
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+    )
+
+
+def _fail_closed_snapshot() -> StatusSnapshotResult:
+    """Mirrors ``ClickHouseStatusChangeSource``'s current team fail-closed branch:
+    an INSUFFICIENT_EVIDENCE state with no facts of any kind.
+    """
+
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.INSUFFICIENT_EVIDENCE,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=ActualCompletion(
+            state=CompletionState.INDETERMINATE,
+            rule_id="actual-completion",
+            rule_version="actual-completion.v4",
+            reason_codes=("team_scope_not_yet_attributed",),
+            required_children=(),
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=(),
+        source_refs=(),
+        warnings=("no_authorized_repositories",),
+    )
+
+
+@dataclass
+class FakeTeamRuntime:
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return _fail_closed_snapshot()
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError(
+            "TeamHealthService must never query CHANGE_FAILURE_RATE for a "
+            "team subject -- the metric does not support DirectScope.TEAM"
+        )
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        return DataHealthResult(sources=(), complete_eligible=False)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_rejects_non_team_scope() -> None:
+    service = TeamHealthService(FakeTeamRuntime())
+    project_scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.PROJECT,
+                entity_id="proj-1",
+                display_label="Project 1",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+    )
+    with pytest.raises(ValueError, match="team direct scope"):
+        await service.evaluate_team(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=project_scope,
+            team_id="team-1",
+            cohort_size=5,
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_rejects_mismatched_team_id() -> None:
+    service = TeamHealthService(FakeTeamRuntime())
+    with pytest.raises(ValueError, match="team_ids must name exactly"):
+        await service.evaluate_team(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=_team_scope(team_id="team-1"),
+            team_id="team-2",
+            cohort_size=5,
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_never_queries_change_failure_rate_metric() -> None:
+    """CHANGE_FAILURE_RATE has no supported_scopes entry for TEAM -- this
+    must be a structural not_applicable, never an attempted, failing call.
+    """
+
+    service = TeamHealthService(FakeTeamRuntime())
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        cohort_size=5,
+        now=_NOW,
+    )
+    finding = next(
+        f for f in profile.findings if f.rule_id == "health_rule.change_failure_rate.v1"
+    )
+    assert finding.state == DimensionState.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_without_attribution_never_reports_healthy() -> None:
+    """With cohort_size=0 (no resolved team_repo_ownership attribution),
+    every applicable rule requiring a minimum cohort must suppress -- never
+    a fabricated healthy/at-risk finding for an unattributed team.
+    """
+
+    service = TeamHealthService(FakeTeamRuntime())
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        cohort_size=0,
+        now=_NOW,
+    )
+    assert profile.findings
+    for finding in profile.findings:
+        assert finding.state in (DimensionState.UNKNOWN, DimensionState.NOT_APPLICABLE)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_with_attribution_still_honest_given_fail_closed_status_source() -> (
+    None
+):
+    """Even with real attribution (cohort_size >= minimum), today's
+    fail-closed team status source means every status-derived dimension
+    stays unknown -- this is the current, honest state (see module
+    docstring), proven so a future SQL-arm change is visible as a real
+    behavior change here, not silently.
+    """
+
+    service = TeamHealthService(FakeTeamRuntime())
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        cohort_size=25,
+        now=_NOW,
+    )
+    incident_finding = next(
+        f for f in profile.findings if f.rule_id == "health_rule.incident_load.v1"
+    )
+    assert incident_finding.state == DimensionState.UNKNOWN

--- a/tests/api/dev/test_chaos_3303_team_health_service.py
+++ b/tests/api/dev/test_chaos_3303_team_health_service.py
@@ -1,12 +1,15 @@
 """Tests for CHAOS-3303's ``TeamHealthService``.
 
-The load-bearing behavior today: ``native_status_change.py`` fails closed
-for every team direct scope (every source it reads is still in
-``TEAM_NOT_APPLICABLE_SOURCES``), so a team health evaluation must never
-fabricate a healthy/zero finding out of that fail-closed response --
-regardless of whether a cohort size is supplied. This is proven with a
-fake runtime that mirrors the real fail-closed shape, not by special-casing
-team scope inside the service.
+Proven against a fake ``PlanExecutorRuntime`` in both directions, not by
+special-casing team scope inside the service itself:
+
+* a runtime that returns real, fresh team-scoped facts (mirroring
+  ``native_status_change.py``'s now-landed ``team_repo_ownership``
+  re-derivation and its real 'team' SQL arms) produces real findings;
+* a runtime that returns the fail-closed shape (a team with no resolved
+  attribution, or a source genuinely unavailable) must never fabricate a
+  healthy/zero finding out of it, regardless of whether a cohort size is
+  supplied.
 """
 
 from __future__ import annotations
@@ -28,6 +31,7 @@ from dev_health_ops.api.dev.data_health_service import DataHealthResult
 from dev_health_ops.api.dev.status_change_service import (
     ActualCompletion,
     CompletionState,
+    IncidentFact,
     StatusResultState,
     StatusSnapshotResult,
 )
@@ -196,14 +200,14 @@ async def test_evaluate_team_without_attribution_never_reports_healthy() -> None
 
 
 @pytest.mark.asyncio
-async def test_evaluate_team_with_attribution_still_honest_given_fail_closed_status_source() -> (
+async def test_evaluate_team_with_attribution_stays_honest_when_runtime_fails_closed() -> (
     None
 ):
-    """Even with real attribution (cohort_size >= minimum), today's
-    fail-closed team status source means every status-derived dimension
-    stays unknown -- this is the current, honest state (see module
-    docstring), proven so a future SQL-arm change is visible as a real
-    behavior change here, not silently.
+    """Even with real attribution (cohort_size >= minimum), a runtime that
+    hands back the fail-closed shape (e.g. a genuinely unresolved
+    ``team_repo_ownership`` lookup) must keep every status-derived dimension
+    unknown -- the service must never treat "cohort size is fine" as
+    license to assume the underlying facts are too.
     """
 
     service = TeamHealthService(FakeTeamRuntime())
@@ -219,3 +223,103 @@ async def test_evaluate_team_with_attribution_still_honest_given_fail_closed_sta
         f for f in profile.findings if f.rule_id == "health_rule.incident_load.v1"
     )
     assert incident_finding.state == DimensionState.UNKNOWN
+
+
+def _real_snapshot() -> StatusSnapshotResult:
+    """Mirrors what ``native_status_change.py`` now genuinely returns for a
+    team with resolved ``team_repo_ownership`` rows: real incident facts and
+    an overall ``COMPLETE`` state (``declared_optional`` now includes TEAM,
+    so the absent single declared status no longer degrades the result).
+    """
+
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.COMPLETE,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=ActualCompletion(
+            state=CompletionState.READY,
+            rule_id="actual-completion",
+            rule_version="actual-completion.v4",
+            reason_codes=(),
+            required_children=(),
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
+        children=(),
+        blockers=(),
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=(
+            IncidentFact(
+                entity_id="inc-1",
+                display_label="inc-1",
+                status="open",
+                active=True,
+                blocking=False,
+                observed_at=_NOW,
+                source_ref_id="ref-1",
+                evidence_ref_ids=(),
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+    )
+
+
+@dataclass
+class FakeAttributedTeamRuntime:
+    """A team WITH resolved team_repo_ownership rows: real facts, no gap."""
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return _real_snapshot()
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError(
+            "TeamHealthService must never query CHANGE_FAILURE_RATE for a "
+            "team subject -- the metric does not support DirectScope.TEAM"
+        )
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        return DataHealthResult(sources=(), complete_eligible=True)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_with_attribution_and_real_facts_reports_real_findings() -> (
+    None
+):
+    """The positive control: once the runtime returns real team-scoped
+    facts (mirroring the now-landed native_status_change.py team arms) and
+    the caller supplies a cohort size that clears every applicable rule's
+    minimum, the incident_load dimension is a genuinely measured finding --
+    not honestly-unknown-by-construction like the fail-closed tests above.
+    """
+
+    service = TeamHealthService(FakeAttributedTeamRuntime())
+    profile = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        cohort_size=25,
+        now=_NOW,
+    )
+    incident_finding = next(
+        f for f in profile.findings if f.rule_id == "health_rule.incident_load.v1"
+    )
+    # 1 incident, sample_count=1 clears minimum_sample=1, value 1.0 <
+    # threshold 10.0 -- a real, measured healthy finding.
+    assert incident_finding.state == DimensionState.HEALTHY
+    assert incident_finding.suppressed_reason is None

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -14,6 +14,7 @@ from dev_health_ops.api.dev.contracts import (
 )
 from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
 from dev_health_ops.api.dev.status_change_service import (
+    ChangeCategory,
     ChangeSummaryRequest,
     CompletionState,
     StatusChangeService,
@@ -59,13 +60,13 @@ def _scope(
     )
 
 
-def _deployment_row(status: str = "success") -> dict[str, Any]:
+def _deployment_row(status: str = "success", *, pr_number: int = 7) -> dict[str, Any]:
     return {
         "entity_id": "deployment-1",
         "display_label": "Production deployment",
         "status": status,
         "environment": "production",
-        "pr_number": 7,
+        "pr_number": pr_number,
         "observed_at": NOW,
         "last_synced": NOW,
     }
@@ -1114,8 +1115,8 @@ async def test_organization_scope_status_snapshot_enumerates_repos_natively(
     # _DEPLOYMENTS_SQL (CHAOS-3255 follow-up — this is the regression the
     # prior HIGH finding actually shipped, and a table-name-only mock
     # cannot detect it re-appearing).
-    assert "IN ('organization', 'repository', 'team')" in pull_request_calls[0]["sql"]
-    assert "IN ('organization', 'repository', 'team')" in deployment_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in pull_request_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in deployment_calls[0]["sql"]
     assert result.pull_requests, "organization scope must surface PR facts"
     assert result.deployments, "organization scope must surface deployment facts"
 
@@ -1192,8 +1193,8 @@ async def test_organization_scope_change_summary_enumerates_repos_natively(
     # Assert the SQL text itself, not just the mocked row: a table-name-only
     # mock returns rows regardless of the real WHERE clause and would not
     # catch the 'organization' branch being deleted again.
-    assert "IN ('organization', 'repository', 'team')" in transitions_calls[0]["sql"]
-    assert "IN ('organization', 'repository', 'team')" in relationship_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in transitions_calls[0]["sql"]
+    assert "IN ('organization', 'repository')" in relationship_calls[0]["sql"]
     change_ids = {change.change_id for change in result.changes}
     assert any(
         change.entity_id == "issue-1" and change.before == "in_progress"
@@ -1325,6 +1326,12 @@ async def test_team_scope_status_snapshot_re_derives_owned_repos_and_executes(
                 "as_of": NOW,
             }
             return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        # _PULL_REQUESTS_SQL now embeds the canonical-primary-attribution
+        # subquery INSIDE its own single query string (no separate
+        # query_dicts round trip for it) -- matching on
+        # "work_item_team_attributions" here would incorrectly intercept
+        # that composite query itself, since the substring appears within
+        # it. Match the outer query's own unique marker instead.
         if "FROM git_pull_requests AS pr" in sql:
             return [_pull_request_row()]
         if "FROM deployments" in sql:
@@ -1349,11 +1356,14 @@ async def test_team_scope_status_snapshot_re_derives_owned_repos_and_executes(
     assert pull_request_calls, "expected the pull_requests read to execute"
     assert deployment_calls, "expected the deployments read to execute"
     assert pull_request_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
-    # Assert the SQL text itself carries the team branch, not just that a
-    # mocked row came back -- a table-name-only mock would still pass even
-    # if 'team' were dropped from the disjunction.
-    assert "IN ('organization', 'repository', 'team')" in pull_request_calls[0]["sql"]
-    assert "IN ('organization', 'repository', 'team')" in deployment_calls[0]["sql"]
+    # Assert the SQL text itself carries the canonical-primary-attribution
+    # team branch, not just that a mocked row came back -- a table-name-only
+    # mock would still pass even if 'team' were dropped from the
+    # disjunction, or if it fell back to the coarser repository-membership
+    # arm (CHAOS-3303 round 2's own regression).
+    assert "IN ('issue', 'project', 'team')" in pull_request_calls[0]["sql"]
+    assert "work_item_team_attributions" in pull_request_calls[0]["sql"]
+    assert "is_primary = 1" in pull_request_calls[0]["sql"]
     assert result.pull_requests, "team scope must surface pull-request facts"
     assert result.deployments, "team scope must surface deployment facts"
     assert (
@@ -1455,7 +1465,8 @@ async def test_team_scope_change_summary_re_derives_owned_repos_and_executes(
     ]
     assert transitions_calls
     assert transitions_calls[0]["params"]["repository_ids"] == ["repo-x"]
-    assert "IN ('organization', 'repository', 'team')" in transitions_calls[0]["sql"]
+    assert "work_item_team_attributions" in transitions_calls[0]["sql"]
+    assert "is_primary = 1" in transitions_calls[0]["sql"]
     assert any(
         change.entity_id == "issue-1" and change.before == "in_progress"
         for change in result.changes
@@ -1498,12 +1509,352 @@ async def test_team_scope_with_zero_owned_repositories_is_explicit_not_masked(
     )
 
 
-def _pull_request_row() -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# CHAOS-3303 round 2 (Codex HIGH, 2026-08-02): repository co-location is not
+# team ownership. A PARENT team with team_repo_ownership access to a shared
+# repository must NEVER receive facts whose canonical PRIMARY work-item
+# attribution belongs to a different (here, CHILD) team -- every one of the
+# nine team arms must exclude them. Parametrized across all nine arms (not
+# sampled) per the round-2 directive; the CHILD-team run is the required
+# positive control proving the mock (and the underlying plumbing) genuinely
+# discriminates by team_id rather than always returning empty.
+#
+# The mock cannot execute the embedded work_item_team_attributions subquery
+# (it interprets SQL by table-name substring, not by running it) -- so, like
+# every other structural regression check already in this file (see the
+# CHAOS-3255 'organization' branch assertions above), each case ALSO asserts
+# the query's own SQL text still contains the canonical-attribution join
+# text, so a future edit that silently reverts to bare repository-membership
+# admission is caught even though the mock's behavioral check alone could
+# not detect it.
+# ---------------------------------------------------------------------------
+
+_PARENT_TEAM_ID = "team-parent"
+_CHILD_TEAM_ID = "team-child"
+_SHARED_REPO_ID = "repo-shared"
+_CHILD_WORK_ITEM_ID = "work-item-child-owned"
+
+
+def _team_scope_for(team_id: str) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.TEAM,
+        repositories=[],
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM, entity_id=team_id, display_label=team_id
+            )
+        ],
+        team_ids=[team_id],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=NOW - timedelta(days=14),
+            end=NOW - timedelta(days=7),
+            timezone="UTC",
+        ),
+    )
+
+
+def _generic_delivery_change_row() -> dict[str, Any]:
+    """The row shape every _*_CHANGES_SQL query feeds into the SAME generic
+    ``ClickHouseStatusChangeSource._delivery_changes`` mapper -- one shape
+    covers all five delivery-projection cases regardless of which table the
+    real SQL selects from.
+    """
+
+    return {
+        "change_id": f"change-{_CHILD_WORK_ITEM_ID}",
+        "entity_id": f"{_SHARED_REPO_ID}#pr7",
+        "display_label": "Child-owned delivery event",
+        "before_value": None,
+        "after_value": "changed",
+        "observed_at": NOW - timedelta(hours=1),
+        "last_synced": NOW,
+    }
+
+
+def _make_team_repo_only_fake_query(*, target_marker: str, target_row: dict[str, Any]):
+    """A fake_query that admits ``target_row`` for the query matching
+    ``target_marker`` ONLY when ``params["team_id"] == _CHILD_TEAM_ID`` --
+    the parent (mere repository co-location) always sees an empty result
+    for that same arm, proving exclusion rather than a client-side crash or
+    an accidentally-always-empty mock.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": _SHARED_REPO_ID}]
+        if target_marker in sql:
+            if params.get("team_id") == _CHILD_TEAM_ID:
+                return [target_row]
+            return []
+        return []
+
+    return fake_query
+
+
+_STATUS_SNAPSHOT_CASE = (
+    "pull_requests",
+    "reviews.review_state AS review_state",
+    lambda: _pull_request_row(),
+    lambda result: result.pull_requests,
+)
+
+_CHANGE_SUMMARY_CASES = (
+    (
+        "transitions",
+        "FROM work_item_transitions AS transition FINAL",
+        lambda: {
+            "entity_id": _CHILD_WORK_ITEM_ID,
+            "display_label": "Child work item",
+            "from_status": "in_progress",
+            "to_status": "done",
+            "observed_at": NOW - timedelta(hours=1),
+            "last_synced": NOW,
+        },
+        lambda result: [
+            c for c in result.changes if c.category is ChangeCategory.STATUS
+        ],
+    ),
+    (
+        "relationships",
+        "edge_id AS change_id",
+        lambda: {
+            "change_id": "edge-child-1",
+            "source_type": "issue",
+            "source_id": _CHILD_WORK_ITEM_ID,
+            "edge_type": "implements",
+            "target_type": "pull_request",
+            "target_id": f"{_SHARED_REPO_ID}#pr7",
+            "provenance": "native",
+            "confidence": 1.0,
+            "observed_at": NOW - timedelta(hours=1),
+            "last_synced": NOW,
+        },
+        lambda result: [
+            c
+            for c in result.changes
+            if c.category
+            in {
+                ChangeCategory.RELATIONSHIP,
+                ChangeCategory.BLOCKER,
+                ChangeCategory.DEPENDENCY,
+            }
+        ],
+    ),
+    (
+        "pull_request_changes",
+        "'#state#'",
+        _generic_delivery_change_row,
+        lambda result: [
+            c for c in result.changes if c.category is ChangeCategory.PULL_REQUEST
+        ],
+    ),
+    (
+        "review_changes",
+        "FROM git_pull_request_reviews AS review FINAL",
+        _generic_delivery_change_row,
+        lambda result: [
+            c for c in result.changes if c.category is ChangeCategory.REVIEW
+        ],
+    ),
+    (
+        "ci_changes",
+        "FROM ci_pipeline_runs AS run FINAL",
+        _generic_delivery_change_row,
+        lambda result: [c for c in result.changes if c.category is ChangeCategory.CI],
+    ),
+    (
+        "deployment_changes",
+        "FROM deployments AS deployment FINAL",
+        _generic_delivery_change_row,
+        lambda result: [
+            c for c in result.changes if c.category is ChangeCategory.DEPLOYMENT
+        ],
+    ),
+    (
+        "incident_changes",
+        "INNER JOIN deployments AS deployment FINAL",
+        _generic_delivery_change_row,
+        lambda result: [
+            c for c in result.changes if c.category is ChangeCategory.INCIDENT
+        ],
+    ),
+)
+
+
+@pytest.mark.asyncio
+async def test_team_arm_excludes_child_owned_facts_pull_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _label, marker, row_factory, extract = _STATUS_SNAPSHOT_CASE
+    row = row_factory()
+
+    parent_query = _make_team_repo_only_fake_query(target_marker=marker, target_row=row)
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", parent_query
+    )
+    parent_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_team_scope_for(_PARENT_TEAM_ID)),
+    )
+    assert extract(parent_result) == (), (
+        "a team with mere repository co-location must not receive facts "
+        "canonically owned by a different team"
+    )
+
+    observed_sql: list[str] = []
+
+    async def child_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed_sql.append(sql)
+        return await parent_query(_client, sql, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", child_query
+    )
+    child_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for(_CHILD_TEAM_ID))
+    )
+    assert extract(child_result), (
+        "positive control: the canonically-owning team must receive the fact "
+        "-- proves the mock discriminates rather than always excluding"
+    )
+    target_sql = next(sql for sql in observed_sql if marker in sql)
+    assert "work_item_team_attributions" in target_sql
+    assert "is_primary = 1" in target_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "label,marker,row_factory,extract",
+    _CHANGE_SUMMARY_CASES,
+    ids=[case[0] for case in _CHANGE_SUMMARY_CASES],
+)
+async def test_team_arm_excludes_child_owned_facts_change_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    label: str,
+    marker: str,
+    row_factory: Any,
+    extract: Any,
+) -> None:
+    del label
+    row = row_factory()
+
+    def _request(team_id: str) -> ChangeSummaryRequest:
+        return ChangeSummaryRequest(
+            scope=_team_scope_for(team_id),
+            current_start=NOW - timedelta(days=7),
+            current_end=NOW,
+            comparison_start=NOW - timedelta(days=14),
+            comparison_end=NOW - timedelta(days=7),
+        )
+
+    parent_query = _make_team_repo_only_fake_query(target_marker=marker, target_row=row)
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", parent_query
+    )
+    parent_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).change_summary("org-a", "permission-v1", _request(_PARENT_TEAM_ID))
+    assert extract(parent_result) == [], (
+        "a team with mere repository co-location must not receive facts "
+        "canonically owned by a different team"
+    )
+
+    observed_sql: list[str] = []
+
+    async def child_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed_sql.append(sql)
+        return await parent_query(_client, sql, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", child_query
+    )
+    child_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).change_summary("org-a", "permission-v1", _request(_CHILD_TEAM_ID))
+    assert extract(child_result), (
+        "positive control: the canonically-owning team must receive the fact "
+        "-- proves the mock discriminates rather than always excluding"
+    )
+    target_sql = next(sql for sql in observed_sql if marker in sql)
+    assert "work_item_team_attributions" in target_sql
+    assert "is_primary = 1" in target_sql
+
+
+@pytest.mark.asyncio
+async def test_team_arm_excludes_child_owned_facts_deployments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ninth arm: _DEPLOYMENTS_SQL has no canonical-attribution join of
+    its own -- team-scoped deployments are admitted only through an already
+    team-owned PR (pr_numbers, derived from the now-correctly-filtered
+    _PULL_REQUESTS_SQL rows). Exclusion is therefore proven end to end: the
+    parent's canonically-excluded PR never contributes a PR number, so its
+    deployment is never admitted either, despite sharing the same repo.
+    """
+
+    child_pr_number = 77
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": _SHARED_REPO_ID}]
+        if "reviews.review_state AS review_state" in sql:
+            if params.get("team_id") == _CHILD_TEAM_ID:
+                return [_pull_request_row(number=child_pr_number)]
+            return []
+        if "FROM deployments FINAL" in sql:
+            if child_pr_number in (params.get("pr_numbers") or []):
+                return [_deployment_row(pr_number=child_pr_number)]
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    parent_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_team_scope_for(_PARENT_TEAM_ID)),
+    )
+    assert parent_result.deployments == (), (
+        "a team with mere repository co-location must not receive deployment "
+        "facts reachable only through a PR canonically owned by a different team"
+    )
+
+    child_result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for(_CHILD_TEAM_ID))
+    )
+    assert child_result.deployments, (
+        "positive control: the canonically-owning team must receive the "
+        "deployment via its own admitted PR"
+    )
+
+
+def _pull_request_row(*, number: int = 3) -> dict[str, Any]:
     return {
         "repository_id": "repo-x",
-        "number": 3,
-        "entity_id": "repo-x#pr3",
-        "display_label": "PR 3",
+        "number": number,
+        "entity_id": f"repo-x#pr{number}",
+        "display_label": f"PR {number}",
         "state": "open",
         "review_state": None,
         "changes_requested": 0,

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -2395,10 +2395,12 @@ async def test_partial_unlinked_activity_alongside_linked_facts_stays_clean(
     """
 
     repo_attributed, repo_unlinked_only = "repo-attributed", "repo-unlinked-only"
+    probe_calls = 0
 
     async def fake_query(
         _client: object, sql: str, _params: dict[str, Any]
     ) -> list[dict[str, Any]]:
+        nonlocal probe_calls
         if "FROM team_repo_ownership" in sql:
             return [
                 {"repository_id": repo_attributed},
@@ -2419,7 +2421,9 @@ async def test_partial_unlinked_activity_alongside_linked_facts_stays_clean(
                     "last_synced": NOW,
                 }
             ]
-        return []  # deployments empty; probe never invoked (guard is False)
+        if "SELECT 1 AS found" in sql:
+            probe_calls += 1
+        return []  # deployments empty; probe must never be invoked (guard is False)
 
     monkeypatch.setattr(
         "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
@@ -2430,6 +2434,18 @@ async def test_partial_unlinked_activity_alongside_linked_facts_stays_clean(
         "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-mixed"))
     )
 
+    # Codex round 5 (MEDIUM): a fake probe that unconditionally returns []
+    # cannot distinguish "the probe was never invoked" (the policy this
+    # test claims to pin) from "the probe was invoked and happened to find
+    # nothing" -- only an invocation count can. This is the actual pin;
+    # the warnings assertion below is necessary but not sufficient on its
+    # own.
+    assert probe_calls == 0, (
+        "the coverage-gap probe must not be invoked at all when the team "
+        "already has attributed facts -- the all-empty-only guard must "
+        "short-circuit before the probe query, not merely produce no "
+        "warning from it"
+    )
     assert not any(
         "attribution coverage" in warning or "could not be canonically" in warning
         for warning in result.warnings

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -60,8 +60,11 @@ def _scope(
     )
 
 
-def _deployment_row(status: str = "success", *, pr_number: int = 7) -> dict[str, Any]:
+def _deployment_row(
+    status: str = "success", *, pr_number: int = 7, repository_id: str = "repo-a"
+) -> dict[str, Any]:
     return {
+        "repository_id": repository_id,
         "entity_id": "deployment-1",
         "display_label": "Production deployment",
         "status": status,
@@ -480,8 +483,16 @@ async def test_native_open_incoming_blocker_is_not_ready(
                     "last_synced": NOW,
                 }
             ]
+        if "FROM git_pull_requests AS pr" in sql:
+            return [
+                _pull_request_row(
+                    number=7, state="merged", review_state="APPROVED", merged=1
+                )
+            ]
         if "FROM deployments" in sql:
-            return [_deployment_row()]
+            # Same (repository_id, pr_number) pair as the PR row above --
+            # the round-3 pair-admission fix requires this.
+            return [_deployment_row(repository_id="repo-x", pr_number=7)]
         return []
 
     monkeypatch.setattr(
@@ -523,8 +534,16 @@ async def test_native_done_issue_is_ready_after_fresh_zero_blocker_projection(
                     "last_synced": NOW,
                 }
             ]
+        if "FROM git_pull_requests AS pr" in sql:
+            return [
+                _pull_request_row(
+                    number=7, state="merged", review_state="APPROVED", merged=1
+                )
+            ]
         if "FROM deployments" in sql:
-            return [_deployment_row()]
+            # Same (repository_id, pr_number) pair as the PR row above --
+            # the round-3 pair-admission fix requires this.
+            return [_deployment_row(repository_id="repo-x", pr_number=7)]
         return []
 
     monkeypatch.setattr(
@@ -910,6 +929,7 @@ async def test_native_pr_assesses_only_the_latest_ci_run_as_a_unit(
         if "FROM deployments" in sql:
             return [
                 {
+                    "repository_id": "repo-a",
                     "entity_id": "deployment-1",
                     "status": "success",
                     "environment": "production",
@@ -1335,7 +1355,11 @@ async def test_team_scope_status_snapshot_re_derives_owned_repos_and_executes(
         if "FROM git_pull_requests AS pr" in sql:
             return [_pull_request_row()]
         if "FROM deployments" in sql:
-            return [_deployment_row()]
+            # Same (repository_id, pr_number) pair as the PR row above --
+            # the round-3 pair-admission fix requires deployments to
+            # genuinely trace through an admitted PR, not merely share a
+            # bare PR number.
+            return [_deployment_row(repository_id="repo-x", pr_number=3)]
         return []
 
     monkeypatch.setattr(
@@ -1819,7 +1843,12 @@ async def test_team_arm_excludes_child_owned_facts_deployments(
             return []
         if "FROM deployments FINAL" in sql:
             if child_pr_number in (params.get("pr_numbers") or []):
-                return [_deployment_row(pr_number=child_pr_number)]
+                # _pull_request_row's repository_id is hardcoded "repo-x"
+                # (not parametrized) -- match it here so the round-3
+                # pair-admission fix sees a genuinely matching pair.
+                return [
+                    _deployment_row(repository_id="repo-x", pr_number=child_pr_number)
+                ]
             return []
         return []
 
@@ -1849,16 +1878,303 @@ async def test_team_arm_excludes_child_owned_facts_deployments(
     )
 
 
-def _pull_request_row(*, number: int = 3) -> dict[str, Any]:
+def _pull_request_row(
+    *,
+    number: int = 3,
+    state: str = "open",
+    review_state: str | None = None,
+    changes_requested: int = 0,
+    merged: int = 0,
+) -> dict[str, Any]:
     return {
         "repository_id": "repo-x",
         "number": number,
         "entity_id": f"repo-x#pr{number}",
         "display_label": f"PR {number}",
-        "state": "open",
-        "review_state": None,
-        "changes_requested": 0,
-        "merged": 0,
+        "state": state,
+        "review_state": review_state,
+        "changes_requested": changes_requested,
+        "merged": merged,
         "observed_at": NOW,
         "last_synced": NOW,
     }
+
+
+@pytest.mark.asyncio
+async def test_deployment_admission_uses_repo_pr_pairs_not_flattened_numbers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 3 (HIGH): _DEPLOYMENTS_SQL's ``ifNull(pull_request_number,
+    0) IN {pr_numbers}`` arm matches a bare, cross-repository-flattened PR
+    NUMBER -- with two repos in the team's accessible set, repo A's
+    team-owned PR #77 must not admit repo B's UNRELATED, differently-owned
+    PR #77 deployment, nor any incident reachable only through it.
+    """
+
+    repo_a, repo_b = "repo-a-owned", "repo-b-other"
+    collision_number = 77
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": repo_a}, {"repository_id": repo_b}]
+        if "SELECT 1 AS found" in sql:
+            return []
+        if "reviews.review_state AS review_state" in sql:
+            # Only repo A's PR is canonically team-owned; repo B's
+            # same-numbered PR is a genuinely different, unrelated pull
+            # request this team never owned (round 2's canonical-attribution
+            # join already excludes it -- exercised by the parent/child
+            # tests above).
+            return [
+                {
+                    "repository_id": repo_a,
+                    "number": collision_number,
+                    "entity_id": f"{repo_a}#pr{collision_number}",
+                    "display_label": f"PR {collision_number}",
+                    "state": "merged",
+                    "review_state": "APPROVED",
+                    "changes_requested": 0,
+                    "merged": 1,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                }
+            ]
+        if "FROM deployments FINAL" in sql:
+            # Simulates the SQL's own (repository-agnostic) admission: with
+            # pr_numbers=[77], ifNull(pull_request_number, 0) IN {77}
+            # matches BOTH repos' deployments -- the collision this fix
+            # must resolve on the Python side, by (repository_id,
+            # pr_number) PAIR rather than bare number.
+            return [
+                {
+                    "repository_id": repo_a,
+                    "entity_id": "deploy-a",
+                    "display_label": "Deploy A",
+                    "status": "success",
+                    "environment": "production",
+                    "pr_number": collision_number,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                },
+                {
+                    "repository_id": repo_b,
+                    "entity_id": "deploy-b",
+                    "display_label": "Deploy B (unrelated PR, same number)",
+                    "status": "success",
+                    "environment": "production",
+                    "pr_number": collision_number,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                },
+            ]
+        if "FROM operational_incidents" in sql:
+            deployment_ids = params.get("deployment_ids") or []
+            rows: list[dict[str, Any]] = []
+            if "deploy-a" in deployment_ids:
+                rows.append(
+                    {
+                        "entity_id": "incident-a",
+                        "display_label": "Incident A",
+                        "status": "resolved",
+                        "active": False,
+                        "observed_at": NOW,
+                        "last_synced": NOW,
+                    }
+                )
+            if "deploy-b" in deployment_ids:
+                rows.append(
+                    {
+                        "entity_id": "incident-b",
+                        "display_label": (
+                            "Incident reachable only via the wrongly-"
+                            "admitted deployment"
+                        ),
+                        "status": "resolved",
+                        "active": False,
+                        "observed_at": NOW,
+                        "last_synced": NOW,
+                    }
+                )
+            return rows
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-1"))
+    )
+
+    deployment_ids_seen = {d.entity_id for d in result.deployments}
+    assert deployment_ids_seen == {"deploy-a"}, (
+        "repo B's unrelated same-numbered-PR deployment must be excluded "
+        "by the (repository_id, pr_number) pair check"
+    )
+    incident_ids_seen = {i.entity_id for i in result.incidents}
+    assert incident_ids_seen == {"incident-a"}, (
+        "an incident reachable ONLY through the wrongly-admitted deployment "
+        "must never propagate to the wrong team"
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_attribution_subquery_bounds_reassignment_by_as_of(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 3 (HIGH): the canonical-attribution subquery's
+    max(computed_at) must be bounded by as_of -- a work item reassigned
+    from team A to team B at t2 must not rewrite a t1 query's result in
+    either direction: team A's t1 snapshot must keep the in-window facts,
+    and team B's t1 snapshot must not retroactively gain them.
+    """
+
+    t1 = NOW - timedelta(days=3)
+    t2 = NOW
+
+    def _admit(team_id: str | None, as_of: datetime | None) -> bool:
+        if as_of is None or team_id is None:
+            return False
+        if as_of < t2:
+            return team_id == "team-a"
+        return team_id == "team-b"
+
+    observed_sql: list[str] = []
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-1"}]
+        if "FROM work_item_transitions AS transition FINAL" in sql:
+            observed_sql.append(sql)
+            if _admit(params.get("team_id"), params.get("as_of")):
+                return [
+                    {
+                        "entity_id": "wi-reassigned",
+                        "display_label": "Reassigned item",
+                        "from_status": "in_progress",
+                        "to_status": "done",
+                        "observed_at": NOW - timedelta(hours=1),
+                        "last_synced": NOW,
+                    }
+                ]
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+
+    async def _status_changes(team_id: str, *, current_end: datetime) -> list[Any]:
+        request = ChangeSummaryRequest(
+            scope=_team_scope_for(team_id),
+            current_start=current_end - timedelta(days=1),
+            current_end=current_end,
+            comparison_start=current_end - timedelta(days=2),
+            comparison_end=current_end - timedelta(days=1),
+        )
+        result = await StatusChangeService(
+            ClickHouseStatusChangeSource(object(), now=NOW)
+        ).change_summary("org-a", "permission-v1", request)
+        return [c for c in result.changes if c.category is ChangeCategory.STATUS]
+
+    team_a_at_t1 = await _status_changes("team-a", current_end=t1)
+    team_b_at_t1 = await _status_changes("team-b", current_end=t1)
+    team_a_at_t2 = await _status_changes("team-a", current_end=t2)
+    team_b_at_t2 = await _status_changes("team-b", current_end=t2)
+
+    assert team_a_at_t1, "team A's t1 snapshot must keep the item's in-window facts"
+    assert not team_b_at_t1, (
+        "team B must not retroactively gain facts it did not own at t1"
+    )
+    assert not team_a_at_t2, (
+        "team A must not keep the item's facts after a real reassignment at t2"
+    )
+    assert team_b_at_t2, (
+        "team B must see the item once genuinely reassigned to it at t2"
+    )
+
+    assert observed_sql, "the transitions arm must have actually been queried"
+    assert all("computed_at <=" in sql for sql in observed_sql), (
+        "the canonical-attribution subquery must bound max(computed_at) by "
+        "as_of, not take a global maximum"
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_with_only_unlinked_repo_activity_discloses_coverage_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 3 (MEDIUM): a team whose accessible repos contain ONLY
+    unlinked delivery facts (standalone PR/deployment activity with no
+    canonical work-item chain) must not resolve a clean READY/COMPLETE with
+    zero attributed facts and no disclosure -- the exclusion itself (repo
+    access != ownership) is correct, but the silent completeness is not.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-unlinked-only"}]
+        if "SELECT 1 AS found" in sql:
+            return [{"found": 1}]
+        return []  # every canonically-scoped read finds nothing
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-solo"))
+    )
+
+    assert result.pull_requests == ()
+    assert result.deployments == ()
+    assert result.actual.state is CompletionState.INDETERMINATE, (
+        "a coverage gap must never resolve as READY"
+    )
+    assert result.state is StatusResultState.DEGRADED, (
+        "a coverage gap must never resolve as a clean COMPLETE"
+    )
+    assert any(
+        "attribution coverage" in warning or "could not be canonically" in warning
+        for warning in result.warnings
+    ), "the coverage gap must be disclosed in warnings, not silently absorbed"
+
+
+@pytest.mark.asyncio
+async def test_team_with_genuinely_no_repo_activity_stays_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control for the coverage-gap disclosure above: a team whose
+    accessible repos have NO activity at all (not even unlinked) must not
+    be forced into a false coverage-gap disclosure -- the existence check
+    itself must discriminate, not fire unconditionally for every empty team.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-genuinely-empty"}]
+        return []  # including "SELECT 1 AS found": nothing exists at all
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-quiet"))
+    )
+
+    assert not any(
+        "attribution coverage" in warning or "could not be canonically" in warning
+        for warning in result.warnings
+    ), "a genuinely empty team must not be wrongly flagged with a coverage gap"

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -1970,9 +1970,9 @@ async def test_deployment_admission_uses_repo_pr_pairs_not_flattened_numbers(
                 },
             ]
         if "FROM operational_incidents" in sql:
-            deployment_ids = params.get("deployment_ids") or []
+            deployment_pairs = params.get("deployment_pairs") or []
             rows: list[dict[str, Any]] = []
-            if "deploy-a" in deployment_ids:
+            if (repo_a, "deploy-a") in deployment_pairs:
                 rows.append(
                     {
                         "entity_id": "incident-a",
@@ -1983,7 +1983,7 @@ async def test_deployment_admission_uses_repo_pr_pairs_not_flattened_numbers(
                         "last_synced": NOW,
                     }
                 )
-            if "deploy-b" in deployment_ids:
+            if (repo_b, "deploy-b") in deployment_pairs:
                 rows.append(
                     {
                         "entity_id": "incident-b",
@@ -2178,3 +2178,263 @@ async def test_team_with_genuinely_no_repo_activity_stays_clean(
         "attribution coverage" in warning or "could not be canonically" in warning
         for warning in result.warnings
     ), "a genuinely empty team must not be wrongly flagged with a coverage gap"
+
+
+@pytest.mark.asyncio
+async def test_incident_propagation_is_scoped_by_repository_not_bare_deployment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 4 (HIGH): deployment IDs are only unique PER REPO in the
+    schema. Round 3's pair filter correctly excludes repo B's deployment
+    from ``deployments``, but _INCIDENTS_SQL matched incident edges on the
+    bare ``edge.deployment_id`` -- an incident edge on the EXCLUDED
+    (repo-b, deployment_id) pair still leaked into the team snapshot
+    because the same deployment_id string collides across repos and
+    repo B remains in the team's authorized repository_ids.
+    """
+
+    repo_a, repo_b = "repo-a-owned", "repo-b-other"
+    shared_deployment_id = "42"  # deliberately identical across both repos
+    pr_number = 5
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": repo_a}, {"repository_id": repo_b}]
+        if "SELECT 1 AS found" in sql:
+            return []
+        if "reviews.review_state AS review_state" in sql:
+            return [
+                {
+                    "repository_id": repo_a,
+                    "number": pr_number,
+                    "entity_id": f"{repo_a}#pr{pr_number}",
+                    "display_label": f"PR {pr_number}",
+                    "state": "merged",
+                    "review_state": "APPROVED",
+                    "changes_requested": 0,
+                    "merged": 1,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                }
+            ]
+        if "FROM deployments FINAL" in sql:
+            return [
+                {
+                    "repository_id": repo_a,
+                    "entity_id": shared_deployment_id,
+                    "display_label": "Deploy repo A",
+                    "status": "success",
+                    "environment": "production",
+                    "pr_number": pr_number,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                },
+                {
+                    "repository_id": repo_b,
+                    "entity_id": shared_deployment_id,
+                    "display_label": "Deploy repo B (unrelated, same ID)",
+                    "status": "success",
+                    "environment": "production",
+                    "pr_number": pr_number,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                },
+            ]
+        if "FROM operational_incidents" in sql:
+            # Discriminate by which admission shape the code actually
+            # sends: the fixed code passes repo-scoped (repo_id,
+            # deployment_id) PAIRS; the pre-fix code passed a bare
+            # deployment_id list that cannot tell repo A's admitted "42"
+            # apart from repo B's excluded "42".
+            deployment_pairs = params.get("deployment_pairs")
+            if deployment_pairs is not None:
+                if (repo_b, shared_deployment_id) in deployment_pairs:
+                    return [_incident_row("incident-leak")]
+                return []
+            deployment_ids = params.get("deployment_ids") or []
+            if shared_deployment_id in deployment_ids:
+                return [_incident_row("incident-leak")]
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-1"))
+    )
+
+    assert {d.entity_id for d in result.deployments} == {shared_deployment_id}
+    assert result.incidents == (), (
+        "an incident edge on the excluded (repo-b, deployment-id) pair "
+        "must not leak into the team snapshot merely because the bare "
+        "deployment_id collides with an admitted deployment in another repo"
+    )
+
+
+def _incident_row(entity_id: str) -> dict[str, Any]:
+    return {
+        "entity_id": entity_id,
+        "display_label": "Leaked incident",
+        "status": "resolved",
+        "active": False,
+        "observed_at": NOW,
+        "last_synced": NOW,
+    }
+
+
+@pytest.mark.asyncio
+async def test_coverage_probe_failure_fails_closed_not_silently_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 4 (HIGH): a TimeoutError/query error on the coverage
+    probe collapsed to an empty result -- the SAME shape as "genuinely
+    nothing found" -- silently restoring the exact false-confidence
+    READY/COMPLETE state the round-3 probe exists to prevent. A probe
+    FAILURE must disclose exactly like a probe that finds activity.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-flaky"}]
+        if "SELECT 1 AS found" in sql:
+            raise TimeoutError("coverage probe timed out")
+        return []  # PRs, deployments genuinely empty
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-flaky"))
+    )
+
+    assert result.actual.state is CompletionState.INDETERMINATE, (
+        "a failed coverage probe must never resolve as READY"
+    )
+    assert result.state is StatusResultState.DEGRADED, (
+        "a failed coverage probe must never resolve as a clean COMPLETE"
+    )
+    assert any(
+        "coverage probe" in warning or "cannot rule out" in warning
+        for warning in result.warnings
+    ), "the probe failure itself must be disclosed, not silently absorbed"
+
+
+@pytest.mark.asyncio
+async def test_unlinked_activity_probe_is_bounded_by_as_of(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 4 (MEDIUM): _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL had no
+    as_of predicate -- a pull request or deployment created strictly AFTER
+    the snapshot's as_of would still trip the probe, falsely degrading a
+    historical (as_of=t1) snapshot with activity that had not happened yet
+    at t1. The probe's SELECT list has no timestamp column to filter
+    client-side (it only returns ``1 AS found``), so this can only be
+    enforced inside the SQL text itself -- verified structurally, mirroring
+    the as_of-bound structural check used for the round-3 canonical-
+    attribution subquery.
+    """
+
+    observed_sql: list[str] = []
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-solo"}]
+        if "SELECT 1 AS found" in sql:
+            observed_sql.append(sql)
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-solo"))
+    )
+
+    assert observed_sql, "the unlinked-activity probe must have actually been queried"
+    for sql in observed_sql:
+        pr_clause, _, deployment_clause = sql.partition("UNION ALL")
+        assert "created_at <= {as_of" in pr_clause, (
+            "the pull-request arm of the probe must bound by as_of, "
+            "mirroring the root _PULL_REQUESTS_SQL bound"
+        )
+        assert "<= {as_of" in deployment_clause, (
+            "the deployment arm of the probe must bound by as_of, "
+            "mirroring the root _DEPLOYMENTS_SQL bound"
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_unlinked_activity_alongside_linked_facts_stays_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ratified policy decision (round 4, team-lead, 2026-08-02): the
+    coverage-gap probe fires ONLY when a team's attributed facts
+    (pull_requests AND deployment_rows) are COMPLETELY empty -- see
+    _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL's docstring. A team with at least
+    one genuinely attributed pull request in ANY repo stays a clean,
+    undisclosed result even if a DIFFERENT repo in its accessible set has
+    purely unlinked activity of its own. Partial-gap detection (an
+    unlinked-specific count query distinguishing "some repos have
+    unattributed activity" from "all of them do") is explicitly deferred,
+    not a defect -- this test pins the shipped behavior so any future
+    change to it is deliberate.
+    """
+
+    repo_attributed, repo_unlinked_only = "repo-attributed", "repo-unlinked-only"
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [
+                {"repository_id": repo_attributed},
+                {"repository_id": repo_unlinked_only},
+            ]
+        if "reviews.review_state AS review_state" in sql:
+            return [
+                {
+                    "repository_id": repo_attributed,
+                    "number": 1,
+                    "entity_id": f"{repo_attributed}#pr1",
+                    "display_label": "PR 1",
+                    "state": "merged",
+                    "review_state": "APPROVED",
+                    "changes_requested": 0,
+                    "merged": 1,
+                    "observed_at": NOW,
+                    "last_synced": NOW,
+                }
+            ]
+        return []  # deployments empty; probe never invoked (guard is False)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(_team_scope_for("team-mixed"))
+    )
+
+    assert not any(
+        "attribution coverage" in warning or "could not be canonically" in warning
+        for warning in result.warnings
+    ), (
+        "partial coverage (linked facts present, unattributed activity "
+        "elsewhere in the team's repos) is the documented, deferred "
+        "policy -- must NOT be flagged in this round"
+    )

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -1114,8 +1114,8 @@ async def test_organization_scope_status_snapshot_enumerates_repos_natively(
     # _DEPLOYMENTS_SQL (CHAOS-3255 follow-up — this is the regression the
     # prior HIGH finding actually shipped, and a table-name-only mock
     # cannot detect it re-appearing).
-    assert "IN ('organization', 'repository')" in pull_request_calls[0]["sql"]
-    assert "IN ('organization', 'repository')" in deployment_calls[0]["sql"]
+    assert "IN ('organization', 'repository', 'team')" in pull_request_calls[0]["sql"]
+    assert "IN ('organization', 'repository', 'team')" in deployment_calls[0]["sql"]
     assert result.pull_requests, "organization scope must surface PR facts"
     assert result.deployments, "organization scope must surface deployment facts"
 
@@ -1192,8 +1192,8 @@ async def test_organization_scope_change_summary_enumerates_repos_natively(
     # Assert the SQL text itself, not just the mocked row: a table-name-only
     # mock returns rows regardless of the real WHERE clause and would not
     # catch the 'organization' branch being deleted again.
-    assert "IN ('organization', 'repository')" in transitions_calls[0]["sql"]
-    assert "IN ('organization', 'repository')" in relationship_calls[0]["sql"]
+    assert "IN ('organization', 'repository', 'team')" in transitions_calls[0]["sql"]
+    assert "IN ('organization', 'repository', 'team')" in relationship_calls[0]["sql"]
     change_ids = {change.change_id for change in result.changes}
     assert any(
         change.entity_id == "issue-1" and change.before == "in_progress"
@@ -1264,6 +1264,234 @@ async def test_team_filtered_organization_scope_is_never_widened_to_the_full_org
         StatusSnapshotRequest(_org_scope(team_ids=["team-a"])),
     )
 
+    assert (
+        "Status reads require the complete authorized repository set; "
+        "scope was not widened." in result.warnings
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3303 — a committed team subject re-derives owned repositories from
+# team_repo_ownership at query time and executes real team-scoped reads.
+#
+# N0 (test_chaos_3301_controls.py) already proves the fail-closed floor
+# using a bare ``object()`` client, which raises before any query can run --
+# that control stays valid unchanged (the new team-repo lookup also raises
+# against that fake and is caught the same way). These tests are the
+# positive/negative pair the CHAOS-3303 planning brief calls "must flip
+# GREEN": a team WITH real ownership rows gets real facts, and a team whose
+# ownership query genuinely returns zero rows (as opposed to a client
+# failure) still fails closed, never silently empty.
+# ---------------------------------------------------------------------------
+
+
+def _team_scope(*, team_id: str = "team-platform") -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.TEAM,
+        repositories=[],
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM,
+                entity_id=team_id,
+                display_label="Platform",
+            )
+        ],
+        team_ids=[team_id],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=NOW - timedelta(days=14),
+            end=NOW - timedelta(days=7),
+            timezone="UTC",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_scope_status_snapshot_re_derives_owned_repos_and_executes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[dict[str, Any]] = []
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.append({"sql": sql, "params": dict(params)})
+        if "FROM team_repo_ownership" in sql:
+            assert params == {
+                "org_id": "org-a",
+                "team_id": "team-platform",
+                "as_of": NOW,
+            }
+            return [{"repository_id": "repo-x"}, {"repository_id": "repo-y"}]
+        if "FROM git_pull_requests AS pr" in sql:
+            return [_pull_request_row()]
+        if "FROM deployments" in sql:
+            return [_deployment_row()]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_team_scope()),
+    )
+
+    pull_request_calls = [
+        item for item in observed if "FROM git_pull_requests AS pr" in item["sql"]
+    ]
+    deployment_calls = [item for item in observed if "FROM deployments" in item["sql"]]
+    assert pull_request_calls, "expected the pull_requests read to execute"
+    assert deployment_calls, "expected the deployments read to execute"
+    assert pull_request_calls[0]["params"]["repository_ids"] == ["repo-x", "repo-y"]
+    # Assert the SQL text itself carries the team branch, not just that a
+    # mocked row came back -- a table-name-only mock would still pass even
+    # if 'team' were dropped from the disjunction.
+    assert "IN ('organization', 'repository', 'team')" in pull_request_calls[0]["sql"]
+    assert "IN ('organization', 'repository', 'team')" in deployment_calls[0]["sql"]
+    assert result.pull_requests, "team scope must surface pull-request facts"
+    assert result.deployments, "team scope must surface deployment facts"
+    assert (
+        "Status reads require the complete authorized repository set; "
+        "scope was not widened." not in result.warnings
+    )
+    # A team has no single declared/children completion tree; this is
+    # structural (see TEAM_NOT_APPLICABLE_SOURCES), never a data gap.
+    assert result.declared is None
+    assert result.children == ()
+    assert result.blockers == ()
+    # declared_optional now includes TEAM (status_change_service.py), so real
+    # fresh evidence with no declared status is COMPLETE, not
+    # INSUFFICIENT_EVIDENCE -- the end-to-end proof this issue's health
+    # services depend on.
+    assert result.state is StatusResultState.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_team_scope_never_queries_declared_work_items_or_blockers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structural, not a data gap: _WORK_ITEMS_SQL/_BLOCKERS_SQL must never
+    even be attempted for a team subject, exactly like organization/
+    repository scope already never attempts them.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return [{"repository_id": "repo-x"}]
+        if "FROM work_items FINAL" in sql:
+            raise AssertionError("_WORK_ITEMS_SQL must not run for a team subject")
+        if "FROM work_graph_edges" in sql and "blocker" in sql:
+            raise AssertionError("_BLOCKERS_SQL must not run for a team subject")
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_team_scope()),
+    )
+    assert result.declared is None
+
+
+@pytest.mark.asyncio
+async def test_team_scope_change_summary_re_derives_owned_repos_and_executes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[dict[str, Any]] = []
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.append({"sql": sql, "params": dict(params)})
+        if "FROM team_repo_ownership" in sql:
+            assert params == {
+                "org_id": "org-a",
+                "team_id": "team-platform",
+                "as_of": NOW,
+            }
+            return [{"repository_id": "repo-x"}]
+        if "FROM work_item_transitions" in sql:
+            return [
+                {
+                    "entity_id": "issue-1",
+                    "display_label": "Issue 1",
+                    "from_status": "in_progress",
+                    "to_status": "done",
+                    "observed_at": NOW - timedelta(hours=1),
+                    "last_synced": NOW,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    request = ChangeSummaryRequest(
+        scope=_team_scope(),
+        current_start=NOW - timedelta(days=7),
+        current_end=NOW,
+        comparison_start=NOW - timedelta(days=14),
+        comparison_end=NOW - timedelta(days=7),
+    )
+
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).change_summary("org-a", "permission-v1", request)
+
+    transitions_calls = [
+        item for item in observed if "FROM work_item_transitions" in item["sql"]
+    ]
+    assert transitions_calls
+    assert transitions_calls[0]["params"]["repository_ids"] == ["repo-x"]
+    assert "IN ('organization', 'repository', 'team')" in transitions_calls[0]["sql"]
+    assert any(
+        change.entity_id == "issue-1" and change.before == "in_progress"
+        for change in result.changes
+    ), "team scope must surface status transition changes"
+    assert "Observed-change scope was not widened." not in result.warnings
+
+
+@pytest.mark.asyncio
+async def test_team_scope_with_zero_owned_repositories_is_explicit_not_masked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely empty team_repo_ownership result (not a client failure --
+    see N0 for that case) must still fail closed, never silently empty.
+    """
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM team_repo_ownership" in sql:
+            return []
+        raise AssertionError(
+            "no fact read may run once the team has zero owned repositories"
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    result = await StatusChangeService(
+        ClickHouseStatusChangeSource(object(), now=NOW)
+    ).status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_team_scope()),
+    )
+
+    assert result.declared is None
     assert (
         "Status reads require the complete authorized repository set; "
         "scope was not widened." in result.warnings


### PR DESCRIPTION
## Summary
- Canonical project/team health computation and portfolio status services (`project_health_service.py`, `team_health_service.py`, `portfolio_status_service.py`, `health_profile_synthesis.py`, `dimension_observation_adapters.py`), building on the CHAOS-3302 governance contracts and CHAOS-3301 team direct-scope.
- Implements the TEAM-scope SQL execution arms in `native_status_change.py` (previously deferred/fail-closed via `TEAM_NOT_APPLICABLE_SOURCES`): all 9 fact-reading arms now join canonically through `work_item_team_attributions` (`is_primary = 1`, snapshot-bounded by `as_of`), and deployment/incident admission is scoped by exact `(repository_id, ...)` pairs rather than bare cross-repository numbers/ids.
- A team whose accessible repos have delivery activity that cannot be canonically attributed now resolves `insufficient_evidence`/`degraded` with an explicit disclosure, never a silent `READY`/`COMPLETE`.

## Test plan
- [x] 5 Codex adversarial review rounds, each with round-by-round RED (new regression test fails, reproducing the exact described defect) then GREEN (fix applied) evidence, plus mutation verification (fix reverted -> regression test fails -> fix restored) for every runtime fix:
  - Round 1: 4 HIGH findings on the service layer (subject relabel/dedup, shadow_only promotion, shared-session gather, forgeable cohort_size)
  - Round 2: 2 findings on the team SQL arms (canonical-primary attribution join, attribution-snapshot timing)
  - Round 3: 3 SQL-semantics findings (deployment admission by `(repo_id, pr_number)` pair not flattened numbers; attribution subquery bounded by `as_of`; coverage-gap disclosure for repos with only unlinked activity)
  - Round 4/5 (repo's round 5): 3 findings (repo-scoped incident admission by `(repo_id, deployment_id)` pair -- deployment ids collide across repos; coverage probe now fails CLOSED on error instead of silently passing; existence probe bounded by `as_of`) + 1 ratified deferral (all-empty-only partial-unlinked disclosure policy, pinned with a dedicated test)
  - Round 5 (repo's round 6, test-only): strengthened the partial-unlinked policy-pinning test to assert the coverage probe is never invoked (not just that it produces no warning) when attributed facts exist -- mutation-verified against an unconditional probe
- [x] Full local gate: **10323 passed / 0 failed**
- [x] `ruff check` + `ruff format --check`: clean
- [x] `mypy`: no issues

## Risk notes
- 6 registry-declared health rules remain honest-unbound (`_UNBOUND_RULE_LIMITATIONS` in `health_profile_synthesis.py`) -- these are import-time-enforced totality gaps, not silent omissions; each surfaces as an explicit limitation rather than a fabricated finding.
- The team coverage-gap disclosure is scoped to the **all-empty-only** case by design: a team with at least one canonically attributed fact in any repo stays a clean result even if a different repo in its accessible set has purely unlinked activity. Partial-gap detection (an unlinked-specific count query distinguishing "some repos have unattributed activity" from "all of them do") is explicitly deferred, not a defect -- ratified and recorded on CHAOS-3303, deferred to the stack-3 follow-on work.
- Plan/step registry wiring for these services is deferred to stack-3, consistent with the rest of the Wave 3.1 build sequence.