### PR TITLE
feat(ask-dev): CHAOS-3305 operational-deficiency inventory (deficiency.operational.v1)

### DIFF
--- a/src/dev_health_ops/api/dev/contracts_v2/__init__.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/__init__.py
@@ -31,6 +31,17 @@ from .base import (
     SourceRequirementState,
 )
 from .compat import project_answer_v2_to_v1
+from .deficiency import (
+    DEFICIENCY_CATEGORIES,
+    DeficiencyCategory,
+    DeficiencyCategoryStatus,
+    DeficiencyEvidenceClassification,
+    DeficiencyFinding,
+    DeficiencyRemediation,
+    DeficiencySeverity,
+    OperationalDeficiencyInventory,
+    finding_sort_key,
+)
 from .embedded import (
     DevCIFactV2,
     DevCoverageV2,
@@ -126,17 +137,38 @@ from .validators import (
 #:
 #: The CHAOS-3302 health-rule governance contracts
 #: (``HealthRuleDefinition``/``DimensionObservation``/``HealthRuleFinding``/
-#: ``TeamQualificationResult``/``CalibrationRecord``) are deliberately NOT
-#: registered here. This registry backs the Ask Dev answer-frame contract
-#: family specifically: ``export_contracts_v2``'s checked-in schema/fixture
-#: export, and the no-answer-projection totality check
-#: (``no_answer_policy.assert_no_answer_policy_is_total`` /
+#: ``TeamQualificationResult``/``CalibrationRecord``) and the CHAOS-3305
+#: operational-deficiency-inventory contracts
+#: (``DeficiencyFinding``/``DeficiencyCategoryStatus``/
+#: ``OperationalDeficiencyInventory``/``DeficiencyRemediation``) are
+#: deliberately NOT registered here. This registry backs the Ask Dev
+#: answer-frame contract family specifically: ``export_contracts_v2``'s
+#: checked-in schema/fixture export, and the no-answer-projection totality
+#: check (``no_answer_policy.assert_no_answer_policy_is_total`` /
 #: ``test_round4_every_v2_identifier_is_classified``) that walks every
 #: member of this dict looking for the answer frame's own disclosure
-#: surface. Health rules are a separate, code-owned governance contract
-#: family with their own manifest (``health_rule_manifest.v1``, see
-#: ``health_rule_manifest.py``) and are never embedded in, or projected
-#: through, a no-answer outcome -- they do not belong in this dict.
+#: surface. Health rules and deficiency findings are separate, code-owned
+#: governance contract families (health rules have their own manifest,
+#: ``health_rule_manifest.v1`` — see ``health_rule_manifest.py``) and are
+#: never embedded in, or projected through, a no-answer outcome directly
+#: -- the frame only ever carries them as opaque ``OpaqueID`` pointers
+#: (``finding_refs``/``deficiency_refs``, ``frame.py``), so they do not
+#: belong in this dict.
+#:
+#: They ARE imported directly above (mirroring the ``health_rules`` import
+#: a few lines up), which is the load-bearing half of "registered": the
+#: reflection sweeps in ``test_contracts_v2.py`` (``_all_v2_contract_models``,
+#: which walks ``ContractModelV2.__subclasses__()``) only discover a model
+#: once *something* has imported its module into the process. Importing
+#: these types here — at ``contracts_v2`` package-init time, which every
+#: consumer (including every test file that does ``import
+#: dev_health_ops.api.dev.contracts_v2 as v2``) already triggers — makes
+#: that discovery unconditional rather than an accident of test collection
+#: order (Codex finding, 2026-08-02: without this import,
+#: ``test_round4_every_v2_identifier_is_classified`` silently skipped every
+#: deficiency contract field when run in isolation, passing only because
+#: some *other* test file happened to import ``contracts_v2.deficiency``
+#: first during full-suite collection).
 CONTRACT_MODELS_V2: dict[str, type[ContractModelV2]] = {
     "dev_message_request.v2": DevMessageRequestV2,
     "dev_question_intent.v1": DevQuestionIntent,
@@ -157,12 +189,19 @@ __all__ = [
     "ANSWERED_OUTCOMES",
     "CANONICAL_NO_ANSWER_COPY",
     "CONTRACT_MODELS_V2",
+    "DEFICIENCY_CATEGORIES",
     "PLAN_REGISTRY",
     "SOURCE_CLASS_VOCABULARY",
     "CalibrationRecord",
     "CalibrationState",
     "Cardinality",
     "ContractModelV2",
+    "DeficiencyCategory",
+    "DeficiencyCategoryStatus",
+    "DeficiencyEvidenceClassification",
+    "DeficiencyFinding",
+    "DeficiencyRemediation",
+    "DeficiencySeverity",
     "DimensionObservation",
     "DimensionState",
     "DevAnswerFact",
@@ -215,6 +254,7 @@ __all__ = [
     "NO_ANSWER_FRAME_FIELD_POLICY",
     "NO_ANSWER_OUTCOMES",
     "NoAnswerFieldPolicy",
+    "OperationalDeficiencyInventory",
     "PlanRegistryID",
     "ProgressStateV2",
     "PublicOutcome",
@@ -228,6 +268,7 @@ __all__ = [
     "StreamEventTypeV2",
     "TeamQualificationBasis",
     "TeamQualificationResult",
+    "finding_sort_key",
     "project_answer_v2_to_v1",
     "scan_public_text",
     "validate_completion_denominator",

--- a/src/dev_health_ops/api/dev/contracts_v2/deficiency.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/deficiency.py
@@ -1,0 +1,531 @@
+"""``deficiency_finding.v1`` and ``deficiency_operational_inventory.v1`` (CHAOS-3305).
+
+The canonical answer to "what operational deficiencies do we have?" -- a
+bounded, versioned, evidence-backed inventory across the eight taxonomy
+categories named verbatim in the issue: data & integration, planning &
+relationships, delivery flow, review & CI, deployment & reliability,
+ownership & code risk, capacity & cognitive load, and investment balance.
+This module defines the wire shapes; :mod:`.operational_deficiency_service`
+computes them from CHAOS-3303's canonical services and CHAOS-3302's health
+rule registry -- never from free-form model output (guardrail: "no
+free-form model-created deficiency").
+
+Two structural decisions carry the ticket's applicability/evidence
+discipline at the type level rather than by convention:
+
+* ``DeficiencyCategory`` is a closed eight-member enum, matching the issue's
+  taxonomy verbatim -- a finding always declares exactly one, never a
+  free-form string.
+* ``DeficiencyFinding.data_semantics`` must agree with ``observed_state``
+  (:func:`DeficiencyFinding.validate_zero_semantics`, mirroring
+  ``DimensionObservation``/``DevSourceObservation`` exactly): a finding
+  about a genuinely queried condition reports ``measured_zero``, and a
+  finding about an unconfigured/unavailable/unauthorized source -- itself
+  the deficiency -- reports ``not_measured``, never a fabricated
+  ``measured_zero`` standing in for "we never checked". A category that
+  was never evaluated at all (no rule registered, calibration pending, the
+  lookup failed) is reported through :class:`DeficiencyCategoryStatus`
+  instead of a finding. This is the type-level enforcement of "no missing
+  data represented as zero or healthy".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Any, Literal, Self, final
+
+from pydantic import AwareDatetime, Field, FiniteFloat, model_validator
+
+from .base import (
+    ContractModelV2,
+    OpaqueID,
+    PlatformVersionToken,
+    ServerHandle,
+    ShortText,
+    SourceRequirementState,
+)
+from .health_rules import DataSemantics, FactKind, RuleApplicability
+from .result import DevRelationshipPath
+
+__all__ = [
+    "DEFICIENCY_CATEGORIES",
+    "DeficiencyCategory",
+    "DeficiencyCategoryStatus",
+    "DeficiencyEvidenceClassification",
+    "DeficiencyFinding",
+    "DeficiencyRemediation",
+    "DeficiencySeverity",
+    "OperationalDeficiencyInventory",
+    "finding_sort_key",
+]
+
+#: The two ``SourceRequirementState`` partitions ``DeficiencyFinding.
+#: validate_zero_semantics`` keys ``data_semantics`` off of -- mirrors
+#: ``contracts_v2.result``'s own private ``_QUERIED_STATES``/
+#: ``_UNMEASURED_STATES`` module constants (a deliberate re-derivation,
+#: not an import, per that module's own docstring rationale). Hoisted to
+#: module level (rather than defined inline in the validator, Codex
+#: finding, round 2) so the totality assertion below can prove, at import
+#: time, that every ``SourceRequirementState`` member falls into EXACTLY
+#: one partition -- a future member added to that enum without updating
+#: either set here fails the import, not one request that reaches it.
+_QUERIED_OBSERVED_STATES = frozenset(
+    {
+        SourceRequirementState.AVAILABLE_CURRENT,
+        SourceRequirementState.AVAILABLE_STALE,
+        SourceRequirementState.AVAILABLE_UNKNOWN,
+    }
+)
+_UNMEASURED_OBSERVED_STATES = frozenset(
+    {
+        SourceRequirementState.UNCONFIGURED,
+        SourceRequirementState.UNAVAILABLE,
+        SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE,
+        SourceRequirementState.NOT_APPLICABLE,
+        SourceRequirementState.TRUNCATED,
+    }
+)
+
+if _QUERIED_OBSERVED_STATES & _UNMEASURED_OBSERVED_STATES:
+    raise RuntimeError(
+        "contracts_v2.deficiency: _QUERIED_OBSERVED_STATES and "
+        "_UNMEASURED_OBSERVED_STATES overlap -- they must be disjoint"
+    )
+_uncovered_observed_states = (
+    frozenset(SourceRequirementState)
+    - _QUERIED_OBSERVED_STATES
+    - _UNMEASURED_OBSERVED_STATES
+)
+if _uncovered_observed_states:
+    raise RuntimeError(
+        "contracts_v2.deficiency: SourceRequirementState member(s) "
+        f"{sorted(state.value for state in _uncovered_observed_states)} "
+        "are in neither _QUERIED_OBSERVED_STATES nor "
+        "_UNMEASURED_OBSERVED_STATES -- DeficiencyFinding.data_semantics "
+        "would have no rule for them"
+    )
+
+
+class DeficiencyCategory(StrEnum):
+    """The eight taxonomy categories named verbatim in CHAOS-3305."""
+
+    DATA_INTEGRATION = "data_integration"
+    PLANNING_RELATIONSHIPS = "planning_relationships"
+    DELIVERY_FLOW = "delivery_flow"
+    REVIEW_CI = "review_ci"
+    DEPLOYMENT_RELIABILITY = "deployment_reliability"
+    OWNERSHIP_CODE_RISK = "ownership_code_risk"
+    CAPACITY_COGNITIVE_LOAD = "capacity_cognitive_load"
+    INVESTMENT_BALANCE = "investment_balance"
+
+
+#: Every category, in the issue's own taxonomy order -- the closed set
+#: :class:`OperationalDeficiencyInventory` requires exactly one
+#: :class:`DeficiencyCategoryStatus` per member of.
+DEFICIENCY_CATEGORIES: tuple[DeficiencyCategory, ...] = tuple(DeficiencyCategory)
+
+
+class DeficiencySeverity(StrEnum):
+    """A deficiency's own severity -- deliberately not ``DimensionState``.
+
+    ``DimensionState`` (CHAOS-3302) also carries ``healthy``/``unknown``/
+    ``not_applicable``, which are never valid on a *finding* (a finding is,
+    by definition, a real deficiency -- an unmeasured or healthy check is
+    reported through :class:`DeficiencyCategoryStatus` instead, never
+    minted as a zero-severity finding). Scoping this enum to the three
+    genuinely triggerable states keeps that guardrail structural rather
+    than conventional.
+    """
+
+    WATCH = "watch"
+    AT_RISK = "at_risk"
+    CRITICAL = "critical"
+
+
+class DeficiencyEvidenceClassification(StrEnum):
+    """Closed reasons a finding may carry no per-item evidence ref (F10).
+
+    Every :class:`DeficiencyFinding` carries either a non-empty
+    ``evidence_ref_ids`` or exactly one of these -- never neither (see
+    :func:`DeficiencyFinding.validate_evidence_or_classification`).
+    """
+
+    #: The deficiency *is* an absence (an unconfigured/unavailable source,
+    #: a missing declared status) -- there is no positive fact to cite,
+    #: only the absence itself, which the finding's own category/kind/
+    #: observed_state already state precisely.
+    STRUCTURAL_ABSENCE = "structural_absence"
+    #: The finding is a cohort/aggregate signal by design (capacity,
+    #: portfolio-level) -- citing a per-item evidence ref would risk
+    #: person-level attribution the guardrails forbid.
+    AGGREGATE_ONLY = "aggregate_only"
+    #: The finding is derived from a ``health_rule_finding.v1`` (CHAOS-3302),
+    #: whose own contract discloses evidentiary backing only as
+    #: ``evidence_source_classes`` (a closed set of source *categories*),
+    #: not per-item evidence handles -- there is no per-fact ref to carry
+    #: at this layer without changing that upstream contract.
+    SOURCE_CLASS_ONLY = "source_class_only"
+
+
+class DeficiencyRemediation(ContractModelV2):
+    """A bounded, server-owned remediation + verification pair.
+
+    Never a rendering of arbitrary producer copy and never an action with
+    write/execution side effects (explicit guardrail) -- both fields are
+    fixed, code-owned template text per finding kind, mirroring
+    ``HealthRuleDefinition.remediation_template``'s own posture.
+    """
+
+    schema_version: Literal["deficiency_remediation.v1"]
+    remediation_template: ShortText
+    verification_condition: ShortText
+
+
+@final
+class DeficiencyFinding(ContractModelV2):
+    """One deterministic, evidence-backed operational deficiency.
+
+    ``rule_id``/``rule_version`` name the deterministic finding kind: for
+    categories drawn directly from :data:`.health_rule_registry.
+    HEALTH_RULE_REGISTRY` (delivery flow, review/CI, deployment/
+    reliability, ownership/code risk) these are the real
+    ``health_rule.<name>.vN`` ids from CHAOS-3302; for categories computed
+    directly from canonical service results with no rule-registry
+    equivalent yet (data/integration, planning/relationships), these are a
+    parallel, equally closed ``deficiency_rule.<name>.v1`` namespace (see
+    ``operational_deficiency_service._DEFICIENCY_RULE_CATEGORY`` for the
+    exhaustive table). Either way, ``rule_id`` is never a free-form or
+    caller-supplied string.
+
+    Subclassing is structurally forbidden (:func:`__init_subclass__` below,
+    plus :func:`typing.final` for the type checker) -- Codex finding,
+    round 3, 2026-08-02, ratified decision: these contract models are a
+    CLOSED family, and subclassing is not a supported use. A subclass
+    changes serialization semantics silently (``model_dump``/
+    ``model_json_schema`` honor the subclass's own fields, not the
+    declared contract type) and can carry extra state (private
+    attributes, computed fields) that pydantic's containment/revalidation
+    machinery was never designed to reason about when the subclass
+    instance is embedded in a ``DeficiencyFinding``-typed field elsewhere.
+    Making this structurally impossible closes that whole class of attack
+    rather than chasing each individual symptom.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        raise TypeError(
+            f"{cls.__name__} may not subclass DeficiencyFinding -- this is "
+            "a closed, frozen wire-contract family (see the class "
+            "docstring). Add a new top-level contract type instead."
+        )
+
+    schema_version: Literal["deficiency_finding.v1"]
+    finding_id: ServerHandle
+    category: DeficiencyCategory
+    rule_id: PlatformVersionToken
+    rule_version: PlatformVersionToken
+    subject_kind: RuleApplicability
+    subject_id: OpaqueID
+    severity: DeficiencySeverity
+    fact_kind: FactKind
+    observed_state: SourceRequirementState
+    data_semantics: DataSemantics
+    sample_count: int | None = Field(default=None, ge=0, le=1_000_000)
+    coverage: FiniteFloat = Field(ge=0, le=1)
+    current_window_days: int = Field(ge=1, le=365)
+    comparison_window_days: int | None = Field(default=None, ge=1, le=365)
+    relationship_paths: tuple[DevRelationshipPath, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    evidence_ref_ids: tuple[OpaqueID, ...] = Field(default_factory=tuple, max_length=25)
+    evidence_classification: DeficiencyEvidenceClassification | None = None
+    blast_radius: ShortText
+    remediation: DeficiencyRemediation
+    limitations: tuple[ShortText, ...] = Field(default_factory=tuple, max_length=10)
+    evaluated_at: AwareDatetime
+
+    @model_validator(mode="after")
+    def validate_zero_semantics(self) -> Self:
+        """Mirrors ``DimensionObservation.validate_zero_semantics`` /
+        ``DevSourceObservation.validate_zero_semantics`` exactly (Codex
+        finding, 2026-08-02): ``observed_state`` decides which
+        ``data_semantics`` values are honest, not a blanket
+        "findings are always measured_zero" rule.
+
+        A finding about a genuinely *queried* condition (e.g. a stale or
+        empty-but-checked source) must report ``measured_zero`` or
+        ``no_data`` -- ``not_measured`` would misrepresent a real, checked
+        deficiency as unchecked. A finding about an *unmeasured* condition
+        (e.g. an unconfigured, unavailable, or unauthorized required
+        source) must report ``not_measured`` **exactly** (Codex finding,
+        round 2: rejecting only ``measured_zero`` in the unmeasured branch
+        left ``no_data`` unrejected -- an unconfigured source is not
+        indistinguishable from a queried source that came back empty; the
+        two are different facts and must not share a spelling). Either way
+        the finding itself is legitimate content (a required source being
+        unconfigured IS an operational deficiency); only the semantics
+        label was wrong.
+        """
+
+        if self.observed_state in _QUERIED_OBSERVED_STATES:
+            if self.data_semantics == "not_measured":
+                raise ValueError(
+                    "a finding about a queried observed_state must report "
+                    "measured_zero or no_data, never not_measured"
+                )
+        else:
+            if self.data_semantics != "not_measured":
+                raise ValueError(
+                    "a finding about an unmeasured observed_state "
+                    f"({self.observed_state.value!r}) must report "
+                    f"data_semantics='not_measured' exactly, not "
+                    f"{self.data_semantics!r} -- measured_zero would claim "
+                    "a checked, real zero, and no_data would claim a "
+                    "queried-but-empty result; neither is true of an "
+                    "unconfigured/unavailable/unauthorized/not_applicable/"
+                    "truncated source"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_evidence_or_classification(self) -> Self:
+        """F10 discipline: evidence refs XOR an explicit no-evidence reason."""
+
+        has_evidence = bool(self.evidence_ref_ids)
+        has_classification = self.evidence_classification is not None
+        if has_evidence and has_classification:
+            raise ValueError(
+                "a finding with real evidence_ref_ids must not also carry an "
+                "evidence_classification -- the classification exists only "
+                "for the no-evidence case"
+            )
+        if not has_evidence and not has_classification:
+            raise ValueError(
+                "a DeficiencyFinding requires either evidence_ref_ids or an "
+                "explicit evidence_classification (F10) -- neither is not a "
+                "valid disclosure"
+            )
+        return self
+
+
+class DeficiencyCategoryStatus(ContractModelV2):
+    """One evaluation-status record per taxonomy category.
+
+    Always present for exactly the eight :data:`DEFICIENCY_CATEGORIES`
+    (see :func:`OperationalDeficiencyInventory.validate_category_coverage`)
+    so "no deficiencies in this category" (``evaluated=True,
+    finding_count=0``) is structurally distinguishable from "this category
+    was never evaluated" (``evaluated=False``) -- the same distinction
+    ``DataHealthState`` draws between a genuine zero and an unmeasured
+    source, applied one level up at the category granularity.
+    """
+
+    schema_version: Literal["deficiency_category_status.v1"]
+    category: DeficiencyCategory
+    evaluated: bool
+    finding_count: int = Field(ge=0, le=200)
+    applicability_states_observed: tuple[SourceRequirementState, ...] = Field(
+        default_factory=tuple, max_length=8
+    )
+    limitation: ShortText | None = None
+
+    @model_validator(mode="after")
+    def validate_status_consistency(self) -> Self:
+        if not self.evaluated and self.finding_count != 0:
+            raise ValueError("an unevaluated category cannot report findings")
+        if not self.evaluated and self.limitation is None:
+            raise ValueError(
+                "an unevaluated category requires a bounded limitation explaining why"
+            )
+        return self
+
+
+@final
+class OperationalDeficiencyInventory(ContractModelV2):
+    """``deficiency.operational.v1``'s result: one subject's full inventory.
+
+    ``findings`` is ordered worst-severity-first, then by category, then by
+    ``finding_id`` for stability (validated below rather than merely
+    documented, so a caller reading the wire payload never needs to
+    re-sort) -- "Order by approved severity, blast radius, evidence
+    quality, and remediation dependency; do not let model prose reorder or
+    invent findings."
+
+    Two after-validators below (Codex findings, 2026-08-02) reconcile the
+    two collections a caller could otherwise silently desynchronize:
+    :func:`validate_category_counts_match_findings` (a declared
+    ``finding_count`` of 0 with a real finding present for that category,
+    or vice versa) and :func:`validate_findings_match_subject` (a finding
+    naming a different subject than the inventory itself). A third,
+    :func:`validate_findings_satisfy_evidence_discipline`, re-checks F10
+    (evidence XOR an explicit no-evidence classification) for every
+    finding at this containment boundary -- not because
+    ``DeficiencyFinding``'s own validator is insufficient in the ordinary
+    case, but because neither a per-model validator nor this one can be
+    made total over ``model_construct``/``model_copy(update=...)``, which
+    both bypass validation entirely by design. This re-check closes the
+    gap for a forged *finding* smuggled into an otherwise normally
+    constructed inventory. It does **not** close the gap for a forged
+    *inventory* itself (``OperationalDeficiencyInventory.model_construct``
+    skips every validator here, including this one) -- that case is
+    caught one layer out, at the persistence/record boundary (mirrors
+    CHAOS-3297 s1's frame validation at ``record_frame``), not here.
+
+    ``model_copy`` is overridden below (Codex finding, round 2,
+    2026-08-02, mirroring ``DevScope.model_copy`` exactly): pydantic's
+    base ``model_copy`` is a raw field copy that never reruns any of the
+    validators above, so ``model_copy(update={"findings": ()})`` on a
+    valid inventory returned a serializable inventory whose
+    ``category_statuses`` still claimed the old, now-wrong finding
+    counts -- the same class of hole as ``DevScope``'s own
+    ``repositories``-on-a-TEAM-scope bug (CHAOS-3301), reopened here for
+    counts, subject matching, ordering, uniqueness, and F10.
+
+    Subclassing is structurally forbidden (:func:`__init_subclass__`
+    below, plus :func:`typing.final`) -- Codex finding, round 3,
+    2026-08-02, ratified decision: this contract model family is CLOSED,
+    subclassing is unsupported, and codex's own repro class (a runtime
+    subtype losing its identity through the revalidating ``model_copy``
+    round-trip above, a ``PrivateAttr`` reset, a computed-field subclass
+    raising) is dead by construction rather than patched piecemeal. A
+    consequence worth stating plainly: ``model_copy``'s round-trip is
+    therefore a REVALIDATING copy, not a reference-preserving one --
+    ``deep=False`` does not skip rebuilding nested models, because
+    ``model_validate(copied.model_dump())`` always reconstructs the whole
+    tree. Callers must compare copies by VALUE, never by object identity
+    of nested fields.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        raise TypeError(
+            f"{cls.__name__} may not subclass OperationalDeficiencyInventory "
+            "-- this is a closed, frozen wire-contract family (see the "
+            "class docstring). Add a new top-level contract type instead."
+        )
+
+    schema_version: Literal["deficiency_operational_inventory.v1"]
+    inventory_id: ServerHandle
+    subject_kind: RuleApplicability
+    subject_id: OpaqueID
+    findings: tuple[DeficiencyFinding, ...] = Field(
+        default_factory=tuple, max_length=200
+    )
+    category_statuses: tuple[DeficiencyCategoryStatus, ...] = Field(
+        min_length=8, max_length=8
+    )
+    evaluated_at: AwareDatetime
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> Self:
+        """Revalidating copy -- see the class docstring. Every production
+        caller only patches ``evaluated_at``-adjacent metadata, so
+        round-tripping the update through ``model_validate`` costs nothing
+        real and closes the construction path.
+        """
+
+        copied = super().model_copy(update=update, deep=deep)
+        return type(self).model_validate(copied.model_dump())
+
+    @model_validator(mode="after")
+    def validate_category_coverage(self) -> Self:
+        categories = [status.category for status in self.category_statuses]
+        if len(set(categories)) != len(categories):
+            raise ValueError("category_statuses must not repeat a category")
+        if set(categories) != set(DEFICIENCY_CATEGORIES):
+            raise ValueError(
+                "category_statuses must cover exactly the eight closed "
+                f"deficiency categories, got: {sorted(categories)}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_finding_ids_unique(self) -> Self:
+        finding_ids = [finding.finding_id for finding in self.findings]
+        if len(finding_ids) != len(set(finding_ids)):
+            raise ValueError(
+                "findings must not repeat a finding_id -- duplicate "
+                "observations must dedupe to one canonical finding"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_findings_are_ordered(self) -> Self:
+        keys = [finding_sort_key(finding) for finding in self.findings]
+        if keys != sorted(keys):
+            raise ValueError(
+                "findings must be ordered worst-severity-first, then by "
+                "category, then by finding_id"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_category_counts_match_findings(self) -> Self:
+        actual_counts: dict[DeficiencyCategory, int] = dict.fromkeys(
+            DEFICIENCY_CATEGORIES, 0
+        )
+        for finding in self.findings:
+            actual_counts[finding.category] += 1
+        for status in self.category_statuses:
+            if status.finding_count != actual_counts[status.category]:
+                raise ValueError(
+                    f"category {status.category.value!r} declares "
+                    f"finding_count={status.finding_count} but {actual_counts[status.category]} "
+                    "finding(s) with that category are actually present in "
+                    "findings -- the declared count and the findings "
+                    "themselves must never diverge"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_findings_match_subject(self) -> Self:
+        for finding in self.findings:
+            if (
+                finding.subject_kind != self.subject_kind
+                or finding.subject_id != self.subject_id
+            ):
+                raise ValueError(
+                    f"finding {finding.finding_id!r} names subject "
+                    f"({finding.subject_kind.value!r}, {finding.subject_id!r}) "
+                    f"but this inventory is for "
+                    f"({self.subject_kind.value!r}, {self.subject_id!r}) -- "
+                    "a finding from a different subject cannot appear in "
+                    "another subject's inventory"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_findings_satisfy_evidence_discipline(self) -> Self:
+        """F10, re-checked at the containment boundary -- see class docstring."""
+
+        for finding in self.findings:
+            has_evidence = bool(finding.evidence_ref_ids)
+            has_classification = finding.evidence_classification is not None
+            if has_evidence == has_classification:
+                raise ValueError(
+                    f"finding {finding.finding_id!r} violates F10: exactly "
+                    "one of evidence_ref_ids or evidence_classification "
+                    "must be set, never both and never neither -- this "
+                    "finding either bypassed DeficiencyFinding's own "
+                    "validator (model_construct/model_copy) or was "
+                    "otherwise smuggled in"
+                )
+        return self
+
+
+#: Worst-first ordinal for :class:`DeficiencySeverity` -- lower sorts
+#: first, mirroring ``portfolio_status_service._DIMENSION_STATE_SEVERITY``'s
+#: own worst-first convention.
+_SEVERITY_ORDER: dict[DeficiencySeverity, int] = {
+    DeficiencySeverity.CRITICAL: 0,
+    DeficiencySeverity.AT_RISK: 1,
+    DeficiencySeverity.WATCH: 2,
+}
+
+
+def finding_sort_key(finding: DeficiencyFinding) -> tuple[int, str, str]:
+    return (
+        _SEVERITY_ORDER[finding.severity],
+        finding.category.value,
+        finding.finding_id,
+    )

--- a/src/dev_health_ops/api/dev/health_profile_synthesis.py
+++ b/src/dev_health_ops/api/dev/health_profile_synthesis.py
@@ -119,6 +119,14 @@ class HealthProfileResult:
     launch_findings: tuple[HealthRuleFinding, ...]
     shadow_findings: tuple[HealthRuleFinding, ...]
     suppressed_findings: tuple[HealthRuleFinding, ...]
+    #: CHAOS-3305 extension: the exact ``window_index=0`` observation each
+    #: finding (in any of the three buckets above) was evaluated from, keyed
+    #: by ``rule_id``. Additive-only (no existing caller reads it) -- lets a
+    #: downstream consumer (e.g. ``OperationalDeficiencyService``) report a
+    #: finding's real ``coverage``/``observed_states``/``sample_count``
+    #: instead of re-deriving or guessing them from the finding alone, which
+    #: carries none of those fields.
+    observations_by_rule: Mapping[str, DimensionObservation]
 
 
 #: Rules with a bound canonical source, handled directly in
@@ -395,4 +403,8 @@ def synthesize_health_profile(
         launch_findings=_ordered(evaluation.launch_findings),
         shadow_findings=_ordered(evaluation.shadow_findings),
         suppressed_findings=_ordered(evaluation.suppressed_findings),
+        observations_by_rule={
+            rule_id: observations[0]
+            for rule_id, observations in observations_by_rule.items()
+        },
     )

--- a/src/dev_health_ops/api/dev/operational_deficiency_service.py
+++ b/src/dev_health_ops/api/dev/operational_deficiency_service.py
@@ -1,0 +1,1678 @@
+"""``OperationalDeficiencyService`` (CHAOS-3305): ``deficiency.operational.v1``.
+
+The canonical answer to "what operational deficiencies do we have?" for one
+committed project or team subject -- a bounded, versioned, evidence-backed
+inventory across the eight taxonomy categories in
+:mod:`.contracts_v2.deficiency`. Composes the exact canonical calls
+``ProjectHealthService``/``TeamHealthService`` (CHAOS-3303) already make
+through the ``PlanExecutorRuntime`` seam -- never a second, parallel query
+path -- and evaluates only rules approved by CHAOS-3302's
+``HEALTH_RULE_REGISTRY``. No dimension, severity, percentage, or finding is
+ever computed here from anything other than an already-computed canonical
+service result.
+
+Coverage today (2026-08-02), stated precisely rather than implied:
+
+* **Category 1 (data & integration)** is fully bound: every ``DataHealthSource``
+  a required source reports maps directly onto a finding kind, except
+  "unusable returned data" (no canonical signal for it exists in
+  ``DataHealthResult`` yet -- see ``_DATA_INTEGRATION_LIMITATION``).
+  **Not attribution-independent for a TEAM subject** (corrected, Codex
+  finding HIGH, 2026-08-02): a TEAM ``DevScope`` carries no
+  ``repository_id`` of its own, so querying ``data_health`` with the raw
+  TEAM scope resolves zero explicit repositories and falls back to
+  querying every repository in the org. ``evaluate_team`` therefore
+  re-scopes the ``data_health`` call to an explicit
+  ``DirectScope.REPOSITORY`` built from the same attribution snapshot
+  used for ``cohort_size``, never the raw TEAM scope.
+* **Category 2 (planning & relationships)** is bound for unresolved
+  blocking dependencies, incomplete required declarations, missing
+  declared status, and declared-complete/observed-work conflicts, all
+  reused directly from ``StatusSnapshotResult.actual``. "Orphaned work /
+  missing project-work-unit mapping" (the ``work_graph_neighbors_service``
+  arm the CHAOS-3305 planning brief named) is **not** bound this round --
+  see ``_PLANNING_RELATIONSHIPS_LIMITATION``.
+* **Categories 3-6 (delivery flow, review/CI, deployment/reliability,
+  ownership/code risk)** are wired to ``HEALTH_RULE_REGISTRY`` via
+  ``health_profile_synthesis.synthesize_health_profile`` -- the same
+  synthesis 3303 already runs. Every rule shipped today is
+  ``calibration_state=provisional`` (3302's own totality test), so every
+  finding is ``shadow_only`` and **none reaches this inventory** (the
+  explicit guardrail: "shadow_only findings never in status/counts"). The
+  moment a future calibration review promotes a rule to a reviewed
+  calibration state, the exact same code path produces a real finding with
+  no change required here -- see ``_deficiency_from_health_rule_finding``.
+  Six of the nine registry rules additionally have no canonical, scope-safe
+  source wired at all yet (``health_profile_synthesis._UNBOUND_RULE_LIMITATIONS``);
+  this module does not attempt to bind any of them, because doing so
+  honestly requires a new canonical ``MetricQueryService``/
+  ``PlanExecutorRuntime`` source (wip_congestion, review latency, flaky
+  test rate, high churn) that does not exist yet -- approximating with a
+  different unit's value is exactly what CHAOS-3303's own module docstring
+  forbids.
+* **Category 7 (capacity & cognitive load)** is not bound. A canonical
+  aggregate-only source likely exists (``graphql/resolvers/cognitive_load.py``),
+  but the CHAOS-3305 planning brief explicitly calls for its aggregation
+  boundary to be *re-verified, not assumed* before any binding -- that
+  verification did not happen this round, so the category is reported
+  ``evaluated=False`` rather than risk a person-level leak.
+* **Category 8 (investment balance)** is bound for TEAM subjects only
+  (2026-08-02, following CHAOS-3304's merge): ``evaluate_team`` calls
+  ``_investment_balance_profile``, an INVESTMENT-ONLY path that fetches
+  only ``investment_mix`` and reuses CHAOS-3304's own adapter/rule pieces
+  (``synthesize_health_profile``/``investment_allocation_shift_observation``/
+  ``HEALTH_RULE_REGISTRY``) -- never ``TeamWorkloadService``'s whole
+  service (Codex finding, HIGH, round 5: composing the full service made
+  its own extra status_snapshot/data_health calls against the raw TEAM
+  scope, reintroducing category 1's own org-wide-widening bug, and an
+  unhandled dependency failure there could lose every category, not just
+  8). Packages the resulting finding exactly like categories 3-6, through
+  the same ``_rule_driven_category_result``. That rule is CHAOS-3331-blocked
+  (``investment_allocation_shift_observation`` reports
+  ``attribution_present=False`` unconditionally, see
+  ``dimension_observation_adapters.py``) -- a genuinely computed shift
+  therefore lands in ``suppressed_findings`` with ``missing_attribution``,
+  never a launch finding, until CHAOS-3331 lands. PROJECT subjects have no
+  team-workload equivalent (the rule's own ``applicability`` is
+  ``(RuleApplicability.TEAM,)``), so category 8 stays ``evaluated=False``
+  for a project inventory -- see
+  ``_INVESTMENT_BALANCE_NOT_APPLICABLE_TO_PROJECT_LIMITATION``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from uuid import UUID, uuid5
+
+from .contracts import DevScope, DirectScope, MetricID
+from .contracts_v2.base import SourceRequirementState
+from .contracts_v2.deficiency import (
+    DeficiencyCategory,
+    DeficiencyCategoryStatus,
+    DeficiencyEvidenceClassification,
+    DeficiencyFinding,
+    DeficiencyRemediation,
+    DeficiencySeverity,
+    OperationalDeficiencyInventory,
+    finding_sort_key,
+)
+from .contracts_v2.health_rules import (
+    DimensionObservation,
+    DimensionState,
+    HealthDimension,
+    HealthRuleFinding,
+    RuleApplicability,
+)
+from .data_health_service import (
+    NATIVE_EVIDENCE_SOURCES,
+    DataHealthResult,
+    DataHealthSource,
+    DataHealthState,
+)
+from .health_profile_synthesis import (
+    HealthEvaluationSources,
+    HealthProfileResult,
+    synthesize_health_profile,
+)
+from .health_rule_registry import HEALTH_RULE_REGISTRY
+from .investigation_plans.builtin_steps import PlanExecutorRuntime
+from .investigation_plans.state_mapping import (
+    UNMEASURED_REQUIREMENT_STATES,
+    data_health_state_to_requirement_state,
+    status_result_state_to_requirement_state,
+)
+from .native_team_workload import TeamInvestmentMixResult
+from .project_health_service import CHANGE_FAILURE_RATE_SUPPORTED_SCOPES
+from .status_change_service import StatusResultState, StatusSnapshotResult
+from .team_health_service import TeamAttributionSource
+from .team_workload_service import TeamWorkloadDataSource
+
+__all__ = ["OperationalDeficiencyService"]
+
+#: Namespace for deterministic ``finding_id``/``inventory_id`` minting --
+#: distinct from ``health_rule_registry._FINDING_ID_NAMESPACE`` (a
+#: different contract's identity space; reusing the same namespace would
+#: risk two unrelated finding kinds colliding on the same UUID5 output for
+#: coincidentally identical input strings).
+_DEFICIENCY_ID_NAMESPACE = UUID("5886b318-7f24-52bd-b661-671ed463397e")
+
+#: A data-health check has no rolling comparison window of its own (it is a
+#: point-in-time freshness/configuration read, not a threshold trend) --
+#: this is the documented, fixed value every category-1 finding reports
+#: for ``current_window_days``, never a fabricated windowed computation.
+_POINT_IN_TIME_WINDOW_DAYS = 1
+
+_DATA_INTEGRATION_LIMITATION = (
+    "unusable_returned_data is not yet bound: DataHealthResult carries no "
+    "canonical signal distinguishing usable-but-low-quality data from "
+    "genuinely complete data."
+)
+_PLANNING_RELATIONSHIPS_LIMITATION = (
+    "orphaned_work and missing_project_work_unit_mapping are not yet "
+    "bound: binding them requires work_graph_neighbors_service, deferred "
+    "in this version."
+)
+_CAPACITY_LIMITATION = (
+    "capacity_cognitive_load is not evaluated: no HEALTH_RULE_REGISTRY "
+    "rule exists for the cognitive_workload_pressure dimension, and the "
+    "existing cognitive_load resolver's aggregation boundary has not been "
+    "re-verified for this service (CHAOS-3305 planning brief requires "
+    "re-verification, not assumption, before binding)."
+)
+_INVESTMENT_BALANCE_NOT_APPLICABLE_TO_PROJECT_LIMITATION = (
+    "health_rule.investment_allocation_shift.v1 -- the only HEALTH_RULE_"
+    "REGISTRY rule bound to the investment_balance dimension -- applies "
+    "only to team subjects (its own RuleApplicability is (TEAM,)). There "
+    "is no project-level investment-balance rule for this service to "
+    "evaluate; this is a scope mismatch, not a missing binding."
+)
+_INVESTMENT_BALANCE_DEPENDENCY_UNAVAILABLE_LIMITATION = (
+    "the investment-mix source failed (raised or timed out) during this "
+    "evaluation, so category 8 could not be assessed for this team -- an "
+    "expected, contained dependency outage, isolated from every other "
+    "category, never a claim that the rule was evaluated and simply "
+    "produced no finding."
+)
+_RULE_DRIVEN_SHADOW_LIMITATION = (
+    "every applicable HEALTH_RULE_REGISTRY rule for this category is "
+    "calibration_state=provisional today -- shadow_only findings are "
+    "computed for calibration review but never surfaced as a deficiency."
+)
+_RULE_DRIVEN_SUPPRESSED_LIMITATION = (
+    "every applicable HEALTH_RULE_REGISTRY rule for this category was "
+    "guardrail-suppressed for this subject (insufficient sample, "
+    "coverage, cohort, or a missing denominator/attribution) -- "
+    "suppressed findings are never surfaced as a deficiency."
+)
+_RULE_DRIVEN_SHADOW_AND_SUPPRESSED_LIMITATION = (
+    "this category's applicable HEALTH_RULE_REGISTRY rules are a mix of "
+    "calibration_state=provisional (shadow_only) and guardrail-suppressed "
+    "(insufficient sample, coverage, cohort, or a missing "
+    "denominator/attribution) for this subject -- neither is ever "
+    "surfaced as a deficiency."
+)
+_RULE_DRIVEN_PARTIAL_LIMITATION = (
+    "not every applicable HEALTH_RULE_REGISTRY rule for this category "
+    "contributed to these findings -- some are calibration_state="
+    "provisional (shadow_only) and/or guardrail-suppressed (insufficient "
+    "sample, coverage, cohort, or a missing denominator/attribution) for "
+    "this subject and are never surfaced as a deficiency, even though "
+    "other rules for this category did produce the finding(s) above."
+)
+_RULE_DRIVEN_UNREGISTERED_LIMITATION = (
+    "no HEALTH_RULE_REGISTRY rule is registered for this category yet."
+)
+_TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION = (
+    "team_repository_ids lookup failed as of the committed scope's window "
+    "end -- cohort size could not be verified, so every team-cohort-gated "
+    "category is honestly unmeasured, never insufficient_cohort (which "
+    "would claim attribution was checked and found too small)."
+)
+
+#: ``HealthDimension`` -> the one ``DeficiencyCategory`` its findings feed,
+#: or ``None`` when a dimension is deliberately excluded (see below).
+#: Total over every ``HealthDimension`` member (enforced at import time)
+#: so a future dimension added to CHAOS-3302 fails import here rather than
+#: silently never reaching the inventory.
+_HEALTH_DIMENSION_TO_DEFICIENCY_CATEGORY: Mapping[str, DeficiencyCategory | None] = {
+    "execution_completion": DeficiencyCategory.DELIVERY_FLOW,
+    "delivery_flow": DeficiencyCategory.DELIVERY_FLOW,
+    "reliability_release": DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+    "review_ci_pressure": DeficiencyCategory.REVIEW_CI,
+    "code_ownership_risk": DeficiencyCategory.OWNERSHIP_CODE_RISK,
+    "cognitive_workload_pressure": DeficiencyCategory.CAPACITY_COGNITIVE_LOAD,
+    "investment_balance": DeficiencyCategory.INVESTMENT_BALANCE,
+    "dependencies_blockers": DeficiencyCategory.PLANNING_RELATIONSHIPS,
+    # DATA_TRUST is intentionally excluded: category 1 (data_integration)
+    # is already computed directly from DataHealthResult (see
+    # _data_integration_findings). Also folding in health_rule.
+    # data_trust_broken.v1 -- the *same* underlying DataHealthResult.
+    # complete_eligible signal, re-expressed as a HealthRuleFinding --
+    # would violate "one canonical finding per observation" by minting a
+    # second finding for the identical condition.
+    "data_trust": None,
+}
+
+_undocumented_dimensions = frozenset(HealthDimension) - frozenset(
+    HealthDimension(value) for value in _HEALTH_DIMENSION_TO_DEFICIENCY_CATEGORY
+)
+if _undocumented_dimensions:
+    raise RuntimeError(
+        "operational_deficiency_service has no deficiency-category binding "
+        f"for HealthDimension member(s): {sorted(_undocumented_dimensions)}"
+    )
+
+#: The rule-registry-fed categories, in a fixed order used only for
+#: deterministic iteration (final ordering of the inventory's own
+#: ``findings`` is enforced by ``finding_sort_key``, not this tuple).
+#: ``INVESTMENT_BALANCE`` (category 8) is included even though its one
+#: bound rule is TEAM-only -- see ``_rule_driven_results``' ``workload_
+#: profile`` handling, which is what actually supplies its bucket for a
+#: TEAM subject and reports it honestly not-applicable for a PROJECT one.
+#: ``CAPACITY_COGNITIVE_LOAD`` (category 7) is deliberately NOT here: no
+#: HEALTH_RULE_REGISTRY rule maps to it via this pipeline today (see the
+#: module docstring and ``_CAPACITY_LIMITATION``).
+_RULE_DRIVEN_CATEGORIES: tuple[DeficiencyCategory, ...] = (
+    DeficiencyCategory.DELIVERY_FLOW,
+    DeficiencyCategory.REVIEW_CI,
+    DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+    DeficiencyCategory.OWNERSHIP_CODE_RISK,
+    DeficiencyCategory.INVESTMENT_BALANCE,
+)
+
+
+def _mint_deficiency_finding_id(
+    *,
+    org_id: str,
+    category: DeficiencyCategory,
+    rule_id: str,
+    subject_kind: str,
+    subject_id: str,
+    discriminator: str,
+) -> str:
+    """Deterministic, REPLAY-STABLE finding identity.
+
+    Deliberately excludes any timestamp (Codex finding, 2026-08-02): a
+    finding's identity is *what it is about* -- the closed
+    (org, category, rule, subject, discriminator) tuple -- never *when it
+    was last evaluated*. ``evaluated_at`` is carried on the finding as
+    ordinary metadata, not folded into this payload; including it here
+    made re-evaluating the exact same underlying condition one second
+    apart mint two different ids, breaking both the dedupe guarantee this
+    function backs (see ``_dedupe_findings``) and the replay/determinism
+    expectation the same canonical deficiency has the same identity across
+    every evaluation that observes it, not just the first one. This
+    intentionally diverges from ``health_rule_registry._mint_finding_id``
+    (which *does* fold in ``observed_at``/``window_index`` because a
+    ``HealthRuleFinding`` identifies one evaluated window instance, not a
+    persistent condition) -- a ``DeficiencyFinding`` identifies the
+    deficiency itself. ``discriminator`` carries whatever distinguishes two
+    findings of the same category/rule/subject that are not the same
+    observation (e.g. a data-integration finding's ``source_system``, or a
+    planning finding's reason code) -- the dedupe key this function's
+    output *is* the finding_id, so two calls with identical inputs
+    (including an identical discriminator) always collapse to one finding.
+    """
+
+    payload = "|".join(
+        (org_id, category.value, rule_id, subject_kind, subject_id, discriminator)
+    )
+    return str(uuid5(_DEFICIENCY_ID_NAMESPACE, payload))
+
+
+def _mint_inventory_id(
+    *, org_id: str, subject_kind: str, subject_id: str, evaluated_at: datetime
+) -> str:
+    normalized = evaluated_at.astimezone(UTC).isoformat(timespec="microseconds")
+    payload = "|".join((org_id, subject_kind, subject_id, normalized))
+    return str(uuid5(_DEFICIENCY_ID_NAMESPACE, f"inventory|{payload}"))
+
+
+def _evidence_or_classification(
+    ids: Sequence[str],
+) -> tuple[tuple[str, ...], DeficiencyEvidenceClassification | None]:
+    deduped = tuple(dict.fromkeys(ids))[:25]
+    if deduped:
+        return deduped, None
+    return (), DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE
+
+
+# ---------------------------------------------------------------------------
+# Category 1: data & integration
+# ---------------------------------------------------------------------------
+
+#: (finding-kind suffix, severity) per non-complete, non-not-applicable
+#: ``DataHealthState`` -- ``COMPLETE`` never fires (no deficiency).
+_DATA_INTEGRATION_KIND_SEVERITY: Mapping[
+    DataHealthState, tuple[str, DeficiencySeverity]
+] = {
+    DataHealthState.UNCONFIGURED: (
+        "unconfigured_required_source",
+        DeficiencySeverity.CRITICAL,
+    ),
+    DataHealthState.UNAVAILABLE: ("active_sync_failure", DeficiencySeverity.CRITICAL),
+    DataHealthState.STALE: ("stale_watermark", DeficiencySeverity.AT_RISK),
+    DataHealthState.NO_DATA: ("missing_subject_coverage", DeficiencySeverity.WATCH),
+    DataHealthState.UNAUTHORIZED: ("source_unauthorized", DeficiencySeverity.AT_RISK),
+}
+
+
+def _data_semantics_for_observed_state(
+    observed_state: SourceRequirementState,
+) -> str:
+    """Mirrors ``DeficiencyFinding.validate_zero_semantics``'s own queried/
+    unmeasured split (Codex finding, 2026-08-02): a finding about an
+    unconfigured/unavailable/unauthorized source -- itself the deficiency
+    -- must report ``not_measured``, never a fabricated ``measured_zero``
+    standing in for "we never checked".
+    """
+
+    if observed_state in UNMEASURED_REQUIREMENT_STATES:
+        return "not_measured"
+    return "measured_zero"
+
+
+def _data_integration_finding(
+    source: DataHealthSource,
+    *,
+    org_id: str,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    now: datetime,
+) -> DeficiencyFinding | None:
+    if not source.required or source.state not in _DATA_INTEGRATION_KIND_SEVERITY:
+        return None
+    kind, severity = _DATA_INTEGRATION_KIND_SEVERITY[source.state]
+    rule_id = f"deficiency_rule.{kind}.v1"
+    observed_state = data_health_state_to_requirement_state(source.state)
+    return DeficiencyFinding(
+        schema_version="deficiency_finding.v1",
+        finding_id=_mint_deficiency_finding_id(
+            org_id=org_id,
+            category=DeficiencyCategory.DATA_INTEGRATION,
+            rule_id=rule_id,
+            subject_kind=subject_kind.value,
+            subject_id=subject_id,
+            discriminator=source.source_system,
+        ),
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        rule_id=rule_id,
+        rule_version=rule_id,
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        severity=severity,
+        fact_kind="observed",
+        observed_state=observed_state,
+        data_semantics=_data_semantics_for_observed_state(observed_state),
+        sample_count=None,
+        coverage=source.coverage,
+        current_window_days=_POINT_IN_TIME_WINDOW_DAYS,
+        comparison_window_days=None,
+        evidence_ref_ids=(),
+        evidence_classification=DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE,
+        blast_radius=(
+            f"Required source '{source.source_system}' is {source.state.value}; "
+            "findings drawing on this source may be degraded or unavailable."
+        ),
+        remediation=DeficiencyRemediation(
+            schema_version="deficiency_remediation.v1",
+            remediation_template=(
+                f"Restore or (re)configure the '{source.source_system}' source integration."
+            ),
+            verification_condition=(
+                f"Resolves once '{source.source_system}' reports DataHealthState.complete "
+                "on the next inventory evaluation."
+            ),
+        ),
+        limitations=(),
+        evaluated_at=now,
+    )
+
+
+def _data_integration_result(
+    data_health: DataHealthResult,
+    *,
+    org_id: str,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    now: datetime,
+) -> tuple[DeficiencyCategoryStatus, tuple[DeficiencyFinding, ...]]:
+    if not data_health.sources:
+        return (
+            DeficiencyCategoryStatus(
+                schema_version="deficiency_category_status.v1",
+                category=DeficiencyCategory.DATA_INTEGRATION,
+                evaluated=False,
+                finding_count=0,
+                applicability_states_observed=(),
+                limitation="data_health_never_queried: no required sources were evaluated.",
+            ),
+            (),
+        )
+    findings = tuple(
+        finding
+        for source in data_health.sources
+        if (
+            finding := _data_integration_finding(
+                source,
+                org_id=org_id,
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                now=now,
+            )
+        )
+        is not None
+    )
+    observed_states = tuple(
+        sorted(
+            {
+                data_health_state_to_requirement_state(source.state)
+                for source in data_health.sources
+            },
+            key=lambda state: state.value,
+        )
+    )
+    status = DeficiencyCategoryStatus(
+        schema_version="deficiency_category_status.v1",
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        evaluated=True,
+        finding_count=len(findings),
+        applicability_states_observed=observed_states,
+        limitation=_DATA_INTEGRATION_LIMITATION,
+    )
+    return status, findings
+
+
+# ---------------------------------------------------------------------------
+# Team data_health batching (Codex finding, HIGH, 2026-08-02): DevScope.
+# repositories caps at 20 (Field(max_length=20)); a team attributed more
+# than 20 repositories raised ValidationError building the REPOSITORY scope
+# and lost its ENTIRE inventory, not just category 1. The public DevScope
+# wire contract is not widened to fix this (no internal scope type crosses
+# the PlanExecutorRuntime protocol boundary either -- data_health's only
+# parameter is a DevScope) -- instead, evaluate_team batches the attributed
+# repository set into <=20-repo DevScope chunks and reconciles the merged
+# result, exactly, never a silent truncation to the first chunk.
+# ---------------------------------------------------------------------------
+
+#: Matches DevScope.repositories' own ``Field(max_length=20)`` exactly --
+#: not an independently chosen batch size.
+_MAX_REPOSITORIES_PER_SCOPE = 20
+
+#: Worst-to-best ordinal for ``DataHealthState`` -- lower is worse. Mirrors
+#: ``dimension_observation_adapters._STATE_SEVERITY``'s own worst-first
+#: convention, at the ``DataHealthState`` layer instead of the mapped
+#: ``SourceRequirementState`` layer (the two enums are not identical, so a
+#: separate table is needed rather than reusing that one directly).
+_DATA_HEALTH_STATE_SEVERITY: Mapping[DataHealthState, int] = {
+    DataHealthState.UNAUTHORIZED: 0,
+    DataHealthState.UNAVAILABLE: 1,
+    DataHealthState.UNCONFIGURED: 2,
+    DataHealthState.STALE: 3,
+    DataHealthState.NO_DATA: 4,
+    DataHealthState.COMPLETE: 5,
+}
+
+
+def _earliest(a: datetime | None, b: datetime | None) -> datetime | None:
+    """The "worse" of two optional timestamps for freshness merging: a
+    missing timestamp on either side means that side's source never
+    succeeded, which is at least as bad as any real timestamp the other
+    side carries, so the merged result must not claim a real one either.
+    Otherwise, the earlier (staler) of the two.
+    """
+
+    if a is None or b is None:
+        return None
+    return min(a, b)
+
+
+#: Synthesized ``warning`` marker for a source_system a batch omitted
+#: entirely -- distinguishes a fail-closed placeholder from anything a
+#: real ``DataHealthService.inspect`` call ever produces.
+_OMITTED_BATCH_SOURCE_WARNING = "batch_omitted_source_system"
+
+#: Every one of ``NATIVE_EVIDENCE_SOURCES`` is unconditionally
+#: ``required=True`` by construction in
+#: ``NativeDataHealthReader.read()`` (the "acr" special case is NOT a
+#: member of this canonical set). Kept as an explicit lookup rather than a
+#: blanket literal so a placeholder's requiredness is always traceable to
+#: this ONE table, not a second, independently-drifting assumption.
+_CANONICAL_SOURCE_REQUIRED: Mapping[str, bool] = dict.fromkeys(
+    NATIVE_EVIDENCE_SOURCES, True
+)
+
+
+def _placeholder_for_omitted_source(
+    source_system: str, batch_repository_ids: Sequence[str]
+) -> DataHealthSource:
+    """A fail-closed stand-in for a source_system one batch never reported
+    at all, scoped to exactly that batch's own repositories -- see
+    ``_merge_data_health_sources``'s docstring for why this must exist.
+
+    ``required`` comes from ``_CANONICAL_SOURCE_REQUIRED`` (Codex finding,
+    MEDIUM, 2026-08-02) -- never a blanket ``True`` literal, which would
+    misreport a genuinely optional source_system as required the moment a
+    batch omits it. Defaults to ``True`` only for a source_system this
+    table has no entry for at all, which is itself a fail-closed choice:
+    an unrecognized source_system omitted by a batch is treated as if it
+    mattered, never silently ignored.
+    """
+
+    return DataHealthSource(
+        source_system=source_system,
+        state=DataHealthState.UNAVAILABLE,
+        required=_CANONICAL_SOURCE_REQUIRED.get(source_system, True),
+        last_successful_at=None,
+        watermark=None,
+        missing_repository_ids=tuple(sorted(batch_repository_ids)),
+        missing_entity_ids=(),
+        coverage=0.0,
+        confidence_impact="insufficient_evidence",
+        freshness_policy_version=None,
+        warning=_OMITTED_BATCH_SOURCE_WARNING,
+    )
+
+
+def _merge_data_health_sources(
+    sources_by_batch: Sequence[tuple[DataHealthSource, ...]],
+    batch_repository_ids: Sequence[Sequence[str]],
+    *,
+    total_repositories: int,
+) -> tuple[DataHealthSource, ...]:
+    """Reconcile one team's chunked ``data_health`` calls into one honest
+    picture, per ``source_system``.
+
+    Fail-closed against an omitted or short batch (Codex finding, HIGH,
+    2026-08-02, round 2): the expected source_system set is
+    ``NATIVE_EVIDENCE_SOURCES`` -- the SAME canonical, production-owned
+    default set ``DataHealthService.inspect`` itself queries against
+    (``PlanExecutorRuntime.data_health`` carries no ``required_sources``
+    parameter of its own, so this is not merely "a" reasonable default,
+    it is the ONLY set any real batch call can ever be answering for) --
+    never derived from what the batches themselves happened to return.
+    The first fix (round 1) unioned the batches' own reported systems,
+    which still silently passed when EVERY batch returned ``sources=()``
+    (empty union, nothing to flag). Pinning the expected set to the
+    canonical contract instead means a total measurement failure across
+    every batch is caught exactly like a partial one -- any batch missing
+    a member of ``NATIVE_EVIDENCE_SOURCES`` gets an explicit
+    ``UNAVAILABLE`` placeholder synthesized for it, scoped to that
+    batch's own repositories, before merging.
+
+    ``required`` is the OR of every batch's own ``required`` flag for that
+    source_system (Codex finding, MEDIUM, round 2) -- "did ANY batch need
+    this source" is independent of which batch's state wins below.
+
+    ``state``/``missing_repository_ids``/``missing_entity_ids``/``coverage``
+    are aggregated over the REQUIRED records ONLY when at least one batch
+    actually required this source_system -- never blended with an
+    unrelated OPTIONAL batch's own failure (Codex finding, MEDIUM PLAUSIBLE,
+    round 5): the round-2 fix above still let an optional+UNAVAILABLE
+    batch's state win the worst-state comparison against a required+
+    COMPLETE batch for the SAME source_system, reporting the merged source
+    as ``required=True``/``UNAVAILABLE`` (blocking ``complete_eligible``)
+    even though every batch that actually required it was fully COMPLETE.
+    "Blocking state" and "required coverage" must answer "how did the
+    batches that needed this source do", not "how did every batch that
+    happened to touch it do, required or not". A source_system no batch
+    ever required falls back to aggregating its optional records instead
+    (still an honest, reportable state -- just never able to block
+    ``complete_eligible`` on its own, since ``required`` stays ``False``).
+    Within whichever pool is chosen, ``state`` is still the WORST record (a
+    degraded batch must never be masked by a healthy one) and
+    ``missing_repository_ids``/``missing_entity_ids`` are still the union
+    (repositories never overlap between chunks by construction, so this is
+    also automatically deduplicated). ``coverage`` is recomputed EXACTLY
+    from ``total_repositories`` (the caller's own known, authoritative
+    repository count) minus the merged missing count -- never a weighted
+    average of each batch's own ratio, which would compound rounding error
+    across an arbitrary number of chunks.
+    """
+
+    expected_source_systems = set(NATIVE_EVIDENCE_SOURCES)
+    normalized_batches: list[tuple[DataHealthSource, ...]] = []
+    for batch_sources, batch_repos in zip(
+        sources_by_batch, batch_repository_ids, strict=True
+    ):
+        present = {source.source_system for source in batch_sources}
+        omitted = expected_source_systems - present
+        placeholders = tuple(
+            _placeholder_for_omitted_source(system, batch_repos) for system in omitted
+        )
+        normalized_batches.append(batch_sources + placeholders)
+
+    # Two independent record pools per source_system -- see the docstring.
+    required_records: dict[str, list[DataHealthSource]] = {}
+    optional_records: dict[str, list[DataHealthSource]] = {}
+    required_by_source: dict[str, bool] = {}
+    for batch_sources in normalized_batches:
+        for source in batch_sources:
+            required_by_source[source.source_system] = (
+                required_by_source.get(source.source_system, False) or source.required
+            )
+            pool = required_records if source.required else optional_records
+            pool.setdefault(source.source_system, []).append(source)
+
+    results: list[DataHealthSource] = []
+    for source_system, required in required_by_source.items():
+        records = required_records.get(source_system) or optional_records.get(
+            source_system, []
+        )
+        missing_repository_ids: set[str] = set()
+        missing_entity_ids: set[str] = set()
+        worst = records[0]
+        for record in records:
+            missing_repository_ids.update(record.missing_repository_ids)
+            missing_entity_ids.update(record.missing_entity_ids)
+            if (
+                _DATA_HEALTH_STATE_SEVERITY[record.state]
+                < _DATA_HEALTH_STATE_SEVERITY[worst.state]
+            ):
+                worst = record
+            elif record is not worst:
+                worst = DataHealthSource(
+                    source_system=worst.source_system,
+                    state=worst.state,
+                    required=worst.required,
+                    last_successful_at=_earliest(
+                        worst.last_successful_at, record.last_successful_at
+                    ),
+                    watermark=_earliest(worst.watermark, record.watermark),
+                    missing_repository_ids=worst.missing_repository_ids,
+                    missing_entity_ids=worst.missing_entity_ids,
+                    coverage=worst.coverage,
+                    confidence_impact=worst.confidence_impact
+                    or record.confidence_impact,
+                    freshness_policy_version=(
+                        worst.freshness_policy_version
+                        or record.freshness_policy_version
+                    ),
+                    warning=worst.warning or record.warning,
+                )
+        missing_repository_ids_tuple = tuple(sorted(missing_repository_ids))
+        coverage = (
+            (total_repositories - len(missing_repository_ids_tuple))
+            / total_repositories
+            if total_repositories
+            else 0.0
+        )
+        results.append(
+            DataHealthSource(
+                source_system=source_system,
+                state=worst.state,
+                required=required,
+                last_successful_at=worst.last_successful_at,
+                watermark=worst.watermark,
+                missing_repository_ids=missing_repository_ids_tuple,
+                missing_entity_ids=tuple(sorted(missing_entity_ids)),
+                coverage=max(0.0, min(1.0, coverage)),
+                confidence_impact=worst.confidence_impact,
+                freshness_policy_version=worst.freshness_policy_version,
+                warning=worst.warning,
+            )
+        )
+    return tuple(results)
+
+
+# ---------------------------------------------------------------------------
+# Category 2: planning & relationships
+# ---------------------------------------------------------------------------
+
+#: (reason code -> (finding-kind suffix, severity)). Reused directly from
+#: ``StatusSnapshotResult.actual.reason_codes`` -- never a re-derivation of
+#: the private "open"/"incomplete" status predicates ``_assess`` computes
+#: (see the module docstring's evidence-aggregation tradeoff note).
+_PLANNING_REASON_CODE_KIND: Mapping[str, tuple[str, DeficiencySeverity]] = {
+    "open_blocker": ("unresolved_blocking_dependency", DeficiencySeverity.AT_RISK),
+    "required_child_incomplete": (
+        "incomplete_required_declaration",
+        DeficiencySeverity.AT_RISK,
+    ),
+    "declared_status_missing": ("missing_declared_status", DeficiencySeverity.WATCH),
+}
+_DECLARED_COMPLETE_CONFLICT_CODE = "declared_complete_conflicts_with_observed_work"
+
+
+def _planning_relationships_result(
+    snapshot: StatusSnapshotResult,
+    *,
+    org_id: str,
+    subject_kind: RuleApplicability,
+    subject_id: str,
+    now: datetime,
+) -> tuple[DeficiencyCategoryStatus, tuple[DeficiencyFinding, ...]]:
+    if snapshot.state is StatusResultState.INSUFFICIENT_EVIDENCE:
+        return (
+            DeficiencyCategoryStatus(
+                schema_version="deficiency_category_status.v1",
+                category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+                evaluated=False,
+                finding_count=0,
+                applicability_states_observed=(),
+                limitation="status_snapshot reported insufficient_evidence: no required source was queried.",
+            ),
+            (),
+        )
+
+    findings: list[DeficiencyFinding] = []
+    blocker_evidence = [
+        ref_id for blocker in snapshot.blockers for ref_id in blocker.evidence_ref_ids
+    ]
+    child_evidence = [
+        ref_id
+        for child in snapshot.actual.required_children
+        for ref_id in child.evidence_ref_ids
+    ]
+    for reason_code, (kind, severity) in _PLANNING_REASON_CODE_KIND.items():
+        if reason_code not in snapshot.actual.reason_codes:
+            continue
+        rule_id = f"deficiency_rule.{kind}.v1"
+        if reason_code == "open_blocker":
+            evidence_ids, classification = _evidence_or_classification(blocker_evidence)
+            blast_radius = "One or more declared blocking dependencies are still open."
+        elif reason_code == "required_child_incomplete":
+            evidence_ids, classification = _evidence_or_classification(child_evidence)
+            blast_radius = "One or more required child work items are not yet complete."
+        else:
+            evidence_ids, classification = (
+                (),
+                DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE,
+            )
+            blast_radius = "No declared status was found for this subject."
+        findings.append(
+            DeficiencyFinding(
+                schema_version="deficiency_finding.v1",
+                finding_id=_mint_deficiency_finding_id(
+                    org_id=org_id,
+                    category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+                    rule_id=rule_id,
+                    subject_kind=subject_kind.value,
+                    subject_id=subject_id,
+                    discriminator=reason_code,
+                ),
+                category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+                rule_id=rule_id,
+                rule_version=rule_id,
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                severity=severity,
+                fact_kind="observed",
+                observed_state=status_result_state_to_requirement_state(snapshot.state),
+                data_semantics="measured_zero",
+                sample_count=None,
+                coverage=1.0,
+                current_window_days=_POINT_IN_TIME_WINDOW_DAYS,
+                comparison_window_days=None,
+                evidence_ref_ids=evidence_ids,
+                evidence_classification=classification,
+                blast_radius=blast_radius,
+                remediation=DeficiencyRemediation(
+                    schema_version="deficiency_remediation.v1",
+                    remediation_template=(
+                        "Review and resolve the outstanding planning/relationship "
+                        "gap with the team before the next assessment."
+                    ),
+                    verification_condition=(
+                        f"Resolves once '{reason_code}' no longer appears in the "
+                        "subject's actual-completion reason codes."
+                    ),
+                ),
+                limitations=(),
+                evaluated_at=now,
+            )
+        )
+    for conflict in snapshot.actual.conflicts:
+        if conflict.code != _DECLARED_COMPLETE_CONFLICT_CODE:
+            continue
+        rule_id = "deficiency_rule.declared_complete_conflict.v1"
+        evidence_ids, classification = _evidence_or_classification(
+            conflict.evidence_ref_ids
+        )
+        findings.append(
+            DeficiencyFinding(
+                schema_version="deficiency_finding.v1",
+                finding_id=_mint_deficiency_finding_id(
+                    org_id=org_id,
+                    category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+                    rule_id=rule_id,
+                    subject_kind=subject_kind.value,
+                    subject_id=subject_id,
+                    discriminator=conflict.code,
+                ),
+                category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+                rule_id=rule_id,
+                rule_version=rule_id,
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                severity=DeficiencySeverity.CRITICAL,
+                fact_kind="observed",
+                observed_state=status_result_state_to_requirement_state(snapshot.state),
+                data_semantics="measured_zero",
+                sample_count=None,
+                coverage=1.0,
+                current_window_days=_POINT_IN_TIME_WINDOW_DAYS,
+                comparison_window_days=None,
+                evidence_ref_ids=evidence_ids,
+                evidence_classification=classification,
+                blast_radius=conflict.message,
+                remediation=DeficiencyRemediation(
+                    schema_version="deficiency_remediation.v1",
+                    remediation_template=(
+                        "Reconcile the declared status against the observed required "
+                        "work before trusting either."
+                    ),
+                    verification_condition=(
+                        "Resolves once the declared-complete/observed-work conflict "
+                        "no longer appears in the subject's actual-completion result."
+                    ),
+                ),
+                limitations=(),
+                evaluated_at=now,
+            )
+        )
+
+    status = DeficiencyCategoryStatus(
+        schema_version="deficiency_category_status.v1",
+        category=DeficiencyCategory.PLANNING_RELATIONSHIPS,
+        evaluated=True,
+        finding_count=len(findings),
+        applicability_states_observed=(
+            status_result_state_to_requirement_state(snapshot.state),
+        ),
+        limitation=_PLANNING_RELATIONSHIPS_LIMITATION,
+    )
+    return status, tuple(findings)
+
+
+# ---------------------------------------------------------------------------
+# Categories 3-6: rule-registry-driven
+# ---------------------------------------------------------------------------
+
+
+def _deficiency_from_health_rule_finding(
+    finding: HealthRuleFinding,
+    *,
+    category: DeficiencyCategory,
+    observation: DimensionObservation | None,
+    org_id: str,
+) -> DeficiencyFinding:
+    rule = HEALTH_RULE_REGISTRY.rule(finding.rule_id)
+    observed_state = (
+        observation.observed_states[0]
+        if observation is not None and observation.observed_states
+        else SourceRequirementState.AVAILABLE_CURRENT
+    )
+    coverage = (
+        observation.coverage if observation is not None else rule.minimum_coverage
+    )
+    sample_count = observation.sample_count if observation is not None else None
+    return DeficiencyFinding(
+        schema_version="deficiency_finding.v1",
+        finding_id=_mint_deficiency_finding_id(
+            org_id=org_id,
+            category=category,
+            rule_id=finding.rule_id,
+            subject_kind=finding.subject_kind.value,
+            subject_id=finding.subject_id,
+            discriminator="",
+        ),
+        category=category,
+        rule_id=finding.rule_id,
+        rule_version=finding.rule_version,
+        subject_kind=finding.subject_kind,
+        subject_id=finding.subject_id,
+        severity=DeficiencySeverity(finding.state.value),
+        fact_kind=finding.fact_kind,
+        observed_state=observed_state,
+        data_semantics="measured_zero",
+        sample_count=sample_count,
+        coverage=coverage,
+        current_window_days=rule.current_window_days,
+        comparison_window_days=rule.comparison_window_days,
+        evidence_ref_ids=(),
+        evidence_classification=DeficiencyEvidenceClassification.SOURCE_CLASS_ONLY,
+        blast_radius=(
+            f"{rule.dimension.value} for {finding.subject_kind.value} "
+            f"'{finding.subject_id}' is {finding.state.value}."
+        ),
+        remediation=DeficiencyRemediation(
+            schema_version="deficiency_remediation.v1",
+            remediation_template=rule.remediation_template,
+            verification_condition=(
+                f"Resolves once {finding.rule_id} reports healthy for "
+                f"{rule.sustained_periods_required} consecutive window(s)."
+            ),
+        ),
+        limitations=(),
+        evaluated_at=finding.evaluated_at,
+    )
+
+
+def _rule_driven_category_result(
+    category: DeficiencyCategory,
+    *,
+    launch: Sequence[HealthRuleFinding],
+    shadow: Sequence[HealthRuleFinding],
+    suppressed: Sequence[HealthRuleFinding],
+    observations_by_rule: Mapping[str, DimensionObservation],
+    org_id: str,
+    unregistered_limitation: str = _RULE_DRIVEN_UNREGISTERED_LIMITATION,
+) -> tuple[DeficiencyCategoryStatus, tuple[DeficiencyFinding, ...]]:
+    if not launch and not shadow and not suppressed:
+        return (
+            DeficiencyCategoryStatus(
+                schema_version="deficiency_category_status.v1",
+                category=category,
+                evaluated=False,
+                finding_count=0,
+                applicability_states_observed=(),
+                limitation=unregistered_limitation,
+            ),
+            (),
+        )
+    # Only HealthProfileResult.launch_findings ever becomes a deficiency --
+    # shadow_findings (calibration-only, every rule shipped today) and
+    # suppressed_findings (guardrail-suppressed) must never feed
+    # status/counts, mirroring PortfolioStatusService's own post-Codex-fix
+    # posture (03da63aeb): a caller that read from a merged bucket would
+    # treat pure calibration data as launch authority.
+    real = [f for f in launch if f.state is not DimensionState.HEALTHY]
+    deficiencies = tuple(
+        _deficiency_from_health_rule_finding(
+            f,
+            category=category,
+            observation=observations_by_rule.get(f.rule_id),
+            org_id=org_id,
+        )
+        for f in real
+    )
+    # Checks BOTH shadow and suppressed, never shadow alone (fixed after
+    # CHAOS-3304 changed health_rule_registry's own partition order to
+    # check suppressed_reason before shadow_only: a rule that is both
+    # provisional AND guardrail-suppressed -- e.g. incident_load with
+    # sample_count=0 clearing the "queried" short-circuit but failing
+    # minimum_sample -- now lands in `suppressed`, not `shadow`. A
+    # category whose only non-launch findings are all suppressed would
+    # otherwise report finding_count=0/limitation=None, indistinguishable
+    # from "genuinely nothing to disclose" when real, silenced
+    # information exists. This was previously masked in every reachable
+    # test scenario only because a SECOND bound rule for the same
+    # category happened to always stay in shadow -- a coincidence of
+    # today's specific rule set, not a structural guarantee, so it is
+    # fixed here rather than left to keep being accidentally protected.
+    #
+    # `launch` is checked FIRST and separately (Codex finding, MEDIUM,
+    # 2026-08-02, round 2): the three wordings above each say "every
+    # applicable rule" was shadow/suppressed -- literally false the
+    # moment `launch` is also non-empty (some rule DID clear calibration
+    # and every guardrail). A mixed category gets its own, honestly
+    # weaker claim ("not every rule contributed") instead.
+    if launch and (shadow or suppressed):
+        limitation = _RULE_DRIVEN_PARTIAL_LIMITATION
+    elif shadow and suppressed:
+        limitation = _RULE_DRIVEN_SHADOW_AND_SUPPRESSED_LIMITATION
+    elif shadow:
+        limitation = _RULE_DRIVEN_SHADOW_LIMITATION
+    elif suppressed:
+        limitation = _RULE_DRIVEN_SUPPRESSED_LIMITATION
+    else:
+        limitation = None
+    status = DeficiencyCategoryStatus(
+        schema_version="deficiency_category_status.v1",
+        category=category,
+        evaluated=True,
+        finding_count=len(deficiencies),
+        applicability_states_observed=(),
+        limitation=limitation,
+    )
+    return status, deficiencies
+
+
+def _rule_driven_results(
+    health_profile: HealthProfileResult,
+    *,
+    org_id: str,
+    workload_profile: HealthProfileResult | None = None,
+    workload_dependency_failed: bool = False,
+) -> tuple[tuple[DeficiencyCategoryStatus, ...], tuple[DeficiencyFinding, ...]]:
+    """Bucket every rule-driven category's launch/shadow/suppressed findings.
+
+    ``INVESTMENT_BALANCE`` (category 8) is a special case: its one bound
+    rule (``health_rule.investment_allocation_shift.v1``) is TEAM-only and
+    reads ``investment_mix``, a source ``health_profile`` never carries
+    (see ``evaluate_team``'s ``rule_engine_sources`` docstring) -- so its
+    bucket in ``health_profile`` is always empty by construction, never a
+    genuine "nothing to report". ``workload_profile`` (``_investment_
+    balance_profile``'s own ``HealthProfileResult``, TEAM subjects only) is
+    the ONLY source this function ever reads that category's bucket from;
+    when it is ``None`` the category reports an honest, scope-specific "not
+    applicable" limitation instead of the generic "unregistered" one -- a
+    rule genuinely IS registered for this dimension, it simply cannot apply
+    to a project subject. ``workload_profile`` is also ``None`` for a TEAM
+    subject whose attribution lookup failed (``evaluate_team`` skips the
+    call entirely in that case) -- the "not applicable to project" wording
+    computed here is discarded either way by ``_assemble``'s own
+    ``attribution_unavailable`` override, which is the actually-correct
+    text for that case.
+    """
+
+    def _bucket(
+        findings: Sequence[HealthRuleFinding],
+    ) -> dict[DeficiencyCategory, list[HealthRuleFinding]]:
+        by_category: dict[DeficiencyCategory, list[HealthRuleFinding]] = {
+            category: [] for category in _RULE_DRIVEN_CATEGORIES
+        }
+        for finding in findings:
+            category = _HEALTH_DIMENSION_TO_DEFICIENCY_CATEGORY[finding.dimension.value]
+            if category in by_category:
+                by_category[category].append(finding)
+        return by_category
+
+    launch_by_category = _bucket(health_profile.launch_findings)
+    shadow_by_category = _bucket(health_profile.shadow_findings)
+    suppressed_by_category = _bucket(health_profile.suppressed_findings)
+    observations_by_rule: Mapping[str, DimensionObservation] = (
+        health_profile.observations_by_rule
+    )
+
+    investment_balance_unregistered_limitation = _RULE_DRIVEN_UNREGISTERED_LIMITATION
+    if workload_profile is not None:
+        workload_launch = _bucket(workload_profile.launch_findings)
+        workload_shadow = _bucket(workload_profile.shadow_findings)
+        workload_suppressed = _bucket(workload_profile.suppressed_findings)
+        investment_findings = (
+            workload_launch[DeficiencyCategory.INVESTMENT_BALANCE]
+            + workload_shadow[DeficiencyCategory.INVESTMENT_BALANCE]
+            + workload_suppressed[DeficiencyCategory.INVESTMENT_BALANCE]
+        )
+        launch_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = workload_launch[
+            DeficiencyCategory.INVESTMENT_BALANCE
+        ]
+        shadow_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = workload_shadow[
+            DeficiencyCategory.INVESTMENT_BALANCE
+        ]
+        suppressed_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = (
+            workload_suppressed[DeficiencyCategory.INVESTMENT_BALANCE]
+        )
+        # Overlay ONLY the observation(s) behind the findings actually
+        # harvested into INVESTMENT_BALANCE's buckets above -- NEVER the
+        # whole workload_profile.observations_by_rule map (Codex finding,
+        # HIGH, round 6): synthesize_health_profile builds a synthesized-
+        # unavailable observation for EVERY OTHER TEAM-applicable rule too
+        # (the three cognitive-load ones today), keyed by their real
+        # rule_id -- a wholesale dict-merge silently overwrote the PRIMARY
+        # profile's own REAL observation for any rule bound in both
+        # profiles (e.g. the moment a shared rule like incident_load is
+        # promoted to launch), corrupting a launch finding's reported
+        # coverage/observed_state/sample_count with unrelated "not
+        # measured" noise and raising ValidationError in
+        # _deficiency_from_health_rule_finding. Keying strictly off the
+        # harvested findings' own rule_ids makes this structurally
+        # impossible: only a rule_id investment_findings actually names can
+        # ever be written here.
+        observations_by_rule = dict(health_profile.observations_by_rule)
+        for finding in investment_findings:
+            observation = workload_profile.observations_by_rule.get(finding.rule_id)
+            if observation is not None:
+                observations_by_rule[finding.rule_id] = observation
+    else:
+        # No workload profile at all -- clear whatever health_profile
+        # itself produced for this dimension (always empty in practice,
+        # since it never carries investment_mix) so this category can
+        # ONLY ever be populated through the branch above, never an
+        # accidental fallback to a source that structurally can't evaluate
+        # this rule. Three distinct reasons land here, each with its own
+        # honest wording (Codex finding, HIGH, round 5): a PROJECT subject
+        # (scope mismatch -- a rule genuinely exists, just not for this
+        # subject kind), a TEAM subject whose investment-mix dependency
+        # raised this evaluation (a real, contained outage -- see
+        # _investment_balance_profile), or a TEAM subject whose attribution
+        # lookup failed (wording irrelevant here, since _assemble's own
+        # attribution_unavailable branch unconditionally overrides
+        # whatever this function computes for every rule-driven category).
+        launch_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = []
+        shadow_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = []
+        suppressed_by_category[DeficiencyCategory.INVESTMENT_BALANCE] = []
+        investment_balance_unregistered_limitation = (
+            _INVESTMENT_BALANCE_DEPENDENCY_UNAVAILABLE_LIMITATION
+            if workload_dependency_failed
+            else _INVESTMENT_BALANCE_NOT_APPLICABLE_TO_PROJECT_LIMITATION
+        )
+
+    statuses: list[DeficiencyCategoryStatus] = []
+    all_findings: list[DeficiencyFinding] = []
+    for category in _RULE_DRIVEN_CATEGORIES:
+        unregistered_limitation = (
+            investment_balance_unregistered_limitation
+            if category is DeficiencyCategory.INVESTMENT_BALANCE
+            else _RULE_DRIVEN_UNREGISTERED_LIMITATION
+        )
+        status, findings = _rule_driven_category_result(
+            category,
+            launch=launch_by_category[category],
+            shadow=shadow_by_category[category],
+            suppressed=suppressed_by_category[category],
+            observations_by_rule=observations_by_rule,
+            org_id=org_id,
+            unregistered_limitation=unregistered_limitation,
+        )
+        statuses.append(status)
+        all_findings.extend(findings)
+    return tuple(statuses), tuple(all_findings)
+
+
+# ---------------------------------------------------------------------------
+# Category 7 & 8: not evaluated this version -- see module docstring.
+# ---------------------------------------------------------------------------
+
+
+def _unevaluated_status(
+    category: DeficiencyCategory, limitation: str
+) -> DeficiencyCategoryStatus:
+    return DeficiencyCategoryStatus(
+        schema_version="deficiency_category_status.v1",
+        category=category,
+        evaluated=False,
+        finding_count=0,
+        applicability_states_observed=(),
+        limitation=limitation,
+    )
+
+
+def _dedupe_findings(
+    findings: Sequence[DeficiencyFinding],
+) -> tuple[DeficiencyFinding, ...]:
+    """Collapse duplicate observations to one canonical finding.
+
+    Keyed by ``finding_id`` -- which is only a valid dedupe key *because*
+    ``_mint_deficiency_finding_id`` is deterministic over
+    (category, rule_id, subject, discriminator, evaluated_at): two calls
+    describing the same underlying condition always mint the identical id,
+    and two calls describing different conditions (different
+    discriminator, different rule_id, ...) never collide. See
+    ``test_chaos_3305_operational_deficiency_service.py``'s dedupe mutation
+    control, which breaks this precondition directly.
+    """
+
+    seen: dict[str, DeficiencyFinding] = {}
+    for finding in findings:
+        seen.setdefault(finding.finding_id, finding)
+    return tuple(seen.values())
+
+
+class OperationalDeficiencyService:
+    """Evaluate the ``deficiency.operational.v1`` inventory for one subject."""
+
+    def __init__(
+        self,
+        runtime: PlanExecutorRuntime,
+        attribution: TeamAttributionSource,
+        workload_source: TeamWorkloadDataSource,
+    ) -> None:
+        self._runtime = runtime
+        self._attribution = attribution
+        # NEVER composes TeamWorkloadService (Codex finding, HIGH, round 5,
+        # 2026-08-02): that service's own evaluate_workload additionally
+        # fetches status_snapshot/data_health with the RAW TEAM scope and
+        # cognitive_load/active_contributor_count -- none of which this
+        # service reads from it (only the investment_balance bucket is
+        # ever harvested, see _rule_driven_results), so composing it
+        # reintroduced the exact raw-TEAM-scope data_health widening this
+        # service's OWN category-1 fix exists to prevent, PLUS made
+        # every evaluate_team call pay for cognitive-load/contributor-count
+        # queries with no caller. Category 8 gets its own narrow,
+        # investment-only path instead -- see _investment_balance_profile.
+        self._workload_source = workload_source
+
+    async def _team_scoped_data_health(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        repository_ids: Sequence[str],
+    ) -> DataHealthResult:
+        """``data_health`` for a team's attributed repositories, batched
+        <=20 at a time (``DevScope.repositories``' own bound) and merged
+        exactly -- see the module-level batching/merge helpers above.
+
+        Sequential, never ``asyncio.gather``: ``PlanExecutorRuntime`` is
+        backed by a single request-scoped session that forbids concurrent
+        use (the same discipline ``PortfolioStatusService``'s own Codex fix
+        established, 03da63aeb) -- an arbitrarily large repository count
+        costs proportionally more round trips, never a race.
+        """
+
+        if not repository_ids:
+            return DataHealthResult(sources=(), complete_eligible=False)
+        batches = [
+            repository_ids[i : i + _MAX_REPOSITORIES_PER_SCOPE]
+            for i in range(0, len(repository_ids), _MAX_REPOSITORIES_PER_SCOPE)
+        ]
+        batch_results: list[DataHealthResult] = []
+        for batch in batches:
+            batch_scope = DevScope(
+                schema_version="dev_scope.v1",
+                organization_id=org_id,
+                direct_scope=DirectScope.REPOSITORY,
+                repositories=list(batch),
+                time_range=scope.time_range,
+                comparison_range=scope.comparison_range,
+            )
+            batch_results.append(
+                await self._runtime.data_health(
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                    scope=batch_scope,
+                )
+            )
+        merged_sources = _merge_data_health_sources(
+            [result.sources for result in batch_results],
+            batches,
+            total_repositories=len(repository_ids),
+        )
+        # Recomputed from the NORMALIZED merged sources, never trusted from
+        # each batch's own complete_eligible flag (Codex finding, HIGH,
+        # 2026-08-02): a batch that omits a source_system entirely could
+        # otherwise still report complete_eligible=True for itself (nothing
+        # in that batch's own result contradicts it), silently overriding
+        # the fail-closed placeholder _merge_data_health_sources just
+        # synthesized for exactly this case.
+        complete_eligible = all(
+            not source.required or source.state is DataHealthState.COMPLETE
+            for source in merged_sources
+        )
+        return DataHealthResult(
+            sources=merged_sources, complete_eligible=complete_eligible
+        )
+
+    async def _investment_balance_profile(
+        self,
+        *,
+        org_id: str,
+        team_id: str,
+        scope: DevScope,
+        cohort_size: int | None,
+        now: datetime,
+    ) -> HealthProfileResult | None:
+        """Category 8 (investment balance): fetch ONLY ``investment_mix``
+        from ``self._workload_source`` and evaluate ONLY the rules
+        ``synthesize_health_profile`` can reach with just that source --
+        reuses CHAOS-3304's exact adapter/rule pieces (``synthesize_health_
+        profile`` -> ``_observation_for_rule`` ->
+        ``investment_allocation_shift_observation`` ->
+        ``HEALTH_RULE_REGISTRY``'s production ``evaluate_registry`` seam),
+        never a second, hand-rolled evaluation path, and never
+        ``TeamWorkloadService``'s WHOLE service (Codex finding, HIGH, round
+        5 -- see this class's own docstring and ``evaluate_team``'s call
+        site for why).
+
+        This deliberately calls ``synthesize_health_profile`` with a
+        ``HealthEvaluationSources`` that leaves ``data_health``/
+        ``status_snapshot``/``cognitive_load`` all at their ``None``
+        defaults -- every OTHER TEAM-applicable rule (the three
+        cognitive-load ones) therefore reports an honest, harmless
+        unavailable observation in the returned profile's own
+        ``shadow_findings`` bucket, which ``_rule_driven_results`` never
+        reads from this profile (only ``DeficiencyCategory.
+        INVESTMENT_BALANCE``'s bucket is ever harvested) -- there is no
+        second source of truth to keep in sync, just an unused byproduct
+        of reusing the shared synthesis function instead of hand-rolling a
+        single-rule evaluator.
+
+        Never touches ``self._runtime`` -- ``investment_mix`` takes
+        ``team_id`` directly as a parameter (no ``DevScope`` to widen), so
+        there is no raw-TEAM-scope org-wide-fallback risk here at all,
+        unlike ``data_health``.
+
+        Returns ``None`` -- never a profile built from partial/default
+        data -- on an EXPECTED dependency failure (the workload source
+        raising or timing out): the caller (``evaluate_team``) reports an
+        honest, dedicated "dependency unavailable" status for category 8
+        rather than letting the raise propagate and lose categories 1-7
+        (Codex finding, HIGH, round 5: ``cognitive_load()`` raising
+        ``RuntimeError`` propagated out of ``evaluate_team`` in the prior
+        ``TeamWorkloadService``-composing design -- this method is the one
+        and only place category 8's dependency is called from
+        ``evaluate_team``, so containing the failure here contains it for
+        the whole inventory). Distinct from a genuinely QUERIED-but-
+        unmeasured source (the workload source returns normally with
+        ``measured=False``) -- that case still calls
+        ``synthesize_health_profile`` below and lands on the SAME honest
+        shadow/provisional path every other never-fired rule does; only an
+        actual exception short-circuits to ``None``.
+        """
+
+        current_range = scope.time_range
+        try:
+            investment_mix = await self._workload_source.investment_mix(
+                org_id=org_id,
+                team_id=team_id,
+                start=current_range.start,
+                end=current_range.end,
+            )
+            investment_mix_comparison: TeamInvestmentMixResult | None = None
+            if scope.comparison_range is not None:
+                comparison_range = scope.comparison_range
+                investment_mix_comparison = await self._workload_source.investment_mix(
+                    org_id=org_id,
+                    team_id=team_id,
+                    start=comparison_range.start,
+                    end=comparison_range.end,
+                )
+        except Exception:
+            # An expected, contained dependency failure -- never lets a
+            # raise from the investment-mix source escape into
+            # evaluate_team and lose categories 1-7 (Codex finding, HIGH,
+            # round 5). `None` is a distinct sentinel from "queried,
+            # unmeasured" -- see the docstring -- so the caller can report
+            # the dedicated dependency-outage limitation, not the generic
+            # shadow/provisional one.
+            return None
+
+        return synthesize_health_profile(
+            applicability=RuleApplicability.TEAM,
+            subject_id=team_id,
+            cohort_size=cohort_size,
+            sources=HealthEvaluationSources(
+                investment_mix=investment_mix,
+                investment_mix_comparison=investment_mix_comparison,
+                change_failure_rate_not_applicable=True,
+            ),
+            org_id=org_id,
+            observed_at=now,
+        )
+
+    async def evaluate_project(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime,
+    ) -> OperationalDeficiencyInventory:
+        if scope.direct_scope is not DirectScope.PROJECT:
+            raise ValueError(
+                "OperationalDeficiencyService requires a project direct scope"
+            )
+        # Mirrors ProjectHealthService's own post-Codex-fix identity rule
+        # (03da63aeb): project_id is never a caller-supplied label -- it is
+        # always the committed DevScope's own (validator-guaranteed unique)
+        # entity_ref, so the same scope can't be submitted under two labels
+        # to mint two "different" subjects with identical underlying data.
+        project_id = scope.entity_refs[0].entity_id
+        if scope.comparison_range is None:
+            raise ValueError(
+                "OperationalDeficiencyService requires scope.comparison_range to "
+                "be resolved for trend/comparison observations"
+            )
+
+        status_snapshot = await self._runtime.status_snapshot(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        data_health = await self._runtime.data_health(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        change_failure_rate_not_applicable = (
+            scope.direct_scope not in CHANGE_FAILURE_RATE_SUPPORTED_SCOPES
+        )
+        change_failure_rate_metric = None
+        if not change_failure_rate_not_applicable:
+            change_failure_rate_metric = await self._runtime.query_metric(
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                metric_id=MetricID.CHANGE_FAILURE_RATE,
+                scope=scope,
+            )
+        health_profile = synthesize_health_profile(
+            applicability=RuleApplicability.PROJECT,
+            subject_id=project_id,
+            cohort_size=None,
+            sources=HealthEvaluationSources(
+                data_health=data_health,
+                status_snapshot=status_snapshot,
+                change_failure_rate_metric=change_failure_rate_metric,
+                change_failure_rate_not_applicable=change_failure_rate_not_applicable,
+            ),
+            org_id=org_id,
+            observed_at=now,
+        )
+        return self._assemble(
+            org_id=org_id,
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id=project_id,
+            data_health=data_health,
+            status_snapshot=status_snapshot,
+            health_profile=health_profile,
+            now=now,
+        )
+
+    async def evaluate_team(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        team_id: str,
+        now: datetime,
+    ) -> OperationalDeficiencyInventory:
+        if scope.direct_scope is not DirectScope.TEAM:
+            raise ValueError(
+                "OperationalDeficiencyService requires a team direct scope"
+            )
+        if scope.team_ids != [team_id]:
+            raise ValueError("scope.team_ids must name exactly this team subject")
+
+        # The ONLY source of cohort_size -- verified, queried at evaluation
+        # time, never a caller-supplied assertion. Mirrors TeamHealthService's
+        # own post-Codex-fix rule (03da63aeb): a naked caller-supplied int
+        # could claim attribution a team never earned and fabricate a
+        # healthy finding for an unattributed team.
+        #
+        # Resolved as of the committed scope's OWN window end, never `now`
+        # (Codex finding, round 2, a37caf322) -- matches the exact instant
+        # TeamHealthService now resolves at and the instant the runtime's
+        # own internal team-repository lookup (status_snapshot's `as_of`
+        # default) uses. team_repo_ownership can change between the scope's
+        # own end and the moment this evaluation happens to run, so
+        # resolving at `now` would judge historical findings against
+        # attribution that did not hold at the time those findings
+        # describe. `ClickHouseStatusChangeSource.team_repository_ids`
+        # caches by the exact (org_id, team_id, as_of) key, so when this
+        # service and the wrapped runtime share one source instance the
+        # call below is a cache hit, not a second round trip.
+        attribution = await self._attribution.team_repository_ids(
+            org_id, team_id, as_of=scope.time_range.end
+        )
+        # The failure/empty distinction now rides TeamAttributionResult
+        # itself (native_status_change.TeamAttributionResult, a37caf322) --
+        # `measured=False` means the lookup failed and cohort_size is
+        # UNKNOWABLE, never a caller-visible zero; `measured=True` with an
+        # empty repository_ids is a genuine, resolved zero cohort. No
+        # try/except needed here: a raised exception from a well-formed
+        # TeamAttributionSource would be a genuine bug to surface, not a
+        # case this service papers over.
+        attribution_unavailable = not attribution.measured
+        cohort_size = len(attribution.repository_ids) if attribution.measured else None
+
+        # status_snapshot is safe to query with the raw TEAM scope directly:
+        # ClickHouseStatusChangeSource re-derives team_repo_ownership (via
+        # canonical-primary work-item attribution, CHAOS-3303 round 2)
+        # internally, so it is already team-aware and never leaks
+        # co-located-but-not-owned repository facts.
+        status_snapshot = await self._runtime.status_snapshot(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+        # data_health is NOT safe to query with the raw TEAM scope (Codex
+        # finding, HIGH, 2026-08-02): a TEAM DevScope's own entity_refs
+        # carry no repository_id, so DataHealthService/NativeDataHealthReader
+        # resolves zero explicit repositories and falls back to querying
+        # EVERY repository in the org -- cross-team disclosure plus false
+        # positive/negative category-1 findings. Category 1 is therefore
+        # NOT attribution-independent for a TEAM subject, unlike category 2
+        # (corrected from an earlier, wrong claim in this module). Fix:
+        # resolve explicit DirectScope.REPOSITORY scope(s) from the SAME
+        # attribution snapshot used for cohort_size, batched <=20 at a time
+        # (Codex finding, HIGH, 2026-08-02: DevScope.repositories caps at
+        # 20 -- a naive single call for a >20-repository team raised
+        # ValidationError and lost the ENTIRE inventory, not just category
+        # 1) and merged exactly -- never the raw TEAM scope, never a silent
+        # truncation to the first batch, and never queried at all when
+        # attribution did not measure a real, non-empty repository set
+        # (that case reports category 1 as never-queried, matching
+        # ``_data_integration_result``'s own empty-sources branch, exactly
+        # as an org-wide fallback must never stand in for "unmeasured").
+        data_health = await self._team_scoped_data_health(
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            scope=scope,
+            repository_ids=attribution.repository_ids if attribution.measured else (),
+        )
+
+        # Unlike TeamHealthService (which has nothing else to report and
+        # skips the runtime entirely on attribution failure), this service
+        # still reports category 2 (planning & relationships) from
+        # status_snapshot above regardless of attribution outcome -- it is
+        # genuinely independent of team cohort attribution. Category 1 now
+        # already reflects attribution honestly (real, team-scoped
+        # data_health when attribution measured a non-empty cohort; never-
+        # queried otherwise), so no further branching is needed for it
+        # here. Only the rule-driven categories (3-6), which take
+        # cohort_size as an input to CHAOS-3302's rule engine, need the
+        # unmeasured treatment: on attribution failure they are synthesized
+        # from EMPTY sources (mirroring TeamHealthService's own fix
+        # exactly) rather than the real, already-fetched ones -- feeding
+        # real facts through with cohort_size=None would still let
+        # `evaluate_rule`'s cohort guard suppress them as the misleading
+        # "insufficient_cohort" (a claim that attribution was checked and
+        # found too small), since that guard runs after the observation is
+        # already considered "measured". Empty sources short-circuit
+        # through `_observation_for_rule`'s "sources is None" branch
+        # instead, landing on the honest not-measured/unavailable path
+        # before the cohort guard is ever reached.
+        rule_engine_sources = (
+            HealthEvaluationSources(change_failure_rate_not_applicable=True)
+            if attribution_unavailable
+            else HealthEvaluationSources(
+                data_health=data_health,
+                status_snapshot=status_snapshot,
+                change_failure_rate_metric=None,
+                change_failure_rate_not_applicable=True,
+            )
+        )
+        health_profile = synthesize_health_profile(
+            applicability=RuleApplicability.TEAM,
+            subject_id=team_id,
+            cohort_size=cohort_size,
+            sources=rule_engine_sources,
+            org_id=org_id,
+            observed_at=now,
+        )
+        # Category 8 (investment balance): an INVESTMENT-ONLY path -- see
+        # _investment_balance_profile -- never TeamWorkloadService's full
+        # evaluate_workload (Codex finding, HIGH, round 5: that made its
+        # own extra status_snapshot/data_health calls against the raw TEAM
+        # scope, reintroducing the exact org-wide-widening bug category 1's
+        # own fix above exists to prevent). Skipped entirely when
+        # attribution is unmeasured -- already-resolved `attribution` is
+        # reused directly rather than re-resolved a second time, and
+        # `_assemble`'s own attribution_unavailable branch uniformly
+        # overrides every rule-driven category's status (now including
+        # this one) with the honest "cohort could not be verified"
+        # limitation regardless, so there is nothing this call could add
+        # in that case.
+        workload_profile = (
+            None
+            if attribution_unavailable
+            else await self._investment_balance_profile(
+                org_id=org_id,
+                team_id=team_id,
+                scope=scope,
+                cohort_size=cohort_size,
+                now=now,
+            )
+        )
+        # Distinguishes "no profile because attribution never resolved"
+        # (wording irrelevant -- _assemble's own override wins regardless)
+        # from "no profile because the investment-mix dependency itself
+        # failed" (Codex finding, HIGH, round 5) -- the ONLY case that
+        # needs the dedicated dependency-outage limitation text.
+        workload_dependency_failed = (
+            not attribution_unavailable and workload_profile is None
+        )
+        return self._assemble(
+            org_id=org_id,
+            subject_kind=RuleApplicability.TEAM,
+            subject_id=team_id,
+            data_health=data_health,
+            status_snapshot=status_snapshot,
+            health_profile=health_profile,
+            now=now,
+            attribution_unavailable=attribution_unavailable,
+            workload_profile=workload_profile,
+            workload_dependency_failed=workload_dependency_failed,
+        )
+
+    def _assemble(
+        self,
+        *,
+        org_id: str,
+        subject_kind: RuleApplicability,
+        subject_id: str,
+        data_health: DataHealthResult,
+        status_snapshot: StatusSnapshotResult,
+        health_profile: HealthProfileResult,
+        now: datetime,
+        attribution_unavailable: bool = False,
+        workload_profile: HealthProfileResult | None = None,
+        workload_dependency_failed: bool = False,
+    ) -> OperationalDeficiencyInventory:
+        data_status, data_findings = _data_integration_result(
+            data_health,
+            org_id=org_id,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            now=now,
+        )
+        planning_status, planning_findings = _planning_relationships_result(
+            status_snapshot,
+            org_id=org_id,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            now=now,
+        )
+        rule_statuses, rule_findings = _rule_driven_results(
+            health_profile,
+            org_id=org_id,
+            workload_profile=workload_profile,
+            workload_dependency_failed=workload_dependency_failed,
+        )
+        if attribution_unavailable:
+            # Categories 1 (data & integration) and 2 (planning &
+            # relationships) are computed from data_health/status_snapshot,
+            # which are queried directly against `scope` -- independent of
+            # team cohort attribution -- so they are unaffected. Only the
+            # rule-driven categories consume cohort_size, and a failed
+            # attribution lookup means whatever they computed (with
+            # cohort_size=None, indistinguishable at the rule-engine layer
+            # from a genuine empty cohort) must not be presented as if
+            # attribution had actually been checked.
+            rule_statuses = tuple(
+                _unevaluated_status(
+                    status.category, _TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION
+                )
+                for status in rule_statuses
+            )
+            rule_findings = ()
+
+        all_statuses = (
+            data_status,
+            planning_status,
+            # rule_statuses now includes INVESTMENT_BALANCE (category 8) --
+            # see _RULE_DRIVEN_CATEGORIES and _rule_driven_results.
+            *rule_statuses,
+            _unevaluated_status(
+                DeficiencyCategory.CAPACITY_COGNITIVE_LOAD, _CAPACITY_LIMITATION
+            ),
+        )
+        all_findings = _dedupe_findings(
+            (*data_findings, *planning_findings, *rule_findings)
+        )
+        ordered_findings = tuple(sorted(all_findings, key=finding_sort_key))
+
+        return OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id=_mint_inventory_id(
+                org_id=org_id,
+                subject_kind=subject_kind.value,
+                subject_id=subject_id,
+                evaluated_at=now,
+            ),
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            findings=ordered_findings,
+            category_statuses=all_statuses,
+            evaluated_at=now,
+        )

--- a/tests/api/dev/test_chaos_3305_deficiency_contracts.py
+++ b/tests/api/dev/test_chaos_3305_deficiency_contracts.py
@@ -1,0 +1,752 @@
+"""Tests for CHAOS-3305's ``deficiency.operational.v1`` wire contracts.
+
+Covers the type-level guardrails ``contracts_v2/deficiency.py`` enforces:
+``data_semantics`` must agree with ``observed_state`` (queried vs.
+unmeasured, mirroring ``DimensionObservation``), every finding carries
+evidence or an explicit no-evidence classification (F10, re-checked at the
+inventory containment boundary too), category coverage is exactly the
+closed eight-category taxonomy, category-declared finding counts and
+finding subjects must reconcile against the findings actually present, and
+findings are both duplicate-free and deterministically ordered.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
+from dev_health_ops.api.dev.contracts_v2.deficiency import (
+    DEFICIENCY_CATEGORIES,
+    DeficiencyCategory,
+    DeficiencyCategoryStatus,
+    DeficiencyEvidenceClassification,
+    DeficiencyFinding,
+    DeficiencyRemediation,
+    DeficiencySeverity,
+    OperationalDeficiencyInventory,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import RuleApplicability
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _remediation() -> DeficiencyRemediation:
+    return DeficiencyRemediation(
+        schema_version="deficiency_remediation.v1",
+        remediation_template="Investigate.",
+        verification_condition="Resolves once re-evaluated healthy.",
+    )
+
+
+def _finding(
+    *,
+    finding_id: str = "11111111-1111-1111-1111-111111111111",
+    category: DeficiencyCategory = DeficiencyCategory.DATA_INTEGRATION,
+    severity: DeficiencySeverity = DeficiencySeverity.CRITICAL,
+    subject_id: str = "proj-1",
+    observed_state: SourceRequirementState = SourceRequirementState.UNCONFIGURED,
+    data_semantics: str = "not_measured",
+    evidence_ref_ids: tuple[str, ...] = (),
+    evidence_classification: DeficiencyEvidenceClassification | None = (
+        DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE
+    ),
+) -> DeficiencyFinding:
+    return DeficiencyFinding(
+        schema_version="deficiency_finding.v1",
+        finding_id=finding_id,
+        category=category,
+        rule_id="deficiency_rule.unconfigured_required_source.v1",
+        rule_version="deficiency_rule.unconfigured_required_source.v1",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id=subject_id,
+        severity=severity,
+        fact_kind="observed",
+        observed_state=observed_state,
+        data_semantics=data_semantics,
+        sample_count=None,
+        coverage=0.0,
+        current_window_days=1,
+        comparison_window_days=None,
+        evidence_ref_ids=evidence_ref_ids,
+        evidence_classification=evidence_classification,
+        blast_radius="Required source is unconfigured.",
+        remediation=_remediation(),
+        limitations=(),
+        evaluated_at=_NOW,
+    )
+
+
+def _all_category_statuses(
+    *, finding_counts: dict[DeficiencyCategory, int] | None = None
+) -> tuple[DeficiencyCategoryStatus, ...]:
+    finding_counts = finding_counts or {}
+    return tuple(
+        DeficiencyCategoryStatus(
+            schema_version="deficiency_category_status.v1",
+            category=category,
+            evaluated=True,
+            finding_count=finding_counts.get(category, 0),
+            applicability_states_observed=(),
+            limitation=None,
+        )
+        for category in DEFICIENCY_CATEGORIES
+    )
+
+
+def test_deficiency_finding_unmeasured_state_rejects_measured_zero() -> None:
+    """An unconfigured/unavailable/unauthorized source is itself the
+    deficiency -- it cannot also claim a measured, checked zero.
+    """
+
+    with pytest.raises(
+        ValidationError, match="must report data_semantics='not_measured'"
+    ):
+        _finding(
+            observed_state=SourceRequirementState.UNCONFIGURED,
+            data_semantics="measured_zero",
+        )
+
+
+def test_deficiency_finding_unmeasured_state_accepts_not_measured() -> None:
+    finding = _finding(
+        observed_state=SourceRequirementState.UNAVAILABLE,
+        data_semantics="not_measured",
+    )
+    assert finding.data_semantics == "not_measured"
+
+
+def test_deficiency_finding_queried_state_rejects_not_measured() -> None:
+    """A stale-but-queried source was genuinely checked -- it cannot claim
+    it was never measured.
+    """
+
+    with pytest.raises(ValidationError, match="queried observed_state"):
+        _finding(
+            observed_state=SourceRequirementState.AVAILABLE_STALE,
+            data_semantics="not_measured",
+        )
+
+
+def test_deficiency_finding_queried_state_accepts_measured_zero() -> None:
+    finding = _finding(
+        observed_state=SourceRequirementState.AVAILABLE_STALE,
+        data_semantics="measured_zero",
+    )
+    assert finding.data_semantics == "measured_zero"
+
+
+def test_deficiency_finding_requires_evidence_or_classification() -> None:
+    with pytest.raises(ValidationError, match="evidence_ref_ids or an explicit"):
+        _finding(evidence_ref_ids=(), evidence_classification=None)
+
+
+def test_deficiency_finding_rejects_evidence_and_classification_together() -> None:
+    with pytest.raises(ValidationError, match="must not also carry"):
+        _finding(
+            evidence_ref_ids=("evidence-1",),
+            evidence_classification=DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE,
+        )
+
+
+def test_deficiency_finding_accepts_evidence_alone() -> None:
+    finding = _finding(evidence_ref_ids=("evidence-1",), evidence_classification=None)
+    assert finding.evidence_ref_ids == ("evidence-1",)
+
+
+def test_deficiency_finding_accepts_classification_alone() -> None:
+    finding = _finding()
+    assert (
+        finding.evidence_classification
+        is DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE
+    )
+
+
+def test_category_status_unevaluated_requires_limitation() -> None:
+    with pytest.raises(ValidationError, match="requires a bounded limitation"):
+        DeficiencyCategoryStatus(
+            schema_version="deficiency_category_status.v1",
+            category=DeficiencyCategory.INVESTMENT_BALANCE,
+            evaluated=False,
+            finding_count=0,
+            applicability_states_observed=(),
+            limitation=None,
+        )
+
+
+def test_category_status_unevaluated_cannot_report_findings() -> None:
+    with pytest.raises(ValidationError, match="cannot report findings"):
+        DeficiencyCategoryStatus(
+            schema_version="deficiency_category_status.v1",
+            category=DeficiencyCategory.INVESTMENT_BALANCE,
+            evaluated=False,
+            finding_count=1,
+            applicability_states_observed=(),
+            limitation="not evaluated",
+        )
+
+
+def test_inventory_requires_exactly_eight_categories() -> None:
+    incomplete_statuses = _all_category_statuses()[:-1]
+    with pytest.raises(ValidationError):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(),
+            category_statuses=incomplete_statuses,
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_duplicate_category() -> None:
+    statuses = _all_category_statuses()
+    duplicated = (*statuses[:-1], statuses[0])
+    with pytest.raises(ValidationError, match="must not repeat a category"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(),
+            category_statuses=duplicated,
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_duplicate_finding_ids() -> None:
+    duplicate_id = "33333333-3333-3333-3333-333333333333"
+    findings = (
+        _finding(finding_id=duplicate_id, severity=DeficiencySeverity.CRITICAL),
+        _finding(finding_id=duplicate_id, severity=DeficiencySeverity.WATCH),
+    )
+    with pytest.raises(ValidationError, match="must not repeat a finding_id"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=findings,
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 2}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_unordered_findings() -> None:
+    watch = _finding(
+        finding_id="44444444-4444-4444-4444-444444444444",
+        severity=DeficiencySeverity.WATCH,
+    )
+    critical = _finding(
+        finding_id="55555555-5555-5555-5555-555555555555",
+        severity=DeficiencySeverity.CRITICAL,
+    )
+    with pytest.raises(ValidationError, match="worst-severity-first"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(watch, critical),
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 2}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_accepts_correctly_ordered_findings() -> None:
+    critical = _finding(
+        finding_id="55555555-5555-5555-5555-555555555555",
+        severity=DeficiencySeverity.CRITICAL,
+    )
+    watch = _finding(
+        finding_id="44444444-4444-4444-4444-444444444444",
+        severity=DeficiencySeverity.WATCH,
+    )
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(critical, watch),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 2}
+        ),
+        evaluated_at=_NOW,
+    )
+    assert [f.finding_id for f in inventory.findings] == [
+        critical.finding_id,
+        watch.finding_id,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Count/subject reconciliation and F10 containment (Codex findings 5 & 6,
+# 2026-08-02). Both codex repros reproduced as permanent RED-then-GREEN
+# regressions.
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_rejects_category_count_understated_against_real_findings() -> None:
+    """Codex repro: finding_count=0 declared for a category that a real
+    finding is actually present for.
+    """
+
+    finding = _finding(finding_id="77777777-7777-7777-7777-777777777777")
+    with pytest.raises(ValidationError, match="finding_count"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(finding,),
+            category_statuses=_all_category_statuses(),  # every count 0
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_category_count_overstated_against_real_findings() -> None:
+    """The converse repro: a declared count with no matching finding present."""
+
+    with pytest.raises(ValidationError, match="finding_count"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(),
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_finding_from_a_different_subject() -> None:
+    """Codex repro: an `other-project` finding embedded in `proj-1`'s inventory."""
+
+    foreign_finding = _finding(
+        finding_id="88888888-8888-8888-8888-888888888888",
+        subject_id="other-project",
+    )
+    with pytest.raises(ValidationError, match="different subject"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(foreign_finding,),
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_model_copy_forged_finding_missing_evidence() -> None:
+    """Codex repro: ``model_copy(update={"evidence_classification": None})``
+    on a finding whose ``evidence_ref_ids`` was already empty produces a
+    finding satisfying neither side of F10, entirely bypassing
+    ``DeficiencyFinding``'s own validator (``model_copy`` never runs
+    validators, by pydantic's own design).
+
+    Empirically (this pydantic version/config), placing that forged
+    instance into ``findings=`` on a *normally constructed*
+    ``OperationalDeficiencyInventory`` still gets caught -- because
+    pydantic revalidates the nested model instance on outer construction,
+    so ``DeficiencyFinding.validate_evidence_or_classification`` fires
+    again and raises first, before this module's own
+    ``validate_findings_satisfy_evidence_discipline`` gets a turn. That
+    nested-revalidation behavior is a pydantic *default*, not a contract
+    guarantee this repo owns or has pinned anywhere -- which is exactly
+    why the inventory-level check exists as an explicit, second,
+    config-independent guarantee. See
+    ``test_inventory_level_f10_check_is_independently_correct`` below for
+    a direct proof of that second check in isolation, not merely "some
+    validator fired first".
+    """
+
+    valid_finding = _finding(finding_id="99999999-9999-9999-9999-999999999999")
+    forged = valid_finding.model_copy(update={"evidence_classification": None})
+    assert forged.evidence_ref_ids == ()
+    assert forged.evidence_classification is None  # bypassed validation entirely
+
+    with pytest.raises(ValidationError, match="requires either evidence_ref_ids"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(forged,),
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_rejects_model_copy_forged_finding_with_both_evidence_fields() -> (
+    None
+):
+    """The other F10 half: a finding carrying both evidence_ref_ids and an
+    evidence_classification, also only reachable by bypassing
+    ``DeficiencyFinding``'s own validator via ``model_copy``. Same
+    nested-revalidation caveat as the test above.
+    """
+
+    valid_finding = _finding(
+        finding_id="10101010-1010-1010-1010-101010101010",
+        evidence_ref_ids=("evidence-1",),
+        evidence_classification=None,
+    )
+    forged = valid_finding.model_copy(
+        update={
+            "evidence_classification": DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE
+        }
+    )
+    assert forged.evidence_ref_ids == ("evidence-1",)
+    assert forged.evidence_classification is not None
+
+    with pytest.raises(ValidationError, match="must not also carry"):
+        OperationalDeficiencyInventory(
+            schema_version="deficiency_operational_inventory.v1",
+            inventory_id="22222222-2222-2222-2222-222222222222",
+            subject_kind=RuleApplicability.PROJECT,
+            subject_id="proj-1",
+            findings=(forged,),
+            category_statuses=_all_category_statuses(
+                finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+            ),
+            evaluated_at=_NOW,
+        )
+
+
+def test_inventory_level_f10_check_is_independently_correct() -> None:
+    """Direct proof that ``validate_findings_satisfy_evidence_discipline``
+    itself is correct and reachable, independent of whether pydantic's
+    nested-model revalidation happens to also catch a forged finding
+    first (see the two tests above). Builds the inventory via
+    ``model_construct`` (skips every validator, including this one, the
+    same way a forged *inventory* would) and then invokes the method
+    directly -- proving the check's own logic, not an accident of
+    validator ordering.
+    """
+
+    valid_finding = _finding(finding_id="12121212-1212-1212-1212-121212121212")
+    forged = valid_finding.model_copy(update={"evidence_classification": None})
+    inventory = OperationalDeficiencyInventory.model_construct(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(forged,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    with pytest.raises(ValueError, match="violates F10"):
+        inventory.validate_findings_satisfy_evidence_discipline()  # type: ignore[operator]
+
+    # Mutation control: a genuinely valid finding must NOT trip this check.
+    valid_inventory = OperationalDeficiencyInventory.model_construct(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(valid_finding,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    valid_inventory.validate_findings_satisfy_evidence_discipline()  # type: ignore[operator]  # does not raise
+
+
+# ---------------------------------------------------------------------------
+# Codex round 2 (2026-08-02), 3 CONFIRMED findings.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_semantics_totality_covers_every_source_requirement_state() -> None:
+    """The import-time totality assertion itself: every
+    ``SourceRequirementState`` member must fall into exactly one of
+    ``_QUERIED_OBSERVED_STATES``/``_UNMEASURED_OBSERVED_STATES``. This
+    re-derives the same check the module performs at import time, so a
+    future member silently dropped from both sets fails here too, not
+    only via the (harder to attribute) RuntimeError at import.
+    """
+
+    from dev_health_ops.api.dev.contracts_v2 import deficiency as deficiency_module
+
+    queried = deficiency_module._QUERIED_OBSERVED_STATES
+    unmeasured = deficiency_module._UNMEASURED_OBSERVED_STATES
+    assert not (queried & unmeasured)
+    assert (queried | unmeasured) == set(SourceRequirementState)
+
+
+def test_deficiency_finding_unmeasured_state_rejects_no_data() -> None:
+    """Codex finding, round 2: the round-1 fix only rejected measured_zero
+    in the unmeasured branch, leaving no_data unrejected -- an
+    unconfigured source is not the same fact as a queried source that
+    came back empty.
+    """
+
+    with pytest.raises(
+        ValidationError, match="must report data_semantics='not_measured'"
+    ):
+        _finding(
+            observed_state=SourceRequirementState.UNCONFIGURED,
+            data_semantics="no_data",
+        )
+
+
+@pytest.mark.parametrize(
+    "observed_state",
+    [
+        SourceRequirementState.UNCONFIGURED,
+        SourceRequirementState.UNAVAILABLE,
+        SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE,
+        SourceRequirementState.NOT_APPLICABLE,
+        SourceRequirementState.TRUNCATED,
+    ],
+)
+def test_deficiency_finding_every_unmeasured_state_rejects_both_queried_semantics(
+    observed_state: SourceRequirementState,
+) -> None:
+    """Exhaustive over every unmeasured state, not just UNCONFIGURED --
+    catches a partial fix that only handles the one state a hand-written
+    test happens to exercise.
+    """
+
+    for bad_semantics in ("measured_zero", "no_data"):
+        with pytest.raises(ValidationError):
+            _finding(observed_state=observed_state, data_semantics=bad_semantics)
+    # The one correct spelling still validates.
+    finding = _finding(observed_state=observed_state, data_semantics="not_measured")
+    assert finding.data_semantics == "not_measured"
+
+
+def test_deficiency_finding_available_unknown_is_a_queried_state() -> None:
+    """AVAILABLE_UNKNOWN specifically named in the round-2 ask -- a future
+    enum addition or a totality-check regression must not silently
+    exclude it from the queried partition.
+    """
+
+    finding = _finding(
+        observed_state=SourceRequirementState.AVAILABLE_UNKNOWN,
+        data_semantics="measured_zero",
+    )
+    assert finding.data_semantics == "measured_zero"
+    with pytest.raises(ValidationError, match="never not_measured"):
+        _finding(
+            observed_state=SourceRequirementState.AVAILABLE_UNKNOWN,
+            data_semantics="not_measured",
+        )
+
+
+def test_inventory_model_copy_revalidates_and_rejects_count_desync() -> None:
+    """Codex repro: ``model_copy(update={"findings": ()})`` on a valid
+    inventory left ``category_statuses`` claiming the old finding count --
+    pydantic's base ``model_copy`` never reruns validators. Mirrors
+    ``DevScope.model_copy``'s own fix.
+    """
+
+    finding = _finding(finding_id="20202020-2020-2020-2020-202020202020")
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(finding,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    with pytest.raises(ValidationError, match="finding_count"):
+        inventory.model_copy(update={"findings": ()})
+
+
+def test_inventory_model_copy_rejects_foreign_subject_injection() -> None:
+    foreign_finding = _finding(
+        finding_id="30303030-3030-3030-3030-303030303030",
+        subject_id="other-project",
+    )
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(),
+        category_statuses=_all_category_statuses(),
+        evaluated_at=_NOW,
+    )
+    with pytest.raises(ValidationError, match="different subject"):
+        inventory.model_copy(
+            update={
+                "findings": (foreign_finding,),
+                "category_statuses": _all_category_statuses(
+                    finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+                ),
+            }
+        )
+
+
+def test_inventory_model_copy_rejects_unordered_findings_injection() -> None:
+    watch = _finding(
+        finding_id="40404040-4040-4040-4040-404040404040",
+        severity=DeficiencySeverity.WATCH,
+    )
+    critical = _finding(
+        finding_id="50505050-5050-5050-5050-505050505050",
+        severity=DeficiencySeverity.CRITICAL,
+    )
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(critical, watch),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 2}
+        ),
+        evaluated_at=_NOW,
+    )
+    with pytest.raises(ValidationError, match="worst-severity-first"):
+        inventory.model_copy(update={"findings": (watch, critical)})
+
+
+def test_inventory_model_copy_rejects_duplicate_finding_ids_injection() -> None:
+    duplicate_id = "60606060-6060-6060-6060-606060606060"
+    finding_a = _finding(finding_id=duplicate_id, severity=DeficiencySeverity.CRITICAL)
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(finding_a,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    finding_b = _finding(finding_id=duplicate_id, severity=DeficiencySeverity.WATCH)
+    with pytest.raises(ValidationError, match="must not repeat a finding_id"):
+        inventory.model_copy(
+            update={
+                "findings": (finding_a, finding_b),
+                "category_statuses": _all_category_statuses(
+                    finding_counts={DeficiencyCategory.DATA_INTEGRATION: 2}
+                ),
+            }
+        )
+
+
+def test_inventory_model_copy_rejects_f10_forged_finding_injection() -> None:
+    valid_finding = _finding(finding_id="70707070-7070-7070-7070-707070707070")
+    forged = valid_finding.model_copy(update={"evidence_classification": None})
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(),
+        category_statuses=_all_category_statuses(),
+        evaluated_at=_NOW,
+    )
+    with pytest.raises(ValidationError):
+        inventory.model_copy(
+            update={
+                "findings": (forged,),
+                "category_statuses": _all_category_statuses(
+                    finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+                ),
+            }
+        )
+
+
+def test_inventory_model_copy_accepts_a_genuinely_valid_update() -> None:
+    """Mutation control / positive path: a legitimate metadata-only update
+    must still succeed -- the revalidating override must not become an
+    unconditional rejection.
+    """
+
+    finding = _finding(finding_id="80808080-8080-8080-8080-808080808080")
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(finding,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    later = _NOW + timedelta(hours=1)
+    updated = inventory.model_copy(update={"evaluated_at": later})
+    assert updated.evaluated_at == later
+    assert updated.findings == inventory.findings
+
+
+# ---------------------------------------------------------------------------
+# Codex round 3 (2026-08-02): closed-family subclassing prohibition.
+# ---------------------------------------------------------------------------
+
+
+def test_deficiency_finding_cannot_be_subclassed() -> None:
+    """Ratified decision: DeficiencyFinding is a closed wire-contract
+    family. Codex's own repro class (a runtime subtype losing its
+    identity through model_copy's revalidating round-trip, a PrivateAttr
+    reset, a computed-field subclass raising) is dead by construction --
+    this test proves the construction itself is impossible, not merely
+    that the round-trip happens to handle it.
+    """
+
+    with pytest.raises(TypeError, match="may not subclass DeficiencyFinding"):
+
+        class EvilFinding(DeficiencyFinding):  # type: ignore[misc]
+            pass
+
+
+def test_operational_deficiency_inventory_cannot_be_subclassed() -> None:
+    with pytest.raises(
+        TypeError, match="may not subclass OperationalDeficiencyInventory"
+    ):
+
+        class EvilInventory(OperationalDeficiencyInventory):  # type: ignore[misc]
+            pass
+
+
+def test_inventory_model_copy_deep_false_still_revalidates_by_value() -> None:
+    """Documented consequence of the round-trip-through-model_validate
+    design (see the class docstring): ``deep=False`` does not skip
+    rebuilding nested models, because the round-trip always reconstructs
+    the whole tree from ``model_dump()``. Callers must compare by value,
+    never by nested-object identity -- this test asserts exactly that
+    boundary rather than leaving it as an unverified docstring claim.
+    """
+
+    finding = _finding(finding_id="90909090-9090-9090-9090-909090909090")
+    inventory = OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="22222222-2222-2222-2222-222222222222",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(finding,),
+        category_statuses=_all_category_statuses(
+            finding_counts={DeficiencyCategory.DATA_INTEGRATION: 1}
+        ),
+        evaluated_at=_NOW,
+    )
+    copied = inventory.model_copy(deep=False)
+    assert copied == inventory  # value-equal
+    assert copied.findings[0] is not inventory.findings[0]  # never identity-preserving

--- a/tests/api/dev/test_chaos_3305_operational_deficiency_service.py
+++ b/tests/api/dev/test_chaos_3305_operational_deficiency_service.py
@@ -1,0 +1,2404 @@
+"""Tests for CHAOS-3305's ``OperationalDeficiencyService``.
+
+A fake ``PlanExecutorRuntime`` double stands in for the exact seam
+CHAOS-3295 built and ``production_runtime.py`` already wires -- mirrors
+``test_chaos_3303_project_health_service.py``'s own fixture pattern, so
+this service is proven against the same canonical contract, not a second
+bespoke query path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
+from dev_health_ops.api.dev.contracts_v2.deficiency import (
+    DEFICIENCY_CATEGORIES,
+    DeficiencyCategory,
+    DeficiencyEvidenceClassification,
+    DeficiencyFinding,
+    DeficiencyRemediation,
+    DeficiencySeverity,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import (
+    CalibrationState,
+    DimensionObservation,
+    DimensionState,
+    HealthDimension,
+    HealthRuleFinding,
+    RuleApplicability,
+)
+from dev_health_ops.api.dev.data_health_service import (
+    NATIVE_EVIDENCE_SOURCES,
+    DataHealthResult,
+    DataHealthSource,
+    DataHealthState,
+)
+from dev_health_ops.api.dev.health_profile_synthesis import HealthProfileResult
+from dev_health_ops.api.dev.metrics.definitions import get_metric
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+)
+from dev_health_ops.api.dev.native_status_change import TeamAttributionResult
+from dev_health_ops.api.dev.native_team_workload import (
+    TeamCognitiveLoadResult,
+    TeamInvestmentMixResult,
+)
+from dev_health_ops.api.dev.operational_deficiency_service import (
+    _INVESTMENT_BALANCE_NOT_APPLICABLE_TO_PROJECT_LIMITATION,
+    _RULE_DRIVEN_PARTIAL_LIMITATION,
+    _RULE_DRIVEN_SHADOW_AND_SUPPRESSED_LIMITATION,
+    _RULE_DRIVEN_SHADOW_LIMITATION,
+    _RULE_DRIVEN_SUPPRESSED_LIMITATION,
+    _TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION,
+    OperationalDeficiencyService,
+    _dedupe_findings,
+    _merge_data_health_sources,
+    _mint_deficiency_finding_id,
+    _rule_driven_category_result,
+    _rule_driven_results,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    CompletionState,
+    ConflictSeverity,
+    StatusConflict,
+    StatusFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+_ORG_ID = "org-1"
+
+
+def _project_scope(*, with_comparison: bool = True) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.PROJECT,
+                entity_id="proj-1",
+                display_label="Project 1",
+            )
+        ],
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+        comparison_range=(
+            DevTimeRange(
+                start=_NOW - timedelta(days=28),
+                end=_NOW - timedelta(days=14),
+                timezone="UTC",
+            )
+            if with_comparison
+            else None
+        ),
+    )
+
+
+def _team_scope(
+    *, end: datetime | None = None, with_comparison: bool = False
+) -> DevScope:
+    resolved_end = end or _NOW
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.TEAM,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM, entity_id="team-1", display_label="Team 1"
+            )
+        ],
+        team_ids=["team-1"],
+        time_range=DevTimeRange(
+            start=resolved_end - timedelta(days=14), end=resolved_end, timezone="UTC"
+        ),
+        comparison_range=(
+            DevTimeRange(
+                start=resolved_end - timedelta(days=28),
+                end=resolved_end - timedelta(days=14),
+                timezone="UTC",
+            )
+            if with_comparison
+            else None
+        ),
+    )
+
+
+def _actual_completion(
+    *,
+    reason_codes: tuple[str, ...] = (),
+    required_children: tuple[StatusFact, ...] = (),
+    conflicts: tuple[StatusConflict, ...] = (),
+) -> ActualCompletion:
+    return ActualCompletion(
+        state=CompletionState.NOT_READY if reason_codes else CompletionState.READY,
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=reason_codes,
+        required_children=required_children,
+        conflicts=conflicts,
+        source_ref_ids=(),
+        evidence_ref_ids=(),
+    )
+
+
+def _snapshot(
+    *,
+    state: StatusResultState = StatusResultState.COMPLETE,
+    actual: ActualCompletion | None = None,
+    blockers: tuple[StatusFact, ...] = (),
+) -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=state,
+        scope=None,  # type: ignore[arg-type]
+        as_of=_NOW,
+        declared=None,
+        actual=actual or _actual_completion(),
+        children=(),
+        blockers=blockers,
+        pull_requests=(),
+        ci=(),
+        deployments=(),
+        incidents=(),
+        source_refs=(),
+        warnings=(),
+    )
+
+
+def _data_health(sources: tuple[DataHealthSource, ...] = ()) -> DataHealthResult:
+    complete_eligible = all(
+        not s.required or s.state is DataHealthState.COMPLETE for s in sources
+    )
+    return DataHealthResult(sources=sources, complete_eligible=complete_eligible)
+
+
+def _source(
+    system: str, state: DataHealthState, *, required: bool = True, coverage: float = 1.0
+) -> DataHealthSource:
+    return DataHealthSource(
+        source_system=system,
+        state=state,
+        required=required,
+        last_successful_at=_NOW,
+        watermark=_NOW,
+        missing_repository_ids=(),
+        missing_entity_ids=(),
+        coverage=coverage,
+        confidence_impact=None,
+        freshness_policy_version="v1",
+    )
+
+
+def _metric_result() -> MetricQueryResult:
+    return MetricQueryResult(
+        definition=get_metric(MetricID.CHANGE_FAILURE_RATE),
+        state=MetricDataState.ZERO,
+        freshness=FreshnessState.FRESH,
+        values=(
+            MetricQueryValue(dimensions=(), value=0.0, comparison_value=0.0, series=()),
+        ),
+        coverage=1.0,
+        current_window_start=_NOW,
+        current_window_end=_NOW,
+        comparison_window_start=_NOW,
+        comparison_window_end=_NOW,
+        watermark=_NOW,
+        source_refs=(),
+    )
+
+
+@dataclass
+class FakeRuntime:
+    data_health_result: DataHealthResult
+    status_snapshot_result: StatusSnapshotResult
+    data_health_scopes: list[DevScope] = field(default_factory=list)
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return self.status_snapshot_result
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        return _metric_result()
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        self.data_health_scopes.append(scope)
+        return self.data_health_result
+
+
+def _runtime(
+    *,
+    sources: tuple[DataHealthSource, ...] = (),
+    snapshot: StatusSnapshotResult | None = None,
+) -> FakeRuntime:
+    return FakeRuntime(
+        data_health_result=_data_health(sources),
+        status_snapshot_result=snapshot or _snapshot(),
+    )
+
+
+@dataclass
+class FakeAttributionSource:
+    """A configurable ``TeamAttributionSource`` double -- mirrors
+    ``test_chaos_3303_team_health_service.py``'s own fixture exactly
+    (a37caf322): ``measured=False`` simulates a genuine lookup failure,
+    distinct from a measured-empty cohort. ``repository_ids`` is the only
+    thing that determines ``cohort_size`` when ``measured=True``.
+    """
+
+    repository_ids: tuple[str, ...] = ()
+    measured: bool = True
+    calls: list[tuple[str, str, datetime]] = field(default_factory=list)
+
+    async def team_repository_ids(
+        self, org_id: str, team_id: str, *, as_of: datetime
+    ) -> TeamAttributionResult:
+        self.calls.append((org_id, team_id, as_of))
+        return TeamAttributionResult(
+            measured=self.measured, repository_ids=self.repository_ids
+        )
+
+
+_NO_ATTRIBUTION = FakeAttributionSource(repository_ids=())
+
+
+def _unmeasured_cognitive_load() -> TeamCognitiveLoadResult:
+    return TeamCognitiveLoadResult(
+        after_hours_commit_ratio=None,
+        weekend_commit_ratio=None,
+        pr_interruption_load=None,
+        review_request_load=None,
+        context_spread_count=None,
+        sample_days=0,
+        measured=False,
+    )
+
+
+def _unmeasured_investment_mix() -> TeamInvestmentMixResult:
+    return TeamInvestmentMixResult(
+        new_value_units=0.0,
+        ktlo_units=0.0,
+        security_units=0.0,
+        infra_units=0.0,
+        unclassified_units=0.0,
+        total_units=0.0,
+        measured=False,
+    )
+
+
+def _measured_investment_mix(
+    *, new_value_units: float, total_units: float
+) -> TeamInvestmentMixResult:
+    return TeamInvestmentMixResult(
+        new_value_units=new_value_units,
+        ktlo_units=total_units - new_value_units,
+        security_units=0.0,
+        infra_units=0.0,
+        unclassified_units=0.0,
+        total_units=total_units,
+        measured=True,
+    )
+
+
+@dataclass
+class FakeWorkloadSource:
+    """A configurable ``TeamWorkloadDataSource`` double.
+
+    Defaults to entirely unmeasured results for every method -- the
+    neutral "no workload data was even attempted" shape every test that
+    predates CHAOS-3304's wiring (categories 1-6, never 8) needs
+    unchanged. ``investment_mix_results`` supplies genuinely measured
+    results IN CALL ORDER (``_investment_balance_profile`` calls
+    ``investment_mix`` for the current window first, then the comparison
+    window if ``scope.comparison_range`` is set) -- category-8-specific
+    tests use this to prove a real, non-``no_data`` shift gets computed
+    (see ``dimension_observation_adapters.investment_allocation_shift_
+    observation``'s own ``comparison_share is None -> no_data`` branch,
+    which this double must clear to reach the ``attribution_present=False``
+    guard the CHAOS-3331 tests below assert against). ``raise_on_
+    investment_mix`` simulates an expected dependency failure (Codex
+    finding, HIGH, round 5) -- ``cognitive_load``/``active_contributor_
+    count`` are never called by ``_investment_balance_profile`` at all
+    (investment-only path), so this double does not need a failure mode
+    for them.
+    """
+
+    investment_mix_results: tuple[TeamInvestmentMixResult, ...] = ()
+    raise_on_investment_mix: bool = False
+    calls: list[tuple[str, str, str, datetime, datetime]] = field(default_factory=list)
+    #: A DEDICATED counter, never derived by filtering ``self.calls`` after
+    #: the fact (Codex finding, MEDIUM, round 6 -- the second time this
+    #: exact class of bug has come back): ``self.calls`` is the complete,
+    #: unfiltered, order-preserving log every test asserts against
+    #: directly. Deriving ``investment_mix``'s own result index from a
+    #: filtered view of that log would silently keep working even if an
+    #: unexpected ``cognitive_load``/``active_contributor_count`` call got
+    #: interleaved -- exactly the bug class a filtered view exists to hide.
+    _investment_mix_call_count: int = field(default=0, init=False, repr=False)
+
+    async def cognitive_load(
+        self, *, org_id: str, team_id: str, start: datetime, end: datetime
+    ) -> TeamCognitiveLoadResult:
+        self.calls.append(("cognitive_load", org_id, team_id, start, end))
+        return _unmeasured_cognitive_load()
+
+    async def active_contributor_count(
+        self, *, org_id: str, team_id: str, start: datetime, end: datetime
+    ) -> int | None:
+        self.calls.append(("active_contributor_count", org_id, team_id, start, end))
+        return None
+
+    async def investment_mix(
+        self, *, org_id: str, team_id: str, start: datetime, end: datetime
+    ) -> TeamInvestmentMixResult:
+        index = self._investment_mix_call_count
+        self._investment_mix_call_count += 1
+        self.calls.append(("investment_mix", org_id, team_id, start, end))
+        if self.raise_on_investment_mix:
+            raise RuntimeError("simulated investment_mix dependency failure")
+        if index < len(self.investment_mix_results):
+            return self.investment_mix_results[index]
+        return _unmeasured_investment_mix()
+
+
+_NO_WORKLOAD = FakeWorkloadSource()
+
+
+@pytest.mark.asyncio
+async def test_fake_workload_source_call_log_mutation_control_catches_interleaved_call() -> (
+    None
+):
+    """Permanent mutation check (Codex finding, MEDIUM, round 6, 2026-08-02
+    -- the second time this exact test-honesty class has come back): proves
+    the exact-equality, complete, unfiltered call-log assertion pattern
+    every test in this file relies on for ``FakeWorkloadSource`` ACTUALLY
+    catches an interleaved, unexpected call -- not merely that a filtered/
+    counted view happens to still pass. Directly exercises
+    ``FakeWorkloadSource`` (never through ``evaluate_team``, which never
+    calls ``cognitive_load`` at all in production) to plant Codex's exact
+    repro: one ``cognitive_load`` call sandwiched between two
+    ``investment_mix`` calls.
+
+    Also proves the SECOND, independently-tracked half of the round-6 fix:
+    ``investment_mix``'s own result-index counter (``_investment_mix_call_
+    count``) is untouched by the interleaved ``cognitive_load`` call --
+    the second ``investment_mix`` call still returns
+    ``investment_mix_results[1]``, not ``investment_mix_results[2]`` (which
+    would be the wrong, out-of-bounds-masking result a filtered-``self.
+    calls``-derived index would produce if ``cognitive_load`` were ever
+    counted as if it were a third ``investment_mix`` call).
+    """
+
+    first_result = _measured_investment_mix(new_value_units=80.0, total_units=100.0)
+    second_result = _measured_investment_mix(new_value_units=20.0, total_units=100.0)
+    workload = FakeWorkloadSource(investment_mix_results=(first_result, second_result))
+    start, end = _NOW - timedelta(days=14), _NOW
+
+    actual_first = await workload.investment_mix(
+        org_id=_ORG_ID, team_id="team-1", start=start, end=end
+    )
+    # Codex's exact repro: an unexpected call interleaved between the two
+    # genuine investment_mix calls.
+    await workload.cognitive_load(
+        org_id=_ORG_ID, team_id="team-1", start=start, end=end
+    )
+    actual_second = await workload.investment_mix(
+        org_id=_ORG_ID, team_id="team-1", start=start, end=end
+    )
+
+    assert actual_first == first_result
+    assert actual_second == second_result
+
+    expected_clean_sequence = [
+        ("investment_mix", _ORG_ID, "team-1", start, end),
+        ("investment_mix", _ORG_ID, "team-1", start, end),
+    ]
+    # The exact-equality pattern this file's real assertions use MUST
+    # reject the interleaved sequence -- proving it is a real check, not
+    # a filtered view that would silently still pass regardless.
+    assert workload.calls != expected_clean_sequence
+    assert workload.calls == [
+        ("investment_mix", _ORG_ID, "team-1", start, end),
+        ("cognitive_load", _ORG_ID, "team-1", start, end),
+        ("investment_mix", _ORG_ID, "team-1", start, end),
+    ]
+
+
+@dataclass
+class RepoAwareFakeRuntime:
+    """A ``data_health`` double whose result depends on which repositories
+    are actually in the queried scope -- lets the batching/merge tests
+    prove real reconciliation across multiple calls, not just "a single
+    call happens to work". ``stale_repos`` is the ground truth: any
+    repository in it makes the ``work_items`` source STALE (with that
+    repository in ``missing_repository_ids``) for whichever batch it
+    lands in; every other repository is COMPLETE.
+    """
+
+    stale_repos: frozenset[str] = field(default_factory=frozenset)
+    scopes_seen: list[DevScope] = field(default_factory=list)
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return _snapshot()
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("not exercised by the batching tests")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        self.scopes_seen.append(scope)
+        repos = tuple(scope.repositories)
+        missing = tuple(sorted(set(repos) & self.stale_repos))
+        work_items_state = (
+            DataHealthState.STALE if missing else DataHealthState.COMPLETE
+        )
+        coverage = (len(repos) - len(missing)) / len(repos) if repos else 0.0
+        # ALL of NATIVE_EVIDENCE_SOURCES, not just work_items (round-4 fix,
+        # same rationale as OmissionAwareFakeRuntime above): only
+        # work_items varies with `stale_repos`, every other canonical
+        # source stays COMPLETE for every repository in this batch, so it
+        # is a genuine "nothing else changed" control rather than an
+        # always-omitted source the fail-closed merge would flag.
+        other_sources = tuple(
+            DataHealthSource(
+                source_system=system,
+                state=DataHealthState.COMPLETE,
+                required=True,
+                last_successful_at=_NOW,
+                watermark=_NOW,
+                missing_repository_ids=(),
+                missing_entity_ids=(),
+                coverage=1.0,
+                confidence_impact=None,
+                freshness_policy_version="v1",
+            )
+            for system in NATIVE_EVIDENCE_SOURCES
+            if system != "work_items"
+        )
+        return DataHealthResult(
+            sources=(
+                DataHealthSource(
+                    source_system="work_items",
+                    state=work_items_state,
+                    required=True,
+                    last_successful_at=_NOW,
+                    watermark=_NOW,
+                    missing_repository_ids=missing,
+                    missing_entity_ids=(),
+                    coverage=coverage,
+                    confidence_impact=None,
+                    freshness_policy_version="v1",
+                ),
+                *other_sources,
+            ),
+            complete_eligible=not missing,
+        )
+
+
+@dataclass
+class OmissionAwareFakeRuntime:
+    """A ``data_health`` double that can make specific BATCHES (by 0-based
+    call order) omit specific source_systems entirely, or return an empty
+    ``sources`` tuple altogether -- reproduces the exact Codex round-3
+    repro (a batch returning ``DataHealthResult(sources=(), complete_
+    eligible=True)``) plus the asymmetric-set variant (one batch missing
+    a source_system another batch reports), without disturbing
+    ``RepoAwareFakeRuntime``'s own existing single-source-system tests.
+
+    Emits two source_systems by default -- ``work_items`` and
+    ``pull_requests``, both COMPLETE for every repository -- so a batch
+    that omits one of them is a genuine partial-set case, not merely
+    "the only source it could have reported".
+    """
+
+    empty_batch_indices: frozenset[int] = field(default_factory=frozenset)
+    omit_source_systems_by_batch_index: dict[int, frozenset[str]] = field(
+        default_factory=dict
+    )
+    scopes_seen: list[DevScope] = field(default_factory=list)
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return _snapshot()
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    def list_metrics(self, scope):
+        return ()
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("not exercised by the omission tests")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise NotImplementedError
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        batch_index = len(self.scopes_seen)
+        self.scopes_seen.append(scope)
+        if batch_index in self.empty_batch_indices:
+            # The exact Codex repro: an empty-but-"healthy" batch result.
+            return DataHealthResult(sources=(), complete_eligible=True)
+        omitted = self.omit_source_systems_by_batch_index.get(batch_index, frozenset())
+        # ALL of NATIVE_EVIDENCE_SOURCES, not just two -- see
+        # _merge_data_health_sources' round-4 fix (Codex finding, HIGH,
+        # 2026-08-02): the expected source set is the CANONICAL contract,
+        # not the union of what batches happen to report, so a "no
+        # omission" positive control must genuinely report every canonical
+        # source or it is no longer testing what it claims to.
+        all_systems = NATIVE_EVIDENCE_SOURCES
+        sources = tuple(
+            DataHealthSource(
+                source_system=system,
+                state=DataHealthState.COMPLETE,
+                required=True,
+                last_successful_at=_NOW,
+                watermark=_NOW,
+                missing_repository_ids=(),
+                missing_entity_ids=(),
+                coverage=1.0,
+                confidence_impact=None,
+                freshness_policy_version="v1",
+            )
+            for system in all_systems
+            if system not in omitted
+        )
+        return DataHealthResult(sources=sources, complete_eligible=True)
+
+
+# ---------------------------------------------------------------------------
+# Omitted/short batch merges must fail closed, never silently healthy
+# (Codex finding, HIGH, round 3, 2026-08-02).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_omitted_batch_never_merges_as_healthy() -> None:
+    """The exact Codex repro: 21 repos, batch 1 (20 repos) reports
+    work_items COMPLETE, batch 2 (1 repo) returns an empty-but-"healthy"
+    DataHealthResult -- the merged result must NOT report COMPLETE/
+    coverage=1.0/complete_eligible=True; the unmeasured repo must degrade
+    the merged picture, never disappear from it.
+    """
+
+    repos = tuple(f"repo-{i}" for i in range(21))
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = OmissionAwareFakeRuntime(empty_batch_indices=frozenset({1}))
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    # Unfiltered -- category 8 must never make its own raw-TEAM-scope
+    # data_health call alongside these (Codex finding, HIGH, round 5).
+    assert len(runtime.scopes_seen) == 2
+    data_findings = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+    # The omitted batch must produce a real, degraded finding -- never
+    # silently healthy (which would mean zero data-integration findings
+    # here despite one whole repository never actually being measured).
+    assert len(data_findings) >= 1
+    assert all(f.coverage < 1.0 for f in data_findings)
+    data_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert data_status.finding_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_all_batches_empty_never_merges_as_healthy() -> None:
+    """Codex finding, HIGH, round 4, 2026-08-02: round 3's fix unioned the
+    batches' OWN reported source_systems as the "expected" set -- which
+    still silently passed when EVERY batch returned ``sources=()``, since
+    the union of nothing is nothing to flag. A single batch (<=20 repos,
+    so there is only ONE batch total) that reports a totally empty result
+    must NOT merge into a healthy, zero-finding category 1 -- every one of
+    NATIVE_EVIDENCE_SOURCES must synthesize an explicit UNAVAILABLE
+    placeholder, exactly like the multi-batch omission case above.
+    """
+
+    repos = tuple(f"repo-{i}" for i in range(5))  # single batch, all empty
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = OmissionAwareFakeRuntime(empty_batch_indices=frozenset({0}))
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    assert len(runtime.scopes_seen) == 1
+    data_findings = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+    # Every canonical source must be flagged unavailable -- never silently
+    # healthy just because the one-and-only batch reported nothing at all.
+    assert len(data_findings) == len(NATIVE_EVIDENCE_SOURCES)
+    assert all(f.coverage == 0.0 for f in data_findings)
+    assert all(f.severity is DeficiencySeverity.CRITICAL for f in data_findings)
+    data_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert data_status.finding_count == len(NATIVE_EVIDENCE_SOURCES)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_asymmetric_source_set_across_batches() -> None:
+    """One batch omits ONE source_system (not its whole result) that
+    another batch does report -- the omitted source must degrade only
+    for the batch that omitted it, while the source both batches agree
+    on stays healthy.
+    """
+
+    repos = tuple(f"repo-{i}" for i in range(21))
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = OmissionAwareFakeRuntime(
+        omit_source_systems_by_batch_index={1: frozenset({"pull_requests"})}
+    )
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    data_findings = {
+        f.blast_radius: f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    }
+    # pull_requests must show up as a genuine, degraded finding (coverage
+    # < 1.0 -- the last batch's repo is unmeasured for it); work_items
+    # must NOT (every batch agreed it was COMPLETE for every repo).
+    assert any("pull_requests" in radius for radius in data_findings)
+    assert not any(
+        "work_items" in radius and "pull_requests" not in radius
+        for radius in data_findings
+    )
+
+
+def test_merge_data_health_sources_required_flag_is_order_independent() -> None:
+    """Codex finding, MEDIUM, round 4, 2026-08-02: ``required`` is merged
+    INDEPENDENTLY of which batch's state wins the worst-state comparison
+    -- the OR of every batch's own ``required`` flag, never copied from
+    whichever record the worst-state comparison happens to keep. Proven
+    in BOTH batch orders: a required+COMPLETE batch's requiredness must
+    never become invisible just because an optional+UNAVAILABLE batch for
+    the SAME source_system happens to be evaluated before OR after it.
+
+    Round-5 correction (Codex finding, MEDIUM PLAUSIBLE, 2026-08-02): the
+    round-4 fix above still let the optional+UNAVAILABLE batch's WORSE
+    STATE win the merge for a source every REQUIRED batch reported
+    COMPLETE -- ``required=True``/``state=UNAVAILABLE`` falsely implies the
+    required dependency itself failed. The merged state must come from the
+    REQUIRED records only when any exist: ``required=True``,
+    ``state=COMPLETE`` (not blocking), in BOTH orders. See
+    ``test_merge_data_health_sources_optional_failure_never_blocks_when_
+    required_batches_complete`` for the full ``complete_eligible``-level
+    regression matching Codex's own repro.
+    """
+
+    required_complete = DataHealthSource(
+        source_system="work_items",
+        state=DataHealthState.COMPLETE,
+        required=True,
+        last_successful_at=_NOW,
+        watermark=_NOW,
+        missing_repository_ids=(),
+        missing_entity_ids=(),
+        coverage=1.0,
+        confidence_impact=None,
+        freshness_policy_version="v1",
+    )
+    optional_unavailable = DataHealthSource(
+        source_system="work_items",
+        state=DataHealthState.UNAVAILABLE,
+        required=False,
+        last_successful_at=None,
+        watermark=None,
+        missing_repository_ids=("repo-b",),
+        missing_entity_ids=(),
+        coverage=0.0,
+        confidence_impact="insufficient_evidence",
+        freshness_policy_version=None,
+    )
+
+    for sources_by_batch in (
+        ((required_complete,), (optional_unavailable,)),
+        ((optional_unavailable,), (required_complete,)),
+    ):
+        merged = _merge_data_health_sources(
+            sources_by_batch, (("repo-a",), ("repo-b",)), total_repositories=2
+        )
+        work_items = next(s for s in merged if s.source_system == "work_items")
+        assert work_items.required is True
+        # The optional batch's failure must never block a source every
+        # REQUIRED batch satisfied.
+        assert work_items.state is DataHealthState.COMPLETE
+        assert work_items.missing_repository_ids == ()
+
+
+def test_merge_data_health_sources_optional_failure_never_blocks_when_required_batches_complete() -> (
+    None
+):
+    """Codex's own round-5 repro, at the ``complete_eligible`` level a
+    caller actually reads: a required+COMPLETE batch plus an optional+
+    UNAVAILABLE batch for the SAME source_system must aggregate
+    eligible=True -- every batch that actually required this source
+    completed; the unrelated optional failure must inform coverage/
+    warnings for that OTHER, optional-only picture, never block this one.
+    """
+
+    required_complete = DataHealthSource(
+        source_system="work_items",
+        state=DataHealthState.COMPLETE,
+        required=True,
+        last_successful_at=_NOW,
+        watermark=_NOW,
+        missing_repository_ids=(),
+        missing_entity_ids=(),
+        coverage=1.0,
+        confidence_impact=None,
+        freshness_policy_version="v1",
+    )
+    optional_unavailable = DataHealthSource(
+        source_system="work_items",
+        state=DataHealthState.UNAVAILABLE,
+        required=False,
+        last_successful_at=None,
+        watermark=None,
+        missing_repository_ids=("repo-b",),
+        missing_entity_ids=(),
+        coverage=0.0,
+        confidence_impact="insufficient_evidence",
+        freshness_policy_version=None,
+    )
+
+    def _complete_required(system: str) -> DataHealthSource:
+        return DataHealthSource(
+            source_system=system,
+            state=DataHealthState.COMPLETE,
+            required=True,
+            last_successful_at=_NOW,
+            watermark=_NOW,
+            missing_repository_ids=(),
+            missing_entity_ids=(),
+            coverage=1.0,
+            confidence_impact=None,
+            freshness_policy_version="v1",
+        )
+
+    # Every OTHER canonical source_system is trivially COMPLETE in both
+    # batches -- this test isolates work_items' own mixed-optionality
+    # resolution, never the (already separately-tested) all-canonical-
+    # sources-omitted behavior.
+    other_systems = [s for s in NATIVE_EVIDENCE_SOURCES if s != "work_items"]
+    batch_a = (required_complete, *(_complete_required(s) for s in other_systems))
+    batch_b = (optional_unavailable, *(_complete_required(s) for s in other_systems))
+    merged = _merge_data_health_sources(
+        (batch_a, batch_b), (("repo-a",), ("repo-b",)), total_repositories=2
+    )
+    complete_eligible = all(
+        not source.required or source.state is DataHealthState.COMPLETE
+        for source in merged
+    )
+    assert complete_eligible is True
+    work_items = next(s for s in merged if s.source_system == "work_items")
+    assert work_items.required is True
+    assert work_items.state is DataHealthState.COMPLETE
+
+
+def test_merge_data_health_sources_optional_only_source_reports_honestly() -> None:
+    """A source_system NO batch ever required still falls back to
+    aggregating its optional records -- an honest, reportable state, just
+    never able to block ``complete_eligible`` on its own (``required``
+    stays ``False``).
+    """
+
+    optional_stale = DataHealthSource(
+        source_system="work_items",
+        state=DataHealthState.STALE,
+        required=False,
+        last_successful_at=_NOW,
+        watermark=_NOW,
+        missing_repository_ids=("repo-a",),
+        missing_entity_ids=(),
+        coverage=0.5,
+        confidence_impact=None,
+        freshness_policy_version="v1",
+    )
+    merged = _merge_data_health_sources(
+        ((optional_stale,),), (("repo-a", "repo-b"),), total_repositories=2
+    )
+    work_items = next(s for s in merged if s.source_system == "work_items")
+    assert work_items.required is False
+    assert work_items.state is DataHealthState.STALE
+    assert work_items.missing_repository_ids == ("repo-a",)
+
+
+def test_placeholder_for_omitted_source_required_matches_canonical_table() -> None:
+    """The requiredness half of the round-4 fix (Codex finding, MEDIUM,
+    2026-08-02): a synthesized omission placeholder must read its
+    ``required`` flag from ``_CANONICAL_SOURCE_REQUIRED``, never a blanket
+    ``True`` literal that would misreport a genuinely optional
+    source_system as required just because a batch failed to mention it.
+    Tested directly against ``_placeholder_for_omitted_source`` (the exact
+    function the fix touched), not through the merge pipeline -- ``_merge_
+    data_health_sources`` only ever routes members of NATIVE_EVIDENCE_
+    SOURCES through this function (its ``expected_source_systems`` is
+    exactly that set), so every member's requiredness is checked directly
+    against the SAME table this function reads, proving they cannot drift
+    apart; the fallback branch for a source_system outside that table
+    (defensive, unreachable via the merge pipeline as currently wired) is
+    proven separately.
+    """
+
+    from dev_health_ops.api.dev.operational_deficiency_service import (
+        _CANONICAL_SOURCE_REQUIRED,
+        _placeholder_for_omitted_source,
+    )
+
+    for source_system in NATIVE_EVIDENCE_SOURCES:
+        placeholder = _placeholder_for_omitted_source(source_system, ("repo-a",))
+        assert placeholder.required == _CANONICAL_SOURCE_REQUIRED[source_system]
+        assert placeholder.required is True  # every canonical source today
+
+    # Fail-closed default for a source_system the table has no entry for.
+    unrecognized = _placeholder_for_omitted_source("some_future_source", ("repo-a",))
+    assert unrecognized.required is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_consistent_batches_produce_no_spurious_findings() -> None:
+    """Positive control: when every batch reports the SAME source_system
+    set, the omission fail-closed logic must never fire -- no placeholder,
+    no synthesized finding, a genuinely healthy team stays healthy.
+    """
+
+    repos = tuple(f"repo-{i}" for i in range(21))
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = OmissionAwareFakeRuntime()  # no omissions, no empty batches
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    data_findings = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+    assert data_findings == []
+    data_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert data_status.finding_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Team data_health batching: >20-repository teams must never crash or
+# silently truncate (Codex finding, HIGH, 2026-08-02).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_exactly_20_repositories_single_batch() -> None:
+    repos = tuple(f"repo-{i}" for i in range(20))
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = RepoAwareFakeRuntime()
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    # Unfiltered: exactly one call total, never a second raw-TEAM-scope
+    # data_health call from category 8 (Codex finding, HIGH, round 5).
+    assert len(runtime.scopes_seen) == 1
+    assert sorted(runtime.scopes_seen[0].repositories) == sorted(repos)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_21_repositories_batches_into_two_calls() -> (
+    None
+):
+    repos = tuple(f"repo-{i}" for i in range(21))
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = RepoAwareFakeRuntime()
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    # Unfiltered call sequence -- exactly the two REPOSITORY batches,
+    # never a third, raw-TEAM-scope call from category 8.
+    assert len(runtime.scopes_seen) == 2
+    assert all(s.direct_scope is DirectScope.REPOSITORY for s in runtime.scopes_seen)
+    batch_sizes = sorted(len(s.repositories) for s in runtime.scopes_seen)
+    assert batch_sizes == [1, 20]
+    all_queried = {repo for s in runtime.scopes_seen for repo in s.repositories}
+    assert all_queried == set(
+        repos
+    )  # every repository queried exactly once, none dropped
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_45_repositories_batches_and_merges() -> None:
+    repos = tuple(f"repo-{i}" for i in range(45))
+    stale = frozenset({"repo-5", "repo-25", "repo-40"})  # one per batch of 20/20/5
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = RepoAwareFakeRuntime(stale_repos=stale)
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    # Unfiltered: 20 + 20 + 5, never truncated to the first batch, and
+    # never a fourth raw-TEAM-scope call from category 8.
+    assert len(runtime.scopes_seen) == 3
+    assert all(s.direct_scope is DirectScope.REPOSITORY for s in runtime.scopes_seen)
+    batch_sizes = sorted(len(s.repositories) for s in runtime.scopes_seen)
+    assert batch_sizes == [5, 20, 20]
+
+    data_findings = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+    assert len(data_findings) == 1
+    finding = data_findings[0]
+    assert finding.rule_id == "deficiency_rule.stale_watermark.v1"
+    # Exact coverage recomputed from the true total, not a per-batch average.
+    assert finding.coverage == pytest.approx((45 - 3) / 45)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_batched_merge_matches_hypothetical_single_call() -> (
+    None
+):
+    """The merged, batched result must be byte-identical in substance to
+    what a single, hypothetical unbounded call would have produced --
+    proving the batching/merge machinery is lossless, not an
+    approximation.
+    """
+
+    repos = tuple(f"repo-{i}" for i in range(45))
+    stale = frozenset({"repo-5", "repo-25", "repo-40"})
+
+    # The hypothetical: what a single call over ALL 45 repos would report,
+    # computed with the exact same ground-truth logic RepoAwareFakeRuntime
+    # uses, just never actually issued (DevScope forbids it).
+    hypothetical_missing = tuple(sorted(set(repos) & stale))
+    hypothetical_coverage = (len(repos) - len(hypothetical_missing)) / len(repos)
+
+    attribution = FakeAttributionSource(repository_ids=repos)
+    runtime = RepoAwareFakeRuntime(stale_repos=stale)
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    finding = next(
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert finding.coverage == pytest.approx(hypothetical_coverage)
+    assert finding.severity is DeficiencySeverity.AT_RISK  # stale_watermark
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_batching_never_calls_runtime_when_no_repos() -> (
+    None
+):
+    runtime = RepoAwareFakeRuntime()
+    service = OperationalDeficiencyService(
+        runtime, FakeAttributionSource(measured=False), _NO_WORKLOAD
+    )
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    assert runtime.scopes_seen == []
+
+
+# ---------------------------------------------------------------------------
+# Scope validation, mirroring ProjectHealthService/TeamHealthService.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_rejects_non_project_scope() -> None:
+    service = OperationalDeficiencyService(_runtime(), _NO_ATTRIBUTION, _NO_WORKLOAD)
+    non_project_scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.ORGANIZATION,
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+    )
+    with pytest.raises(ValueError, match="project direct scope"):
+        await service.evaluate_project(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=non_project_scope,
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_requires_comparison_range() -> None:
+    service = OperationalDeficiencyService(_runtime(), _NO_ATTRIBUTION, _NO_WORKLOAD)
+    with pytest.raises(ValueError, match="comparison_range"):
+        await service.evaluate_project(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=_project_scope(with_comparison=False),
+            now=_NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_rejects_mismatched_team_ids() -> None:
+    service = OperationalDeficiencyService(_runtime(), _NO_ATTRIBUTION, _NO_WORKLOAD)
+    scope = _team_scope()
+    with pytest.raises(ValueError, match="scope.team_ids"):
+        await service.evaluate_team(
+            org_id=_ORG_ID,
+            permission_fingerprint="fp",
+            scope=scope,
+            team_id="other-team",
+            now=_NOW,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Team attribution: snapshot resolved at scope.time_range.end (never `now`),
+# and lookup failure kept structurally distinct from a genuinely empty
+# cohort.
+# ---------------------------------------------------------------------------
+
+_RULE_DRIVEN_CATEGORY_SET = {
+    DeficiencyCategory.DELIVERY_FLOW,
+    DeficiencyCategory.REVIEW_CI,
+    DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+    DeficiencyCategory.OWNERSHIP_CODE_RISK,
+}
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_resolves_attribution_at_scope_end_not_now() -> None:
+    """Boundary control: `now` genuinely differs from `scope.time_range.end`
+    -- the attribution lookup must use the scope's own committed window
+    end, never the evaluation-time `now` (Codex finding, same class as
+    3303/3304: ownership can expire between scope end and `now`, wrongly
+    suppressing real historical findings as insufficient_cohort).
+    """
+
+    scope_end = _NOW - timedelta(days=3)
+    scope = _team_scope(end=scope_end)
+    attribution = FakeAttributionSource(repository_ids=("repo-1",))
+    service = OperationalDeficiencyService(_runtime(), attribution, _NO_WORKLOAD)
+
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=scope,
+        team_id="team-1",
+        now=_NOW,
+    )
+
+    # Exactly one lookup, complete unfiltered log: category 8's own
+    # _investment_balance_profile takes the already-resolved cohort_size
+    # as a parameter and never re-resolves attribution itself (Codex
+    # finding, HIGH, round 5 -- composing the WHOLE TeamWorkloadService
+    # made a second, independent lookup here).
+    assert attribution.calls == [(_ORG_ID, "team-1", scope_end)]
+    assert scope_end != _NOW
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_attribution_failure_is_unmeasured_not_insufficient_cohort() -> (
+    None
+):
+    """A genuine attribution-lookup failure must never be presented as
+    "insufficient_cohort" -- that phrase claims attribution was checked
+    and found too small, which is a different fact from "attribution could
+    not be checked at all".
+    """
+
+    attribution = FakeAttributionSource(measured=False)
+    service = OperationalDeficiencyService(_runtime(), attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    for status in inventory.category_statuses:
+        if status.category in _RULE_DRIVEN_CATEGORY_SET:
+            assert status.evaluated is False
+            assert status.finding_count == 0
+            # The exact unmeasured-attribution limitation, not the generic
+            # shadow-calibration or insufficient-cohort text a merely-empty
+            # (but successfully resolved) cohort would carry.
+            assert status.limitation == _TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION
+    # Category 2 (planning & relationships) IS independent of team
+    # attribution -- status_snapshot is queried regardless (see the
+    # dedicated test below). Category 1 (data & integration) is NOT
+    # (Codex finding, HIGH): on attribution failure there is no verified
+    # repository set to scope data_health to, so it must never be queried
+    # at all -- never-queried, not the org-wide fallback a raw TEAM scope
+    # would otherwise trigger.
+    data_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert data_status.evaluated is False  # never queried, not org-wide
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_is_scoped_to_attributed_repositories() -> None:
+    """Codex finding, HIGH, 2026-08-02: data_health must be queried against
+    an explicit DirectScope.REPOSITORY scope built from the SAME
+    attribution snapshot used for cohort_size -- never the raw TEAM scope
+    (which NativeDataHealthReader would resolve to zero explicit
+    repositories and fall back to querying every repository in the org).
+    """
+
+    attribution = FakeAttributionSource(repository_ids=("repo-a", "repo-b"))
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    # Unfiltered: exactly one data_health call total -- category 8 must
+    # never make its own second, raw-TEAM-scope call (Codex finding, HIGH,
+    # round 5).
+    assert len(runtime.data_health_scopes) == 1
+    called_scope = runtime.data_health_scopes[0]
+    assert called_scope.direct_scope is DirectScope.REPOSITORY
+    assert sorted(called_scope.repositories) == ["repo-a", "repo-b"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_never_called_when_attribution_unmeasured() -> (
+    None
+):
+    attribution = FakeAttributionSource(measured=False)
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    assert runtime.data_health_scopes == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_data_health_never_called_when_cohort_genuinely_empty() -> (
+    None
+):
+    """The batched ``_team_scoped_data_health`` path (category 1) is never
+    invoked for a genuinely empty (but measured) cohort -- an empty
+    ``repository_ids`` short-circuits before any batch is issued. Category
+    8's own ``_investment_balance_profile`` never touches ``self._runtime``
+    at all (it only calls ``self._workload_source.investment_mix``, which
+    takes ``team_id`` directly, no ``DevScope``) -- so this is a genuinely
+    UNFILTERED, complete assertion: zero ``data_health`` calls, period
+    (Codex finding, HIGH, round 5: a prior composition via
+    ``TeamWorkloadService`` made its own extra, raw-TEAM-scope call here).
+    """
+
+    attribution = FakeAttributionSource(repository_ids=())
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    assert runtime.data_health_scopes == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_status_snapshot_always_called_with_raw_team_scope() -> (
+    None
+):
+    """Category 2 genuinely IS attribution-independent: status_snapshot's
+    own ClickHouseStatusChangeSource re-derives team_repo_ownership
+    internally, so the raw TEAM scope is safe to pass through directly,
+    regardless of attribution outcome.
+    """
+
+    attribution = FakeAttributionSource(measured=False)
+    runtime = _runtime()
+    service = OperationalDeficiencyService(runtime, attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    planning_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.PLANNING_RELATIONSHIPS
+    )
+    assert planning_status.evaluated is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_empty_cohort_stays_evaluated_true() -> None:
+    """A genuinely resolved, empty cohort (the lookup succeeded and
+    returned zero repositories) is a different fact from a lookup failure
+    -- the rule-driven categories are still `evaluated=True` (the check
+    ran; it just found nothing to attribute), not the unmeasured branch a
+    failure produces.
+    """
+
+    attribution = FakeAttributionSource(repository_ids=())
+    service = OperationalDeficiencyService(_runtime(), attribution, _NO_WORKLOAD)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(),
+        team_id="team-1",
+        now=_NOW,
+    )
+    for status in inventory.category_statuses:
+        if status.category in _RULE_DRIVEN_CATEGORY_SET:
+            assert status.evaluated is True
+            assert status.limitation != _TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION
+
+
+# ---------------------------------------------------------------------------
+# Category 1: data & integration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_integration_finding_for_unconfigured_required_source() -> None:
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.UNCONFIGURED),))
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    data_findings = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+    assert len(data_findings) == 1
+    assert data_findings[0].severity is DeficiencySeverity.CRITICAL
+    assert data_findings[0].rule_id == "deficiency_rule.unconfigured_required_source.v1"
+    status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert status.evaluated is True
+    assert status.finding_count == 1
+
+
+@pytest.mark.asyncio
+async def test_data_integration_optional_unconfigured_source_is_not_a_deficiency() -> (
+    None
+):
+    """Guardrail: no missing optional integration is treated as a failure."""
+
+    runtime = _runtime(
+        sources=(_source("acr", DataHealthState.UNCONFIGURED, required=False),)
+    )
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    assert not [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+
+
+@pytest.mark.asyncio
+async def test_data_integration_complete_source_is_not_a_deficiency() -> None:
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.COMPLETE),))
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    assert not [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.DATA_INTEGRATION
+    ]
+
+
+@pytest.mark.asyncio
+async def test_data_integration_distinguishes_stale_missing_and_unconfigured() -> None:
+    runtime = _runtime(
+        sources=(
+            _source("work_items", DataHealthState.STALE),
+            _source("pull_requests", DataHealthState.NO_DATA),
+            _source("reviews", DataHealthState.UNCONFIGURED),
+        )
+    )
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    kinds_by_rule = {f.rule_id: f.severity for f in inventory.findings}
+    assert (
+        kinds_by_rule["deficiency_rule.stale_watermark.v1"]
+        is DeficiencySeverity.AT_RISK
+    )
+    assert (
+        kinds_by_rule["deficiency_rule.missing_subject_coverage.v1"]
+        is DeficiencySeverity.WATCH
+    )
+    assert (
+        kinds_by_rule["deficiency_rule.unconfigured_required_source.v1"]
+        is DeficiencySeverity.CRITICAL
+    )
+    assert len(inventory.findings) >= 3  # never collapsed into one finding
+
+
+@pytest.mark.asyncio
+async def test_data_integration_never_queried_is_unevaluated() -> None:
+    runtime = _runtime(sources=())
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert status.evaluated is False
+    assert status.limitation is not None
+
+
+# ---------------------------------------------------------------------------
+# Category 2: planning & relationships.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_planning_relationships_open_blocker_finding() -> None:
+    blocker = StatusFact(
+        entity_type="issue",
+        entity_id="BLOCK-1",
+        display_label="Blocking issue",
+        status="open",
+        observed_at=_NOW,
+        source_ref_id="ref-1",
+        evidence_ref_ids=("evidence-1",),
+        required=True,
+    )
+    snapshot = _snapshot(
+        state=StatusResultState.COMPLETE,
+        actual=_actual_completion(reason_codes=("open_blocker",)),
+        blockers=(blocker,),
+    )
+    runtime = _runtime(snapshot=snapshot)
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    planning = [
+        f
+        for f in inventory.findings
+        if f.category is DeficiencyCategory.PLANNING_RELATIONSHIPS
+    ]
+    assert len(planning) == 1
+    assert planning[0].rule_id == "deficiency_rule.unresolved_blocking_dependency.v1"
+    assert planning[0].evidence_ref_ids == ("evidence-1",)
+    assert planning[0].evidence_classification is None
+
+
+@pytest.mark.asyncio
+async def test_planning_relationships_missing_declared_status_has_no_evidence() -> None:
+    snapshot = _snapshot(
+        state=StatusResultState.COMPLETE,
+        actual=_actual_completion(reason_codes=("declared_status_missing",)),
+    )
+    runtime = _runtime(snapshot=snapshot)
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    finding = next(
+        f
+        for f in inventory.findings
+        if f.rule_id == "deficiency_rule.missing_declared_status.v1"
+    )
+    assert finding.evidence_ref_ids == ()
+    from dev_health_ops.api.dev.contracts_v2.deficiency import (
+        DeficiencyEvidenceClassification,
+    )
+
+    assert (
+        finding.evidence_classification
+        is DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE
+    )
+    assert finding.severity is DeficiencySeverity.WATCH
+
+
+@pytest.mark.asyncio
+async def test_planning_relationships_declared_complete_conflict() -> None:
+    conflict = StatusConflict(
+        code="declared_complete_conflicts_with_observed_work",
+        message="Declared completion conflicts with required work.",
+        severity=ConflictSeverity.BLOCKING,
+        source_ref_ids=(),
+        evidence_ref_ids=("evidence-2",),
+    )
+    snapshot = _snapshot(
+        state=StatusResultState.COMPLETE,
+        actual=_actual_completion(
+            reason_codes=("open_blocker",), conflicts=(conflict,)
+        ),
+    )
+    runtime = _runtime(snapshot=snapshot)
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    finding = next(
+        f
+        for f in inventory.findings
+        if f.rule_id == "deficiency_rule.declared_complete_conflict.v1"
+    )
+    assert finding.severity is DeficiencySeverity.CRITICAL
+    assert finding.evidence_ref_ids == ("evidence-2",)
+
+
+@pytest.mark.asyncio
+async def test_planning_relationships_insufficient_evidence_is_unevaluated() -> None:
+    snapshot = _snapshot(state=StatusResultState.INSUFFICIENT_EVIDENCE)
+    runtime = _runtime(snapshot=snapshot)
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.PLANNING_RELATIONSHIPS
+    )
+    assert status.evaluated is False
+
+
+# ---------------------------------------------------------------------------
+# Categories 3-6: rule-registry-driven, shadow_only exclusion.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rule_driven_categories_produce_no_findings_while_all_rules_are_provisional() -> (
+    None
+):
+    """Every HEALTH_RULE_REGISTRY rule shipped today is provisional --
+    shadow_only findings must never appear in the inventory's status/counts.
+    """
+
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.COMPLETE),))
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    rule_driven = {
+        DeficiencyCategory.DELIVERY_FLOW,
+        DeficiencyCategory.REVIEW_CI,
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        DeficiencyCategory.OWNERSHIP_CODE_RISK,
+    }
+    for status in inventory.category_statuses:
+        if status.category in rule_driven:
+            assert status.evaluated is True
+            assert status.finding_count == 0
+            assert status.limitation is not None
+    assert not [f for f in inventory.findings if f.category in rule_driven]
+
+
+def _health_rule_finding(
+    *,
+    rule_id: str = "health_rule.incident_load.v1",
+    dimension: HealthDimension = HealthDimension.RELIABILITY_RELEASE,
+    shadow_only: bool = True,
+    suppressed_reason: str | None = None,
+    state: DimensionState = DimensionState.UNKNOWN,
+    calibration_state: CalibrationState = CalibrationState.PROVISIONAL,
+) -> HealthRuleFinding:
+    return HealthRuleFinding(
+        schema_version="health_rule_finding.v1",
+        finding_id="11111111-1111-1111-1111-111111111111",
+        rule_id=rule_id,
+        rule_version=rule_id,
+        dimension=dimension,
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        state=state,
+        fact_kind="observed",
+        shadow_only=shadow_only,
+        evidence_source_classes=(),
+        remediation_template="x",
+        calibration_state=calibration_state,
+        evaluated_at=_NOW,
+        suppressed_reason=suppressed_reason,
+    )
+
+
+def test_rule_driven_category_status_discloses_suppressed_only_findings() -> None:
+    """Codex/CHAOS-3304 interaction (2026-08-02): health_rule_registry's
+    partition order now checks suppressed_reason before shadow_only, so a
+    rule that is both provisional AND guardrail-suppressed lands in
+    ``suppressed``, never ``shadow``. A category whose only non-launch
+    findings are all suppressed must still disclose a limitation -- never
+    the accidental ``limitation=None`` a shadow-only check would produce,
+    which reads as "genuinely nothing to disclose" and hides a real,
+    silenced finding.
+    """
+
+    suppressed_finding = _health_rule_finding(suppressed_reason="insufficient_sample")
+    status, deficiencies = _rule_driven_category_result(
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        launch=(),
+        shadow=(),
+        suppressed=(suppressed_finding,),
+        observations_by_rule={},
+        org_id=_ORG_ID,
+    )
+    assert status.evaluated is True
+    assert status.finding_count == 0
+    assert deficiencies == ()
+    assert status.limitation == _RULE_DRIVEN_SUPPRESSED_LIMITATION
+
+
+def test_rule_driven_category_status_discloses_mixed_shadow_and_suppressed() -> None:
+    shadow_finding = _health_rule_finding(
+        rule_id="health_rule.change_failure_rate.v1", suppressed_reason=None
+    )
+    suppressed_finding = _health_rule_finding(suppressed_reason="insufficient_sample")
+    status, _ = _rule_driven_category_result(
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        launch=(),
+        shadow=(shadow_finding,),
+        suppressed=(suppressed_finding,),
+        observations_by_rule={},
+        org_id=_ORG_ID,
+    )
+    assert status.limitation == _RULE_DRIVEN_SHADOW_AND_SUPPRESSED_LIMITATION
+
+
+def test_rule_driven_category_status_partial_when_launch_and_suppressed_coexist() -> (
+    None
+):
+    """Codex finding, MEDIUM, round 4, 2026-08-02: the suppressed-only
+    wording ("every applicable rule was guardrail-suppressed") is
+    literally false the moment a DIFFERENT rule in the same category also
+    cleared every guardrail and launched. A mixed category must disclose
+    the weaker, honest "not every rule contributed" claim instead.
+    """
+
+    launch_finding = _health_rule_finding(
+        rule_id="health_rule.change_failure_rate.v1",
+        shadow_only=False,
+        suppressed_reason=None,
+        state=DimensionState.WATCH,
+        calibration_state=CalibrationState.PRODUCT_APPROVED,
+    )
+    suppressed_finding = _health_rule_finding(suppressed_reason="insufficient_sample")
+    status, deficiencies = _rule_driven_category_result(
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        launch=(launch_finding,),
+        shadow=(),
+        suppressed=(suppressed_finding,),
+        observations_by_rule={},
+        org_id=_ORG_ID,
+    )
+    assert status.limitation == _RULE_DRIVEN_PARTIAL_LIMITATION
+    assert status.finding_count == 1
+    assert len(deficiencies) == 1
+
+
+def test_rule_driven_category_status_partial_when_launch_and_shadow_coexist() -> None:
+    """Same claim, the shadow-only-coexists-with-launch variant."""
+
+    launch_finding = _health_rule_finding(
+        rule_id="health_rule.change_failure_rate.v1",
+        shadow_only=False,
+        suppressed_reason=None,
+        state=DimensionState.WATCH,
+        calibration_state=CalibrationState.PRODUCT_APPROVED,
+    )
+    shadow_finding = _health_rule_finding(suppressed_reason=None)
+    status, deficiencies = _rule_driven_category_result(
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        launch=(launch_finding,),
+        shadow=(shadow_finding,),
+        suppressed=(),
+        observations_by_rule={},
+        org_id=_ORG_ID,
+    )
+    assert status.limitation == _RULE_DRIVEN_PARTIAL_LIMITATION
+    assert status.finding_count == 1
+    assert len(deficiencies) == 1
+
+
+def test_rule_driven_category_status_shadow_only_unchanged() -> None:
+    """Positive control: the pre-3304 shadow-only case still gets the
+    original, more specific limitation text -- this fix must not blur
+    the two cases together.
+    """
+
+    shadow_finding = _health_rule_finding(suppressed_reason=None)
+    status, _ = _rule_driven_category_result(
+        DeficiencyCategory.DEPLOYMENT_RELIABILITY,
+        launch=(),
+        shadow=(shadow_finding,),
+        suppressed=(),
+        observations_by_rule={},
+        org_id=_ORG_ID,
+    )
+    assert status.limitation == _RULE_DRIVEN_SHADOW_LIMITATION
+
+
+def _real_observation(
+    *, rule_id: str, coverage: float, sample_count: int | None
+) -> DimensionObservation:
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=RuleApplicability.TEAM,
+        subject_id="team-1",
+        cohort_size=10,
+        observed_states=(SourceRequirementState.AVAILABLE_CURRENT,),
+        data_semantics="measured_zero",
+        sample_count=sample_count,
+        coverage=coverage,
+        current_value=1.0,
+        comparison_value=None,
+        denominator_present=False,
+        attribution_present=True,
+        window_index=0,
+        observed_at=_NOW,
+    )
+
+
+def _unavailable_observation(*, rule_id: str) -> DimensionObservation:
+    return DimensionObservation(
+        schema_version="dimension_observation.v1",
+        subject_kind=RuleApplicability.TEAM,
+        subject_id="team-1",
+        cohort_size=None,
+        observed_states=(SourceRequirementState.UNAVAILABLE,),
+        data_semantics="not_measured",
+        sample_count=None,
+        coverage=0.0,
+        current_value=None,
+        comparison_value=None,
+        denominator_present=False,
+        attribution_present=False,
+        window_index=0,
+        observed_at=_NOW,
+    )
+
+
+def test_rule_driven_results_does_not_overwrite_primary_observation_with_workload_noise() -> (
+    None
+):
+    """Codex finding, HIGH, round 6, 2026-08-02: the exact repro. A rule
+    shared by BOTH profiles (e.g. ``incident_load``, TEAM-applicable, so
+    ``_investment_balance_profile``'s own ``synthesize_health_profile``
+    call also evaluates it and produces a synthesized-UNAVAILABLE
+    observation for it, since that profile's sources never carry
+    ``status_snapshot``) must keep the PRIMARY profile's own REAL
+    observation -- never get silently overwritten by workload_profile's
+    unrelated noise for a rule this function never harvested a finding
+    from. A wholesale ``{**health, **workload}`` dict merge corrupts the
+    real launch finding's ``observed_state``/``coverage``/``sample_count``
+    with the unavailable observation's, and ``_deficiency_from_health_rule_
+    finding``'s hardcoded ``data_semantics="measured_zero"`` combined with
+    an UNAVAILABLE (unmeasured) ``observed_state`` raises
+    ``ValidationError`` -- taking down the WHOLE inventory over an
+    unrelated category-8 evaluation, not merely losing one field.
+    """
+
+    launch_rule_id = "health_rule.incident_load.v1"
+    investment_rule_id = "health_rule.investment_allocation_shift.v1"
+    real_observation = _real_observation(
+        rule_id=launch_rule_id, coverage=0.9, sample_count=7
+    )
+    launch_finding = _health_rule_finding(
+        rule_id=launch_rule_id,
+        dimension=HealthDimension.RELIABILITY_RELEASE,
+        shadow_only=False,
+        suppressed_reason=None,
+        state=DimensionState.WATCH,
+        calibration_state=CalibrationState.PRODUCT_APPROVED,
+    )
+    health_profile = HealthProfileResult(
+        subject_kind=RuleApplicability.TEAM,
+        subject_id="team-1",
+        observations=(real_observation,),
+        launch_findings=(launch_finding,),
+        shadow_findings=(),
+        suppressed_findings=(),
+        observations_by_rule={launch_rule_id: real_observation},
+    )
+
+    # workload_profile: the byproduct of _investment_balance_profile
+    # reusing synthesize_health_profile -- it ALSO evaluates incident_load
+    # (TEAM-applicable) with no status_snapshot source, producing a
+    # synthesized-unavailable observation for the SAME rule_id, plus its
+    # own genuine investment_mix-sourced shadow finding.
+    unavailable_incident_load = _unavailable_observation(rule_id=launch_rule_id)
+    incident_load_noise_finding = _health_rule_finding(
+        rule_id=launch_rule_id,
+        dimension=HealthDimension.RELIABILITY_RELEASE,
+        shadow_only=True,
+        suppressed_reason=None,
+        state=DimensionState.UNKNOWN,
+    )
+    investment_observation = _real_observation(
+        rule_id=investment_rule_id, coverage=0.5, sample_count=None
+    )
+    investment_finding = _health_rule_finding(
+        rule_id=investment_rule_id,
+        dimension=HealthDimension.INVESTMENT_BALANCE,
+        shadow_only=True,
+        suppressed_reason=None,
+        state=DimensionState.UNKNOWN,
+    )
+    workload_profile = HealthProfileResult(
+        subject_kind=RuleApplicability.TEAM,
+        subject_id="team-1",
+        observations=(unavailable_incident_load, investment_observation),
+        launch_findings=(),
+        shadow_findings=(incident_load_noise_finding, investment_finding),
+        suppressed_findings=(),
+        observations_by_rule={
+            launch_rule_id: unavailable_incident_load,
+            investment_rule_id: investment_observation,
+        },
+    )
+
+    # Must not raise -- the exact Codex repro.
+    statuses, findings = _rule_driven_results(
+        health_profile, org_id=_ORG_ID, workload_profile=workload_profile
+    )
+
+    reliability_status = next(
+        s for s in statuses if s.category is DeficiencyCategory.DEPLOYMENT_RELIABILITY
+    )
+    assert reliability_status.evaluated is True
+    assert reliability_status.finding_count == 1
+    reliability_finding = next(
+        f for f in findings if f.category is DeficiencyCategory.DEPLOYMENT_RELIABILITY
+    )
+    # The REAL primary observation survived -- never overwritten by
+    # workload_profile's unrelated unavailable noise for the same rule_id.
+    assert reliability_finding.coverage == 0.9
+    assert reliability_finding.sample_count == 7
+    assert (
+        reliability_finding.observed_state is SourceRequirementState.AVAILABLE_CURRENT
+    )
+    assert reliability_finding.data_semantics == "measured_zero"
+
+    investment_status = next(
+        s for s in statuses if s.category is DeficiencyCategory.INVESTMENT_BALANCE
+    )
+    assert investment_status.evaluated is True
+    assert investment_status.finding_count == 0  # shadow-only, no launch
+
+
+# ---------------------------------------------------------------------------
+# Categories 7 & 8: always unevaluated this version.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capacity_is_unevaluated_and_investment_balance_not_applicable_for_project() -> (
+    None
+):
+    """Category 7 (capacity/cognitive load) has no rule bound via this
+    pipeline for either scope -- see ``_CAPACITY_LIMITATION``. Category 8
+    (investment balance) DOES have a bound rule now (CHAOS-3304 merged),
+    but that rule is TEAM-only -- a project subject reports an honest
+    "not applicable to this scope" limitation, distinct from "nobody
+    built this yet" (see ``test_evaluate_team_investment_balance_*``
+    below for the TEAM-scope-evaluated case).
+    """
+
+    runtime = _runtime()
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    capacity = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.CAPACITY_COGNITIVE_LOAD
+    )
+    assert capacity.evaluated is False
+    assert capacity.finding_count == 0
+    assert capacity.limitation is not None
+
+    investment = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.INVESTMENT_BALANCE
+    )
+    assert investment.evaluated is False
+    assert investment.finding_count == 0
+    assert (
+        investment.limitation
+        == _INVESTMENT_BALANCE_NOT_APPLICABLE_TO_PROJECT_LIMITATION
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_investment_balance_wired_but_missing_attribution_suppressed() -> (
+    None
+):
+    """CHAOS-3304's ``investment_allocation_shift.v1`` is CHAOS-3331-blocked:
+    ``investment_allocation_shift_observation`` reports
+    ``attribution_present=False`` unconditionally even for genuinely
+    measured, non-``no_data`` investment-mix facts (see
+    ``dimension_observation_adapters.py``). A real, computed shift must
+    therefore land in ``suppressed_findings`` with reason
+    ``missing_attribution`` -- never a launch finding -- and category 8
+    must report ``evaluated=True`` with the partial/suppressed limitation,
+    not the old "not yet merged" wording. Both windows need genuinely
+    measured, non-zero-total investment mix data (current AND comparison)
+    to clear the adapter's own ``comparison_share is None -> no_data``
+    short-circuit and reach the attribution guard at all.
+    """
+
+    workload = FakeWorkloadSource(
+        investment_mix_results=(
+            _measured_investment_mix(new_value_units=80.0, total_units=100.0),
+            _measured_investment_mix(new_value_units=20.0, total_units=100.0),
+        )
+    )
+    attribution = FakeAttributionSource(repository_ids=("repo-1", "repo-2"))
+    runtime = _runtime()
+    service = OperationalDeficiencyService(runtime, attribution, workload)
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(with_comparison=True),
+        team_id="team-1",
+        now=_NOW,
+    )
+    investment = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.INVESTMENT_BALANCE
+    )
+    assert investment.evaluated is True
+    # Suppressed, never a launch finding -- CHAOS-3331 is not resolved.
+    assert investment.finding_count == 0
+    assert investment.limitation is not None
+    assert not any(
+        f.category is DeficiencyCategory.INVESTMENT_BALANCE for f in inventory.findings
+    )
+    # The workload source was genuinely invoked for TEAM scope (structural
+    # wiring, not merely a status-text claim) -- the COMPLETE, unfiltered,
+    # ordered call log, both windows, exact arguments (Codex finding,
+    # MEDIUM, round 6: a filtered/counted view would keep passing even if
+    # an unexpected cognitive_load/active_contributor_count call got
+    # interleaved -- this equality check cannot).
+    assert workload.calls == [
+        ("investment_mix", _ORG_ID, "team-1", _NOW - timedelta(days=14), _NOW),
+        (
+            "investment_mix",
+            _ORG_ID,
+            "team-1",
+            _NOW - timedelta(days=28),
+            _NOW - timedelta(days=14),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_investment_balance_category_in_rule_driven_categories() -> (
+    None
+):
+    """Structural assertion (Codex round-4 finding #2): INVESTMENT_BALANCE
+    must be a member of the rule-driven-categories partition, not merely
+    described as wired in prose.
+    """
+
+    from dev_health_ops.api.dev.operational_deficiency_service import (
+        _RULE_DRIVEN_CATEGORIES,
+    )
+
+    assert DeficiencyCategory.INVESTMENT_BALANCE in _RULE_DRIVEN_CATEGORIES
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_investment_balance_unavailable_when_attribution_fails() -> (
+    None
+):
+    """Mirrors the other rule-driven categories' existing attribution-
+    unavailable behavior (``_TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION``):
+    a failed team_repository_ids lookup must never let category 8 report
+    whatever the (unmeasured) workload profile happened to compute.
+    """
+
+    workload = FakeWorkloadSource(
+        investment_mix_results=(
+            _measured_investment_mix(new_value_units=80.0, total_units=100.0),
+            _measured_investment_mix(new_value_units=20.0, total_units=100.0),
+        )
+    )
+    runtime = _runtime()
+    service = OperationalDeficiencyService(
+        runtime, FakeAttributionSource(measured=False), workload
+    )
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(with_comparison=True),
+        team_id="team-1",
+        now=_NOW,
+    )
+    investment = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.INVESTMENT_BALANCE
+    )
+    assert investment.evaluated is False
+    assert investment.limitation == _TEAM_ATTRIBUTION_UNAVAILABLE_LIMITATION
+    # The investment-mix source must never even be called when attribution
+    # is unmeasured -- nothing meaningful could be reported regardless.
+    assert workload.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_investment_balance_failure_isolated_from_other_categories() -> (
+    None
+):
+    """Codex finding, HIGH, round 5, 2026-08-02: an EXPECTED dependency
+    failure (the investment-mix source raising) must degrade ONLY category
+    8 to an honest unevaluated/limitation status -- it must never propagate
+    out of ``evaluate_team`` and lose categories 1-7. Category 1 gets a
+    real, non-empty ``DataHealthSource`` set here specifically so this test
+    can prove the REST of the inventory survives intact, not merely that
+    the call didn't crash.
+    """
+
+    workload = FakeWorkloadSource(raise_on_investment_mix=True)
+    attribution = FakeAttributionSource(repository_ids=("repo-1", "repo-2"))
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, attribution, workload)
+
+    inventory = await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(with_comparison=True),
+        team_id="team-1",
+        now=_NOW,
+    )
+
+    investment = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.INVESTMENT_BALANCE
+    )
+    assert investment.evaluated is False
+    assert investment.limitation is not None
+    assert not any(
+        f.category is DeficiencyCategory.INVESTMENT_BALANCE for f in inventory.findings
+    )
+    # Category 1 (and the rest of the inventory) survived the raise --
+    # the stale work_items source still produced its real finding.
+    data_status = next(
+        s
+        for s in inventory.category_statuses
+        if s.category is DeficiencyCategory.DATA_INTEGRATION
+    )
+    assert data_status.evaluated is True
+    assert data_status.finding_count >= 1
+    assert len(inventory.category_statuses) == len(DEFICIENCY_CATEGORIES)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_team_investment_balance_measured_empty_cohort_makes_no_team_scoped_runtime_call() -> (
+    None
+):
+    """Codex's exact round-5 repro: a measured-EMPTY team (zero attributed
+    repositories, so zero REPOSITORY data_health batches) must still never
+    trigger a single raw-TEAM-scope ``data_health``/``status_snapshot``
+    call from category 8 -- ``_investment_balance_profile`` never touches
+    ``self._runtime`` at all, so this holds structurally, not by luck of
+    what the fake happens to return.
+    """
+
+    workload = FakeWorkloadSource(
+        investment_mix_results=(
+            _measured_investment_mix(new_value_units=80.0, total_units=100.0),
+            _measured_investment_mix(new_value_units=20.0, total_units=100.0),
+        )
+    )
+    attribution = FakeAttributionSource(repository_ids=())  # measured, empty
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, attribution, workload)
+
+    await service.evaluate_team(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_team_scope(with_comparison=True),
+        team_id="team-1",
+        now=_NOW,
+    )
+
+    assert runtime.data_health_scopes == []
+    # The investment-mix source still ran, unaffected by the empty cohort
+    # -- the complete, unfiltered, ordered call log, both windows.
+    assert workload.calls == [
+        ("investment_mix", _ORG_ID, "team-1", _NOW - timedelta(days=14), _NOW),
+        (
+            "investment_mix",
+            _ORG_ID,
+            "team-1",
+            _NOW - timedelta(days=28),
+            _NOW - timedelta(days=14),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Inventory-level invariants: full category coverage, ordering.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inventory_covers_every_taxonomy_category_exactly_once() -> None:
+    runtime = _runtime()
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    categories = [s.category for s in inventory.category_statuses]
+    assert set(categories) == set(DEFICIENCY_CATEGORIES)
+    assert len(categories) == len(set(categories))
+
+
+@pytest.mark.asyncio
+async def test_inventory_findings_are_ordered_worst_first() -> None:
+    runtime = _runtime(
+        sources=(
+            _source("work_items", DataHealthState.NO_DATA),  # watch
+            _source("pull_requests", DataHealthState.UNAVAILABLE),  # critical
+        )
+    )
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    severities = [f.severity for f in inventory.findings]
+    order = {
+        DeficiencySeverity.CRITICAL: 0,
+        DeficiencySeverity.AT_RISK: 1,
+        DeficiencySeverity.WATCH: 2,
+    }
+    assert [order[s] for s in severities] == sorted(order[s] for s in severities)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_project_is_deterministic_across_repeated_calls() -> None:
+    """Same ``now`` twice -- the baseline determinism proof."""
+
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    inventory_a = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    inventory_b = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    assert inventory_a.inventory_id == inventory_b.inventory_id
+    assert [f.finding_id for f in inventory_a.findings] == [
+        f.finding_id for f in inventory_b.findings
+    ]
+
+
+@pytest.mark.asyncio
+async def test_finding_ids_are_replay_stable_across_different_evaluation_times() -> (
+    None
+):
+    """Codex finding, 2026-08-02: the same underlying deficiency,
+    re-evaluated one second apart, must mint the SAME finding_id --
+    identity is what the finding is about, never when it was last
+    evaluated. This is the real regression the same-``now``-twice test
+    above cannot catch (proven RED against the pre-fix
+    ``_mint_deficiency_finding_id``, which folded ``evaluated_at`` into
+    the uuid5 payload: same inputs one second apart minted two different
+    ids).
+    """
+
+    runtime = _runtime(sources=(_source("work_items", DataHealthState.STALE),))
+    service = OperationalDeficiencyService(runtime, _NO_ATTRIBUTION, _NO_WORKLOAD)
+    later = _NOW + timedelta(seconds=1)
+    inventory_a = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=_NOW,
+    )
+    inventory_b = await service.evaluate_project(
+        org_id=_ORG_ID,
+        permission_fingerprint="fp",
+        scope=_project_scope(),
+        now=later,
+    )
+    assert inventory_a.findings and inventory_b.findings
+    assert [f.finding_id for f in inventory_a.findings] == [
+        f.finding_id for f in inventory_b.findings
+    ]
+    # evaluated_at is still real, per-evaluation metadata -- it is not
+    # frozen out of the finding, only out of the finding's identity.
+    assert inventory_a.findings[0].evaluated_at == _NOW
+    assert inventory_b.findings[0].evaluated_at == later
+
+
+# ---------------------------------------------------------------------------
+# Dedup: one canonical finding per observation, with a load-bearing-guard
+# mutation control (Four Verification Rules #2/#4).
+# ---------------------------------------------------------------------------
+
+
+def _dummy_finding(finding_id: str) -> DeficiencyFinding:
+    """A minimal, structurally valid finding -- only ``finding_id`` varies,
+    since these dedup tests exercise ``_dedupe_findings``/the mint
+    function's key discipline, not the finding's own field content.
+    """
+
+    return DeficiencyFinding(
+        schema_version="deficiency_finding.v1",
+        finding_id=finding_id,
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        rule_id="deficiency_rule.stale_watermark.v1",
+        rule_version="deficiency_rule.stale_watermark.v1",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        severity=DeficiencySeverity.AT_RISK,
+        fact_kind="observed",
+        observed_state=SourceRequirementState.AVAILABLE_STALE,
+        data_semantics="measured_zero",
+        sample_count=None,
+        coverage=1.0,
+        current_window_days=1,
+        comparison_window_days=None,
+        evidence_ref_ids=(),
+        evidence_classification=DeficiencyEvidenceClassification.STRUCTURAL_ABSENCE,
+        blast_radius="Required source is stale.",
+        remediation=DeficiencyRemediation(
+            schema_version="deficiency_remediation.v1",
+            remediation_template="Investigate.",
+            verification_condition="Resolves once re-evaluated fresh.",
+        ),
+        limitations=(),
+        evaluated_at=_NOW,
+    )
+
+
+def test_dedupe_collapses_identical_finding_ids() -> None:
+    duplicate_id = "66666666-6666-6666-6666-666666666666"
+    findings = (
+        _dummy_finding(duplicate_id),
+        _dummy_finding(duplicate_id),
+    )
+    deduped = _dedupe_findings(findings)
+    assert len(deduped) == 1
+
+
+def test_dedupe_key_is_deterministic_over_identical_inputs() -> None:
+    """The dedupe guard is only load-bearing because minting is
+    deterministic. A mutation that made minting non-deterministic (e.g.
+    injecting a random component) would silently defeat _dedupe_findings
+    without touching it at all -- this control kills exactly that mutation
+    by asserting two calls with identical inputs mint identical ids and,
+    conversely, that a differing discriminator (the axis a duplicate-
+    observation bug would fail to vary) mints a different id.
+    """
+
+    same_a = _mint_deficiency_finding_id(
+        org_id=_ORG_ID,
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        rule_id="deficiency_rule.stale_watermark.v1",
+        subject_kind="project",
+        subject_id="proj-1",
+        discriminator="work_items",
+    )
+    same_b = _mint_deficiency_finding_id(
+        org_id=_ORG_ID,
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        rule_id="deficiency_rule.stale_watermark.v1",
+        subject_kind="project",
+        subject_id="proj-1",
+        discriminator="work_items",
+    )
+    different_discriminator = _mint_deficiency_finding_id(
+        org_id=_ORG_ID,
+        category=DeficiencyCategory.DATA_INTEGRATION,
+        rule_id="deficiency_rule.stale_watermark.v1",
+        subject_kind="project",
+        subject_id="proj-1",
+        discriminator="pull_requests",
+    )
+    assert same_a == same_b
+    assert same_a != different_discriminator
+
+
+def test_dedupe_mutation_control_wrong_key_produces_duplicates() -> None:
+    """Plant the defect a correct dedupe key exists to catch: key by
+    object identity instead of the deterministic finding_id. The OLD
+    (correct) dedupe collapses two content-identical findings to one; a
+    broken key that ignores content lets the duplicate through -- proving
+    _dedupe_findings' use of finding_id, not object identity, is what
+    makes deduplication work at all.
+    """
+
+    duplicate_id = "77777777-7777-7777-7777-777777777777"
+    findings = (
+        _dummy_finding(duplicate_id),
+        _dummy_finding(duplicate_id),
+    )
+
+    # Correct behavior (the guard under test).
+    assert len(_dedupe_findings(findings)) == 1
+
+    # The mutation: dedupe by object identity instead of finding_id.
+    broken_seen: dict[int, object] = {}
+    for finding in findings:
+        broken_seen.setdefault(id(finding), finding)
+    assert len(broken_seen) == 2  # old test's assumption fails under the mutation

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -906,6 +906,14 @@ _NON_HANDLE_IDENTIFIER_REASONS: dict[str, str] = {
     "DimensionObservation.subject_id": "provider entity key",
     "HealthRuleFinding.subject_id": "provider entity key",
     "TeamQualificationResult.team_id": "provider entity key",
+    # CHAOS-3305 operational-deficiency-inventory contracts
+    # (contracts_v2.deficiency) -- same category as the CHAOS-3302 rows
+    # above: subject identifiers name real project/team/portfolio entities,
+    # and evidence_ref_ids is scoped to one inventory document, the same
+    # category as DevSourceObservation.evidence_ref_ids above.
+    "DeficiencyFinding.subject_id": "provider entity key",
+    "OperationalDeficiencyInventory.subject_id": "provider entity key",
+    "DeficiencyFinding.evidence_ref_ids": "intra-document key",
 }
 
 


### PR DESCRIPTION
## Summary
- Implements the `deficiency.operational.v1` plan and `OperationalDeficiencyService`, evaluating only CHAOS-3302-approved rules over committed org/project/team scope across the full eight-category operational-deficiency taxonomy.
- Categories 1 (data & integration) and 2 (planning & relationships) are fully computed from `DataHealthResult`/`StatusSnapshotResult`. Categories 3-6 are wired to `HEALTH_RULE_REGISTRY` via `health_profile_synthesis` (shadow-only findings structurally excluded from the inventory). Category 8 (investment balance) is bound for TEAM subjects via a narrow, investment-only path that reuses CHAOS-3304's own adapter/rule pieces without composing its whole service. Category 7 (capacity/cognitive load) stays honestly `evaluated=False` pending CHAOS-3331.

## Test plan
- 7 Codex adversarial-review rounds, round-by-round: r1 found 6 CONFIRMED issues (contract registration gap, team-scope data_health widening, measured_zero misuse, replay-unstable finding IDs, count/subject reconciliation, F10 structural gaps); r2 (>20-repo crash, unmeasured-state zero-semantics gap); r3 (model_copy bypass -> structural subclass prohibition, omitted/empty-batch merges as healthy); r4 (all-batches-empty false-pass, category-8 hardcoded stale assumption, required-flag merge order-dependence, limitation-text honesty); r5 (investment-only path redesign to eliminate raw-TEAM-scope data_health widening + dependency-failure isolation, required-OR aggregation scoped to required batches only); r6 (observations_by_rule wholesale-overwrite corrupting a shared rule's real observation, filtered call-log test-honesty class); r7 confirmed both r6 fixes clean with two-sided (blind-old/catching-new) proof on the call-log class.
- Full `tests/api/dev/` suite: 1161 passed, 0 failed, 25 skipped.
- Focused set (`test_native_status_change`, `test_chaos_3301_controls`, `test_chaos_3303_team_health_service`, `test_status_change_service`, `test_chaos_3305_deficiency_contracts`, `test_contracts_v2`, `test_chaos_3303_project_health_service`): 342 passed, 0 failed.
- `ruff format --check` / `ruff check`: clean. `mypy` over `src/` + `tests/` (1918 files): clean. `export_contracts_v2 check`: 81 artifacts verified, no drift.
- CI runs the full gate on this PR; the above is the lane-side local result at the same commit.

## Risk notes
- Deficiency contracts (`DeficiencyFinding`, `OperationalDeficiencyInventory`, etc.) are deliberately excluded from `CONTRACT_MODELS_V2` — they're a governance-family contract, reachable only via an opaque pointer, imported into `contracts_v2/__init__.py` solely for reflection visibility.
- Category 7 (capacity & cognitive load) stays honestly `evaluated=False` for every subject — no `HEALTH_RULE_REGISTRY` rule is bound to this category via this pipeline yet, and the CHAOS-3305 planning brief calls for the aggregation boundary to be re-verified (not assumed) before binding it.
- Category 8 (investment balance) can report THREE distinct, honest not-evaluated shapes depending on cause: attribution unmeasured, investment-mix dependency failure (raised/timed out), or (PROJECT scope only) not applicable to this subject kind. All three carry their own limitation text, never conflated.
- `OperationalDeficiencyInventory`/`DeficiencyFinding` are marked `@final` with `__init_subclass__` raising `TypeError`, making subclassing structurally impossible — closes a `model_copy`/`model_construct` bypass residual identified in round 3. A residual `model_construct` bypass on the inventory itself is caught at persistence, not at construction (documented in the module).