### PR TITLE
feat(ask-dev): CHAOS-3285 per-role provider readiness certification

### DIFF
--- a/docs-data/ia/contribute.tsv
+++ b/docs-data/ia/contribute.tsv
@@ -9,6 +9,7 @@ con-storage	con-arch	/contribute/architecture/data-and-storage/	Data and storage
 con-contracts	con-arch	/contribute/architecture/contracts/	Stable contracts and source-of-truth rules	architecture	true	public	planned	false	
 con-ask-dev-v2	con-arch	/contribute/architecture/ask-dev-contracts-v2/	Ask Dev v2 contracts (Wave 3.1)	architecture	true	public	planned	false	
 con-ask-dev-preflight	con-arch	/contribute/architecture/ask-dev-subject-preflight/	Ask Dev subject preflight	architecture	true	public	planned	false	
+con-ask-dev-role-readiness	con-arch	/contribute/architecture/ask-dev-role-readiness/	Ask Dev role readiness	architecture	true	public	planned	false	
 con-dev	contribute	/contribute/development/	Develop and test	landing	true	public	planned	false	
 con-commands	con-dev	/contribute/development/commands/	Common development commands	task-guide	true	public	planned	false	
 con-tests	con-dev	/contribute/development/testing/	Testing layers and local validation	task-guide	true	public	planned	false	

--- a/docs/contribute/architecture/ask-dev-role-readiness.md
+++ b/docs/contribute/architecture/ask-dev-role-readiness.md
@@ -1,0 +1,210 @@
+---
+page_id: con-ask-dev-role-readiness
+summary: Why Ask Dev certifies a provider per role instead of with one pass/fail badge, and how a stale certification is forced to re-run.
+content_type: architecture
+owner: engineering
+source_of_truth:
+  - src/dev_health_ops/llm/agent/roles.py
+  - src/dev_health_ops/llm/agent/role_readiness.py
+  - src/dev_health_ops/llm/agent/probes/legacy_agent.py
+  - src/dev_health_ops/llm/agent/readiness.py
+  - src/dev_health_ops/api/dev/production_runtime.py
+  - src/dev_health_ops/api/admin/routers/ask_dev.py
+  - src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+  - tests/api/dev/test_live_openai_smoke.py
+  - Amendment TRD v2 -- Ask Dev Wave 3.1 (Linear, project Ask Dev)
+applicability: current
+lifecycle: active
+---
+
+# Ask Dev role readiness
+
+A provider certified against a small synthetic exchange can still exhaust its
+output budget on the first real question. Ask Dev certifies a provider
+**per role** it is actually asked to perform, against a request built from the
+real production producers -- never a hand-authored miniature -- and treats a
+structural rejection (the provider cannot handle the shape at all) as a
+different, non-retryable outcome from a transient one (the network blipped).
+{: .fc-page-lede }
+
+## Why one badge was not enough
+
+Before this work, Ask Dev certified a provider with a single exchange: a
+512-token echo call against one tiny tool, followed by a second call with no
+tools at all. That request is roughly 1 KB. A real Ask Dev round is the full
+nine-tool registry, the fixed policy sections, and the complete decision
+grammar -- roughly 12 KB at round one, more once tool results accumulate --
+capped at the same 4,096-token output budget the echo probe never came close
+to touching. A provider that passed certification could still exhaust its
+reasoning budget on the very first real question, and the resulting failure
+carried no distinct identity: it surfaced as `internal_error`, indistinguishable
+from a genuine server bug.
+
+Fixing that budget accounting is a separate, decision-gated change (the
+4,096-token envelope is a ratified TRD number; widening it has its own
+coupled risks -- see the budget policy module for the current state). What
+this page describes is the certification model that makes such a defect
+detectable and describable at all: a role-scoped, production-representative
+probe with a verdict vocabulary that distinguishes "this provider cannot do
+this" from "try again."
+
+## The role model
+
+Ask Dev asks a provider to do three structurally different things, and a
+provider may be capable of one and not another:
+
+| Role | Shape | Consumes |
+| --- | --- | --- |
+| `legacy_agent` | The full open-ended agent loop: nine tools, `tool_choice` negotiation, and the complete decision grammar, across multiple rounds. | The retained multi-round investigation path. |
+| `intent_classification` | A strict, small typed decision with no tools and no source data. | The fallback classifier when the deterministic interpreter abstains. |
+| `answer_frame_narrative` | Strict prose generation over one compact canonical frame, with no tool registry. | Optional narration over an already-computed, deterministic answer. |
+
+`AgentRole` (`llm/agent/roles.py`) names these three. Only `legacy_agent` has a
+working probe today; `intent_classification` and `answer_frame_narrative` are
+valid enum members and store slots with no probe wired to them yet -- the
+per-role store can hold a certification for either once their probes land,
+but nothing produces one yet.
+
+## Certification states
+
+A per-role certification is one of:
+
+| State | Meaning | Selectable? |
+| --- | --- | --- |
+| `compatible` | The probe completed with a valid typed decision inside budget. | Yes |
+| `incompatible` | A deterministic, structural rejection: output exhaustion, an unsupported request parameter, a malformed decision. Re-running the identical request will not help. | Never |
+| `failed` | A transient or environmental failure: timeout, rate limit, transport error, missing credentials. Worth retrying once the condition clears. | No, but recoverable |
+| `stale` | A stored record whose certification key no longer matches the provider's current capability inputs. | No |
+| `unchecked` | No record exists for this (provider, role) pair yet. | No |
+
+This is a deliberate split of what used to be one boolean `FAILED`. Output
+exhaustion is `incompatible`: retrying the same provider against the same
+prompt, tool registry, and budget will exhaust again every time, so the
+runtime must never keep selecting it hoping for a different result. A rate
+limit is `failed`: the same request may well succeed a minute later.
+`RoleCertificationState` and the mapping from a probe's safe error code to
+one of these states live in `llm/agent/roles.py` and
+`llm/agent/readiness.py::role_state_for_safe_error_code`.
+
+## What invalidates a certification
+
+A certification is keyed by a **certification key**, not just a provider/model
+pair. `production_runtime.py::_readiness_fingerprint` folds every capability
+input that can flip a verdict: the provider's source, identity, and base URL;
+the adapter's wire-contract version (`READINESS_VERSION`); the composed
+prompt's version (`PROMPT_VERSION`); the tool registry's contract version
+(`TOOL_CONTRACT_VERSION`); the per-family token budget policy's version
+(`BUDGET_POLICY_VERSION`); and the role being certified. Changing any of
+these -- a prompt-section edit, a new tool, a budget policy change, asking
+about a different role -- produces a different key, and a stored record under
+the old key simply stops being read as current. Nothing has to notice and
+manually invalidate anything.
+
+This also gives certification an explicit migration story. The fingerprint
+formula changed when this role model landed, which means every certification
+recorded before that change reads as stale under the new formula and the
+runtime falls back to "not yet certified" until an operator re-runs
+preflight -- the same self-invalidating pattern already established when the
+adapter's own wire contract last changed (`READINESS_VERSION` v2 -> v3).
+
+## Storage and backward compatibility
+
+The per-role profile persists under settings keys distinct from the original
+single-record store: `ask_dev_role_certification_profile` for an
+organization's own BYO provider, `platform_ask_dev_role_certification_profile`
+for the platform-owned provider (same `org_id=""` sentinel scoping the
+original platform key uses). The new store never reads the old
+`ask_dev_agent_readiness` / `platform_ask_dev_agent_readiness` keys, so a
+certification recorded before this model existed can never be misread as a
+certification for any role -- it is simply invisible to the new code path. A
+rolled-back deploy that falls back to reading the old key is unaffected by
+anything the new store has written.
+
+`RoleCertificationProfile.with_record()` updates exactly one role's record
+and leaves every other role's stored record untouched: certifying
+`legacy_agent` can never overwrite an already-certified
+`answer_frame_narrative`, once that role has a probe of its own.
+
+## The `legacy_agent` probe
+
+`llm/agent/probes/legacy_agent.py::certify_legacy_agent` is built exclusively
+from the real production producers: `PromptComposer` for the fixed policy
+sections and the committed-subject section, `AskDevToolRegistry` for the
+complete nine-tool manifest and each tool's real input schema (via
+`DevOrchestrator._provider_tool_input_schema`, not a re-implementation of it),
+`DevRunLimits` for the real per-call output cap, and `DevAnswer`'s own JSON
+schema for the decision grammar. A production-floor assertion fails loudly if
+the composed request or the tool count ever silently shrinks below what a
+real round sends -- a probe that got smaller without anyone noticing would
+otherwise read as coverage it no longer provides.
+
+The probe runs two rounds that mirror the worst production shape:
+
+1. **Round one** -- tools offered, no tool result yet. The wire sends
+   `tool_choice: "required"` with no structured-output grammar.
+2. **Round two** -- tools still offered, and a synthetic, schema-valid,
+   non-tenant tool result is now in the conversation. The wire sends
+   `tool_choice: "auto"` **and** the full `DevAnswer` grammar at the same
+   time -- the combined shape every real round two and later actually sends,
+   and the one the original echo probe never sent at all (its second call
+   dropped tools entirely).
+
+The synthetic tool result comes from the checked-in contract fixtures
+(`contract_fixtures.positive_fixtures()`), never a live tool call and never
+tenant data, satisfying the guardrail that readiness must not touch real
+source data.
+
+## Admin surfaces
+
+Both admin readiness endpoints (`GET /admin/ask-dev`,
+`GET /admin/platform/ask-dev/readiness`) gained an additive `role_readiness`
+array, one entry per role, using a safe display vocabulary
+(`RoleReadinessState`) that is deliberately **not** the internal
+`RoleCertificationState` enum: it extends the existing `ReadinessState`
+values with exactly one new state, `not_yet_certified`, so a role nothing has
+certified reads as visibly distinct from `stale_readiness` (was certified,
+now invalidated) and from any failure-derived state. No prompt text, tool
+text, or provider payload is ever included.
+
+The existing CHAOS-3265 boundary applies unchanged: an organization relying
+on platform fallback sees the platform role's *state* (it carries no
+identity) but never the platform's specific remediation text, which is
+replaced with the same generic message the single-readiness field already
+uses.
+
+Platform preflight (`POST /admin/platform/ask-dev/readiness`) now also
+certifies the `legacy_agent` role in the new per-role store, on the same
+already-resolved provider, immediately after the existing certification call
+-- so the projection reflects a real result instead of staying
+`not_yet_certified` forever. That call is best-effort: a failure in it can
+never regress the original, already-relied-upon certification result.
+
+An organization's own BYO provider is not yet certified through this new
+model -- that requires wiring `POST /llm-settings/readiness`
+(`api/admin/routers/settings.py`), which is a separate, not-yet-scheduled
+change. Until then a BYO-sourced organization's `role_readiness` honestly
+reports `not_yet_certified` for every role.
+
+## The live convergence gate
+
+`tests/api/dev/test_live_openai_smoke.py` exercises the real adapter against
+a real OpenAI-compatible endpoint when live credentials are configured. By
+default, a missing credential is a `pytest.skip` -- an ordinary local run
+without live credentials configured is not an error. Setting
+`ASK_DEV_LIVE_GATE=1` marks the run as the actual convergence gate: under
+that flag, a missing credential becomes a `pytest.fail` instead. A gate that
+can silently skip its own measurement reads as passing coverage it never
+took; the flag exists so that failure is loud rather than invisible. Whether
+CI sets that flag for the Wave 3.1 convergence gate is a separate workflow
+change, not implemented here.
+
+## What is not built yet
+
+- `intent_classification` and `answer_frame_narrative` have no probes. Their
+  enum members and store slots exist so the store's shape does not need to
+  change again when the probes land.
+- The BYO `POST /llm-settings/readiness` route does not yet certify the new
+  per-role store.
+- The 4,096-token output envelope is unchanged. Whether it needs amending
+  (and how) is a decision gated on the live per-role probe's real numbers
+  against `gpt-5-nano`, not decided by this page.

--- a/docs/contribute/architecture/ask-dev-role-readiness.md
+++ b/docs/contribute/architecture/ask-dev-role-readiness.md
@@ -8,9 +8,11 @@ source_of_truth:
   - src/dev_health_ops/llm/agent/role_readiness.py
   - src/dev_health_ops/llm/agent/probes/legacy_agent.py
   - src/dev_health_ops/llm/agent/readiness.py
+  - src/dev_health_ops/llm/agent/openai_compatible.py
   - src/dev_health_ops/api/dev/production_runtime.py
   - src/dev_health_ops/api/admin/routers/ask_dev.py
   - src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+  - src/dev_health_ops/api/admin/routers/settings.py
   - tests/api/dev/test_live_openai_smoke.py
   - Amendment TRD v2 -- Ask Dev Wave 3.1 (Linear, project Ask Dev)
 applicability: current
@@ -91,14 +93,39 @@ one of these states live in `llm/agent/roles.py` and
 A certification is keyed by a **certification key**, not just a provider/model
 pair. `production_runtime.py::_readiness_fingerprint` folds every capability
 input that can flip a verdict: the provider's source, identity, and base URL;
-the adapter's wire-contract version (`READINESS_VERSION`); the composed
-prompt's version (`PROMPT_VERSION`); the tool registry's contract version
+a non-reversible fingerprint of the credential material actually used on the
+wire (`_credential_fingerprint` -- the raw key is never stored, logged, or
+otherwise exposed; see "Credential rotation" below); the adapter's
+wire-contract version (`READINESS_VERSION`); the composed prompt's version
+(`PROMPT_VERSION`); the tool registry's contract version
 (`TOOL_CONTRACT_VERSION`); the per-family token budget policy's version
-(`BUDGET_POLICY_VERSION`); and the role being certified. Changing any of
-these -- a prompt-section edit, a new tool, a budget policy change, asking
-about a different role -- produces a different key, and a stored record under
-the old key simply stops being read as current. Nothing has to notice and
-manually invalidate anything.
+(`BUDGET_POLICY_VERSION`); the role being certified; a canonical contract
+digest folding both prompt shapes, the real response grammar, the real tool
+manifest, and the real run limits (`_canonical_contract_digest`); and a
+wire-request digest folding the COMPLETE non-secret request the adapter would
+send at both probe round shapes -- tool_choice, parallel_tool_calls,
+temperature, reasoning_effort, the full `response_format` wrapper and schema
+body, serialized tool payloads, and the resolved `max_completion_tokens`
+(`_wire_request_digest`). Both digests are computed by calling the same
+producer functions the adapter's `decide()` call itself consumes
+(`build_completion_request` in `openai_compatible.py`), so nothing about the
+request can be assembled independently of what gets fingerprinted. Changing
+any of these -- a prompt-section edit, a new tool, a budget policy change, a
+capability-policy change (e.g. which models get `temperature` or
+`parallel_tool_calls`), a rotated credential, asking about a different role
+-- produces a different key, and a stored record under the old key simply
+stops being read as current. Nothing has to notice and manually invalidate
+anything.
+
+### Credential rotation
+
+The certification key depends on WHICH credential was actually tested, not
+just the provider/model/base URL triple. Certifying provider key A, then
+saving key B for the exact same provider/model/base URL, produces a
+different key for B -- so a stored certification for A can never be found
+under B's key, and live selection fails closed until B is re-certified. This
+is enforced by construction (folding `_credential_fingerprint` into the key),
+not by any save/rotation code path remembering to invalidate anything.
 
 This also gives certification an explicit migration story. The fingerprint
 formula changed when this role model landed, which means every certification
@@ -138,21 +165,43 @@ the composed request or the tool count ever silently shrinks below what a
 real round sends -- a probe that got smaller without anyone noticing would
 otherwise read as coverage it no longer provides.
 
-The probe runs two rounds that mirror the worst production shape:
+The probe runs **two fully independent, complete two-round chains** -- four
+provider calls total -- because `PromptComposer` composes two distinct
+prompt shapes (`PROMPT_VERSION`, committed subject; `LEGACY_PROMPT_VERSION`,
+uncommitted subject / the Wave 3.1 flag off) and a real run can select
+either one. Each chain's own round one produces the tool request/result its
+own round two uses -- never borrowed from the other chain -- so a provider
+that fails only on one specific shape (e.g. the uncommitted-subject prompt
+combined with round one's `tool_choice: "required"`) cannot silently pass by
+having that exact combination never sent to it. Both chains must
+independently certify `compatible` for the role to certify `compatible`
+overall.
+
+Each chain's two rounds mirror the worst production shape:
 
 1. **Round one** -- tools offered, no tool result yet. The wire sends
-   `tool_choice: "required"` with no structured-output grammar.
-2. **Round two** -- tools still offered, and a synthetic, schema-valid,
-   non-tenant tool result is now in the conversation. The wire sends
-   `tool_choice: "auto"` **and** the full `DevAnswer` grammar at the same
-   time -- the combined shape every real round two and later actually sends,
-   and the one the original echo probe never sent at all (its second call
-   dropped tools entirely).
+   `tool_choice: "required"` with no structured-output grammar, under this
+   chain's own prompt shape.
+2. **Round two** -- built from round one's own tool request/result: tools
+   still offered, and a synthetic, schema-valid, non-tenant tool result is
+   now in the conversation. The wire sends `tool_choice: "auto"` **and** the
+   full `DevAnswer` grammar at the same time -- the combined shape every
+   real round two and later actually sends, and the one the original echo
+   probe never sent at all (its second call dropped tools entirely).
 
 The synthetic tool result comes from the checked-in contract fixtures
 (`contract_fixtures.positive_fixtures()`), never a live tool call and never
 tenant data, satisfying the guardrail that readiness must not touch real
 source data.
+
+### Full preflight call count
+
+A complete preflight run makes **6 provider calls**: 2 for the original
+binary transport-echo probe (`AgentReadinessService.certify`, unchanged),
+plus 4 for the `legacy_agent` role probe above (2 independent chains x 2
+rounds each). Both the platform and BYO readiness routes' tests pin this
+count (`provider.calls == 6`) so a chain silently vanishing in a future
+refactor fails loudly rather than passing unnoticed.
 
 ## Admin surfaces
 
@@ -172,18 +221,27 @@ identity) but never the platform's specific remediation text, which is
 replaced with the same generic message the single-readiness field already
 uses.
 
-Platform preflight (`POST /admin/platform/ask-dev/readiness`) now also
-certifies the `legacy_agent` role in the new per-role store, on the same
-already-resolved provider, immediately after the existing certification call
--- so the projection reflects a real result instead of staying
-`not_yet_certified` forever. That call is best-effort: a failure in it can
-never regress the original, already-relied-upon certification result.
+Both platform preflight (`POST /admin/platform/ask-dev/readiness`) and BYO
+preflight (`POST /llm-settings/readiness`, `api/admin/routers/settings.py`)
+certify the `legacy_agent` role in the new per-role store, on the same
+already-resolved provider, immediately after the existing binary certify
+call -- so the projection reflects a real result instead of staying
+`not_yet_certified` forever. That call runs inside a `session.begin_nested()`
+SAVEPOINT and is best-effort: a failure in it can never regress the original,
+already-relied-upon binary certification result, and cannot poison the
+session or roll back that earlier write.
 
-An organization's own BYO provider is not yet certified through this new
-model -- that requires wiring `POST /llm-settings/readiness`
-(`api/admin/routers/settings.py`), which is a separate, not-yet-scheduled
-change. Until then a BYO-sourced organization's `role_readiness` honestly
-reports `not_yet_certified` for every role.
+All three admin readiness surfaces (org `GET /admin/ask-dev`, platform
+`GET /admin/platform/ask-dev/readiness`, BYO `GET /admin/llm-settings/status`)
+derive their **effective** `readiness`/availability from the binary
+transport check AND a current, `compatible` `legacy_agent` role certification
+together -- never the binary check alone. The prior binary-only result is
+still surfaced, under its own name, as a separate diagnostic field
+(`binary_transport_readiness`): a provider can read
+`binary_transport_readiness: "ready"` while the effective `readiness` is
+unavailable, if the transport works but the role has never been certified
+(or was certified `incompatible`/`failed`) against the real production
+request shape.
 
 ## The live convergence gate
 
@@ -194,17 +252,20 @@ without live credentials configured is not an error. Setting
 `ASK_DEV_LIVE_GATE=1` marks the run as the actual convergence gate: under
 that flag, a missing credential becomes a `pytest.fail` instead. A gate that
 can silently skip its own measurement reads as passing coverage it never
-took; the flag exists so that failure is loud rather than invisible. Whether
-CI sets that flag for the Wave 3.1 convergence gate is a separate workflow
-change, not implemented here.
+took; the flag exists so that failure is loud rather than invisible. Under
+that flag the gate also runs the real `certify_legacy_agent` probe against
+the live provider, not only the transport echo -- previously the explicit
+live gate exercised the echo alone. The resulting state is not forced to
+`compatible`: a live provider genuinely hitting the 4,096-token envelope is
+an expected, not a failing, outcome. Whether CI sets `ASK_DEV_LIVE_GATE=1`
+for the Wave 3.1 convergence gate is a separate workflow change, not
+implemented here.
 
 ## What is not built yet
 
 - `intent_classification` and `answer_frame_narrative` have no probes. Their
   enum members and store slots exist so the store's shape does not need to
   change again when the probes land.
-- The BYO `POST /llm-settings/readiness` route does not yet certify the new
-  per-role store.
 - The 4,096-token output envelope is unchanged. Whether it needs amending
   (and how) is a decision gated on the live per-role probe's real numbers
   against `gpt-5-nano`, not decided by this page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,6 +242,7 @@ nav:
           - Stable contracts: contribute/architecture/contracts.md
           - Ask Dev v2 contracts: contribute/architecture/ask-dev-contracts-v2.md
           - Ask Dev subject preflight: contribute/architecture/ask-dev-subject-preflight.md
+          - Ask Dev role readiness: contribute/architecture/ask-dev-role-readiness.md
       - Develop and test:
           - contribute/development/index.md
           - Commands: contribute/development/commands.md

--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -53,6 +53,14 @@ from dev_health_ops.llm.agent.readiness import (
     SettingsAgentReadinessStore,
     readiness_failure_state,
 )
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    RoleCertificationProfile,
+    RoleCertificationRecord,
+    RoleCertificationState,
+    SettingsRoleCertificationStore,
+)
 from dev_health_ops.models.dev_persistence import DevRun
 from dev_health_ops.models.settings import SettingCategory
 
@@ -73,9 +81,119 @@ EntitlementState = Literal[
     "enabled", "not_entitled", "globally_disabled", "org_disabled", "unavailable"
 ]
 
+# CHAOS-3285: the safe, wire-stable vocabulary for a per-role certification
+# projection. This is deliberately NOT RoleCertificationState (that enum is
+# an internal capability-model detail -- COMPATIBLE/INCOMPATIBLE/FAILED/
+# STALE/UNCHECKED -- and must never leak onto the admin wire). It extends the
+# existing ReadinessState vocabulary with exactly one new value,
+# "not_yet_certified", so a role nothing has ever certified reads as visibly
+# distinct from "stale_readiness" (was certified, now invalidated) and from
+# every FAILED-derived state (a certification attempt that did not pass).
+RoleReadinessState = Literal[
+    "ready",
+    "unsupported_model",
+    "missing_credentials",
+    "disabled",
+    "degraded",
+    "stale_readiness",
+    "not_yet_certified",
+]
+
+_ROLE_ORDER: tuple[AgentRole, ...] = (
+    AgentRole.LEGACY_AGENT,
+    AgentRole.INTENT_CLASSIFICATION,
+    AgentRole.ANSWER_FRAME_NARRATIVE,
+)
+
 
 class StrictAdminModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class AskDevRoleReadiness(StrictAdminModel):
+    schema_version: Literal["ask_dev_role_readiness.v1"] = "ask_dev_role_readiness.v1"
+    role: Literal["legacy_agent", "intent_classification", "answer_frame_narrative"]
+    state: RoleReadinessState
+    checked_at: AwareDatetime | None = None
+    safe_remediation: str | None = Field(default=None, max_length=2_048)
+
+
+def _role_readiness_entry(
+    role: AgentRole,
+    record: RoleCertificationRecord | None,
+    *,
+    certification_key: str | None,
+) -> AskDevRoleReadiness:
+    """Project one role's stored certification record into the safe wire
+    vocabulary. ``certification_key`` is the CURRENT capability-input
+    fingerprint for that role (e.g. from ``_readiness_fingerprint``); when
+    unavailable (a role with no probe yet) a stored record's state is
+    reported as-is, without a staleness check against a key we cannot
+    compute here.
+    """
+
+    if record is None:
+        return AskDevRoleReadiness(
+            role=role.value,
+            state="not_yet_certified",
+            checked_at=None,
+            safe_remediation="This Ask Dev role has not been certified yet.",
+        )
+    # Deliberately NOT record.is_current() -- that method also requires
+    # state is COMPATIBLE, which is right for runtime *selection* but wrong
+    # for admin *display*: a FAILED/INCOMPATIBLE record whose capability
+    # inputs still match the current configuration must show its actual
+    # failure reason (e.g. unsupported_model), not be recolored as merely
+    # "stale" just because it never became COMPATIBLE. Staleness here means
+    # only one thing: the record was computed against a DIFFERENT
+    # certification_key than the one in effect now.
+    if certification_key is not None and record.certification_key != certification_key:
+        return AskDevRoleReadiness(
+            role=role.value,
+            state="stale_readiness",
+            checked_at=_checked_at(record.checked_at),
+            safe_remediation=(
+                "This role's certification is stale for the current "
+                "configuration. Run preflight again."
+            ),
+        )
+    if record.state is RoleCertificationState.COMPATIBLE:
+        return AskDevRoleReadiness(
+            role=role.value,
+            state="ready",
+            checked_at=_checked_at(record.checked_at),
+            safe_remediation=None,
+        )
+    state, remediation = readiness_failure_state(record.safe_error_code)
+    return AskDevRoleReadiness(
+        role=role.value,
+        state=state,
+        checked_at=_checked_at(record.checked_at),
+        safe_remediation=remediation,
+    )
+
+
+def _role_readiness_list(
+    profile: RoleCertificationProfile,
+    *,
+    legacy_agent_certification_key: str | None,
+) -> list[AskDevRoleReadiness]:
+    """Build the full three-role projection. Only ``legacy_agent`` has a
+    live certification_key today (CHAOS-3285 PR3's probe); intent/narrative
+    have no probe yet (PR4) so their entries fall back to reporting whatever
+    is stored (ordinarily nothing -> not_yet_certified)."""
+
+    certification_keys: dict[AgentRole, str | None] = {
+        AgentRole.LEGACY_AGENT: legacy_agent_certification_key,
+        AgentRole.INTENT_CLASSIFICATION: None,
+        AgentRole.ANSWER_FRAME_NARRATIVE: None,
+    }
+    return [
+        _role_readiness_entry(
+            role, profile.for_role(role), certification_key=certification_keys[role]
+        )
+        for role in _ROLE_ORDER
+    ]
 
 
 class AskDevAdminSettings(StrictAdminModel):
@@ -171,6 +289,13 @@ class AskDevAdminResponse(StrictAdminModel):
     request_limits: AskDevAdminRequestLimits
     platform_allowance_bounds: AskDevPlatformAllowanceBounds
     no_training_by_default: Literal[True] = True
+    # CHAOS-3285: additive field. A single generic readiness badge cannot
+    # represent "certified for narrative but not for the legacy full-agent
+    # role" -- see AskDevRoleReadiness. Deliberately NOT a schema_version
+    # bump: dev-health-web has not yet been updated to read this field, and
+    # bumping schema_version on an already-deployed contract is a
+    # coordinated, separate change (plan risk R6).
+    role_readiness: list[AskDevRoleReadiness] = Field(default_factory=list)
 
 
 class AskDevAdminUsageResponse(StrictAdminModel):
@@ -272,6 +397,15 @@ def _platform_readiness_store(session: AsyncSession) -> SettingsAgentReadinessSt
     )
 
 
+def _platform_role_store(session: AsyncSession) -> SettingsRoleCertificationStore:
+    """The platform-owned provider's per-role certification store."""
+
+    return SettingsRoleCertificationStore(
+        SettingsService(session, _PLATFORM_SETTINGS_ORG_ID),
+        key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    )
+
+
 async def _feature_state(
     session: AsyncSession, org_id: str
 ) -> tuple[EntitlementState, bool, str | None]:
@@ -324,6 +458,11 @@ async def _admin_response(
     readiness: ReadinessState = "missing_credentials"
     failure_reason: str | None = None
     resolution = None
+    # CHAOS-3285: only populated when a candidate actually resolves below --
+    # entitlement-disabled/org-disabled runs never attempted a certification
+    # check at all, so an empty list (no data) is more honest here than a
+    # fabricated "not_yet_certified" landscape for a feature that is off.
+    role_readiness: list[AskDevRoleReadiness] = []
 
     if not entitled:
         readiness = "disabled"
@@ -346,6 +485,14 @@ async def _admin_response(
                 # stale/absent org-scoped record this org can no longer
                 # produce.
                 readiness_record = await _platform_readiness_store(session).load()
+                role_store = _platform_role_store(session)
+            else:
+                role_store = SettingsRoleCertificationStore(settings_service)
+            role_profile = await role_store.load()
+            role_readiness = _role_readiness_list(
+                role_profile,
+                legacy_agent_certification_key=resolution.readiness_fingerprint,
+            )
             if readiness_record is None:
                 readiness = "stale_readiness"
                 failure_reason = "The configured Ask Dev model has not been certified."
@@ -405,6 +552,22 @@ async def _admin_response(
         provider_source = None
         if readiness != "ready":
             failure_reason = _PLATFORM_GENERIC_UNAVAILABLE_MESSAGE
+        # Same boundary (CHAOS-3265): a per-role remediation string must not
+        # carry platform-specific diagnostic text into an org's response
+        # either. The role/state landscape itself is safe to show (it
+        # carries no identity), only the free-text remediation is redacted.
+        role_readiness = [
+            entry.model_copy(
+                update={
+                    "safe_remediation": (
+                        None
+                        if entry.state == "ready"
+                        else _PLATFORM_GENERIC_UNAVAILABLE_MESSAGE
+                    )
+                }
+            )
+            for entry in role_readiness
+        ]
 
     available = entitled and not policy.emergency_disabled and readiness == "ready"
     limits = DevAdmissionLimits()
@@ -447,6 +610,7 @@ async def _admin_response(
             cost_minimum_microusd=PLATFORM_MONTHLY_COST_LIMIT_MIN_MICROUSD,
             cost_maximum_microusd=platform_operator_cost_limit_microusd(),
         ),
+        role_readiness=role_readiness,
     )
 
 

--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -275,7 +275,14 @@ class AskDevAdminResponse(StrictAdminModel):
     effective_provider_label: str | None = Field(default=None, max_length=256)
     effective_model_label: str | None = Field(default=None, max_length=256)
     provider_source: Literal["platform", "byo"] | None = None
+    # CHAOS-3285 round 2 (Codex HIGH): this is now the EFFECTIVE readiness --
+    # combining the transport-echo binary check AND the legacy_agent role
+    # certification live selection actually requires. A binary-ready-but-
+    # role-incompatible provider must never report "ready" here (it would
+    # contradict live selection, which already rejects it). The raw,
+    # binary-only result is kept separately below as a named diagnostic.
     readiness: ReadinessState
+    binary_transport_readiness: ReadinessState
     readiness_checked_at: AwareDatetime | None = None
     readiness_version: str | None = Field(default=None, max_length=128)
     administrator_safe_failure_reason: str | None = Field(
@@ -543,6 +550,36 @@ async def _admin_response(
                         exc_info=True,
                     )
 
+    # CHAOS-3285 round 2 (Codex HIGH): the binary transport check alone is
+    # never sufficient for "ready" -- live selection (production_runtime.py
+    # _candidate()) also requires a current, COMPATIBLE legacy_agent role
+    # certification. Combine them here so this response can never claim
+    # availability that selection would reject. Only override when the
+    # binary check itself passed: a binary failure (missing credentials,
+    # unsupported model, ...) already explains why nothing is available and
+    # must keep its own specific reason rather than being masked by a role
+    # state that was never meaningfully evaluated against a failing binary
+    # candidate in the first place.
+    binary_transport_readiness: ReadinessState = readiness
+    legacy_role_entry = next(
+        (entry for entry in role_readiness if entry.role == "legacy_agent"), None
+    )
+    if (
+        readiness == "ready"
+        and legacy_role_entry is not None
+        and legacy_role_entry.state != "ready"
+    ):
+        # "not_yet_certified" has no ReadinessState counterpart (it exists
+        # only to distinguish "never certified" from "stale" in the per-role
+        # array); both mean the same thing for this combined top-level
+        # field -- run preflight -- so it collapses to stale_readiness here.
+        readiness = (
+            "stale_readiness"
+            if legacy_role_entry.state == "not_yet_certified"
+            else legacy_role_entry.state
+        )
+        failure_reason = legacy_role_entry.safe_remediation
+
     if provider_source == "platform":
         # This organization's admin surface must never expose the
         # platform-owned provider's identity or its platform-specific
@@ -580,6 +617,7 @@ async def _admin_response(
         effective_model_label=model_label,
         provider_source=provider_source,
         readiness=readiness,
+        binary_transport_readiness=binary_transport_readiness,
         readiness_checked_at=(
             _checked_at(readiness_record.checked_at) if readiness_record else None
         ),

--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -37,8 +37,19 @@ from dev_health_ops.llm.agent.readiness import (
     SettingsAgentReadinessStore,
     readiness_failure_state,
 )
+from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    SettingsRoleCertificationStore,
+)
 
-from .ask_dev import StrictAdminModel, _checked_at
+from .ask_dev import (
+    AskDevRoleReadiness,
+    StrictAdminModel,
+    _checked_at,
+    _role_readiness_list,
+)
 from .common import get_session
 
 router = APIRouter()
@@ -56,6 +67,11 @@ class PlatformAskDevReadinessResponse(StrictAdminModel):
     readiness_checked_at: AwareDatetime | None = None
     readiness_version: str | None = Field(default=None, max_length=128)
     safe_remediation: str | None = Field(default=None, max_length=2_048)
+    # CHAOS-3285: additive field, same rationale as AskDevAdminResponse's
+    # role_readiness -- a single generic badge cannot represent per-role
+    # certification. No schema_version bump here either (plan risk R6: web
+    # is a separate, coordinated change).
+    role_readiness: list[AskDevRoleReadiness] = Field(default_factory=list)
 
 
 def _platform_store(session: AsyncSession) -> SettingsAgentReadinessStore:
@@ -75,6 +91,18 @@ def _platform_store(session: AsyncSession) -> SettingsAgentReadinessStore:
     return SettingsAgentReadinessStore(
         SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
         key=PLATFORM_READINESS_SETTING_KEY,
+    )
+
+
+def _platform_role_store(session: AsyncSession) -> SettingsRoleCertificationStore:
+    """The platform-owned provider's per-role certification store -- same
+    ``org_id=""`` sentinel scoping and dedicated-key rationale as
+    ``_platform_store`` above (CHAOS-3265), under a key distinct from both
+    the ordinary per-org role store AND the legacy binary platform key."""
+
+    return SettingsRoleCertificationStore(
+        SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+        key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
     )
 
 
@@ -105,6 +133,10 @@ async def _platform_readiness_response(
                 else READINESS_VERSION
             ),
             safe_remediation=exc.safe_message,
+            # No candidate resolved -- there is nothing to project a
+            # per-role certification_key against (same reasoning as
+            # ask_dev.py's empty-list-when-unresolvable choice).
+            role_readiness=[],
         )
     try:
         readiness_state: ReadinessState
@@ -142,6 +174,11 @@ async def _platform_readiness_response(
                 "This configuration has not been certified under the current "
                 "readiness requirements. Run preflight again."
             )
+        role_profile = await _platform_role_store(session).load()
+        role_readiness = _role_readiness_list(
+            role_profile,
+            legacy_agent_certification_key=resolution.readiness_fingerprint,
+        )
         return PlatformAskDevReadinessResponse(
             configured=True,
             provider_label=resolution.provider_label,
@@ -156,6 +193,7 @@ async def _platform_readiness_response(
                 else READINESS_VERSION
             ),
             safe_remediation=safe_remediation,
+            role_readiness=role_readiness,
         )
     finally:
         try:
@@ -204,6 +242,27 @@ async def run_platform_ask_dev_readiness(
             model=resolution.model,
             fingerprint=resolution.readiness_fingerprint,
         )
+        try:
+            # CHAOS-3285: certify the legacy_agent role in the new per-role
+            # store too, on the same already-resolved provider, so the
+            # per-role projection reflects real preflight results rather
+            # than staying "not_yet_certified" forever. Best-effort: a bug
+            # here must never regress the existing (tested, relied-upon)
+            # binary certify() call above -- certify_legacy_agent already
+            # turns every AgentProviderError into a FAILED/INCOMPATIBLE
+            # record internally, so only a genuinely unexpected failure
+            # (e.g. store I/O) reaches this except.
+            await RoleReadinessService(_platform_role_store(session)).certify_role(
+                AgentRole.LEGACY_AGENT,
+                resolution.provider,
+                certification_key=resolution.readiness_fingerprint,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to certify the legacy_agent role during platform "
+                "Ask Dev preflight",
+                exc_info=True,
+            )
     finally:
         try:
             await resolution.provider.aclose()

--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -275,11 +275,25 @@ async def run_platform_ask_dev_readiness(
             # turns every AgentProviderError into a FAILED/INCOMPATIBLE
             # record internally, so only a genuinely unexpected failure
             # (e.g. store I/O) reaches this except.
-            await RoleReadinessService(_platform_role_store(session)).certify_role(
-                AgentRole.LEGACY_AGENT,
-                resolution.provider,
-                certification_key=resolution.readiness_fingerprint,
-            )
+            #
+            # CHAOS-3285 round 2 (Codex MEDIUM): the whole attempt runs
+            # inside a SAVEPOINT (begin_nested), never bare. A DB error
+            # caught by a plain except -- without a rollback or savepoint --
+            # leaves the session's transaction unable to accept further
+            # operations; the NEXT query on it raises PendingRollbackError,
+            # and when the request's own session dependency later tries to
+            # commit, THAT failure rolls back the whole transaction --
+            # silently discarding the binary certify() write just above,
+            # despite this being "caught". begin_nested()'s __aexit__ rolls
+            # back only to the savepoint on an exception, leaving the outer
+            # transaction (and the binary write already flushed into it)
+            # intact and the session usable for the rest of this request.
+            async with session.begin_nested():
+                await RoleReadinessService(_platform_role_store(session)).certify_role(
+                    AgentRole.LEGACY_AGENT,
+                    resolution.provider,
+                    certification_key=resolution.readiness_fingerprint,
+                )
         except Exception:
             logger.warning(
                 "Failed to certify the legacy_agent role during platform "

--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -63,7 +63,11 @@ class PlatformAskDevReadinessResponse(StrictAdminModel):
     configured: bool
     provider_label: str | None = Field(default=None, max_length=256)
     model_label: str | None = Field(default=None, max_length=256)
+    # CHAOS-3285 round 2 (Codex HIGH): the EFFECTIVE readiness -- binary
+    # transport check AND legacy_agent role certification combined. See
+    # AskDevAdminResponse's identical field for the full rationale.
     readiness: ReadinessState
+    binary_transport_readiness: ReadinessState
     readiness_checked_at: AwareDatetime | None = None
     readiness_version: str | None = Field(default=None, max_length=128)
     safe_remediation: str | None = Field(default=None, max_length=2_048)
@@ -124,6 +128,7 @@ async def _platform_readiness_response(
             provider_label=None,
             model_label=None,
             readiness=readiness,
+            binary_transport_readiness=readiness,
             readiness_checked_at=(
                 _checked_at(readiness_record.checked_at) if readiness_record else None
             ),
@@ -179,11 +184,29 @@ async def _platform_readiness_response(
             role_profile,
             legacy_agent_certification_key=resolution.readiness_fingerprint,
         )
+        # CHAOS-3285 round 2 (Codex HIGH): combine binary + role, same as
+        # ask_dev.py -- only override when the binary check itself passed.
+        binary_transport_readiness = readiness_state
+        legacy_role_entry = next(
+            (entry for entry in role_readiness if entry.role == "legacy_agent"), None
+        )
+        if (
+            readiness_state == "ready"
+            and legacy_role_entry is not None
+            and legacy_role_entry.state != "ready"
+        ):
+            readiness_state = (
+                "stale_readiness"
+                if legacy_role_entry.state == "not_yet_certified"
+                else legacy_role_entry.state
+            )
+            safe_remediation = legacy_role_entry.safe_remediation
         return PlatformAskDevReadinessResponse(
             configured=True,
             provider_label=resolution.provider_label,
             model_label=resolution.model_label,
             readiness=readiness_state,
+            binary_transport_readiness=binary_transport_readiness,
             readiness_checked_at=(
                 _checked_at(readiness_record.checked_at) if readiness_record else None
             ),

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -52,6 +52,8 @@ from dev_health_ops.llm.agent.readiness import (
     SettingsAgentReadinessStore,
     readiness_failure_state,
 )
+from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
+from dev_health_ops.llm.agent.roles import AgentRole, SettingsRoleCertificationStore
 from dev_health_ops.llm.budget import BUDGET_CATEGORY, get_budget_status
 from dev_health_ops.llm.credentials import (
     evaluate_org_llm_status,
@@ -307,6 +309,29 @@ async def run_llm_settings_readiness(
             model=resolution.model,
             fingerprint=resolution.readiness_fingerprint,
         )
+        try:
+            # CHAOS-3285: certify the legacy_agent role in the new per-role
+            # store too, on the same already-resolved provider. Live
+            # selection (resolve_production_provider) now REQUIRES a
+            # current, COMPATIBLE legacy_agent role record in addition to
+            # the binary record above -- without this call, this org's BYO
+            # candidate would become permanently unselectable for live
+            # traffic despite the binary preflight above reporting "ready"
+            # (Codex CHAOS-3285 review). Best-effort: a bug here must never
+            # regress the existing, already-relied-upon binary preflight
+            # result written above.
+            await RoleReadinessService(
+                SettingsRoleCertificationStore(SettingsService(session, org_id))
+            ).certify_role(
+                AgentRole.LEGACY_AGENT,
+                resolution.provider,
+                certification_key=resolution.readiness_fingerprint,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to certify the legacy_agent role during BYO Ask Dev preflight",
+                exc_info=True,
+            )
     finally:
         try:
             await resolution.provider.aclose()

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -64,7 +64,7 @@ from dev_health_ops.metrics.schemas import LLMTokenSpendSummaryRecord
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.models.settings import SettingCategory
 
-from .ask_dev import _checked_at
+from .ask_dev import _checked_at, _role_readiness_list
 from .common import get_session
 
 router = APIRouter()
@@ -189,33 +189,66 @@ async def _llm_settings_status_response(
     # reports "stale" with a safe, accurate remediation -- never silently
     # reused as "ready", and never reported as if something is broken.
     readiness_record = await SettingsAgentReadinessStore(svc).load()
-    readiness: Literal["ready", "failed", "stale", "never_checked"] = "never_checked"
+    binary_transport_readiness: Literal["ready", "failed", "stale", "never_checked"] = (
+        "never_checked"
+    )
     readiness_checked_at: datetime | None = None
     readiness_safe_failure_reason: str | None = None
+    # Computed unconditionally (not just when a binary record exists): it is
+    # also the legacy_agent role's certification_key, needed below
+    # regardless of whether the binary probe has ever run.
+    current_byo = await _byo_candidate(svc, readiness=None, certification=True)
+    current_fingerprint = (
+        _readiness_fingerprint(current_byo) if current_byo is not None else None
+    )
     if readiness_record is not None:
         readiness_checked_at = _checked_at(readiness_record.checked_at)
-        current_byo = await _byo_candidate(svc, readiness=None, certification=True)
-        current_fingerprint = (
-            _readiness_fingerprint(current_byo) if current_byo is not None else None
-        )
         is_current = (
             current_fingerprint is not None
             and readiness_record.fingerprint == current_fingerprint
             and readiness_record.readiness_version == READINESS_VERSION
         )
         if not is_current:
-            readiness = "stale"
+            binary_transport_readiness = "stale"
             readiness_safe_failure_reason = (
                 "This configuration has not been certified under the current "
                 "readiness requirements. Run preflight again."
             )
         elif readiness_record.outcome is AgentReadinessOutcome.READY:
-            readiness = "ready"
+            binary_transport_readiness = "ready"
         else:
-            readiness = "failed"
+            binary_transport_readiness = "failed"
             _, readiness_safe_failure_reason = readiness_failure_state(
                 readiness_record.safe_error_code
             )
+
+    # CHAOS-3285 round 2 (Codex HIGH): the binary transport check alone is
+    # never sufficient for "ready" -- live selection also requires a
+    # current, COMPATIBLE legacy_agent role certification (see
+    # production_runtime.py _candidate()). Combine them the same way
+    # ask_dev.py's admin surface does, only overriding when the binary
+    # check itself passed.
+    role_profile = await SettingsRoleCertificationStore(svc).load()
+    role_readiness = _role_readiness_list(
+        role_profile, legacy_agent_certification_key=current_fingerprint
+    )
+    legacy_role_entry = next(
+        (entry for entry in role_readiness if entry.role == "legacy_agent"), None
+    )
+    readiness = binary_transport_readiness
+    if (
+        binary_transport_readiness == "ready"
+        and legacy_role_entry is not None
+        and legacy_role_entry.state != "ready"
+    ):
+        readiness_safe_failure_reason = legacy_role_entry.safe_remediation
+        readiness = (
+            "never_checked"
+            if legacy_role_entry.state == "not_yet_certified"
+            else "stale"
+            if legacy_role_entry.state == "stale_readiness"
+            else "failed"
+        )
     return LLMSettingsStatusResponse(
         configured=evaluation.configured,
         active=evaluation.active,
@@ -223,6 +256,7 @@ async def _llm_settings_status_response(
         reason_code=evaluation.reason_code,
         last_fallback_at=last_fallback_at,
         readiness=readiness,
+        binary_transport_readiness=binary_transport_readiness,
         readiness_checked_at=readiness_checked_at,
         readiness_safe_failure_reason=readiness_safe_failure_reason,
     )

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -354,13 +354,22 @@ async def run_llm_settings_readiness(
             # (Codex CHAOS-3285 review). Best-effort: a bug here must never
             # regress the existing, already-relied-upon binary preflight
             # result written above.
-            await RoleReadinessService(
-                SettingsRoleCertificationStore(SettingsService(session, org_id))
-            ).certify_role(
-                AgentRole.LEGACY_AGENT,
-                resolution.provider,
-                certification_key=resolution.readiness_fingerprint,
-            )
+            #
+            # CHAOS-3285 round 2 (Codex MEDIUM): run inside a SAVEPOINT
+            # (begin_nested), never bare -- see platform_ask_dev.py's
+            # identical comment for the full rationale. A DB error caught
+            # without a rollback/savepoint poisons the session's
+            # transaction; the request's own session dependency then rolls
+            # back the WHOLE transaction on its final commit attempt,
+            # silently discarding the binary certify() write just above.
+            async with session.begin_nested():
+                await RoleReadinessService(
+                    SettingsRoleCertificationStore(SettingsService(session, org_id))
+                ).certify_role(
+                    AgentRole.LEGACY_AGENT,
+                    resolution.provider,
+                    certification_key=resolution.readiness_fingerprint,
+                )
         except Exception:
             logger.warning(
                 "Failed to certify the legacy_agent role during BYO Ask Dev preflight",

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -73,7 +73,17 @@ class LLMSettingsStatusResponse(BaseModel):
         "active",
     ]
     last_fallback_at: datetime | None = None
+    # CHAOS-3285 round 2 (Codex HIGH): `readiness` is the EFFECTIVE state --
+    # the binary transport-echo check AND the legacy_agent role
+    # certification live selection actually requires, combined. A
+    # binary-ready-but-role-incompatible BYO config must never report
+    # "ready" here. `binary_transport_readiness` is the raw, binary-only
+    # result, kept as a separately-named diagnostic (see ask_dev.py's
+    # AskDevAdminResponse.binary_transport_readiness for the full rationale).
     readiness: Literal["ready", "failed", "stale", "never_checked"] = "never_checked"
+    binary_transport_readiness: Literal["ready", "failed", "stale", "never_checked"] = (
+        "never_checked"
+    )
     readiness_checked_at: AwareDatetime | None = None
     readiness_safe_failure_reason: str | None = None
 

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -19,12 +19,17 @@ from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.licensing import evaluate_org_feature_async
 from dev_health_ops.licensing.registry import ASK_DEV_WAVE_3_1_FEATURE
 from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
-from dev_health_ops.llm.agent.contracts import AgentLLMProvider
+from dev_health_ops.llm.agent.contracts import (
+    AgentLLMProvider,
+    AgentMessage,
+    AgentMessageRole,
+    AgentToolRequest,
+)
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
 from dev_health_ops.llm.agent.openai_compatible import (
     READINESS_VERSION,
     OpenAICompatibleAgentProvider,
-    wire_policy_kwargs,
+    build_completion_request,
 )
 from dev_health_ops.llm.agent.policy import (
     CERTIFIED_PLATFORM_AGENT_PROVIDERS,
@@ -34,6 +39,7 @@ from dev_health_ops.llm.agent.policy import (
     AgentProviderSource,
     resolve_agent_provider_selection,
 )
+from dev_health_ops.llm.agent.probes.legacy_agent import _probe_registry, _probe_tools
 from dev_health_ops.llm.agent.readiness import (
     PLATFORM_READINESS_SETTING_KEY,
     PLATFORM_SETTINGS_ORG_ID,
@@ -691,30 +697,79 @@ def _canonical_contract_digest() -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:24]
 
 
-@functools.cache
-def _wire_policy_digest(model: str) -> str:
-    """Content digest of every capability-gated wire control the adapter
-    conditionally sends for ``model``, at both probe round shapes.
+def _wire_request_probe_messages(*, round_1: bool) -> tuple[AgentMessage, ...]:
+    """Fixed, deterministic placeholder messages matching one probe round's
+    STRUCTURAL shape (which roles appear, whether a ``tool_calls``/
+    ``tool_call_id`` key is present in the built request) -- never real
+    conversation content, which varies per call and is neither needed nor
+    safe to fingerprint. Prompt CONTENT is separately invalidated via
+    ``_canonical_contract_digest``'s ``PROMPT_VERSION``/
+    ``LEGACY_PROMPT_VERSION`` folding; this is only about the request's
+    mechanical shape. Content is always this exact placeholder so the
+    digest is stable across runs and never varies with real conversation
+    text."""
 
-    CHAOS-3285 round 4 (Codex HIGH): toggling ``supports_temperature``
-    changed the real outbound request while ``_readiness_fingerprint``
-    stayed identical -- the fingerprint never referenced any adapter
-    capability-policy function at all, only the bare ``model`` string
-    (which does not change when a policy FUNCTION's behavior changes for an
-    already-certified model, e.g. a future deploy widening an exclusion
-    list). This folds ``wire_policy_kwargs``'s actual output -- the same
-    function ``OpenAICompatibleAgentProvider.decide()`` calls -- for round 1
-    (tools offered, no grammar: ``tool_choice="required"``) and round 2
-    (tools offered, grammar: ``tool_choice="auto"``, response_format
-    present), so a capability policy change for this model invalidates
-    certification even though ``model`` itself never changed. Cached per
-    model (not a single shared cache like ``_canonical_contract_digest``)
+    system = AgentMessage(AgentMessageRole.SYSTEM, "")
+    user = AgentMessage(AgentMessageRole.USER, "")
+    if round_1:
+        return (system, user)
+    tool_request = AgentToolRequest(
+        tool_id="wire_request_digest_scaffold", arguments={}, call_id="scaffold"
+    )
+    assistant = AgentMessage(AgentMessageRole.ASSISTANT, "", tool_request=tool_request)
+    tool_result_message = AgentMessage(
+        AgentMessageRole.TOOL, "{}", tool_call_id="scaffold"
+    )
+    return (system, user, assistant, tool_result_message)
+
+
+@functools.cache
+def _wire_request_digest(model: str) -> str:
+    """Content digest of the COMPLETE non-secret wire request
+    ``OpenAICompatibleAgentProvider.decide()`` would send for ``model``, at
+    both probe round shapes -- built by calling
+    ``openai_compatible.build_completion_request`` directly, the SAME
+    producer ``decide()`` itself consumes to build its actual request.
+
+    CHAOS-3285 round 5 (Codex HIGH): round 4's ``_wire_policy_digest``
+    covered only the capability-gated controls extracted into the narrower
+    ``wire_policy_kwargs`` -- ``decide()`` itself still independently
+    assembled ``max_completion_tokens`` (via ``model_family_budget``), the
+    full generated response_format schema body, and the serialized tool
+    payloads, none of which the fingerprint ever hashed; changing the
+    response_format wrapper's literal ``"name"``/``"strict"`` values left
+    the fingerprint unchanged. This replaces that narrower digest by
+    calling the SAME single producer ``decide()`` calls, so no field
+    assembled inside it can independently drift from what gets
+    fingerprinted again.
+
+    Tools and the response schema are the same real producers
+    ``_canonical_contract_digest`` uses (the full 9-tool registry via
+    ``_probe_registry``/``_probe_tools``, the real ``DevAnswer`` schema);
+    ``max_output_tokens`` is the real ``DevRunLimits`` per-call cap. Cached
+    per model (not a single shared cache like ``_canonical_contract_digest``)
     since this genuinely varies by candidate, and models seen per process
     are a small, bounded set.
     """
 
-    round_1 = wire_policy_kwargs(model, tools_present=True, allow_final_answer=False)
-    round_2 = wire_policy_kwargs(model, tools_present=True, allow_final_answer=True)
+    registry = _probe_registry()
+    tools = _probe_tools(registry)
+    response_schema = DevAnswer.model_json_schema(mode="validation")
+    max_output_tokens = DevRunLimits().max_output_tokens_per_call
+    round_1 = build_completion_request(
+        model=model,
+        messages=_wire_request_probe_messages(round_1=True),
+        tools=tools,
+        response_schema=response_schema,
+        max_output_tokens=max_output_tokens,
+    )
+    round_2 = build_completion_request(
+        model=model,
+        messages=_wire_request_probe_messages(round_1=False),
+        tools=tools,
+        response_schema=response_schema,
+        max_output_tokens=max_output_tokens,
+    )
     canonical = json.dumps(
         {"round_1": round_1, "round_2": round_2},
         sort_keys=True,
@@ -738,10 +793,12 @@ def _readiness_fingerprint(
     per-family token-budget policy can each independently change the wire
     shape a certified provider was actually tested against. Also folds
     ``role`` now that certification is per-role rather than a single binary
-    verdict (see ``llm.agent.roles``), and (round 4) ``_wire_policy_digest``
-    -- the real per-model wire-policy controls (tool_choice,
-    parallel_tool_calls, temperature, reasoning_effort, response-format
-    wrapper), see its docstring.
+    verdict (see ``llm.agent.roles``), (round 5) ``_wire_request_digest``
+    -- the COMPLETE non-secret wire request the adapter would send for this
+    model at both probe round shapes (tool_choice, parallel_tool_calls,
+    temperature, reasoning_effort, the full response_format wrapper AND
+    schema body, serialized tool payloads, max_completion_tokens), see its
+    docstring.
 
     Migration/invalidation semantics (explicit): this changes the computed
     fingerprint value for the existing single-role (legacy binary) selection
@@ -769,7 +826,7 @@ def _readiness_fingerprint(
                 BUDGET_POLICY_VERSION,
                 role.value,
                 _canonical_contract_digest(),
-                _wire_policy_digest(candidate.model),
+                _wire_request_digest(candidate.model),
             )
         ).encode()
     ).hexdigest()[:24]

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -24,6 +24,7 @@ from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErr
 from dev_health_ops.llm.agent.openai_compatible import (
     READINESS_VERSION,
     OpenAICompatibleAgentProvider,
+    wire_policy_kwargs,
 )
 from dev_health_ops.llm.agent.policy import (
     CERTIFIED_PLATFORM_AGENT_PROVIDERS,
@@ -690,6 +691,39 @@ def _canonical_contract_digest() -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:24]
 
 
+@functools.cache
+def _wire_policy_digest(model: str) -> str:
+    """Content digest of every capability-gated wire control the adapter
+    conditionally sends for ``model``, at both probe round shapes.
+
+    CHAOS-3285 round 4 (Codex HIGH): toggling ``supports_temperature``
+    changed the real outbound request while ``_readiness_fingerprint``
+    stayed identical -- the fingerprint never referenced any adapter
+    capability-policy function at all, only the bare ``model`` string
+    (which does not change when a policy FUNCTION's behavior changes for an
+    already-certified model, e.g. a future deploy widening an exclusion
+    list). This folds ``wire_policy_kwargs``'s actual output -- the same
+    function ``OpenAICompatibleAgentProvider.decide()`` calls -- for round 1
+    (tools offered, no grammar: ``tool_choice="required"``) and round 2
+    (tools offered, grammar: ``tool_choice="auto"``, response_format
+    present), so a capability policy change for this model invalidates
+    certification even though ``model`` itself never changed. Cached per
+    model (not a single shared cache like ``_canonical_contract_digest``)
+    since this genuinely varies by candidate, and models seen per process
+    are a small, bounded set.
+    """
+
+    round_1 = wire_policy_kwargs(model, tools_present=True, allow_final_answer=False)
+    round_2 = wire_policy_kwargs(model, tools_present=True, allow_final_answer=True)
+    canonical = json.dumps(
+        {"round_1": round_1, "round_2": round_2},
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()[:24]
+
+
 def _readiness_fingerprint(
     candidate: AgentProviderCandidate, *, role: AgentRole = AgentRole.LEGACY_AGENT
 ) -> str:
@@ -704,7 +738,10 @@ def _readiness_fingerprint(
     per-family token-budget policy can each independently change the wire
     shape a certified provider was actually tested against. Also folds
     ``role`` now that certification is per-role rather than a single binary
-    verdict (see ``llm.agent.roles``).
+    verdict (see ``llm.agent.roles``), and (round 4) ``_wire_policy_digest``
+    -- the real per-model wire-policy controls (tool_choice,
+    parallel_tool_calls, temperature, reasoning_effort, response-format
+    wrapper), see its docstring.
 
     Migration/invalidation semantics (explicit): this changes the computed
     fingerprint value for the existing single-role (legacy binary) selection
@@ -732,6 +769,7 @@ def _readiness_fingerprint(
                 BUDGET_POLICY_VERSION,
                 role.value,
                 _canonical_contract_digest(),
+                _wire_policy_digest(candidate.model),
             )
         ).encode()
     ).hexdigest()[:24]

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -780,10 +780,11 @@ def _wire_request_digest(model: str) -> str:
 
 
 def _credential_fingerprint(credentials: LLMCredentials) -> str:
-    """Non-reversible fingerprint of the credential material actually used
-    on the wire -- the raw ``api_key`` is NEVER stored, logged, or included
-    in any return value anywhere; only its SHA-256 digest is, and only
-    inside this function.
+    """Non-reversible fingerprint of ALL identity-bearing credential material
+    actually used on the wire -- api_key, organization, project, and
+    custom_headers. The raw ``api_key`` and any header value are NEVER
+    stored, logged, or included in any return value anywhere; only this
+    function's SHA-256 digest is.
 
     CHAOS-3285 round 5 (Codex HIGH, ratified design): certifying provider
     key A, then saving key B for the exact same provider/model/base_url,
@@ -796,9 +797,33 @@ def _credential_fingerprint(credentials: LLMCredentials) -> str:
     the new credential's key, so ``is_current()`` reads False and selection
     fails closed until the NEW credential is re-certified. This does not
     rely on any save/rotation code path remembering to invalidate anything.
+
+    CHAOS-3285 round 6 (Codex HIGH): api_key alone was not the whole
+    identity. The OpenAI SDK reads organization/project/custom headers
+    AMBIENTLY from OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS
+    when a client is constructed without them -- codex's exact repro:
+    flipping OPENAI_PROJECT_ID from one project to another changed the real
+    OpenAI-Project wire header while this fingerprint stayed byte-for-byte
+    identical, since it never referenced organization/project/headers at
+    all. ``LLMCredentials`` now resolves these explicitly (see
+    ``credentials.py``) instead of leaving them for the SDK to infer, which
+    makes them representable here. Folded via a canonical JSON structure
+    (sorted keys, a sorted list of [name, value] header pairs) rather than
+    naive string concatenation, so there is no ambiguity between e.g.
+    organization="ab" + project="c" and organization="a" + project="bc".
     """
 
-    return hashlib.sha256(credentials.api_key.encode()).hexdigest()[:24]
+    canonical = json.dumps(
+        {
+            "api_key": credentials.api_key,
+            "organization": credentials.organization,
+            "project": credentials.project,
+            "custom_headers": [list(pair) for pair in credentials.custom_headers],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()[:24]
 
 
 def _readiness_fingerprint(
@@ -870,6 +895,14 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
             if isinstance(candidate, _AcceptanceOpenAICandidate)
             else "openai_compatible"
         ),
+        # CHAOS-3285 round 6 (Codex HIGH): passed explicitly so the
+        # AsyncOpenAI client never falls back to ambient
+        # OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS -- see
+        # OpenAICompatibleAgentProvider.__init__ and
+        # LLMCredentials/_credential_fingerprint.
+        organization=candidate.credentials.organization,
+        project=candidate.credentials.project,
+        custom_headers=candidate.credentials.custom_headers,
     )
 
 

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.licensing import evaluate_org_feature_async
 from dev_health_ops.licensing.registry import ASK_DEV_WAVE_3_1_FEATURE
+from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
 from dev_health_ops.llm.agent.contracts import AgentLLMProvider
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
 from dev_health_ops.llm.agent.openai_compatible import (
@@ -35,6 +36,7 @@ from dev_health_ops.llm.agent.readiness import (
     PLATFORM_SETTINGS_ORG_ID,
     SettingsAgentReadinessStore,
 )
+from dev_health_ops.llm.agent.roles import AgentRole
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.budget import attach_agent_budget_guard
 from dev_health_ops.llm.credentials import LLMCredentials, resolve_llm_credentials
@@ -570,8 +572,32 @@ def _candidate(
     )
 
 
-def _readiness_fingerprint(candidate: AgentProviderCandidate) -> str:
-    """Fingerprint every capability input that invalidates certification."""
+def _readiness_fingerprint(
+    candidate: AgentProviderCandidate, *, role: AgentRole = AgentRole.LEGACY_AGENT
+) -> str:
+    """Fingerprint every capability input that invalidates certification.
+
+    CHAOS-3285: extended to fold ``PROMPT_VERSION``, ``TOOL_CONTRACT_VERSION``,
+    and ``BUDGET_POLICY_VERSION`` -- previously only a manual
+    ``READINESS_VERSION`` bump invalidated a stale certification, even though
+    the composed prompt, tool registry, or per-family token-budget policy
+    can each independently change the wire shape a certified provider was
+    actually tested against. Also folds ``role`` now that certification is
+    per-role rather than a single binary verdict (see ``llm.agent.roles``).
+
+    Migration/invalidation semantics (explicit): this changes the computed
+    fingerprint value for the existing single-role (legacy binary) selection
+    path too, since every call site below defaults ``role`` to
+    ``AgentRole.LEGACY_AGENT`` -- the role today's production runtime
+    actually exercises (full tool registry, full ``DevAnswer`` grammar).
+    Every previously stored ``AgentReadinessRecord.fingerprint`` was computed
+    without these folded inputs, so it no longer equals the newly computed
+    value here and ``AgentReadinessRecord.is_current`` returns ``False``:
+    existing certifications become stale and the runtime fails closed until
+    re-certified -- exactly the same self-invalidating pattern already
+    established for the ``READINESS_VERSION`` bump (CHAOS-3254). No stored
+    record is silently reinterpreted as still current.
+    """
 
     return hashlib.sha256(
         "\0".join(
@@ -581,6 +607,10 @@ def _readiness_fingerprint(candidate: AgentProviderCandidate) -> str:
                 candidate.model,
                 candidate.credentials.base_url,
                 READINESS_VERSION,
+                PROMPT_VERSION,
+                TOOL_CONTRACT_VERSION,
+                BUDGET_POLICY_VERSION,
+                role.value,
             )
         ).encode()
     ).hexdigest()[:24]

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import functools
 import hashlib
+import json
 import os
 import uuid
 from collections.abc import Mapping, Sequence
@@ -55,6 +57,7 @@ from dev_health_ops.models.settings import SettingCategory
 
 from .contracts import (
     DevActualCompletion,
+    DevAnswer,
     DevCIFact,
     DevContractVersions,
     DevDataHealth,
@@ -97,8 +100,9 @@ from .metrics.clickhouse import ClickHouseMetricSource
 from .metrics.service import MetricQueryRequest, MetricQueryService
 from .native_evidence import native_evidence_adapters
 from .native_status_change import ClickHouseStatusChangeSource
+from .orchestrator import DevRunLimits
 from .org_policy import load_ask_dev_org_policy
-from .prompts import PROMPT_VERSION
+from .prompts import LEGACY_PROMPT_VERSION, PROMPT_VERSION
 from .question_interpreter import QuestionInterpreter
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
@@ -630,18 +634,77 @@ def _candidate(
     )
 
 
+@functools.lru_cache(maxsize=1)
+def _canonical_contract_digest() -> str:
+    """Content digest of every capability input a role certification must
+    invalidate on, beyond the coarse version-string constants already
+    folded into ``_readiness_fingerprint``.
+
+    CHAOS-3285 round 2 (Codex HIGH): the fingerprint previously hashed only
+    ``PROMPT_VERSION`` -- the committed-subject prompt shape
+    (``subject_committed=True``). ``PromptComposer`` actually selects
+    between that and ``LEGACY_PROMPT_VERSION`` (the uncommitted-subject /
+    flag-off shape) per run, and the ``legacy_agent`` probe forces
+    ``subject_committed=True`` unconditionally -- so the uncommitted-subject
+    prompt shape was never probed, and a text-only change to ONLY that
+    shape's section (with no version bump, since it was never folded at
+    all) never invalidated anything either.
+
+    Rather than track more bare version-string constants (each one an
+    opportunity to forget folding the next thing that can change the wire
+    shape), this folds actual CONTENT: both prompt version constants, the
+    real ``DevAnswer`` response grammar the adapter sends on the wire, the
+    real tool registry manifest (every tool's real schema, not just the
+    registry's own version string), and the real ``DevRunLimits`` values (a
+    limit changing without anyone bumping a version string must still
+    invalidate). Computed from the real producers -- ``AskDevToolRegistry``,
+    ``DevAnswer.model_json_schema()``, ``DevRunLimits`` -- never hand-
+    maintained, and never touches a database or executes a tool.
+    Memoized: every input here is fixed at import time by the running code,
+    never per-request data, so recomputing per call would be pure overhead
+    on the request hot path.
+    """
+
+    async def _unused_executor(_context: object, _request: object) -> Any:
+        raise AssertionError(  # pragma: no cover - never invoked
+            "contract digest must never execute a tool"
+        )
+
+    registry = AskDevToolRegistry({tool_id: _unused_executor for tool_id in ToolID})
+    manifest = registry.manifest(allowed_tool_ids=None)
+    limits = DevRunLimits()
+    payload = {
+        "prompt_version": PROMPT_VERSION,
+        "legacy_prompt_version": LEGACY_PROMPT_VERSION,
+        "response_schema": DevAnswer.model_json_schema(mode="validation"),
+        "tool_manifest": manifest,
+        "limits": {
+            "max_output_tokens_per_call": limits.max_output_tokens_per_call,
+            "max_total_input_tokens": limits.max_total_input_tokens,
+            "max_total_output_tokens": limits.max_total_output_tokens,
+            "model_rounds": limits.model_rounds,
+            "tool_calls": limits.tool_calls,
+        },
+    }
+    canonical = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:24]
+
+
 def _readiness_fingerprint(
     candidate: AgentProviderCandidate, *, role: AgentRole = AgentRole.LEGACY_AGENT
 ) -> str:
     """Fingerprint every capability input that invalidates certification.
 
-    CHAOS-3285: extended to fold ``PROMPT_VERSION``, ``TOOL_CONTRACT_VERSION``,
-    and ``BUDGET_POLICY_VERSION`` -- previously only a manual
-    ``READINESS_VERSION`` bump invalidated a stale certification, even though
-    the composed prompt, tool registry, or per-family token-budget policy
-    can each independently change the wire shape a certified provider was
-    actually tested against. Also folds ``role`` now that certification is
-    per-role rather than a single binary verdict (see ``llm.agent.roles``).
+    CHAOS-3285: extended to fold ``TOOL_CONTRACT_VERSION``,
+    ``BUDGET_POLICY_VERSION``, and ``_canonical_contract_digest()`` (which
+    itself folds both prompt shapes, the real response grammar, the real
+    tool manifest, and the real run limits -- see its docstring) --
+    previously only a manual ``READINESS_VERSION`` bump invalidated a stale
+    certification, even though the composed prompt, tool registry, or
+    per-family token-budget policy can each independently change the wire
+    shape a certified provider was actually tested against. Also folds
+    ``role`` now that certification is per-role rather than a single binary
+    verdict (see ``llm.agent.roles``).
 
     Migration/invalidation semantics (explicit): this changes the computed
     fingerprint value for the existing single-role (legacy binary) selection
@@ -665,10 +728,10 @@ def _readiness_fingerprint(
                 candidate.model,
                 candidate.credentials.base_url,
                 READINESS_VERSION,
-                PROMPT_VERSION,
                 TOOL_CONTRACT_VERSION,
                 BUDGET_POLICY_VERSION,
                 role.value,
+                _canonical_contract_digest(),
             )
         ).encode()
     ).hexdigest()[:24]

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -36,7 +36,12 @@ from dev_health_ops.llm.agent.readiness import (
     PLATFORM_SETTINGS_ORG_ID,
     SettingsAgentReadinessStore,
 )
-from dev_health_ops.llm.agent.roles import AgentRole
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    RoleCertificationProfile,
+    SettingsRoleCertificationStore,
+)
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.budget import attach_agent_budget_guard
 from dev_health_ops.llm.credentials import LLMCredentials, resolve_llm_credentials
@@ -253,17 +258,35 @@ def _platform_readiness_store(session: AsyncSession) -> SettingsAgentReadinessSt
     )
 
 
+def _platform_role_store(session: AsyncSession) -> SettingsRoleCertificationStore:
+    """Per-role certification store for the platform-owned provider -- same
+    ``org_id=""`` sentinel scoping and dedicated-key rationale as
+    ``_platform_readiness_store`` (CHAOS-3265)."""
+
+    return SettingsRoleCertificationStore(
+        SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+        key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    )
+
+
 async def resolve_production_provider(
     session: AsyncSession, *, org_id: str
 ) -> ProductionProviderResolution:
     settings = SettingsService(session, org_id)
     byo_readiness = await SettingsAgentReadinessStore(settings).load()
     platform_readiness = await _platform_readiness_store(session).load()
+    # CHAOS-3285: live selection additionally requires a CURRENT, COMPATIBLE
+    # legacy_agent role certification -- see _candidate()'s docstring for why
+    # the old binary AgentReadinessRecord alone is not sufficient here.
+    byo_role_profile = await SettingsRoleCertificationStore(settings).load()
+    platform_role_profile = await _platform_role_store(session).load()
 
     byo, platform, policy = await _provider_candidates(
         settings,
         byo_readiness=byo_readiness,
         platform_readiness=platform_readiness,
+        byo_role_profile=byo_role_profile,
+        platform_role_profile=platform_role_profile,
     )
     return _resolve_provider_selection(
         byo=byo,
@@ -379,6 +402,7 @@ async def _byo_candidate(
     *,
     readiness: Any,
     certification: bool = False,
+    role_profile: RoleCertificationProfile | None = None,
 ) -> AgentProviderCandidate | None:
     byo_provider_name = (await settings.get("provider", _LLM_CATEGORY) or "").strip()
     byo_model = (await settings.get("model", _LLM_CATEGORY) or "").strip()
@@ -395,6 +419,7 @@ async def _byo_candidate(
         source=AgentProviderSource.BYO,
         readiness=readiness,
         certification=certification,
+        role_profile=role_profile,
     )
 
 
@@ -402,6 +427,7 @@ def _platform_candidate(
     *,
     readiness: Any,
     certification: bool = False,
+    role_profile: RoleCertificationProfile | None = None,
 ) -> tuple[AgentProviderCandidate | None, str]:
     """Build the platform candidate purely from operator environment state.
 
@@ -442,6 +468,7 @@ def _platform_candidate(
         readiness=readiness,
         certification=certification,
         acceptance=acceptance is not None,
+        role_profile=role_profile,
     )
     return platform, platform_provider_name
 
@@ -452,16 +479,23 @@ async def _provider_candidates(
     byo_readiness: Any,
     platform_readiness: Any,
     certification: bool = False,
+    byo_role_profile: RoleCertificationProfile | None = None,
+    platform_role_profile: RoleCertificationProfile | None = None,
 ) -> tuple[
     AgentProviderCandidate | None,
     AgentProviderCandidate | None,
     AgentProviderPolicy,
 ]:
     byo = await _byo_candidate(
-        settings, readiness=byo_readiness, certification=certification
+        settings,
+        readiness=byo_readiness,
+        certification=certification,
+        role_profile=byo_role_profile,
     )
     platform, platform_provider_name = _platform_candidate(
-        readiness=platform_readiness, certification=certification
+        readiness=platform_readiness,
+        certification=certification,
+        role_profile=platform_role_profile,
     )
     org_policy = await load_ask_dev_org_policy(settings)
     policy = AgentProviderPolicy(
@@ -531,6 +565,7 @@ def _candidate(
     readiness: Any,
     certification: bool = False,
     acceptance: bool = False,
+    role_profile: RoleCertificationProfile | None = None,
 ) -> AgentProviderCandidate | None:
     if (
         not provider_name
@@ -553,6 +588,28 @@ def _candidate(
         readiness_current=certification,
     )
     provider_fingerprint = _readiness_fingerprint(candidate)
+    # CHAOS-3285: live selection (certification=False) additionally requires
+    # a CURRENT, COMPATIBLE legacy_agent role certification -- not just the
+    # old binary AgentReadinessRecord. Without this, an operator could
+    # re-certify through a route that only ever runs the old 512-token echo
+    # probe (or the new role probe could simply never have run), the binary
+    # store would read "current", and this candidate would become
+    # selectable for live traffic having never demonstrated it can handle
+    # the real production request shape at all -- the exact gap the role
+    # model exists to close (Codex CHAOS-3285 review). `role_profile is
+    # None` fails closed (never current), the same direction as every other
+    # missing-input default in this function; only ``certification=True``
+    # (the "give me a candidate to certify" preflight paths) bypasses this,
+    # exactly as it already bypasses the binary check below.
+    legacy_agent_record = (
+        role_profile.for_role(AgentRole.LEGACY_AGENT)
+        if role_profile is not None
+        else None
+    )
+    legacy_agent_current = bool(
+        legacy_agent_record is not None
+        and legacy_agent_record.is_current(certification_key=provider_fingerprint)
+    )
     current = bool(
         certification
         or (
@@ -561,6 +618,7 @@ def _candidate(
                 fingerprint=provider_fingerprint,
                 readiness_version=READINESS_VERSION,
             )
+            and legacy_agent_current
         )
     )
     return candidate_type(

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -779,6 +779,28 @@ def _wire_request_digest(model: str) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()[:24]
 
 
+def _credential_fingerprint(credentials: LLMCredentials) -> str:
+    """Non-reversible fingerprint of the credential material actually used
+    on the wire -- the raw ``api_key`` is NEVER stored, logged, or included
+    in any return value anywhere; only its SHA-256 digest is, and only
+    inside this function.
+
+    CHAOS-3285 round 5 (Codex HIGH, ratified design): certifying provider
+    key A, then saving key B for the exact same provider/model/base_url,
+    left the stored certification (keyed only on provider/model/base_url)
+    reading as still current -- so live selection kept using it while every
+    real request actually carried B's Authorization header, never having
+    demonstrated B can handle the production request shape at all. Folding
+    this fingerprint into the certification key makes a rotated credential
+    unfindable by construction: a prior certification's key can never equal
+    the new credential's key, so ``is_current()`` reads False and selection
+    fails closed until the NEW credential is re-certified. This does not
+    rely on any save/rotation code path remembering to invalidate anything.
+    """
+
+    return hashlib.sha256(credentials.api_key.encode()).hexdigest()[:24]
+
+
 def _readiness_fingerprint(
     candidate: AgentProviderCandidate, *, role: AgentRole = AgentRole.LEGACY_AGENT
 ) -> str:
@@ -798,7 +820,8 @@ def _readiness_fingerprint(
     model at both probe round shapes (tool_choice, parallel_tool_calls,
     temperature, reasoning_effort, the full response_format wrapper AND
     schema body, serialized tool payloads, max_completion_tokens), see its
-    docstring.
+    docstring -- and (round 5) ``_credential_fingerprint`` -- see its
+    docstring for the credential-rotation gap this closes.
 
     Migration/invalidation semantics (explicit): this changes the computed
     fingerprint value for the existing single-role (legacy binary) selection
@@ -821,6 +844,7 @@ def _readiness_fingerprint(
                 candidate.provider,
                 candidate.model,
                 candidate.credentials.base_url,
+                _credential_fingerprint(candidate.credentials),
                 READINESS_VERSION,
                 TOOL_CONTRACT_VERSION,
                 BUDGET_POLICY_VERSION,

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -106,57 +106,6 @@ def _fingerprint(*parts: str) -> str:
     return hashlib.sha256("\0".join(parts).encode()).hexdigest()[:24]
 
 
-def wire_policy_kwargs(
-    model: str, *, tools_present: bool, allow_final_answer: bool
-) -> dict[str, Any]:
-    """Every model-capability-gated wire control this adapter conditionally
-    sends, for one (model, round-shape) combination.
-
-    Pure and deterministic: no network call, no per-request data (messages,
-    tool schemas, response schema content) -- only the model string and the
-    round shape (whether tools are offered, whether a final answer is
-    allowed this round). ``decide()`` below calls this directly to build
-    ``completion_kwargs``, rather than duplicating the same capability-gated
-    assembly inline.
-
-    CHAOS-3285 round 4 (Codex HIGH): before this extraction, the readiness
-    fingerprint never referenced any of ``supports_temperature``,
-    ``supports_parallel_tool_calls``, or ``chat_completion_reasoning_effort``
-    at all -- so a capability-policy change (e.g. ``supports_temperature``
-    gaining a new excluded model family on some future deploy) silently
-    changed the real outbound request for an already-COMPATIBLE-certified
-    model while its stored certification stayed "current" forever. The
-    readiness fingerprint now hashes THIS function's output directly (see
-    ``production_runtime._wire_policy_digest``) -- the same function
-    ``decide()`` calls -- so it can never drift from what actually gets
-    sent on the wire the way a hand-maintained list of "which controls
-    matter" could.
-    """
-
-    kwargs: dict[str, Any] = {
-        "tool_choice": (
-            ("auto" if allow_final_answer else "required") if tools_present else None
-        ),
-    }
-    if tools_present and supports_parallel_tool_calls(model):
-        kwargs["parallel_tool_calls"] = False
-    if supports_temperature(model):
-        kwargs["temperature"] = 0
-    reasoning_effort = chat_completion_reasoning_effort(model)
-    if reasoning_effort is not None:
-        kwargs["reasoning_effort"] = reasoning_effort
-    if allow_final_answer:
-        # The wrapper's own shape, not the (separately folded) nested
-        # decision schema body: whether a structured-output response is
-        # required at all, and under what name/strictness.
-        kwargs["response_format_wrapper"] = {
-            "type": "json_schema",
-            "name": "ask_dev_decision",
-            "strict": True,
-        }
-    return kwargs
-
-
 def _estimated_cost_microusd(
     *, model: str, input_tokens: int, output_tokens: int
 ) -> int | None:
@@ -254,52 +203,23 @@ class OpenAICompatibleAgentProvider:
         wire_tool_ids = build_wire_tool_name_map(item.tool_id for item in tools)
         started = time.monotonic()
         create_completion = cast(Any, self._client.chat.completions.create)
-        allow_final_answer = not tools or any(
-            message.role is AgentMessageRole.TOOL for message in messages
+        # CHAOS-3285 round 5 (Codex HIGH): the ENTIRE request -- not just the
+        # capability-gated controls round 4 extracted -- is assembled by
+        # build_completion_request, the single producer the readiness
+        # fingerprint's wire-request digest also consumes directly (see
+        # production_runtime._wire_request_digest). Round 4's narrower
+        # extraction still left max_completion_tokens, the response_format
+        # wrapper's literal name/strict values, and the full generated
+        # schema body assembled independently right here, invisible to the
+        # fingerprint; nothing about the request is assembled anywhere else
+        # now, so nothing here can drift from what gets fingerprinted again.
+        completion_kwargs = build_completion_request(
+            model=self.model,
+            messages=messages,
+            tools=tools,
+            response_schema=response_schema,
+            max_output_tokens=max_output_tokens,
         )
-        budget = model_family_budget(self.model)
-        # CHAOS-3285 round 4: every capability-gated wire control below is
-        # assembled by wire_policy_kwargs -- the SAME function the readiness
-        # fingerprint hashes for this model at both probe round shapes (see
-        # production_runtime._wire_policy_digest) -- so this call site and
-        # the fingerprint can never independently drift on what a capability
-        # policy change actually sends.
-        policy = wire_policy_kwargs(
-            self.model, tools_present=bool(tools), allow_final_answer=allow_final_answer
-        )
-        completion_kwargs: dict[str, Any] = {
-            "model": self.model,
-            "messages": [self._message_payload(item) for item in messages],
-            "tools": [self._tool_payload(item) for item in tools] or None,
-            "tool_choice": policy["tool_choice"],
-            "max_completion_tokens": budget.request_max_completion_tokens(
-                max_output_tokens
-            ),
-        }
-        if "parallel_tool_calls" in policy:
-            # Ask Dev's runtime is a sequential one-decision-per-round state
-            # machine (TRD 11-12, 20.4). Explicitly disabling native parallel
-            # tool calls keeps a standards-compliant OpenAI-compatible model
-            # from returning multiple tool calls in one response, which the
-            # normalizer must otherwise reject (CHAOS-3254).
-            completion_kwargs["parallel_tool_calls"] = policy["parallel_tool_calls"]
-        if "temperature" in policy:
-            completion_kwargs["temperature"] = policy["temperature"]
-        if "reasoning_effort" in policy:
-            completion_kwargs["reasoning_effort"] = policy["reasoning_effort"]
-        if allow_final_answer:
-            completion_kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "ask_dev_decision",
-                    "strict": True,
-                    "schema": self._decision_response_schema(
-                        self._answer_draft_schema(response_schema),
-                        tools,
-                        allow_final_answer=True,
-                    ),
-                },
-            }
         provider_task = asyncio.create_task(create_completion(**completion_kwargs))
         cancel_task = asyncio.create_task(signal.wait()) if signal is not None else None
         try:
@@ -783,3 +703,84 @@ class OpenAICompatibleAgentProvider:
             await close()
         if self._http_client is not None:
             await self._http_client.aclose()
+
+
+def build_completion_request(
+    *,
+    model: str,
+    messages: Sequence[AgentMessage],
+    tools: Sequence[AgentToolDefinition],
+    response_schema: Mapping[str, Any],
+    max_output_tokens: int,
+) -> dict[str, Any]:
+    """The COMPLETE request ``OpenAICompatibleAgentProvider.decide()`` sends
+    to the wire for one call -- every keyword argument passed to
+    ``client.chat.completions.create(**...)``. ``decide()`` calls this
+    directly and dispatches its return value wholesale; nothing about the
+    request is assembled anywhere else.
+
+    This is the single producer the readiness fingerprint's wire-request
+    digest also consumes (``production_runtime._wire_request_digest``), so
+    every field assembled here -- the capability-gated wire controls
+    (tool_choice, parallel_tool_calls, temperature, reasoning_effort), the
+    model-resolved ``max_completion_tokens`` budget, the full
+    ``response_format`` (both the wrapper's name/strict literals AND the
+    generated schema body), the serialized tool definitions, and the
+    message scaffold shape -- can never independently drift between what
+    actually gets sent and what gets fingerprinted.
+
+    CHAOS-3285 round 5 (Codex HIGH): round 4's narrower
+    ``wire_policy_kwargs`` covered only the capability-gated controls, plus
+    a HAND-DUPLICATED copy of the response_format wrapper's name/strict
+    literals -- ``decide()`` itself still independently assembled
+    ``max_completion_tokens`` (via ``model_family_budget``), the full
+    generated schema body, and the serialized tool payloads, none of which
+    the fingerprint ever hashed. Changing any of those (e.g. the wrapper's
+    literal ``"name"``/``"strict"`` values) left the fingerprint unchanged.
+    This function replaces that narrower extraction entirely.
+    """
+
+    allow_final_answer = not tools or any(
+        message.role is AgentMessageRole.TOOL for message in messages
+    )
+    budget = model_family_budget(model)
+    request: dict[str, Any] = {
+        "model": model,
+        "messages": [
+            OpenAICompatibleAgentProvider._message_payload(item) for item in messages
+        ],
+        "tools": [OpenAICompatibleAgentProvider._tool_payload(item) for item in tools]
+        or None,
+        "tool_choice": (
+            ("auto" if allow_final_answer else "required") if tools else None
+        ),
+        "max_completion_tokens": budget.request_max_completion_tokens(
+            max_output_tokens
+        ),
+    }
+    if tools and supports_parallel_tool_calls(model):
+        # Ask Dev's runtime is a sequential one-decision-per-round state
+        # machine (TRD 11-12, 20.4). Explicitly disabling native parallel
+        # tool calls keeps a standards-compliant OpenAI-compatible model
+        # from returning multiple tool calls in one response, which the
+        # normalizer must otherwise reject (CHAOS-3254).
+        request["parallel_tool_calls"] = False
+    if supports_temperature(model):
+        request["temperature"] = 0
+    reasoning_effort = chat_completion_reasoning_effort(model)
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    if allow_final_answer:
+        request["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ask_dev_decision",
+                "strict": True,
+                "schema": OpenAICompatibleAgentProvider._decision_response_schema(
+                    OpenAICompatibleAgentProvider._answer_draft_schema(response_schema),
+                    tools,
+                    allow_final_answer=True,
+                ),
+            },
+        }
+    return request

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -106,6 +106,57 @@ def _fingerprint(*parts: str) -> str:
     return hashlib.sha256("\0".join(parts).encode()).hexdigest()[:24]
 
 
+def wire_policy_kwargs(
+    model: str, *, tools_present: bool, allow_final_answer: bool
+) -> dict[str, Any]:
+    """Every model-capability-gated wire control this adapter conditionally
+    sends, for one (model, round-shape) combination.
+
+    Pure and deterministic: no network call, no per-request data (messages,
+    tool schemas, response schema content) -- only the model string and the
+    round shape (whether tools are offered, whether a final answer is
+    allowed this round). ``decide()`` below calls this directly to build
+    ``completion_kwargs``, rather than duplicating the same capability-gated
+    assembly inline.
+
+    CHAOS-3285 round 4 (Codex HIGH): before this extraction, the readiness
+    fingerprint never referenced any of ``supports_temperature``,
+    ``supports_parallel_tool_calls``, or ``chat_completion_reasoning_effort``
+    at all -- so a capability-policy change (e.g. ``supports_temperature``
+    gaining a new excluded model family on some future deploy) silently
+    changed the real outbound request for an already-COMPATIBLE-certified
+    model while its stored certification stayed "current" forever. The
+    readiness fingerprint now hashes THIS function's output directly (see
+    ``production_runtime._wire_policy_digest``) -- the same function
+    ``decide()`` calls -- so it can never drift from what actually gets
+    sent on the wire the way a hand-maintained list of "which controls
+    matter" could.
+    """
+
+    kwargs: dict[str, Any] = {
+        "tool_choice": (
+            ("auto" if allow_final_answer else "required") if tools_present else None
+        ),
+    }
+    if tools_present and supports_parallel_tool_calls(model):
+        kwargs["parallel_tool_calls"] = False
+    if supports_temperature(model):
+        kwargs["temperature"] = 0
+    reasoning_effort = chat_completion_reasoning_effort(model)
+    if reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
+    if allow_final_answer:
+        # The wrapper's own shape, not the (separately folded) nested
+        # decision schema body: whether a structured-output response is
+        # required at all, and under what name/strictness.
+        kwargs["response_format_wrapper"] = {
+            "type": "json_schema",
+            "name": "ask_dev_decision",
+            "strict": True,
+        }
+    return kwargs
+
+
 def _estimated_cost_microusd(
     *, model: str, input_tokens: int, output_tokens: int
 ) -> int | None:
@@ -207,29 +258,35 @@ class OpenAICompatibleAgentProvider:
             message.role is AgentMessageRole.TOOL for message in messages
         )
         budget = model_family_budget(self.model)
+        # CHAOS-3285 round 4: every capability-gated wire control below is
+        # assembled by wire_policy_kwargs -- the SAME function the readiness
+        # fingerprint hashes for this model at both probe round shapes (see
+        # production_runtime._wire_policy_digest) -- so this call site and
+        # the fingerprint can never independently drift on what a capability
+        # policy change actually sends.
+        policy = wire_policy_kwargs(
+            self.model, tools_present=bool(tools), allow_final_answer=allow_final_answer
+        )
         completion_kwargs: dict[str, Any] = {
             "model": self.model,
             "messages": [self._message_payload(item) for item in messages],
             "tools": [self._tool_payload(item) for item in tools] or None,
-            "tool_choice": (
-                ("auto" if allow_final_answer else "required") if tools else None
-            ),
+            "tool_choice": policy["tool_choice"],
             "max_completion_tokens": budget.request_max_completion_tokens(
                 max_output_tokens
             ),
         }
-        if tools and supports_parallel_tool_calls(self.model):
+        if "parallel_tool_calls" in policy:
             # Ask Dev's runtime is a sequential one-decision-per-round state
             # machine (TRD 11-12, 20.4). Explicitly disabling native parallel
             # tool calls keeps a standards-compliant OpenAI-compatible model
             # from returning multiple tool calls in one response, which the
             # normalizer must otherwise reject (CHAOS-3254).
-            completion_kwargs["parallel_tool_calls"] = False
-        if supports_temperature(self.model):
-            completion_kwargs["temperature"] = 0
-        reasoning_effort = chat_completion_reasoning_effort(self.model)
-        if reasoning_effort is not None:
-            completion_kwargs["reasoning_effort"] = reasoning_effort
+            completion_kwargs["parallel_tool_calls"] = policy["parallel_tool_calls"]
+        if "temperature" in policy:
+            completion_kwargs["temperature"] = policy["temperature"]
+        if "reasoning_effort" in policy:
+            completion_kwargs["reasoning_effort"] = policy["reasoning_effort"]
         if allow_final_answer:
             completion_kwargs["response_format"] = {
                 "type": "json_schema",

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -136,9 +136,15 @@ class OpenAICompatibleAgentProvider:
         client: Any | None = None,
         disclosure_key: str = "openai_compatible",
         context_window_tokens: int | None = None,
+        organization: str = "",
+        project: str = "",
+        custom_headers: tuple[tuple[str, str], ...] = (),
     ) -> None:
         self.model = model
         self.base_url = base_url or ""
+        self.organization = organization
+        self.project = project
+        self.custom_headers = custom_headers
         self._http_client: Any | None = None
         if client is None:
             from openai import AsyncOpenAI
@@ -151,11 +157,45 @@ class OpenAICompatibleAgentProvider:
             pin_content_carrying_client_loggers()
 
             self._http_client = make_hardened_async_httpx_client()
+            # CHAOS-3285 round 6 (Codex HIGH): AsyncOpenAI reads
+            # OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS from the
+            # process environment AMBIENTLY whenever organization/project
+            # are left as Python None or default_headers is left unset --
+            # a change to any of those env vars silently changes the wire
+            # identity headers without ever touching this constructor's
+            # inputs, and without changing certification.
+            #
+            # Empirically verified (openai==2.36.0 _client.py): the SDK's
+            # env fallback is gated on `if organization is None:` /
+            # `if project is None:` -- passing ANY non-None value (including
+            # "") suppresses it. But passing "" also SENDS an empty
+            # `OpenAI-Organization: ` header rather than omitting it, which
+            # is not the same as "not configured". So: pass explicit
+            # (possibly empty) strings to suppress the env read during
+            # __init__, then reset back to None afterward when genuinely
+            # not configured, so the header is correctly OMITTED
+            # (`default_headers` treats `None` as "send Omit()", verified
+            # against the same source) rather than sent empty.
+            #
+            # OPENAI_CUSTOM_HEADERS has no such `is None` gate at all -- the
+            # SDK unconditionally merges it into `_custom_headers` whenever
+            # the env var is set, regardless of what `default_headers` this
+            # constructor passes. The only way to suppress it is to
+            # overwrite `_custom_headers` post-construction with exactly
+            # our own explicitly-resolved set (also empirically verified).
             client = AsyncOpenAI(
                 api_key=api_key,
                 base_url=base_url or None,
+                organization=organization,
+                project=project,
+                default_headers=dict(custom_headers) if custom_headers else None,
                 http_client=self._http_client,
             )
+            if not organization:
+                client.organization = None
+            if not project:
+                client.project = None
+            client._custom_headers = dict(custom_headers)
         self._client = client
         self._capabilities = AgentProviderCapabilities(
             structured_output=StructuredOutputMode.JSON_SCHEMA,

--- a/src/dev_health_ops/llm/agent/probes/__init__.py
+++ b/src/dev_health_ops/llm/agent/probes/__init__.py
@@ -1,0 +1,10 @@
+"""Production-representative per-role readiness probes (CHAOS-3285).
+
+Each probe is built exclusively from the real production producers
+(``PromptComposer``, ``AskDevToolRegistry``, ``DevRunLimits``, the
+``DevAnswer``/``DevToolResult`` contracts) -- never a hand-authored
+miniature -- so a passing probe genuinely demonstrates the provider can
+handle the real wire shape, not a reduced synthetic echo.
+"""
+
+from __future__ import annotations

--- a/src/dev_health_ops/llm/agent/probes/legacy_agent.py
+++ b/src/dev_health_ops/llm/agent/probes/legacy_agent.py
@@ -38,12 +38,14 @@ from dev_health_ops.api.dev.contracts import (
 )
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator, DevRunLimits
 from dev_health_ops.api.dev.prompts.composer import (
+    ComposedPrompt,
     PromptComposer,
     PromptConversationTurn,
 )
 from dev_health_ops.api.dev.tool_registry import TOOL_DEFINITIONS, AskDevToolRegistry
 
 from ..contracts import (
+    AgentDecisionResult,
     AgentFinalAnswer,
     AgentLLMProvider,
     AgentMessage,
@@ -195,6 +197,58 @@ def _merge_usage(left: AgentUsage, right: AgentUsage) -> AgentUsage:
     )
 
 
+async def _decide_round_2(
+    *,
+    provider: AgentLLMProvider,
+    composer: PromptComposer,
+    scope_resolution: DevScopeResolution,
+    history: tuple[PromptConversationTurn, ...],
+    tools: tuple[AgentToolDefinition, ...],
+    response_schema: Mapping[str, object],
+    tool_request: AgentToolRequest,
+    tool_result: DevToolResult,
+    timeout_seconds: float,
+    max_output_tokens: int,
+    subject_committed: bool,
+    signal: CancellationSignal | None,
+) -> tuple[AgentDecisionResult, ComposedPrompt]:
+    """Round 2 for one prompt shape (committed or uncommitted subject):
+    tools offered AND a synthetic tool result already in the conversation
+    -- ``tool_choice="auto"`` and the full ``DevAnswer`` grammar
+    simultaneously, the combined worst-case shape. Shares the SAME
+    synthetic tool request/result across both shapes: the tool-result
+    content does not depend on ``subject_committed`` at all, only the
+    system/user prompt sections do, so reusing it isolates exactly the
+    prompt-shape dimension CHAOS-3285 round 2 (Codex HIGH) flagged as
+    never invalidated.
+    """
+
+    composed = composer.compose(
+        question=_PROBE_QUESTION,
+        scope=scope_resolution,
+        prior_turns=history,
+        tool_results=(tool_result,),
+        allowed_tools=None,
+        subject_committed=subject_committed,
+    )
+    messages = (
+        AgentMessage(AgentMessageRole.SYSTEM, composed.system_text),
+        AgentMessage(AgentMessageRole.USER, composed.user_text),
+        AgentMessage(AgentMessageRole.ASSISTANT, "", tool_request=tool_request),
+        AgentMessage(
+            AgentMessageRole.TOOL,
+            tool_result.model_dump_json(),
+            tool_call_id=tool_request.call_id,
+        ),
+    )
+    result = await provider.decide(
+        messages, tools, response_schema, timeout_seconds, max_output_tokens, signal
+    )
+    if not isinstance(result.decision, (AgentFinalAnswer, AgentToolRequest)):
+        raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+    return result, composed
+
+
 async def certify_legacy_agent(
     provider: AgentLLMProvider,
     *,
@@ -206,6 +260,25 @@ async def certify_legacy_agent(
     shape. Returns a verdict derived from whatever the provider actually
     does with that shape -- including reproducing ``OUTPUT_EXHAUSTED``
     against a provider/budget combination that cannot handle it.
+
+    Three calls, not two (CHAOS-3285 round 2, Codex HIGH): round 1 (tools
+    offered, no tool result yet, always composed with
+    ``subject_committed=True``, the lower-risk shape regardless of which
+    prompt variant a real run ends up using -- the fixed subject-section
+    text is a small delta against the tool registry + grammar + history
+    that actually dominate exhaustion risk); round 2 under the
+    committed-subject shape (``PROMPT_VERSION``); and round 2 AGAIN under
+    the uncommitted-subject shape (``LEGACY_PROMPT_VERSION`` -- an
+    organization-wide question, or the Wave 3.1 flag off). Both round-2
+    calls exercise the actual combined worst-case shape (tool_choice="auto"
+    + the strict grammar), the one that determines exhaustion, so BOTH
+    prompt shapes a real run can select must independently certify
+    COMPATIBLE for the role to certify COMPATIBLE overall. This is what
+    makes ``_canonical_contract_digest``'s folding of BOTH prompt version
+    constants meaningful: without probing both shapes, invalidating on a
+    LEGACY_PROMPT_VERSION change would correctly force re-certification,
+    but the re-certification itself would still never have tested the
+    shape that changed.
     """
 
     limits = limits or DevRunLimits()
@@ -244,46 +317,50 @@ async def certify_legacy_agent(
             raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
 
         tool_result = _probe_tool_result(result_1.decision)
-        composed_round_2 = composer.compose(
-            question=_PROBE_QUESTION,
-            scope=scope_resolution,
-            prior_turns=history,
-            tool_results=(tool_result,),
-            allowed_tools=None,
-            subject_committed=True,
-        )
-        messages_round_2 = (
-            AgentMessage(AgentMessageRole.SYSTEM, composed_round_2.system_text),
-            AgentMessage(AgentMessageRole.USER, composed_round_2.user_text),
-            AgentMessage(
-                AgentMessageRole.ASSISTANT, "", tool_request=result_1.decision
-            ),
-            AgentMessage(
-                AgentMessageRole.TOOL,
-                tool_result.model_dump_json(),
-                tool_call_id=result_1.decision.call_id,
-            ),
-        )
-        result_2 = await provider.decide(
-            messages_round_2,
-            tools,
-            response_schema,
-            timeout_seconds,
-            limits.max_output_tokens_per_call,
-            signal,
-        )
-        usage = _merge_usage(usage, result_2.usage)
-        if not isinstance(result_2.decision, (AgentFinalAnswer, AgentToolRequest)):
-            raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
 
+        result_2_committed, composed_round_2_committed = await _decide_round_2(
+            provider=provider,
+            composer=composer,
+            scope_resolution=scope_resolution,
+            history=history,
+            tools=tools,
+            response_schema=response_schema,
+            tool_request=result_1.decision,
+            tool_result=tool_result,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=limits.max_output_tokens_per_call,
+            subject_committed=True,
+            signal=signal,
+        )
+        usage = _merge_usage(usage, result_2_committed.usage)
+
+        result_2_uncommitted, composed_round_2_uncommitted = await _decide_round_2(
+            provider=provider,
+            composer=composer,
+            scope_resolution=scope_resolution,
+            history=history,
+            tools=tools,
+            response_schema=response_schema,
+            tool_request=result_1.decision,
+            tool_result=tool_result,
+            timeout_seconds=timeout_seconds,
+            max_output_tokens=limits.max_output_tokens_per_call,
+            subject_committed=False,
+            signal=signal,
+        )
+        usage = _merge_usage(usage, result_2_uncommitted.usage)
+
+        observed_bytes = max(
+            len(composed_round_2_committed.system_text.encode("utf-8"))
+            + len(composed_round_2_committed.user_text.encode("utf-8")),
+            len(composed_round_2_uncommitted.system_text.encode("utf-8"))
+            + len(composed_round_2_uncommitted.user_text.encode("utf-8")),
+        )
         return LegacyAgentProbeResult(
             state=RoleCertificationState.COMPATIBLE,
             safe_error_code=None,
             usage=usage,
-            observed_request_bytes=(
-                len(composed_round_2.system_text.encode("utf-8"))
-                + len(composed_round_2.user_text.encode("utf-8"))
-            ),
+            observed_request_bytes=observed_bytes,
         )
     except AgentProviderError as exc:
         safe = safe_agent_provider_error(exc)

--- a/src/dev_health_ops/llm/agent/probes/legacy_agent.py
+++ b/src/dev_health_ops/llm/agent/probes/legacy_agent.py
@@ -17,6 +17,12 @@ sends ``tool_choice="auto"`` **and** the full ``DevAnswer`` grammar
 simultaneously -- the combined shape every real round >= 2 sends and which
 the synthetic readiness echo probe never exercises at all.
 
+CHAOS-3285 round 4 (Codex HIGH): those two rounds are run as TWO
+independent, complete chains -- one entirely under the committed-subject
+prompt shape, one entirely under the uncommitted-subject shape -- each
+chain's own round 1 producing the tool request/result its own round 2
+uses. See ``certify_legacy_agent`` and ``_probe_chain``.
+
 The synthetic round-2 tool result is schema-valid, fabricated content from
 the checked-in production contract fixtures (``contract_fixtures.py``) --
 never a live tool call, never tenant data (ticket guardrail: "Readiness
@@ -215,12 +221,10 @@ async def _decide_round_2(
     """Round 2 for one prompt shape (committed or uncommitted subject):
     tools offered AND a synthetic tool result already in the conversation
     -- ``tool_choice="auto"`` and the full ``DevAnswer`` grammar
-    simultaneously, the combined worst-case shape. Shares the SAME
-    synthetic tool request/result across both shapes: the tool-result
-    content does not depend on ``subject_committed`` at all, only the
-    system/user prompt sections do, so reusing it isolates exactly the
-    prompt-shape dimension CHAOS-3285 round 2 (Codex HIGH) flagged as
-    never invalidated.
+    simultaneously, the combined worst-case shape. ``tool_request`` and
+    ``tool_result`` are this SAME shape's own round 1 -- see ``_probe_chain``
+    -- never borrowed from the other shape's chain (CHAOS-3285 round 4,
+    Codex HIGH).
     """
 
     composed = composer.compose(
@@ -249,6 +253,89 @@ async def _decide_round_2(
     return result, composed
 
 
+@dataclass(frozen=True, slots=True)
+class _ProbeChainResult:
+    round_2: AgentDecisionResult
+    composed_round_2: ComposedPrompt
+    usage: AgentUsage
+
+
+async def _probe_chain(
+    *,
+    provider: AgentLLMProvider,
+    composer: PromptComposer,
+    scope_resolution: DevScopeResolution,
+    history: tuple[PromptConversationTurn, ...],
+    tools: tuple[AgentToolDefinition, ...],
+    response_schema: Mapping[str, object],
+    timeout_seconds: float,
+    max_output_tokens: int,
+    subject_committed: bool,
+    signal: CancellationSignal | None,
+) -> _ProbeChainResult:
+    """One full, independent two-round chain for ONE prompt shape: round 1
+    (tools offered, no tool result yet, ``tool_choice="required"``) composed
+    under THIS shape's ``subject_committed`` value, then round 2 built from
+    THAT round's own tool request/result.
+
+    CHAOS-3285 round 4 (Codex HIGH): before this fix, round 1 was ALWAYS
+    composed with ``subject_committed=True`` regardless of which shape round
+    2 went on to probe, and round 2's uncommitted-subject call reused round
+    1's committed-subject tool request/result. A provider that fails ONLY
+    on the combination of the uncommitted-subject prompt AND
+    ``tool_choice="required"`` (round 1's own shape under that variant) --
+    or that produces a different tool call/arguments under that shape --
+    still certified COMPATIBLE, because that combination was never sent to
+    it at all. Each shape now runs its own complete, independent chain, and
+    ``certify_legacy_agent`` requires BOTH to succeed.
+    """
+
+    composed_round_1 = composer.compose(
+        question=_PROBE_QUESTION,
+        scope=scope_resolution,
+        prior_turns=history,
+        tool_results=(),
+        allowed_tools=None,
+        subject_committed=subject_committed,
+    )
+    _assert_production_shape(composed_round_1.system_text, tools)
+    messages_round_1 = (
+        AgentMessage(AgentMessageRole.SYSTEM, composed_round_1.system_text),
+        AgentMessage(AgentMessageRole.USER, composed_round_1.user_text),
+    )
+    result_1 = await provider.decide(
+        messages_round_1,
+        tools,
+        response_schema,
+        timeout_seconds,
+        max_output_tokens,
+        signal,
+    )
+    if not isinstance(result_1.decision, AgentToolRequest):
+        raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+    tool_result = _probe_tool_result(result_1.decision)
+    result_2, composed_round_2 = await _decide_round_2(
+        provider=provider,
+        composer=composer,
+        scope_resolution=scope_resolution,
+        history=history,
+        tools=tools,
+        response_schema=response_schema,
+        tool_request=result_1.decision,
+        tool_result=tool_result,
+        timeout_seconds=timeout_seconds,
+        max_output_tokens=max_output_tokens,
+        subject_committed=subject_committed,
+        signal=signal,
+    )
+    return _ProbeChainResult(
+        round_2=result_2,
+        composed_round_2=composed_round_2,
+        usage=_merge_usage(result_1.usage, result_2.usage),
+    )
+
+
 async def certify_legacy_agent(
     provider: AgentLLMProvider,
     *,
@@ -261,24 +348,23 @@ async def certify_legacy_agent(
     does with that shape -- including reproducing ``OUTPUT_EXHAUSTED``
     against a provider/budget combination that cannot handle it.
 
-    Three calls, not two (CHAOS-3285 round 2, Codex HIGH): round 1 (tools
-    offered, no tool result yet, always composed with
-    ``subject_committed=True``, the lower-risk shape regardless of which
-    prompt variant a real run ends up using -- the fixed subject-section
-    text is a small delta against the tool registry + grammar + history
-    that actually dominate exhaustion risk); round 2 under the
-    committed-subject shape (``PROMPT_VERSION``); and round 2 AGAIN under
-    the uncommitted-subject shape (``LEGACY_PROMPT_VERSION`` -- an
-    organization-wide question, or the Wave 3.1 flag off). Both round-2
-    calls exercise the actual combined worst-case shape (tool_choice="auto"
-    + the strict grammar), the one that determines exhaustion, so BOTH
-    prompt shapes a real run can select must independently certify
-    COMPATIBLE for the role to certify COMPATIBLE overall. This is what
-    makes ``_canonical_contract_digest``'s folding of BOTH prompt version
-    constants meaningful: without probing both shapes, invalidating on a
-    LEGACY_PROMPT_VERSION change would correctly force re-certification,
-    but the re-certification itself would still never have tested the
-    shape that changed.
+    Four calls, two independent chains (CHAOS-3285 round 4, Codex HIGH):
+    a full committed-subject chain (round 1 under ``PROMPT_VERSION`` with
+    ``tool_choice="required"``, then round 2 built from THAT round's own
+    tool request/result under the combined ``tool_choice="auto"`` + strict
+    grammar shape), and a full uncommitted-subject chain (the same two
+    rounds again, entirely under ``LEGACY_PROMPT_VERSION`` -- an
+    organization-wide question, or the Wave 3.1 flag off). Round 1 is no
+    longer always composed with ``subject_committed=True`` and reused
+    across chains: each shape's round 1 is composed under its OWN
+    ``subject_committed`` value, and its round 2 is built from THAT round's
+    own tool request/result, never the other chain's. Both chains must
+    independently succeed for the role to certify COMPATIBLE overall. This
+    is what makes ``_canonical_contract_digest``'s folding of BOTH prompt
+    version constants meaningful: without probing both shapes end-to-end,
+    invalidating on a ``LEGACY_PROMPT_VERSION`` change would correctly
+    force re-certification, but the re-certification itself would still
+    never have tested the shape that changed.
     """
 
     limits = limits or DevRunLimits()
@@ -291,70 +377,39 @@ async def certify_legacy_agent(
     usage = AgentUsage()
 
     try:
-        composed_round_1 = composer.compose(
-            question=_PROBE_QUESTION,
-            scope=scope_resolution,
-            prior_turns=history,
-            tool_results=(),
-            allowed_tools=None,
-            subject_committed=True,
-        )
-        _assert_production_shape(composed_round_1.system_text, tools)
-        messages_round_1 = (
-            AgentMessage(AgentMessageRole.SYSTEM, composed_round_1.system_text),
-            AgentMessage(AgentMessageRole.USER, composed_round_1.user_text),
-        )
-        result_1 = await provider.decide(
-            messages_round_1,
-            tools,
-            response_schema,
-            timeout_seconds,
-            limits.max_output_tokens_per_call,
-            signal,
-        )
-        usage = _merge_usage(usage, result_1.usage)
-        if not isinstance(result_1.decision, AgentToolRequest):
-            raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
-
-        tool_result = _probe_tool_result(result_1.decision)
-
-        result_2_committed, composed_round_2_committed = await _decide_round_2(
+        committed = await _probe_chain(
             provider=provider,
             composer=composer,
             scope_resolution=scope_resolution,
             history=history,
             tools=tools,
             response_schema=response_schema,
-            tool_request=result_1.decision,
-            tool_result=tool_result,
             timeout_seconds=timeout_seconds,
             max_output_tokens=limits.max_output_tokens_per_call,
             subject_committed=True,
             signal=signal,
         )
-        usage = _merge_usage(usage, result_2_committed.usage)
+        usage = _merge_usage(usage, committed.usage)
 
-        result_2_uncommitted, composed_round_2_uncommitted = await _decide_round_2(
+        uncommitted = await _probe_chain(
             provider=provider,
             composer=composer,
             scope_resolution=scope_resolution,
             history=history,
             tools=tools,
             response_schema=response_schema,
-            tool_request=result_1.decision,
-            tool_result=tool_result,
             timeout_seconds=timeout_seconds,
             max_output_tokens=limits.max_output_tokens_per_call,
             subject_committed=False,
             signal=signal,
         )
-        usage = _merge_usage(usage, result_2_uncommitted.usage)
+        usage = _merge_usage(usage, uncommitted.usage)
 
         observed_bytes = max(
-            len(composed_round_2_committed.system_text.encode("utf-8"))
-            + len(composed_round_2_committed.user_text.encode("utf-8")),
-            len(composed_round_2_uncommitted.system_text.encode("utf-8"))
-            + len(composed_round_2_uncommitted.user_text.encode("utf-8")),
+            len(committed.composed_round_2.system_text.encode("utf-8"))
+            + len(committed.composed_round_2.user_text.encode("utf-8")),
+            len(uncommitted.composed_round_2.system_text.encode("utf-8"))
+            + len(uncommitted.composed_round_2.user_text.encode("utf-8")),
         )
         return LegacyAgentProbeResult(
             state=RoleCertificationState.COMPATIBLE,

--- a/src/dev_health_ops/llm/agent/probes/legacy_agent.py
+++ b/src/dev_health_ops/llm/agent/probes/legacy_agent.py
@@ -1,0 +1,306 @@
+"""Production-sized ``legacy_agent`` role readiness probe (CHAOS-3285).
+
+Unlike ``readiness.py``'s ``AgentReadinessService.certify`` (a 512-token echo
+against one 240-byte tool), this probe is built from the exact real
+producers the production Ask Dev orchestrator uses: ``PromptComposer`` (the
+full fixed-policy sections + the committed-subject section + the complete
+tool registry), ``AskDevToolRegistry`` (all nine registered tools, real
+per-tool input schemas via ``DevOrchestrator._provider_tool_input_schema``),
+``DevRunLimits`` (the real per-call output-token cap), and ``DevAnswer``'s
+own JSON schema. It never hand-authors a miniature payload.
+
+Two rounds mirror the worst-case production shape identified by the
+CHAOS-3285 root-cause analysis: round 1 (tools offered, no tool result yet)
+sends ``tool_choice="required"`` with no structured-output grammar; round 2
+(tools offered *and* a synthetic tool result already in the conversation)
+sends ``tool_choice="auto"`` **and** the full ``DevAnswer`` grammar
+simultaneously -- the combined shape every real round >= 2 sends and which
+the synthetic readiness echo probe never exercises at all.
+
+The synthetic round-2 tool result is schema-valid, fabricated content from
+the checked-in production contract fixtures (``contract_fixtures.py``) --
+never a live tool call, never tenant data (ticket guardrail: "Readiness
+cannot make a real source/tool call with tenant data").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevAnswer,
+    DevScopeResolution,
+    DevToolResult,
+    ToolID,
+)
+from dev_health_ops.api.dev.orchestrator import DevOrchestrator, DevRunLimits
+from dev_health_ops.api.dev.prompts.composer import (
+    PromptComposer,
+    PromptConversationTurn,
+)
+from dev_health_ops.api.dev.tool_registry import TOOL_DEFINITIONS, AskDevToolRegistry
+
+from ..contracts import (
+    AgentFinalAnswer,
+    AgentLLMProvider,
+    AgentMessage,
+    AgentMessageRole,
+    AgentToolDefinition,
+    AgentToolRequest,
+    AgentUsage,
+    CancellationSignal,
+)
+from ..errors import (
+    AgentProviderError,
+    AgentProviderErrorCode,
+    safe_agent_provider_error,
+)
+from ..readiness import role_state_for_safe_error_code
+from ..roles import RoleCertificationState
+
+_PROBE_QUESTION = (
+    "What changed in this repository during the selected period, and is the "
+    "in-flight work complete?"
+)
+_PROBE_RUN_ID = "role-probe-legacy-agent-01"
+
+# A production round-1 system prompt (full fixed policy sections + the
+# committed-subject section + the complete nine-tool registry) measures
+# ~5.8 KB per the CHAOS-3285 root-cause analysis; the synthetic readiness
+# echo probe's entire request is well under 1 KB. This floor sits
+# comfortably below the real measurement -- so ordinary prompt-text edits
+# don't flake the probe -- but well above anything a shrunk/miniature probe
+# could ever produce (Rule 4: a measurement that did not happen must fail
+# loudly, not silently read as coverage).
+_PRODUCTION_FLOOR_BYTES = 4_000
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyAgentProbeResult:
+    state: RoleCertificationState
+    safe_error_code: str | None
+    usage: AgentUsage
+    observed_request_bytes: int
+
+
+async def _unused_executor(context: object, request: object) -> DevToolResult:
+    # The probe never actually executes a tool -- it only needs a real,
+    # fully-validated AskDevToolRegistry to produce the exact production
+    # tool manifest/schemas. A real invocation here would be a probe defect.
+    raise AssertionError("legacy_agent probe must never execute a real tool")
+
+
+def _probe_registry() -> AskDevToolRegistry:
+    return AskDevToolRegistry({tool_id: _unused_executor for tool_id in ToolID})
+
+
+def _probe_tools(registry: AskDevToolRegistry) -> tuple[AgentToolDefinition, ...]:
+    """Mirror ``DevOrchestrator._provider_tools`` verbatim: the real producer
+    of the wire tool definitions, never a hand-rolled schema."""
+
+    manifest = registry.manifest(allowed_tool_ids=None)
+    tools = manifest["tools"]
+    assert isinstance(tools, list)
+    return tuple(
+        AgentToolDefinition(
+            tool_id=str(item["tool_id"]),
+            description=str(item["description"]),
+            input_schema=DevOrchestrator._provider_tool_input_schema(
+                ToolID(str(item["tool_id"])), int(item["max_items"])
+            ),
+        )
+        for item in tools
+        if isinstance(item, Mapping)
+    )
+
+
+def _probe_scope_resolution() -> DevScopeResolution:
+    return DevScopeResolution.model_validate(
+        positive_fixtures()["dev_scope_resolution.v1"]
+    )
+
+
+def _probe_history() -> tuple[PromptConversationTurn, ...]:
+    """A representative (not maximal) prior conversation.
+
+    The dominant cost driver in the CHAOS-3285 measurement is the fixed
+    system prompt + full tool registry + full grammar (~12.6 KB round-1
+    floor), not history -- so a representative multi-turn history proves the
+    mechanism without needing to hit ``MAX_PRIOR_CONTENT_BYTES``.
+    """
+
+    return tuple(
+        PromptConversationTurn(
+            role="user" if index % 2 == 0 else "assistant",
+            content=(
+                f"Prior conversation turn {index}: representative "
+                "production-sized context describing previously observed "
+                "status, delivered work, and open follow-up questions from "
+                "an earlier round of this investigation. "
+            )
+            * 4,
+        )
+        for index in range(6)
+    )
+
+
+def _probe_tool_result(tool_request: AgentToolRequest) -> DevToolResult:
+    """A schema-valid, fabricated tool result -- never a live call, never
+    tenant data (CHAOS-3285 guardrail)."""
+
+    payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+    payload["run_id"] = _PROBE_RUN_ID
+    payload["tool_call_id"] = tool_request.call_id
+    payload["tool_id"] = tool_request.tool_id
+    return DevToolResult.model_validate(payload)
+
+
+def _assert_production_shape(
+    system_text: str, tools: tuple[AgentToolDefinition, ...]
+) -> None:
+    if len(tools) != len(TOOL_DEFINITIONS):
+        raise AssertionError(
+            f"legacy_agent probe must advertise the full {len(TOOL_DEFINITIONS)}-tool "
+            f"registry, got {len(tools)}"
+        )
+    observed_bytes = len(system_text.encode("utf-8"))
+    if observed_bytes < _PRODUCTION_FLOOR_BYTES:
+        raise AssertionError(
+            f"legacy_agent probe's composed system prompt ({observed_bytes} bytes) "
+            f"is below the production-representative floor ({_PRODUCTION_FLOOR_BYTES} "
+            "bytes) -- the probe shrank and no longer reproduces the real request shape"
+        )
+
+
+def _merge_usage(left: AgentUsage, right: AgentUsage) -> AgentUsage:
+    cost = None
+    if (
+        left.estimated_cost_microusd is not None
+        or right.estimated_cost_microusd is not None
+    ):
+        cost = (left.estimated_cost_microusd or 0) + (
+            right.estimated_cost_microusd or 0
+        )
+    reasoning_tokens = None
+    if left.reasoning_tokens is not None or right.reasoning_tokens is not None:
+        reasoning_tokens = (left.reasoning_tokens or 0) + (right.reasoning_tokens or 0)
+    return AgentUsage(
+        input_tokens=left.input_tokens + right.input_tokens,
+        output_tokens=left.output_tokens + right.output_tokens,
+        estimated_cost_microusd=cost,
+        reasoning_tokens=reasoning_tokens,
+    )
+
+
+async def certify_legacy_agent(
+    provider: AgentLLMProvider,
+    *,
+    timeout_seconds: float,
+    limits: DevRunLimits | None = None,
+    signal: CancellationSignal | None = None,
+) -> LegacyAgentProbeResult:
+    """Certify the ``legacy_agent`` role against the real production request
+    shape. Returns a verdict derived from whatever the provider actually
+    does with that shape -- including reproducing ``OUTPUT_EXHAUSTED``
+    against a provider/budget combination that cannot handle it.
+    """
+
+    limits = limits or DevRunLimits()
+    registry = _probe_registry()
+    composer = PromptComposer(registry)
+    tools = _probe_tools(registry)
+    scope_resolution = _probe_scope_resolution()
+    history = _probe_history()
+    response_schema = DevAnswer.model_json_schema(mode="validation")
+    usage = AgentUsage()
+
+    try:
+        composed_round_1 = composer.compose(
+            question=_PROBE_QUESTION,
+            scope=scope_resolution,
+            prior_turns=history,
+            tool_results=(),
+            allowed_tools=None,
+            subject_committed=True,
+        )
+        _assert_production_shape(composed_round_1.system_text, tools)
+        messages_round_1 = (
+            AgentMessage(AgentMessageRole.SYSTEM, composed_round_1.system_text),
+            AgentMessage(AgentMessageRole.USER, composed_round_1.user_text),
+        )
+        result_1 = await provider.decide(
+            messages_round_1,
+            tools,
+            response_schema,
+            timeout_seconds,
+            limits.max_output_tokens_per_call,
+            signal,
+        )
+        usage = _merge_usage(usage, result_1.usage)
+        if not isinstance(result_1.decision, AgentToolRequest):
+            raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+        tool_result = _probe_tool_result(result_1.decision)
+        composed_round_2 = composer.compose(
+            question=_PROBE_QUESTION,
+            scope=scope_resolution,
+            prior_turns=history,
+            tool_results=(tool_result,),
+            allowed_tools=None,
+            subject_committed=True,
+        )
+        messages_round_2 = (
+            AgentMessage(AgentMessageRole.SYSTEM, composed_round_2.system_text),
+            AgentMessage(AgentMessageRole.USER, composed_round_2.user_text),
+            AgentMessage(
+                AgentMessageRole.ASSISTANT, "", tool_request=result_1.decision
+            ),
+            AgentMessage(
+                AgentMessageRole.TOOL,
+                tool_result.model_dump_json(),
+                tool_call_id=result_1.decision.call_id,
+            ),
+        )
+        result_2 = await provider.decide(
+            messages_round_2,
+            tools,
+            response_schema,
+            timeout_seconds,
+            limits.max_output_tokens_per_call,
+            signal,
+        )
+        usage = _merge_usage(usage, result_2.usage)
+        if not isinstance(result_2.decision, (AgentFinalAnswer, AgentToolRequest)):
+            raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+        return LegacyAgentProbeResult(
+            state=RoleCertificationState.COMPATIBLE,
+            safe_error_code=None,
+            usage=usage,
+            observed_request_bytes=(
+                len(composed_round_2.system_text.encode("utf-8"))
+                + len(composed_round_2.user_text.encode("utf-8"))
+            ),
+        )
+    except AgentProviderError as exc:
+        safe = safe_agent_provider_error(exc)
+        # A failure raised by provider.decide() itself (e.g. OUTPUT_EXHAUSTED)
+        # carries the usage of the call that failed, which was never merged
+        # into ``usage`` above because that call's ``result`` was never
+        # returned; a failure this function raised itself over an
+        # already-returned decision has no separate usage to add (it is
+        # already folded into ``usage``).
+        if safe.usage is not None:
+            usage = _merge_usage(usage, safe.usage)
+        return LegacyAgentProbeResult(
+            state=role_state_for_safe_error_code(safe.code.value),
+            safe_error_code=safe.code.value,
+            usage=usage,
+            observed_request_bytes=0,
+        )
+
+
+__all__ = ["LegacyAgentProbeResult", "certify_legacy_agent"]

--- a/src/dev_health_ops/llm/agent/readiness.py
+++ b/src/dev_health_ops/llm/agent/readiness.py
@@ -29,6 +29,7 @@ from .errors import (
     AgentProviderErrorCode,
     safe_agent_provider_error,
 )
+from .roles import RoleCertificationState
 
 READINESS_SETTING_KEY = "ask_dev_agent_readiness"
 READINESS_MAX_OUTPUT_TOKENS = 512
@@ -312,6 +313,30 @@ def readiness_failure_state(safe_error_code: str | None) -> tuple[ReadinessState
     if safe_error_code == "provider_unavailable":
         return "degraded", "The configured Ask Dev model endpoint is unavailable."
     return "degraded", "The configured Ask Dev model failed readiness."
+
+
+def role_state_for_safe_error_code(
+    safe_error_code: str | None,
+) -> RoleCertificationState:
+    """Map a safe provider error code to a per-role certification verdict.
+
+    Reuses ``readiness_failure_state``'s existing safe_error_code ->
+    admin-facing-state mapping rather than re-deriving the same
+    classification twice (CHAOS-3285): ``"unsupported_model"`` is exactly
+    the deterministic/structural case (including ``output_exhausted``,
+    which maps there today) -- these become INCOMPATIBLE, since retrying
+    the same request shape against the same provider will not resolve
+    them. Every other failure state (missing credentials, disabled,
+    degraded/transient) becomes FAILED -- an operator or transient-retry
+    condition, not a structural one. ``None`` (no error) is COMPATIBLE.
+    """
+
+    if safe_error_code is None:
+        return RoleCertificationState.COMPATIBLE
+    state, _ = readiness_failure_state(safe_error_code)
+    if state == "unsupported_model":
+        return RoleCertificationState.INCOMPATIBLE
+    return RoleCertificationState.FAILED
 
 
 def _add_usage(left: AgentUsage, right: AgentUsage) -> AgentUsage:

--- a/src/dev_health_ops/llm/agent/role_readiness.py
+++ b/src/dev_health_ops/llm/agent/role_readiness.py
@@ -56,8 +56,11 @@ class RoleReadinessService:
             state=probe_result.state,
             safe_error_code=probe_result.safe_error_code,
         )
-        profile = await self._store.load()
-        await self._store.save(profile.with_record(record))
+        # Writes exactly this role's row -- no read-modify-write of the
+        # whole profile, so a concurrent certification of a sibling role can
+        # never be lost regardless of commit order (see
+        # SettingsRoleCertificationStore's docstring).
+        await self._store.save_record(record)
         return record
 
 

--- a/src/dev_health_ops/llm/agent/role_readiness.py
+++ b/src/dev_health_ops/llm/agent/role_readiness.py
@@ -1,0 +1,64 @@
+"""Ties a per-role probe to the per-role certification store (CHAOS-3285).
+
+Only ``AgentRole.LEGACY_AGENT`` has a working probe in this changeset;
+``INTENT_CLASSIFICATION`` and ``ANSWER_FRAME_NARRATIVE`` are valid role
+arguments the store can hold a slot for, but certifying them raises
+``NotImplementedError`` until their probes land (CHAOS-3285 PR4).
+
+The caller supplies ``certification_key`` -- computed by
+``api.dev.production_runtime._readiness_fingerprint(candidate, role=role)``,
+which folds every capability input that must invalidate a stale
+certification (prompt/tool-contract/budget-policy versions, provider
+identity, role). This module deliberately does not import anything from
+``api.dev`` itself, to keep the dependency direction one-way (``api.dev`` ->
+``llm.agent``, never the reverse) at the module-import level.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .contracts import AgentLLMProvider, CancellationSignal
+from .probes.legacy_agent import certify_legacy_agent
+from .roles import (
+    AgentRole,
+    RoleCertificationRecord,
+    RoleCertificationStore,
+)
+
+
+class RoleReadinessService:
+    def __init__(self, store: RoleCertificationStore):
+        self._store = store
+
+    async def certify_role(
+        self,
+        role: AgentRole,
+        provider: AgentLLMProvider,
+        *,
+        certification_key: str,
+        timeout_seconds: float = 30,
+        signal: CancellationSignal | None = None,
+    ) -> RoleCertificationRecord:
+        if role is not AgentRole.LEGACY_AGENT:
+            raise NotImplementedError(
+                f"{role.value} has no production-representative probe yet "
+                "(CHAOS-3285 PR4)"
+            )
+        probe_result = await certify_legacy_agent(
+            provider, timeout_seconds=timeout_seconds, signal=signal
+        )
+        record = RoleCertificationRecord(
+            role=role,
+            certification_key=certification_key,
+            readiness_version=provider.capabilities.readiness_version,
+            checked_at=datetime.now(timezone.utc).isoformat(),
+            state=probe_result.state,
+            safe_error_code=probe_result.safe_error_code,
+        )
+        profile = await self._store.load()
+        await self._store.save(profile.with_record(record))
+        return record
+
+
+__all__ = ["RoleReadinessService"]

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -124,11 +124,22 @@ def _empty_profile() -> RoleCertificationProfile:
 
 
 class RoleCertificationStore(Protocol):
-    async def load(self) -> RoleCertificationProfile: ...
+    # CHAOS-3285 round 6: `pass`, not `...`, as the stub body -- CodeQL's
+    # py/ineffectual-statement flags a bare `...` (an Ellipsis literal) as
+    # an expression statement whose value is discarded, which is exactly
+    # what it looks like out of context even though it's the conventional
+    # Protocol/stub-method body. `pass` is the statement form purpose-built
+    # for this (not an expression statement at all), carries the identical
+    # "no body" meaning, and is unambiguous to both type checkers and
+    # CodeQL.
+    async def load(self) -> RoleCertificationProfile:
+        pass
 
-    async def save_record(self, record: RoleCertificationRecord) -> None: ...
+    async def save_record(self, record: RoleCertificationRecord) -> None:
+        pass
 
-    async def save(self, profile: RoleCertificationProfile) -> None: ...
+    async def save(self, profile: RoleCertificationProfile) -> None:
+        pass
 
 
 def _role_setting_key(base_key: str, role: AgentRole) -> str:
@@ -243,7 +254,16 @@ class SettingsRoleCertificationStore:
 
     async def load(self) -> RoleCertificationProfile:
         records: dict[AgentRole, RoleCertificationRecord] = {}
-        for role in AgentRole:
+        # CHAOS-3285 round 6: CodeQL py/non-iterable-in-for-loop false
+        # positive -- AgentRole(str, Enum) IS iterable, via its metaclass
+        # (EnumType/EnumMeta provides __iter__ for the class object itself;
+        # the Enum subclass does not define its own __iter__, which is what
+        # a syntactic non-iterable check sees). Verified empirically
+        # (`list(AgentRole)` succeeds) and this is the SAME established
+        # pattern already used unflagged elsewhere in this codebase --
+        # `for tool_id in ToolID` in production_runtime.py,
+        # probes/legacy_agent.py, and tool_registry.py.
+        for role in AgentRole:  # lgtm[py/non-iterable-in-for-loop]
             record = await self._load_role(role)
             if record is not None:
                 records[role] = record

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -18,13 +18,18 @@ reads the old key back is unaffected by anything written here.
 from __future__ import annotations
 
 import json
+import uuid
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Protocol
+from typing import Any, Protocol
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
-from dev_health_ops.models.settings import SettingCategory
+from dev_health_ops.models.settings import Setting, SettingCategory
 
 #: Version of the persisted profile envelope's own JSON shape -- distinct
 #: from ``readiness_version``/``certification_key`` below, which invalidate
@@ -131,6 +136,96 @@ def _role_setting_key(base_key: str, role: AgentRole) -> str:
     return f"{base_key}:{role.value}"
 
 
+async def _upsert_setting_row(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    category: str,
+    key: str,
+    value: str,
+    description: str,
+) -> None:
+    """Atomic, single-statement insert-or-update of exactly one settings row,
+    targeting the table's own ``uq_settings_org_category_key`` unique
+    constraint -- never ``SettingsService.set()``'s select-then-insert-or-
+    update, which races under true concurrent writers: two sessions can both
+    observe "no row yet", both attempt INSERT, and the loser's flush raises
+    ``IntegrityError``. Bypassing the ORM here mirrors the codebase's
+    existing dialect-aware upsert precedent (``sync.dispatch_outbox.
+    upsert_outbox_wakeup``).
+
+    Winner policy for two sessions certifying the SAME role concurrently:
+    **last COMMIT wins** -- ``ON CONFLICT DO UPDATE`` always applies whichever
+    writer's transaction commits last, overwriting the other's value. This is
+    the same "the most recent preflight result governs" semantic an operator
+    already expects from re-running preflight; this fix only makes it
+    race-safe (no uncaught ``IntegrityError``) rather than changing what it
+    means to certify a role twice.
+    """
+
+    now = datetime.now(timezone.utc)
+    dialect_name = session.get_bind().dialect.name
+    table = Setting.__table__
+    insert_values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "org_id": org_id,
+        "category": category,
+        "key": key,
+        "value": value,
+        "is_encrypted": False,
+        "description": description,
+        "created_at": now,
+        "updated_at": now,
+    }
+    if dialect_name in ("postgresql", "sqlite"):
+        dialect_insert: Any
+        if dialect_name == "postgresql":
+            from sqlalchemy.dialects.postgresql import insert as dialect_insert
+        else:
+            from sqlalchemy.dialects.sqlite import insert as dialect_insert
+
+        stmt = dialect_insert(table).values(**insert_values)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["org_id", "category", "key"],
+            set_={
+                "value": stmt.excluded.value,
+                "description": stmt.excluded.description,
+                "updated_at": stmt.excluded.updated_at,
+            },
+        )
+        await session.execute(stmt)
+        await session.flush()
+        return
+    # Any other dialect: still atomic (a SAVEPOINT rolls back only this
+    # operation on conflict, never the caller's outer transaction, unlike an
+    # uncaught IntegrityError from a bare select-then-insert), just not a
+    # single-statement native upsert.
+    async with session.begin_nested():
+        existing = (
+            await session.execute(
+                select(Setting).where(
+                    Setting.org_id == org_id,
+                    Setting.category == category,
+                    Setting.key == key,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            session.add(
+                Setting(
+                    key=key,
+                    category=category,
+                    value=value,
+                    org_id=org_id,
+                    description=description,
+                )
+            )
+        else:
+            existing.value = value
+            existing.description = description
+        await session.flush()
+
+
 class SettingsRoleCertificationStore:
     """Persists one settings row **per role**, not one shared envelope blob.
 
@@ -144,12 +239,12 @@ class SettingsRoleCertificationStore:
     updates touched logically independent roles. Splitting storage per role
     removes the shared mutable state that race depended on: two different
     roles are two different settings rows, so there is no read-before-write
-    dependency between them and no commit order can lose either one. A
-    same-role concurrent write (two sessions certifying the identical role at
-    the identical moment) still resolves via ``SettingsService.set()``'s
-    existing select-or-insert semantics -- the same behavior every other
-    settings-backed value in this codebase already has; broadening that to a
-    general atomic upsert is out of scope here.
+    dependency between them and no commit order can lose either one.
+
+    A same-role concurrent write (two sessions certifying the identical role
+    at the identical moment) is handled by ``_upsert_setting_row``'s atomic
+    ``INSERT ... ON CONFLICT DO UPDATE`` -- see that function's docstring for
+    the stated winner policy.
     """
 
     def __init__(
@@ -210,9 +305,10 @@ class SettingsRoleCertificationStore:
             return None
 
     async def save_record(self, record: RoleCertificationRecord) -> None:
-        """Upsert exactly one role's row. This is the write path
+        """Atomically upsert exactly one role's row. This is the write path
         ``RoleReadinessService`` uses -- no read-modify-write of any other
-        role's data, so certifying one role can never lose another's."""
+        role's data, so certifying one role can never lose another's, and no
+        select-then-insert race against a concurrent same-role write."""
 
         payload = {
             "version": ROLE_CERTIFICATION_PROFILE_VERSION,
@@ -222,10 +318,12 @@ class SettingsRoleCertificationStore:
                 "state": record.state.value,
             },
         }
-        await self._settings.set(
-            _role_setting_key(self._base_key, record.role),
-            json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        await _upsert_setting_row(
+            self._settings.session,
+            org_id=self._settings.org_id,
             category=SettingCategory.LLM.value,
+            key=_role_setting_key(self._base_key, record.role),
+            value=json.dumps(payload, separators=(",", ":"), sort_keys=True),
             description=f"Safe Ask Dev {record.role.value} role certification result",
         )
 

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -122,24 +122,58 @@ def _empty_profile() -> RoleCertificationProfile:
 class RoleCertificationStore(Protocol):
     async def load(self) -> RoleCertificationProfile: ...
 
+    async def save_record(self, record: RoleCertificationRecord) -> None: ...
+
     async def save(self, profile: RoleCertificationProfile) -> None: ...
 
 
+def _role_setting_key(base_key: str, role: AgentRole) -> str:
+    return f"{base_key}:{role.value}"
+
+
 class SettingsRoleCertificationStore:
-    """Persists the per-role profile envelope under a key distinct from the
-    legacy binary readiness record (see module docstring for the
-    backward-compatibility rationale)."""
+    """Persists one settings row **per role**, not one shared envelope blob.
+
+    This is deliberate, not incidental: an earlier version of this store held
+    the whole three-role profile as a single JSON blob under one settings
+    key, read-modified-written on every certification. Two roles certifying
+    concurrently (session A certifies ``legacy_agent``, session B certifies
+    ``intent_classification``, both starting from the same snapshot) raced a
+    classic lost update -- whichever session's ``save()`` committed second
+    silently discarded the other's sibling record, even though the two
+    updates touched logically independent roles. Splitting storage per role
+    removes the shared mutable state that race depended on: two different
+    roles are two different settings rows, so there is no read-before-write
+    dependency between them and no commit order can lose either one. A
+    same-role concurrent write (two sessions certifying the identical role at
+    the identical moment) still resolves via ``SettingsService.set()``'s
+    existing select-or-insert semantics -- the same behavior every other
+    settings-backed value in this codebase already has; broadening that to a
+    general atomic upsert is out of scope here.
+    """
 
     def __init__(
         self, settings: SettingsService, *, key: str = ROLE_CERTIFICATION_SETTING_KEY
     ):
         self._settings = settings
-        self._key = key
+        self._base_key = key
 
     async def load(self) -> RoleCertificationProfile:
-        raw = await self._settings.get(self._key, category=SettingCategory.LLM.value)
+        records: dict[AgentRole, RoleCertificationRecord] = {}
+        for role in AgentRole:
+            record = await self._load_role(role)
+            if record is not None:
+                records[role] = record
+        return RoleCertificationProfile(
+            version=ROLE_CERTIFICATION_PROFILE_VERSION, records=records
+        )
+
+    async def _load_role(self, role: AgentRole) -> RoleCertificationRecord | None:
+        raw = await self._settings.get(
+            _role_setting_key(self._base_key, role), category=SettingCategory.LLM.value
+        )
         if not raw:
-            return _empty_profile()
+            return None
         try:
             payload = json.loads(raw)
             if (
@@ -147,52 +181,62 @@ class SettingsRoleCertificationStore:
                 or payload.get("version") != ROLE_CERTIFICATION_PROFILE_VERSION
             ):
                 # An envelope-shape mismatch (including a future version this
-                # build predates) is never partially trusted -- every role
+                # build predates) is never partially trusted -- the role
                 # reads as UNCHECKED rather than risk misreading a foreign
                 # shape as a certification.
-                return _empty_profile()
-            raw_records = payload.get("records")
-            if not isinstance(raw_records, Mapping):
-                return _empty_profile()
-            records: dict[AgentRole, RoleCertificationRecord] = {}
-            for role_value, record_payload in raw_records.items():
-                role = AgentRole(role_value)
-                records[role] = RoleCertificationRecord(
-                    role=role,
-                    certification_key=str(record_payload["certification_key"]),
-                    readiness_version=str(record_payload["readiness_version"]),
-                    checked_at=str(record_payload["checked_at"]),
-                    state=RoleCertificationState(record_payload["state"]),
-                    safe_error_code=(
-                        str(record_payload["safe_error_code"])
-                        if record_payload.get("safe_error_code")
-                        else None
-                    ),
-                )
-            return RoleCertificationProfile(
-                version=ROLE_CERTIFICATION_PROFILE_VERSION, records=records
+                return None
+            record_payload = payload.get("record")
+            if not isinstance(record_payload, Mapping):
+                return None
+            stored_role = AgentRole(record_payload["role"])
+            if stored_role is not role:
+                # Defensive: a row found under this role's own key must
+                # actually describe this role. A mismatch means storage was
+                # corrupted or hand-edited -- never trust it either way.
+                return None
+            return RoleCertificationRecord(
+                role=stored_role,
+                certification_key=str(record_payload["certification_key"]),
+                readiness_version=str(record_payload["readiness_version"]),
+                checked_at=str(record_payload["checked_at"]),
+                state=RoleCertificationState(record_payload["state"]),
+                safe_error_code=(
+                    str(record_payload["safe_error_code"])
+                    if record_payload.get("safe_error_code")
+                    else None
+                ),
             )
         except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-            return _empty_profile()
+            return None
 
-    async def save(self, profile: RoleCertificationProfile) -> None:
+    async def save_record(self, record: RoleCertificationRecord) -> None:
+        """Upsert exactly one role's row. This is the write path
+        ``RoleReadinessService`` uses -- no read-modify-write of any other
+        role's data, so certifying one role can never lose another's."""
+
         payload = {
             "version": ROLE_CERTIFICATION_PROFILE_VERSION,
-            "records": {
-                record.role.value: {
-                    **asdict(record),
-                    "role": record.role.value,
-                    "state": record.state.value,
-                }
-                for record in profile.records.values()
+            "record": {
+                **asdict(record),
+                "role": record.role.value,
+                "state": record.state.value,
             },
         }
         await self._settings.set(
-            self._key,
+            _role_setting_key(self._base_key, record.role),
             json.dumps(payload, separators=(",", ":"), sort_keys=True),
             category=SettingCategory.LLM.value,
-            description="Safe per-role Ask Dev provider certification result",
+            description=f"Safe Ask Dev {record.role.value} role certification result",
         )
+
+    async def save(self, profile: RoleCertificationProfile) -> None:
+        """Upsert every record in ``profile`` -- a convenience for tests and
+        bulk seeding. Each record is written through ``save_record``, so this
+        is exactly as safe (and touches exactly the same rows) as calling
+        ``save_record`` once per record."""
+
+        for record in profile.records.values():
+            await self.save_record(record)
 
 
 __all__ = [

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -25,7 +25,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Protocol
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
@@ -161,10 +160,29 @@ async def _upsert_setting_row(
     already expects from re-running preflight; this fix only makes it
     race-safe (no uncaught ``IntegrityError``) rather than changing what it
     means to certify a role twice.
+
+    Only ``postgresql`` (production) and ``sqlite`` (tests) are supported.
+    CHAOS-3285 round 4 (Codex MEDIUM, ratified): a prior version of this
+    function fell back to a SAVEPOINT-guarded select-then-insert for any
+    OTHER dialect, still racy in the same way ``SettingsService.set()`` is
+    (two sessions can both observe "no row yet" inside their own savepoint
+    and both attempt INSERT) -- an "atomic fallback" this function cannot
+    actually honor. Rejecting loudly here, naming the dialect, is strictly
+    better than a claimed guarantee this function cannot keep on a dialect
+    nobody has verified against.
     """
 
     now = datetime.now(timezone.utc)
     dialect_name = session.get_bind().dialect.name
+    if dialect_name not in ("postgresql", "sqlite"):
+        raise NotImplementedError(
+            f"SettingsRoleCertificationStore has no atomic upsert for the "
+            f"{dialect_name!r} SQLAlchemy dialect -- only 'postgresql' "
+            "(production) and 'sqlite' (tests) are supported. Add native "
+            "ON CONFLICT DO UPDATE support for this dialect before using "
+            "it here; do not reintroduce a non-atomic fallback."
+        )
+
     table = Setting.__table__
     insert_values: dict[str, Any] = {
         "id": uuid.uuid4(),
@@ -177,53 +195,23 @@ async def _upsert_setting_row(
         "created_at": now,
         "updated_at": now,
     }
-    if dialect_name in ("postgresql", "sqlite"):
-        dialect_insert: Any
-        if dialect_name == "postgresql":
-            from sqlalchemy.dialects.postgresql import insert as dialect_insert
-        else:
-            from sqlalchemy.dialects.sqlite import insert as dialect_insert
+    dialect_insert: Any
+    if dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as dialect_insert
+    else:
+        from sqlalchemy.dialects.sqlite import insert as dialect_insert
 
-        stmt = dialect_insert(table).values(**insert_values)
-        stmt = stmt.on_conflict_do_update(
-            index_elements=["org_id", "category", "key"],
-            set_={
-                "value": stmt.excluded.value,
-                "description": stmt.excluded.description,
-                "updated_at": stmt.excluded.updated_at,
-            },
-        )
-        await session.execute(stmt)
-        await session.flush()
-        return
-    # Any other dialect: still atomic (a SAVEPOINT rolls back only this
-    # operation on conflict, never the caller's outer transaction, unlike an
-    # uncaught IntegrityError from a bare select-then-insert), just not a
-    # single-statement native upsert.
-    async with session.begin_nested():
-        existing = (
-            await session.execute(
-                select(Setting).where(
-                    Setting.org_id == org_id,
-                    Setting.category == category,
-                    Setting.key == key,
-                )
-            )
-        ).scalar_one_or_none()
-        if existing is None:
-            session.add(
-                Setting(
-                    key=key,
-                    category=category,
-                    value=value,
-                    org_id=org_id,
-                    description=description,
-                )
-            )
-        else:
-            existing.value = value
-            existing.description = description
-        await session.flush()
+    stmt = dialect_insert(table).values(**insert_values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["org_id", "category", "key"],
+        set_={
+            "value": stmt.excluded.value,
+            "description": stmt.excluded.description,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    await session.execute(stmt)
+    await session.flush()
 
 
 class SettingsRoleCertificationStore:

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -1,0 +1,208 @@
+"""Per-role capability certification model for Ask Dev provider readiness.
+
+CHAOS-3285: a provider/model may be certified for one Ask Dev role and not
+another (a small strict-schema call may fit a fixed output budget while the
+full tool-registry agent loop exhausts it). This module is the role-aware
+successor to the single binary ``AgentReadinessRecord`` in ``readiness.py``.
+
+Backward compatibility / invalidation semantics (explicit, per CHAOS-3285
+plan R5): the per-role profile is persisted under a **new** settings key
+(``ROLE_CERTIFICATION_SETTING_KEY`` / ``PLATFORM_ROLE_CERTIFICATION_SETTING_KEY``),
+never the legacy ``ask_dev_agent_readiness`` / ``platform_ask_dev_agent_readiness``
+keys the old binary store still owns. The new store never reads the old key,
+so an old binary record can never be interpreted as a certification for any
+role -- it is simply invisible to this module. A rolled-back deploy that
+reads the old key back is unaffected by anything written here.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field, replace
+from enum import Enum
+from typing import Protocol
+
+from dev_health_ops.api.services.configuration.generic import SettingsService
+from dev_health_ops.models.settings import SettingCategory
+
+#: Version of the persisted profile envelope's own JSON shape -- distinct
+#: from ``readiness_version``/``certification_key`` below, which invalidate
+#: an individual role's *capability* certification. Bumping this constant is
+#: for when the envelope's storage shape itself changes incompatibly.
+ROLE_CERTIFICATION_PROFILE_VERSION = "ask-dev-role-certification.v1"
+
+ROLE_CERTIFICATION_SETTING_KEY = "ask_dev_role_certification_profile"
+PLATFORM_ROLE_CERTIFICATION_SETTING_KEY = "platform_ask_dev_role_certification_profile"
+
+
+class AgentRole(str, Enum):
+    """The Wave 3.1 Ask Dev provider roles (CHAOS-3285 plan §2.1).
+
+    Only ``LEGACY_AGENT`` has a working probe in this changeset.
+    ``INTENT_CLASSIFICATION`` and ``ANSWER_FRAME_NARRATIVE`` land as enum
+    members and store slots only -- their probes are CHAOS-3285 PR4, gated
+    on CHAOS-3294's ``dev_question_intent.v1`` / ``dev_narrative.v1``
+    schemas landing on main.
+    """
+
+    LEGACY_AGENT = "legacy_agent"
+    INTENT_CLASSIFICATION = "intent_classification"
+    ANSWER_FRAME_NARRATIVE = "answer_frame_narrative"
+
+
+class RoleCertificationState(str, Enum):
+    """Verdict for one (provider, role) certification attempt.
+
+    ``COMPATIBLE`` and ``INCOMPATIBLE``/``FAILED`` split what the old binary
+    ``AgentReadinessOutcome.FAILED`` conflated: a deterministic, structural
+    rejection (unsupported request shape, output/reasoning exhaustion,
+    malformed structured output) will not resolve by retrying and must never
+    be treated as "try again later"; a transient/environmental failure
+    (timeout, rate limit, transport, missing credentials) might.
+    """
+
+    COMPATIBLE = "compatible"
+    INCOMPATIBLE = "incompatible"
+    FAILED = "failed"
+    STALE = "stale"
+    UNCHECKED = "unchecked"
+
+
+@dataclass(frozen=True, slots=True)
+class RoleCertificationRecord:
+    role: AgentRole
+    certification_key: str
+    readiness_version: str
+    checked_at: str
+    state: RoleCertificationState
+    safe_error_code: str | None = None
+
+    def is_current(self, *, certification_key: str) -> bool:
+        """True only for a COMPATIBLE record whose capability inputs still match.
+
+        An INCOMPATIBLE, FAILED, or STALE record is never current -- the
+        runtime must not select a provider on the strength of a record that
+        isn't an affirmative, still-valid COMPATIBLE verdict (CHAOS-3285
+        acceptance: "an old record must not read as certified for any role").
+        """
+
+        return (
+            self.state is RoleCertificationState.COMPATIBLE
+            and self.certification_key == certification_key
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RoleCertificationProfile:
+    """The full per-role certification envelope persisted for one provider slot."""
+
+    version: str = ROLE_CERTIFICATION_PROFILE_VERSION
+    records: Mapping[AgentRole, RoleCertificationRecord] = field(default_factory=dict)
+
+    def for_role(self, role: AgentRole) -> RoleCertificationRecord | None:
+        return self.records.get(role)
+
+    def with_record(self, record: RoleCertificationRecord) -> RoleCertificationProfile:
+        """Return a new profile with ``record`` set, leaving every other role's
+        stored record untouched -- certifying one role must never clobber an
+        already-certified sibling role."""
+
+        updated = dict(self.records)
+        updated[record.role] = record
+        return replace(self, records=updated)
+
+
+def _empty_profile() -> RoleCertificationProfile:
+    return RoleCertificationProfile(
+        version=ROLE_CERTIFICATION_PROFILE_VERSION, records={}
+    )
+
+
+class RoleCertificationStore(Protocol):
+    async def load(self) -> RoleCertificationProfile: ...
+
+    async def save(self, profile: RoleCertificationProfile) -> None: ...
+
+
+class SettingsRoleCertificationStore:
+    """Persists the per-role profile envelope under a key distinct from the
+    legacy binary readiness record (see module docstring for the
+    backward-compatibility rationale)."""
+
+    def __init__(
+        self, settings: SettingsService, *, key: str = ROLE_CERTIFICATION_SETTING_KEY
+    ):
+        self._settings = settings
+        self._key = key
+
+    async def load(self) -> RoleCertificationProfile:
+        raw = await self._settings.get(self._key, category=SettingCategory.LLM.value)
+        if not raw:
+            return _empty_profile()
+        try:
+            payload = json.loads(raw)
+            if (
+                not isinstance(payload, Mapping)
+                or payload.get("version") != ROLE_CERTIFICATION_PROFILE_VERSION
+            ):
+                # An envelope-shape mismatch (including a future version this
+                # build predates) is never partially trusted -- every role
+                # reads as UNCHECKED rather than risk misreading a foreign
+                # shape as a certification.
+                return _empty_profile()
+            raw_records = payload.get("records")
+            if not isinstance(raw_records, Mapping):
+                return _empty_profile()
+            records: dict[AgentRole, RoleCertificationRecord] = {}
+            for role_value, record_payload in raw_records.items():
+                role = AgentRole(role_value)
+                records[role] = RoleCertificationRecord(
+                    role=role,
+                    certification_key=str(record_payload["certification_key"]),
+                    readiness_version=str(record_payload["readiness_version"]),
+                    checked_at=str(record_payload["checked_at"]),
+                    state=RoleCertificationState(record_payload["state"]),
+                    safe_error_code=(
+                        str(record_payload["safe_error_code"])
+                        if record_payload.get("safe_error_code")
+                        else None
+                    ),
+                )
+            return RoleCertificationProfile(
+                version=ROLE_CERTIFICATION_PROFILE_VERSION, records=records
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return _empty_profile()
+
+    async def save(self, profile: RoleCertificationProfile) -> None:
+        payload = {
+            "version": ROLE_CERTIFICATION_PROFILE_VERSION,
+            "records": {
+                record.role.value: {
+                    **asdict(record),
+                    "role": record.role.value,
+                    "state": record.state.value,
+                }
+                for record in profile.records.values()
+            },
+        }
+        await self._settings.set(
+            self._key,
+            json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            category=SettingCategory.LLM.value,
+            description="Safe per-role Ask Dev provider certification result",
+        )
+
+
+__all__ = [
+    "PLATFORM_ROLE_CERTIFICATION_SETTING_KEY",
+    "ROLE_CERTIFICATION_PROFILE_VERSION",
+    "ROLE_CERTIFICATION_SETTING_KEY",
+    "AgentRole",
+    "RoleCertificationProfile",
+    "RoleCertificationRecord",
+    "RoleCertificationState",
+    "RoleCertificationStore",
+    "SettingsRoleCertificationStore",
+]

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -29,6 +29,20 @@ logger = logging.getLogger(__name__)
 class LLMCredentials:
     api_key: str = field(default="", repr=False)
     base_url: str = ""
+    # CHAOS-3285 round 6 (Codex HIGH): organization/project/custom_headers are
+    # identity-bearing material the OpenAI SDK will read AMBIENTLY from
+    # OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS when the client is
+    # constructed without them -- so a provider certified against one org/
+    # project/header set could silently start sending a DIFFERENT one on the
+    # wire without the certification key ever changing. Resolved explicitly
+    # here (never left for the SDK to infer) so they are both representable
+    # in the certification key and suppressible at the client (see
+    # OpenAICompatibleAgentProvider.__init__). custom_headers is a sorted
+    # tuple of (name, value) pairs, not a dict, so this stays hashable and
+    # has one canonical ordering for the fingerprint.
+    organization: str = ""
+    project: str = ""
+    custom_headers: tuple[tuple[str, str], ...] = ()
 
 
 _API_KEY_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
@@ -53,6 +67,23 @@ _BASE_URL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     "lmstudio": ("LLM_BASE_URL", "LMSTUDIO_BASE_URL"),
     "qwen-local": ("LLM_BASE_URL", "OLLAMA_BASE_URL"),
     "qwen-lmstudio": ("LLM_BASE_URL", "LMSTUDIO_BASE_URL"),
+}
+
+# CHAOS-3285 round 6: only the OpenAI wire protocol has an
+# organization/project/custom-headers concept at all -- these are
+# deliberately absent for every other provider (an empty tuple from
+# `.get(provider_name, ())` resolves to "" / no headers, never an
+# accidental cross-provider leak of an OpenAI-scoped env var).
+_ORGANIZATION_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_ORGANIZATION", "OPENAI_ORG_ID"),
+}
+
+_PROJECT_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_PROJECT", "OPENAI_PROJECT_ID"),
+}
+
+_CUSTOM_HEADERS_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_CUSTOM_HEADERS", "OPENAI_CUSTOM_HEADERS"),
 }
 
 _API_KEY_REQUIRED_PROVIDERS = {"openai", "anthropic", "gemini", "qwen"}
@@ -343,6 +374,22 @@ def _first_env(names: tuple[str, ...]) -> str:
     return ""
 
 
+def _parse_custom_headers(raw: str) -> tuple[tuple[str, str], ...]:
+    """Mirror the OpenAI SDK's own OPENAI_CUSTOM_HEADERS parsing exactly
+    (colon-split, one header per line) so resolving it ourselves stays
+    behavior-preserving for an operator's existing configuration -- but
+    returns a SORTED tuple of pairs, never a dict, so there is one
+    canonical order to fold into the certification key regardless of the
+    line order in the raw value."""
+
+    parsed: dict[str, str] = {}
+    for line in raw.split("\n"):
+        colon = line.find(":")
+        if colon >= 0:
+            parsed[line[:colon].strip()] = line[colon + 1 :].strip()
+    return tuple(sorted(parsed.items()))
+
+
 def _normalize_provider(provider: str) -> str:
     return (provider or "auto").strip().lower()
 
@@ -611,13 +658,24 @@ def resolve_llm_org_settings_credentials(
 def _env_llm_credentials(provider_name: str) -> LLMCredentials:
     """Platform/default credentials sourced *only* from environment variables.
 
-    Source-bound: both api_key and base_url come from the environment, never
-    mixed with org-scoped or per-call values (CHAOS-2550 credential-isolation
-    invariant).
+    Source-bound: api_key, base_url, organization, project, and
+    custom_headers all come from the environment, never mixed with
+    org-scoped or per-call values (CHAOS-2550 credential-isolation
+    invariant). organization/project/custom_headers are resolved explicitly
+    HERE, from the same env vars the OpenAI SDK would otherwise read
+    ambiently on its own, so they become representable in the certification
+    key and suppressible at the client construction site (CHAOS-3285 round
+    6, Codex HIGH) instead of silently varying the wire identity underneath
+    an unchanged certification.
     """
     return LLMCredentials(
         api_key=_first_env(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ())),
         base_url=_first_env(_BASE_URL_ENV_BY_PROVIDER.get(provider_name, ())),
+        organization=_first_env(_ORGANIZATION_ENV_BY_PROVIDER.get(provider_name, ())),
+        project=_first_env(_PROJECT_ENV_BY_PROVIDER.get(provider_name, ())),
+        custom_headers=_parse_custom_headers(
+            _first_env(_CUSTOM_HEADERS_ENV_BY_PROVIDER.get(provider_name, ()))
+        ),
     )
 
 

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -240,6 +240,21 @@ async def test_admin_projection_nulls_platform_identity_until_platform_admin_cer
                 outcome=AgentReadinessOutcome.READY,
             )
         )
+        # CHAOS-3285 round 2: effective readiness also requires a current,
+        # COMPATIBLE legacy_agent role certification -- mirror what a real
+        # POST /platform/ask-dev/readiness run now also writes.
+        await SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        ).save_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.COMPATIBLE,
+            )
+        )
         await session.commit()
 
     certified = await admin_context.client.get("/api/v1/admin/ask-dev")
@@ -306,6 +321,19 @@ async def test_byo_source_keeps_its_own_identity_and_failure_reason(
                 readiness_version=READINESS_VERSION,
                 checked_at=datetime.now(timezone.utc).isoformat(),
                 outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        # CHAOS-3285 round 2: effective readiness also requires a current,
+        # COMPATIBLE legacy_agent role certification.
+        await SettingsRoleCertificationStore(
+            SettingsService(session, str(admin_context.org_id))
+        ).save_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="byo-readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.COMPATIBLE,
             )
         )
         await session.commit()
@@ -761,3 +789,82 @@ async def test_role_readiness_platform_boundary_redacts_remediation_not_state(
     assert roles["legacy_agent"]["safe_remediation"] == (
         "Ask Dev is temporarily unavailable. Contact your platform operator."
     )
+
+
+@pytest.mark.asyncio
+async def test_binary_ready_role_absent_reports_unavailable_not_ready(
+    admin_context,
+):
+    """CHAOS-3285 round 2 (Codex HIGH): the exact contradiction codex found --
+    the binary transport-echo check passing must never, by itself, report
+    "ready"/available when the legacy_agent role has no certification at
+    all. Live selection (production_runtime.py) already rejects this
+    candidate; the admin surface must agree, not contradict it."""
+
+    async with admin_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        # Deliberately NO role-certification row at all.
+        await session.commit()
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] != "ready"
+    assert body["binary_transport_readiness"] == "ready"
+    assert body["chat_window_available"] is False
+    assert body["full_page_available"] is False
+    roles = {entry["role"]: entry for entry in body["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "not_yet_certified"
+
+
+@pytest.mark.asyncio
+async def test_binary_ready_role_incompatible_reports_unavailable_not_ready(
+    admin_context,
+):
+    """Same contradiction, with a role record present but INCOMPATIBLE
+    rather than absent -- must also fail to report ready/available."""
+
+    async with admin_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        await SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        ).save_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.INCOMPATIBLE,
+                safe_error_code="output_exhausted",
+            )
+        )
+        await session.commit()
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] != "ready"
+    assert body["binary_transport_readiness"] == "ready"
+    assert body["chat_window_available"] is False
+    assert body["full_page_available"] is False

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -41,6 +41,13 @@ from dev_health_ops.llm.agent.readiness import (
     SettingsAgentReadinessStore,
     readiness_failure_state,
 )
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    RoleCertificationRecord,
+    RoleCertificationState,
+    SettingsRoleCertificationStore,
+)
 from dev_health_ops.models.dev_persistence import DevConversation, DevRun
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import Setting
@@ -597,3 +604,160 @@ async def test_global_disable_has_precedence(monkeypatch: pytest.MonkeyPatch):
     )
     assert (state, allowed) == ("globally_disabled", False)
     assert reason == "Ask Dev is globally disabled."
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_shows_not_yet_certified_with_no_stored_record(
+    admin_context, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3285: before anything certifies a role, every role reads as
+    the honest not_yet_certified state -- distinct from stale_readiness (was
+    certified, now invalidated) and from any FAILED-derived state."""
+
+    async def byo_resolution(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=FakeReadinessProvider(),
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="org-model",
+            provider_label="OpenAI compatible",
+            model_label="org-model",
+            readiness_fingerprint="byo-readiness-fingerprint",
+        )
+
+    monkeypatch.setattr(ask_dev_admin, "resolve_certification_provider", byo_resolution)
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    body = response.json()
+    roles = {entry["role"]: entry for entry in body["role_readiness"]}
+    assert set(roles) == {
+        "legacy_agent",
+        "intent_classification",
+        "answer_frame_narrative",
+    }
+    for entry in roles.values():
+        assert entry["state"] == "not_yet_certified"
+        assert entry["checked_at"] is None
+        assert entry["safe_remediation"]
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_reflects_a_current_legacy_agent_certification(
+    admin_context, monkeypatch: pytest.MonkeyPatch
+):
+    async def byo_resolution(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=FakeReadinessProvider(),
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="org-model",
+            provider_label="OpenAI compatible",
+            model_label="org-model",
+            readiness_fingerprint="byo-readiness-fingerprint",
+        )
+
+    monkeypatch.setattr(ask_dev_admin, "resolve_certification_provider", byo_resolution)
+
+    async with admin_context.maker() as session:
+        store = SettingsRoleCertificationStore(
+            SettingsService(session, str(admin_context.org_id))
+        )
+        profile = (await store.load()).with_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="byo-readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.COMPATIBLE,
+            )
+        )
+        await store.save(profile)
+        await session.commit()
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    roles = {entry["role"]: entry for entry in response.json()["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "ready"
+    assert roles["legacy_agent"]["safe_remediation"] is None
+    assert roles["legacy_agent"]["checked_at"] is not None
+    assert roles["intent_classification"]["state"] == "not_yet_certified"
+    assert roles["answer_frame_narrative"]["state"] == "not_yet_certified"
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_reports_stale_when_certification_key_changed(
+    admin_context, monkeypatch: pytest.MonkeyPatch
+):
+    """A record certified under a DIFFERENT capability-input key (e.g. the
+    prompt/tool/budget contract changed since) must never read as ready."""
+
+    async def byo_resolution(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=FakeReadinessProvider(),
+            source=AgentProviderSource.BYO,
+            family="openai",
+            model="org-model",
+            provider_label="OpenAI compatible",
+            model_label="org-model",
+            readiness_fingerprint="byo-readiness-fingerprint-current",
+        )
+
+    monkeypatch.setattr(ask_dev_admin, "resolve_certification_provider", byo_resolution)
+
+    async with admin_context.maker() as session:
+        store = SettingsRoleCertificationStore(
+            SettingsService(session, str(admin_context.org_id))
+        )
+        profile = (await store.load()).with_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="byo-readiness-fingerprint-stale",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.COMPATIBLE,
+            )
+        )
+        await store.save(profile)
+        await session.commit()
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    roles = {entry["role"]: entry for entry in response.json()["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "stale_readiness"
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_platform_boundary_redacts_remediation_not_state(
+    admin_context,
+):
+    """CHAOS-3265 boundary applied to the new per-role surface: an org
+    relying on platform fallback must see the platform role's state (it
+    carries no identity) but never platform's own specific remediation
+    text -- same discipline as the existing single-readiness field."""
+
+    async with admin_context.maker() as session:
+        store = SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        )
+        profile = (await store.load()).with_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key="readiness-fingerprint",
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.INCOMPATIBLE,
+                safe_error_code="output_exhausted",
+            )
+        )
+        await store.save(profile)
+        await session.commit()
+
+    response = await admin_context.client.get("/api/v1/admin/ask-dev")
+    assert response.status_code == 200
+    roles = {entry["role"]: entry for entry in response.json()["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "unsupported_model"
+    assert roles["legacy_agent"]["safe_remediation"] == (
+        "Ask Dev is temporarily unavailable. Contact your platform operator."
+    )

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -420,6 +420,7 @@ async def test_admin_llm_settings_status_reports_unconfigured_valid_and_invalid_
             "reason_code": "not_configured",
             "last_fallback_at": None,
             "readiness": "never_checked",
+            "binary_transport_readiness": "never_checked",
             "readiness_checked_at": None,
             "readiness_safe_failure_reason": None,
         }
@@ -435,6 +436,7 @@ async def test_admin_llm_settings_status_reports_unconfigured_valid_and_invalid_
             "reason_code": "active",
             "last_fallback_at": None,
             "readiness": "never_checked",
+            "binary_transport_readiness": "never_checked",
             "readiness_checked_at": None,
             "readiness_safe_failure_reason": None,
         }
@@ -534,6 +536,7 @@ async def test_admin_llm_settings_status_ignores_stale_or_cross_org_fallback_row
         "reason_code": "active",
         "last_fallback_at": None,
         "readiness": "never_checked",
+        "binary_transport_readiness": "never_checked",
         "readiness_checked_at": None,
         "readiness_safe_failure_reason": None,
     }
@@ -545,9 +548,58 @@ async def test_admin_llm_settings_status_ignores_stale_or_cross_org_fallback_row
         "reason_code": "invalid_base_url",
         "last_fallback_at": None,
         "readiness": "never_checked",
+        "binary_transport_readiness": "never_checked",
         "readiness_checked_at": None,
         "readiness_safe_failure_reason": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_binary_ready_role_absent_reports_unavailable_not_ready(session_maker):
+    """CHAOS-3285 round 2 (Codex HIGH): the BYO status endpoint must agree
+    with live selection -- a binary-ready record with no legacy_agent role
+    certification at all must never report "ready" here either."""
+
+    from dev_health_ops.llm.agent.readiness import (
+        AgentReadinessOutcome,
+        AgentReadinessRecord,
+        SettingsAgentReadinessStore,
+    )
+
+    state = await _seed_org(session_maker, "team")
+    await _set_llm_settings(
+        session_maker,
+        state["org_id"],
+        provider="openai",
+        api_key="sk-org",
+        base_url="https://api.openai.com/v1",
+    )
+    fingerprint = await _real_byo_fingerprint(session_maker, state["org_id"])
+
+    async with session_maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, state["org_id"])
+        ).save(
+            AgentReadinessRecord(
+                fingerprint=fingerprint,
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        # Deliberately NO role-certification row at all.
+        await session.commit()
+
+    app = _make_app(session_maker, state)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.get("/api/v1/admin/llm-settings/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] != "ready"
+    assert body["binary_transport_readiness"] == "ready"
 
 
 # Removed: test_byo_llm_status_reason_codes_match_documented_contract.

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -99,12 +99,19 @@ class FakeReadinessProvider:
     async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
         # CHAOS-3285: BYO preflight now runs the OLD binary transport-echo
         # probe (calls 1-2) AND the NEW production-sized legacy_agent role
-        # probe (calls 3-4) against the same resolved provider. Odd calls
+        # probe (calls 3-6: two independent 2-call chains, committed-subject
+        # then uncommitted-subject -- CHAOS-3285 round 4, Codex HIGH)
+        # against the same resolved provider, 6 calls total. Odd calls
         # request a tool; even calls answer. Call 1 must echo
         # READINESS_ECHO_TOOL_ID exactly (readiness.py's own strict match);
         # every later tool_request round names a real registered tool
         # instead, since certify_legacy_agent validates its synthetic tool
-        # result against the real DevToolResult/ToolID contract.
+        # result against the real DevToolResult/ToolID contract. This fake
+        # is round-aware by parity (odd/even), not call-count-specific, so
+        # it transparently supports however many role-probe rounds the real
+        # probe currently makes -- but see the pinned provider.calls == 6
+        # assertion in the success test below, which fails loudly if a
+        # chain silently vanishes.
         self.calls += 1
         if self.calls % 2 == 1:
             tool_id = READINESS_ECHO_TOOL_ID if self.calls == 1 else "query_metric.v1"
@@ -1006,6 +1013,11 @@ async def test_llm_settings_readiness_succeeds_independent_of_ask_dev_selection(
         assert body["readiness_checked_at"] is not None
         assert body["readiness_safe_failure_reason"] is None
         assert provider.closed is True
+        # CHAOS-3285 round 5 (Codex LOW): pin the full preflight call count
+        # (2 binary transport-echo + 4 legacy_agent role-probe calls, two
+        # independent 2-call chains) so a chain silently vanishing in a
+        # future refactor fails loudly here rather than passing unnoticed.
+        assert provider.calls == 6
 
         after_dev_run_count = await _dev_run_count(session_maker, state["org_id"])
         assert before_dev_run_count == 0

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -97,19 +97,34 @@ class FakeReadinessProvider:
         )
 
     async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        # CHAOS-3285: BYO preflight now runs the OLD binary transport-echo
+        # probe (calls 1-2) AND the NEW production-sized legacy_agent role
+        # probe (calls 3-4) against the same resolved provider. Odd calls
+        # request a tool; even calls answer. Call 1 must echo
+        # READINESS_ECHO_TOOL_ID exactly (readiness.py's own strict match);
+        # every later tool_request round names a real registered tool
+        # instead, since certify_legacy_agent validates its synthetic tool
+        # result against the real DevToolResult/ToolID contract.
         self.calls += 1
-        if self.calls == 1:
+        if self.calls % 2 == 1:
+            tool_id = READINESS_ECHO_TOOL_ID if self.calls == 1 else "query_metric.v1"
+            arguments = (
+                {"nonce": "ready-v1"} if tool_id == READINESS_ECHO_TOOL_ID else {}
+            )
             return AgentDecisionResult(
-                decision=AgentToolRequest(
-                    READINESS_ECHO_TOOL_ID, {"nonce": "ready-v1"}, "call-1"
-                ),
+                decision=AgentToolRequest(tool_id, arguments, f"call-{self.calls}"),
                 usage=AgentUsage(input_tokens=3, output_tokens=2),
                 latency_ms=1,
                 provider_fingerprint="provider",
                 model_fingerprint="model",
             )
+        value = (
+            {"nonce": "ready-v1"}
+            if self.calls == 2
+            else {"status": "complete", "direct_summary": "Stub role probe answer."}
+        )
         return AgentDecisionResult(
-            decision=AgentFinalAnswer(value={"nonce": "ready-v1"}),
+            decision=AgentFinalAnswer(value=value),
             usage=AgentUsage(input_tokens=4, output_tokens=1),
             latency_ms=1,
             provider_fingerprint="provider",
@@ -1152,6 +1167,13 @@ async def test_llm_settings_readiness_can_flip_ask_dev_selection_to_byo(
         AgentReadinessRecord,
         SettingsAgentReadinessStore,
     )
+    from dev_health_ops.llm.agent.roles import (
+        PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        AgentRole,
+        RoleCertificationRecord,
+        RoleCertificationState,
+        SettingsRoleCertificationStore,
+    )
 
     state = await _seed_org(session_maker, "team")
     await _set_llm_settings(
@@ -1188,6 +1210,21 @@ async def test_llm_settings_readiness_can_flip_ask_dev_selection_to_byo(
                 readiness_version=READINESS_VERSION,
                 checked_at=datetime.now(timezone.utc).isoformat(),
                 outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        # CHAOS-3285: live selection also requires a current, COMPATIBLE
+        # legacy_agent role certification -- mirror what a real
+        # POST /platform/ask-dev/readiness run now also writes.
+        await SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        ).save_record(
+            RoleCertificationRecord(
+                role=AgentRole.LEGACY_AGENT,
+                certification_key=platform_fingerprint,
+                readiness_version=READINESS_VERSION,
+                checked_at=datetime.now(timezone.utc).isoformat(),
+                state=RoleCertificationState.COMPATIBLE,
             )
         )
         await session.commit()

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -46,6 +46,11 @@ from dev_health_ops.llm.agent.readiness import (
     AgentReadinessRecord,
     SettingsAgentReadinessStore,
 )
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    SettingsRoleCertificationStore,
+)
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import Setting
 from dev_health_ops.models.users import Organization, User
@@ -76,19 +81,34 @@ class FakeReadinessProvider:
         )
 
     async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        # CHAOS-3285: the platform POST route now runs the OLD binary
+        # transport-echo probe (calls 1-2) AND the NEW production-sized
+        # legacy_agent role probe (calls 3-4) against the same resolved
+        # provider. Odd calls request a tool; even calls answer. Call 1 must
+        # echo READINESS_ECHO_TOOL_ID exactly (readiness.py's own strict
+        # match) -- every later tool_request round names a real registered
+        # tool instead, since certify_legacy_agent validates its synthetic
+        # tool result against the real DevToolResult/ToolID contract.
         self.calls += 1
-        if self.calls == 1:
+        if self.calls % 2 == 1:
+            tool_id = READINESS_ECHO_TOOL_ID if self.calls == 1 else "query_metric.v1"
+            arguments = (
+                {"nonce": "ready-v1"} if tool_id == READINESS_ECHO_TOOL_ID else {}
+            )
             return AgentDecisionResult(
-                decision=AgentToolRequest(
-                    READINESS_ECHO_TOOL_ID, {"nonce": "ready-v1"}, "call-1"
-                ),
+                decision=AgentToolRequest(tool_id, arguments, f"call-{self.calls}"),
                 usage=AgentUsage(input_tokens=3, output_tokens=2),
                 latency_ms=1,
                 provider_fingerprint="provider",
                 model_fingerprint="model",
             )
+        value = (
+            {"nonce": "ready-v1"}
+            if self.calls == 2
+            else {"status": "complete", "direct_summary": "Stub role probe answer."}
+        )
         return AgentDecisionResult(
-            decision=AgentFinalAnswer(value={"nonce": "ready-v1"}),
+            decision=AgentFinalAnswer(value=value),
             usage=AgentUsage(input_tokens=4, output_tokens=1),
             latency_ms=1,
             provider_fingerprint="provider",
@@ -576,3 +596,82 @@ async def test_stale_readiness_version_reports_stale_not_ready(
     )
     assert posted.status_code == 200
     assert posted.json()["readiness"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_post_certifies_legacy_agent_role_and_projects_it(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3285: preflight now also certifies the legacy_agent role in the
+    new per-role store, on the same resolved provider -- so the per-role
+    projection reflects real results instead of staying not_yet_certified
+    forever. intent/narrative have no probe yet (PR4) and stay
+    not_yet_certified."""
+
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    before = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    before_roles = {entry["role"]: entry for entry in before.json()["role_readiness"]}
+    assert before_roles["legacy_agent"]["state"] == "not_yet_certified"
+
+    posted = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert posted.status_code == 200
+    posted_roles = {entry["role"]: entry for entry in posted.json()["role_readiness"]}
+    assert posted_roles["legacy_agent"]["state"] == "ready"
+    assert posted_roles["legacy_agent"]["safe_remediation"] is None
+    assert posted_roles["legacy_agent"]["checked_at"] is not None
+    assert posted_roles["intent_classification"]["state"] == "not_yet_certified"
+    assert posted_roles["answer_frame_narrative"]["state"] == "not_yet_certified"
+
+    async with platform_context.maker() as session:
+        stored = await SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        ).load()
+        record = stored.for_role(AgentRole.LEGACY_AGENT)
+        assert record is not None
+        assert record.certification_key == _FINGERPRINT
+
+    after = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    after_roles = {entry["role"]: entry for entry in after.json()["role_readiness"]}
+    assert after_roles["legacy_agent"]["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_role_certification_failure_does_not_regress_binary_readiness(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """A failing provider must still land the existing binary readiness
+    outcome cleanly (no 500), and the new per-role projection must report
+    the same failure -- not silently swallow it, and not crash the route."""
+
+    provider = FailingReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    posted = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert posted.status_code == 200
+    posted_body = posted.json()
+    assert posted_body["readiness"] == "unsupported_model"
+    roles = {entry["role"]: entry for entry in posted_body["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "unsupported_model"

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -83,12 +83,19 @@ class FakeReadinessProvider:
     async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
         # CHAOS-3285: the platform POST route now runs the OLD binary
         # transport-echo probe (calls 1-2) AND the NEW production-sized
-        # legacy_agent role probe (calls 3-4) against the same resolved
-        # provider. Odd calls request a tool; even calls answer. Call 1 must
-        # echo READINESS_ECHO_TOOL_ID exactly (readiness.py's own strict
-        # match) -- every later tool_request round names a real registered
-        # tool instead, since certify_legacy_agent validates its synthetic
-        # tool result against the real DevToolResult/ToolID contract.
+        # legacy_agent role probe (calls 3-6: two independent 2-call chains,
+        # committed-subject then uncommitted-subject -- CHAOS-3285 round 4,
+        # Codex HIGH) against the same resolved provider, 6 calls total. Odd
+        # calls request a tool; even calls answer. Call 1 must echo
+        # READINESS_ECHO_TOOL_ID exactly (readiness.py's own strict match)
+        # -- every later tool_request round names a real registered tool
+        # instead, since certify_legacy_agent validates its synthetic tool
+        # result against the real DevToolResult/ToolID contract. This fake
+        # is round-aware by parity (odd/even), not call-count-specific, so
+        # it transparently supports however many role-probe rounds the real
+        # probe currently makes -- but see the pinned provider.calls == 6
+        # assertion in the success test below, which fails loudly if a
+        # chain silently vanishes.
         self.calls += 1
         if self.calls % 2 == 1:
             tool_id = READINESS_ECHO_TOOL_ID if self.calls == 1 else "query_metric.v1"
@@ -627,6 +634,11 @@ async def test_post_certifies_legacy_agent_role_and_projects_it(
         "/api/v1/admin/platform/ask-dev/readiness"
     )
     assert posted.status_code == 200
+    # CHAOS-3285 round 5 (Codex LOW): pin the full preflight call count (2
+    # binary transport-echo + 4 legacy_agent role-probe calls, two
+    # independent 2-call chains) so a chain silently vanishing in a future
+    # refactor fails loudly here rather than passing unnoticed.
+    assert provider.calls == 6
     posted_roles = {entry["role"]: entry for entry in posted.json()["role_readiness"]}
     assert posted_roles["legacy_agent"]["state"] == "ready"
     assert posted_roles["legacy_agent"]["safe_remediation"] is None

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -675,3 +675,46 @@ async def test_role_certification_failure_does_not_regress_binary_readiness(
     assert posted_body["readiness"] == "unsupported_model"
     roles = {entry["role"]: entry for entry in posted_body["role_readiness"]}
     assert roles["legacy_agent"]["state"] == "unsupported_model"
+
+
+@pytest.mark.asyncio
+async def test_binary_ready_role_absent_reports_unavailable_not_ready(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """CHAOS-3285 round 2 (Codex HIGH): the platform surface must agree with
+    live selection -- a binary-ready record with no legacy_agent role
+    certification at all must never report "ready" here."""
+
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        platform_ask_dev, "resolve_platform_certification_provider", resolve
+    )
+
+    async with platform_context.maker() as session:
+        await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).save(
+            AgentReadinessRecord(
+                fingerprint=_FINGERPRINT,
+                readiness_version=READINESS_VERSION,
+                checked_at="2026-07-29T12:00:00+00:00",
+                outcome=AgentReadinessOutcome.READY,
+            )
+        )
+        # Deliberately NO role-certification row at all.
+        await session.commit()
+
+    response = await platform_context.client.get(
+        "/api/v1/admin/platform/ask-dev/readiness"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["readiness"] != "ready"
+    assert body["binary_transport_readiness"] == "ready"
+    roles = {entry["role"]: entry for entry in body["role_readiness"]}
+    assert roles["legacy_agent"]["state"] == "not_yet_certified"

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -50,6 +50,13 @@ from dev_health_ops.llm.agent.readiness import (
     AgentReadinessService,
     SettingsAgentReadinessStore,
 )
+from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    RoleCertificationState,
+    SettingsRoleCertificationStore,
+)
 from dev_health_ops.llm.agent.scripted_openai_service import ScriptedOpenAIServer
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import Setting
@@ -159,8 +166,26 @@ async def test_acceptance_openai_runs_real_readiness_grounding_and_capabilities(
         model=certification.model,
         fingerprint=fingerprint,
     )
-    await certification.provider.aclose()
     assert readiness.outcome is AgentReadinessOutcome.READY
+
+    # CHAOS-3285: live selection also requires a current, COMPATIBLE
+    # legacy_agent role certification -- run the real production-sized probe
+    # against the SAME real scripted server (never a stub) before closing
+    # the provider, mirroring what the real admin routes now do.
+    role_record = await RoleReadinessService(
+        SettingsRoleCertificationStore(
+            SettingsService(settings_session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        )
+    ).certify_role(
+        AgentRole.LEGACY_AGENT,
+        certification.provider,
+        certification_key=fingerprint,
+    )
+    await certification.provider.aclose()
+    assert role_record.state is RoleCertificationState.COMPATIBLE, (
+        role_record.safe_error_code
+    )
 
     production = await resolve_production_provider(settings_session, org_id=_ORG_ID)
     assert isinstance(production.provider, OpenAICompatibleAgentProvider)
@@ -360,7 +385,11 @@ async def test_acceptance_openai_runs_real_readiness_grounding_and_capabilities(
     assert capability.effective_provider_label == "OpenAI compatible"
     assert capability.effective_model_label == ACCEPTANCE_OPENAI_MODEL
     assert capability.provider_source == "platform"
-    assert len(scripted_openai_server.requests) == 8
+    # CHAOS-3285: 2 more requests than before -- the new production-sized
+    # legacy_agent role probe's two rounds, run against this same real
+    # scripted server above, in addition to the original transport-echo
+    # probe (2) and the orchestrator run's own requests.
+    assert len(scripted_openai_server.requests) == 10
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -385,14 +385,16 @@ async def test_acceptance_openai_runs_real_readiness_grounding_and_capabilities(
     assert capability.effective_provider_label == "OpenAI compatible"
     assert capability.effective_model_label == ACCEPTANCE_OPENAI_MODEL
     assert capability.provider_source == "platform"
-    # CHAOS-3285: 3 more requests than the pre-role-probe baseline of 8 --
-    # the new production-sized legacy_agent role probe's three rounds (round
-    # 1, round 2 under the committed-subject prompt shape, and round 2 AGAIN
-    # under the uncommitted-subject shape -- CHAOS-3285 round 2, Codex HIGH),
-    # run against this same real scripted server above, in addition to the
-    # original transport-echo probe (2) and the orchestrator run's own
-    # requests.
-    assert len(scripted_openai_server.requests) == 11
+    # CHAOS-3285: 4 more requests than the pre-role-probe baseline of 8 --
+    # the new production-sized legacy_agent role probe's two independent,
+    # complete chains (CHAOS-3285 round 4, Codex HIGH): round 1 + round 2
+    # under the committed-subject prompt shape, then round 1 + round 2 AGAIN
+    # entirely under the uncommitted-subject shape (round 1 is no longer
+    # always committed-subject, and round 2 no longer reuses the other
+    # chain's round-1 tool request/result) -- run against this same real
+    # scripted server above, in addition to the original transport-echo
+    # probe (2) and the orchestrator run's own requests.
+    assert len(scripted_openai_server.requests) == 12
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_acceptance_openai_runtime.py
+++ b/tests/api/dev/test_acceptance_openai_runtime.py
@@ -385,11 +385,14 @@ async def test_acceptance_openai_runs_real_readiness_grounding_and_capabilities(
     assert capability.effective_provider_label == "OpenAI compatible"
     assert capability.effective_model_label == ACCEPTANCE_OPENAI_MODEL
     assert capability.provider_source == "platform"
-    # CHAOS-3285: 2 more requests than before -- the new production-sized
-    # legacy_agent role probe's two rounds, run against this same real
-    # scripted server above, in addition to the original transport-echo
-    # probe (2) and the orchestrator run's own requests.
-    assert len(scripted_openai_server.requests) == 10
+    # CHAOS-3285: 3 more requests than the pre-role-probe baseline of 8 --
+    # the new production-sized legacy_agent role probe's three rounds (round
+    # 1, round 2 under the committed-subject prompt shape, and round 2 AGAIN
+    # under the uncommitted-subject shape -- CHAOS-3285 round 2, Codex HIGH),
+    # run against this same real scripted server above, in addition to the
+    # original transport-echo probe (2) and the orchestrator run's own
+    # requests.
+    assert len(scripted_openai_server.requests) == 11
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_live_openai_smoke.py
+++ b/tests/api/dev/test_live_openai_smoke.py
@@ -31,11 +31,13 @@ import httpx
 import pytest
 
 from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.llm.agent.probes.legacy_agent import certify_legacy_agent
 from dev_health_ops.llm.agent.readiness import (
     AgentReadinessOutcome,
     AgentReadinessRecord,
     AgentReadinessService,
 )
+from dev_health_ops.llm.agent.roles import RoleCertificationState
 
 #: Set to "1" to mark this run as the Wave 3.1 live convergence gate: missing
 #: credentials become a hard failure instead of a skip. Unset (or any other
@@ -130,11 +132,38 @@ async def test_live_openai_gpt5_readiness() -> None:
             model=model,
             fingerprint=provider.model_fingerprint,
         )
+        assert record.outcome is AgentReadinessOutcome.READY
+        assert record.safe_error_code is None
+
+        # CHAOS-3285 round 2 (Codex MEDIUM): the live gate must also run the
+        # REAL production-sized legacy_agent probe against the real API --
+        # not just the old 512-token echo probe above, which cannot observe
+        # output/reasoning exhaustion at all. This is exactly the empirical
+        # measurement the CHAOS-3285 plan's live-verification phase calls
+        # for: does the configured model actually pass the production
+        # request shape, against the real provider, right now.
+        #
+        # legacy_agent is deliberately NOT asserted COMPATIBLE
+        # unconditionally: per the ratified TRD Option B, this role may
+        # legitimately exhaust the existing 4,096-token envelope -- THAT is
+        # the measurement this run is taking, not a test failure. Only a
+        # genuinely unclassified outcome (an exception certify_legacy_agent
+        # itself does not already turn into a state) fails this test.
+        probe_result = await certify_legacy_agent(provider, timeout_seconds=60)
+        print(
+            "[ASK_DEV_LIVE_GATE] legacy_agent role vs "
+            f"{model}: state={probe_result.state.value} "
+            f"safe_error_code={probe_result.safe_error_code} "
+            f"reasoning_tokens={probe_result.usage.reasoning_tokens} "
+            f"output_tokens={probe_result.usage.output_tokens}"
+        )
+        assert probe_result.state in (
+            RoleCertificationState.COMPATIBLE,
+            RoleCertificationState.INCOMPATIBLE,
+            RoleCertificationState.FAILED,
+        )
     finally:
         await provider.aclose()
-
-    assert record.outcome is AgentReadinessOutcome.READY
-    assert record.safe_error_code is None
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_live_openai_smoke.py
+++ b/tests/api/dev/test_live_openai_smoke.py
@@ -5,6 +5,19 @@ turn smoke requires an already configured authenticated Dev Health deployment:
 ``ASK_DEV_LIVE_API_BASE_URL``, ``ASK_DEV_LIVE_API_TOKEN``, and
 ``ASK_DEV_LIVE_ORG_ID``. Neither test prints credentials, prompts, or provider
 payloads. They are intentionally outside the deterministic release gate.
+
+Missing-credential behavior (CHAOS-3285 acceptance: "missing credentials
+clearly leave the live gate non-passing rather than silently skipped"):
+
+* By default (``ASK_DEV_LIVE_GATE`` unset) -- an ordinary local run without
+  live credentials configured -- missing env vars still ``pytest.skip``.
+  This is the only mode where skipping is legitimate: nobody asked for the
+  live gate to run here.
+* When ``ASK_DEV_LIVE_GATE=1`` is set -- the explicit signal that this run
+  IS the live convergence gate, not an incidental local pass -- missing env
+  vars ``pytest.fail`` instead. A gate that silently skips its own
+  measurement reads as passing coverage it never actually took (verification
+  Rule 4); the whole point of the flag is to make that failure loud instead.
 """
 
 from __future__ import annotations
@@ -24,6 +37,11 @@ from dev_health_ops.llm.agent.readiness import (
     AgentReadinessService,
 )
 
+#: Set to "1" to mark this run as the Wave 3.1 live convergence gate: missing
+#: credentials become a hard failure instead of a skip. Unset (or any other
+#: value) preserves today's default local-run behavior.
+LIVE_GATE_ENV_VAR = "ASK_DEV_LIVE_GATE"
+
 
 class _ReadinessStore:
     record: AgentReadinessRecord | None = None
@@ -35,12 +53,63 @@ class _ReadinessStore:
         self.record = record
 
 
+def _live_gate_required() -> bool:
+    return os.getenv(LIVE_GATE_ENV_VAR, "").strip() == "1"
+
+
 def _required_environment(*names: str) -> dict[str, str]:
     values = {name: os.getenv(name, "").strip() for name in names}
     missing = [name for name, value in values.items() if not value]
     if missing:
-        pytest.skip("live OpenAI smoke is not configured")
+        reason = f"live OpenAI smoke is not configured (missing: {', '.join(missing)})"
+        if _live_gate_required():
+            pytest.fail(
+                f"{reason}. {LIVE_GATE_ENV_VAR}=1 requires these credentials to be "
+                "present -- the live gate must fail, not skip, when it cannot take "
+                "its measurement."
+            )
+        pytest.skip(reason)
     return values
+
+
+def test_missing_credentials_skip_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordinary local-run case: no live gate requested, so a missing
+    credential is a legitimate skip, unchanged from before CHAOS-3285."""
+
+    monkeypatch.delenv(LIVE_GATE_ENV_VAR, raising=False)
+    monkeypatch.delenv("_ASK_DEV_LIVE_SMOKE_TEST_VAR", raising=False)
+
+    with pytest.raises(pytest.skip.Exception):
+        _required_environment("_ASK_DEV_LIVE_SMOKE_TEST_VAR")
+
+
+def test_missing_credentials_fail_loudly_when_gate_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 acceptance: with the live gate explicitly requested, a
+    missing credential must FAIL (non-passing), never silently skip -- the
+    exact defect class verification Rule 4 exists to catch (a measurement
+    that did not happen must not read as coverage)."""
+
+    monkeypatch.setenv(LIVE_GATE_ENV_VAR, "1")
+    monkeypatch.delenv("_ASK_DEV_LIVE_SMOKE_TEST_VAR", raising=False)
+
+    with pytest.raises(pytest.fail.Exception):
+        _required_environment("_ASK_DEV_LIVE_SMOKE_TEST_VAR")
+
+
+def test_present_credentials_are_returned_regardless_of_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate flag only changes missing-credential behavior; a fully
+    configured run is unaffected either way."""
+
+    monkeypatch.setenv(LIVE_GATE_ENV_VAR, "1")
+    monkeypatch.setenv("_ASK_DEV_LIVE_SMOKE_TEST_VAR", "configured-value")
+
+    assert _required_environment("_ASK_DEV_LIVE_SMOKE_TEST_VAR") == {
+        "_ASK_DEV_LIVE_SMOKE_TEST_VAR": "configured-value"
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -56,6 +56,9 @@ def _fingerprint(
     provider: str = "openai",
     role: AgentRole = AgentRole.LEGACY_AGENT,
     api_key: str = "test-key",
+    organization: str = "",
+    project: str = "",
+    custom_headers: tuple[tuple[str, str], ...] = (),
 ) -> str:
     # CHAOS-3285: mirrors production_runtime._readiness_fingerprint's
     # extended formula. Every fixture in this file that builds a "current"
@@ -70,7 +73,11 @@ def _fingerprint(
     # defaults to "test-key" -- most fixtures in this file monkeypatch
     # OPENAI_API_KEY to that value; the "local" provider fixtures (whose
     # resolved credentials.api_key is genuinely "") pass api_key="" instead
-    # (CHAOS-3285 round 5).
+    # (CHAOS-3285 round 5). organization/project/custom_headers default to
+    # "empty" -- most fixtures never configure them; CHAOS-3285 round 6's
+    # own tests pass real values. _credential_fingerprint (the real
+    # producer) is reused directly here, not re-derived, for the same
+    # anti-drift reason.
     return hashlib.sha256(
         "\0".join(
             (
@@ -78,7 +85,14 @@ def _fingerprint(
                 provider,
                 model,
                 base_url,
-                hashlib.sha256(api_key.encode()).hexdigest()[:24],
+                production_runtime._credential_fingerprint(
+                    LLMCredentials(
+                        api_key=api_key,
+                        organization=organization,
+                        project=project,
+                        custom_headers=custom_headers,
+                    )
+                ),
                 READINESS_VERSION,
                 TOOL_CONTRACT_VERSION,
                 BUDGET_POLICY_VERSION,
@@ -583,6 +597,138 @@ async def test_credential_rotation_invalidates_certification(
     assert exc_info.value.code == "provider_not_configured"
 
 
+@pytest.mark.asyncio
+async def test_organization_rotation_invalidates_certification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same guard as credential (api_key) rotation, for organization:
+    certify under org A, flip OPENAI_ORG_ID to org B for the exact same
+    provider/model/base_url/api_key -- selection must fail closed until B
+    is re-certified."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_ORG_ID", "org-a")
+    fingerprint_a = _fingerprint(organization="org-a")
+    role_key, role_value = _role_certification_setting(certification_key=fingerprint_a)
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": fingerprint_a,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.model == "certified-model"
+
+    monkeypatch.setenv("OPENAI_ORG_ID", "org-b")
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_project_rotation_invalidates_certification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex's exact repro: flipping OPENAI_PROJECT_ID from one project to
+    another for the exact same provider/model/base_url/api_key must
+    invalidate certification -- previously this left the fingerprint
+    byte-for-byte identical while the real OpenAI-Project wire header
+    changed."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "project-a")
+    fingerprint_a = _fingerprint(project="project-a")
+    role_key, role_value = _role_certification_setting(certification_key=fingerprint_a)
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": fingerprint_a,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.model == "certified-model"
+
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "project-b")
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_custom_header_rotation_invalidates_certification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same guard, for custom identity headers: changing
+    OPENAI_CUSTOM_HEADERS for the exact same provider/model/base_url/
+    api_key must invalidate certification."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "X-Tenant: tenant-a")
+    fingerprint_a = _fingerprint(custom_headers=(("X-Tenant", "tenant-a"),))
+    role_key, role_value = _role_certification_setting(certification_key=fingerprint_a)
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": fingerprint_a,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.model == "certified-model"
+
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "X-Tenant: tenant-b")
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
 def test_credential_fingerprint_never_leaks_the_raw_api_key() -> None:
     """The credential fingerprint folded into the certification key must be
     non-reversible: the raw api_key string itself must never appear in the
@@ -594,6 +740,56 @@ def test_credential_fingerprint_never_leaks_the_raw_api_key() -> None:
 
     assert "super-secret-key-value" not in fingerprint
     assert len(fingerprint) == 24
+
+
+def test_credential_fingerprint_changes_with_organization() -> None:
+    baseline = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", organization="org-a")
+    )
+    changed = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", organization="org-b")
+    )
+    assert baseline != changed
+
+
+def test_credential_fingerprint_changes_with_project() -> None:
+    baseline = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", project="project-a")
+    )
+    changed = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", project="project-b")
+    )
+    assert baseline != changed
+
+
+def test_credential_fingerprint_changes_with_custom_headers() -> None:
+    baseline = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", custom_headers=(("X-Tenant", "a"),))
+    )
+    changed = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", custom_headers=(("X-Tenant", "b"),))
+    )
+    assert baseline != changed
+
+
+def test_credential_fingerprint_has_no_concatenation_ambiguity() -> None:
+    """CHAOS-3285 round 6 (Codex HIGH): folding identity fields via naive
+    string concatenation (or a `\\0`-joined tuple, this function's own
+    OUTER formula) can collide across different field boundaries -- e.g.
+    organization="ab" + project="c" naively concatenates to the same
+    string as organization="a" + project="bc". _credential_fingerprint
+    uses a JSON-canonical structure internally (sort_keys, one key per
+    field) specifically to avoid this; prove two genuinely different
+    (organization, project) splits that share a naive concatenation do NOT
+    collide."""
+
+    split_one = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", organization="ab", project="c")
+    )
+    split_two = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="k", organization="a", project="bc")
+    )
+    assert split_one != split_two
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -12,11 +12,17 @@ from dev_health_ops.api.dev import production_runtime
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevScope, DevToolRequest, ToolID
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.api.dev.prompts import PROMPT_VERSION
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
-from dev_health_ops.api.dev.tool_registry import ToolExecutionContext
+from dev_health_ops.api.dev.tool_registry import (
+    TOOL_CONTRACT_VERSION,
+    ToolExecutionContext,
+)
+from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
 from dev_health_ops.llm.agent.readiness import PLATFORM_READINESS_SETTING_KEY
+from dev_health_ops.llm.agent.roles import AgentRole
 from dev_health_ops.llm.credentials import LLMCredentials
 
 
@@ -43,10 +49,31 @@ class FakeSettingsService:
 
 
 def _fingerprint(
-    base_url: str = "", model: str = "certified-model", provider: str = "openai"
+    base_url: str = "",
+    model: str = "certified-model",
+    provider: str = "openai",
+    role: AgentRole = AgentRole.LEGACY_AGENT,
 ) -> str:
+    # CHAOS-3285: mirrors production_runtime._readiness_fingerprint's
+    # extended formula. Every fixture in this file that builds a "current"
+    # stored AgentReadinessRecord by hand must fold the same inputs the
+    # real function now folds, or it would exercise a fingerprint formula
+    # that no longer matches production and every "certification is
+    # current" assertion below would be testing nothing.
     return hashlib.sha256(
-        "\0".join(("platform", provider, model, base_url, READINESS_VERSION)).encode()
+        "\0".join(
+            (
+                "platform",
+                provider,
+                model,
+                base_url,
+                READINESS_VERSION,
+                PROMPT_VERSION,
+                TOOL_CONTRACT_VERSION,
+                BUDGET_POLICY_VERSION,
+                role.value,
+            )
+        ).encode()
     ).hexdigest()[:24]
 
 
@@ -68,6 +95,67 @@ def test_readiness_fingerprint_changes_when_source_changes() -> None:
     assert production_runtime._readiness_fingerprint(
         platform
     ) != production_runtime._readiness_fingerprint(byo)
+
+
+def test_readiness_fingerprint_changes_when_role_changes() -> None:
+    """CHAOS-3285: certification is now per-role -- a fingerprint computed
+    for one role must never collide with another role's fingerprint for the
+    otherwise-identical candidate, or a legacy_agent certification could be
+    misread as covering intent_classification/answer_frame_narrative too."""
+
+    credentials = LLMCredentials(base_url="https://models.example.com/v1")
+    candidate = AgentProviderCandidate(
+        provider="openai",
+        model="certified-model",
+        credentials=credentials,
+        source=AgentProviderSource.PLATFORM,
+    )
+
+    fingerprints = {
+        role: production_runtime._readiness_fingerprint(candidate, role=role)
+        for role in AgentRole
+    }
+    assert len(set(fingerprints.values())) == len(AgentRole)
+    # The default (no explicit role) must be legacy_agent -- production's
+    # existing single-role selection path calls _readiness_fingerprint
+    # without a role argument, and it is exactly the legacy_agent shape
+    # (full tool registry, full DevAnswer grammar) that path exercises.
+    assert (
+        production_runtime._readiness_fingerprint(candidate)
+        == fingerprints[AgentRole.LEGACY_AGENT]
+    )
+
+
+def test_readiness_fingerprint_invalidates_pre_chaos_3285_stored_records() -> None:
+    """CHAOS-3285 migration semantics: a fingerprint computed under the old
+    (pre-PR3) formula -- which folded only source/provider/model/base_url/
+    READINESS_VERSION -- must never equal the new formula's output. This is
+    the mechanism that makes every previously stored AgentReadinessRecord
+    read as stale rather than silently still-current after this change
+    (see the docstring on _readiness_fingerprint)."""
+
+    credentials = LLMCredentials(base_url="https://models.example.com/v1")
+    candidate = AgentProviderCandidate(
+        provider="openai",
+        model="certified-model",
+        credentials=credentials,
+        source=AgentProviderSource.PLATFORM,
+    )
+    pre_change_fingerprint = hashlib.sha256(
+        "\0".join(
+            (
+                candidate.source.value,
+                candidate.provider,
+                candidate.model,
+                candidate.credentials.base_url,
+                READINESS_VERSION,
+            )
+        ).encode()
+    ).hexdigest()[:24]
+
+    assert pre_change_fingerprint != production_runtime._readiness_fingerprint(
+        candidate
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -55,6 +55,7 @@ def _fingerprint(
     model: str = "certified-model",
     provider: str = "openai",
     role: AgentRole = AgentRole.LEGACY_AGENT,
+    api_key: str = "test-key",
 ) -> str:
     # CHAOS-3285: mirrors production_runtime._readiness_fingerprint's
     # extended formula. Every fixture in this file that builds a "current"
@@ -65,7 +66,11 @@ def _fingerprint(
     # contract digest (CHAOS-3285 round 2) is reused directly from the real
     # producer rather than re-derived here -- hand-duplicating a digest
     # computation is exactly the kind of drift that got the bare
-    # PROMPT_VERSION constant caught in the first place.
+    # PROMPT_VERSION constant caught in the first place. ``api_key``
+    # defaults to "test-key" -- most fixtures in this file monkeypatch
+    # OPENAI_API_KEY to that value; the "local" provider fixtures (whose
+    # resolved credentials.api_key is genuinely "") pass api_key="" instead
+    # (CHAOS-3285 round 5).
     return hashlib.sha256(
         "\0".join(
             (
@@ -73,6 +78,7 @@ def _fingerprint(
                 provider,
                 model,
                 base_url,
+                hashlib.sha256(api_key.encode()).hexdigest()[:24],
                 READINESS_VERSION,
                 TOOL_CONTRACT_VERSION,
                 BUDGET_POLICY_VERSION,
@@ -528,6 +534,69 @@ async def test_wire_policy_change_invalidates_stored_certification(
 
 
 @pytest.mark.asyncio
+async def test_credential_rotation_invalidates_certification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 5 (Codex HIGH), codex's exact repro: certify
+    provider key A, then rotate to key B for the exact same
+    provider/model/base_url -- selection must fail closed until B is
+    re-certified. Before this fix, the certification key never depended on
+    WHICH credential was actually tested, so B's rotation silently
+    inherited A's certification while every real request already carried
+    B's Authorization header, never having demonstrated B can handle the
+    production request shape at all."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "key-a")
+    fingerprint_a = _fingerprint(api_key="key-a")
+    role_key, role_value = _role_certification_setting(certification_key=fingerprint_a)
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": fingerprint_a,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+    session = cast(Any, object())
+
+    # Sanity: certified under key A, selection succeeds.
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.model == "certified-model"
+
+    # Rotate to key B -- same provider/model/base_url, a different
+    # credential -- without re-running preflight.
+    monkeypatch.setenv("OPENAI_API_KEY", "key-b")
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+def test_credential_fingerprint_never_leaks_the_raw_api_key() -> None:
+    """The credential fingerprint folded into the certification key must be
+    non-reversible: the raw api_key string itself must never appear in the
+    fingerprint's output."""
+
+    fingerprint = production_runtime._credential_fingerprint(
+        LLMCredentials(api_key="super-secret-key-value")
+    )
+
+    assert "super-secret-key-value" not in fingerprint
+    assert len(fingerprint) == 24
+
+
+@pytest.mark.asyncio
 async def test_provider_resolution_requires_current_certification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -689,6 +758,7 @@ async def test_platform_local_provider_uses_only_operator_environment(
         provider="local",
         model="google/gemma-4-e4b",
         base_url="http://host.docker.internal:1234/v1",
+        api_key="",
     )
     role_key, role_value = _role_certification_setting(
         certification_key=local_fingerprint
@@ -743,6 +813,7 @@ async def test_explicit_fail_closed_prevents_platform_fallback(
                     provider="local",
                     model="local-agent-model",
                     base_url="http://host.docker.internal:1234/v1",
+                    api_key="",
                 ),
                 "readiness_version": READINESS_VERSION,
                 "checked_at": "2026-07-29T12:00:00+00:00",

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -12,7 +12,6 @@ from dev_health_ops.api.dev import production_runtime
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevScope, DevToolRequest, ToolID
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
-from dev_health_ops.api.dev.prompts import PROMPT_VERSION
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
 from dev_health_ops.api.dev.tool_registry import (
     TOOL_CONTRACT_VERSION,
@@ -62,7 +61,11 @@ def _fingerprint(
     # stored AgentReadinessRecord by hand must fold the same inputs the
     # real function now folds, or it would exercise a fingerprint formula
     # that no longer matches production and every "certification is
-    # current" assertion below would be testing nothing.
+    # current" assertion below would be testing nothing. The canonical
+    # contract digest (CHAOS-3285 round 2) is reused directly from the real
+    # producer rather than re-derived here -- hand-duplicating a digest
+    # computation is exactly the kind of drift that got the bare
+    # PROMPT_VERSION constant caught in the first place.
     return hashlib.sha256(
         "\0".join(
             (
@@ -71,10 +74,10 @@ def _fingerprint(
                 model,
                 base_url,
                 READINESS_VERSION,
-                PROMPT_VERSION,
                 TOOL_CONTRACT_VERSION,
                 BUDGET_POLICY_VERSION,
                 role.value,
+                production_runtime._canonical_contract_digest(),
             )
         ).encode()
     ).hexdigest()[:24]
@@ -187,6 +190,56 @@ def test_readiness_fingerprint_invalidates_pre_chaos_3285_stored_records() -> No
     assert pre_change_fingerprint != production_runtime._readiness_fingerprint(
         candidate
     )
+
+
+def test_canonical_contract_digest_folds_the_legacy_prompt_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 2 (Codex HIGH): the fingerprint previously folded
+    only PROMPT_VERSION -- the committed-subject prompt shape
+    (subject_committed=True). PromptComposer also produces
+    LEGACY_PROMPT_VERSION's shape (uncommitted subject / the flag-off
+    path), which the legacy_agent probe never exercises (it forces
+    subject_committed=True unconditionally) -- so a text-only change to
+    ONLY that prompt shape never invalidated any certification at all,
+    since LEGACY_PROMPT_VERSION was never folded anywhere. Prove the
+    canonical contract digest now folds it."""
+
+    production_runtime._canonical_contract_digest.cache_clear()
+    try:
+        baseline = production_runtime._canonical_contract_digest()
+
+        monkeypatch.setattr(
+            production_runtime, "LEGACY_PROMPT_VERSION", "changed-legacy-version"
+        )
+        production_runtime._canonical_contract_digest.cache_clear()
+        changed = production_runtime._canonical_contract_digest()
+
+        assert baseline != changed
+    finally:
+        production_runtime._canonical_contract_digest.cache_clear()
+
+
+def test_canonical_contract_digest_folds_the_real_run_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DevRunLimits value changing (e.g. the per-call output cap) must
+    invalidate certification even if nobody remembers to bump a version
+    string for it."""
+    from dev_health_ops.api.dev.orchestrator import DevRunLimits
+
+    production_runtime._canonical_contract_digest.cache_clear()
+    try:
+        baseline = production_runtime._canonical_contract_digest()
+
+        smaller_limits = DevRunLimits(max_output_tokens_per_call=2_048)
+        monkeypatch.setattr(production_runtime, "DevRunLimits", lambda: smaller_limits)
+        production_runtime._canonical_contract_digest.cache_clear()
+        changed = production_runtime._canonical_contract_digest()
+
+        assert baseline != changed
+    finally:
+        production_runtime._canonical_contract_digest.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -22,7 +22,10 @@ from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
 from dev_health_ops.llm.agent.readiness import PLATFORM_READINESS_SETTING_KEY
-from dev_health_ops.llm.agent.roles import AgentRole
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+)
 from dev_health_ops.llm.credentials import LLMCredentials
 
 
@@ -75,6 +78,34 @@ def _fingerprint(
             )
         ).encode()
     ).hexdigest()[:24]
+
+
+def _role_certification_setting(
+    *,
+    key_prefix: str = PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    role: AgentRole = AgentRole.LEGACY_AGENT,
+    certification_key: str,
+    state: str = "compatible",
+) -> tuple[str, str]:
+    """(settings_key, json_value) for one role's row under
+    SettingsRoleCertificationStore's per-role key format (CHAOS-3285)."""
+
+    return (
+        f"{key_prefix}:{role.value}",
+        json.dumps(
+            {
+                "version": "ask-dev-role-certification.v1",
+                "record": {
+                    "role": role.value,
+                    "certification_key": certification_key,
+                    "readiness_version": READINESS_VERSION,
+                    "checked_at": "2026-07-29T12:00:00+00:00",
+                    "state": state,
+                    "safe_error_code": None,
+                },
+            }
+        ),
+    )
 
 
 def test_readiness_fingerprint_changes_when_source_changes() -> None:
@@ -171,6 +202,7 @@ async def test_provider_resolution_requires_current_certification(
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "certified-model")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    role_key, role_value = _role_certification_setting(certification_key=_fingerprint())
     FakeSettingsService.values = {
         PLATFORM_READINESS_SETTING_KEY: json.dumps(
             {
@@ -180,7 +212,8 @@ async def test_provider_resolution_requires_current_certification(
                 "outcome": "ready",
                 "safe_error_code": None,
             }
-        )
+        ),
+        role_key: role_value,
     }
 
     session = cast(Any, object())
@@ -212,6 +245,84 @@ async def test_provider_resolution_requires_current_certification(
 
 
 @pytest.mark.asyncio
+async def test_echo_only_certification_does_not_restore_live_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 (Codex HIGH): the old binary AgentReadinessRecord being
+    "ready" must NOT be sufficient for live selection on its own. Before the
+    role-gate fix, an operator could re-certify through a route that only
+    ever runs the old 512-token echo probe (or the new role probe simply
+    never having run at all), the binary store would read current, and this
+    candidate would become selectable for real traffic having never
+    demonstrated it can handle the production request shape. This is the RED
+    half: binary readiness alone, with NO legacy_agent role certification on
+    record, must fail closed."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": _fingerprint(),
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        # Deliberately NO role-certification row at all.
+    }
+
+    session = cast(Any, object())
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_incompatible_legacy_agent_role_does_not_restore_live_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same gate, with a role record present but INCOMPATIBLE (e.g. the
+    production-sized probe reproduced output exhaustion) rather than absent
+    -- an INCOMPATIBLE verdict must never be silently treated as good
+    enough for live selection either."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    role_key, role_value = _role_certification_setting(
+        certification_key=_fingerprint(), state="incompatible"
+    )
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": _fingerprint(),
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+
+    session = cast(Any, object())
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
 async def test_platform_local_provider_uses_only_operator_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -236,20 +347,25 @@ async def test_platform_local_provider_uses_only_operator_environment(
     monkeypatch.setenv("LOCAL_LLM_BASE_URL", "http://host.docker.internal:1234/v1")
     monkeypatch.delenv("LLM_API_KEY", raising=False)
     monkeypatch.delenv("LOCAL_LLM_API_KEY", raising=False)
+    local_fingerprint = _fingerprint(
+        provider="local",
+        model="google/gemma-4-e4b",
+        base_url="http://host.docker.internal:1234/v1",
+    )
+    role_key, role_value = _role_certification_setting(
+        certification_key=local_fingerprint
+    )
     FakeSettingsService.values = {
         PLATFORM_READINESS_SETTING_KEY: json.dumps(
             {
-                "fingerprint": _fingerprint(
-                    provider="local",
-                    model="google/gemma-4-e4b",
-                    base_url="http://host.docker.internal:1234/v1",
-                ),
+                "fingerprint": local_fingerprint,
                 "readiness_version": READINESS_VERSION,
                 "checked_at": "2026-07-29T12:00:00+00:00",
                 "outcome": "ready",
                 "safe_error_code": None,
             }
         ),
+        role_key: role_value,
         # A complete organization BYO bundle remains database-owned and does
         # not overwrite the independently resolved platform candidate.
         "provider": "openai",

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -78,6 +78,7 @@ def _fingerprint(
                 BUDGET_POLICY_VERSION,
                 role.value,
                 production_runtime._canonical_contract_digest(),
+                production_runtime._wire_policy_digest(model),
             )
         ).encode()
     ).hexdigest()[:24]
@@ -240,6 +241,184 @@ def test_canonical_contract_digest_folds_the_real_run_limits(
         assert baseline != changed
     finally:
         production_runtime._canonical_contract_digest.cache_clear()
+
+
+def test_wire_policy_kwargs_differs_between_probe_round_shapes() -> None:
+    """Round 1 (tools offered, no grammar yet) and round 2 (tools offered,
+    grammar) are genuinely distinct wire-policy shapes -- tool_choice
+    switches from "required" to "auto", and the response_format wrapper
+    only appears once a final answer is allowed."""
+
+    round_1 = production_runtime.wire_policy_kwargs(
+        "certified-model", tools_present=True, allow_final_answer=False
+    )
+    round_2 = production_runtime.wire_policy_kwargs(
+        "certified-model", tools_present=True, allow_final_answer=True
+    )
+
+    assert round_1["tool_choice"] == "required"
+    assert round_2["tool_choice"] == "auto"
+    assert "response_format_wrapper" not in round_1
+    assert "response_format_wrapper" in round_2
+
+
+def test_wire_policy_digest_changes_when_supports_temperature_toggles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 4 (Codex HIGH): before this fix, the readiness
+    fingerprint never called any adapter capability-policy function at all
+    -- only the bare candidate.model string, which does not change when a
+    policy FUNCTION's behavior changes for an already-certified model (e.g.
+    supports_temperature gaining a new excluded family on a future deploy).
+    Prove the digest reacts to the policy itself, holding the model string
+    fixed."""
+
+    from dev_health_ops.llm.agent import openai_compatible
+
+    production_runtime._wire_policy_digest.cache_clear()
+    try:
+        baseline = production_runtime._wire_policy_digest("certified-model")
+
+        monkeypatch.setattr(
+            openai_compatible, "supports_temperature", lambda _model: False
+        )
+        production_runtime._wire_policy_digest.cache_clear()
+        changed = production_runtime._wire_policy_digest("certified-model")
+
+        assert baseline != changed
+    finally:
+        production_runtime._wire_policy_digest.cache_clear()
+
+
+def test_wire_policy_digest_changes_when_parallel_tool_calls_support_toggles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.llm.agent import openai_compatible
+
+    production_runtime._wire_policy_digest.cache_clear()
+    try:
+        baseline = production_runtime._wire_policy_digest("certified-model")
+
+        monkeypatch.setattr(
+            openai_compatible, "supports_parallel_tool_calls", lambda _model: False
+        )
+        production_runtime._wire_policy_digest.cache_clear()
+        changed = production_runtime._wire_policy_digest("certified-model")
+
+        assert baseline != changed
+    finally:
+        production_runtime._wire_policy_digest.cache_clear()
+
+
+def test_wire_policy_digest_changes_when_reasoning_effort_toggles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.llm.agent import openai_compatible
+
+    production_runtime._wire_policy_digest.cache_clear()
+    try:
+        baseline = production_runtime._wire_policy_digest("certified-model")
+
+        monkeypatch.setattr(
+            openai_compatible,
+            "chat_completion_reasoning_effort",
+            lambda _model: "minimal",
+        )
+        production_runtime._wire_policy_digest.cache_clear()
+        changed = production_runtime._wire_policy_digest("certified-model")
+
+        assert baseline != changed
+    finally:
+        production_runtime._wire_policy_digest.cache_clear()
+
+
+def test_readiness_fingerprint_changes_when_wire_policy_toggles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full fingerprint formula (not just the digest in isolation)
+    reacts to a wire-policy change -- the exact codex repro: toggling
+    supports_temperature changed the emitted request while
+    _readiness_fingerprint stayed identical."""
+
+    from dev_health_ops.llm.agent import openai_compatible
+
+    credentials = LLMCredentials(base_url="https://models.example.com/v1")
+    candidate = AgentProviderCandidate(
+        provider="openai",
+        model="certified-model",
+        credentials=credentials,
+        source=AgentProviderSource.PLATFORM,
+    )
+
+    production_runtime._wire_policy_digest.cache_clear()
+    try:
+        baseline = production_runtime._readiness_fingerprint(candidate)
+
+        monkeypatch.setattr(
+            openai_compatible, "supports_temperature", lambda _model: False
+        )
+        production_runtime._wire_policy_digest.cache_clear()
+        changed = production_runtime._readiness_fingerprint(candidate)
+
+        assert baseline != changed
+    finally:
+        production_runtime._wire_policy_digest.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_wire_policy_change_invalidates_stored_certification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a certification stored under today's wire policy must be
+    invalidated -- selection fails closed -- once the policy changes for
+    this model, even though the candidate itself (model/provider/base_url)
+    never changed. Closes the loop codex asked for: fingerprint changes ->
+    stored certification invalidated, not just a digest changing in
+    isolation."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    stored_fingerprint = _fingerprint()
+    role_key, role_value = _role_certification_setting(
+        certification_key=stored_fingerprint
+    )
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": stored_fingerprint,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+    session = cast(Any, object())
+
+    # Sanity: certified under today's real wire policy, selection succeeds.
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.model == "certified-model"
+
+    from dev_health_ops.llm.agent import openai_compatible
+
+    monkeypatch.setattr(openai_compatible, "supports_temperature", lambda _model: False)
+    production_runtime._wire_policy_digest.cache_clear()
+    try:
+        with pytest.raises(DevRuntimeUnavailable) as exc_info:
+            await production_runtime.resolve_production_provider(
+                session, org_id="org_01"
+            )
+        assert exc_info.value.code == "provider_not_configured"
+    finally:
+        production_runtime._wire_policy_digest.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -78,7 +78,7 @@ def _fingerprint(
                 BUDGET_POLICY_VERSION,
                 role.value,
                 production_runtime._canonical_contract_digest(),
-                production_runtime._wire_policy_digest(model),
+                production_runtime._wire_request_digest(model),
             )
         ).encode()
     ).hexdigest()[:24]
@@ -243,29 +243,39 @@ def test_canonical_contract_digest_folds_the_real_run_limits(
         production_runtime._canonical_contract_digest.cache_clear()
 
 
-def test_wire_policy_kwargs_differs_between_probe_round_shapes() -> None:
+def test_build_completion_request_differs_between_probe_round_shapes() -> None:
     """Round 1 (tools offered, no grammar yet) and round 2 (tools offered,
-    grammar) are genuinely distinct wire-policy shapes -- tool_choice
-    switches from "required" to "auto", and the response_format wrapper
-    only appears once a final answer is allowed."""
+    grammar) are genuinely distinct wire request shapes -- tool_choice
+    switches from "required" to "auto", and response_format only appears
+    once a final answer is allowed."""
 
-    round_1 = production_runtime.wire_policy_kwargs(
-        "certified-model", tools_present=True, allow_final_answer=False
+    from dev_health_ops.llm.agent.openai_compatible import build_completion_request
+
+    round_1 = build_completion_request(
+        model="certified-model",
+        messages=production_runtime._wire_request_probe_messages(round_1=True),
+        tools=production_runtime._probe_tools(production_runtime._probe_registry()),
+        response_schema={"type": "object"},
+        max_output_tokens=4096,
     )
-    round_2 = production_runtime.wire_policy_kwargs(
-        "certified-model", tools_present=True, allow_final_answer=True
+    round_2 = build_completion_request(
+        model="certified-model",
+        messages=production_runtime._wire_request_probe_messages(round_1=False),
+        tools=production_runtime._probe_tools(production_runtime._probe_registry()),
+        response_schema={"type": "object"},
+        max_output_tokens=4096,
     )
 
     assert round_1["tool_choice"] == "required"
     assert round_2["tool_choice"] == "auto"
-    assert "response_format_wrapper" not in round_1
-    assert "response_format_wrapper" in round_2
+    assert "response_format" not in round_1
+    assert "response_format" in round_2
 
 
-def test_wire_policy_digest_changes_when_supports_temperature_toggles(
+def test_wire_request_digest_changes_when_supports_temperature_toggles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CHAOS-3285 round 4 (Codex HIGH): before this fix, the readiness
+    """CHAOS-3285 round 4 (Codex HIGH): before that fix, the readiness
     fingerprint never called any adapter capability-policy function at all
     -- only the bare candidate.model string, which does not change when a
     policy FUNCTION's behavior changes for an already-certified model (e.g.
@@ -275,61 +285,157 @@ def test_wire_policy_digest_changes_when_supports_temperature_toggles(
 
     from dev_health_ops.llm.agent import openai_compatible
 
-    production_runtime._wire_policy_digest.cache_clear()
+    production_runtime._wire_request_digest.cache_clear()
     try:
-        baseline = production_runtime._wire_policy_digest("certified-model")
+        baseline = production_runtime._wire_request_digest("certified-model")
 
         monkeypatch.setattr(
             openai_compatible, "supports_temperature", lambda _model: False
         )
-        production_runtime._wire_policy_digest.cache_clear()
-        changed = production_runtime._wire_policy_digest("certified-model")
+        production_runtime._wire_request_digest.cache_clear()
+        changed = production_runtime._wire_request_digest("certified-model")
 
         assert baseline != changed
     finally:
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
 
 
-def test_wire_policy_digest_changes_when_parallel_tool_calls_support_toggles(
+def test_wire_request_digest_changes_when_parallel_tool_calls_support_toggles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from dev_health_ops.llm.agent import openai_compatible
 
-    production_runtime._wire_policy_digest.cache_clear()
+    production_runtime._wire_request_digest.cache_clear()
     try:
-        baseline = production_runtime._wire_policy_digest("certified-model")
+        baseline = production_runtime._wire_request_digest("certified-model")
 
         monkeypatch.setattr(
             openai_compatible, "supports_parallel_tool_calls", lambda _model: False
         )
-        production_runtime._wire_policy_digest.cache_clear()
-        changed = production_runtime._wire_policy_digest("certified-model")
+        production_runtime._wire_request_digest.cache_clear()
+        changed = production_runtime._wire_request_digest("certified-model")
 
         assert baseline != changed
     finally:
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
 
 
-def test_wire_policy_digest_changes_when_reasoning_effort_toggles(
+def test_wire_request_digest_changes_when_reasoning_effort_toggles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from dev_health_ops.llm.agent import openai_compatible
 
-    production_runtime._wire_policy_digest.cache_clear()
+    production_runtime._wire_request_digest.cache_clear()
     try:
-        baseline = production_runtime._wire_policy_digest("certified-model")
+        baseline = production_runtime._wire_request_digest("certified-model")
 
         monkeypatch.setattr(
             openai_compatible,
             "chat_completion_reasoning_effort",
             lambda _model: "minimal",
         )
-        production_runtime._wire_policy_digest.cache_clear()
-        changed = production_runtime._wire_policy_digest("certified-model")
+        production_runtime._wire_request_digest.cache_clear()
+        changed = production_runtime._wire_request_digest("certified-model")
 
         assert baseline != changed
     finally:
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
+
+
+def test_wire_request_digest_changes_when_the_max_token_policy_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 5 (Codex HIGH): decide() independently resolved
+    max_completion_tokens via model_family_budget -- a field round 4's
+    narrower wire_policy_kwargs never covered at all. build_completion_request
+    now assembles it, so a DevRunLimits change (which flows into the
+    max_output_tokens argument) must change the digest."""
+
+    from dev_health_ops.api.dev.orchestrator import DevRunLimits
+
+    production_runtime._wire_request_digest.cache_clear()
+    try:
+        baseline = production_runtime._wire_request_digest("certified-model")
+
+        smaller_limits = DevRunLimits(max_output_tokens_per_call=2_048)
+        monkeypatch.setattr(production_runtime, "DevRunLimits", lambda: smaller_limits)
+        production_runtime._wire_request_digest.cache_clear()
+        changed = production_runtime._wire_request_digest("certified-model")
+
+        assert baseline != changed
+    finally:
+        production_runtime._wire_request_digest.cache_clear()
+
+
+def test_wire_request_digest_is_sensitive_to_the_response_wrapper_and_tool_fields() -> (
+    None
+):
+    """CHAOS-3285 round 5 (Codex HIGH): round 4's wire_policy_kwargs
+    hand-duplicated the response_format wrapper's name/strict literals
+    separately from decide()'s own assembly of them -- so a change to
+    EITHER decide()'s real literals OR the full generated schema body, or
+    to how a tool gets serialized, could drift from the hand-duplicated
+    copy without the digest ever knowing. Now that build_completion_request
+    is the single producer both decide() and the digest consume, there is
+    no hand-duplicated copy left to drift -- but the digest's own
+    serialize-then-hash step must still not silently drop any of these
+    fields. Prove each one, mutating the SAME real producer's own output,
+    changes what gets hashed."""
+
+    from dev_health_ops.llm.agent.openai_compatible import build_completion_request
+
+    registry = production_runtime._probe_registry()
+    tools = production_runtime._probe_tools(registry)
+    response_schema = {"type": "object", "properties": {"status": {"type": "string"}}}
+    round_1 = build_completion_request(
+        model="certified-model",
+        messages=production_runtime._wire_request_probe_messages(round_1=True),
+        tools=tools,
+        response_schema=response_schema,
+        max_output_tokens=4096,
+    )
+    round_2 = build_completion_request(
+        model="certified-model",
+        messages=production_runtime._wire_request_probe_messages(round_1=False),
+        tools=tools,
+        response_schema=response_schema,
+        max_output_tokens=4096,
+    )
+
+    def _digest(
+        round_1_payload: dict[str, Any], round_2_payload: dict[str, Any]
+    ) -> str:
+        canonical = json.dumps(
+            {"round_1": round_1_payload, "round_2": round_2_payload},
+            sort_keys=True,
+            default=str,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()[:24]
+
+    baseline = _digest(round_1, round_2)
+
+    mutated_name = json.loads(json.dumps(round_2))
+    mutated_name["response_format"]["json_schema"]["name"] = "a_different_name"
+    assert _digest(round_1, mutated_name) != baseline, "wrapper name change not hashed"
+
+    mutated_strict = json.loads(json.dumps(round_2))
+    mutated_strict["response_format"]["json_schema"]["strict"] = False
+    assert _digest(round_1, mutated_strict) != baseline, "strict flag change not hashed"
+
+    mutated_max_tokens = json.loads(json.dumps(round_2))
+    mutated_max_tokens["max_completion_tokens"] = (
+        mutated_max_tokens["max_completion_tokens"] + 1
+    )
+    assert _digest(round_1, mutated_max_tokens) != baseline, (
+        "max_completion_tokens change not hashed"
+    )
+
+    mutated_tools = json.loads(json.dumps(round_2))
+    mutated_tools["tools"][0]["function"]["description"] = "a different description"
+    assert _digest(round_1, mutated_tools) != baseline, (
+        "tool serialization change not hashed"
+    )
 
 
 def test_readiness_fingerprint_changes_when_wire_policy_toggles(
@@ -350,19 +456,19 @@ def test_readiness_fingerprint_changes_when_wire_policy_toggles(
         source=AgentProviderSource.PLATFORM,
     )
 
-    production_runtime._wire_policy_digest.cache_clear()
+    production_runtime._wire_request_digest.cache_clear()
     try:
         baseline = production_runtime._readiness_fingerprint(candidate)
 
         monkeypatch.setattr(
             openai_compatible, "supports_temperature", lambda _model: False
         )
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
         changed = production_runtime._readiness_fingerprint(candidate)
 
         assert baseline != changed
     finally:
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
 
 
 @pytest.mark.asyncio
@@ -410,7 +516,7 @@ async def test_wire_policy_change_invalidates_stored_certification(
     from dev_health_ops.llm.agent import openai_compatible
 
     monkeypatch.setattr(openai_compatible, "supports_temperature", lambda _model: False)
-    production_runtime._wire_policy_digest.cache_clear()
+    production_runtime._wire_request_digest.cache_clear()
     try:
         with pytest.raises(DevRuntimeUnavailable) as exc_info:
             await production_runtime.resolve_production_provider(
@@ -418,7 +524,7 @@ async def test_wire_policy_change_invalidates_stored_certification(
             )
         assert exc_info.value.code == "provider_not_configured"
     finally:
-        production_runtime._wire_policy_digest.cache_clear()
+        production_runtime._wire_request_digest.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -16,7 +16,10 @@ from dev_health_ops.llm.agent.contracts import (
     AgentToolRequest,
 )
 from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
-from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.llm.agent.openai_compatible import (
+    OpenAICompatibleAgentProvider,
+    build_completion_request,
+)
 
 
 class Completions:
@@ -76,6 +79,52 @@ def response(
             ),
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_decide_sends_exactly_what_build_completion_request_produces() -> None:
+    """CHAOS-3285 round 5 (Codex HIGH): the readiness fingerprint's
+    wire-request digest calls build_completion_request directly and hashes
+    its output; that is only a meaningful guarantee if decide() actually
+    dispatches EXACTLY that output, not an independently-assembled
+    approximation of it (round 4's gap: decide() still built
+    max_completion_tokens, the response_format wrapper's literal name/
+    strict, and the full schema body itself). Prove it differentially: the
+    real kwargs decide() sends to the wire must equal what
+    build_completion_request returns for the identical inputs."""
+
+    call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(name="lookup", arguments="{}"),
+    )
+    client = Client([response(tool_call=call)])
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model="gpt-5-mini", client=client
+    )
+    messages = [
+        AgentMessage(AgentMessageRole.SYSTEM, "sys"),
+        AgentMessage(AgentMessageRole.USER, "question"),
+    ]
+    tools = [
+        AgentToolDefinition(
+            "lookup",
+            "Lookup a work unit",
+            {"type": "object", "properties": {"id": {"type": "string"}}},
+        )
+    ]
+    response_schema = {"type": "object", "properties": {"status": {"type": "string"}}}
+
+    await provider.decide(messages, tools, response_schema, 1, 256)
+
+    sent = client.chat.completions.calls[0]
+    expected = build_completion_request(
+        model="gpt-5-mini",
+        messages=messages,
+        tools=tools,
+        response_schema=response_schema,
+        max_output_tokens=256,
+    )
+    assert sent == expected
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_openai_compatible.py
+++ b/tests/llm/agent/test_openai_compatible.py
@@ -128,6 +128,95 @@ async def test_decide_sends_exactly_what_build_completion_request_produces() -> 
 
 
 @pytest.mark.asyncio
+async def test_real_client_construction_suppresses_ambient_organization_and_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 6 (Codex HIGH), codex's exact repro mechanism: the
+    AsyncOpenAI SDK reads OPENAI_ORG_ID/OPENAI_PROJECT_ID from the process
+    environment whenever organization/project are left as Python None.
+    Constructing the REAL client (client=None, the production path -- every
+    existing test in this file injects a fake and so never exercised this
+    branch at all) must never leak ambient env identity when organization/
+    project are explicitly "not configured" (empty string)."""
+
+    monkeypatch.setenv("OPENAI_ORG_ID", "ambient-org-from-env")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "ambient-project-from-env")
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key="test-key", model="gpt-5-mini", organization="", project=""
+    )
+    try:
+        assert provider._client.organization is None
+        assert provider._client.project is None
+    finally:
+        await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_client_construction_uses_explicit_organization_and_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inverse: when organization/project ARE explicitly configured,
+    the real client uses exactly those values -- not whatever the ambient
+    environment happens to hold, even when it differs (proving this is a
+    genuine override, not merely "env happens to agree")."""
+
+    monkeypatch.setenv("OPENAI_ORG_ID", "ambient-org-from-env")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "ambient-project-from-env")
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key="test-key",
+        model="gpt-5-mini",
+        organization="configured-org",
+        project="configured-project",
+    )
+    try:
+        assert provider._client.organization == "configured-org"
+        assert provider._client.project == "configured-project"
+    finally:
+        await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_client_construction_suppresses_ambient_custom_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3285 round 6 (Codex HIGH): OPENAI_CUSTOM_HEADERS has no `is
+    None` gate at all in the SDK -- it unconditionally merges into the
+    client's headers whenever the env var is set, regardless of what
+    default_headers this constructor passes. The real client's header set
+    must never include an ambient env header we did not explicitly
+    configure."""
+
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "X-Ambient-Leak: leaked-value")
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key="test-key", model="gpt-5-mini", custom_headers=()
+    )
+    try:
+        assert "X-Ambient-Leak" not in provider._client.default_headers
+    finally:
+        await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_client_construction_uses_explicit_custom_headers_only() -> None:
+    """When custom_headers ARE configured, the real client's headers
+    reflect exactly that set -- nothing more, nothing silently added from
+    the environment."""
+
+    provider = OpenAICompatibleAgentProvider(
+        api_key="test-key",
+        model="gpt-5-mini",
+        custom_headers=(("X-Configured", "configured-value"),),
+    )
+    try:
+        assert provider._client.default_headers["X-Configured"] == "configured-value"
+    finally:
+        await provider.aclose()
+
+
+@pytest.mark.asyncio
 async def test_normalizes_native_tool_decision_and_usage() -> None:
     call = SimpleNamespace(
         id="call-1",

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -33,17 +33,6 @@ from dev_health_ops.llm.agent.readiness import (
 )
 from dev_health_ops.llm.agent.roles import RoleCertificationState
 
-# A model whose per-byte reasoning-token cost is high enough that the
-# production-sized legacy_agent request (full 9-tool registry + fixed policy
-# sections + full DevAnswer grammar -- measured ~51-65 KB serialized wire
-# request for this probe's fixtures) exceeds the 4,096-token flat envelope
-# (TRD Option B -- this PR does not change that cap), while the ~0.5-1.5 KB
-# transport-echo probe's own request stays comfortably under its own
-# 512-token cap. 0.15 tokens/byte gives ~7.8K reasoning tokens for the
-# production request (1.9x over the 4,096 cap) and ~230 for the echo
-# request (2.2x under its 512 cap) -- wide margins in both directions, not a
-# knife-edge calibration.
-_NONCOMPLIANT_TOKENS_PER_BYTE = 0.15
 # A model whose per-byte cost is low enough that even the full
 # production-sized request (~65 KB) stays well inside the 4,096-token
 # envelope (~1.3K reasoning tokens at this rate).
@@ -96,6 +85,15 @@ class _RequestSizeDrivenClient:
         self.requests: list[dict[str, Any]] = []
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
 
+    def reasoning_tokens_for(self, kwargs: dict[str, Any]) -> int:
+        """The deterministic function under test: reasoning cost as a
+        function of the REAL serialized request. Exposed so counterfactual
+        tests can evaluate it against a modified copy of a captured request
+        without needing a second live round-trip."""
+
+        serialized = json.dumps(kwargs, sort_keys=True, default=str).encode("utf-8")
+        return round(len(serialized) * self._tokens_per_byte)
+
     async def _create(self, **kwargs: Any) -> Any:
         self.requests.append(kwargs)
         tools = kwargs.get("tools") or []
@@ -104,7 +102,7 @@ class _RequestSizeDrivenClient:
             self._echo_mode = "readiness_echo_v1" in tool_names
 
         serialized = json.dumps(kwargs, sort_keys=True, default=str).encode("utf-8")
-        reasoning_tokens = round(len(serialized) * self._tokens_per_byte)
+        reasoning_tokens = self.reasoning_tokens_for(kwargs)
         max_completion = int(kwargs["max_completion_tokens"])
         if reasoning_tokens >= max_completion:
             return _stub_response(
@@ -161,33 +159,126 @@ class _Store:
         self.record = record
 
 
+async def _uncalibrated_round_requests() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run the real probe against a client that never exhausts (rate 0), to
+    observe the two real request shapes it sends without inducing exhaustion.
+    Calibration is derived from these -- never a hand-guessed rate."""
+
+    provider, client = _provider(tokens_per_byte=0.0)
+    result = await certify_legacy_agent(provider, timeout_seconds=30)
+    assert result.state is RoleCertificationState.COMPATIBLE, (
+        "calibration precondition failed: a rate of 0 must never exhaust"
+    )
+    assert len(client.requests) == 2
+    return client.requests[0], client.requests[1]
+
+
+def _without_grammar(round_2: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in round_2.items() if key != "response_format"}
+
+
+def _without_history(
+    round_1: dict[str, Any], round_2: dict[str, Any]
+) -> dict[str, Any]:
+    """Round 2's shape (tool_choice=auto, the strict grammar) with round 1's
+    own tool-result-free messages -- isolates the grammar dimension from the
+    accumulated tool-result history dimension."""
+
+    without_history = dict(round_2)
+    without_history["messages"] = round_1["messages"]
+    return without_history
+
+
+def _calibrate_noncompliant_rate(
+    round_1: dict[str, Any], round_2: dict[str, Any], *, cap: int
+) -> float:
+    """Find a tokens-per-byte rate where round 1 alone stays under the cap,
+    EITHER of round 2's two structural additions (the strict grammar,
+    the tool-result history) alone also stays under the cap, and only their
+    COMBINATION -- round 2 as actually sent -- reaches it. This is what
+    "round 2 alone exhausts, and both dimensions are required" means as a
+    falsifiable, calibrated claim rather than "the request is big."
+    """
+
+    client = _RequestSizeDrivenClient(tokens_per_byte=1.0)
+    insufficient_alone = max(
+        client.reasoning_tokens_for(round_1),
+        client.reasoning_tokens_for(_without_grammar(round_2)),
+        client.reasoning_tokens_for(_without_history(round_1, round_2)),
+    )
+    full_combination = client.reasoning_tokens_for(round_2)
+    lower = cap / full_combination
+    upper = cap / insufficient_alone
+    assert lower < upper, (
+        "no rate exists where round 1 and each single dimension of round 2 "
+        "stay under the cap while their combination exceeds it -- the "
+        "production request shape changed enough that this calibration "
+        "needs to be revisited, not silently forced"
+    )
+    return (lower + upper) / 2
+
+
 @pytest.mark.asyncio
 async def test_production_sized_legacy_probe_reproduces_exhaustion() -> None:
-    """The new probe (RED): reproduces OUTPUT_EXHAUSTED for a provider whose
-    reasoning cost, applied to the real production request shape, exceeds
-    the 4,096-token envelope."""
+    """The new probe (RED): round 1 (tools offered, no grammar, no tool
+    result yet) succeeds; round 2 alone -- the combined tool_choice="auto"
+    AND strict DevAnswer grammar AND accumulated tool-result history shape
+    every real round >= 2 sends -- is what exhausts the 4,096-token envelope
+    (TRD Option B; this PR does not change that cap)."""
 
-    provider, client = _provider(tokens_per_byte=_NONCOMPLIANT_TOKENS_PER_BYTE)
+    round_1_shape, round_2_shape = await _uncalibrated_round_requests()
+    rate = _calibrate_noncompliant_rate(round_1_shape, round_2_shape, cap=4096)
+
+    provider, client = _provider(tokens_per_byte=rate)
     result = await certify_legacy_agent(provider, timeout_seconds=30)
 
     assert result.state is RoleCertificationState.INCOMPATIBLE
     assert result.safe_error_code == "output_exhausted"
+    assert len(client.requests) == 2
+
+    round_1, round_2 = client.requests
+    # Round 1 genuinely succeeded (did not itself exhaust) -- the defect is
+    # specifically in round 2, not "any request this size fails."
+    assert round_1.get("tool_choice") == "required"
+    assert "response_format" not in round_1
+    assert client.reasoning_tokens_for(round_1) < round_1["max_completion_tokens"]
+
+    # Round 2 is the one that exhausted, and carries exactly the claimed
+    # combined shape.
+    assert round_2.get("tool_choice") == "auto"
+    response_format = round_2.get("response_format")
+    assert response_format is not None
+    assert response_format["json_schema"]["strict"] is True
+    max_completion = round_2["max_completion_tokens"]
+    assert client.reasoning_tokens_for(round_2) >= max_completion
+
+    # Counterfactuals: removing EITHER dimension alone -- the grammar, or
+    # the accumulated tool-result history -- avoids exhaustion at this same
+    # rate. Only their combination does.
+    assert client.reasoning_tokens_for(_without_grammar(round_2)) < max_completion
+    assert (
+        client.reasoning_tokens_for(_without_history(round_1, round_2)) < max_completion
+    )
+
     # Sanity: the request that triggered exhaustion really was
     # production-sized, not a shrunk stand-in (Rule 4).
-    assert len(client.requests) >= 1
-    round_1_request = client.requests[0]
-    round_1_bytes = len(json.dumps(round_1_request, sort_keys=True, default=str))
-    assert round_1_bytes >= _PRODUCTION_FLOOR_BYTES
+    assert (
+        len(json.dumps(round_2, sort_keys=True, default=str)) >= _PRODUCTION_FLOOR_BYTES
+    )
 
 
 @pytest.mark.asyncio
 async def test_transport_echo_probe_does_not_reproduce_exhaustion() -> None:
     """The OLD probe (fail-before pair): the exact same non-compliant
-    provider certifies READY under the pre-existing 512-token echo probe,
-    because that probe's request is never production-sized. This is what
-    makes the new probe an actual gap-closer, not a redundant check."""
+    provider (calibrated against the production request shape) certifies
+    READY under the pre-existing 512-token echo probe, because that probe's
+    request is never production-sized. This is what makes the new probe an
+    actual gap-closer, not a redundant check."""
 
-    provider, client = _provider(tokens_per_byte=_NONCOMPLIANT_TOKENS_PER_BYTE)
+    round_1_shape, round_2_shape = await _uncalibrated_round_requests()
+    rate = _calibrate_noncompliant_rate(round_1_shape, round_2_shape, cap=4096)
+
+    provider, client = _provider(tokens_per_byte=rate)
     store = _Store()
     record = await AgentReadinessService(store).certify(
         provider,
@@ -253,6 +344,9 @@ class _InMemoryRoleStore:
 
     async def save(self, profile) -> None:
         self.profile = profile
+
+    async def save_record(self, record) -> None:
+        self.profile = self.profile.with_record(record)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -411,6 +411,20 @@ def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
     no real structure at all. Compare the ``kind`` property -- the field
     every decision variant depends on -- against the REAL generated schema
     field-for-field, not just its presence.
+
+    CHAOS-3285 round 6 (Codex MEDIUM): comparing only ``properties`` (round
+    5's fix) is STILL insufficient -- deleting the schema's top-level
+    ``$defs`` (leaving a dangling ``$ref`` inside a ``properties`` value
+    that points at a now-missing definition, e.g. ``AnswerStatus``) never
+    touches ``properties`` itself, so a properties-only comparison cannot
+    see it; neither can a mutation to the top-level ``type`` or
+    ``additionalProperties``, both siblings of ``properties``, not inside
+    it. Compare the COMPLETE schema tree -- every key ``_decision_response_
+    schema`` actually returns -- against the real one, not a sub-dict of
+    it. Per the ratified calibration-completeness threat-model policy, this
+    is the LAST round of narrowing this comparison: from field-presence, to
+    one field, to a sub-tree, to the complete tree everything else was
+    compared against.
     """
 
     response_format = round_2.get("response_format")
@@ -431,13 +445,14 @@ def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
         "-- padding does not substitute for the actual schema shape"
     )
 
-    real_properties = _real_decision_schema()["properties"]
-    assert properties == real_properties, (
-        "grammar's full properties tree does not match the real generated "
-        "schema -- comparing only 'kind' (round 5) is insufficient: every "
-        "OTHER property could still be retyped to {'type': 'null'} with "
-        "padding, and 'kind' alone would never catch it (CHAOS-3285 round "
-        "6, Codex MEDIUM)"
+    real_schema = _real_decision_schema()
+    assert schema == real_schema, (
+        "grammar's COMPLETE schema tree does not match the real generated "
+        "schema -- comparing only 'properties' (round 6) or only 'kind' "
+        "(round 5) is insufficient: deleting $defs (dangling $ref), or "
+        "changing the top-level type/additionalProperties, touches "
+        "neither and would never be caught by a sub-tree comparison "
+        "(CHAOS-3285 round 6, Codex MEDIUM)"
     )
 
 
@@ -854,8 +869,60 @@ async def test_calibration_fails_loudly_on_a_kind_preserved_all_null_schema() ->
         }
     }
 
-    with pytest.raises(AssertionError, match="full properties tree does not match"):
+    with pytest.raises(AssertionError, match="COMPLETE schema tree does not match"):
         _calibrate_noncompliant_rate(round_1, kind_preserved_schema, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_when_defs_is_deleted() -> None:
+    """CHAOS-3285 round 6 (Codex MEDIUM), codex's exact repro: deleting the
+    schema's top-level $defs leaves a DANGLING $ref inside properties
+    (properties.value.anyOf[0].properties.status.$ref points at
+    "#/$defs/AnswerStatus", which no longer exists) -- properties itself
+    is completely untouched, so a properties-only comparison (this
+    round's earlier state) would never catch it. The full schema-tree
+    comparison must."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_schema = round_2["response_format"]["json_schema"]["schema"]
+    assert "$defs" in real_schema, "sanity: the real schema must have $defs to delete"
+    mutated_schema = {
+        key: value for key, value in real_schema.items() if key != "$defs"
+    }
+    defs_deleted = dict(round_2)
+    defs_deleted["response_format"] = {
+        "json_schema": {"strict": True, "schema": mutated_schema}
+    }
+
+    with pytest.raises(AssertionError, match="COMPLETE schema tree does not match"):
+        _calibrate_noncompliant_rate(round_1, defs_deleted, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_when_answerstatus_definition_is_corrupted() -> (
+    None
+):
+    """Same guard: $defs.AnswerStatus corrupted (its real enum values
+    stripped) while properties itself is completely untouched -- also
+    invisible to a properties-only comparison, since the corruption lives
+    entirely in the sibling $defs key."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_schema = round_2["response_format"]["json_schema"]["schema"]
+    real_defs = real_schema.get("$defs")
+    assert isinstance(real_defs, dict) and "AnswerStatus" in real_defs, (
+        "sanity: the real schema must define AnswerStatus to corrupt"
+    )
+    corrupted_defs = dict(real_defs)
+    corrupted_defs["AnswerStatus"] = {"type": "string"}  # real enum values stripped
+    mutated_schema = {**real_schema, "$defs": corrupted_defs}
+    answerstatus_corrupted = dict(round_2)
+    answerstatus_corrupted["response_format"] = {
+        "json_schema": {"strict": True, "schema": mutated_schema}
+    }
+
+    with pytest.raises(AssertionError, match="COMPLETE schema tree does not match"):
+        _calibrate_noncompliant_rate(round_1, answerstatus_corrupted, cap=4096)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -25,7 +25,10 @@ from dev_health_ops.api.dev.prompts.composer import (
     LEGACY_PROMPT_VERSION,
     PROMPT_VERSION,
 )
-from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.llm.agent.openai_compatible import (
+    _DECISION_FIELDS,
+    OpenAICompatibleAgentProvider,
+)
 from dev_health_ops.llm.agent.probes.legacy_agent import (
     _PRODUCTION_FLOOR_BYTES,
     _assert_production_shape,
@@ -369,6 +372,70 @@ _MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES = 1_500
 _MIN_CALIBRATION_RELATIVE_MARGIN = 1.03
 
 
+def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
+    """CHAOS-3285 round 4 (Codex MEDIUM): byte-size margins ALONE can be
+    satisfied by PADDING -- a large ``description`` string stuffed into an
+    otherwise-empty schema, with no real ``properties``/``required`` -- so a
+    mutation that gutted the grammar's actual structure but kept its byte
+    size large would still clear the margin checks below. Assert the real
+    decision-schema shape is present BEFORE trusting any byte margin:
+    non-empty ``properties``, and a ``required`` set matching the real
+    decision envelope (``_DECISION_FIELDS``, the actual producer -- never a
+    hand-guessed field list)."""
+
+    response_format = round_2.get("response_format")
+    assert isinstance(response_format, dict), "round 2 must carry a response_format"
+    json_schema = response_format.get("json_schema")
+    assert isinstance(json_schema, dict), "response_format must wrap a json_schema"
+    assert json_schema.get("strict") is True, "grammar must be strict"
+    schema = json_schema.get("schema")
+    assert isinstance(schema, dict), "json_schema must carry a schema body"
+    properties = schema.get("properties")
+    assert isinstance(properties, dict) and properties, (
+        "grammar has no real schema properties -- padding a description "
+        "string does not substitute for actual grammar structure"
+    )
+    required = schema.get("required")
+    assert isinstance(required, list) and set(required) == _DECISION_FIELDS, (
+        "grammar's required fields do not match the real decision envelope "
+        "-- padding does not substitute for the actual schema shape"
+    )
+
+
+def _assert_structurally_real_history(round_2: dict[str, Any]) -> None:
+    """Same guard for the accumulated tool-result history dimension: a
+    large padded content string in the assistant/tool messages is not the
+    same as a real tool request followed by a schema-shaped tool result."""
+
+    messages = round_2.get("messages")
+    assert isinstance(messages, list) and len(messages) >= 4, (
+        "round 2 must carry the full history shape: system, user, "
+        "assistant tool-request, tool result"
+    )
+    assistant_message = messages[2]
+    assert assistant_message.get("role") == "assistant"
+    tool_calls = assistant_message.get("tool_calls")
+    assert isinstance(tool_calls, list) and tool_calls, (
+        "history's assistant message has no real tool_calls -- padding "
+        "content does not substitute for a real tool request"
+    )
+    tool_message = messages[3]
+    assert tool_message.get("role") == "tool"
+    content = tool_message.get("content")
+    assert isinstance(content, str)
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        parsed = None
+    assert isinstance(parsed, dict) and {"run_id", "tool_id", "tool_call_id"} <= set(
+        parsed
+    ), (
+        "history's tool message content is not a schema-shaped tool "
+        "result -- padding does not substitute for real tool-result "
+        "structure"
+    )
+
+
 def _calibrate_noncompliant_rate(
     round_1: dict[str, Any], round_2: dict[str, Any], *, cap: int
 ) -> float:
@@ -384,8 +451,15 @@ def _calibrate_noncompliant_rate(
     difference is not a real proof that the grammar or the history
     dimension matters -- it means the probe's production shape has become
     degenerate (round 1 and round 2 barely differ) and this calibration
-    must refuse to silently produce a knife-edge rate.
+    must refuse to silently produce a knife-edge rate. CHAOS-3285 round 4
+    (Codex MEDIUM): byte margins are necessary but NOT sufficient -- a
+    padded-but-structurally-empty grammar or history can satisfy them
+    without the dimension actually contributing any real structure, so
+    semantic-structure checks run FIRST, before any byte-margin math.
     """
+
+    _assert_structurally_real_grammar(round_2)
+    _assert_structurally_real_history(round_2)
 
     client = _RequestSizeDrivenClient(tokens_per_byte=1.0)
     insufficient_alone = max(
@@ -429,7 +503,10 @@ async def test_calibration_fails_loudly_when_the_grammar_degenerates() -> None:
     round 2's size were to collapse to near-nothing -- simulating a future
     regression that degenerates the combined-shape claim -- calibration
     must refuse to proceed with a knife-edge rate, not silently pick one
-    that no longer proves the grammar dimension matters."""
+    that no longer proves the grammar dimension matters. CHAOS-3285 round 4:
+    an empty schema is caught by the structural check now, before it would
+    even reach the byte-margin math -- a strictly earlier, more precise
+    failure than before."""
 
     round_1, round_2 = await _uncalibrated_round_requests()
     degenerate_grammar = dict(round_2)
@@ -437,7 +514,7 @@ async def test_calibration_fails_loudly_when_the_grammar_degenerates() -> None:
         "json_schema": {"strict": True, "schema": {}}
     }
 
-    with pytest.raises(AssertionError, match="calibration margin too small"):
+    with pytest.raises(AssertionError, match="no real schema properties"):
         _calibrate_noncompliant_rate(round_1, degenerate_grammar, cap=4096)
 
 
@@ -446,14 +523,67 @@ async def test_calibration_fails_loudly_when_the_history_degenerates() -> None:
     """Same guard, for the accumulated tool-result history dimension: if
     round 2's messages collapsed to be identical to round 1's (the
     synthetic tool result contributing nothing), calibration must refuse
-    to proceed."""
+    to proceed. CHAOS-3285 round 4: round 1 has only 2 messages (no
+    assistant tool-request, no tool result), so the structural shape check
+    now catches this before the byte-margin math."""
 
     round_1, round_2 = await _uncalibrated_round_requests()
     degenerate_history = dict(round_2)
     degenerate_history["messages"] = round_1["messages"]
 
-    with pytest.raises(AssertionError, match="calibration margin too small"):
+    with pytest.raises(AssertionError, match="full history shape"):
         _calibrate_noncompliant_rate(round_1, degenerate_history, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_padded_but_structurally_empty_grammar() -> (
+    None
+):
+    """CHAOS-3285 round 4 (Codex MEDIUM): byte-size margins ALONE can be
+    satisfied by PADDING -- a large ``description`` string stuffed into an
+    otherwise-empty schema, with no real ``properties``/``required`` -- so a
+    mutant that gutted the grammar's actual structure while keeping its
+    byte size large would previously have cleared the (byte-only) margin
+    checks. Structural checks must catch this even though the byte margin
+    would pass."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    padded_empty_grammar = dict(round_2)
+    padded_empty_grammar["response_format"] = {
+        "json_schema": {
+            "strict": True,
+            # Padded well past _MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES --
+            # the byte-margin check alone would pass this.
+            "schema": {"description": "x" * 5_000},
+        }
+    }
+
+    with pytest.raises(AssertionError, match="no real schema properties"):
+        _calibrate_noncompliant_rate(round_1, padded_empty_grammar, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_padded_but_structurally_empty_history() -> (
+    None
+):
+    """Same guard for history: a large padded content string in the
+    assistant/tool messages is not the same as a real tool request followed
+    by a schema-shaped tool result, even when it is byte-large enough to
+    clear the margin checks on its own."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    padded_empty_history = dict(round_2)
+    padded_empty_history["messages"] = [
+        round_2["messages"][0],
+        round_2["messages"][1],
+        # Padded well past _MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES, but no
+        # real tool_calls -- not a real tool request.
+        {"role": "assistant", "content": "x" * 5_000},
+        {"role": "tool", "content": "x" * 5_000, "tool_call_id": "stub"},
+    ]
+
+    with pytest.raises(AssertionError, match="no real tool_calls"):
+        _calibrate_noncompliant_rate(round_1, padded_empty_history, cap=4096)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -169,44 +169,63 @@ async def _uncalibrated_round_requests() -> tuple[dict[str, Any], dict[str, Any]
     it sends without inducing exhaustion. Calibration is derived from
     these -- never a hand-guessed rate.
 
-    CHAOS-3285 round 2 (Codex HIGH): the probe now sends a THIRD request --
-    round 2 again under the uncommitted-subject prompt shape
-    (LEGACY_PROMPT_VERSION), proving that shape too rather than only ever
-    exercising the committed one. This calibration helper deliberately
-    keeps using only the first two (round 1 and the committed round 2):
-    the combined-shape claim it exists to prove (tool_choice="auto" + the
-    strict grammar + accumulated history, together, is what exhausts) is
-    the same claim for either prompt shape, and testing it twice here would
-    duplicate coverage rather than add any."""
+    CHAOS-3285 round 4 (Codex HIGH): the probe now runs two fully
+    independent chains -- committed-subject (requests[0], requests[1]) and
+    uncommitted-subject (requests[2], requests[3]) -- four requests total.
+    This calibration helper deliberately keeps using only the committed
+    chain's two requests: the combined-shape claim it exists to prove
+    (tool_choice="auto" + the strict grammar + accumulated history,
+    together, is what exhausts) is the same claim for either prompt shape,
+    and testing it twice here would duplicate coverage rather than add
+    any."""
 
     provider, client = _provider(tokens_per_byte=0.0)
     result = await certify_legacy_agent(provider, timeout_seconds=30)
     assert result.state is RoleCertificationState.COMPATIBLE, (
         "calibration precondition failed: a rate of 0 must never exhaust"
     )
-    assert len(client.requests) == 3
+    assert len(client.requests) == 4
     return client.requests[0], client.requests[1]
 
 
 @pytest.mark.asyncio
 async def test_certify_legacy_agent_probes_both_prompt_shapes() -> None:
-    """CHAOS-3285 round 2 (Codex HIGH): before this fix, the probe forced
+    """CHAOS-3285 round 2 (Codex HIGH): before that fix, the probe forced
     ``subject_committed=True`` unconditionally, so PromptComposer's OTHER
     shape -- ``LEGACY_PROMPT_VERSION`` (uncommitted subject / the Wave 3.1
-    flag off) -- was never exercised at all, and the fingerprint never
-    folded that constant either, so a text-only change to only that shape
-    invalidated nothing. Prove both shapes are now actually sent, not just
-    that a fingerprint constant changed."""
+    flag off) -- was never exercised at all. CHAOS-3285 round 4 (Codex
+    HIGH): round 1 itself is now also composed under each chain's own
+    shape (it was previously ALWAYS committed-subject, even for the
+    "uncommitted" chain's round 2, which then reused round 1's committed
+    tool request/result). Prove all four requests -- both rounds, both
+    shapes -- are genuinely distinct and shape-correct."""
 
     provider, client = _provider(tokens_per_byte=0.0)
     result = await certify_legacy_agent(provider, timeout_seconds=30)
 
     assert result.state is RoleCertificationState.COMPATIBLE
-    assert len(client.requests) == 3
+    assert len(client.requests) == 4
 
-    round_2_committed, round_2_uncommitted = client.requests[1], client.requests[2]
-    # Both are the same worst-case combined shape (tool_choice="auto" + the
-    # strict grammar)...
+    round_1_committed, round_2_committed, round_1_uncommitted, round_2_uncommitted = (
+        client.requests
+    )
+
+    # Round 1: tool_choice="required", no grammar yet, under EACH chain's
+    # own shape -- the exact combination round 4 found was never sent for
+    # the uncommitted chain before this fix.
+    for round_1 in (round_1_committed, round_1_uncommitted):
+        assert round_1.get("tool_choice") == "required"
+        assert "response_format" not in round_1
+    round_1_committed_text = round_1_committed["messages"][0]["content"]
+    round_1_uncommitted_text = round_1_uncommitted["messages"][0]["content"]
+    assert round_1_committed_text != round_1_uncommitted_text
+    assert PROMPT_VERSION in round_1_committed_text
+    assert PROMPT_VERSION not in round_1_uncommitted_text
+    assert LEGACY_PROMPT_VERSION in round_1_uncommitted_text
+    assert LEGACY_PROMPT_VERSION not in round_1_committed_text
+
+    # Round 2: both are the same worst-case combined shape (tool_choice=
+    # "auto" + the strict grammar)...
     for request in (round_2_committed, round_2_uncommitted):
         assert request.get("tool_choice") == "auto"
         assert request.get("response_format") is not None
@@ -221,6 +240,103 @@ async def test_certify_legacy_agent_probes_both_prompt_shapes() -> None:
     assert PROMPT_VERSION not in uncommitted_system_text
     assert LEGACY_PROMPT_VERSION in uncommitted_system_text
     assert LEGACY_PROMPT_VERSION not in committed_system_text
+
+
+class _UncommittedRound1DefectClient:
+    """A provider that fails ONLY on round 1's own ``tool_choice="required"``
+    shape under the uncommitted-subject prompt -- the committed chain
+    entirely, and the uncommitted chain's round 2, all succeed normally.
+    Isolates the exact combination CHAOS-3285 round 4 (Codex HIGH) found
+    was never sent to the provider at all before this fix (round 1 was
+    always composed committed-subject, and round 2's uncommitted call
+    reused round 1's committed tool request/result)."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        tools = kwargs.get("tools") or []
+        system_text = str(kwargs["messages"][0]["content"])
+        serialized = json.dumps(kwargs, sort_keys=True, default=str).encode("utf-8")
+
+        if (
+            kwargs.get("tool_choice") == "required"
+            and LEGACY_PROMPT_VERSION in system_text
+        ):
+            # The defect: this exact shape exhausts every time.
+            max_completion = int(kwargs["max_completion_tokens"])
+            return _stub_response(
+                finish_reason="length",
+                content="",
+                tool_calls=None,
+                prompt_tokens=len(serialized) // 4,
+                completion_tokens=max_completion,
+                reasoning_tokens=max_completion,
+            )
+
+        if kwargs.get("tool_choice") == "required":
+            name = str(tools[0]["function"]["name"])
+            return _stub_response(
+                finish_reason="tool_calls",
+                content=None,
+                tool_calls=[_stub_tool_call(name=name, arguments={})],
+                prompt_tokens=len(serialized) // 4,
+                completion_tokens=8,
+                reasoning_tokens=8,
+            )
+
+        return _stub_response(
+            finish_reason="stop",
+            content=json.dumps(
+                {
+                    "kind": "final_answer",
+                    "value": {
+                        "status": "complete",
+                        "direct_summary": "Stub legacy_agent answer.",
+                    },
+                }
+            ),
+            tool_calls=None,
+            prompt_tokens=len(serialized) // 4,
+            completion_tokens=12,
+            reasoning_tokens=12,
+        )
+
+
+@pytest.mark.asyncio
+async def test_certify_legacy_agent_fails_on_a_defect_isolated_to_uncommitted_round_1() -> (
+    None
+):
+    """CHAOS-3285 round 4 (Codex HIGH): a provider that fails ONLY on the
+    combination of the uncommitted-subject prompt (LEGACY_PROMPT_VERSION)
+    AND round 1's own tool_choice="required" shape must certify as failing
+    overall -- not COMPATIBLE. Before this fix, round 1 was ALWAYS composed
+    under subject_committed=True regardless of which chain it fed, so this
+    exact combination was never sent to the provider at all, and a provider
+    genuinely broken on it would still have certified COMPATIBLE."""
+
+    client = _UncommittedRound1DefectClient()
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used",
+        model="gpt-5-nano",
+        base_url="http://127.0.0.1:1/v1",
+        client=client,
+    )
+
+    result = await certify_legacy_agent(provider, timeout_seconds=30)
+
+    assert result.state is not RoleCertificationState.COMPATIBLE
+    # The defect really was reached -- round 1 under the uncommitted shape
+    # was actually sent, not skipped or silently reusing the committed
+    # chain's round 1.
+    uncommitted_round_1_sent = any(
+        request.get("tool_choice") == "required"
+        and LEGACY_PROMPT_VERSION in str(request["messages"][0]["content"])
+        for request in client.requests
+    )
+    assert uncommitted_round_1_sent
 
 
 def _without_grammar(round_2: dict[str, Any]) -> dict[str, Any]:

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -239,6 +239,20 @@ def _without_history(
     return without_history
 
 
+# CHAOS-3285 round 2 (Codex MEDIUM): the calibration window
+# (cap/full_combination, cap/insufficient_alone) is non-empty for ANY
+# strictly-positive byte difference, even one byte -- that alone proves
+# nothing about whether the grammar/history dimensions meaningfully drive
+# exhaustion, only that they are non-identical. These margins require the
+# combined shape to be substantively larger than the largest single
+# dimension, in both absolute and relative terms, before trusting the
+# calibration at all. Measured against the real production shapes this
+# probe currently sends: absolute margin ~3.7 KB, relative margin ~6% --
+# both comfortably clear these floors with room for prompt-text drift.
+_MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES = 1_500
+_MIN_CALIBRATION_RELATIVE_MARGIN = 1.03
+
+
 def _calibrate_noncompliant_rate(
     round_1: dict[str, Any], round_2: dict[str, Any], *, cap: int
 ) -> float:
@@ -248,6 +262,13 @@ def _calibrate_noncompliant_rate(
     COMBINATION -- round 2 as actually sent -- reaches it. This is what
     "round 2 alone exhausts, and both dimensions are required" means as a
     falsifiable, calibrated claim rather than "the request is big."
+
+    Rule 4 (a measurement that did not happen must fail loudly): a
+    calibration window that exists only because of a trivial byte
+    difference is not a real proof that the grammar or the history
+    dimension matters -- it means the probe's production shape has become
+    degenerate (round 1 and round 2 barely differ) and this calibration
+    must refuse to silently produce a knife-edge rate.
     """
 
     client = _RequestSizeDrivenClient(tokens_per_byte=1.0)
@@ -258,6 +279,23 @@ def _calibrate_noncompliant_rate(
     )
     full_combination = client.reasoning_tokens_for(round_2)
 
+    absolute_margin = full_combination - insufficient_alone
+    relative_margin = (
+        full_combination / insufficient_alone if insufficient_alone else float("inf")
+    )
+    assert absolute_margin >= _MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES, (
+        f"calibration margin too small ({absolute_margin} bytes < "
+        f"{_MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES}) -- the probe's production "
+        "shape is degenerate: neither the grammar nor the accumulated "
+        "tool-result history contributes enough size to isolate the "
+        "combined-shape claim from noise, not just calibrate a valid rate"
+    )
+    assert relative_margin >= _MIN_CALIBRATION_RELATIVE_MARGIN, (
+        f"calibration margin too small ({relative_margin:.3f}x < "
+        f"{_MIN_CALIBRATION_RELATIVE_MARGIN}x) -- same degenerate-shape failure "
+        "as the absolute margin check, expressed relatively"
+    )
+
     lower = cap / full_combination
     upper = cap / insufficient_alone
     assert lower < upper, (
@@ -267,6 +305,39 @@ def _calibrate_noncompliant_rate(
         "needs to be revisited, not silently forced"
     )
     return (lower + upper) / 2
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_when_the_grammar_degenerates() -> None:
+    """Mutation test (Rule 3/4): if the DevAnswer grammar's contribution to
+    round 2's size were to collapse to near-nothing -- simulating a future
+    regression that degenerates the combined-shape claim -- calibration
+    must refuse to proceed with a knife-edge rate, not silently pick one
+    that no longer proves the grammar dimension matters."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    degenerate_grammar = dict(round_2)
+    degenerate_grammar["response_format"] = {
+        "json_schema": {"strict": True, "schema": {}}
+    }
+
+    with pytest.raises(AssertionError, match="calibration margin too small"):
+        _calibrate_noncompliant_rate(round_1, degenerate_grammar, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_when_the_history_degenerates() -> None:
+    """Same guard, for the accumulated tool-result history dimension: if
+    round 2's messages collapsed to be identical to round 1's (the
+    synthetic tool result contributing nothing), calibration must refuse
+    to proceed."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    degenerate_history = dict(round_2)
+    degenerate_history["messages"] = round_1["messages"]
+
+    with pytest.raises(AssertionError, match="calibration margin too small"):
+        _calibrate_noncompliant_rate(round_1, degenerate_history, cap=4096)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -431,11 +431,13 @@ def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
         "-- padding does not substitute for the actual schema shape"
     )
 
-    real_kind_property = _real_decision_schema()["properties"]["kind"]
-    assert properties.get("kind") == real_kind_property, (
-        "grammar's 'kind' property does not match the real generated "
-        "schema's non-null decision-kind enum -- an inert (e.g. all-null) "
-        "grammar does not substitute for the actual decision-kind field"
+    real_properties = _real_decision_schema()["properties"]
+    assert properties == real_properties, (
+        "grammar's full properties tree does not match the real generated "
+        "schema -- comparing only 'kind' (round 5) is insufficient: every "
+        "OTHER property could still be retyped to {'type': 'null'} with "
+        "padding, and 'kind' alone would never catch it (CHAOS-3285 round "
+        "6, Codex MEDIUM)"
     )
 
 
@@ -511,6 +513,44 @@ def _assert_structurally_real_history(round_2: dict[str, Any]) -> None:
             f"DevToolResult -- padding/all-null fields do not substitute "
             f"for a real tool-result payload: {exc}"
         ) from exc
+
+    # CHAOS-3285 round 6 (Codex MEDIUM), codex's exact repro: a VALID
+    # DevToolResult -- schema_version/run_id/tool_call_id/tool_id/status all
+    # present and well-formed -- can still be an "empty-success" result:
+    # every data field empty, serialized_bytes falsely claimed as 0 while
+    # padded "warnings" entries make the real payload kilobytes large.
+    # Pydantic validation alone (above) does not catch either defect: it
+    # has no cross-field rule tying serialized_bytes to the real encoded
+    # size, and "no data" is a legitimately valid (if useless) DevToolResult
+    # shape on its own.
+    declared_bytes = parsed.get("serialized_bytes")
+    assert isinstance(declared_bytes, int), "serialized_bytes must be an integer"
+    actual_bytes = len(
+        json.dumps(parsed, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    assert actual_bytes > 0
+    relative_error = abs(declared_bytes - actual_bytes) / actual_bytes
+    assert relative_error <= 0.2, (
+        f"tool result's declared serialized_bytes ({declared_bytes}) does "
+        f"not match its actual encoded size ({actual_bytes} bytes, "
+        f"{relative_error:.1%} off) -- a claimed byte count this far from "
+        "reality (e.g. serialized_bytes=0 padded with kilobytes of "
+        "warnings) is not a truthful tool-result payload"
+    )
+
+    has_real_data = bool(
+        parsed.get("scope_resolution")
+        or parsed.get("metrics")
+        or parsed.get("metric_definitions")
+        or parsed.get("evidence")
+    )
+    assert has_real_data, (
+        "tool result has no real data-bearing content -- "
+        "scope_resolution/metrics/metric_definitions/evidence are all "
+        "empty. An 'empty-success' result (status='success', everything "
+        "else empty, padded only with warnings) is not a representative "
+        "production tool result"
+    )
 
 
 def _calibrate_noncompliant_rate(
@@ -739,6 +779,83 @@ async def test_calibration_fails_loudly_on_a_null_tool_result() -> None:
         AssertionError, match="does not validate as a real DevToolResult"
     ):
         _calibrate_noncompliant_rate(round_1, null_tool_result, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_an_empty_success_tool_result() -> None:
+    """CHAOS-3285 round 6 (Codex MEDIUM), codex's exact repro: a VALID
+    DevToolResult -- schema_version/run_id/tool_call_id/tool_id/status all
+    present and well-formed -- can still be an "empty-success" result:
+    every data field empty, serialized_bytes falsely claimed as 0 while a
+    padded "warnings" entry makes the real payload kilobytes large.
+    Pydantic validation alone (round 5's fix) does not catch either
+    defect: it has no cross-field rule tying serialized_bytes to the real
+    encoded size, and "no data" is a legitimately valid DevToolResult
+    shape on its own."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_call_id = round_2["messages"][2]["tool_calls"][0]["id"]
+    empty_success_result = {
+        "schema_version": "dev_tool_result.v1",
+        "run_id": "run_01",
+        "tool_call_id": real_call_id,
+        "tool_id": "query_metric.v1",
+        "status": "success",
+        "warnings": ["x" * 2_000],
+        "serialized_bytes": 0,
+    }
+    empty_success = dict(round_2)
+    empty_success["messages"] = [
+        round_2["messages"][0],
+        round_2["messages"][1],
+        round_2["messages"][2],
+        {
+            "role": "tool",
+            "tool_call_id": real_call_id,
+            "content": json.dumps(empty_success_result),
+        },
+    ]
+
+    with pytest.raises(
+        AssertionError,
+        match="does not match its actual encoded size",
+    ):
+        _calibrate_noncompliant_rate(round_1, empty_success, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_a_kind_preserved_all_null_schema() -> None:
+    """CHAOS-3285 round 6 (Codex MEDIUM), codex's exact repro: keep the
+    'kind' property EXACTLY matching the real schema -- satisfying round
+    5's kind-only comparison -- while retyping every OTHER property to
+    {"type": "null"} with description padding to keep the byte margins
+    satisfied. Comparing the FULL properties tree (not just kind) must
+    catch it."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_properties = round_2["response_format"]["json_schema"]["schema"]["properties"]
+    real_required = round_2["response_format"]["json_schema"]["schema"]["required"]
+    kind_preserved_properties = {
+        key: (
+            real_properties["kind"]
+            if key == "kind"
+            else {"type": "null", "description": "x" * 500}
+        )
+        for key in real_properties
+    }
+    kind_preserved_schema = dict(round_2)
+    kind_preserved_schema["response_format"] = {
+        "json_schema": {
+            "strict": True,
+            "schema": {
+                "properties": kind_preserved_properties,
+                "required": real_required,
+            },
+        }
+    }
+
+    with pytest.raises(AssertionError, match="full properties tree does not match"):
+        _calibrate_noncompliant_rate(round_1, kind_preserved_schema, cap=4096)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev.contracts import DevAnswer, DevToolResult
 from dev_health_ops.api.dev.prompts.composer import (
     LEGACY_PROMPT_VERSION,
     PROMPT_VERSION,
@@ -32,6 +33,8 @@ from dev_health_ops.llm.agent.openai_compatible import (
 from dev_health_ops.llm.agent.probes.legacy_agent import (
     _PRODUCTION_FLOOR_BYTES,
     _assert_production_shape,
+    _probe_registry,
+    _probe_tools,
     certify_legacy_agent,
 )
 from dev_health_ops.llm.agent.readiness import (
@@ -372,6 +375,25 @@ _MIN_CALIBRATION_ABSOLUTE_MARGIN_BYTES = 1_500
 _MIN_CALIBRATION_RELATIVE_MARGIN = 1.03
 
 
+def _real_decision_schema() -> dict[str, Any]:
+    """The real generated decision-envelope schema the legacy_agent probe's
+    round 2 actually sends -- built from the SAME real producers the probe
+    uses (the full 9-tool registry, the real ``DevAnswer`` schema), never
+    hand-authored. Used to compare the grammar's actual FIELD-LEVEL
+    structure, not just field presence (CHAOS-3285 round 5, Codex
+    MEDIUM)."""
+
+    registry = _probe_registry()
+    tools = _probe_tools(registry)
+    return OpenAICompatibleAgentProvider._decision_response_schema(
+        OpenAICompatibleAgentProvider._answer_draft_schema(
+            DevAnswer.model_json_schema(mode="validation")
+        ),
+        tools,
+        allow_final_answer=True,
+    )
+
+
 def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
     """CHAOS-3285 round 4 (Codex MEDIUM): byte-size margins ALONE can be
     satisfied by PADDING -- a large ``description`` string stuffed into an
@@ -381,7 +403,15 @@ def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
     decision-schema shape is present BEFORE trusting any byte margin:
     non-empty ``properties``, and a ``required`` set matching the real
     decision envelope (``_DECISION_FIELDS``, the actual producer -- never a
-    hand-guessed field list)."""
+    hand-guessed field list).
+
+    CHAOS-3285 round 5 (Codex MEDIUM): field PRESENCE alone is still not
+    enough -- an all-null grammar (every property typed ``{"type": "null"}``)
+    satisfies "non-empty properties, matching required keys" while carrying
+    no real structure at all. Compare the ``kind`` property -- the field
+    every decision variant depends on -- against the REAL generated schema
+    field-for-field, not just its presence.
+    """
 
     response_format = round_2.get("response_format")
     assert isinstance(response_format, dict), "round 2 must carry a response_format"
@@ -401,11 +431,31 @@ def _assert_structurally_real_grammar(round_2: dict[str, Any]) -> None:
         "-- padding does not substitute for the actual schema shape"
     )
 
+    real_kind_property = _real_decision_schema()["properties"]["kind"]
+    assert properties.get("kind") == real_kind_property, (
+        "grammar's 'kind' property does not match the real generated "
+        "schema's non-null decision-kind enum -- an inert (e.g. all-null) "
+        "grammar does not substitute for the actual decision-kind field"
+    )
+
 
 def _assert_structurally_real_history(round_2: dict[str, Any]) -> None:
     """Same guard for the accumulated tool-result history dimension: a
     large padded content string in the assistant/tool messages is not the
-    same as a real tool request followed by a schema-shaped tool result."""
+    same as a real tool request followed by a schema-shaped tool result.
+
+    CHAOS-3285 round 5 (Codex MEDIUM): a ``tool_calls`` list containing a
+    single empty dict (``[{}]``) satisfies "non-empty list" without
+    describing a real tool call, and a tool-result payload of
+    ``{"run_id": null, "tool_id": null, "tool_call_id": null}`` satisfies a
+    bare key-presence check without being usable at all. Validate the FULL
+    OpenAI wire shape a real tool call requires (nonempty id, type, a real
+    function name/arguments), that the tool result's ``tool_call_id``
+    genuinely matches the assistant's call id, and parse the tool result
+    content through the REAL ``DevToolResult`` model -- whose ``run_id``/
+    ``tool_id``/``tool_call_id`` fields are constrained to nonempty strings
+    -- rather than a bare dict-subset check.
+    """
 
     messages = round_2.get("messages")
     assert isinstance(messages, list) and len(messages) >= 4, (
@@ -419,21 +469,48 @@ def _assert_structurally_real_history(round_2: dict[str, Any]) -> None:
         "history's assistant message has no real tool_calls -- padding "
         "content does not substitute for a real tool request"
     )
+    tool_call = tool_calls[0]
+    assert isinstance(tool_call, dict), "tool call entry must be an object"
+    call_id = tool_call.get("id")
+    assert isinstance(call_id, str) and call_id, (
+        "tool call has no real (nonempty) id -- an empty tool_calls entry "
+        "does not substitute for a real tool request"
+    )
+    assert tool_call.get("type") == "function", "tool call must be type=function"
+    function = tool_call.get("function")
+    assert isinstance(function, dict), "tool call must carry a function object"
+    assert isinstance(function.get("name"), str) and function["name"], (
+        "tool call's function.name must be a real (nonempty) value"
+    )
+    assert isinstance(function.get("arguments"), str), (
+        "tool call's function.arguments must be a serialized string"
+    )
+
     tool_message = messages[3]
     assert tool_message.get("role") == "tool"
+    tool_call_id = tool_message.get("tool_call_id")
+    assert isinstance(tool_call_id, str) and tool_call_id, (
+        "tool result has no real (nonempty) tool_call_id"
+    )
+    assert tool_call_id == call_id, (
+        "tool result's tool_call_id does not match the assistant's tool "
+        "call id -- history is not a real request/result exchange"
+    )
     content = tool_message.get("content")
     assert isinstance(content, str)
     try:
         parsed = json.loads(content)
     except json.JSONDecodeError:
         parsed = None
-    assert isinstance(parsed, dict) and {"run_id", "tool_id", "tool_call_id"} <= set(
-        parsed
-    ), (
-        "history's tool message content is not a schema-shaped tool "
-        "result -- padding does not substitute for real tool-result "
-        "structure"
-    )
+    assert isinstance(parsed, dict), "tool result content must be a JSON object"
+    try:
+        DevToolResult.model_validate(parsed)
+    except Exception as exc:  # pydantic.ValidationError
+        raise AssertionError(
+            "history's tool message content does not validate as a real "
+            f"DevToolResult -- padding/all-null fields do not substitute "
+            f"for a real tool-result payload: {exc}"
+        ) from exc
 
 
 def _calibrate_noncompliant_rate(
@@ -584,6 +661,84 @@ async def test_calibration_fails_loudly_on_padded_but_structurally_empty_history
 
     with pytest.raises(AssertionError, match="no real tool_calls"):
         _calibrate_noncompliant_rate(round_1, padded_empty_history, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_an_all_null_grammar() -> None:
+    """CHAOS-3285 round 5 (Codex MEDIUM), codex's exact repro: a grammar
+    where every property is retyped ``{"type": "null"}`` satisfies "non-
+    empty properties, matching required keys" -- the round 4 checks --
+    while carrying no real structure at all (every field can only ever be
+    null). The per-field kind-property comparison against the real
+    generated schema must catch this."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_properties = round_2["response_format"]["json_schema"]["schema"]["properties"]
+    all_null_grammar = dict(round_2)
+    all_null_grammar["response_format"] = {
+        "json_schema": {
+            "strict": True,
+            "schema": {
+                "properties": {key: {"type": "null"} for key in real_properties},
+                "required": sorted(real_properties),
+            },
+        }
+    }
+
+    with pytest.raises(
+        AssertionError, match="does not match the real generated schema"
+    ):
+        _calibrate_noncompliant_rate(round_1, all_null_grammar, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_an_empty_tool_call() -> None:
+    """CHAOS-3285 round 5 (Codex MEDIUM), codex's exact repro:
+    ``tool_calls=[{}]`` (a list containing one empty dict) satisfies the
+    round 4 "non-empty list" check without describing a real tool call at
+    all."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    empty_tool_call = dict(round_2)
+    empty_tool_call["messages"] = [
+        round_2["messages"][0],
+        round_2["messages"][1],
+        {"role": "assistant", "tool_calls": [{}]},
+        round_2["messages"][3],
+    ]
+
+    with pytest.raises(AssertionError, match=r"no real \(nonempty\) id"):
+        _calibrate_noncompliant_rate(round_1, empty_tool_call, cap=4096)
+
+
+@pytest.mark.asyncio
+async def test_calibration_fails_loudly_on_a_null_tool_result() -> None:
+    """CHAOS-3285 round 5 (Codex MEDIUM), codex's exact repro: a tool
+    result of ``{"run_id": null, "tool_id": null, "tool_call_id": null}``
+    satisfies the round 4 bare key-presence check while being entirely
+    unusable. Parsing through the real ``DevToolResult`` model (whose
+    fields require nonempty values) must catch it."""
+
+    round_1, round_2 = await _uncalibrated_round_requests()
+    real_call_id = round_2["messages"][2]["tool_calls"][0]["id"]
+    null_tool_result = dict(round_2)
+    null_tool_result["messages"] = [
+        round_2["messages"][0],
+        round_2["messages"][1],
+        round_2["messages"][2],
+        {
+            "role": "tool",
+            "tool_call_id": real_call_id,
+            "content": json.dumps(
+                {"run_id": None, "tool_id": None, "tool_call_id": None}
+            ),
+        },
+    ]
+
+    with pytest.raises(
+        AssertionError, match="does not validate as a real DevToolResult"
+    ):
+        _calibrate_noncompliant_rate(round_1, null_tool_result, cap=4096)
 
 
 @pytest.mark.asyncio

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -1,0 +1,286 @@
+"""CHAOS-3285: the production-sized legacy_agent probe reproduces
+OUTPUT_EXHAUSTED where the synthetic transport-echo probe cannot, and clears
+a compliant provider under the identical request-shape mechanism.
+
+Per the "four verification rules" (Rule 2 -- observe the guard failing):
+exhaustion here is a deterministic function of the REAL serialized request
+the production ``OpenAICompatibleAgentProvider.decide()`` builds -- driven by
+``_RequestSizeDrivenClient.tokens_per_byte`` -- never a hard-coded "return
+exhausted". The RED/GREEN pair below proves both directions: the same
+provider/budget combination that reproduces exhaustion for a
+production-sized request clears it for a smaller (compliant) one, and the
+old 512-token echo probe cannot see either case because its own request is
+never production-sized.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+from dev_health_ops.llm.agent.probes.legacy_agent import (
+    _PRODUCTION_FLOOR_BYTES,
+    _assert_production_shape,
+    certify_legacy_agent,
+)
+from dev_health_ops.llm.agent.readiness import (
+    AgentReadinessOutcome,
+    AgentReadinessService,
+)
+from dev_health_ops.llm.agent.roles import RoleCertificationState
+
+# A model whose per-byte reasoning-token cost is high enough that the
+# production-sized legacy_agent request (full 9-tool registry + fixed policy
+# sections + full DevAnswer grammar -- measured ~51-65 KB serialized wire
+# request for this probe's fixtures) exceeds the 4,096-token flat envelope
+# (TRD Option B -- this PR does not change that cap), while the ~0.5-1.5 KB
+# transport-echo probe's own request stays comfortably under its own
+# 512-token cap. 0.15 tokens/byte gives ~7.8K reasoning tokens for the
+# production request (1.9x over the 4,096 cap) and ~230 for the echo
+# request (2.2x under its 512 cap) -- wide margins in both directions, not a
+# knife-edge calibration.
+_NONCOMPLIANT_TOKENS_PER_BYTE = 0.15
+# A model whose per-byte cost is low enough that even the full
+# production-sized request (~65 KB) stays well inside the 4,096-token
+# envelope (~1.3K reasoning tokens at this rate).
+_COMPLIANT_TOKENS_PER_BYTE = 0.02
+
+
+def _stub_response(
+    *,
+    finish_reason: str,
+    content: str | None,
+    tool_calls: list[Any] | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    reasoning_tokens: int,
+) -> Any:
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _stub_tool_call(*, name: str, arguments: dict[str, Any]) -> Any:
+    return SimpleNamespace(
+        id="stub-call-1",
+        function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+    )
+
+
+class _RequestSizeDrivenClient:
+    """Fake OpenAI client whose exhaustion behavior is a deterministic
+    function of the REAL serialized request the adapter builds -- never a
+    hard-coded "return exhausted" (verification Rule 2).
+
+    Serves both the readiness-echo (single tool, tiny request) and the
+    legacy_agent (full registry, production-sized request) request shapes:
+    round 1 always names whichever tool is offered first (schema-compliant
+    args are not validated client-side by the adapter); round 2 answers
+    ``{"nonce": "ready-v1"}`` when the flow was echo (detected from round 1's
+    tool name) or a DevAnswer-shaped draft otherwise.
+    """
+
+    def __init__(self, *, tokens_per_byte: float) -> None:
+        self._tokens_per_byte = tokens_per_byte
+        self._echo_mode: bool | None = None
+        self.requests: list[dict[str, Any]] = []
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        tools = kwargs.get("tools") or []
+        if self._echo_mode is None:
+            tool_names = {str(item["function"]["name"]) for item in tools}
+            self._echo_mode = "readiness_echo_v1" in tool_names
+
+        serialized = json.dumps(kwargs, sort_keys=True, default=str).encode("utf-8")
+        reasoning_tokens = round(len(serialized) * self._tokens_per_byte)
+        max_completion = int(kwargs["max_completion_tokens"])
+        if reasoning_tokens >= max_completion:
+            return _stub_response(
+                finish_reason="length",
+                content="",
+                tool_calls=None,
+                prompt_tokens=len(serialized) // 4,
+                completion_tokens=max_completion,
+                reasoning_tokens=reasoning_tokens,
+            )
+
+        if kwargs.get("tool_choice") == "required":
+            name = str(tools[0]["function"]["name"])
+            arguments = {"nonce": "ready-v1"} if self._echo_mode else {}
+            return _stub_response(
+                finish_reason="tool_calls",
+                content=None,
+                tool_calls=[_stub_tool_call(name=name, arguments=arguments)],
+                prompt_tokens=len(serialized) // 4,
+                completion_tokens=8,
+                reasoning_tokens=reasoning_tokens,
+            )
+
+        value = (
+            {"nonce": "ready-v1"}
+            if self._echo_mode
+            else {"status": "complete", "direct_summary": "Stub legacy_agent answer."}
+        )
+        return _stub_response(
+            finish_reason="stop",
+            content=json.dumps({"kind": "final_answer", "value": value}),
+            tool_calls=None,
+            prompt_tokens=len(serialized) // 4,
+            completion_tokens=12,
+            reasoning_tokens=reasoning_tokens,
+        )
+
+
+def _provider(
+    *, tokens_per_byte: float, model: str = "gpt-5-nano"
+) -> tuple[OpenAICompatibleAgentProvider, _RequestSizeDrivenClient]:
+    client = _RequestSizeDrivenClient(tokens_per_byte=tokens_per_byte)
+    provider = OpenAICompatibleAgentProvider(
+        api_key="not-used", model=model, base_url="http://127.0.0.1:1/v1", client=client
+    )
+    return provider, client
+
+
+class _Store:
+    async def load(self):  # pragma: no cover - readiness.py's own store protocol
+        return None
+
+    async def save(self, record) -> None:
+        self.record = record
+
+
+@pytest.mark.asyncio
+async def test_production_sized_legacy_probe_reproduces_exhaustion() -> None:
+    """The new probe (RED): reproduces OUTPUT_EXHAUSTED for a provider whose
+    reasoning cost, applied to the real production request shape, exceeds
+    the 4,096-token envelope."""
+
+    provider, client = _provider(tokens_per_byte=_NONCOMPLIANT_TOKENS_PER_BYTE)
+    result = await certify_legacy_agent(provider, timeout_seconds=30)
+
+    assert result.state is RoleCertificationState.INCOMPATIBLE
+    assert result.safe_error_code == "output_exhausted"
+    # Sanity: the request that triggered exhaustion really was
+    # production-sized, not a shrunk stand-in (Rule 4).
+    assert len(client.requests) >= 1
+    round_1_request = client.requests[0]
+    round_1_bytes = len(json.dumps(round_1_request, sort_keys=True, default=str))
+    assert round_1_bytes >= _PRODUCTION_FLOOR_BYTES
+
+
+@pytest.mark.asyncio
+async def test_transport_echo_probe_does_not_reproduce_exhaustion() -> None:
+    """The OLD probe (fail-before pair): the exact same non-compliant
+    provider certifies READY under the pre-existing 512-token echo probe,
+    because that probe's request is never production-sized. This is what
+    makes the new probe an actual gap-closer, not a redundant check."""
+
+    provider, client = _provider(tokens_per_byte=_NONCOMPLIANT_TOKENS_PER_BYTE)
+    store = _Store()
+    record = await AgentReadinessService(store).certify(
+        provider,
+        provider_name="openai",
+        model=provider.model,
+        fingerprint="probe-fingerprint",
+    )
+
+    assert record.outcome is AgentReadinessOutcome.READY
+    # Sanity: the transport-echo probe's own requests really were tiny
+    # relative to the production floor -- confirming it genuinely could not
+    # have observed the defect, not that our stub is miscalibrated.
+    for request in client.requests:
+        assert (
+            len(json.dumps(request, sort_keys=True, default=str))
+            < _PRODUCTION_FLOOR_BYTES
+        )
+
+
+@pytest.mark.asyncio
+async def test_production_sized_legacy_probe_certifies_a_compliant_model() -> None:
+    """The new probe (GREEN): the identical production-sized request shape
+    certifies COMPATIBLE against a provider whose reasoning cost fits the
+    same 4,096-token envelope."""
+
+    provider, _client = _provider(tokens_per_byte=_COMPLIANT_TOKENS_PER_BYTE)
+    result = await certify_legacy_agent(provider, timeout_seconds=30)
+
+    assert result.state is RoleCertificationState.COMPATIBLE
+    assert result.safe_error_code is None
+    assert result.observed_request_bytes >= _PRODUCTION_FLOOR_BYTES
+
+
+def test_production_shape_guard_fails_loudly_on_a_shrunk_probe() -> None:
+    """Rule 4: a probe whose composed request silently shrank below
+    production scale must fail loudly, not silently pass as coverage."""
+
+    from dev_health_ops.api.dev.tool_registry import TOOL_DEFINITIONS
+    from dev_health_ops.llm.agent.contracts import AgentToolDefinition
+
+    full_tool_set = tuple(
+        AgentToolDefinition(tool_id=item.tool_id.value, description="", input_schema={})
+        for item in TOOL_DEFINITIONS
+    )
+
+    with pytest.raises(
+        AssertionError, match="below the production-representative floor"
+    ):
+        _assert_production_shape("tiny prompt", tools=full_tool_set)
+
+    with pytest.raises(AssertionError, match="full 9-tool registry"):
+        _assert_production_shape("x" * (_PRODUCTION_FLOOR_BYTES + 1), tools=())
+
+
+class _InMemoryRoleStore:
+    def __init__(self) -> None:
+        from dev_health_ops.llm.agent.roles import RoleCertificationProfile
+
+        self.profile = RoleCertificationProfile()
+
+    async def load(self):
+        return self.profile
+
+    async def save(self, profile) -> None:
+        self.profile = profile
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_service_persists_legacy_agent_certification() -> None:
+    from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
+    from dev_health_ops.llm.agent.roles import AgentRole
+
+    provider, _client = _provider(tokens_per_byte=_COMPLIANT_TOKENS_PER_BYTE)
+    store = _InMemoryRoleStore()
+    service = RoleReadinessService(store)
+
+    record = await service.certify_role(
+        AgentRole.LEGACY_AGENT, provider, certification_key="key-01"
+    )
+
+    assert record.state is RoleCertificationState.COMPATIBLE
+    assert store.profile.for_role(AgentRole.LEGACY_AGENT) == record
+
+
+@pytest.mark.asyncio
+async def test_role_readiness_service_rejects_unimplemented_roles() -> None:
+    from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
+    from dev_health_ops.llm.agent.roles import AgentRole
+
+    provider, _client = _provider(tokens_per_byte=_COMPLIANT_TOKENS_PER_BYTE)
+    service = RoleReadinessService(_InMemoryRoleStore())
+
+    with pytest.raises(NotImplementedError):
+        await service.certify_role(
+            AgentRole.INTENT_CLASSIFICATION, provider, certification_key="key-01"
+        )

--- a/tests/llm/agent/test_role_readiness.py
+++ b/tests/llm/agent/test_role_readiness.py
@@ -21,6 +21,10 @@ from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev.prompts.composer import (
+    LEGACY_PROMPT_VERSION,
+    PROMPT_VERSION,
+)
 from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
 from dev_health_ops.llm.agent.probes.legacy_agent import (
     _PRODUCTION_FLOOR_BYTES,
@@ -161,16 +165,62 @@ class _Store:
 
 async def _uncalibrated_round_requests() -> tuple[dict[str, Any], dict[str, Any]]:
     """Run the real probe against a client that never exhausts (rate 0), to
-    observe the two real request shapes it sends without inducing exhaustion.
-    Calibration is derived from these -- never a hand-guessed rate."""
+    observe the real round-1 and round-2 (committed-subject) request shapes
+    it sends without inducing exhaustion. Calibration is derived from
+    these -- never a hand-guessed rate.
+
+    CHAOS-3285 round 2 (Codex HIGH): the probe now sends a THIRD request --
+    round 2 again under the uncommitted-subject prompt shape
+    (LEGACY_PROMPT_VERSION), proving that shape too rather than only ever
+    exercising the committed one. This calibration helper deliberately
+    keeps using only the first two (round 1 and the committed round 2):
+    the combined-shape claim it exists to prove (tool_choice="auto" + the
+    strict grammar + accumulated history, together, is what exhausts) is
+    the same claim for either prompt shape, and testing it twice here would
+    duplicate coverage rather than add any."""
 
     provider, client = _provider(tokens_per_byte=0.0)
     result = await certify_legacy_agent(provider, timeout_seconds=30)
     assert result.state is RoleCertificationState.COMPATIBLE, (
         "calibration precondition failed: a rate of 0 must never exhaust"
     )
-    assert len(client.requests) == 2
+    assert len(client.requests) == 3
     return client.requests[0], client.requests[1]
+
+
+@pytest.mark.asyncio
+async def test_certify_legacy_agent_probes_both_prompt_shapes() -> None:
+    """CHAOS-3285 round 2 (Codex HIGH): before this fix, the probe forced
+    ``subject_committed=True`` unconditionally, so PromptComposer's OTHER
+    shape -- ``LEGACY_PROMPT_VERSION`` (uncommitted subject / the Wave 3.1
+    flag off) -- was never exercised at all, and the fingerprint never
+    folded that constant either, so a text-only change to only that shape
+    invalidated nothing. Prove both shapes are now actually sent, not just
+    that a fingerprint constant changed."""
+
+    provider, client = _provider(tokens_per_byte=0.0)
+    result = await certify_legacy_agent(provider, timeout_seconds=30)
+
+    assert result.state is RoleCertificationState.COMPATIBLE
+    assert len(client.requests) == 3
+
+    round_2_committed, round_2_uncommitted = client.requests[1], client.requests[2]
+    # Both are the same worst-case combined shape (tool_choice="auto" + the
+    # strict grammar)...
+    for request in (round_2_committed, round_2_uncommitted):
+        assert request.get("tool_choice") == "auto"
+        assert request.get("response_format") is not None
+
+    # ...but the composed system prompt genuinely differs between them --
+    # proof this is really two distinct prompt shapes being sent, not the
+    # same request twice.
+    committed_system_text = round_2_committed["messages"][0]["content"]
+    uncommitted_system_text = round_2_uncommitted["messages"][0]["content"]
+    assert committed_system_text != uncommitted_system_text
+    assert PROMPT_VERSION in committed_system_text
+    assert PROMPT_VERSION not in uncommitted_system_text
+    assert LEGACY_PROMPT_VERSION in uncommitted_system_text
+    assert LEGACY_PROMPT_VERSION not in committed_system_text
 
 
 def _without_grammar(round_2: dict[str, Any]) -> dict[str, Any]:
@@ -207,6 +257,7 @@ def _calibrate_noncompliant_rate(
         client.reasoning_tokens_for(_without_history(round_1, round_2)),
     )
     full_combination = client.reasoning_tokens_for(round_2)
+
     lower = cap / full_combination
     upper = cap / insufficient_alone
     assert lower < upper, (

--- a/tests/llm/agent/test_roles.py
+++ b/tests/llm/agent/test_roles.py
@@ -424,3 +424,54 @@ async def test_savepoint_wrapped_failure_does_not_lose_an_earlier_write(
             SettingsService(verify_session, org_id)
         ).load()
     assert final.for_role(AgentRole.LEGACY_AGENT) == earlier_write
+
+
+class _FakeDialect:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeBind:
+    def __init__(self, dialect_name: str) -> None:
+        self.dialect = _FakeDialect(dialect_name)
+
+
+class _FakeUnsupportedDialectSession:
+    """A session double exposing only what ``_upsert_setting_row`` reads
+    before it must reject -- ``get_bind().dialect.name`` -- so this test
+    proves the rejection happens WITHOUT ever attempting a database
+    operation, on a dialect with no engine available to test against at
+    all (real production is postgresql, tests are sqlite; a fake is the
+    only way to exercise the "some other dialect" branch)."""
+
+    def __init__(self, dialect_name: str) -> None:
+        self._dialect_name = dialect_name
+
+    def get_bind(self) -> _FakeBind:
+        return _FakeBind(self._dialect_name)
+
+
+@pytest.mark.asyncio
+async def test_upsert_setting_row_rejects_a_dialect_without_native_upsert() -> None:
+    """CHAOS-3285 round 4 (Codex MEDIUM, ratified): a prior version of
+    ``_upsert_setting_row`` fell back to a SAVEPOINT-guarded select-then-
+    insert for any dialect other than postgresql/sqlite -- itself still
+    racy under true concurrent same-role writers (two sessions can both
+    observe "no row yet" inside their own savepoint and both attempt
+    INSERT), so the fallback's implicit "atomic" claim was one this
+    function could not actually honor. Production runs postgresql, tests
+    run sqlite -- both have a native upsert -- so an unsupported dialect
+    must be rejected loudly and by name, not silently handled by a
+    guarantee that does not hold."""
+
+    from dev_health_ops.llm.agent.roles import _upsert_setting_row
+
+    with pytest.raises(NotImplementedError, match="mysql"):
+        await _upsert_setting_row(
+            _FakeUnsupportedDialectSession("mysql"),  # type: ignore[arg-type]
+            org_id="org_1",
+            category="llm",
+            key="some_key",
+            value="some_value",
+            description="some description",
+        )

--- a/tests/llm/agent/test_roles.py
+++ b/tests/llm/agent/test_roles.py
@@ -414,12 +414,26 @@ async def test_savepoint_wrapped_failure_does_not_lose_an_earlier_write(
         # The session must still be usable here -- a poisoned session (the
         # pre-fix shape) would raise PendingRollbackError on this next query
         # instead of returning the earlier write untouched.
-        reloaded = await store.load()
+        #
+        # CHAOS-3285 round 6: CodeQL py/unreachable-statement false
+        # positives on this line and the `async with session_maker() as
+        # verify_session:` line below -- CodeQL's control-flow analysis
+        # does not model `pytest.raises` (or any context manager) as
+        # capable of suppressing the exception raised inside its `with`
+        # block; it sees the unconditional `raise RuntimeError(...)` above
+        # and marks everything textually after it, within this function, as
+        # unreachable. `pytest.raises` genuinely catches and swallows a
+        # matching exception -- this is the standard idiom for "assert this
+        # raises, then keep asserting postconditions" -- and this code
+        # provably executes: this exact test's RED/GREEN history at
+        # CHAOS-3285 round 2 is what the assertions below verify (dropping
+        # the SAVEPOINT wrap makes them fail).
+        reloaded = await store.load()  # lgtm[py/unreachable-statement]
         assert reloaded.for_role(AgentRole.LEGACY_AGENT) == earlier_write
 
         await session.commit()
 
-    async with session_maker() as verify_session:
+    async with session_maker() as verify_session:  # lgtm[py/unreachable-statement]
         final = await SettingsRoleCertificationStore(
             SettingsService(verify_session, org_id)
         ).load()

--- a/tests/llm/agent/test_roles.py
+++ b/tests/llm/agent/test_roles.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from dev_health_ops.llm.agent.roles import (
+    ROLE_CERTIFICATION_PROFILE_VERSION,
+    AgentRole,
+    RoleCertificationProfile,
+    RoleCertificationRecord,
+    RoleCertificationState,
+    SettingsRoleCertificationStore,
+)
+
+
+class _FakeSettingsService:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    async def get(self, key: str, category: str, default=None):
+        del category
+        return self.values.get(key, default)
+
+    async def set(self, key: str, value: str, *, category: str, description: str):
+        del category, description
+        self.values[key] = value
+
+
+def _record(
+    role: AgentRole = AgentRole.LEGACY_AGENT,
+    *,
+    state: RoleCertificationState = RoleCertificationState.COMPATIBLE,
+    certification_key: str = "key-01",
+) -> RoleCertificationRecord:
+    return RoleCertificationRecord(
+        role=role,
+        certification_key=certification_key,
+        readiness_version="ask-dev-agent-v3",
+        checked_at="2026-08-02T00:00:00+00:00",
+        state=state,
+        safe_error_code=None
+        if state is RoleCertificationState.COMPATIBLE
+        else "output_exhausted",
+    )
+
+
+def test_is_current_requires_compatible_state_and_matching_key() -> None:
+    compatible = _record(
+        state=RoleCertificationState.COMPATIBLE, certification_key="k1"
+    )
+    assert compatible.is_current(certification_key="k1")
+    assert not compatible.is_current(certification_key="k2")
+
+    incompatible = _record(
+        state=RoleCertificationState.INCOMPATIBLE, certification_key="k1"
+    )
+    assert not incompatible.is_current(certification_key="k1")
+
+
+def test_with_record_does_not_clobber_other_roles() -> None:
+    profile = RoleCertificationProfile()
+    legacy = _record(AgentRole.LEGACY_AGENT)
+    profile = profile.with_record(legacy)
+    intent = _record(AgentRole.INTENT_CLASSIFICATION, certification_key="k-intent")
+    profile = profile.with_record(intent)
+
+    assert profile.for_role(AgentRole.LEGACY_AGENT) == legacy
+    assert profile.for_role(AgentRole.INTENT_CLASSIFICATION) == intent
+    assert profile.for_role(AgentRole.ANSWER_FRAME_NARRATIVE) is None
+
+
+@pytest.mark.asyncio
+async def test_store_round_trips_a_profile() -> None:
+    settings = _FakeSettingsService()
+    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+
+    empty = await store.load()
+    assert empty.records == {}
+
+    profile = RoleCertificationProfile().with_record(_record(AgentRole.LEGACY_AGENT))
+    await store.save(profile)
+
+    reloaded = await store.load()
+    assert reloaded.for_role(AgentRole.LEGACY_AGENT) == _record(AgentRole.LEGACY_AGENT)
+
+
+@pytest.mark.asyncio
+async def test_store_never_reads_the_legacy_binary_readiness_key() -> None:
+    """CHAOS-3285 backward compatibility: a pre-existing single-role
+    AgentReadinessRecord stored under the OLD binary key must never be
+    interpreted as a certification for any role by the NEW per-role store --
+    the new store reads a different key entirely."""
+
+    settings = _FakeSettingsService()
+    settings.values["ask_dev_agent_readiness"] = json.dumps(
+        {
+            "fingerprint": "old-fingerprint",
+            "readiness_version": "ask-dev-agent-v3",
+            "checked_at": "2026-08-01T00:00:00+00:00",
+            "outcome": "ready",
+            "safe_error_code": None,
+        }
+    )
+
+    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+    profile = await store.load()
+
+    assert profile.records == {}
+    for role in AgentRole:
+        assert profile.for_role(role) is None
+
+
+@pytest.mark.asyncio
+async def test_store_never_trusts_a_mismatched_envelope_version() -> None:
+    settings = _FakeSettingsService()
+    settings.values["ask_dev_role_certification_profile"] = json.dumps(
+        {"version": "some-future-version", "records": {}}
+    )
+    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+
+    profile = await store.load()
+
+    assert profile.records == {}
+
+
+def test_profile_version_is_pinned() -> None:
+    assert ROLE_CERTIFICATION_PROFILE_VERSION == "ask-dev-role-certification.v1"

--- a/tests/llm/agent/test_roles.py
+++ b/tests/llm/agent/test_roles.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.llm.agent.roles import (
     ROLE_CERTIFICATION_PROFILE_VERSION,
     AgentRole,
@@ -12,6 +15,11 @@ from dev_health_ops.llm.agent.roles import (
     RoleCertificationState,
     SettingsRoleCertificationStore,
 )
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import Setting
+from tests._helpers import tables_of
+
+_TABLES = tables_of(Setting)
 
 
 class _FakeSettingsService:
@@ -86,6 +94,105 @@ async def test_store_round_trips_a_profile() -> None:
 
 
 @pytest.mark.asyncio
+async def test_save_record_writes_only_that_roles_own_key() -> None:
+    """The storage-level guarantee behind the sibling-survival fix: writing
+    one role never touches another role's settings row at all."""
+
+    settings = _FakeSettingsService()
+    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+
+    await store.save_record(_record(AgentRole.LEGACY_AGENT))
+
+    assert set(settings.values) == {"ask_dev_role_certification_profile:legacy_agent"}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes_to_different_roles_both_survive_in_memory() -> None:
+    """The lost-update reproduction, in-memory: two independent stores
+    (simulating two concurrent request handlers) each load a snapshot BEFORE
+    either commits, then each certifies a DIFFERENT role. Under the old
+    whole-envelope design, whichever save() landed second would overwrite
+    the sibling role's row with a blob that never knew about it. Per-role
+    storage makes this safe by construction: reproduced here directly
+    against the store (not through RoleReadinessService, since that no
+    longer even performs a read before writing)."""
+
+    settings = _FakeSettingsService()
+    store_a = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+    store_b = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+
+    # Both "sessions" observe the same empty starting state.
+    profile_a = await store_a.load()
+    profile_b = await store_b.load()
+    assert profile_a.records == {} and profile_b.records == {}
+
+    legacy = _record(AgentRole.LEGACY_AGENT, certification_key="k-legacy")
+    intent = _record(AgentRole.INTENT_CLASSIFICATION, certification_key="k-intent")
+
+    # A certifies and "commits" first...
+    await store_a.save(profile_a.with_record(legacy))
+    # ...then B certifies a DIFFERENT role from its stale pre-A snapshot and
+    # "commits" second.
+    await store_b.save(profile_b.with_record(intent))
+
+    reloaded = await SettingsRoleCertificationStore(settings).load()  # type: ignore[arg-type]
+    assert reloaded.for_role(AgentRole.LEGACY_AGENT) == legacy
+    assert reloaded.for_role(AgentRole.INTENT_CLASSIFICATION) == intent
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes_to_different_roles_both_survive_across_db_sessions(
+    tmp_path: Path,
+) -> None:
+    """The same barrier, against a real database with two independent
+    SQLAlchemy sessions/transactions -- the two-session proof, not just an
+    in-memory stand-in. Interleaves the sessions so B's read genuinely
+    precedes A's commit, then commits B AFTER A, and asserts both roles'
+    records are present regardless of that commit order."""
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'roles-barrier.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    org_id = "org-roles-barrier"
+    legacy = _record(AgentRole.LEGACY_AGENT, certification_key="k-legacy")
+    intent = _record(AgentRole.INTENT_CLASSIFICATION, certification_key="k-intent")
+
+    async with maker() as session_a, maker() as session_b:
+        store_a = SettingsRoleCertificationStore(SettingsService(session_a, org_id))
+        store_b = SettingsRoleCertificationStore(SettingsService(session_b, org_id))
+
+        # Both sessions observe the pre-write state before either writes.
+        await store_a.load()
+        await store_b.load()
+
+        # Session B's write and commit happen BEFORE session A's, deliberately
+        # the reverse of certification order below -- proving the fix does
+        # not depend on commit order.
+        await store_b.save_record(intent)
+        await session_b.commit()
+
+        await store_a.save_record(legacy)
+        await session_a.commit()
+
+    async with maker() as verify_session:
+        reloaded = await SettingsRoleCertificationStore(
+            SettingsService(verify_session, org_id)
+        ).load()
+
+    assert reloaded.for_role(AgentRole.LEGACY_AGENT) == legacy
+    assert reloaded.for_role(AgentRole.INTENT_CLASSIFICATION) == intent
+    assert reloaded.for_role(AgentRole.ANSWER_FRAME_NARRATIVE) is None
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_store_never_reads_the_legacy_binary_readiness_key() -> None:
     """CHAOS-3285 backward compatibility: a pre-existing single-role
     AgentReadinessRecord stored under the OLD binary key must never be
@@ -114,14 +221,50 @@ async def test_store_never_reads_the_legacy_binary_readiness_key() -> None:
 @pytest.mark.asyncio
 async def test_store_never_trusts_a_mismatched_envelope_version() -> None:
     settings = _FakeSettingsService()
-    settings.values["ask_dev_role_certification_profile"] = json.dumps(
-        {"version": "some-future-version", "records": {}}
+    settings.values["ask_dev_role_certification_profile:legacy_agent"] = json.dumps(
+        {
+            "version": "some-future-version",
+            "record": {
+                "role": "legacy_agent",
+                "certification_key": "k1",
+                "readiness_version": "ask-dev-agent-v3",
+                "checked_at": "2026-08-01T00:00:00+00:00",
+                "state": "compatible",
+                "safe_error_code": None,
+            },
+        }
     )
     store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
 
     profile = await store.load()
 
     assert profile.records == {}
+
+
+@pytest.mark.asyncio
+async def test_store_never_trusts_a_role_mismatched_row() -> None:
+    """Defense in depth: a row found under role R's own key must actually
+    describe role R. A hand-edited or corrupted mismatch is never trusted."""
+
+    settings = _FakeSettingsService()
+    settings.values["ask_dev_role_certification_profile:legacy_agent"] = json.dumps(
+        {
+            "version": ROLE_CERTIFICATION_PROFILE_VERSION,
+            "record": {
+                "role": "intent_classification",
+                "certification_key": "k1",
+                "readiness_version": "ask-dev-agent-v3",
+                "checked_at": "2026-08-01T00:00:00+00:00",
+                "state": "compatible",
+                "safe_error_code": None,
+            },
+        }
+    )
+    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+
+    profile = await store.load()
+
+    assert profile.for_role(AgentRole.LEGACY_AGENT) is None
 
 
 def test_profile_version_is_pinned() -> None:

--- a/tests/llm/agent/test_roles.py
+++ b/tests/llm/agent/test_roles.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.llm.agent.roles import (
@@ -20,6 +28,30 @@ from dev_health_ops.models.settings import Setting
 from tests._helpers import tables_of
 
 _TABLES = tables_of(Setting)
+
+
+@pytest_asyncio.fixture
+async def session_maker(
+    tmp_path: Path,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """A real aiosqlite-backed session factory. save_record() now performs a
+    dialect-aware atomic upsert (INSERT ... ON CONFLICT DO UPDATE) directly
+    against the settings table, so its own tests need a real SQLAlchemy
+    session/engine -- a plain dict-backed fake can no longer stand in for
+    the write path (it still works fine for read-only tests of load())."""
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'roles.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
 
 
 class _FakeSettingsService:
@@ -79,91 +111,71 @@ def test_with_record_does_not_clobber_other_roles() -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_round_trips_a_profile() -> None:
-    settings = _FakeSettingsService()
-    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+async def test_store_round_trips_a_profile(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_maker() as session:
+        store = SettingsRoleCertificationStore(SettingsService(session, "org-01"))
 
-    empty = await store.load()
-    assert empty.records == {}
+        empty = await store.load()
+        assert empty.records == {}
 
-    profile = RoleCertificationProfile().with_record(_record(AgentRole.LEGACY_AGENT))
-    await store.save(profile)
+        profile = RoleCertificationProfile().with_record(
+            _record(AgentRole.LEGACY_AGENT)
+        )
+        await store.save(profile)
+        await session.commit()
 
-    reloaded = await store.load()
+    async with session_maker() as verify_session:
+        reloaded = await SettingsRoleCertificationStore(
+            SettingsService(verify_session, "org-01")
+        ).load()
     assert reloaded.for_role(AgentRole.LEGACY_AGENT) == _record(AgentRole.LEGACY_AGENT)
 
 
 @pytest.mark.asyncio
-async def test_save_record_writes_only_that_roles_own_key() -> None:
+async def test_save_record_writes_only_that_roles_own_key(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
     """The storage-level guarantee behind the sibling-survival fix: writing
     one role never touches another role's settings row at all."""
 
-    settings = _FakeSettingsService()
-    store = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
+    async with session_maker() as session:
+        store = SettingsRoleCertificationStore(SettingsService(session, "org-01"))
+        await store.save_record(_record(AgentRole.LEGACY_AGENT))
+        await session.commit()
 
-    await store.save_record(_record(AgentRole.LEGACY_AGENT))
-
-    assert set(settings.values) == {"ask_dev_role_certification_profile:legacy_agent"}
-
-
-@pytest.mark.asyncio
-async def test_concurrent_writes_to_different_roles_both_survive_in_memory() -> None:
-    """The lost-update reproduction, in-memory: two independent stores
-    (simulating two concurrent request handlers) each load a snapshot BEFORE
-    either commits, then each certifies a DIFFERENT role. Under the old
-    whole-envelope design, whichever save() landed second would overwrite
-    the sibling role's row with a blob that never knew about it. Per-role
-    storage makes this safe by construction: reproduced here directly
-    against the store (not through RoleReadinessService, since that no
-    longer even performs a read before writing)."""
-
-    settings = _FakeSettingsService()
-    store_a = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
-    store_b = SettingsRoleCertificationStore(settings)  # type: ignore[arg-type]
-
-    # Both "sessions" observe the same empty starting state.
-    profile_a = await store_a.load()
-    profile_b = await store_b.load()
-    assert profile_a.records == {} and profile_b.records == {}
-
-    legacy = _record(AgentRole.LEGACY_AGENT, certification_key="k-legacy")
-    intent = _record(AgentRole.INTENT_CLASSIFICATION, certification_key="k-intent")
-
-    # A certifies and "commits" first...
-    await store_a.save(profile_a.with_record(legacy))
-    # ...then B certifies a DIFFERENT role from its stale pre-A snapshot and
-    # "commits" second.
-    await store_b.save(profile_b.with_record(intent))
-
-    reloaded = await SettingsRoleCertificationStore(settings).load()  # type: ignore[arg-type]
-    assert reloaded.for_role(AgentRole.LEGACY_AGENT) == legacy
-    assert reloaded.for_role(AgentRole.INTENT_CLASSIFICATION) == intent
+    async with session_maker() as verify_session:
+        rows = (
+            (
+                await verify_session.execute(
+                    select(Setting.key).where(Setting.org_id == "org-01")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert set(rows) == {"ask_dev_role_certification_profile:legacy_agent"}
 
 
 @pytest.mark.asyncio
 async def test_concurrent_writes_to_different_roles_both_survive_across_db_sessions(
-    tmp_path: Path,
+    session_maker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """The same barrier, against a real database with two independent
-    SQLAlchemy sessions/transactions -- the two-session proof, not just an
-    in-memory stand-in. Interleaves the sessions so B's read genuinely
-    precedes A's commit, then commits B AFTER A, and asserts both roles'
-    records are present regardless of that commit order."""
-
-    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'roles-barrier.db'}")
-    async with engine.begin() as connection:
-        await connection.run_sync(
-            lambda sync_connection: Base.metadata.create_all(
-                sync_connection, tables=_TABLES
-            )
-        )
-    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    """The two-session sibling-role barrier: two independent SQLAlchemy
+    sessions/transactions each observe the pre-write state before either
+    writes, then each certifies a DIFFERENT role. Under the old
+    whole-envelope design, whichever save() landed second would overwrite
+    the sibling role's row with a blob that never knew about it. Per-role
+    storage makes this safe by construction. Session B's write and commit
+    happen BEFORE session A's -- deliberately the reverse of certification
+    order below -- proving the fix does not depend on commit order."""
 
     org_id = "org-roles-barrier"
     legacy = _record(AgentRole.LEGACY_AGENT, certification_key="k-legacy")
     intent = _record(AgentRole.INTENT_CLASSIFICATION, certification_key="k-intent")
 
-    async with maker() as session_a, maker() as session_b:
+    async with session_maker() as session_a, session_maker() as session_b:
         store_a = SettingsRoleCertificationStore(SettingsService(session_a, org_id))
         store_b = SettingsRoleCertificationStore(SettingsService(session_b, org_id))
 
@@ -171,16 +183,13 @@ async def test_concurrent_writes_to_different_roles_both_survive_across_db_sessi
         await store_a.load()
         await store_b.load()
 
-        # Session B's write and commit happen BEFORE session A's, deliberately
-        # the reverse of certification order below -- proving the fix does
-        # not depend on commit order.
         await store_b.save_record(intent)
         await session_b.commit()
 
         await store_a.save_record(legacy)
         await session_a.commit()
 
-    async with maker() as verify_session:
+    async with session_maker() as verify_session:
         reloaded = await SettingsRoleCertificationStore(
             SettingsService(verify_session, org_id)
         ).load()
@@ -189,7 +198,104 @@ async def test_concurrent_writes_to_different_roles_both_survive_across_db_sessi
     assert reloaded.for_role(AgentRole.INTENT_CLASSIFICATION) == intent
     assert reloaded.for_role(AgentRole.ANSWER_FRAME_NARRATIVE) is None
 
-    await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_concurrent_first_writes_to_the_same_role_do_not_raise(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """CHAOS-3285 round 2 (Codex MEDIUM): two sessions truly racing a
+    first-ever certification of the SAME role -- via asyncio.gather, so
+    both sessions' own internal "does a row exist yet" checks and their
+    INSERT attempts are genuinely concurrent, not sequential. Before the
+    atomic-upsert fix (a bare select-then-insert), both sessions could
+    observe "no row yet" and both attempt INSERT; the loser's flush raised
+    IntegrityError, and -- caught without a rollback/savepoint by a caller
+    (platform_ask_dev.py / settings.py's best-effort role-certify try/except)
+    -- poisoned that session for any later query in the same transaction,
+    including an unrelated earlier write (the binary readiness certify()
+    call each of those routes runs just before). The single-statement
+    ``INSERT ... ON CONFLICT DO UPDATE`` this fix uses is atomic at the
+    database level: there is no window in which two overlapping statements
+    can both decide "insert" and conflict, so this must complete without
+    raising regardless of how the two sessions' internal operations
+    interleave. The exact winner between two truly concurrent writers is
+    not asserted here (it is whichever committed last, at the database's
+    discretion) -- only that a value from one of the two writers, not a
+    corrupted mix, is what a later reader observes.
+    """
+
+    org_id = "org-same-role-race"
+    key = "k-shared"
+    compatible = _record(
+        AgentRole.LEGACY_AGENT,
+        state=RoleCertificationState.COMPATIBLE,
+        certification_key=key,
+    )
+    incompatible = _record(
+        AgentRole.LEGACY_AGENT,
+        state=RoleCertificationState.INCOMPATIBLE,
+        certification_key=key,
+    )
+
+    async def certify(record: RoleCertificationRecord) -> None:
+        async with session_maker() as session:
+            store = SettingsRoleCertificationStore(SettingsService(session, org_id))
+            await store.load()
+            await store.save_record(record)
+            await session.commit()
+
+    # Both writers' load()/save_record()/commit() sequences run concurrently
+    # under the same event loop -- asyncio.gather does not serialize them
+    # the way two sequential `await` calls in one coroutine would.
+    await asyncio.gather(certify(compatible), certify(incompatible))
+
+    async with session_maker() as verify_session:
+        reloaded = await SettingsRoleCertificationStore(
+            SettingsService(verify_session, org_id)
+        ).load()
+
+    winner = reloaded.for_role(AgentRole.LEGACY_AGENT)
+    assert winner in (compatible, incompatible)
+
+
+@pytest.mark.asyncio
+async def test_sequential_writes_to_the_same_role_apply_last_commit_wins(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Stated winner policy, verified deterministically: when session B's
+    write and commit happen strictly AFTER session A's commit, B's
+    (opposing) verdict is what a later reader observes -- last COMMIT wins,
+    not "the first insert wins" and not "an arbitrary/undefined result"."""
+
+    org_id = "org-same-role-sequential"
+    key = "k-shared"
+    compatible = _record(
+        AgentRole.LEGACY_AGENT,
+        state=RoleCertificationState.COMPATIBLE,
+        certification_key=key,
+    )
+    incompatible = _record(
+        AgentRole.LEGACY_AGENT,
+        state=RoleCertificationState.INCOMPATIBLE,
+        certification_key=key,
+    )
+
+    async with session_maker() as session_a:
+        store_a = SettingsRoleCertificationStore(SettingsService(session_a, org_id))
+        await store_a.save_record(compatible)
+        await session_a.commit()
+
+    async with session_maker() as session_b:
+        store_b = SettingsRoleCertificationStore(SettingsService(session_b, org_id))
+        await store_b.save_record(incompatible)
+        await session_b.commit()
+
+    async with session_maker() as verify_session:
+        reloaded = await SettingsRoleCertificationStore(
+            SettingsService(verify_session, org_id)
+        ).load()
+
+    assert reloaded.for_role(AgentRole.LEGACY_AGENT) == incompatible
 
 
 @pytest.mark.asyncio
@@ -269,3 +375,52 @@ async def test_store_never_trusts_a_role_mismatched_row() -> None:
 
 def test_profile_version_is_pinned() -> None:
     assert ROLE_CERTIFICATION_PROFILE_VERSION == "ask-dev-role-certification.v1"
+
+
+@pytest.mark.asyncio
+async def test_savepoint_wrapped_failure_does_not_lose_an_earlier_write(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """CHAOS-3285 round 2 (Codex MEDIUM): direct proof of the SAVEPOINT
+    pattern platform_ask_dev.py and settings.py now wrap the role-certify
+    call in. A `try/except Exception: log` around a DB operation WITHOUT a
+    rollback or savepoint leaves the session's transaction unable to accept
+    further operations; the request's own session dependency then rolls
+    back the WHOLE transaction on its eventual commit, silently discarding
+    an earlier write already flushed into the same transaction (e.g. the
+    binary readiness certify() call each route runs just before). Wrapping
+    the risky operation in ``session.begin_nested()`` confines that damage
+    to a SAVEPOINT: on failure, only the nested operation rolls back: the
+    earlier write and the session's usability for the rest of the request
+    both survive.
+    """
+
+    org_id = "org-savepoint-proof"
+    earlier_write = _record(AgentRole.LEGACY_AGENT, certification_key="k1")
+
+    async with session_maker() as session:
+        store = SettingsRoleCertificationStore(SettingsService(session, org_id))
+        # Stand-in for "the binary readiness certify() call that already
+        # ran, and must survive, before the role-certify attempt below."
+        await store.save_record(earlier_write)
+
+        with pytest.raises(RuntimeError, match="simulated"):
+            async with session.begin_nested():
+                # Stand-in for an unexpected failure during the role-certify
+                # attempt -- a bare `except Exception` around this, with no
+                # savepoint, is exactly what Codex round 2 flagged.
+                raise RuntimeError("simulated unexpected DB/provider failure")
+
+        # The session must still be usable here -- a poisoned session (the
+        # pre-fix shape) would raise PendingRollbackError on this next query
+        # instead of returning the earlier write untouched.
+        reloaded = await store.load()
+        assert reloaded.for_role(AgentRole.LEGACY_AGENT) == earlier_write
+
+        await session.commit()
+
+    async with session_maker() as verify_session:
+        final = await SettingsRoleCertificationStore(
+            SettingsService(verify_session, org_id)
+        ).load()
+    assert final.for_role(AgentRole.LEGACY_AGENT) == earlier_write

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -415,3 +415,63 @@ def test_org_provider_without_credential_material_falls_back_consistently():
     assert isinstance(provider, OpenAIProvider)
     assert provider._impl.cfg.api_key == "sk-platform"
     assert provider._impl.cfg.base_url == "https://platform.invalid/v1"
+
+
+def test_env_platform_credentials_resolve_organization_project_and_custom_headers():
+    """CHAOS-3285 round 6 (Codex HIGH): the OpenAI SDK reads
+    OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS AMBIENTLY when a
+    client is constructed without them -- codex's exact repro flipped
+    OPENAI_PROJECT_ID with an identical certification fingerprint.
+    LLMCredentials now resolves these explicitly, from the SAME env vars,
+    so they become part of the credential bundle instead of invisible to
+    it."""
+
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_ORG_ID": "org-abc",
+            "OPENAI_PROJECT_ID": "proj-abc",
+            "OPENAI_CUSTOM_HEADERS": "X-Custom: header-value\nX-Other: other-value",
+        },
+        clear=True,
+    ):
+        credentials = creds.resolve_llm_credentials("openai", org_id=None)
+
+    assert credentials.organization == "org-abc"
+    assert credentials.project == "proj-abc"
+    assert credentials.custom_headers == (
+        ("X-Custom", "header-value"),
+        ("X-Other", "other-value"),
+    )
+
+
+def test_org_byo_credentials_never_pick_up_platform_organization_or_project():
+    """Source-bound resolution (CHAOS-2550) extends to organization/project/
+    custom_headers too: an org's own BYO credentials must never inherit the
+    PLATFORM operator's OpenAI org/project, even when the platform operator
+    has them configured via env."""
+
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://api.openai.com/v1",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_ORG_ID": "platform-org",
+            "OPENAI_PROJECT_ID": "platform-project",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            credentials = creds.resolve_llm_credentials("openai", org_id="org-1")
+
+    assert credentials.api_key == "sk-org"
+    assert credentials.organization == ""
+    assert credentials.project == ""
+    assert credentials.custom_headers == ()


### PR DESCRIPTION
## Summary

Ask Dev currently certifies a provider with one binary badge from a 512-token echo call against a single tiny tool. A provider that passes that certification can still exhaust its output budget on the very first real question, and the failure has no distinct identity -- it surfaces as `internal_error`, indistinguishable from a genuine server bug.

This PR replaces the binary badge with a **per-role certification model**: `AgentRole` (`legacy_agent`, `intent_classification`, `answer_frame_narrative`) names the structurally different things Ask Dev asks a provider to do, and `legacy_agent` (the only role with a working probe in this PR; `intent_classification`/`answer_frame_narrative` land as enum members and store slots only, gated on CHAOS-3294's schemas -- PR4) gets a production-sized probe built exclusively from real production producers (`PromptComposer`, `AskDevToolRegistry`, `DevRunLimits`, `DevAnswer`'s own schema) -- never a hand-authored miniature.

The probe runs **two fully independent, complete two-round chains** (4 provider calls) because `PromptComposer` composes two distinct prompt shapes (committed-subject / uncommitted-subject) a real run can select between, and each chain's own round 1 produces the tool request/result its own round 2 uses -- so a provider failing on only one specific shape can't silently pass by having that combination never sent to it.

The certification key is a fingerprint folding every capability input that can flip a verdict: provider identity, a non-reversible credential fingerprint (api_key, organization, project, custom_headers -- explicitly resolved rather than left for the OpenAI SDK to infer ambiently from `OPENAI_ORG_ID`/`OPENAI_PROJECT_ID`/`OPENAI_CUSTOM_HEADERS`), the COMPLETE non-secret wire request (built by the same single producer `decide()` itself consumes), the composed prompt/tool-contract/budget-policy versions, and the role. Changing any of these invalidates the stored certification automatically -- nothing has to notice and manually invalidate anything.

All three admin readiness surfaces (org, platform, BYO) now derive effective readiness from the binary transport check AND a current, compatible `legacy_agent` role certification together, with the prior binary-only result kept as a separate diagnostic field (`binary_transport_readiness`).

## Verification discipline

This PR went through 6 rounds of adversarial Codex review, each fixed with RED-first tests (the new test reproducing the exact defect fails against the pre-fix code, then passes against the fix) before moving to the next round:

- **Round 1**: initial NO-SHIP -- the old binary-only echo probe was still reachable in production selection paths.
- **Round 2**: 3 findings -- `RoleReadinessService` had zero production callers (BYO route never wired); exhaustion RED test's calibration rate wasn't isolating the claimed combined-shape effect; whole-envelope read-modify-write lost sibling roles under concurrent certification.
- **Round 3**: admin surfaces reported `ready` from the binary record alone while selection rejected (role absent/incompatible); select-then-insert raced on first same-role certification with an unrolled-back `IntegrityError`; calibration was self-oracling (any nonzero size difference passed); fingerprint hashed `PROMPT_VERSION` only, missing the uncommitted-subject shape entirely.
- **Round 4**: the digest still wasn't the wire (`max_completion_tokens`, the full response_format schema body, and tool serialization were assembled independently of what got fingerprinted); credential rotation (same provider/model/base_url, different key) preserved certification; calibration accepted all-null inert exchanges (`{"type":"null"}` properties, `tool_calls=[{}]`, null tool-result fields); the 6-call preflight was undocumented and unpinned.
- **Round 5**: ambient SDK identity (`OPENAI_ORG_ID`/`OPENAI_PROJECT_ID`/`OPENAI_CUSTOM_HEADERS`) bypassed the credential fingerprint entirely -- verified empirically against the installed `openai` SDK's actual source before fixing; calibration still accepted a valid-but-useless "empty-success" `DevToolResult` (serialized_bytes falsely claimed as 0) and a kind-preserved-but-otherwise-null schema.
- **Round 6** (final, per the ratified calibration-completeness threat-model policy -- no further rounds for this specific class): schema equality compared only the `properties` sub-dict, so deleting the schema's top-level `$defs` (leaving a dangling `$ref`) or corrupting a definition directly went uncaught. Fixed to compare the complete schema tree.

## TEST-EVIDENCE

- 6 Codex adversarial review rounds, each finding fixed with a RED-first test verified against the pre-fix code (temporarily reverted just that round's change, confirmed the new test fails/reproduces the defect) before being confirmed GREEN with the fix restored -- documented round-by-round in each commit message.
- Full breadth lane-side suite (`tests/api/dev/` + `tests/llm/agent/` + `tests/api/admin/` + `tests/test_llm_source_bound_resolver.py`) post-rebase onto `origin/main`: **1909 passed, 26 skipped (expected -- live-gate tests without credentials), 0 failures**.
- Repo-wide `mypy`: 1016 source files, 0 errors. Repo-wide `ruff check` + `ruff format --check`: clean. (Pre-push hook re-ran ruff-format-check/ruff-check/mypy on push; all passed.)
- Per the current gate policy, the full `ci/local_validate.sh` gate (including the Go stages) is **not** run lane-side pre-push; PR CI is the arbiter of the full matrix.

## RISK-NOTES

- **Preflight call count**: a full preflight now makes 6 provider calls (2 for the original binary transport-echo probe, unchanged; 4 for the new `legacy_agent` role probe -- 2 independent chains x 2 rounds each), up from 2 before any role probe existed. Documented in `docs/contribute/architecture/ask-dev-role-readiness.md` and pinned with `provider.calls == 6` assertions on both the platform and BYO readiness-route success tests so a chain can't silently vanish in a future refactor.
- **Credential + identity fingerprint keying**: the certification key now depends on organization/project/custom_headers in addition to api_key and base_url, resolved explicitly (never left for the OpenAI SDK's ambient env fallback). A credential, org, project, or custom-header rotation for an otherwise-identical provider/model/base_url now correctly invalidates the stored certification and requires re-preflight.
- **TRD Option B** (the 4,096-token output envelope) is unchanged by this PR; whether it needs amending is a decision gated on the live per-role probe's real numbers, not decided here.
- **PR4 deferred**: `intent_classification`/`answer_frame_narrative` have no working probes yet -- enum members and store slots only, gated on CHAOS-3294's schemas landing on main.
- **Winner policy for the atomic per-role upsert**: two sessions certifying the identical role concurrently -- "last COMMIT wins" (documented explicitly; `ON CONFLICT DO UPDATE` semantics).
- **Dialect support**: the atomic per-role upsert supports only `postgresql` (production) and `sqlite` (tests) natively. Any other dialect is rejected loudly (`NotImplementedError` naming the dialect) rather than falling back to a non-atomic, still-racy select-then-insert.