### PR TITLE
feat(ask-dev): CHAOS-3296 evidence minting + relationship-closure security hardening

### DIFF
--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -105,7 +105,7 @@
       },
       "schema": {
         "path": "schemas/dev_source_requirement.v1.schema.json",
-        "sha256": "70a3327b99a75169557bc3e51701f5a81af991f1c41e606ea7ce50b5a47952fd"
+        "sha256": "02ade04f31bd1e3ea4a0b510ff4eedb56c0ee520c566c729b7404d0680134189"
       },
       "schema_version": "dev_source_requirement.v1"
     },
@@ -123,7 +123,7 @@
       },
       "schema": {
         "path": "schemas/dev_investigation_plan.v1.schema.json",
-        "sha256": "ffca7df3c81e1d29aef725f604c3591fd306f60d94771cb59f19abfb89b167e5"
+        "sha256": "656eb8454ae7fdceb6d7d4811cbdcfea7f961d5ee991e8f34254e509c1661aa8"
       },
       "schema_version": "dev_investigation_plan.v1"
     },
@@ -141,7 +141,7 @@
       },
       "schema": {
         "path": "schemas/dev_source_observation.v1.schema.json",
-        "sha256": "a4d88d94e750611d75ebcd62d91f2b4a854de7d206679566d446c584ab3fc580"
+        "sha256": "499e7cd267a9f5661d667e469bb4a59453c500058ef11152674b2606cedd76b8"
       },
       "schema_version": "dev_source_observation.v1"
     },
@@ -159,7 +159,7 @@
       },
       "schema": {
         "path": "schemas/dev_investigation_result.v1.schema.json",
-        "sha256": "5974250a3cb0398d9925deeb770891367f7e7aeffc0d39cea4a70a8928a50bf2"
+        "sha256": "41297fbb8d7707d44bbf6a018d7dba9296d86e345bf1c9a2039266658173a3fb"
       },
       "schema_version": "dev_investigation_result.v1"
     },
@@ -287,7 +287,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "5f5f94cb696d0e400232436de559f3d61fbb12b86422cca0b0badb6494469a89"
+        "sha256": "4e00565d33f52d64d5b085fadccde060ce5a0032beab4ff3118768f7572e9152"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -373,7 +373,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "c6469a7ebb1cf4b77fc7f1053de9d0e8186e494fdf507deeb6dce7d3fc6f364e"
+        "sha256": "99dfec58f9092b5f3108514366fdd5ba5d56a3b968ad4017fd8ceb9348d23305"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -391,7 +391,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "ddfa6ac83c69619baa33cc65660b80eb840a77069b065c2923c9a3edbf1617cf"
+        "sha256": "c797f671f99b821b41b7d7af777b815bbac43311cb51ac63fe808bbd0d735c65"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -105,7 +105,7 @@
       },
       "schema": {
         "path": "schemas/dev_source_requirement.v1.schema.json",
-        "sha256": "02ade04f31bd1e3ea4a0b510ff4eedb56c0ee520c566c729b7404d0680134189"
+        "sha256": "70a3327b99a75169557bc3e51701f5a81af991f1c41e606ea7ce50b5a47952fd"
       },
       "schema_version": "dev_source_requirement.v1"
     },
@@ -123,7 +123,7 @@
       },
       "schema": {
         "path": "schemas/dev_investigation_plan.v1.schema.json",
-        "sha256": "656eb8454ae7fdceb6d7d4811cbdcfea7f961d5ee991e8f34254e509c1661aa8"
+        "sha256": "ffca7df3c81e1d29aef725f604c3591fd306f60d94771cb59f19abfb89b167e5"
       },
       "schema_version": "dev_investigation_plan.v1"
     },
@@ -141,7 +141,7 @@
       },
       "schema": {
         "path": "schemas/dev_source_observation.v1.schema.json",
-        "sha256": "0c9834842eca2b65e4738390034ec64802b70bca59f64209b5fd208adb298065"
+        "sha256": "a4d88d94e750611d75ebcd62d91f2b4a854de7d206679566d446c584ab3fc580"
       },
       "schema_version": "dev_source_observation.v1"
     },
@@ -159,7 +159,7 @@
       },
       "schema": {
         "path": "schemas/dev_investigation_result.v1.schema.json",
-        "sha256": "df97343fa7a0fbc014a94ff586ae10207af7082d155113d9b4b2c8807d9553d0"
+        "sha256": "5974250a3cb0398d9925deeb770891367f7e7aeffc0d39cea4a70a8928a50bf2"
       },
       "schema_version": "dev_investigation_result.v1"
     },
@@ -287,7 +287,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "44d8bcf0ecbb4c02c7349569a580e6970843ee9d9147c6e07d9a8ee3d8426823"
+        "sha256": "5f5f94cb696d0e400232436de559f3d61fbb12b86422cca0b0badb6494469a89"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -373,7 +373,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "39be43c8da7f8543fe7d494c7dd06059a8f83fd4e23047bc5aaf6a41b0aa92b5"
+        "sha256": "c6469a7ebb1cf4b77fc7f1053de9d0e8186e494fdf507deeb6dce7d3fc6f364e"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -391,7 +391,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "c249fb353acf4d4032057f89cfa7ded1d789709276b2c825642d5f6a839560c8"
+        "sha256": "ddfa6ac83c69619baa33cc65660b80eb840a77069b065c2923c9a3edbf1617cf"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
@@ -1103,6 +1103,13 @@
           "title": "Confidence",
           "type": "number"
         },
+        "edge_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Edge Id",
+          "type": "string"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -1153,7 +1160,8 @@
         "target_entity_id",
         "provenance",
         "confidence",
-        "observed_at"
+        "observed_at",
+        "edge_id"
       ],
       "title": "DevGraphEdgeV2",
       "type": "object"

--- a/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
@@ -875,6 +875,13 @@
           "title": "Confidence",
           "type": "number"
         },
+        "edge_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Edge Id",
+          "type": "string"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -925,7 +932,8 @@
         "target_entity_id",
         "provenance",
         "confidence",
-        "observed_at"
+        "observed_at",
+        "edge_id"
       ],
       "title": "DevGraphEdgeV2",
       "type": "object"

--- a/contracts/ask-dev/v2/schemas/dev_investigation_result.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_investigation_result.v1.schema.json
@@ -213,6 +213,13 @@
           "title": "Confidence",
           "type": "number"
         },
+        "edge_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Edge Id",
+          "type": "string"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -263,7 +270,8 @@
         "target_entity_id",
         "provenance",
         "confidence",
-        "observed_at"
+        "observed_at",
+        "edge_id"
       ],
       "title": "DevGraphEdgeV2",
       "type": "object"

--- a/contracts/ask-dev/v2/schemas/dev_source_observation.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_source_observation.v1.schema.json
@@ -213,6 +213,13 @@
           "title": "Confidence",
           "type": "number"
         },
+        "edge_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Edge Id",
+          "type": "string"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -263,7 +270,8 @@
         "target_entity_id",
         "provenance",
         "confidence",
-        "observed_at"
+        "observed_at",
+        "edge_id"
       ],
       "title": "DevGraphEdgeV2",
       "type": "object"

--- a/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
@@ -1263,6 +1263,13 @@
           "title": "Confidence",
           "type": "number"
         },
+        "edge_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Edge Id",
+          "type": "string"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -1313,7 +1320,8 @@
         "target_entity_id",
         "provenance",
         "confidence",
-        "observed_at"
+        "observed_at",
+        "edge_id"
       ],
       "title": "DevGraphEdgeV2",
       "type": "object"

--- a/src/dev_health_ops/api/dev/contracts_v2/embedded.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/embedded.py
@@ -203,6 +203,20 @@ class DevIncidentFactV2(ContractModelV2, DevIncidentFact):
 
 
 class DevGraphEdgeV2(ContractModelV2, DevGraphEdge):
+    #: CHAOS-3296 round-4 closure: v1's ``DevGraphEdge`` never carried the
+    #: work-graph edge's own canonical identity -- only its endpoints
+    #: (``source_entity_id``/``target_entity_id``) and relationship token
+    #: survived to the wire. ``_wire_work_graph_content`` (builtin_steps.py)
+    #: always mints each edge's evidence handle against ``item.edge_id``
+    #: (``WorkGraphNeighborEdge.edge_id``), but that identity was previously
+    #: DISCARDED before construction, so no verifier could ever check a
+    #: handle against the edge it actually claims to back -- Codex round 3
+    #: (2026-08-02, [HIGH]) confirmed this let one legitimately-minted edge
+    #: handle "verify" an arbitrary second, fabricated edge. A v2-only
+    #: addition (v1 stays untouched, additive per this module's own
+    #: mirror-not-reimplement posture) -- required, not defaulted, so every
+    #: construction site must be deliberate about identity.
+    edge_id: OpaqueID
     evidence_ref_ids: tuple[OpaqueID, ...] = Field(  # type: ignore[assignment]
         default_factory=tuple, max_length=25
     )

--- a/src/dev_health_ops/api/dev/evidence_service.py
+++ b/src/dev_health_ops/api/dev/evidence_service.py
@@ -250,6 +250,47 @@ def _authorized_entity_ids(resolution: ScopeResolution) -> set[str]:
     }
 
 
+class IdentityPayload(Protocol):
+    """CHAOS-3296 round 5: exactly the fields
+    :meth:`EvidenceReferenceSigner._payload` binds into its HMAC, and
+    nothing else -- ``DevEvidenceRef``, ``EvidenceRecord``, and a
+    verifier-only candidate a caller reconstructs from a re-derived
+    identity plus its own already-authorized ambient scope (never from the
+    fact or handle being checked; see ``investigation_plans.executor.
+    _CandidateIdentity``) are all structurally this shape. Widening
+    ``_payload`` to this protocol -- rather than the ``DevEvidenceRef |
+    EvidenceRecord`` union it used before -- is what lets a caller
+    recompute the actual signature via THIS code (never a parallel
+    reimplementation) without constructing a full contract object it has
+    no other use for.
+    """
+
+    # Read-only (``@property``, not plain annotations): every real
+    # implementer -- ``DevEvidenceRef`` (pydantic, frozen), ``EvidenceRecord``
+    # (frozen dataclass), ``_CandidateIdentity`` (frozen dataclass) -- exposes
+    # these as immutable attributes; a plain Protocol annotation requires a
+    # SETTABLE attribute for structural matching, which none of them are.
+    @property
+    def source_system(self) -> str: ...
+    @property
+    def source_version(self) -> str: ...
+    @property
+    def entity_type(self) -> str: ...
+    @property
+    def entity_id(self) -> str: ...
+    @property
+    def repository_ids(self) -> Sequence[str]: ...
+
+
+class SignedIdentity(IdentityPayload, Protocol):
+    """:class:`IdentityPayload` plus the claimed handle itself -- what
+    :meth:`EvidenceReferenceSigner.verify` needs on top of what
+    ``_payload`` needs, to compare the recomputed signature against."""
+
+    @property
+    def evidence_ref_id(self) -> str: ...
+
+
 class EvidenceReferenceSigner:
     """Issue and verify stable non-enumerable evidence handles."""
 
@@ -262,7 +303,7 @@ class EvidenceReferenceSigner:
         self._key = hashlib.sha256(b"ask-dev-evidence-v1\0" + key).digest()
 
     @staticmethod
-    def _payload(org_id: str, evidence: DevEvidenceRef | EvidenceRecord) -> bytes:
+    def _payload(org_id: str, evidence: IdentityPayload) -> bytes:
         repository_ids = sorted(evidence.repository_ids)
         payload = {
             "org": org_id,
@@ -278,7 +319,7 @@ class EvidenceReferenceSigner:
         digest = hmac.new(self._key, self._payload(org_id, record), hashlib.sha256)
         return f"ev1_{digest.hexdigest()[:40]}"
 
-    def verify(self, org_id: str, evidence: DevEvidenceRef) -> bool:
+    def verify(self, org_id: str, evidence: SignedIdentity) -> bool:
         expected = hmac.new(
             self._key, self._payload(org_id, evidence), hashlib.sha256
         ).hexdigest()[:40]

--- a/src/dev_health_ops/api/dev/investigation_plans/__init__.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/__init__.py
@@ -17,7 +17,7 @@ Public surface:
 from __future__ import annotations
 
 from .builtin_steps import PlanExecutorRuntime, register_builtin_steps
-from .executor import PlanExecutionError, PlanExecutor, wrap_runtime_with_mint_receipts
+from .executor import PlanExecutionError, PlanExecutor
 from .plan_documents import CORE_PLANS_BY_INTENT, CORE_QUESTION_INTENT_IDS
 from .registry_validation import validate_registry
 from .steps import (
@@ -45,7 +45,6 @@ __all__ = [
     "plan_registry_manifest",
     "register_builtin_steps",
     "validate_registry",
-    "wrap_runtime_with_mint_receipts",
 ]
 
 

--- a/src/dev_health_ops/api/dev/investigation_plans/__init__.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/__init__.py
@@ -17,7 +17,7 @@ Public surface:
 from __future__ import annotations
 
 from .builtin_steps import PlanExecutorRuntime, register_builtin_steps
-from .executor import PlanExecutionError, PlanExecutor
+from .executor import PlanExecutionError, PlanExecutor, wrap_runtime_with_mint_receipts
 from .plan_documents import CORE_PLANS_BY_INTENT, CORE_QUESTION_INTENT_IDS
 from .registry_validation import validate_registry
 from .steps import (
@@ -45,6 +45,7 @@ __all__ = [
     "plan_registry_manifest",
     "register_builtin_steps",
     "validate_registry",
+    "wrap_runtime_with_mint_receipts",
 ]
 
 

--- a/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
@@ -12,16 +12,42 @@ implements the port over the exact service instances
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+import hashlib
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
 from typing import Protocol
 
-from ..contracts import DevScope, MetricID
-from ..contracts_v2.base import SourceClass, SourceRequirementState
+from ..contracts import DevMetricPoint, DevScope, FreshnessState, MetricID
+from ..contracts_v2.base import EvidenceHandle, SourceClass, SourceRequirementState
+from ..contracts_v2.embedded import (
+    DevCIFactV2,
+    DevDeploymentFactV2,
+    DevGraphEdgeV2,
+    DevIncidentFactV2,
+    DevMetricRefV2,
+    DevPullRequestFactV2,
+    DevRequiredChildFactV2,
+    DevScopeV2,
+    DevStatusFactV2,
+)
+from ..contracts_v2.result import DevObservedChangeV2, DevSourceContent
 from ..data_health_service import DataHealthResult
 from ..metrics.definitions import MetricDefinition
 from ..metrics.service import MetricQueryResult
-from ..status_change_service import ChangeSummaryResult, StatusSnapshotResult
-from ..work_graph_neighbors_service import WorkGraphNeighborsResult
+from ..status_change_service import (
+    ChangeSummaryResult,
+    CIFact,
+    DeploymentFact,
+    IncidentFact,
+    ObservedChange,
+    PullRequestFact,
+    StatusFact,
+    StatusSnapshotResult,
+)
+from ..work_graph_neighbors_service import (
+    WorkGraphNeighborEdge,
+    WorkGraphNeighborsResult,
+)
 from .state_mapping import (
     UNMEASURED_REQUIREMENT_STATES,
     data_health_state_to_requirement_state,
@@ -40,6 +66,422 @@ __all__ = ["PlanExecutorRuntime", "register_builtin_steps"]
 #: No dedicated field carries this signal, so it is recognized here by its
 #: pinned warning string.
 _ASSESSMENT_SOURCE_BOUND_WARNING = "status assessment source bound reached"
+
+#: A signer-issued evidence handle minted for one fact.
+_Mint = Callable[..., EvidenceHandle]
+
+#: CHAOS-3296 evidence-minting identity conventions. These mirror
+#: ``production_runtime.py``'s proven v1 tool-call wiring
+#: (``_STATUS_ENTITY_SOURCE_SYSTEM`` et al.) *by value*, not by import:
+#: ``production_runtime.py`` already imports this package
+#: (``build_default_registry``), so importing back would be circular. A
+#: drift between the two surfaces as an evidence-expansion ``NO_MATCHES``,
+#: never a type error -- keep in sync deliberately.
+_STATUS_ENTITY_SOURCE_SYSTEM: Mapping[str, str] = {
+    "issue": "work_items",
+    "pull_request": "pull_requests",
+    "work_unit": "work_units",
+    "project": "work_items",
+}
+_CHANGE_CATEGORY_SOURCE_SYSTEM: Mapping[str, str] = {
+    "entity": "work_items",
+    "status": "work_items",
+    "relationship": "work_graph",
+    "blocker": "work_items",
+    "dependency": "work_items",
+    "pull_request": "pull_requests",
+    "review": "reviews",
+    "ci": "ci_runs",
+    "deployment": "deployments",
+    "incident": "incidents",
+    "metric": "metrics",
+}
+_CHANGE_COLLISION_PRONE_CATEGORIES = frozenset({"status", "metric"})
+_CI_ACCEPTANCE_CHECK_MARKER = "#check"
+_STATUS_EVIDENCE_SOURCE_VERSION = "status-snapshot-evidence.v1"
+_CHANGE_EVIDENCE_SOURCE_VERSION = "change-summary-evidence.v1"
+_GRAPH_EVIDENCE_SOURCE_VERSION = "work-graph-evidence.v1"
+_METRIC_EVIDENCE_SOURCE_VERSION = "metric-query-evidence.v1"
+#: Every ``DevSourceContent`` field caps at 25 except ``required_children``
+#: (100, matching ``StatusSnapshotRequest``'s own assessment bound). A
+#: category over this limit is capped here, deterministically (encounter
+#: order) -- priority-ordered truncation is explicitly a later "Evidence
+#: prioritization and bounds" concern (issue body), not this deliverable's.
+_CONTENT_CATEGORY_LIMIT = 25
+_REQUIRED_CHILDREN_LIMIT = 100
+
+
+def _ci_evidence_identity(entity_id: str) -> str:
+    # ci_acceptance_checks rows carry a "{repo}#ci{run}#check{key}" entity_id;
+    # the "ci_runs" adapter only indexes "{repo}#ci{run}". Coarsen to the run
+    # so expansion resolves the underlying CI run instead of NO_MATCHES.
+    return entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
+
+
+def _scope_evidence_binding(scope: DevScope) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """(valid_entity_ids, repository_ids) bound to the caller's own
+    already-authorized scope -- never to a supporting fact's own id."""
+
+    return (
+        tuple(item.entity_id for item in scope.entity_refs),
+        tuple(scope.repositories),
+    )
+
+
+def _capped(items: object, limit: int = _CONTENT_CATEGORY_LIMIT) -> tuple:
+    return tuple(items)[:limit]  # type: ignore[arg-type]
+
+
+def _wire_status_snapshot_content(
+    result: StatusSnapshotResult,
+    *,
+    mint: _Mint,
+    org_id: str,
+    scope: DevScope,
+) -> DevSourceContent:
+    freshness_by_ref: dict[str, FreshnessState] = {
+        ref.ref_id: ref.freshness for ref in result.source_refs
+    }
+    valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+
+    def status_source_system(entity_type: str) -> str:
+        return _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
+
+    def mint_status(fact: StatusFact) -> str:
+        return mint(
+            org_id=org_id,
+            source_system=status_source_system(fact.entity_type),
+            source_version=_STATUS_EVIDENCE_SOURCE_VERSION,
+            entity_type=fact.entity_type,
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            freshness=freshness_by_ref.get(fact.source_ref_id, FreshnessState.UNKNOWN),
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+
+    def wire_status_fact(fact: StatusFact) -> DevStatusFactV2:
+        evidence_id = mint_status(fact)
+        return DevStatusFactV2(
+            fact_id=f"{fact.entity_type}:{fact.entity_id}",
+            text=f"{fact.display_label}: {fact.status}",
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    def wire_required_child(fact: StatusFact) -> DevRequiredChildFactV2:
+        evidence_id = mint_status(fact)
+        return DevRequiredChildFactV2(
+            fact_id=f"{fact.entity_type}:{fact.entity_id}",
+            text=fact.display_label,
+            status=fact.status,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    def mint_delivery(
+        *,
+        source_system: str,
+        entity_type: str,
+        entity_id: str,
+        display_label: str,
+        observed_at: datetime,
+        source_ref_id: str,
+        source_version: str = _STATUS_EVIDENCE_SOURCE_VERSION,
+    ) -> str:
+        return mint(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness_by_ref.get(source_ref_id, FreshnessState.UNKNOWN),
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+
+    def wire_pull_request(fact: PullRequestFact) -> DevPullRequestFactV2:
+        evidence_id = mint_delivery(
+            source_system="pull_requests",
+            entity_type="pull_request",
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            source_ref_id=fact.source_ref_id,
+        )
+        return DevPullRequestFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            state=fact.state,
+            review_state=fact.review_state,
+            changes_requested=fact.changes_requested,
+            merged=fact.merged,
+            required=fact.required,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    def wire_ci(fact: CIFact) -> DevCIFactV2:
+        lookup_entity_id = _ci_evidence_identity(fact.entity_id)
+        source_version = (
+            f"{_STATUS_EVIDENCE_SOURCE_VERSION}:{fact.entity_id}"
+            if lookup_entity_id != fact.entity_id
+            else _STATUS_EVIDENCE_SOURCE_VERSION
+        )
+        evidence_id = mint_delivery(
+            source_system="ci_runs",
+            entity_type="ci_run",
+            entity_id=lookup_entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            source_ref_id=fact.source_ref_id,
+            source_version=source_version,
+        )
+        return DevCIFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            conclusion=fact.conclusion,
+            required=fact.required,
+            skipped_required_work=fact.skipped_required_work,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    def wire_deployment(fact: DeploymentFact) -> DevDeploymentFactV2:
+        evidence_id = mint_delivery(
+            source_system="deployments",
+            entity_type="deployment",
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            source_ref_id=fact.source_ref_id,
+        )
+        return DevDeploymentFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            status=fact.status,
+            environment=fact.environment,
+            required=fact.required,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    def wire_incident(fact: IncidentFact) -> DevIncidentFactV2:
+        evidence_id = mint_delivery(
+            source_system="incidents",
+            entity_type="incident",
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            source_ref_id=fact.source_ref_id,
+        )
+        return DevIncidentFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            status=fact.status,
+            active=fact.active,
+            blocking=fact.blocking,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    status_facts = _capped(
+        wire_status_fact(fact)
+        for fact in (
+            ([result.declared] if result.declared else [])
+            + list(result.children)
+            + list(result.blockers)
+        )
+    )
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=status_facts,
+        required_children=_capped(
+            (wire_required_child(fact) for fact in result.actual.required_children),
+            limit=_REQUIRED_CHILDREN_LIMIT,
+        ),
+        pull_requests=_capped(wire_pull_request(fact) for fact in result.pull_requests),
+        ci_checks=_capped(wire_ci(fact) for fact in result.ci),
+        deployments=_capped(wire_deployment(fact) for fact in result.deployments),
+        incidents=_capped(wire_incident(fact) for fact in result.incidents),
+    )
+
+
+def _wire_change_summary_content(
+    result: ChangeSummaryResult,
+    *,
+    mint: _Mint,
+    org_id: str,
+    scope: DevScope,
+) -> DevSourceContent:
+    freshness_by_ref: dict[str, FreshnessState] = {
+        ref.ref_id: ref.freshness for ref in result.source_refs
+    }
+    valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+
+    def change_freshness(item: ObservedChange) -> FreshnessState:
+        for ref_id in item.source_ref_ids:
+            freshness = freshness_by_ref.get(ref_id)
+            if freshness is not None:
+                return freshness
+        return FreshnessState.UNKNOWN
+
+    def change_evidence_identity(item: ObservedChange) -> tuple[str, str, str]:
+        category = item.category.value
+        source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
+        if category == "relationship":
+            return source_system, item.change_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+        if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+            return (
+                source_system,
+                item.entity_id,
+                f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}",
+            )
+        return source_system, item.entity_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+
+    def wire_change(item: ObservedChange) -> DevObservedChangeV2:
+        source_system, lookup_entity_id, source_version = change_evidence_identity(item)
+        evidence_id = mint(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=item.entity_type,
+            entity_id=lookup_entity_id,
+            display_label=item.display_label,
+            observed_at=item.observed_at,
+            freshness=change_freshness(item),
+            confidence=item.confidence if item.confidence is not None else 1.0,
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+        return DevObservedChangeV2(
+            change_id=item.change_id,
+            category=item.category.value,
+            entity_type=item.entity_type,
+            entity_id=item.entity_id,
+            display_label=item.display_label,
+            before=item.before,
+            after=item.after,
+            observed_at=item.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        observed_changes=_capped(wire_change(item) for item in result.changes),
+    )
+
+
+def _wire_work_graph_content(
+    result: WorkGraphNeighborsResult,
+    *,
+    mint: _Mint,
+    org_id: str,
+    scope: DevScope,
+) -> DevSourceContent:
+    valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+
+    def wire_edge(item: WorkGraphNeighborEdge) -> DevGraphEdgeV2:
+        evidence_id = mint(
+            org_id=org_id,
+            source_system="work_graph",
+            source_version=_GRAPH_EVIDENCE_SOURCE_VERSION,
+            entity_type="work_graph_edge",
+            entity_id=item.edge_id,
+            display_label=(
+                f"{item.source_type}:{item.source_id} {item.relationship_type} "
+                f"{item.target_type}:{item.target_id}"
+            ),
+            observed_at=item.observed_at,
+            freshness=FreshnessState.UNKNOWN,
+            confidence=item.confidence,
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+        return DevGraphEdgeV2(
+            source_entity_id=item.source_id,
+            relationship=item.relationship_type,
+            target_entity_id=item.target_id,
+            provenance=(item.provenance.strip() or "persisted")[:2_048],
+            confidence=max(0.0, min(1.0, item.confidence)),
+            observed_at=item.observed_at,
+            evidence_ref_ids=(evidence_id,),
+        )
+
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        graph_edges=_capped(wire_edge(item) for item in result.edges),
+    )
+
+
+def _wire_metric_content(
+    results: Sequence[MetricQueryResult],
+    *,
+    mint: _Mint,
+    org_id: str,
+    scope: DevScope,
+) -> DevSourceContent:
+    valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+    scope_v2 = DevScopeV2.model_validate(scope.model_dump(mode="json"))
+    refs: list[DevMetricRefV2] = []
+    for result in results:
+        for value in result.values:
+            dimensions = tuple(f"{key}={item}" for key, item in value.dimensions)
+            digest_seed = (
+                f"{result.definition.metric_id.value}:{value.dimensions}:"
+                f"{scope.time_range.start.isoformat()}:{scope.time_range.end.isoformat()}"
+            )
+            metric_ref_id = (
+                f"metric:{hashlib.sha256(digest_seed.encode()).hexdigest()[:32]}"
+            )
+            evidence_id = mint(
+                org_id=org_id,
+                source_system="metrics",
+                source_version=_METRIC_EVIDENCE_SOURCE_VERSION,
+                entity_type="metric",
+                entity_id=metric_ref_id,
+                display_label=result.definition.label,
+                observed_at=result.watermark or scope.time_range.end,
+                freshness=result.freshness,
+                valid_entity_ids=valid_entity_ids,
+                repository_ids=repository_ids,
+            )
+            refs.append(
+                DevMetricRefV2(
+                    schema_version="dev_metric_ref.v1",
+                    metric_ref_id=metric_ref_id,
+                    metric_id=result.definition.metric_id,
+                    label=result.definition.label,
+                    definition_version=result.definition.definition_version,
+                    unit=result.definition.unit,
+                    aggregation=result.definition.aggregation,
+                    display_precision=result.definition.display_precision,
+                    resolved_scope=scope_v2,
+                    dimensions=dimensions,
+                    current_window=scope.time_range,
+                    comparison_window=(
+                        scope.comparison_range
+                        if value.comparison_value is not None
+                        else None
+                    ),
+                    value=value.value,
+                    comparison_value=value.comparison_value,
+                    series=tuple(
+                        DevMetricPoint(timestamp=point.timestamp, value=point.value)
+                        for point in value.series
+                    ),
+                    query_version=result.definition.query_version,
+                    source_version=result.definition.source_version,
+                    freshness=result.freshness,
+                    coverage=result.coverage,
+                    evidence_ref_ids=(evidence_id,),
+                )
+            )
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        metric_refs=_capped(refs),
+    )
 
 
 class PlanExecutorRuntime(Protocol):
@@ -72,6 +514,31 @@ class PlanExecutorRuntime(Protocol):
         self, *, org_id: str, permission_fingerprint: str, scope: DevScope
     ) -> DataHealthResult:
         """Enumerate required source health for ``scope`` (trust.data.v1 core call)."""
+        ...
+
+    def mint_evidence(
+        self,
+        *,
+        org_id: str,
+        source_system: str,
+        source_version: str,
+        entity_type: str,
+        entity_id: str,
+        display_label: str,
+        observed_at: datetime,
+        freshness: FreshnessState,
+        confidence: float = 1.0,
+        valid_entity_ids: Sequence[str] = (),
+        repository_ids: Sequence[str] = (),
+    ) -> EvidenceHandle:
+        """CHAOS-3296: issue one signer-backed, ``get_evidence.v1``-expandable
+        evidence handle for a fact a step already fetched.
+
+        ``valid_entity_ids``/``repository_ids`` must be bound to the
+        caller's own already-authorized scope, never to the supporting
+        fact's own entity id -- see ``production_runtime._mint_evidence``,
+        the concrete production implementation of this method.
+        """
         ...
 
 
@@ -159,6 +626,7 @@ def _status_mapped_outcome(
     limitation: str,
     watermark=None,
     query_version: str = "unversioned",
+    content: DevSourceContent | None = None,
 ) -> StepOutcome:
     """Build a ``StepOutcome`` from a state already mapped through this
     module's ``state_mapping`` functions.
@@ -176,6 +644,10 @@ def _status_mapped_outcome(
     """
 
     if state in UNMEASURED_REQUIREMENT_STATES:
+        # DevSourceObservation.validate_content_semantics rejects content on
+        # an unmeasured state -- never forward it here even if a caller
+        # passed one (defense in depth; every caller below already only
+        # builds content on the queried branch).
         return StepOutcome(
             observed_state=state,
             data_semantics="not_measured",
@@ -190,6 +662,7 @@ def _status_mapped_outcome(
         usable_fact_count=usable_fact_count,
         watermark=watermark,
         query_version=query_version,
+        content=content,
     )
 
 
@@ -222,6 +695,16 @@ def register_builtin_steps(
             (1 if result.declared else 0) + len(result.children) + len(result.blockers)
         )
         state = status_result_state_to_requirement_state(result.state)
+        content = (
+            None
+            if state in UNMEASURED_REQUIREMENT_STATES
+            else _wire_status_snapshot_content(
+                result,
+                mint=runtime.mint_evidence,
+                org_id=ctx.org_id,
+                scope=ctx.scope,
+            )
+        )
         return _status_mapped_outcome(
             state,
             usable_fact_count=usable,
@@ -231,6 +714,7 @@ def register_builtin_steps(
                 default=None,
             ),
             query_version="status-snapshot.v1",
+            content=content,
         )
 
     async def change_summary_run(ctx: StepContext) -> StepOutcome:
@@ -247,11 +731,23 @@ def register_builtin_steps(
             scope=ctx.scope,
         )
         usable = len(result.changes)
+        state = status_result_state_to_requirement_state(result.state)
+        content = (
+            None
+            if state in UNMEASURED_REQUIREMENT_STATES
+            else _wire_change_summary_content(
+                result,
+                mint=runtime.mint_evidence,
+                org_id=ctx.org_id,
+                scope=ctx.scope,
+            )
+        )
         return _status_mapped_outcome(
-            status_result_state_to_requirement_state(result.state),
+            state,
             usable_fact_count=usable,
             limitation="change_summary_insufficient_evidence",
             query_version="change-summary.v1",
+            content=content,
         )
 
     async def required_source_health_run(ctx: StepContext) -> StepOutcome:
@@ -288,6 +784,12 @@ def register_builtin_steps(
             usable_fact_count=usable,
             watermark=result.watermark,
             query_version=result.query_version,
+            content=_wire_work_graph_content(
+                result,
+                mint=runtime.mint_evidence,
+                org_id=ctx.org_id,
+                scope=ctx.scope,
+            ),
         )
 
     async def list_metrics_run(ctx: StepContext) -> StepOutcome:
@@ -334,7 +836,13 @@ def register_builtin_steps(
             ),
             return_exceptions=True,
         )
-        return _combined_metric_outcome(results, query_version="query-metric.v1")
+        return _combined_metric_outcome(
+            results,
+            query_version="query-metric.v1",
+            mint=runtime.mint_evidence,
+            org_id=ctx.org_id,
+            scope=ctx.scope,
+        )
 
     async def registered_metric_query_run(ctx: StepContext) -> StepOutcome:
         metric_ids = ctx.requested_metric_ids or tuple(
@@ -353,7 +861,13 @@ def register_builtin_steps(
             ),
             return_exceptions=True,
         )
-        return _combined_metric_outcome(results, query_version="query-metric.v1")
+        return _combined_metric_outcome(
+            results,
+            query_version="query-metric.v1",
+            mint=runtime.mint_evidence,
+            org_id=ctx.org_id,
+            scope=ctx.scope,
+        )
 
     registry.register(
         PlanStepDefinition(
@@ -498,7 +1012,12 @@ def register_builtin_steps(
 
 
 def _combined_metric_outcome(
-    results: Sequence[MetricQueryResult | BaseException], *, query_version: str
+    results: Sequence[MetricQueryResult | BaseException],
+    *,
+    query_version: str,
+    mint: _Mint,
+    org_id: str,
+    scope: DevScope,
 ) -> StepOutcome:
     """One combined observation across every requested metric (batched_fan_out)."""
 
@@ -537,6 +1056,7 @@ def _combined_metric_outcome(
         data_semantics=queried_semantics(usable),
         usable_fact_count=usable,
         query_version=query_version,
+        content=_wire_metric_content(successful, mint=mint, org_id=org_id, scope=scope),
     )
 
 

--- a/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import Protocol
@@ -118,6 +119,74 @@ def _ci_evidence_identity(entity_id: str) -> str:
     return entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
 
 
+def _content_digest(**claim_fields: object) -> str:
+    """Canonical digest of a fact's own ASSERTED CONTENT -- the claim
+    fields beyond bare identity, keyed by the exact canonical model field
+    names, never a display/truncated form. Embedded into a minted
+    ``source_version`` (see :func:`_bind_content`) so the real signer's
+    HMAC binds not just WHICH entity a piece of evidence is for, but WHAT
+    it is being cited to prove.
+
+    CHAOS-3296 round-5 structural inversion (Codex finding, HIGH, round 4,
+    2026-08-02, generalized beyond its original ``ci_checks``-only scope
+    after review: the gap is not CI-specific -- ANY category whose minted
+    identity tuple does not already uniquely determine its content lets a
+    genuinely-minted handle for one claim "verify" a fabricated, different
+    claim about the same identity). Binding a digest of the claim itself at
+    mint means two facts differing in any bound field mint different,
+    non-interchangeable handles: a real handle for one claim can never
+    verify a different claim about the same entity. ``default=str`` so a
+    non-JSON-native claim field (e.g. an enum) never raises here -- the
+    digest only needs to be a deterministic function of the value, not a
+    faithful re-encoding of it.
+    """
+
+    canonical = json.dumps(
+        claim_fields, sort_keys=True, separators=(",", ":"), default=str
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def _bind_content(source_version: str, **claim_fields: object) -> str:
+    """Fold :func:`_content_digest` of ``claim_fields`` into ``source_version``.
+
+    Every ``wire_*`` mint call site below uses this (never a bespoke
+    string-format) and every corresponding
+    ``relationship_matrix.EVIDENCE_IDENTITY_TABLE`` cell recomputes the
+    SAME claim fields from the wire fact and calls this SAME function --
+    the only way mint and verify can be PROVEN to agree, rather than
+    merely described as agreeing, is for both to call the exact same code.
+    """
+
+    return f"{source_version}#content:{_content_digest(**claim_fields)}"
+
+
+def _ci_check_source_version(
+    fact_entity_id: str,
+    *,
+    conclusion: str,
+    required: bool | None,
+    skipped_required_work: bool | None,
+) -> str:
+    """The exact ``source_version`` :func:`_wire_status_snapshot_content`'s
+    ``wire_ci`` mints against for one CI check fact -- round 4's run-vs-check
+    discriminator (embed the full, uncoarsened ``entity_id`` when coarsening
+    actually changed it) plus round 5's content digest (``conclusion``/
+    ``required``/``skipped_required_work``, ``DevCIFactV2``'s own claim
+    fields), always. A SHARED function, imported directly by
+    ``relationship_matrix.py``'s ``_identity_ci_check`` cell (never
+    duplicated)."""
+
+    lookup_entity_id = _ci_evidence_identity(fact_entity_id)
+    discriminator = f":{fact_entity_id}" if lookup_entity_id != fact_entity_id else ""
+    return _bind_content(
+        f"{_STATUS_EVIDENCE_SOURCE_VERSION}{discriminator}",
+        conclusion=conclusion,
+        required=required,
+        skipped_required_work=skipped_required_work,
+    )
+
+
 def _scope_evidence_binding(scope: DevScope) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """(valid_entity_ids, repository_ids) bound to the caller's own
     already-authorized scope -- never to a supporting fact's own id."""
@@ -148,10 +217,24 @@ def _wire_status_snapshot_content(
         return _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
 
     def mint_status(fact: StatusFact) -> str:
+        # CHAOS-3296 round 5: the SAME composed "{label}: {status}" string
+        # ``wire_status_fact`` writes verbatim onto ``DevStatusFactV2.text``
+        # -- that field IS this fact's asserted content on the wire, so
+        # binding it here (rather than the raw ``fact.status`` alone) means
+        # ``_identity_status_fact`` can recompute the identical claim
+        # straight from ``fact.text`` with no parsing. ``wire_required_child``
+        # stores ``display_label``/``status`` as two SEPARATE wire fields
+        # instead, but ``_identity_required_child`` reconstructs this exact
+        # same composed string from them (see relationship_matrix.py) -- one
+        # shared mint-time claim, two ways to recover it depending on which
+        # wire shape kept which piece.
         return mint(
             org_id=org_id,
             source_system=status_source_system(fact.entity_type),
-            source_version=_STATUS_EVIDENCE_SOURCE_VERSION,
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION,
+                claim=f"{fact.display_label}: {fact.status}",
+            ),
             entity_type=fact.entity_type,
             entity_id=fact.entity_id,
             display_label=fact.display_label,
@@ -209,6 +292,17 @@ def _wire_status_snapshot_content(
             display_label=fact.display_label,
             observed_at=fact.observed_at,
             source_ref_id=fact.source_ref_id,
+            # CHAOS-3296 round 5: bind DevPullRequestFactV2's own claim
+            # fields -- a genuine handle for one PR state must never
+            # authenticate a fabricated claim of a different state.
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION,
+                state=fact.state,
+                review_state=fact.review_state,
+                changes_requested=fact.changes_requested,
+                merged=fact.merged,
+                required=fact.required,
+            ),
         )
         return DevPullRequestFactV2(
             entity_id=fact.entity_id,
@@ -224,10 +318,11 @@ def _wire_status_snapshot_content(
 
     def wire_ci(fact: CIFact) -> DevCIFactV2:
         lookup_entity_id = _ci_evidence_identity(fact.entity_id)
-        source_version = (
-            f"{_STATUS_EVIDENCE_SOURCE_VERSION}:{fact.entity_id}"
-            if lookup_entity_id != fact.entity_id
-            else _STATUS_EVIDENCE_SOURCE_VERSION
+        source_version = _ci_check_source_version(
+            fact.entity_id,
+            conclusion=fact.conclusion,
+            required=fact.required,
+            skipped_required_work=fact.skipped_required_work,
         )
         evidence_id = mint_delivery(
             source_system="ci_runs",
@@ -256,6 +351,14 @@ def _wire_status_snapshot_content(
             display_label=fact.display_label,
             observed_at=fact.observed_at,
             source_ref_id=fact.source_ref_id,
+            # CHAOS-3296 round 5: bind DevDeploymentFactV2's own claim
+            # fields.
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION,
+                status=fact.status,
+                environment=fact.environment,
+                required=fact.required,
+            ),
         )
         return DevDeploymentFactV2(
             entity_id=fact.entity_id,
@@ -275,6 +378,13 @@ def _wire_status_snapshot_content(
             display_label=fact.display_label,
             observed_at=fact.observed_at,
             source_ref_id=fact.source_ref_id,
+            # CHAOS-3296 round 5: bind DevIncidentFactV2's own claim fields.
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION,
+                status=fact.status,
+                active=fact.active,
+                blocking=fact.blocking,
+            ),
         )
         return DevIncidentFactV2(
             entity_id=fact.entity_id,
@@ -331,14 +441,25 @@ def _wire_change_summary_content(
         category = item.category.value
         source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
         if category == "relationship":
-            return source_system, item.change_id, _CHANGE_EVIDENCE_SOURCE_VERSION
-        if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
-            return (
-                source_system,
-                item.entity_id,
-                f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}",
-            )
-        return source_system, item.entity_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+            base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
+            lookup_entity_id = item.change_id
+        elif category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+            base_source_version = f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}"
+            lookup_entity_id = item.entity_id
+        else:
+            base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
+            lookup_entity_id = item.entity_id
+        # CHAOS-3296 round 5: bind DevObservedChangeV2's own claim fields --
+        # ``before``/``after`` are the only ``ObservedChange`` fields that
+        # actually survive onto the wire type (``claim_kind``/
+        # ``relationship_chain``/``metric_value``/``metric_comparison_value``
+        # do not), so they are the only ones a verifier could ever
+        # recompute; binding them closes the reachable half of this
+        # category's forgery surface.
+        source_version = _bind_content(
+            base_source_version, before=item.before, after=item.after
+        )
+        return source_system, lookup_entity_id, source_version
 
     def wire_change(item: ObservedChange) -> DevObservedChangeV2:
         source_system, lookup_entity_id, source_version = change_evidence_identity(item)
@@ -386,7 +507,15 @@ def _wire_work_graph_content(
         evidence_id = mint(
             org_id=org_id,
             source_system="work_graph",
-            source_version=_GRAPH_EVIDENCE_SOURCE_VERSION,
+            # CHAOS-3296 round 5: bind DevGraphEdgeV2's own claim fields --
+            # a genuine handle for edge_id X must never authenticate a
+            # fabricated relationship/orientation for that same edge_id.
+            source_version=_bind_content(
+                _GRAPH_EVIDENCE_SOURCE_VERSION,
+                relationship=item.relationship_type,
+                source_entity_id=item.source_id,
+                target_entity_id=item.target_id,
+            ),
             entity_type="work_graph_edge",
             entity_id=item.edge_id,
             display_label=(
@@ -439,7 +568,15 @@ def _wire_metric_content(
             evidence_id = mint(
                 org_id=org_id,
                 source_system="metrics",
-                source_version=_METRIC_EVIDENCE_SOURCE_VERSION,
+                # CHAOS-3296 round 5: bind DevMetricRefV2's own claim
+                # fields -- a genuine handle for one metric value must
+                # never authenticate a fabricated different value for the
+                # same ``metric_ref_id``.
+                source_version=_bind_content(
+                    _METRIC_EVIDENCE_SOURCE_VERSION,
+                    value=value.value,
+                    comparison_value=value.comparison_value,
+                ),
                 entity_type="metric",
                 entity_id=metric_ref_id,
                 display_label=result.definition.label,

--- a/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
@@ -15,8 +15,9 @@ import asyncio
 import hashlib
 import json
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol
+from typing import Any, Protocol
 
 from ..contracts import DevMetricPoint, DevScope, FreshnessState, MetricID
 from ..contracts_v2.base import EvidenceHandle, SourceClass, SourceRequirementState
@@ -110,6 +111,14 @@ _METRIC_EVIDENCE_SOURCE_VERSION = "metric-query-evidence.v1"
 #: prioritization and bounds" concern (issue body), not this deliverable's.
 _CONTENT_CATEGORY_LIMIT = 25
 _REQUIRED_CHILDREN_LIMIT = 100
+#: A handle-shaped placeholder for the construct-then-project-then-mint-
+#: then-patch pattern (see :func:`_claim_projection`) on the ONE category
+#: whose contract requires ``evidence_ref_ids`` non-empty at construction
+#: time (``DevStatusFactV2``, inherited from v1's ``DevStatusFact`` --
+#: every other embedded type defaults it to an empty tuple). Never read by
+#: anything: ``_claim_projection`` excludes ``evidence_ref_ids`` from the
+#: digest, and the real handle overwrites this immediately after minting.
+_PLACEHOLDER_EVIDENCE_REF_ID = "ev1_" + "0" * 40
 
 
 def _ci_evidence_identity(entity_id: str) -> str:
@@ -119,13 +128,21 @@ def _ci_evidence_identity(entity_id: str) -> str:
     return entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
 
 
-def _content_digest(**claim_fields: object) -> str:
+def _content_digest(claim: Mapping[str, object]) -> str:
     """Canonical digest of a fact's own ASSERTED CONTENT -- the claim
     fields beyond bare identity, keyed by the exact canonical model field
     names, never a display/truncated form. Embedded into a minted
     ``source_version`` (see :func:`_bind_content`) so the real signer's
     HMAC binds not just WHICH entity a piece of evidence is for, but WHAT
     it is being cited to prove.
+
+    ``claim`` is a single ``Mapping``, never ``**kwargs`` -- CHAOS-3296
+    round 6 found that ``**kwargs`` collides with :func:`_bind_content`'s
+    OWN ``source_version`` parameter the moment a real claim field happens
+    to be named ``source_version`` (``DevMetricRefV2.source_version`` is
+    exactly this: the metric DEFINITION's own version, a genuine field
+    :func:`_claim_projection` legitimately includes). A single dict
+    argument has no name of its own to collide with anything.
 
     CHAOS-3296 round-5 structural inversion (Codex finding, HIGH, round 4,
     2026-08-02, generalized beyond its original ``ci_checks``-only scope
@@ -142,49 +159,178 @@ def _content_digest(**claim_fields: object) -> str:
     """
 
     canonical = json.dumps(
-        claim_fields, sort_keys=True, separators=(",", ":"), default=str
+        dict(claim), sort_keys=True, separators=(",", ":"), default=str
     )
     return hashlib.sha256(canonical.encode()).hexdigest()[:16]
 
 
-def _bind_content(source_version: str, **claim_fields: object) -> str:
-    """Fold :func:`_content_digest` of ``claim_fields`` into ``source_version``.
+def _bind_content(source_version: str, claim: Mapping[str, object]) -> str:
+    """Fold :func:`_content_digest` of ``claim`` into ``source_version``.
 
     Every ``wire_*`` mint call site below uses this (never a bespoke
     string-format) and every corresponding
     ``relationship_matrix.EVIDENCE_IDENTITY_TABLE`` cell recomputes the
-    SAME claim fields from the wire fact and calls this SAME function --
+    SAME claim mapping from the wire fact and calls this SAME function --
     the only way mint and verify can be PROVEN to agree, rather than
     merely described as agreeing, is for both to call the exact same code.
+
+    Never pass a hand-composed, delimiter-joined string as a single claim
+    field (e.g. ``f"{label}: {status}"``) when the two parts are ever
+    independently recoverable on the wire -- Codex round 6 flagged exactly
+    this shape as collision-prone (``"Repo: Alpha", "blocked"`` and
+    ``"Repo", "Alpha: blocked"`` compose to the identical string). Pass
+    each semantic part as its OWN dict key instead; JSON's own key/value
+    delimiting makes two different field sets produce different digests
+    unconditionally, with no delimiter for an attacker-controlled value to
+    collide across.
     """
 
-    return f"{source_version}#content:{_content_digest(**claim_fields)}"
+    return f"{source_version}#content:{_content_digest(claim)}"
+
+
+#: Fields every ``DevSourceContent`` embedded fact model carries that are
+#: NEVER part of its own asserted claim: ``schema_version`` is a fixed
+#: contract-version literal (never forgeable content), and
+#: ``evidence_ref_ids`` is the handle(s) being authenticated -- binding it
+#: into its own digest would be circular.
+_CLAIM_PROJECTION_EXCLUDED_FIELDS = frozenset({"schema_version", "evidence_ref_ids"})
+
+
+def _claim_projection(fact: Any) -> dict[str, object]:
+    """Every semantic field ``fact`` (a ``DevSourceContent`` embedded
+    pydantic model) carries except :data:`_CLAIM_PROJECTION_EXCLUDED_FIELDS`
+    -- derived PROGRAMMATICALLY from the wire model's own ``model_fields``,
+    never a hand-picked list.
+
+    CHAOS-3296 round 6 (Codex findings, HIGH): round 5's content binding
+    used hand-picked claim-field lists per category, and two of them
+    (``metric_refs``: bound ``value``/``comparison_value`` but not
+    ``metric_id``/``dimensions``/``series``/...; ``graph_edges``: bound
+    ``relationship``/orientation but not ``provenance``/``confidence``/
+    ``observed_at``) were incomplete -- a genuine handle for one claim
+    verified a fabricated DIFFERENT claim that happened to leave the
+    hand-picked fields unchanged. A hand list can always miss a field a
+    future change adds; reflecting on ``model_fields`` cannot -- a new
+    field is bound automatically the moment it exists on the model, so
+    this class of gap fails closed (an added-but-unbound field is
+    structurally impossible) rather than needing to be remembered.
+    """
+
+    return {
+        name: getattr(fact, name)
+        for name in type(fact).model_fields
+        if name not in _CLAIM_PROJECTION_EXCLUDED_FIELDS
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class _AuthorizationScope:
+    """A deeply immutable snapshot of the CALLER's already-authorized
+    scope -- captured ONCE, from :class:`~.steps.StepContext`'s ``scope``,
+    BEFORE any registered step (this executor's threat model's adversary)
+    gets a chance to run at all.
+
+    CHAOS-3296 round 6 (Codex finding, HIGH): ``DevScope`` is a frozen
+    pydantic model, but its OWN ``repositories``/``team_ids``/
+    ``entity_refs`` fields are mutable list VALUES -- pydantic's
+    ``frozen=True`` blocks attribute REASSIGNMENT, never mutation of
+    whatever an attribute already points to. A step that mutated
+    ``context.scope.repositories`` in place mid-run, then minted evidence
+    against the mutated (self-chosen) value, verified clean -- because
+    verification ALSO re-read ``context.scope.repositories`` AFTER the
+    step had already run, seeing the SAME self-chosen mutation the step
+    itself just wrote. Capturing fresh, independently-owned tuples here,
+    and never reading ``context.scope`` for anything authorization-relevant
+    again after this snapshot is taken, makes it impossible for any step to
+    retroactively rewrite what it was ever authorized to see.
+
+    ``repositories`` is exposed here for completeness but is NOT folded
+    into :func:`_authorization_scope_digest` -- it is already natively
+    bound into the real signer's HMAC (``EvidenceReferenceSigner._payload``'s
+    ``"repositories"`` key, via ``_CandidateIdentity.repository_ids`` at
+    verify time); folding it into the digest too would be redundant, not
+    incorrect, but the snapshot's ``repositories`` value is still the one
+    ``executor._evidence_signature_failures`` must use in place of a fresh
+    (mutation-vulnerable) read of ``context.scope.repositories``.
+    """
+
+    direct_scope: str
+    team_ids: tuple[str, ...]
+    entity_ids: tuple[str, ...]
+    repositories: tuple[str, ...]
+
+
+def _snapshot_authorization_scope(scope: DevScope) -> _AuthorizationScope:
+    return _AuthorizationScope(
+        direct_scope=scope.direct_scope.value,
+        team_ids=tuple(scope.team_ids),
+        entity_ids=tuple(ref.entity_id for ref in scope.entity_refs),
+        repositories=tuple(scope.repositories),
+    )
+
+
+def _authorization_scope_digest(auth_scope: _AuthorizationScope) -> str:
+    """Digest of the scope facets NOT already natively bound by the real
+    signer (see :class:`_AuthorizationScope`'s own docstring for why
+    ``repositories`` is excluded here specifically).
+
+    CHAOS-3296 round 6 (Codex finding, HIGH): a TEAM-scoped investigation
+    (``direct_scope=TEAM``) has an EMPTY ``repositories`` -- nothing
+    previously bound ``team_ids`` at all, so two investigations scoped to
+    DIFFERENT teams, both querying the same entity with the same content,
+    minted the exact same handle (repositories=() for both, team_ids
+    unsigned). Binding ``team_ids``/``direct_scope``/``entity_ids`` here,
+    folded into every minted ``source_version`` (see
+    :func:`_scope_bound_mint`) and recomputed at verify time from this
+    SAME snapshot type (never from the fact, never from a live re-read of
+    ``context.scope``), closes it: a handle genuinely minted under a
+    DIFFERENT team's/entity's authorization scope can never verify under
+    this one.
+    """
+
+    return _content_digest(
+        {
+            "direct_scope": auth_scope.direct_scope,
+            "team_ids": auth_scope.team_ids,
+            "entity_ids": auth_scope.entity_ids,
+        }
+    )
+
+
+def _scope_bound_mint(mint: _Mint, scope: DevScope) -> _Mint:
+    """Wrap ``mint`` so every call through it embeds
+    :func:`_authorization_scope_digest` of the CURRENT step's authorization
+    scope into ``source_version``.
+
+    Applied ONCE, here, at the top of each ``_wire_*_content`` function --
+    rather than touching every individual mint call site below -- is what
+    makes it structurally impossible for any CURRENT or FUTURE category to
+    omit this binding.
+    """
+
+    digest = _authorization_scope_digest(_snapshot_authorization_scope(scope))
+
+    def wrapped(*, source_version: str, **kwargs: object) -> EvidenceHandle:
+        return mint(source_version=f"{source_version}#scope:{digest}", **kwargs)
+
+    return wrapped
 
 
 def _ci_check_source_version(
-    fact_entity_id: str,
-    *,
-    conclusion: str,
-    required: bool | None,
-    skipped_required_work: bool | None,
+    fact_entity_id: str, *, claim: Mapping[str, object]
 ) -> str:
     """The exact ``source_version`` :func:`_wire_status_snapshot_content`'s
     ``wire_ci`` mints against for one CI check fact -- round 4's run-vs-check
     discriminator (embed the full, uncoarsened ``entity_id`` when coarsening
-    actually changed it) plus round 5's content digest (``conclusion``/
-    ``required``/``skipped_required_work``, ``DevCIFactV2``'s own claim
-    fields), always. A SHARED function, imported directly by
+    actually changed it) plus round 5/6's content digest of ``claim``
+    (round 6: :func:`_claim_projection` of the constructed ``DevCIFactV2``,
+    not a hand-picked field list). A SHARED function, imported directly by
     ``relationship_matrix.py``'s ``_identity_ci_check`` cell (never
     duplicated)."""
 
     lookup_entity_id = _ci_evidence_identity(fact_entity_id)
     discriminator = f":{fact_entity_id}" if lookup_entity_id != fact_entity_id else ""
-    return _bind_content(
-        f"{_STATUS_EVIDENCE_SOURCE_VERSION}{discriminator}",
-        conclusion=conclusion,
-        required=required,
-        skipped_required_work=skipped_required_work,
-    )
+    return _bind_content(f"{_STATUS_EVIDENCE_SOURCE_VERSION}{discriminator}", claim)
 
 
 def _scope_evidence_binding(scope: DevScope) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -212,29 +358,18 @@ def _wire_status_snapshot_content(
         ref.ref_id: ref.freshness for ref in result.source_refs
     }
     valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+    # CHAOS-3296 round 6: every mint below now goes through this scope-bound
+    # wrapper -- see _scope_bound_mint's own docstring.
+    mint = _scope_bound_mint(mint, scope)
 
     def status_source_system(entity_type: str) -> str:
         return _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
 
-    def mint_status(fact: StatusFact) -> str:
-        # CHAOS-3296 round 5: the SAME composed "{label}: {status}" string
-        # ``wire_status_fact`` writes verbatim onto ``DevStatusFactV2.text``
-        # -- that field IS this fact's asserted content on the wire, so
-        # binding it here (rather than the raw ``fact.status`` alone) means
-        # ``_identity_status_fact`` can recompute the identical claim
-        # straight from ``fact.text`` with no parsing. ``wire_required_child``
-        # stores ``display_label``/``status`` as two SEPARATE wire fields
-        # instead, but ``_identity_required_child`` reconstructs this exact
-        # same composed string from them (see relationship_matrix.py) -- one
-        # shared mint-time claim, two ways to recover it depending on which
-        # wire shape kept which piece.
+    def mint_status_identity(fact: StatusFact, *, source_version: str) -> str:
         return mint(
             org_id=org_id,
             source_system=status_source_system(fact.entity_type),
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION,
-                claim=f"{fact.display_label}: {fact.status}",
-            ),
+            source_version=source_version,
             entity_type=fact.entity_type,
             entity_id=fact.entity_id,
             display_label=fact.display_label,
@@ -245,21 +380,39 @@ def _wire_status_snapshot_content(
         )
 
     def wire_status_fact(fact: StatusFact) -> DevStatusFactV2:
-        evidence_id = mint_status(fact)
-        return DevStatusFactV2(
+        # CHAOS-3296 round 6 (Codex ask: check the status composed-string
+        # delimiter question): construct-then-project like every other
+        # category. ``DevStatusFactV2`` carries only ``fact_id``/``text``
+        # (the WHOLE composed "{label}: {status}" as ONE field) -- never
+        # decomposed/reconstructed anywhere, so there is no delimiter for
+        # two different (label, status) pairs to collide across. Contrast
+        # required_children below, whose wire type keeps label and status
+        # as genuinely SEPARATE fields -- projecting THAT model binds them
+        # as separate JSON keys, not a delimiter-joined string, for the
+        # same collision-safety reason.
+        provisional = DevStatusFactV2(
             fact_id=f"{fact.entity_type}:{fact.entity_id}",
             text=f"{fact.display_label}: {fact.status}",
-            evidence_ref_ids=(evidence_id,),
+            evidence_ref_ids=(_PLACEHOLDER_EVIDENCE_REF_ID,),
         )
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
+        evidence_id = mint_status_identity(fact, source_version=source_version)
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     def wire_required_child(fact: StatusFact) -> DevRequiredChildFactV2:
-        evidence_id = mint_status(fact)
-        return DevRequiredChildFactV2(
+        provisional = DevRequiredChildFactV2(
             fact_id=f"{fact.entity_type}:{fact.entity_id}",
             text=fact.display_label,
             status=fact.status,
-            evidence_ref_ids=(evidence_id,),
+            evidence_ref_ids=(),
         )
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
+        evidence_id = mint_status_identity(fact, source_version=source_version)
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     def mint_delivery(
         *,
@@ -269,7 +422,7 @@ def _wire_status_snapshot_content(
         display_label: str,
         observed_at: datetime,
         source_ref_id: str,
-        source_version: str = _STATUS_EVIDENCE_SOURCE_VERSION,
+        source_version: str,
     ) -> str:
         return mint(
             org_id=org_id,
@@ -285,26 +438,13 @@ def _wire_status_snapshot_content(
         )
 
     def wire_pull_request(fact: PullRequestFact) -> DevPullRequestFactV2:
-        evidence_id = mint_delivery(
-            source_system="pull_requests",
-            entity_type="pull_request",
-            entity_id=fact.entity_id,
-            display_label=fact.display_label,
-            observed_at=fact.observed_at,
-            source_ref_id=fact.source_ref_id,
-            # CHAOS-3296 round 5: bind DevPullRequestFactV2's own claim
-            # fields -- a genuine handle for one PR state must never
-            # authenticate a fabricated claim of a different state.
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION,
-                state=fact.state,
-                review_state=fact.review_state,
-                changes_requested=fact.changes_requested,
-                merged=fact.merged,
-                required=fact.required,
-            ),
-        )
-        return DevPullRequestFactV2(
+        # CHAOS-3296 round 6: construct the wire model FIRST (evidence_ref_ids
+        # still empty), project ITS OWN fields programmatically
+        # (:func:`_claim_projection`), mint against that digest, then patch
+        # in the real handle -- the digest is computed from EXACTLY what
+        # the wire presents, never a hand-picked subset that can silently
+        # miss a future field.
+        provisional = DevPullRequestFactV2(
             entity_id=fact.entity_id,
             display_label=fact.display_label,
             state=fact.state,
@@ -313,16 +453,35 @@ def _wire_status_snapshot_content(
             merged=fact.merged,
             required=fact.required,
             observed_at=fact.observed_at,
-            evidence_ref_ids=(evidence_id,),
+            evidence_ref_ids=(),
         )
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
+        evidence_id = mint_delivery(
+            source_system="pull_requests",
+            entity_type="pull_request",
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            observed_at=fact.observed_at,
+            source_ref_id=fact.source_ref_id,
+            source_version=source_version,
+        )
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     def wire_ci(fact: CIFact) -> DevCIFactV2:
         lookup_entity_id = _ci_evidence_identity(fact.entity_id)
-        source_version = _ci_check_source_version(
-            fact.entity_id,
+        provisional = DevCIFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
             conclusion=fact.conclusion,
             required=fact.required,
             skipped_required_work=fact.skipped_required_work,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(),
+        )
+        source_version = _ci_check_source_version(
+            fact.entity_id, claim=_claim_projection(provisional)
         )
         evidence_id = mint_delivery(
             source_system="ci_runs",
@@ -333,17 +492,21 @@ def _wire_status_snapshot_content(
             source_ref_id=fact.source_ref_id,
             source_version=source_version,
         )
-        return DevCIFactV2(
-            entity_id=fact.entity_id,
-            display_label=fact.display_label,
-            conclusion=fact.conclusion,
-            required=fact.required,
-            skipped_required_work=fact.skipped_required_work,
-            observed_at=fact.observed_at,
-            evidence_ref_ids=(evidence_id,),
-        )
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     def wire_deployment(fact: DeploymentFact) -> DevDeploymentFactV2:
+        provisional = DevDeploymentFactV2(
+            entity_id=fact.entity_id,
+            display_label=fact.display_label,
+            status=fact.status,
+            environment=fact.environment,
+            required=fact.required,
+            observed_at=fact.observed_at,
+            evidence_ref_ids=(),
+        )
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
         evidence_id = mint_delivery(
             source_system="deployments",
             entity_type="deployment",
@@ -351,26 +514,23 @@ def _wire_status_snapshot_content(
             display_label=fact.display_label,
             observed_at=fact.observed_at,
             source_ref_id=fact.source_ref_id,
-            # CHAOS-3296 round 5: bind DevDeploymentFactV2's own claim
-            # fields.
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION,
-                status=fact.status,
-                environment=fact.environment,
-                required=fact.required,
-            ),
+            source_version=source_version,
         )
-        return DevDeploymentFactV2(
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
+
+    def wire_incident(fact: IncidentFact) -> DevIncidentFactV2:
+        provisional = DevIncidentFactV2(
             entity_id=fact.entity_id,
             display_label=fact.display_label,
             status=fact.status,
-            environment=fact.environment,
-            required=fact.required,
+            active=fact.active,
+            blocking=fact.blocking,
             observed_at=fact.observed_at,
-            evidence_ref_ids=(evidence_id,),
+            evidence_ref_ids=(),
         )
-
-    def wire_incident(fact: IncidentFact) -> DevIncidentFactV2:
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
         evidence_id = mint_delivery(
             source_system="incidents",
             entity_type="incident",
@@ -378,23 +538,9 @@ def _wire_status_snapshot_content(
             display_label=fact.display_label,
             observed_at=fact.observed_at,
             source_ref_id=fact.source_ref_id,
-            # CHAOS-3296 round 5: bind DevIncidentFactV2's own claim fields.
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION,
-                status=fact.status,
-                active=fact.active,
-                blocking=fact.blocking,
-            ),
+            source_version=source_version,
         )
-        return DevIncidentFactV2(
-            entity_id=fact.entity_id,
-            display_label=fact.display_label,
-            status=fact.status,
-            active=fact.active,
-            blocking=fact.blocking,
-            observed_at=fact.observed_at,
-            evidence_ref_ids=(evidence_id,),
-        )
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     status_facts = _capped(
         wire_status_fact(fact)
@@ -429,6 +575,7 @@ def _wire_change_summary_content(
         ref.ref_id: ref.freshness for ref in result.source_refs
     }
     valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+    mint = _scope_bound_mint(mint, scope)
 
     def change_freshness(item: ObservedChange) -> FreshnessState:
         for ref_id in item.source_ref_ids:
@@ -437,32 +584,43 @@ def _wire_change_summary_content(
                 return freshness
         return FreshnessState.UNKNOWN
 
-    def change_evidence_identity(item: ObservedChange) -> tuple[str, str, str]:
+    def change_base_identity(item: ObservedChange) -> tuple[str, str, str]:
         category = item.category.value
         source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
         if category == "relationship":
-            base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
-            lookup_entity_id = item.change_id
-        elif category in _CHANGE_COLLISION_PRONE_CATEGORIES:
-            base_source_version = f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}"
-            lookup_entity_id = item.entity_id
-        else:
-            base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
-            lookup_entity_id = item.entity_id
-        # CHAOS-3296 round 5: bind DevObservedChangeV2's own claim fields --
-        # ``before``/``after`` are the only ``ObservedChange`` fields that
-        # actually survive onto the wire type (``claim_kind``/
-        # ``relationship_chain``/``metric_value``/``metric_comparison_value``
-        # do not), so they are the only ones a verifier could ever
-        # recompute; binding them closes the reachable half of this
-        # category's forgery surface.
-        source_version = _bind_content(
-            base_source_version, before=item.before, after=item.after
-        )
-        return source_system, lookup_entity_id, source_version
+            return source_system, item.change_id, _CHANGE_EVIDENCE_SOURCE_VERSION
+        if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+            return (
+                source_system,
+                item.entity_id,
+                f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{item.change_id}",
+            )
+        return source_system, item.entity_id, _CHANGE_EVIDENCE_SOURCE_VERSION
 
     def wire_change(item: ObservedChange) -> DevObservedChangeV2:
-        source_system, lookup_entity_id, source_version = change_evidence_identity(item)
+        source_system, lookup_entity_id, base_source_version = change_base_identity(
+            item
+        )
+        # CHAOS-3296 round 6: construct first, project ITS OWN fields
+        # (before/after -- the only ``ObservedChange`` fields that survive
+        # onto the wire type at all; ``claim_kind``/``relationship_chain``/
+        # ``metric_value``/``metric_comparison_value`` do not, so binding
+        # them is unreachable regardless of hand-list vs projection), then
+        # mint against that digest.
+        provisional = DevObservedChangeV2(
+            change_id=item.change_id,
+            category=item.category.value,
+            entity_type=item.entity_type,
+            entity_id=item.entity_id,
+            display_label=item.display_label,
+            before=item.before,
+            after=item.after,
+            observed_at=item.observed_at,
+            evidence_ref_ids=(),
+        )
+        source_version = _bind_content(
+            base_source_version, _claim_projection(provisional)
+        )
         evidence_id = mint(
             org_id=org_id,
             source_system=source_system,
@@ -476,17 +634,7 @@ def _wire_change_summary_content(
             valid_entity_ids=valid_entity_ids,
             repository_ids=repository_ids,
         )
-        return DevObservedChangeV2(
-            change_id=item.change_id,
-            category=item.category.value,
-            entity_type=item.entity_type,
-            entity_id=item.entity_id,
-            display_label=item.display_label,
-            before=item.before,
-            after=item.after,
-            observed_at=item.observed_at,
-            evidence_ref_ids=(evidence_id,),
-        )
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     return DevSourceContent(
         schema_version="dev_source_content.v1",
@@ -502,20 +650,35 @@ def _wire_work_graph_content(
     scope: DevScope,
 ) -> DevSourceContent:
     valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+    mint = _scope_bound_mint(mint, scope)
 
     def wire_edge(item: WorkGraphNeighborEdge) -> DevGraphEdgeV2:
+        # CHAOS-3296 round 6 (Codex finding, HIGH): round 5 bound only
+        # relationship/source_entity_id/target_entity_id -- provenance,
+        # confidence, and observed_at were NOT bound, so a genuine handle
+        # verified a fact with a forged provenance ("fabricated-
+        # authoritative-source"), confidence, and a year-2036 timestamp.
+        # Construct the (already-normalized: stripped/truncated provenance,
+        # clamped confidence) wire model first, project ITS OWN fields --
+        # the normalization happens exactly once, here, and the digest
+        # reflects the SAME normalized values a verifier will read back.
+        provisional = DevGraphEdgeV2(
+            edge_id=item.edge_id,
+            source_entity_id=item.source_id,
+            relationship=item.relationship_type,
+            target_entity_id=item.target_id,
+            provenance=(item.provenance.strip() or "persisted")[:2_048],
+            confidence=max(0.0, min(1.0, item.confidence)),
+            observed_at=item.observed_at,
+            evidence_ref_ids=(),
+        )
+        source_version = _bind_content(
+            _GRAPH_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+        )
         evidence_id = mint(
             org_id=org_id,
             source_system="work_graph",
-            # CHAOS-3296 round 5: bind DevGraphEdgeV2's own claim fields --
-            # a genuine handle for edge_id X must never authenticate a
-            # fabricated relationship/orientation for that same edge_id.
-            source_version=_bind_content(
-                _GRAPH_EVIDENCE_SOURCE_VERSION,
-                relationship=item.relationship_type,
-                source_entity_id=item.source_id,
-                target_entity_id=item.target_id,
-            ),
+            source_version=source_version,
             entity_type="work_graph_edge",
             entity_id=item.edge_id,
             display_label=(
@@ -528,21 +691,32 @@ def _wire_work_graph_content(
             valid_entity_ids=valid_entity_ids,
             repository_ids=repository_ids,
         )
-        return DevGraphEdgeV2(
-            edge_id=item.edge_id,
-            source_entity_id=item.source_id,
-            relationship=item.relationship_type,
-            target_entity_id=item.target_id,
-            provenance=(item.provenance.strip() or "persisted")[:2_048],
-            confidence=max(0.0, min(1.0, item.confidence)),
-            observed_at=item.observed_at,
-            evidence_ref_ids=(evidence_id,),
-        )
+        return provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
 
     return DevSourceContent(
         schema_version="dev_source_content.v1",
         graph_edges=_capped(wire_edge(item) for item in result.edges),
     )
+
+
+def _metric_ref_id(
+    *, metric_id: str, dimensions: tuple[str, ...], window_start: str, window_end: str
+) -> str:
+    """The canonical, deterministic ``metric_ref_id`` for one
+    ``(metric_id, dimensions, window)`` triple -- called identically at
+    mint time (from the raw query result) and at verify time (from the
+    wire fact's OWN ``metric_id``/``dimensions``/``current_window``
+    fields, see ``relationship_matrix._identity_metric_ref``) so a wire
+    fact's claimed ``metric_ref_id`` can be independently RECOMPUTED and
+    checked, never merely trusted as a free-form entity id (Codex round 6
+    ask: "recompute/validate metric_ref_id from the same inputs").
+    ``dimensions`` must already be the flattened ``"key=value"`` wire form
+    (never the raw ``(key, value)`` tuple pairs) -- that flattened form is
+    the only one still recoverable from the wire fact alone.
+    """
+
+    digest_seed = f"{metric_id}:{dimensions}:{window_start}:{window_end}"
+    return f"metric:{hashlib.sha256(digest_seed.encode()).hexdigest()[:32]}"
 
 
 def _wire_metric_content(
@@ -553,30 +727,61 @@ def _wire_metric_content(
     scope: DevScope,
 ) -> DevSourceContent:
     valid_entity_ids, repository_ids = _scope_evidence_binding(scope)
+    mint = _scope_bound_mint(mint, scope)
     scope_v2 = DevScopeV2.model_validate(scope.model_dump(mode="json"))
     refs: list[DevMetricRefV2] = []
     for result in results:
         for value in result.values:
             dimensions = tuple(f"{key}={item}" for key, item in value.dimensions)
-            digest_seed = (
-                f"{result.definition.metric_id.value}:{value.dimensions}:"
-                f"{scope.time_range.start.isoformat()}:{scope.time_range.end.isoformat()}"
+            metric_ref_id = _metric_ref_id(
+                metric_id=result.definition.metric_id.value,
+                dimensions=dimensions,
+                window_start=scope.time_range.start.isoformat(),
+                window_end=scope.time_range.end.isoformat(),
             )
-            metric_ref_id = (
-                f"metric:{hashlib.sha256(digest_seed.encode()).hexdigest()[:32]}"
+            # CHAOS-3296 round 6 (Codex finding, HIGH): round 5 bound only
+            # value/comparison_value -- metric_id, dimensions, series, and
+            # every other field were NOT bound, so a genuine handle
+            # verified a fact re-labeled as a DIFFERENT metric with a
+            # forged 999-point series. Construct first, project the
+            # model's ENTIRE field set (minus schema_version/
+            # evidence_ref_ids) programmatically.
+            provisional = DevMetricRefV2(
+                schema_version="dev_metric_ref.v1",
+                metric_ref_id=metric_ref_id,
+                metric_id=result.definition.metric_id,
+                label=result.definition.label,
+                definition_version=result.definition.definition_version,
+                unit=result.definition.unit,
+                aggregation=result.definition.aggregation,
+                display_precision=result.definition.display_precision,
+                resolved_scope=scope_v2,
+                dimensions=dimensions,
+                current_window=scope.time_range,
+                comparison_window=(
+                    scope.comparison_range
+                    if value.comparison_value is not None
+                    else None
+                ),
+                value=value.value,
+                comparison_value=value.comparison_value,
+                series=tuple(
+                    DevMetricPoint(timestamp=point.timestamp, value=point.value)
+                    for point in value.series
+                ),
+                query_version=result.definition.query_version,
+                source_version=result.definition.source_version,
+                freshness=result.freshness,
+                coverage=result.coverage,
+                evidence_ref_ids=(),
+            )
+            source_version = _bind_content(
+                _METRIC_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
             )
             evidence_id = mint(
                 org_id=org_id,
                 source_system="metrics",
-                # CHAOS-3296 round 5: bind DevMetricRefV2's own claim
-                # fields -- a genuine handle for one metric value must
-                # never authenticate a fabricated different value for the
-                # same ``metric_ref_id``.
-                source_version=_bind_content(
-                    _METRIC_EVIDENCE_SOURCE_VERSION,
-                    value=value.value,
-                    comparison_value=value.comparison_value,
-                ),
+                source_version=source_version,
                 entity_type="metric",
                 entity_id=metric_ref_id,
                 display_label=result.definition.label,
@@ -586,35 +791,7 @@ def _wire_metric_content(
                 repository_ids=repository_ids,
             )
             refs.append(
-                DevMetricRefV2(
-                    schema_version="dev_metric_ref.v1",
-                    metric_ref_id=metric_ref_id,
-                    metric_id=result.definition.metric_id,
-                    label=result.definition.label,
-                    definition_version=result.definition.definition_version,
-                    unit=result.definition.unit,
-                    aggregation=result.definition.aggregation,
-                    display_precision=result.definition.display_precision,
-                    resolved_scope=scope_v2,
-                    dimensions=dimensions,
-                    current_window=scope.time_range,
-                    comparison_window=(
-                        scope.comparison_range
-                        if value.comparison_value is not None
-                        else None
-                    ),
-                    value=value.value,
-                    comparison_value=value.comparison_value,
-                    series=tuple(
-                        DevMetricPoint(timestamp=point.timestamp, value=point.value)
-                        for point in value.series
-                    ),
-                    query_version=result.definition.query_version,
-                    source_version=result.definition.source_version,
-                    freshness=result.freshness,
-                    coverage=result.coverage,
-                    evidence_ref_ids=(evidence_id,),
-                )
+                provisional.model_copy(update={"evidence_ref_ids": (evidence_id,)})
             )
     return DevSourceContent(
         schema_version="dev_source_content.v1",

--- a/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/builtin_steps.py
@@ -400,6 +400,7 @@ def _wire_work_graph_content(
             repository_ids=repository_ids,
         )
         return DevGraphEdgeV2(
+            edge_id=item.edge_id,
             source_entity_id=item.source_id,
             relationship=item.relationship_type,
             target_entity_id=item.target_id,

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -29,6 +29,11 @@ from ..contracts_v2.result import (
     DevSourceObservation,
 )
 from ..evidence_service import EvidenceReferenceSigner
+from .builtin_steps import (
+    _authorization_scope_digest,
+    _AuthorizationScope,
+    _snapshot_authorization_scope,
+)
 from .relationship_matrix import (
     CONTENT_SLOT_FIELDS,
     EVIDENCE_IDENTITY_TABLE,
@@ -396,6 +401,7 @@ def _evidence_signature_failures(
     content: DevSourceContent,
     context: StepContext,
     signer: EvidenceReferenceSigner,
+    authorization_scope: _AuthorizationScope,
 ) -> tuple[str, ...]:
     """Every claimed ``entity_id`` from a fact citing a handle that does not
     cryptographically verify -- CHAOS-3296 round-5 structural inversion (see
@@ -408,17 +414,24 @@ def _evidence_signature_failures(
     distinct "existence" check, because a signature that does not verify is
     exactly as invalid whether or not it happens to resemble a real one.
 
-    ``context.org_id``/``context.scope.repositories`` -- the caller's own
-    already-authorized scope, mirroring exactly what
-    ``builtin_steps._scope_evidence_binding`` bound at mint -- are supplied
-    fresh for every candidate, never read from the fact or the handle being
-    checked (round-4 finding 1: a per-run receipt that omitted these let a
-    handle honestly minted for a DIFFERENT tenant/repository scope verify
-    clean whenever the remaining fields happened to match).
+    ``authorization_scope`` -- NEVER a fresh read of ``context.scope`` here
+    -- is the SAME :class:`_AuthorizationScope` snapshot :meth:`PlanExecutor.
+    run` captured before any step ran (round-6 finding, HIGH: a step that
+    mutated ``context.scope.repositories`` in place mid-run, then minted
+    against its own self-chosen value, previously verified clean, because
+    verification ALSO re-read the SAME mutated list AFTER the step had
+    already run). Its ``repositories`` supplies ``_CandidateIdentity``'s
+    natively-signer-bound field; its ``team_ids``/``direct_scope``/
+    ``entity_ids`` digest (:func:`~.builtin_steps._authorization_scope_digest`)
+    is appended to every derived ``source_version``, mirroring exactly what
+    ``builtin_steps._scope_bound_mint`` folded in at mint time (round-6
+    finding, HIGH: a TEAM-scoped investigation has empty ``repositories``,
+    and nothing previously bound ``team_ids`` at all, so two DIFFERENT
+    teams' investigations minted identical handles for identical content).
     """
 
     invalid: set[str] = set()
-    repository_ids = tuple(context.scope.repositories)
+    scope_digest = _authorization_scope_digest(authorization_scope)
     for slot, fact in _content_field_facts(content):
         cell = EVIDENCE_IDENTITY_TABLE[slot]
         if cell.mode != "required" or cell.derive is None:
@@ -428,10 +441,10 @@ def _evidence_signature_failures(
             candidate = _CandidateIdentity(
                 evidence_ref_id=handle,
                 source_system=source_system,
-                source_version=source_version,
+                source_version=f"{source_version}#scope:{scope_digest}",
                 entity_type=entity_type,
                 entity_id=entity_id,
-                repository_ids=repository_ids,
+                repository_ids=authorization_scope.repositories,
             )
             if not signer.verify(context.org_id, candidate):
                 invalid.add(entity_id)
@@ -493,6 +506,12 @@ class PlanExecutor:
         subject_entity_id: str | None = None,
         subject_set_fingerprint: str | None = None,
     ) -> DevInvestigationResult:
+        # CHAOS-3296 round 6: captured BEFORE any step (this executor's
+        # threat model's adversary) gets to run at all -- see
+        # _AuthorizationScope's own docstring for why this must never be a
+        # fresh read of context.scope taken later, after a step has already
+        # had the chance to mutate it.
+        authorization_scope = _snapshot_authorization_scope(context.scope)
         registered = self._registry.for_plan(plan.plan_id)
         known_steps = set(plan.mandatory_steps) | set(plan.conditional_steps)
         missing = known_steps - registered.keys()
@@ -602,6 +621,7 @@ class PlanExecutor:
                 run_id=run_id,
                 plan_id=plan.plan_id,
                 context=context,
+                authorization_scope=authorization_scope,
             )
             for requirement in plan.source_requirements
         ]
@@ -664,6 +684,7 @@ class PlanExecutor:
         run_id: str,
         plan_id: str,
         context: StepContext,
+        authorization_scope: _AuthorizationScope,
     ) -> tuple[DevSourceObservation, bool]:
         # A deterministic representative step_id for this requirement, used
         # only to seed the observation's minted id -- ``step_ids`` is already
@@ -692,6 +713,7 @@ class PlanExecutor:
                 outcome,
                 observation_id,
                 context,
+                authorization_scope,
             )
         if step_ids and all(step_id in not_applicable for step_id in step_ids):
             return self._unmeasured_observation(
@@ -730,6 +752,7 @@ class PlanExecutor:
         outcome: StepOutcome,
         observation_id: str,
         context: StepContext,
+        authorization_scope: _AuthorizationScope,
     ) -> tuple[DevSourceObservation, bool]:
         content = outcome.content
         if content is not None:
@@ -777,7 +800,7 @@ class PlanExecutor:
                 # re-derived identity via the real signer, not merely exist
                 # in something this executor tracked itself.
                 invalid = _evidence_signature_failures(
-                    content, context, self._evidence_signer
+                    content, context, self._evidence_signer, authorization_scope
                 )
                 if invalid:
                     return self._unmeasured_observation(

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -17,9 +17,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from ..contracts import DevScope, DirectScope
 from ..contracts_v2.base import SourceClass, SourceRequirementState
 from ..contracts_v2.plan import DevInvestigationPlan, DevSourceRequirement
-from ..contracts_v2.result import DevInvestigationResult, DevSourceObservation
+from ..contracts_v2.result import (
+    DevInvestigationResult,
+    DevRelationshipPath,
+    DevSourceContent,
+    DevSourceObservation,
+)
+from .relationship_matrix import MIN_RELATIONSHIP_CONFIDENCE, approved_relationship
 from .steps import (
     PlanRegistryError,
     PlanStepDefinition,
@@ -58,6 +65,178 @@ class _Attempt:
     step_id: str
     outcome: StepOutcome | None
     failed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _PathCandidate:
+    """One un-verified hop extracted from a step's ``DevSourceContent``,
+    before relationship-matrix/confidence/self-loop/touching-root checks.
+
+    ``source_entity_id`` is ``None`` for every fact category except
+    ``graph_edges``: a status/PR/CI/deployment/incident/change/metric fact
+    has no orientation of its own (the canonical service that produced it
+    already scoped the query to the committed subject, so it is always
+    read as subject -> fact). A work-graph edge is bidirectional by
+    construction (``GraphDirection.BOTH``), so its own recorded
+    ``source_entity_id``/``target_entity_id`` must be checked against the
+    committed root explicitly.
+    """
+
+    relationship: str
+    target_entity_id: str
+    source_entity_id: str | None
+    provenance: str
+    confidence: float
+    observed_at: datetime
+    evidence_ref_ids: tuple[str, ...]
+
+
+def _root_entity_id(scope: DevScope) -> str | None:
+    """The committed single subject a relationship path closes over, or
+    ``None`` when there is none to close over (organization/repository
+    scope legitimately shows broad facts -- PRD v2 §3.2/§7)."""
+
+    if scope.direct_scope in (DirectScope.ORGANIZATION, DirectScope.REPOSITORY):
+        return None
+    if not scope.entity_refs:
+        return None
+    return scope.entity_refs[0].entity_id
+
+
+def _content_candidates(
+    content: DevSourceContent, *, now: datetime
+) -> list[_PathCandidate]:
+    """Every fact in ``content``, projected to one un-verified path candidate
+    each. Only the slot(s) matching the observation's own ``source_class``
+    are ever non-empty (CHAOS-3295's own invariant), so this always iterates
+    a small, single-category list in practice.
+    """
+
+    candidates: list[_PathCandidate] = []
+    for status_fact in content.status_facts:
+        candidates.append(
+            _PathCandidate(
+                "status_assessment",
+                status_fact.fact_id,
+                None,
+                "status_change_service",
+                1.0,
+                now,
+                status_fact.evidence_ref_ids,
+            )
+        )
+    for child_fact in content.required_children:
+        candidates.append(
+            _PathCandidate(
+                "required_child",
+                child_fact.fact_id,
+                None,
+                "status_change_service",
+                1.0,
+                now,
+                child_fact.evidence_ref_ids,
+            )
+        )
+    for pr_fact in content.pull_requests:
+        candidates.append(
+            _PathCandidate(
+                "linked_pull_request",
+                pr_fact.entity_id,
+                None,
+                "status_change_service:pull_requests",
+                1.0,
+                pr_fact.observed_at,
+                pr_fact.evidence_ref_ids,
+            )
+        )
+    for ci_fact in content.ci_checks:
+        candidates.append(
+            _PathCandidate(
+                "linked_ci_run",
+                ci_fact.entity_id,
+                None,
+                "status_change_service:ci_runs",
+                1.0,
+                ci_fact.observed_at,
+                ci_fact.evidence_ref_ids,
+            )
+        )
+    for deployment_fact in content.deployments:
+        candidates.append(
+            _PathCandidate(
+                "linked_deployment",
+                deployment_fact.entity_id,
+                None,
+                "status_change_service:deployments",
+                1.0,
+                deployment_fact.observed_at,
+                deployment_fact.evidence_ref_ids,
+            )
+        )
+    for incident_fact in content.incidents:
+        candidates.append(
+            _PathCandidate(
+                "linked_incident",
+                incident_fact.entity_id,
+                None,
+                "status_change_service:incidents",
+                1.0,
+                incident_fact.observed_at,
+                incident_fact.evidence_ref_ids,
+            )
+        )
+    for edge in content.graph_edges:
+        candidates.append(
+            _PathCandidate(
+                edge.relationship,
+                edge.target_entity_id,
+                edge.source_entity_id,
+                edge.provenance,
+                edge.confidence,
+                edge.observed_at,
+                edge.evidence_ref_ids,
+            )
+        )
+    for change in content.observed_changes:
+        candidates.append(
+            _PathCandidate(
+                "observed_change",
+                change.entity_id,
+                None,
+                "status_change_service:change_summary",
+                1.0,
+                change.observed_at,
+                change.evidence_ref_ids,
+            )
+        )
+    for ref in content.metric_refs:
+        candidates.append(
+            _PathCandidate(
+                "metric_scoped_to_subject",
+                ref.metric_ref_id,
+                None,
+                "metrics_service",
+                1.0,
+                now,
+                ref.evidence_ref_ids,
+            )
+        )
+    return candidates
+
+
+def _resolve_target(candidate: _PathCandidate, root_entity_id: str) -> str | None:
+    """The candidate's "other end" relative to ``root_entity_id``, or
+    ``None`` when the candidate does not actually touch the root at all
+    (cross-tenant/forged-ID acceptance criterion) -- never a fabricated
+    orientation."""
+
+    if candidate.source_entity_id is None:
+        return candidate.target_entity_id
+    if candidate.source_entity_id == root_entity_id:
+        return candidate.target_entity_id
+    if candidate.target_entity_id == root_entity_id:
+        return candidate.source_entity_id
+    return None
 
 
 class PlanExecutor:
@@ -169,7 +348,7 @@ class PlanExecutor:
                 (definition.source_class, definition.adapter_id), []
             ).append(step_id)
 
-        observations = tuple(
+        observation_results = [
             self._observation_for_requirement(
                 requirement,
                 sorted(
@@ -183,8 +362,22 @@ class PlanExecutor:
                 blocked=blocked,
                 run_id=run_id,
                 plan_id=plan.plan_id,
+                context=context,
             )
             for requirement in plan.source_requirements
+        ]
+        observations = tuple(
+            observation for observation, _closed in observation_results
+        )
+        # CHAOS-3296: true only when every content-bearing observation's
+        # facts all minted a verified relationship path back to the
+        # committed subject -- one rejected/unrelated/self-referential/
+        # unapproved/low-confidence candidate anywhere is enough to flip
+        # this False. Never claims a check that did not run: an unmeasured
+        # observation (no content) and a broad org/repository scope (no
+        # single subject to close over) both contribute a vacuous True.
+        relationship_closure_verified = all(
+            closed for _observation, closed in observation_results
         )
 
         return DevInvestigationResult(
@@ -206,10 +399,7 @@ class PlanExecutor:
             completed_steps=tuple(sorted(completed)),
             skipped_steps=tuple(sorted(not_applicable | blocked)),
             failed_steps=tuple(sorted(failed)),
-            # 3296 populates DevSourceObservation.relationship_paths and owns
-            # the actual closure check; this executor never claims a check it
-            # did not run.
-            relationship_closure_verified=False,
+            relationship_closure_verified=relationship_closure_verified,
             completed_at=self._now(),
         )
 
@@ -234,7 +424,8 @@ class PlanExecutor:
         blocked: set[str],
         run_id: str,
         plan_id: str,
-    ) -> DevSourceObservation:
+        context: StepContext,
+    ) -> tuple[DevSourceObservation, bool]:
         # A deterministic representative step_id for this requirement, used
         # only to seed the observation's minted id -- ``step_ids`` is already
         # sorted by the caller, so this is stable across runs regardless of
@@ -256,7 +447,7 @@ class PlanExecutor:
         if completed_step is not None:
             outcome = completed[completed_step].outcome
             assert outcome is not None
-            return self._to_observation(requirement, outcome, observation_id)
+            return self._to_observation(requirement, outcome, observation_id, context)
         if step_ids and all(step_id in not_applicable for step_id in step_ids):
             return self._unmeasured_observation(
                 requirement,
@@ -293,8 +484,15 @@ class PlanExecutor:
         requirement: DevSourceRequirement,
         outcome: StepOutcome,
         observation_id: str,
-    ) -> DevSourceObservation:
-        return DevSourceObservation(
+        context: StepContext,
+    ) -> tuple[DevSourceObservation, bool]:
+        relationship_paths, closed = self._mint_relationship_paths(
+            source_class=requirement.source_class,
+            content=outcome.content,
+            context=context,
+            observation_id=observation_id,
+        )
+        observation = DevSourceObservation(
             schema_version="dev_source_observation.v1",
             observation_id=observation_id,
             source_class=requirement.source_class,
@@ -306,13 +504,14 @@ class PlanExecutor:
             subject_coverage=outcome.subject_coverage,
             usable_fact_count=outcome.usable_fact_count,
             sample_count=outcome.sample_count,
-            relationship_paths=(),
+            relationship_paths=relationship_paths,
             evidence_ref_ids=(),
             limitation=outcome.limitation,
             observed_at=self._now(),
             query_version=outcome.query_version,
             content=outcome.content,
         )
+        return observation, closed
 
     def _unmeasured_observation(
         self,
@@ -320,8 +519,8 @@ class PlanExecutor:
         state: SourceRequirementState,
         limitation: str,
         observation_id: str,
-    ) -> DevSourceObservation:
-        return DevSourceObservation(
+    ) -> tuple[DevSourceObservation, bool]:
+        observation = DevSourceObservation(
             schema_version="dev_source_observation.v1",
             observation_id=observation_id,
             source_class=requirement.source_class,
@@ -340,3 +539,55 @@ class PlanExecutor:
             query_version="unversioned",
             content=None,
         )
+        # An unmeasured source never ran -- nothing to close over. That gap
+        # is disclosed separately (subject_coverage/limitation on this same
+        # observation), not folded into relationship_closure_verified.
+        return observation, True
+
+    def _mint_relationship_paths(
+        self,
+        *,
+        source_class: SourceClass,
+        content: DevSourceContent | None,
+        context: StepContext,
+        observation_id: str,
+    ) -> tuple[tuple[DevRelationshipPath, ...], bool]:
+        if content is None:
+            return (), True
+        root_entity_id = _root_entity_id(context.scope)
+        if root_entity_id is None:
+            return (), True
+        accepted: dict[tuple[str, str], tuple[_PathCandidate, str]] = {}
+        rejected = 0
+        for candidate in _content_candidates(content, now=context.now):
+            resolved_target = _resolve_target(candidate, root_entity_id)
+            if (
+                resolved_target is None
+                or resolved_target == root_entity_id
+                or candidate.confidence < MIN_RELATIONSHIP_CONFIDENCE
+                or not approved_relationship(source_class, candidate.relationship)
+            ):
+                rejected += 1
+                continue
+            key = (candidate.relationship, resolved_target)
+            existing = accepted.get(key)
+            if existing is None or candidate.confidence > existing[0].confidence:
+                accepted[key] = (candidate, resolved_target)
+        paths = tuple(
+            DevRelationshipPath(
+                path_id=_mint(
+                    "relationship_path", context.run_id, observation_id, str(index)
+                ),
+                source_entity_id=root_entity_id,
+                relationship=candidate.relationship,
+                target_entity_id=resolved_target,
+                provenance=candidate.provenance[:2_048],
+                confidence=max(0.0, min(1.0, candidate.confidence)),
+                observed_at=candidate.observed_at,
+                evidence_ref_ids=candidate.evidence_ref_ids[:25],
+            )
+            for index, (_key, (candidate, resolved_target)) in enumerate(
+                sorted(accepted.items())
+            )
+        )
+        return paths, rejected == 0

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from ..contracts import DevScope, DirectScope
+from ..contracts import DirectScope
 from ..contracts_v2.base import SourceClass, SourceRequirementState
 from ..contracts_v2.plan import DevInvestigationPlan, DevSourceRequirement
 from ..contracts_v2.result import (
@@ -229,16 +229,35 @@ class _PathCandidate:
     evidence_ref_ids: tuple[str, ...]
 
 
-def _root_entity_id(scope: DevScope) -> str | None:
+def _root_entity_id(auth_scope: _AuthorizationScope) -> str | None:
     """The committed single subject a relationship path closes over, or
     ``None`` when there is none to close over (organization/repository
-    scope legitimately shows broad facts -- PRD v2 §3.2/§7)."""
+    scope legitimately shows broad facts -- PRD v2 §3.2/§7).
 
-    if scope.direct_scope in (DirectScope.ORGANIZATION, DirectScope.REPOSITORY):
+    CHAOS-3296 round 6 (Codex finding, HIGH): this previously took the raw
+    ``StepContext.scope`` and read it directly INSIDE ``_mint_relationship_
+    paths``, which runs AFTER every step has already executed -- a step
+    that mutated ``context.scope.entity_refs`` in place mid-run (swapping
+    in a foreign project's entity after minting its own evidence) caused
+    every relationship path to be rooted at, and closed over, an entity the
+    caller was never authorized to see, with ``relationship_closure_
+    verified`` reporting True throughout (``result.subject_entity_id``,
+    passed in from outside and never re-derived from ``context.scope``,
+    still showed the real committed subject -- only the paths themselves
+    were mis-rooted). Taking the SAME pre-step ``_AuthorizationScope``
+    snapshot used for evidence-signature verification closes this: there
+    is no ``context.scope`` read left anywhere on the relationship-path
+    construction path, live or otherwise.
+    """
+
+    if auth_scope.direct_scope in (
+        DirectScope.ORGANIZATION.value,
+        DirectScope.REPOSITORY.value,
+    ):
         return None
-    if not scope.entity_refs:
+    if not auth_scope.entity_ids:
         return None
-    return scope.entity_refs[0].entity_id
+    return auth_scope.entity_ids[0]
 
 
 def _content_candidates(
@@ -811,7 +830,7 @@ class PlanExecutor:
                         closed=False,
                     )
         return self._budgeted_observation(
-            requirement, outcome, content, observation_id, context
+            requirement, outcome, content, observation_id, context, authorization_scope
         )
 
     def _budgeted_observation(
@@ -821,6 +840,7 @@ class PlanExecutor:
         content: DevSourceContent | None,
         observation_id: str,
         context: StepContext,
+        authorization_scope: _AuthorizationScope,
     ) -> tuple[DevSourceObservation, bool]:
         """Construct the final observation, then -- before returning it to
         persistence or presentation -- shrink ``content`` deterministically
@@ -849,6 +869,7 @@ class PlanExecutor:
                 source_class=requirement.source_class,
                 content=working_content,
                 context=context,
+                authorization_scope=authorization_scope,
                 observation_id=observation_id,
             )
             usable_fact_count = outcome.usable_fact_count
@@ -952,11 +973,12 @@ class PlanExecutor:
         source_class: SourceClass,
         content: DevSourceContent | None,
         context: StepContext,
+        authorization_scope: _AuthorizationScope,
         observation_id: str,
     ) -> tuple[tuple[DevRelationshipPath, ...], bool]:
         if content is None:
             return (), True
-        root_entity_id = _root_entity_id(context.scope)
+        root_entity_id = _root_entity_id(authorization_scope)
         if root_entity_id is None:
             return (), True
         accepted: dict[tuple[str, str], tuple[_PathCandidate, str]] = {}

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -12,16 +12,15 @@ entirely the plan document plus each step's own ``applicable`` predicate
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import json
 import uuid
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from ..contracts import DevScope, DirectScope, FreshnessState
-from ..contracts_v2.base import EvidenceHandle, SourceClass, SourceRequirementState
+from ..contracts import DevScope, DirectScope
+from ..contracts_v2.base import SourceClass, SourceRequirementState
 from ..contracts_v2.plan import DevInvestigationPlan, DevSourceRequirement
 from ..contracts_v2.result import (
     DevInvestigationResult,
@@ -29,7 +28,7 @@ from ..contracts_v2.result import (
     DevSourceContent,
     DevSourceObservation,
 )
-from .builtin_steps import PlanExecutorRuntime
+from ..evidence_service import EvidenceReferenceSigner
 from .relationship_matrix import (
     CONTENT_SLOT_FIELDS,
     EVIDENCE_IDENTITY_TABLE,
@@ -47,59 +46,57 @@ from .steps import (
     StepRegistry,
 )
 
-__all__ = ["PlanExecutionError", "PlanExecutor", "wrap_runtime_with_mint_receipts"]
+__all__ = ["PlanExecutionError", "PlanExecutor"]
 
 
 @dataclass(frozen=True, slots=True)
-class _MintedReceipt:
-    """The identity a ``mint_evidence`` call actually issued a handle
-    against -- the same four fields ``EvidenceReferenceSigner._payload``
-    binds into its HMAC (``evidence_service.py``), captured directly from
-    the mint call's own keyword arguments rather than re-derived from
-    anything a step could shape afterward.
+class _CandidateIdentity:
+    """CHAOS-3296 round-5 structural inversion (Codex findings, HIGH, round
+    4, 2026-08-02): rounds 1-4 all verified a cited evidence handle by
+    comparing a re-derived SUBSET of its identity against a per-run RECEIPT
+    this executor maintained itself -- an adversary only had to vary
+    whatever the receipt didn't carry. Round 4's receipt bound
+    (source_system, source_version, entity_type, entity_id) but not the
+    tenant/repository scope the real signer's HMAC also binds, so a handle
+    honestly minted for a DIFFERENT org verified clean as long as those four
+    fields happened to match (finding 1); and no round bound the fact's own
+    asserted CONTENT at all, so a genuine handle for a failing CI check
+    verified a fabricated fact claiming it passed (finding 2, closed instead
+    by folding a content digest into ``source_version`` at mint -- see
+    ``builtin_steps._ci_check_source_version``).
 
-    Codex finding (MEDIUM, round 2, 2026-08-02): recording only the bare
-    handle string (round 1's fix) proved merely that *some* handle was
-    minted during this step -- a step could mint once for a real entity and
-    reuse that same string on an arbitrary number of fabricated facts, and
-    the round-1 check could not tell the difference. Binding identity here
-    closes that: verification compares each fact's own claimed identity
-    against the receipt of every handle it cites (see
-    ``_evidence_identity_mismatches``).
+    This type carries exactly the fields
+    :class:`~..evidence_service.EvidenceReferenceSigner` (``_payload``/
+    ``verify``) binds into the real HMAC, reconstructed independently at
+    verification time rather than looked up from anything a step could
+    shape:
 
-    ``source_version`` added in round 4 (Codex [MEDIUM], 2026-08-02): CI
-    checks mint against the coarsened run-level ``entity_id`` but embed the
-    check-specific discriminator into ``source_version`` -- dropping that
-    field let one check's handle "verify" a fabricated fact for a different
-    check on the same run.
+    - ``source_system``/``source_version``/``entity_type``/``entity_id``
+      come from :data:`EVIDENCE_IDENTITY_TABLE`'s per-category ``derive``,
+      applied to the fact being verified -- never trusted from the fact's
+      own citation.
+    - ``repository_ids`` comes from the CURRENT ``StepContext``'s own
+      already-authorized scope (``context.scope.repositories`` -- the exact
+      value ``builtin_steps._scope_evidence_binding`` used at mint), never
+      from the fact or the cited handle.
+    - ``org_id`` is not a field here at all: it is supplied directly to
+      ``signer.verify`` from ``context.org_id``, for the same reason.
+
+    Because ``signer.verify`` recomputes the actual signature via the exact
+    code every real mint call already goes through (never reimplemented
+    here), a handle can only verify against a candidate if ``signer.issue``
+    was genuinely called, for THIS org, with THIS exact tuple -- there is no
+    receipt to be silently missing a field from, because there is no
+    receipt. See :func:`_evidence_signature_failures`.
     """
 
+    evidence_ref_id: str
     source_system: str
     source_version: str
     entity_type: str
     entity_id: str
+    repository_ids: Sequence[str]
 
-
-#: Per-step-invocation scope (CHAOS-3296 Codex finding, MEDIUM 2026-08-01):
-#: every evidence handle a ``PlanExecutorRuntime`` actually issues during one
-#: step's own ``run()`` call is recorded here, keyed by the handle and
-#: mapped to the identity it was minted against (see
-#: :class:`_MintReceiptRuntime`), isolated per ``asyncio`` task -- concurrent
-#: sibling steps (``asyncio.gather`` in :meth:`PlanExecutor.run`) each run in
-#: their own task with their own copy of this context var, so one step's
-#: receipts can never leak into another's. ``None`` (the default, and the
-#: only value any pre-3296 test or ``verify_mint_receipts=False`` run ever
-#: sees) means "no receipt tracking is active" -- content is accepted
-#: unverified, exactly today's behavior.
-_MINTED_EVIDENCE_HANDLES: contextvars.ContextVar[dict[str, _MintedReceipt] | None] = (
-    contextvars.ContextVar("chaos_3296_minted_evidence_handles", default=None)
-)
-
-#: A shared, never-mutated empty receipt map -- used as ``_to_observation``'s
-#: default so an ordinary mutable-default pitfall never applies (nothing
-#: ever writes into it; every real receipt map is its own fresh ``dict``
-#: from :meth:`PlanExecutor._run_one`).
-_EMPTY_RECEIPTS: Mapping[str, _MintedReceipt] = {}
 
 #: Codex finding (HIGH, 2026-08-02, round 2): raising the persistence
 #: envelope (``persistence/service.py``'s ``_SOURCE_OBSERVATION_PAYLOAD_
@@ -197,125 +194,10 @@ class PlanExecutionError(RuntimeError):
 
 
 @dataclass(slots=True)
-class _MintReceiptRuntime:
-    """A ``PlanExecutorRuntime`` pass-through that records every evidence
-    handle it actually issues -- and the identity it issued that handle
-    against -- into whichever step-scoped receipt map
-    :data:`_MINTED_EVIDENCE_HANDLES` names for the calling ``asyncio`` task.
-
-    CHAOS-3296 Codex finding (MEDIUM, 2026-08-01; sharpened round 2,
-    2026-08-02): a step's own ``StepOutcome.content`` is entirely
-    producer-controlled -- nothing previously stopped a step from embedding
-    a syntactically-valid-looking ``ev1_...`` string it fabricated inline
-    rather than one this exact ``mint_evidence`` call actually signed, and
-    round 1's existence-only receipt set could not stop a step from minting
-    once for a real entity and reusing that same handle on an arbitrary
-    number of fabricated facts. Wrapping the runtime here, once, at
-    registration (see :func:`wrap_runtime_with_mint_receipts`), means every
-    builtin step's ``mint=runtime.mint_evidence`` (``builtin_steps.py``)
-    transparently goes through this recorder with no change to that module --
-    the executor, not any individual step, becomes the sole authority on
-    which handles a step's own run genuinely minted, and what each one was
-    minted to prove.
-    """
-
-    _inner: PlanExecutorRuntime
-
-    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
-        return await self._inner.status_snapshot(
-            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
-        )
-
-    async def change_summary(self, *, org_id, permission_fingerprint, scope):
-        return await self._inner.change_summary(
-            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
-        )
-
-    def list_metrics(self, scope):
-        return self._inner.list_metrics(scope)
-
-    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
-        return await self._inner.query_metric(
-            org_id=org_id,
-            permission_fingerprint=permission_fingerprint,
-            metric_id=metric_id,
-            scope=scope,
-        )
-
-    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
-        return await self._inner.work_graph_neighbors(
-            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
-        )
-
-    async def data_health(self, *, org_id, permission_fingerprint, scope):
-        return await self._inner.data_health(
-            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
-        )
-
-    def mint_evidence(
-        self,
-        *,
-        org_id: str,
-        source_system: str,
-        source_version: str,
-        entity_type: str,
-        entity_id: str,
-        display_label: str,
-        observed_at: datetime,
-        freshness: FreshnessState,
-        confidence: float = 1.0,
-        valid_entity_ids=(),
-        repository_ids=(),
-    ) -> EvidenceHandle:
-        handle = self._inner.mint_evidence(
-            org_id=org_id,
-            source_system=source_system,
-            source_version=source_version,
-            entity_type=entity_type,
-            entity_id=entity_id,
-            display_label=display_label,
-            observed_at=observed_at,
-            freshness=freshness,
-            confidence=confidence,
-            valid_entity_ids=valid_entity_ids,
-            repository_ids=repository_ids,
-        )
-        receipts = _MINTED_EVIDENCE_HANDLES.get()
-        if receipts is not None:
-            receipts[handle] = _MintedReceipt(
-                source_system=source_system,
-                source_version=source_version,
-                entity_type=entity_type,
-                entity_id=entity_id,
-            )
-        return handle
-
-
-def wrap_runtime_with_mint_receipts(
-    runtime: PlanExecutorRuntime,
-) -> PlanExecutorRuntime:
-    """Wrap ``runtime`` so :class:`PlanExecutor` can verify -- not merely
-    trust -- which evidence handles a step's own execution actually minted.
-
-    Call this exactly once, before ``register_builtin_steps``/
-    ``build_default_registry`` bakes ``runtime`` into every step closure
-    (``production_runtime.py``'s only call site). Has no effect unless the
-    owning :class:`PlanExecutor` was also constructed with
-    ``verify_mint_receipts=True`` -- with that flag off (every pre-3296 test
-    fixture, and any caller that has not opted in), :data:`
-    _MINTED_EVIDENCE_HANDLES` is never set, so this wrapper degrades to a
-    plain pass-through.
-    """
-
-    return _MintReceiptRuntime(runtime)
-
-
-@dataclass(slots=True)
 class _Attempt:
     step_id: str
     outcome: StepOutcome | None
     failed: bool
-    minted_evidence_handles: Mapping[str, _MintedReceipt] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -475,31 +357,6 @@ def _content_candidates(
     return candidates
 
 
-def _unminted_evidence_handles(
-    content: DevSourceContent,
-    minted_evidence_handles: Mapping[str, _MintedReceipt],
-    *,
-    now: datetime,
-) -> frozenset[str]:
-    """Every evidence handle ``content`` claims that this step's own receipt
-    map (:data:`_MINTED_EVIDENCE_HANDLES`, captured per-step in
-    :meth:`PlanExecutor._run_one`) never actually recorded -- i.e. a handle
-    that is not proven to have come from this exact step's
-    ``runtime.mint_evidence`` calls. Reuses :func:`_content_candidates`
-    (already a total per-fact-category walk) rather than a second, parallel
-    traversal of ``DevSourceContent``'s nine fields. Existence-only: a
-    handle that *was* minted, but for a different entity, passes this check
-    and is instead caught by :func:`_evidence_identity_mismatches`.
-    """
-
-    claimed = {
-        handle
-        for candidate in _content_candidates(content, now=now)
-        for handle in candidate.evidence_ref_ids
-    }
-    return frozenset(claimed - minted_evidence_handles.keys())
-
-
 def _content_field_facts(content: DevSourceContent) -> list[tuple[str, Any]]:
     """``(field_name, fact)`` for every fact in every ``CONTENT_SLOT_FIELDS``
     category, in stable declared field order and each field's own tuple
@@ -535,40 +392,51 @@ def _missing_evidence_facts(content: DevSourceContent) -> tuple[str, ...]:
     )
 
 
-def _evidence_identity_mismatches(
-    content: DevSourceContent, minted_evidence_handles: Mapping[str, _MintedReceipt]
+def _evidence_signature_failures(
+    content: DevSourceContent,
+    context: StepContext,
+    signer: EvidenceReferenceSigner,
 ) -> tuple[str, ...]:
-    """Every claimed ``entity_id`` from a fact citing a handle that WAS
-    minted this step -- just not for that fact's own identity. A handle
-    absent from ``minted_evidence_handles`` entirely is
-    :func:`_unminted_evidence_handles`'s concern; a fact with no handles at
-    all is :func:`_missing_evidence_facts`'s. Here a receipt exists, it is
-    simply bound to a different identity (source_system, source_version,
-    entity_type, entity_id -- the exact four the real signer's HMAC binds)
-    than the fact citing it claims, per :data:`EVIDENCE_IDENTITY_TABLE`'s
-    per-category derivation -- exactly the "mint once for issue-1, reuse on
-    a fabricated issue-999 fact" forgery this finding closes, now complete
-    across every evidence-capable category including graph_edges and
-    check-specific CI identity (round-3 Codex findings 2 and 3).
+    """Every claimed ``entity_id`` from a fact citing a handle that does not
+    cryptographically verify -- CHAOS-3296 round-5 structural inversion (see
+    :class:`_CandidateIdentity` for the full history this replaces). A fact
+    with no handles at all is :func:`_missing_evidence_facts`'s concern,
+    checked first and separately; here every cited handle is checked
+    against ``signer.verify`` directly, so "the handle was never minted at
+    all" and "the handle was minted, but for a different identity/tenant/
+    content" collapse into the SAME failure mode -- there is no longer a
+    distinct "existence" check, because a signature that does not verify is
+    exactly as invalid whether or not it happens to resemble a real one.
+
+    ``context.org_id``/``context.scope.repositories`` -- the caller's own
+    already-authorized scope, mirroring exactly what
+    ``builtin_steps._scope_evidence_binding`` bound at mint -- are supplied
+    fresh for every candidate, never read from the fact or the handle being
+    checked (round-4 finding 1: a per-run receipt that omitted these let a
+    handle honestly minted for a DIFFERENT tenant/repository scope verify
+    clean whenever the remaining fields happened to match).
     """
 
-    mismatched: set[str] = set()
+    invalid: set[str] = set()
+    repository_ids = tuple(context.scope.repositories)
     for slot, fact in _content_field_facts(content):
         cell = EVIDENCE_IDENTITY_TABLE[slot]
         if cell.mode != "required" or cell.derive is None:
             continue
         source_system, source_version, entity_type, entity_id = cell.derive(fact)
         for handle in fact.evidence_ref_ids:
-            receipt = minted_evidence_handles.get(handle)
-            if receipt is not None and (
-                receipt.source_system != source_system
-                or receipt.source_version != source_version
-                or receipt.entity_type != entity_type
-                or receipt.entity_id != entity_id
-            ):
-                mismatched.add(entity_id)
+            candidate = _CandidateIdentity(
+                evidence_ref_id=handle,
+                source_system=source_system,
+                source_version=source_version,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                repository_ids=repository_ids,
+            )
+            if not signer.verify(context.org_id, candidate):
+                invalid.add(entity_id)
                 break
-    return tuple(sorted(mismatched))
+    return tuple(sorted(invalid))
 
 
 def _resolve_target(candidate: _PathCandidate, root_entity_id: str) -> str | None:
@@ -592,7 +460,7 @@ class PlanExecutor:
         *,
         registry: StepRegistry,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
-        verify_mint_receipts: bool = False,
+        evidence_signer: EvidenceReferenceSigner | None = None,
         content_byte_budget: int = _CONTENT_BYTE_BUDGET_DEFAULT,
     ) -> None:
         self._registry = registry
@@ -604,15 +472,17 @@ class PlanExecutor:
         #: precisely-at-budget / one-item-over without needing to reverse
         #: engineer the real ~56KiB target's byte arithmetic.
         self._content_byte_budget = content_byte_budget
-        #: CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): off by default so
+        #: CHAOS-3296 Codex finding (MEDIUM, 2026-08-01; superseded by the
+        #: round-5 structural inversion, 2026-08-02): ``None`` by default so
         #: every pre-3296 test/harness that hand-builds ``StepOutcome.content``
         #: (bypassing ``register_builtin_steps``/real minting entirely) is
         #: completely unaffected. ``production_runtime.py`` is the one caller
-        #: that turns this on, paired with ``wrap_runtime_with_mint_receipts``
-        #: wrapping the runtime it registers steps against -- without both
-        #: halves, this flag alone has nothing to verify against and would
-        #: reject every real fact's evidence citation.
-        self._verify_mint_receipts = verify_mint_receipts
+        #: that passes the real ``EvidenceReferenceSigner`` here -- the exact
+        #: instance every builtin step's ``mint_evidence`` already signs
+        #: through, never a second parallel signer. With no signer, every
+        #: evidence-provenance check in :meth:`_to_observation` is skipped
+        #: and content is accepted unverified, exactly today's behavior.
+        self._evidence_signer = evidence_signer
 
     async def run(
         self,
@@ -696,12 +566,10 @@ class PlanExecutor:
                 if isinstance(attempt_result, BaseException):
                     failed.add(step_id)
                     continue
-                step_outcome, minted = attempt_result
                 completed[step_id] = _Attempt(
                     step_id,
-                    step_outcome,
+                    attempt_result,
                     failed=False,
-                    minted_evidence_handles=minted,
                 )
             for step_id in ready:
                 remaining.pop(step_id, None)
@@ -779,21 +647,10 @@ class PlanExecutor:
         definition: PlanStepDefinition,
         context: StepContext,
         plan: DevInvestigationPlan,
-    ) -> tuple[StepOutcome, Mapping[str, _MintedReceipt]]:
-        # Each ``_run_one`` call is its own ``asyncio`` task (``run``'s
-        # ``asyncio.gather`` wraps each coroutine passed to it), so setting
-        # this context var here is isolated from every concurrent sibling
-        # step by construction -- no cross-step leakage, no locking needed.
-        token = _MINTED_EVIDENCE_HANDLES.set({}) if self._verify_mint_receipts else None
-        try:
-            outcome = await asyncio.wait_for(
-                definition.run(context), timeout=plan.per_step_timeout_seconds
-            )
-            minted = dict(_MINTED_EVIDENCE_HANDLES.get() or {})
-            return outcome, minted
-        finally:
-            if token is not None:
-                _MINTED_EVIDENCE_HANDLES.reset(token)
+    ) -> StepOutcome:
+        return await asyncio.wait_for(
+            definition.run(context), timeout=plan.per_step_timeout_seconds
+        )
 
     def _observation_for_requirement(
         self,
@@ -835,7 +692,6 @@ class PlanExecutor:
                 outcome,
                 observation_id,
                 context,
-                minted_evidence_handles=attempt.minted_evidence_handles,
             )
         if step_ids and all(step_id in not_applicable for step_id in step_ids):
             return self._unmeasured_observation(
@@ -874,8 +730,6 @@ class PlanExecutor:
         outcome: StepOutcome,
         observation_id: str,
         context: StepContext,
-        *,
-        minted_evidence_handles: Mapping[str, _MintedReceipt] = _EMPTY_RECEIPTS,
     ) -> tuple[DevSourceObservation, bool]:
         content = outcome.content
         if content is not None:
@@ -897,7 +751,7 @@ class PlanExecutor:
                     observation_id,
                     closed=False,
                 )
-            if self._verify_mint_receipts:
+            if self._evidence_signer is not None:
                 # Codex finding (HIGH, round 3, 2026-08-02): every check below
                 # only ever inspects handles a fact actually cites -- a fact
                 # citing NONE skipped every one of them, so a step needed no
@@ -916,42 +770,20 @@ class PlanExecutor:
                         observation_id,
                         closed=False,
                     )
-                # Codex finding (MEDIUM, 2026-08-01): pydantic's ``EvidenceHandle``
-                # pattern only proves a string is *shaped* like ``ev1_...`` --
-                # never that this exact step run actually minted it through
-                # the signer. A step that fabricated a plausible-looking
-                # handle inline (bug or forged adapter) would otherwise pass
-                # through unnoticed; every real handle a builtin step embeds
-                # came from ``runtime.mint_evidence`` via
-                # ``wrap_runtime_with_mint_receipts``, so any evidence_ref_id
-                # in ``content`` that this step's own receipt map never
-                # recorded is a handle this run did not actually mint.
-                unminted = _unminted_evidence_handles(
-                    content, minted_evidence_handles, now=context.now
+                # CHAOS-3296 round 5 (structural inversion, superseding
+                # rounds 1-4's per-run receipt comparison -- see
+                # :class:`_CandidateIdentity`): every cited handle must
+                # cryptographically verify against the CURRENT tenant's
+                # re-derived identity via the real signer, not merely exist
+                # in something this executor tracked itself.
+                invalid = _evidence_signature_failures(
+                    content, context, self._evidence_signer
                 )
-                if unminted:
+                if invalid:
                     return self._unmeasured_observation(
                         requirement,
                         SourceRequirementState.UNAVAILABLE,
-                        "unminted_evidence_handle",
-                        observation_id,
-                        closed=False,
-                    )
-                # Codex finding (MEDIUM, round 2, 2026-08-02): a handle
-                # existing in the receipt map is not enough -- round 1's
-                # check could not stop a step minting once for a real
-                # entity and reusing that exact handle to "prove" an
-                # arbitrary, fabricated second fact. Every fact's own
-                # claimed identity must match the identity its cited
-                # handle(s) were actually minted against.
-                mismatched = _evidence_identity_mismatches(
-                    content, minted_evidence_handles
-                )
-                if mismatched:
-                    return self._unmeasured_observation(
-                        requirement,
-                        SourceRequirementState.UNAVAILABLE,
-                        "evidence_entity_mismatch:" + ",".join(mismatched),
+                        "evidence_signature_invalid:" + ",".join(invalid),
                         observation_id,
                         closed=False,
                     )

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -18,6 +18,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 
 from ..contracts import DevScope, DirectScope, FreshnessState
 from ..contracts_v2.base import EvidenceHandle, SourceClass, SourceRequirementState
@@ -31,6 +32,7 @@ from ..contracts_v2.result import (
 from .builtin_steps import PlanExecutorRuntime
 from .relationship_matrix import (
     CONTENT_SLOT_FIELDS,
+    EVIDENCE_IDENTITY_TABLE,
     MAX_RELATIONSHIP_PATHS,
     MIN_RELATIONSHIP_CONFIDENCE,
     approved_relationship,
@@ -51,7 +53,7 @@ __all__ = ["PlanExecutionError", "PlanExecutor", "wrap_runtime_with_mint_receipt
 @dataclass(frozen=True, slots=True)
 class _MintedReceipt:
     """The identity a ``mint_evidence`` call actually issued a handle
-    against -- the same three fields ``EvidenceReferenceSigner._payload``
+    against -- the same four fields ``EvidenceReferenceSigner._payload``
     binds into its HMAC (``evidence_service.py``), captured directly from
     the mint call's own keyword arguments rather than re-derived from
     anything a step could shape afterward.
@@ -64,9 +66,16 @@ class _MintedReceipt:
     closes that: verification compares each fact's own claimed identity
     against the receipt of every handle it cites (see
     ``_evidence_identity_mismatches``).
+
+    ``source_version`` added in round 4 (Codex [MEDIUM], 2026-08-02): CI
+    checks mint against the coarsened run-level ``entity_id`` but embed the
+    check-specific discriminator into ``source_version`` -- dropping that
+    field let one check's handle "verify" a fabricated fact for a different
+    check on the same run.
     """
 
     source_system: str
+    source_version: str
     entity_type: str
     entity_id: str
 
@@ -275,6 +284,7 @@ class _MintReceiptRuntime:
         if receipts is not None:
             receipts[handle] = _MintedReceipt(
                 source_system=source_system,
+                source_version=source_version,
                 entity_type=entity_type,
                 entity_id=entity_id,
             )
@@ -490,80 +500,71 @@ def _unminted_evidence_handles(
     return frozenset(claimed - minted_evidence_handles.keys())
 
 
-#: Codex finding (MEDIUM, round 2, 2026-08-02): the exact identity each
-#: content category minted its evidence against, mirroring
-#: ``builtin_steps.py``'s own ``_wire_*_content`` derivation *by value*
-#: (matching this package's established ``_STATUS_ENTITY_SOURCE_SYSTEM``
-#: posture) so this can never spuriously reject a legitimately-minted fact
-#: by guessing wrong at how identity was derived. ``graph_edges`` is
-#: deliberately absent: ``DevGraphEdgeV2`` never preserves the ``edge_id``
-#: ``_wire_work_graph_content`` minted against on the wire (only
-#: source/target/relationship survive), so no identity claim can be
-#: faithfully reconstructed for that one category here -- its handles still
-#: go through :func:`_unminted_evidence_handles`'s existence-only check,
-#: never through identity comparison. Only ``entity_type``/``entity_id`` are
-#: compared (not ``source_system``): those two answer "is this citing the
-#: right real-world thing," the question this finding is about; verifying
-#: the more failure-prone, per-category ``source_system`` derivation too
-#: would add drift risk for a lower-value check.
-def _content_fact_claims(
-    content: DevSourceContent,
-) -> list[tuple[str, str, tuple[str, ...]]]:
-    claims: list[tuple[str, str, tuple[str, ...]]] = []
-    for status_fact in content.status_facts:
-        entity_type, _sep, entity_id = status_fact.fact_id.partition(":")
-        claims.append((entity_type, entity_id, status_fact.evidence_ref_ids))
-    for child_fact in content.required_children:
-        entity_type, _sep, entity_id = child_fact.fact_id.partition(":")
-        claims.append((entity_type, entity_id, child_fact.evidence_ref_ids))
-    for pr_fact in content.pull_requests:
-        claims.append(("pull_request", pr_fact.entity_id, pr_fact.evidence_ref_ids))
-    for ci_fact in content.ci_checks:
-        # Mirrors builtin_steps._ci_evidence_identity's coarsening exactly:
-        # a ci_acceptance_checks row's "{repo}#ci{run}#check{key}" entity_id
-        # was minted against the coarsened "{repo}#ci{run}" run identity.
-        lookup_entity_id = ci_fact.entity_id.split("#check", 1)[0]
-        claims.append(("ci_run", lookup_entity_id, ci_fact.evidence_ref_ids))
-    for deployment_fact in content.deployments:
-        claims.append(
-            ("deployment", deployment_fact.entity_id, deployment_fact.evidence_ref_ids)
+def _content_field_facts(content: DevSourceContent) -> list[tuple[str, Any]]:
+    """``(field_name, fact)`` for every fact in every ``CONTENT_SLOT_FIELDS``
+    category, in stable declared field order and each field's own tuple
+    order -- never dict/set iteration."""
+
+    return [
+        (slot, item) for slot in CONTENT_SLOT_FIELDS for item in getattr(content, slot)
+    ]
+
+
+def _missing_evidence_facts(content: DevSourceContent) -> tuple[str, ...]:
+    """CHAOS-3296 round-4 (Codex finding, HIGH, 2026-08-02): every
+    ``"required"``-cell fact citing ZERO evidence handles -- the
+    "evidence-free forgery" class. Rounds 1-2 only ever inspected handles a
+    fact actually cited; a fact citing none skipped every check (unminted
+    existence, identity match) entirely, so a step needed no mint call at
+    all to fabricate a fully-believed fact. ``evidence_ref_ids`` has no
+    ``min_length`` on any of these nine embedded types at the contract
+    layer (only ``status_facts`` requires >=1 there), so this is a real,
+    structurally-reachable gap, not a hypothetical one. Sorted field names,
+    deterministic.
+    """
+
+    return tuple(
+        sorted(
+            {
+                slot
+                for slot, fact in _content_field_facts(content)
+                if EVIDENCE_IDENTITY_TABLE[slot].mode == "required"
+                and not fact.evidence_ref_ids
+            }
         )
-    for incident_fact in content.incidents:
-        claims.append(
-            ("incident", incident_fact.entity_id, incident_fact.evidence_ref_ids)
-        )
-    for change in content.observed_changes:
-        # Mirrors builtin_steps._wire_change_summary_content's
-        # change_evidence_identity exactly: a "relationship" category change
-        # was minted against its own change_id, every other category against
-        # entity_id.
-        lookup_entity_id = (
-            change.change_id if change.category == "relationship" else change.entity_id
-        )
-        claims.append((change.entity_type, lookup_entity_id, change.evidence_ref_ids))
-    for ref in content.metric_refs:
-        claims.append(("metric", ref.metric_ref_id, ref.evidence_ref_ids))
-    return claims
+    )
 
 
 def _evidence_identity_mismatches(
     content: DevSourceContent, minted_evidence_handles: Mapping[str, _MintedReceipt]
 ) -> tuple[str, ...]:
     """Every claimed ``entity_id`` from a fact citing a handle that WAS
-    minted this step -- just not for that fact's own entity. A handle
+    minted this step -- just not for that fact's own identity. A handle
     absent from ``minted_evidence_handles`` entirely is
-    :func:`_unminted_evidence_handles`'s concern, not this function's; here
-    a receipt exists, it is simply bound to a different identity than the
-    fact citing it claims -- exactly the "mint once for issue-1, reuse on a
-    fabricated issue-999 fact" forgery this finding closes.
+    :func:`_unminted_evidence_handles`'s concern; a fact with no handles at
+    all is :func:`_missing_evidence_facts`'s. Here a receipt exists, it is
+    simply bound to a different identity (source_system, source_version,
+    entity_type, entity_id -- the exact four the real signer's HMAC binds)
+    than the fact citing it claims, per :data:`EVIDENCE_IDENTITY_TABLE`'s
+    per-category derivation -- exactly the "mint once for issue-1, reuse on
+    a fabricated issue-999 fact" forgery this finding closes, now complete
+    across every evidence-capable category including graph_edges and
+    check-specific CI identity (round-3 Codex findings 2 and 3).
     """
 
     mismatched: set[str] = set()
-    for entity_type, entity_id, evidence_ref_ids in _content_fact_claims(content):
-        for handle in evidence_ref_ids:
+    for slot, fact in _content_field_facts(content):
+        cell = EVIDENCE_IDENTITY_TABLE[slot]
+        if cell.mode != "required" or cell.derive is None:
+            continue
+        source_system, source_version, entity_type, entity_id = cell.derive(fact)
+        for handle in fact.evidence_ref_ids:
             receipt = minted_evidence_handles.get(handle)
             if receipt is not None and (
-                receipt.entity_type != entity_type or receipt.entity_id != entity_id
+                receipt.source_system != source_system
+                or receipt.source_version != source_version
+                or receipt.entity_type != entity_type
+                or receipt.entity_id != entity_id
             ):
                 mismatched.add(entity_id)
                 break
@@ -897,6 +898,24 @@ class PlanExecutor:
                     closed=False,
                 )
             if self._verify_mint_receipts:
+                # Codex finding (HIGH, round 3, 2026-08-02): every check below
+                # only ever inspects handles a fact actually cites -- a fact
+                # citing NONE skipped every one of them, so a step needed no
+                # mint call at all to fabricate a fully-believed fact (a
+                # forged CI conclusion with evidence_ref_ids=() was accepted
+                # as available_current with a minted "verified" relationship
+                # path). Require-known-good, not reject-known-bad: every
+                # evidence-capable fact MUST cite >=1 handle before its
+                # identity is even considered.
+                missing = _missing_evidence_facts(content)
+                if missing:
+                    return self._unmeasured_observation(
+                        requirement,
+                        SourceRequirementState.UNAVAILABLE,
+                        "evidence_required:" + ",".join(missing),
+                        observation_id,
+                        closed=False,
+                    )
                 # Codex finding (MEDIUM, 2026-08-01): pydantic's ``EvidenceHandle``
                 # pattern only proves a string is *shaped* like ``ev1_...`` --
                 # never that this exact step run actually minted it through

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -12,13 +12,14 @@ entirely the plan document plus each step's own ``applicable`` predicate
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from ..contracts import DevScope, DirectScope
-from ..contracts_v2.base import SourceClass, SourceRequirementState
+from ..contracts import DevScope, DirectScope, FreshnessState
+from ..contracts_v2.base import EvidenceHandle, SourceClass, SourceRequirementState
 from ..contracts_v2.plan import DevInvestigationPlan, DevSourceRequirement
 from ..contracts_v2.result import (
     DevInvestigationResult,
@@ -26,7 +27,13 @@ from ..contracts_v2.result import (
     DevSourceContent,
     DevSourceObservation,
 )
-from .relationship_matrix import MIN_RELATIONSHIP_CONFIDENCE, approved_relationship
+from .builtin_steps import PlanExecutorRuntime
+from .relationship_matrix import (
+    MAX_RELATIONSHIP_PATHS,
+    MIN_RELATIONSHIP_CONFIDENCE,
+    approved_relationship,
+    content_slot_violations,
+)
 from .steps import (
     PlanRegistryError,
     PlanStepDefinition,
@@ -35,7 +42,21 @@ from .steps import (
     StepRegistry,
 )
 
-__all__ = ["PlanExecutionError", "PlanExecutor"]
+__all__ = ["PlanExecutionError", "PlanExecutor", "wrap_runtime_with_mint_receipts"]
+
+#: Per-step-invocation scope (CHAOS-3296 Codex finding, MEDIUM 2026-08-01):
+#: every evidence handle a ``PlanExecutorRuntime`` actually issues during one
+#: step's own ``run()`` call is recorded here (see
+#: :class:`_MintReceiptRuntime`), isolated per ``asyncio`` task -- concurrent
+#: sibling steps (``asyncio.gather`` in :meth:`PlanExecutor.run`) each run in
+#: their own task with their own copy of this context var, so one step's
+#: receipts can never leak into another's. ``None`` (the default, and the
+#: only value any pre-3296 test or ``verify_mint_receipts=False`` run ever
+#: sees) means "no receipt tracking is active" -- content is accepted
+#: unverified, exactly today's behavior.
+_MINTED_EVIDENCE_HANDLES: contextvars.ContextVar[set[str] | None] = (
+    contextvars.ContextVar("chaos_3296_minted_evidence_handles", default=None)
+)
 
 #: Fixed namespace for every CHAOS-3295-minted id. A constant, not a secret --
 #: it exists only so ``uuid5`` output cannot collide with a UUID minted by an
@@ -61,10 +82,115 @@ class PlanExecutionError(RuntimeError):
 
 
 @dataclass(slots=True)
+class _MintReceiptRuntime:
+    """A ``PlanExecutorRuntime`` pass-through that records every evidence
+    handle it actually issues into whichever step-scoped receipt set
+    :data:`_MINTED_EVIDENCE_HANDLES` names for the calling ``asyncio`` task.
+
+    CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): a step's own
+    ``StepOutcome.content`` is entirely producer-controlled -- nothing
+    previously stopped a step from embedding a syntactically-valid-looking
+    ``ev1_...`` string it fabricated inline rather than one this exact
+    ``mint_evidence`` call actually signed. Wrapping the runtime here, once,
+    at registration (see :func:`wrap_runtime_with_mint_receipts`), means
+    every builtin step's ``mint=runtime.mint_evidence`` (``builtin_steps.py``)
+    transparently goes through this recorder with no change to that module --
+    the executor, not any individual step, becomes the sole authority on
+    which handles a step's own run genuinely minted.
+    """
+
+    _inner: PlanExecutorRuntime
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        return await self._inner.status_snapshot(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        return await self._inner.change_summary(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+
+    def list_metrics(self, scope):
+        return self._inner.list_metrics(scope)
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        return await self._inner.query_metric(
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            metric_id=metric_id,
+            scope=scope,
+        )
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        return await self._inner.work_graph_neighbors(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        return await self._inner.data_health(
+            org_id=org_id, permission_fingerprint=permission_fingerprint, scope=scope
+        )
+
+    def mint_evidence(
+        self,
+        *,
+        org_id: str,
+        source_system: str,
+        source_version: str,
+        entity_type: str,
+        entity_id: str,
+        display_label: str,
+        observed_at: datetime,
+        freshness: FreshnessState,
+        confidence: float = 1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ) -> EvidenceHandle:
+        handle = self._inner.mint_evidence(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+        receipts = _MINTED_EVIDENCE_HANDLES.get()
+        if receipts is not None:
+            receipts.add(handle)
+        return handle
+
+
+def wrap_runtime_with_mint_receipts(
+    runtime: PlanExecutorRuntime,
+) -> PlanExecutorRuntime:
+    """Wrap ``runtime`` so :class:`PlanExecutor` can verify -- not merely
+    trust -- which evidence handles a step's own execution actually minted.
+
+    Call this exactly once, before ``register_builtin_steps``/
+    ``build_default_registry`` bakes ``runtime`` into every step closure
+    (``production_runtime.py``'s only call site). Has no effect unless the
+    owning :class:`PlanExecutor` was also constructed with
+    ``verify_mint_receipts=True`` -- with that flag off (every pre-3296 test
+    fixture, and any caller that has not opted in), :data:`
+    _MINTED_EVIDENCE_HANDLES` is never set, so this wrapper degrades to a
+    plain pass-through.
+    """
+
+    return _MintReceiptRuntime(runtime)
+
+
+@dataclass(slots=True)
 class _Attempt:
     step_id: str
     outcome: StepOutcome | None
     failed: bool
+    minted_evidence_handles: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -224,6 +350,29 @@ def _content_candidates(
     return candidates
 
 
+def _unminted_evidence_handles(
+    content: DevSourceContent,
+    minted_evidence_handles: frozenset[str],
+    *,
+    now: datetime,
+) -> frozenset[str]:
+    """Every evidence handle ``content`` claims that this step's own receipt
+    set (:data:`_MINTED_EVIDENCE_HANDLES`, captured per-step in
+    :meth:`PlanExecutor._run_one`) never actually recorded -- i.e. a handle
+    that is not proven to have come from this exact step's
+    ``runtime.mint_evidence`` calls. Reuses :func:`_content_candidates`
+    (already a total per-fact-category walk) rather than a second, parallel
+    traversal of ``DevSourceContent``'s nine fields.
+    """
+
+    claimed = {
+        handle
+        for candidate in _content_candidates(content, now=now)
+        for handle in candidate.evidence_ref_ids
+    }
+    return frozenset(claimed - minted_evidence_handles)
+
+
 def _resolve_target(candidate: _PathCandidate, root_entity_id: str) -> str | None:
     """The candidate's "other end" relative to ``root_entity_id``, or
     ``None`` when the candidate does not actually touch the root at all
@@ -245,9 +394,19 @@ class PlanExecutor:
         *,
         registry: StepRegistry,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
+        verify_mint_receipts: bool = False,
     ) -> None:
         self._registry = registry
         self._now = now
+        #: CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): off by default so
+        #: every pre-3296 test/harness that hand-builds ``StepOutcome.content``
+        #: (bypassing ``register_builtin_steps``/real minting entirely) is
+        #: completely unaffected. ``production_runtime.py`` is the one caller
+        #: that turns this on, paired with ``wrap_runtime_with_mint_receipts``
+        #: wrapping the runtime it registers steps against -- without both
+        #: halves, this flag alone has nothing to verify against and would
+        #: reject every real fact's evidence citation.
+        self._verify_mint_receipts = verify_mint_receipts
 
     async def run(
         self,
@@ -327,11 +486,17 @@ class PlanExecutor:
                 ),
                 return_exceptions=True,
             )
-            for step_id, outcome in zip(runnable_now, outcomes, strict=True):
-                if isinstance(outcome, BaseException):
+            for step_id, attempt_result in zip(runnable_now, outcomes, strict=True):
+                if isinstance(attempt_result, BaseException):
                     failed.add(step_id)
                     continue
-                completed[step_id] = _Attempt(step_id, outcome, failed=False)
+                step_outcome, minted = attempt_result
+                completed[step_id] = _Attempt(
+                    step_id,
+                    step_outcome,
+                    failed=False,
+                    minted_evidence_handles=minted,
+                )
             for step_id in ready:
                 remaining.pop(step_id, None)
 
@@ -408,10 +573,23 @@ class PlanExecutor:
         definition: PlanStepDefinition,
         context: StepContext,
         plan: DevInvestigationPlan,
-    ) -> StepOutcome:
-        return await asyncio.wait_for(
-            definition.run(context), timeout=plan.per_step_timeout_seconds
+    ) -> tuple[StepOutcome, frozenset[str]]:
+        # Each ``_run_one`` call is its own ``asyncio`` task (``run``'s
+        # ``asyncio.gather`` wraps each coroutine passed to it), so setting
+        # this context var here is isolated from every concurrent sibling
+        # step by construction -- no cross-step leakage, no locking needed.
+        token = (
+            _MINTED_EVIDENCE_HANDLES.set(set()) if self._verify_mint_receipts else None
         )
+        try:
+            outcome = await asyncio.wait_for(
+                definition.run(context), timeout=plan.per_step_timeout_seconds
+            )
+            minted = frozenset(_MINTED_EVIDENCE_HANDLES.get() or ())
+            return outcome, minted
+        finally:
+            if token is not None:
+                _MINTED_EVIDENCE_HANDLES.reset(token)
 
     def _observation_for_requirement(
         self,
@@ -445,9 +623,16 @@ class PlanExecutor:
 
         completed_step = next((s for s in step_ids if s in completed), None)
         if completed_step is not None:
-            outcome = completed[completed_step].outcome
+            attempt = completed[completed_step]
+            outcome = attempt.outcome
             assert outcome is not None
-            return self._to_observation(requirement, outcome, observation_id, context)
+            return self._to_observation(
+                requirement,
+                outcome,
+                observation_id,
+                context,
+                minted_evidence_handles=attempt.minted_evidence_handles,
+            )
         if step_ids and all(step_id in not_applicable for step_id in step_ids):
             return self._unmeasured_observation(
                 requirement,
@@ -485,10 +670,54 @@ class PlanExecutor:
         outcome: StepOutcome,
         observation_id: str,
         context: StepContext,
+        *,
+        minted_evidence_handles: frozenset[str] = frozenset(),
     ) -> tuple[DevSourceObservation, bool]:
+        content = outcome.content
+        if content is not None:
+            # Codex finding (MEDIUM, 2026-08-01): a step registered under one
+            # source_class returning content shaped for a different one (e.g.
+            # STATUS_CHANGE content carrying graph_edges) previously reached
+            # relationship-path minting and persistence unfiltered -- the
+            # matrix is a closed, code-owned vocabulary of what a source
+            # class may ever claim, same posture as ``approved_relationship``
+            # below. Reject structurally: demote to unmeasured rather than
+            # pass mismatched content through, and disclose the failure via
+            # ``closed=False`` rather than a vacuous True.
+            slot_violations = content_slot_violations(requirement.source_class, content)
+            if slot_violations:
+                return self._unmeasured_observation(
+                    requirement,
+                    SourceRequirementState.UNAVAILABLE,
+                    "content_source_class_mismatch:" + ",".join(slot_violations),
+                    observation_id,
+                    closed=False,
+                )
+            if self._verify_mint_receipts:
+                # Codex finding (MEDIUM, 2026-08-01): pydantic's ``EvidenceHandle``
+                # pattern only proves a string is *shaped* like ``ev1_...`` --
+                # never that this exact step run actually minted it through
+                # the signer. A step that fabricated a plausible-looking
+                # handle inline (bug or forged adapter) would otherwise pass
+                # through unnoticed; every real handle a builtin step embeds
+                # came from ``runtime.mint_evidence`` via
+                # ``wrap_runtime_with_mint_receipts``, so any evidence_ref_id
+                # in ``content`` that this step's own receipt set never
+                # recorded is a handle this run did not actually mint.
+                unminted = _unminted_evidence_handles(
+                    content, minted_evidence_handles, now=context.now
+                )
+                if unminted:
+                    return self._unmeasured_observation(
+                        requirement,
+                        SourceRequirementState.UNAVAILABLE,
+                        "unminted_evidence_handle",
+                        observation_id,
+                        closed=False,
+                    )
         relationship_paths, closed = self._mint_relationship_paths(
             source_class=requirement.source_class,
-            content=outcome.content,
+            content=content,
             context=context,
             observation_id=observation_id,
         )
@@ -519,6 +748,8 @@ class PlanExecutor:
         state: SourceRequirementState,
         limitation: str,
         observation_id: str,
+        *,
+        closed: bool = True,
     ) -> tuple[DevSourceObservation, bool]:
         observation = DevSourceObservation(
             schema_version="dev_source_observation.v1",
@@ -539,10 +770,12 @@ class PlanExecutor:
             query_version="unversioned",
             content=None,
         )
-        # An unmeasured source never ran -- nothing to close over. That gap
-        # is disclosed separately (subject_coverage/limitation on this same
-        # observation), not folded into relationship_closure_verified.
-        return observation, True
+        # An unmeasured source never ran -- nothing to close over -- so
+        # ``closed`` stays True by default. ``_to_observation`` overrides it
+        # to False for the two content-integrity guards above: those *did*
+        # run a check, and it failed, which must never present as the
+        # vacuous "nothing to verify" case.
+        return observation, closed
 
     def _mint_relationship_paths(
         self,
@@ -573,6 +806,22 @@ class PlanExecutor:
             existing = accepted.get(key)
             if existing is None or candidate.confidence > existing[0].confidence:
                 accepted[key] = (candidate, resolved_target)
+        # Codex finding (HIGH, 2026-08-01): ``DevSourceObservation.
+        # relationship_paths`` is bounded to ``MAX_RELATIONSHIP_PATHS`` at
+        # the contract layer (``max_length=25``) -- a dense-but-legitimate
+        # result that accepted more than that previously reached
+        # ``DevRelationshipPath``/``DevSourceObservation`` construction
+        # unbudgeted, raising ``too_long`` deep inside pydantic and turning
+        # the whole run into an ``internal_error`` instead of a disclosed,
+        # partial answer. Apply the budget here, deterministically --
+        # ``sorted(accepted.items())`` is already keyed on
+        # ``(relationship, target_entity_id)``, so truncation always drops
+        # the same tail regardless of dict/candidate-discovery order -- and
+        # flip closure False whenever the budget actually bites, exactly
+        # like any other dropped candidate.
+        sorted_accepted = sorted(accepted.items())
+        truncated = len(sorted_accepted) > MAX_RELATIONSHIP_PATHS
+        budgeted = sorted_accepted[:MAX_RELATIONSHIP_PATHS]
         paths = tuple(
             DevRelationshipPath(
                 path_id=_mint(
@@ -586,8 +835,6 @@ class PlanExecutor:
                 observed_at=candidate.observed_at,
                 evidence_ref_ids=candidate.evidence_ref_ids[:25],
             )
-            for index, (_key, (candidate, resolved_target)) in enumerate(
-                sorted(accepted.items())
-            )
+            for index, (_key, (candidate, resolved_target)) in enumerate(budgeted)
         )
-        return paths, rejected == 0
+        return paths, rejected == 0 and not truncated

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import json
 import uuid
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from ..contracts import DevScope, DirectScope, FreshnessState
@@ -29,11 +30,13 @@ from ..contracts_v2.result import (
 )
 from .builtin_steps import PlanExecutorRuntime
 from .relationship_matrix import (
+    CONTENT_SLOT_FIELDS,
     MAX_RELATIONSHIP_PATHS,
     MIN_RELATIONSHIP_CONFIDENCE,
     approved_relationship,
     content_slot_violations,
 )
+from .state_mapping import queried_semantics
 from .steps import (
     PlanRegistryError,
     PlanStepDefinition,
@@ -44,9 +47,34 @@ from .steps import (
 
 __all__ = ["PlanExecutionError", "PlanExecutor", "wrap_runtime_with_mint_receipts"]
 
+
+@dataclass(frozen=True, slots=True)
+class _MintedReceipt:
+    """The identity a ``mint_evidence`` call actually issued a handle
+    against -- the same three fields ``EvidenceReferenceSigner._payload``
+    binds into its HMAC (``evidence_service.py``), captured directly from
+    the mint call's own keyword arguments rather than re-derived from
+    anything a step could shape afterward.
+
+    Codex finding (MEDIUM, round 2, 2026-08-02): recording only the bare
+    handle string (round 1's fix) proved merely that *some* handle was
+    minted during this step -- a step could mint once for a real entity and
+    reuse that same string on an arbitrary number of fabricated facts, and
+    the round-1 check could not tell the difference. Binding identity here
+    closes that: verification compares each fact's own claimed identity
+    against the receipt of every handle it cites (see
+    ``_evidence_identity_mismatches``).
+    """
+
+    source_system: str
+    entity_type: str
+    entity_id: str
+
+
 #: Per-step-invocation scope (CHAOS-3296 Codex finding, MEDIUM 2026-08-01):
 #: every evidence handle a ``PlanExecutorRuntime`` actually issues during one
-#: step's own ``run()`` call is recorded here (see
+#: step's own ``run()`` call is recorded here, keyed by the handle and
+#: mapped to the identity it was minted against (see
 #: :class:`_MintReceiptRuntime`), isolated per ``asyncio`` task -- concurrent
 #: sibling steps (``asyncio.gather`` in :meth:`PlanExecutor.run`) each run in
 #: their own task with their own copy of this context var, so one step's
@@ -54,9 +82,87 @@ __all__ = ["PlanExecutionError", "PlanExecutor", "wrap_runtime_with_mint_receipt
 #: only value any pre-3296 test or ``verify_mint_receipts=False`` run ever
 #: sees) means "no receipt tracking is active" -- content is accepted
 #: unverified, exactly today's behavior.
-_MINTED_EVIDENCE_HANDLES: contextvars.ContextVar[set[str] | None] = (
+_MINTED_EVIDENCE_HANDLES: contextvars.ContextVar[dict[str, _MintedReceipt] | None] = (
     contextvars.ContextVar("chaos_3296_minted_evidence_handles", default=None)
 )
+
+#: A shared, never-mutated empty receipt map -- used as ``_to_observation``'s
+#: default so an ordinary mutable-default pitfall never applies (nothing
+#: ever writes into it; every real receipt map is its own fresh ``dict``
+#: from :meth:`PlanExecutor._run_one`).
+_EMPTY_RECEIPTS: Mapping[str, _MintedReceipt] = {}
+
+#: Codex finding (HIGH, 2026-08-02, round 2): raising the persistence
+#: envelope (``persistence/service.py``'s ``_SOURCE_OBSERVATION_PAYLOAD_
+#: MAX_BYTES``) from 16KiB to 64KiB only moved the failure -- a genuinely
+#: contract-valid observation (every category at its own ``max_length``,
+#: every string at its own bound) still serializes past 64KiB by an order
+#: of magnitude (~615KiB at the true maximum), and a legal metric
+#: observation with dense 366-point series alone cleared 64KiB in
+#: isolation. Bounding the CONTRACT does not bound the WIRE PAYLOAD --
+#: the fix has to happen at construction, before persistence ever sees it,
+#: so the persisted object is exactly the presented object (never a
+#: silent divergence between "what we showed" and "what we stored").
+#: Kept as a literal duplicate of the numeric relationship to the
+#: persistence envelope (64KiB), not an import -- this domain-layer module
+#: has no dependency on the storage layer (see ``_STATUS_ENTITY_SOURCE_
+#: SYSTEM`` in ``builtin_steps.py`` for the same by-value-not-import
+#: posture); the two constants must be changed together.
+_CONTENT_BYTE_BUDGET_DEFAULT = 56 * 1024
+
+
+def _observation_json_bytes(observation: DevSourceObservation) -> int:
+    """Byte-for-byte the same encoding ``persistence.service._bounded_json``
+    measures the persisted payload with -- so a budget check here is the
+    exact same measurement the persistence backstop would otherwise apply,
+    just performed before construction commits to a shape that might not
+    fit."""
+
+    encoded = json.dumps(
+        observation.model_dump(mode="json"), separators=(",", ":"), sort_keys=True
+    )
+    return len(encoded.encode("utf-8"))
+
+
+def _total_content_facts(content: DevSourceContent) -> int:
+    return sum(len(getattr(content, slot)) for slot in CONTENT_SLOT_FIELDS)
+
+
+def _drop_lowest_priority_item(
+    content: DevSourceContent, dropped: dict[str, int]
+) -> DevSourceContent | None:
+    """Remove exactly one item from the lowest-priority non-empty
+    ``DevSourceContent`` field (tail-drop -- fields are already tuples in
+    stable, service-determined order, so this never touches dict/set
+    iteration order). ``CONTENT_SLOT_FIELDS`` is walked in reverse: the
+    last field in that priority list is the first ever dropped. Returns
+    ``None`` once every field is empty -- nothing left to drop."""
+
+    for slot in reversed(CONTENT_SLOT_FIELDS):
+        items = getattr(content, slot)
+        if items:
+            dropped[slot] = dropped.get(slot, 0) + 1
+            return content.model_copy(update={slot: items[:-1]})
+    return None
+
+
+def _dropped_summary(dropped: dict[str, int]) -> str:
+    return ",".join(
+        f"{field}:{count}" for field, count in sorted(dropped.items()) if count
+    )
+
+
+def _downgrade_for_truncation(state: SourceRequirementState) -> SourceRequirementState:
+    """A truncated result can never claim to be fully current -- downgrade
+    exactly once, never re-upgrade an already-imperfect state. Mirrors
+    ``state_mapping.work_graph_result_state_to_requirement_state``'s own
+    "truncated but real facts survive" reasoning: PARTIAL/STALE, never
+    the zero-fact TRUNCATED state, as long as at least one fact remains."""
+
+    if state is SourceRequirementState.AVAILABLE_CURRENT:
+        return SourceRequirementState.AVAILABLE_STALE
+    return state
+
 
 #: Fixed namespace for every CHAOS-3295-minted id. A constant, not a secret --
 #: it exists only so ``uuid5`` output cannot collide with a UUID minted by an
@@ -84,19 +190,24 @@ class PlanExecutionError(RuntimeError):
 @dataclass(slots=True)
 class _MintReceiptRuntime:
     """A ``PlanExecutorRuntime`` pass-through that records every evidence
-    handle it actually issues into whichever step-scoped receipt set
+    handle it actually issues -- and the identity it issued that handle
+    against -- into whichever step-scoped receipt map
     :data:`_MINTED_EVIDENCE_HANDLES` names for the calling ``asyncio`` task.
 
-    CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): a step's own
-    ``StepOutcome.content`` is entirely producer-controlled -- nothing
-    previously stopped a step from embedding a syntactically-valid-looking
-    ``ev1_...`` string it fabricated inline rather than one this exact
-    ``mint_evidence`` call actually signed. Wrapping the runtime here, once,
-    at registration (see :func:`wrap_runtime_with_mint_receipts`), means
-    every builtin step's ``mint=runtime.mint_evidence`` (``builtin_steps.py``)
+    CHAOS-3296 Codex finding (MEDIUM, 2026-08-01; sharpened round 2,
+    2026-08-02): a step's own ``StepOutcome.content`` is entirely
+    producer-controlled -- nothing previously stopped a step from embedding
+    a syntactically-valid-looking ``ev1_...`` string it fabricated inline
+    rather than one this exact ``mint_evidence`` call actually signed, and
+    round 1's existence-only receipt set could not stop a step from minting
+    once for a real entity and reusing that same handle on an arbitrary
+    number of fabricated facts. Wrapping the runtime here, once, at
+    registration (see :func:`wrap_runtime_with_mint_receipts`), means every
+    builtin step's ``mint=runtime.mint_evidence`` (``builtin_steps.py``)
     transparently goes through this recorder with no change to that module --
     the executor, not any individual step, becomes the sole authority on
-    which handles a step's own run genuinely minted.
+    which handles a step's own run genuinely minted, and what each one was
+    minted to prove.
     """
 
     _inner: PlanExecutorRuntime
@@ -162,7 +273,11 @@ class _MintReceiptRuntime:
         )
         receipts = _MINTED_EVIDENCE_HANDLES.get()
         if receipts is not None:
-            receipts.add(handle)
+            receipts[handle] = _MintedReceipt(
+                source_system=source_system,
+                entity_type=entity_type,
+                entity_id=entity_id,
+            )
         return handle
 
 
@@ -190,7 +305,7 @@ class _Attempt:
     step_id: str
     outcome: StepOutcome | None
     failed: bool
-    minted_evidence_handles: frozenset[str] = frozenset()
+    minted_evidence_handles: Mapping[str, _MintedReceipt] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -352,17 +467,19 @@ def _content_candidates(
 
 def _unminted_evidence_handles(
     content: DevSourceContent,
-    minted_evidence_handles: frozenset[str],
+    minted_evidence_handles: Mapping[str, _MintedReceipt],
     *,
     now: datetime,
 ) -> frozenset[str]:
     """Every evidence handle ``content`` claims that this step's own receipt
-    set (:data:`_MINTED_EVIDENCE_HANDLES`, captured per-step in
+    map (:data:`_MINTED_EVIDENCE_HANDLES`, captured per-step in
     :meth:`PlanExecutor._run_one`) never actually recorded -- i.e. a handle
     that is not proven to have come from this exact step's
     ``runtime.mint_evidence`` calls. Reuses :func:`_content_candidates`
     (already a total per-fact-category walk) rather than a second, parallel
-    traversal of ``DevSourceContent``'s nine fields.
+    traversal of ``DevSourceContent``'s nine fields. Existence-only: a
+    handle that *was* minted, but for a different entity, passes this check
+    and is instead caught by :func:`_evidence_identity_mismatches`.
     """
 
     claimed = {
@@ -370,7 +487,87 @@ def _unminted_evidence_handles(
         for candidate in _content_candidates(content, now=now)
         for handle in candidate.evidence_ref_ids
     }
-    return frozenset(claimed - minted_evidence_handles)
+    return frozenset(claimed - minted_evidence_handles.keys())
+
+
+#: Codex finding (MEDIUM, round 2, 2026-08-02): the exact identity each
+#: content category minted its evidence against, mirroring
+#: ``builtin_steps.py``'s own ``_wire_*_content`` derivation *by value*
+#: (matching this package's established ``_STATUS_ENTITY_SOURCE_SYSTEM``
+#: posture) so this can never spuriously reject a legitimately-minted fact
+#: by guessing wrong at how identity was derived. ``graph_edges`` is
+#: deliberately absent: ``DevGraphEdgeV2`` never preserves the ``edge_id``
+#: ``_wire_work_graph_content`` minted against on the wire (only
+#: source/target/relationship survive), so no identity claim can be
+#: faithfully reconstructed for that one category here -- its handles still
+#: go through :func:`_unminted_evidence_handles`'s existence-only check,
+#: never through identity comparison. Only ``entity_type``/``entity_id`` are
+#: compared (not ``source_system``): those two answer "is this citing the
+#: right real-world thing," the question this finding is about; verifying
+#: the more failure-prone, per-category ``source_system`` derivation too
+#: would add drift risk for a lower-value check.
+def _content_fact_claims(
+    content: DevSourceContent,
+) -> list[tuple[str, str, tuple[str, ...]]]:
+    claims: list[tuple[str, str, tuple[str, ...]]] = []
+    for status_fact in content.status_facts:
+        entity_type, _sep, entity_id = status_fact.fact_id.partition(":")
+        claims.append((entity_type, entity_id, status_fact.evidence_ref_ids))
+    for child_fact in content.required_children:
+        entity_type, _sep, entity_id = child_fact.fact_id.partition(":")
+        claims.append((entity_type, entity_id, child_fact.evidence_ref_ids))
+    for pr_fact in content.pull_requests:
+        claims.append(("pull_request", pr_fact.entity_id, pr_fact.evidence_ref_ids))
+    for ci_fact in content.ci_checks:
+        # Mirrors builtin_steps._ci_evidence_identity's coarsening exactly:
+        # a ci_acceptance_checks row's "{repo}#ci{run}#check{key}" entity_id
+        # was minted against the coarsened "{repo}#ci{run}" run identity.
+        lookup_entity_id = ci_fact.entity_id.split("#check", 1)[0]
+        claims.append(("ci_run", lookup_entity_id, ci_fact.evidence_ref_ids))
+    for deployment_fact in content.deployments:
+        claims.append(
+            ("deployment", deployment_fact.entity_id, deployment_fact.evidence_ref_ids)
+        )
+    for incident_fact in content.incidents:
+        claims.append(
+            ("incident", incident_fact.entity_id, incident_fact.evidence_ref_ids)
+        )
+    for change in content.observed_changes:
+        # Mirrors builtin_steps._wire_change_summary_content's
+        # change_evidence_identity exactly: a "relationship" category change
+        # was minted against its own change_id, every other category against
+        # entity_id.
+        lookup_entity_id = (
+            change.change_id if change.category == "relationship" else change.entity_id
+        )
+        claims.append((change.entity_type, lookup_entity_id, change.evidence_ref_ids))
+    for ref in content.metric_refs:
+        claims.append(("metric", ref.metric_ref_id, ref.evidence_ref_ids))
+    return claims
+
+
+def _evidence_identity_mismatches(
+    content: DevSourceContent, minted_evidence_handles: Mapping[str, _MintedReceipt]
+) -> tuple[str, ...]:
+    """Every claimed ``entity_id`` from a fact citing a handle that WAS
+    minted this step -- just not for that fact's own entity. A handle
+    absent from ``minted_evidence_handles`` entirely is
+    :func:`_unminted_evidence_handles`'s concern, not this function's; here
+    a receipt exists, it is simply bound to a different identity than the
+    fact citing it claims -- exactly the "mint once for issue-1, reuse on a
+    fabricated issue-999 fact" forgery this finding closes.
+    """
+
+    mismatched: set[str] = set()
+    for entity_type, entity_id, evidence_ref_ids in _content_fact_claims(content):
+        for handle in evidence_ref_ids:
+            receipt = minted_evidence_handles.get(handle)
+            if receipt is not None and (
+                receipt.entity_type != entity_type or receipt.entity_id != entity_id
+            ):
+                mismatched.add(entity_id)
+                break
+    return tuple(sorted(mismatched))
 
 
 def _resolve_target(candidate: _PathCandidate, root_entity_id: str) -> str | None:
@@ -395,9 +592,17 @@ class PlanExecutor:
         registry: StepRegistry,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
         verify_mint_receipts: bool = False,
+        content_byte_budget: int = _CONTENT_BYTE_BUDGET_DEFAULT,
     ) -> None:
         self._registry = registry
         self._now = now
+        #: CHAOS-3296 Codex finding (HIGH, round 2): the deterministic,
+        #: disclosed-truncation byte budget every constructed observation is
+        #: held to (see :meth:`_budgeted_observation`). Overridable so tests
+        #: can pin an exact, small budget and construct boundary fixtures at
+        #: precisely-at-budget / one-item-over without needing to reverse
+        #: engineer the real ~56KiB target's byte arithmetic.
+        self._content_byte_budget = content_byte_budget
         #: CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): off by default so
         #: every pre-3296 test/harness that hand-builds ``StepOutcome.content``
         #: (bypassing ``register_builtin_steps``/real minting entirely) is
@@ -573,19 +778,17 @@ class PlanExecutor:
         definition: PlanStepDefinition,
         context: StepContext,
         plan: DevInvestigationPlan,
-    ) -> tuple[StepOutcome, frozenset[str]]:
+    ) -> tuple[StepOutcome, Mapping[str, _MintedReceipt]]:
         # Each ``_run_one`` call is its own ``asyncio`` task (``run``'s
         # ``asyncio.gather`` wraps each coroutine passed to it), so setting
         # this context var here is isolated from every concurrent sibling
         # step by construction -- no cross-step leakage, no locking needed.
-        token = (
-            _MINTED_EVIDENCE_HANDLES.set(set()) if self._verify_mint_receipts else None
-        )
+        token = _MINTED_EVIDENCE_HANDLES.set({}) if self._verify_mint_receipts else None
         try:
             outcome = await asyncio.wait_for(
                 definition.run(context), timeout=plan.per_step_timeout_seconds
             )
-            minted = frozenset(_MINTED_EVIDENCE_HANDLES.get() or ())
+            minted = dict(_MINTED_EVIDENCE_HANDLES.get() or {})
             return outcome, minted
         finally:
             if token is not None:
@@ -671,7 +874,7 @@ class PlanExecutor:
         observation_id: str,
         context: StepContext,
         *,
-        minted_evidence_handles: frozenset[str] = frozenset(),
+        minted_evidence_handles: Mapping[str, _MintedReceipt] = _EMPTY_RECEIPTS,
     ) -> tuple[DevSourceObservation, bool]:
         content = outcome.content
         if content is not None:
@@ -702,7 +905,7 @@ class PlanExecutor:
                 # through unnoticed; every real handle a builtin step embeds
                 # came from ``runtime.mint_evidence`` via
                 # ``wrap_runtime_with_mint_receipts``, so any evidence_ref_id
-                # in ``content`` that this step's own receipt set never
+                # in ``content`` that this step's own receipt map never
                 # recorded is a handle this run did not actually mint.
                 unminted = _unminted_evidence_handles(
                     content, minted_evidence_handles, now=context.now
@@ -715,32 +918,124 @@ class PlanExecutor:
                         observation_id,
                         closed=False,
                     )
-        relationship_paths, closed = self._mint_relationship_paths(
-            source_class=requirement.source_class,
-            content=content,
-            context=context,
-            observation_id=observation_id,
+                # Codex finding (MEDIUM, round 2, 2026-08-02): a handle
+                # existing in the receipt map is not enough -- round 1's
+                # check could not stop a step minting once for a real
+                # entity and reusing that exact handle to "prove" an
+                # arbitrary, fabricated second fact. Every fact's own
+                # claimed identity must match the identity its cited
+                # handle(s) were actually minted against.
+                mismatched = _evidence_identity_mismatches(
+                    content, minted_evidence_handles
+                )
+                if mismatched:
+                    return self._unmeasured_observation(
+                        requirement,
+                        SourceRequirementState.UNAVAILABLE,
+                        "evidence_entity_mismatch:" + ",".join(mismatched),
+                        observation_id,
+                        closed=False,
+                    )
+        return self._budgeted_observation(
+            requirement, outcome, content, observation_id, context
         )
-        observation = DevSourceObservation(
-            schema_version="dev_source_observation.v1",
-            observation_id=observation_id,
-            source_class=requirement.source_class,
-            adapter_id=requirement.adapter_id,
-            requirement_level=requirement.requirement_level,
-            observed_state=outcome.observed_state,
-            data_semantics=outcome.data_semantics,
-            watermark=outcome.watermark,
-            subject_coverage=outcome.subject_coverage,
-            usable_fact_count=outcome.usable_fact_count,
-            sample_count=outcome.sample_count,
-            relationship_paths=relationship_paths,
-            evidence_ref_ids=(),
-            limitation=outcome.limitation,
-            observed_at=self._now(),
-            query_version=outcome.query_version,
-            content=outcome.content,
-        )
-        return observation, closed
+
+    def _budgeted_observation(
+        self,
+        requirement: DevSourceRequirement,
+        outcome: StepOutcome,
+        content: DevSourceContent | None,
+        observation_id: str,
+        context: StepContext,
+    ) -> tuple[DevSourceObservation, bool]:
+        """Construct the final observation, then -- before returning it to
+        persistence or presentation -- shrink ``content`` deterministically
+        until the *exact* payload persistence will store fits
+        ``self._content_byte_budget``.
+
+        Codex finding (HIGH, 2026-08-02, round 2): raising the persistence
+        envelope only moved the "valid run becomes internal_error" bug to a
+        higher threshold -- the true contract-legal maximum is far larger
+        than any envelope this layer could reasonably hold. The fix has to
+        cap what gets CONSTRUCTED, using the contract's own disclosed
+        mechanisms (a downgraded ``observed_state``/``TRUNCATED`` plus a
+        bounded ``limitation``), never a second silent truncation notion and
+        never converting a legitimate answer into an opaque platform error.
+
+        Every iteration re-derives ``relationship_paths`` from the CURRENT
+        (possibly already-shrunk) ``content`` -- never the original -- so a
+        dropped fact can never leave behind an orphaned relationship path
+        that cites content no longer present on the wire.
+        """
+
+        dropped: dict[str, int] = {}
+        working_content = content
+        while True:
+            relationship_paths, paths_closed = self._mint_relationship_paths(
+                source_class=requirement.source_class,
+                content=working_content,
+                context=context,
+                observation_id=observation_id,
+            )
+            usable_fact_count = outcome.usable_fact_count
+            observed_state = outcome.observed_state
+            data_semantics = outcome.data_semantics
+            limitation = outcome.limitation
+            if dropped:
+                # Recomputed from what actually survived -- never the
+                # step's original count, which may describe facts this
+                # observation no longer carries.
+                usable_fact_count = (
+                    _total_content_facts(working_content)
+                    if working_content is not None
+                    else 0
+                )
+                if usable_fact_count == 0:
+                    return self._unmeasured_observation(
+                        requirement,
+                        SourceRequirementState.TRUNCATED,
+                        "budget_truncated_to_empty:" + _dropped_summary(dropped),
+                        observation_id,
+                        closed=False,
+                    )
+                observed_state = _downgrade_for_truncation(observed_state)
+                data_semantics = queried_semantics(usable_fact_count)
+                limitation = "budget_truncated:" + _dropped_summary(dropped)
+            observation = DevSourceObservation(
+                schema_version="dev_source_observation.v1",
+                observation_id=observation_id,
+                source_class=requirement.source_class,
+                adapter_id=requirement.adapter_id,
+                requirement_level=requirement.requirement_level,
+                observed_state=observed_state,
+                data_semantics=data_semantics,
+                watermark=outcome.watermark,
+                subject_coverage=outcome.subject_coverage,
+                usable_fact_count=usable_fact_count,
+                sample_count=outcome.sample_count,
+                relationship_paths=relationship_paths,
+                evidence_ref_ids=(),
+                limitation=limitation,
+                observed_at=self._now(),
+                query_version=outcome.query_version,
+                content=working_content,
+            )
+            if _observation_json_bytes(observation) <= self._content_byte_budget:
+                return observation, paths_closed and not dropped
+            if working_content is None:
+                # Nothing left to drop yet still over budget: the non-content
+                # fields alone (e.g. an extreme ``provenance``/handle set on
+                # relationship_paths) exceed the budget. Fail closed exactly
+                # like the empty-after-truncation case above rather than
+                # persisting an oversized payload.
+                return self._unmeasured_observation(
+                    requirement,
+                    SourceRequirementState.TRUNCATED,
+                    "budget_truncated_to_empty:" + _dropped_summary(dropped),
+                    observation_id,
+                    closed=False,
+                )
+            working_content = _drop_lowest_priority_item(working_content, dropped)
 
     def _unmeasured_observation(
         self,

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -22,13 +22,18 @@ from dataclasses import dataclass
 from typing import Literal
 
 from ..contracts_v2.base import SourceClass
+from ..contracts_v2.result import DevSourceContent
 from ..work_graph_neighbors_service import ALLOWED_RELATIONSHIP_TYPES
 
 __all__ = [
+    "APPROVED_CONTENT_SLOTS",
+    "CONTENT_SLOT_FIELDS",
+    "MAX_RELATIONSHIP_PATHS",
     "MIN_RELATIONSHIP_CONFIDENCE",
     "RelationshipMatrixEntry",
     "RELATIONSHIP_MATRIX",
     "approved_relationship",
+    "content_slot_violations",
 ]
 
 #: A path minted below this confidence is treated the same as an unapproved
@@ -37,6 +42,16 @@ __all__ = [
 #: still appear in ``content`` (the adapter's own bounded output is
 #: untouched), it simply never contributes a verified relationship path.
 MIN_RELATIONSHIP_CONFIDENCE = 0.3
+
+#: The most relationship paths one observation may carry -- must match
+#: ``DevSourceObservation.relationship_paths``'s own ``max_length=25``
+#: (``contracts_v2/result.py``). Codex finding (HIGH, 2026-08-01): a dense
+#: but otherwise valid result minting more than 25 verified paths raised
+#: ``too_long`` deep inside ``DevSourceObservation`` construction, turning a
+#: real (if partial) answer into a whole-run ``internal_error``. The
+#: executor applies this budget itself, deterministically, before
+#: construction -- see ``executor._mint_relationship_paths``.
+MAX_RELATIONSHIP_PATHS = 25
 
 Role = Literal["direct", "supporting"]
 Requirement = Literal["required", "conditional", "not_applicable"]
@@ -229,3 +244,95 @@ def approved_relationship(source_class: SourceClass, relationship: str) -> bool:
     """
 
     return relationship in RELATIONSHIP_MATRIX[source_class].approved_relationship_types
+
+
+#: Every ``DevSourceContent`` collection field name -- the closed vocabulary
+#: :func:`content_slot_violations` walks. Written out rather than derived
+#: from ``DevSourceContent.model_fields`` so a future field addition there
+#: is a visible, reviewed edit here too (the same posture as
+#: ``PLAN_ID_BY_INTENT``'s written-out mapping), not a silently-included slot
+#: no ``SourceClass`` entry below has judged yet.
+CONTENT_SLOT_FIELDS: tuple[str, ...] = (
+    "status_facts",
+    "required_children",
+    "pull_requests",
+    "ci_checks",
+    "deployments",
+    "incidents",
+    "graph_edges",
+    "observed_changes",
+    "metric_refs",
+)
+
+#: Which ``DevSourceContent`` slot(s) each ``SourceClass``'s own registered
+#: builtin steps (``investigation_plans/builtin_steps.py``) are ever allowed
+#: to populate. Codex finding (MEDIUM, 2026-08-01): nothing previously
+#: enforced this at observation construction -- a step registered under one
+#: source class returning content shaped for a *different* one (e.g.
+#: STATUS_CHANGE content carrying ``graph_edges``) would be minted,
+#: relationship-path-checked, persisted, and presented exactly like
+#: legitimate content. One entry per :class:`SourceClass` -- completeness is
+#: asserted at import time below, the same posture as ``RELATIONSHIP_MATRIX``
+#: itself. Derived from -- and must stay in lockstep with -- which
+#: ``_wire_*_content`` helper each registered step in ``builtin_steps.py``
+#: calls: ``status_snapshot``/``change_summary`` both register under
+#: STATUS_CHANGE (the six flattened status categories plus
+#: ``observed_changes``); ``work_graph_expansion`` under WORK_GRAPH
+#: (``graph_edges`` only); the metric steps under WORK_ITEM (``metric_refs``
+#: only). SOURCE_HEALTH and every not-yet-adapted class mint no content at
+#: all (``StepOutcome.content`` stays ``None`` for those steps), matching
+#: ``RELATIONSHIP_MATRIX``'s own "empty vocabulary, not fabricated" posture
+#: for the same not-yet-landed classes.
+APPROVED_CONTENT_SLOTS: dict[SourceClass, frozenset[str]] = {
+    SourceClass.STATUS_CHANGE: frozenset(
+        {
+            "status_facts",
+            "required_children",
+            "pull_requests",
+            "ci_checks",
+            "deployments",
+            "incidents",
+            "observed_changes",
+        }
+    ),
+    SourceClass.WORK_ITEM: frozenset({"metric_refs"}),
+    SourceClass.WORK_GRAPH: frozenset({"graph_edges"}),
+    SourceClass.PULL_REQUEST: frozenset(),
+    SourceClass.CI_RUN: frozenset(),
+    SourceClass.DEPLOYMENT: frozenset(),
+    SourceClass.INCIDENT: frozenset(),
+    SourceClass.SOURCE_HEALTH: frozenset(),
+    SourceClass.CODE_CHANGE: frozenset(),
+    SourceClass.REVIEW: frozenset(),
+    SourceClass.TEST_REPORT: frozenset(),
+    SourceClass.OPERATIONAL_CONTROL: frozenset(),
+}
+
+_missing_content_slots = set(SourceClass) - set(APPROVED_CONTENT_SLOTS)
+if _missing_content_slots:
+    raise RuntimeError(
+        f"content_slot_matrix.v1 is missing entries for: {sorted(_missing_content_slots)}"
+    )
+_unknown_content_fields = {
+    field for slots in APPROVED_CONTENT_SLOTS.values() for field in slots
+} - set(CONTENT_SLOT_FIELDS)
+if _unknown_content_fields:
+    raise RuntimeError(
+        f"content_slot_matrix.v1 approves unknown DevSourceContent fields: "
+        f"{sorted(_unknown_content_fields)}"
+    )
+
+
+def content_slot_violations(
+    source_class: SourceClass, content: DevSourceContent
+) -> tuple[str, ...]:
+    """Every populated ``DevSourceContent`` field name ``source_class`` is
+    not approved to carry, sorted for a deterministic limitation string.
+
+    Empty for legitimate content -- including an all-empty
+    ``DevSourceContent`` for a queried-but-empty result, which populates no
+    field at all regardless of ``source_class``.
+    """
+
+    populated = {field for field in CONTENT_SLOT_FIELDS if getattr(content, field)}
+    return tuple(sorted(populated - APPROVED_CONTENT_SLOTS[source_class]))

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -19,15 +19,41 @@ verify," independent of which plan or subject kind asked.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from ..contracts_v2.base import SourceClass
 from ..contracts_v2.result import DevSourceContent
 from ..work_graph_neighbors_service import ALLOWED_RELATIONSHIP_TYPES
 
+# CHAOS-3296 round-4 closure: imported BY REFERENCE, not duplicated by value
+# -- unlike ``_STATUS_ENTITY_SOURCE_SYSTEM``'s existing by-value posture
+# elsewhere in this package (circular-import driven), there is no cycle here
+# (``builtin_steps.py`` imports neither this module nor ``executor.py``), so
+# a real import is strictly stronger than a copy: if a minting call site's
+# identity derivation ever changes shape, this import breaks at MODULE LOAD
+# for the whole test suite, not just whenever a specific drift test happens
+# to run. This is exactly the "the cell's test breaks if minting changes"
+# property the round-4 closure requires -- enforced at the strongest
+# available layer, with :func:`test_evidence_identity_table_matches_the_real_minting_call_sites`-style
+# tests (see ``tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py``)
+# as the second, still-necessary layer for logic an import alone cannot
+# catch (a constant staying correct while the *call* that uses it changes).
+from .builtin_steps import (
+    _CHANGE_CATEGORY_SOURCE_SYSTEM,
+    _CHANGE_COLLISION_PRONE_CATEGORIES,
+    _CHANGE_EVIDENCE_SOURCE_VERSION,
+    _CI_ACCEPTANCE_CHECK_MARKER,
+    _GRAPH_EVIDENCE_SOURCE_VERSION,
+    _METRIC_EVIDENCE_SOURCE_VERSION,
+    _STATUS_ENTITY_SOURCE_SYSTEM,
+    _STATUS_EVIDENCE_SOURCE_VERSION,
+)
+
 __all__ = [
     "APPROVED_CONTENT_SLOTS",
     "CONTENT_SLOT_FIELDS",
+    "EVIDENCE_IDENTITY_TABLE",
+    "EvidenceIdentityCell",
     "MAX_RELATIONSHIP_PATHS",
     "MIN_RELATIONSHIP_CONFIDENCE",
     "RelationshipMatrixEntry",
@@ -346,3 +372,187 @@ def content_slot_violations(
 
     populated = {field for field in CONTENT_SLOT_FIELDS if getattr(content, field)}
     return tuple(sorted(populated - APPROVED_CONTENT_SLOTS[source_class]))
+
+
+# -- Evidence identity table (CHAOS-3296 round-4 closure) -------------------
+#
+# Codex round 3 (2026-08-02) confirmed the mint-receipt verification built in
+# rounds 1-2 was reject-known-bad (flag a handle only if it is PRESENT and
+# wrong) rather than require-known-good (every evidence-capable fact MUST
+# cite >=1 receipted handle whose FULL identity matches). That shape left
+# three holes: a fact with zero evidence_ref_ids skipped every check
+# entirely; graph_edges was excluded from identity comparison because
+# DevGraphEdgeV2 never preserved the edge_id minting bound identity to; and
+# CI-check identity collapsed to the run level (entity_type/entity_id only),
+# discarding the check-specific discriminator the real signer's HMAC
+# actually binds into source_version.
+#
+# This table closes all three by construction: one cell per
+# CONTENT_SLOT_FIELDS entry (import-time-total, same posture as
+# APPROVED_CONTENT_SLOTS), each either "required" (every fact in that field
+# must cite >=1 handle whose (source_system, source_version, entity_type,
+# entity_id) -- the exact four fields the real EvidenceReferenceSigner binds
+# into its HMAC, evidence_service.py's EvidenceReferenceSigner._payload --
+# match what THIS field's own minting call site actually passed) or
+# "accepted_risk" (a category the platform has explicitly decided may
+# legitimately carry no evidence, with its own rationale -- there are
+# currently none; every wire_* helper in builtin_steps.py mints
+# unconditionally for every fact it constructs, so an empty cell here would
+# be a fabricated exemption, not an honest one).
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceIdentityCell:
+    mode: Literal["required", "accepted_risk"]
+    #: ``None`` only for "accepted_risk" cells. Takes one fact object from
+    #: the corresponding ``DevSourceContent`` field's tuple and returns
+    #: exactly ``(source_system, source_version, entity_type, entity_id)``
+    #: -- must match what that field's own ``builtin_steps.py`` wiring
+    #: function passed to ``mint_evidence`` for that same fact, which the
+    #: source-anchored tests prove by spying on a real mint call and
+    #: comparing.
+    derive: Any | None = None
+    #: ``None`` for "required" cells; a short, reviewed sentence for
+    #: "accepted_risk" ones explaining why no evidence is, and always will
+    #: be, legitimate for that category.
+    rationale: str | None = None
+
+
+def _identity_status_like(fact: Any) -> tuple[str, str, str, str]:
+    """``status_facts`` / ``required_children`` -- both wired by
+    ``_wire_status_snapshot_content``'s ``mint_status``, which mints against
+    the raw ``StatusFact.entity_type``/``entity_id`` pair the wire fact's own
+    ``fact_id`` encodes as ``f"{entity_type}:{entity_id}"``."""
+
+    entity_type, _sep, entity_id = fact.fact_id.partition(":")
+    source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
+    return source_system, _STATUS_EVIDENCE_SOURCE_VERSION, entity_type, entity_id
+
+
+def _identity_pull_request(fact: Any) -> tuple[str, str, str, str]:
+    """``wire_pull_request`` -> ``mint_delivery(source_system="pull_requests",
+    entity_type="pull_request", entity_id=fact.entity_id)`` with the default
+    (unoverridden) ``source_version``."""
+
+    return (
+        "pull_requests",
+        _STATUS_EVIDENCE_SOURCE_VERSION,
+        "pull_request",
+        fact.entity_id,
+    )
+
+
+def _identity_ci_check(fact: Any) -> tuple[str, str, str, str]:
+    """``wire_ci`` coarsens ``fact.entity_id`` (strip the
+    ``#check...`` acceptance-check suffix) for the minted ``entity_id``, but
+    -- when coarsening actually changed anything -- embeds the FULL,
+    uncoarsened id into ``source_version`` specifically so two checks on the
+    same run mint distinct, non-interchangeable handles. Losing that
+    discriminator (round 2's gap) let one check's handle verify another's
+    fabricated fact; comparing ``source_version`` too closes it."""
+
+    lookup_entity_id = fact.entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
+    source_version = (
+        f"{_STATUS_EVIDENCE_SOURCE_VERSION}:{fact.entity_id}"
+        if lookup_entity_id != fact.entity_id
+        else _STATUS_EVIDENCE_SOURCE_VERSION
+    )
+    return "ci_runs", source_version, "ci_run", lookup_entity_id
+
+
+def _identity_deployment(fact: Any) -> tuple[str, str, str, str]:
+    return "deployments", _STATUS_EVIDENCE_SOURCE_VERSION, "deployment", fact.entity_id
+
+
+def _identity_incident(fact: Any) -> tuple[str, str, str, str]:
+    return "incidents", _STATUS_EVIDENCE_SOURCE_VERSION, "incident", fact.entity_id
+
+
+def _identity_observed_change(change: Any) -> tuple[str, str, str, str]:
+    """Mirrors ``_wire_change_summary_content``'s ``change_evidence_identity``
+    closure exactly: a ``"relationship"``-category change mints against its
+    own ``change_id`` (never ``entity_id``); a collision-prone category
+    (``status``/``metric``) embeds ``change_id`` into ``source_version`` on
+    top of minting against ``entity_id``; every other category mints
+    straight against ``entity_id`` with the base source_version. Every input
+    (``category``, ``change_id``, ``entity_id``, ``entity_type``) survives
+    unchanged onto ``DevObservedChangeV2``, so this is fully reconstructible
+    from the wire fact alone."""
+
+    category = change.category
+    source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
+    if category == "relationship":
+        return (
+            source_system,
+            _CHANGE_EVIDENCE_SOURCE_VERSION,
+            change.entity_type,
+            change.change_id,
+        )
+    if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+        return (
+            source_system,
+            f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{change.change_id}",
+            change.entity_type,
+            change.entity_id,
+        )
+    return (
+        source_system,
+        _CHANGE_EVIDENCE_SOURCE_VERSION,
+        change.entity_type,
+        change.entity_id,
+    )
+
+
+def _identity_graph_edge(edge: Any) -> tuple[str, str, str, str]:
+    """``wire_edge`` mints against ``item.edge_id`` -- CHAOS-3296 round-4
+    adds ``DevGraphEdgeV2.edge_id`` specifically so this identity survives
+    to the wire; round 1-3 could not implement this cell at all."""
+
+    return "work_graph", _GRAPH_EVIDENCE_SOURCE_VERSION, "work_graph_edge", edge.edge_id
+
+
+def _identity_metric_ref(ref: Any) -> tuple[str, str, str, str]:
+    return "metrics", _METRIC_EVIDENCE_SOURCE_VERSION, "metric", ref.metric_ref_id
+
+
+EVIDENCE_IDENTITY_TABLE: dict[str, EvidenceIdentityCell] = {
+    "status_facts": EvidenceIdentityCell(mode="required", derive=_identity_status_like),
+    "required_children": EvidenceIdentityCell(
+        mode="required", derive=_identity_status_like
+    ),
+    "pull_requests": EvidenceIdentityCell(
+        mode="required", derive=_identity_pull_request
+    ),
+    "ci_checks": EvidenceIdentityCell(mode="required", derive=_identity_ci_check),
+    "deployments": EvidenceIdentityCell(mode="required", derive=_identity_deployment),
+    "incidents": EvidenceIdentityCell(mode="required", derive=_identity_incident),
+    "graph_edges": EvidenceIdentityCell(mode="required", derive=_identity_graph_edge),
+    "observed_changes": EvidenceIdentityCell(
+        mode="required", derive=_identity_observed_change
+    ),
+    "metric_refs": EvidenceIdentityCell(mode="required", derive=_identity_metric_ref),
+}
+
+_missing_evidence_cells = set(CONTENT_SLOT_FIELDS) - set(EVIDENCE_IDENTITY_TABLE)
+if _missing_evidence_cells:
+    raise RuntimeError(
+        f"evidence_identity_table.v1 is missing cells for: {sorted(_missing_evidence_cells)}"
+    )
+_unknown_evidence_cells = set(EVIDENCE_IDENTITY_TABLE) - set(CONTENT_SLOT_FIELDS)
+if _unknown_evidence_cells:
+    raise RuntimeError(
+        f"evidence_identity_table.v1 has cells for unknown fields: "
+        f"{sorted(_unknown_evidence_cells)}"
+    )
+_malformed_evidence_cells = sorted(
+    field
+    for field, cell in EVIDENCE_IDENTITY_TABLE.items()
+    if (cell.mode == "required") == (cell.derive is None)
+    or (cell.mode == "accepted_risk") == (cell.rationale is None)
+)
+if _malformed_evidence_cells:
+    raise RuntimeError(
+        f"evidence_identity_table.v1 cells must pair mode='required' with a "
+        f"derive function (never both/neither), and mode='accepted_risk' "
+        f"with a rationale: {_malformed_evidence_cells}"
+    )

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -1,0 +1,231 @@
+"""The versioned source/relationship matrix (CHAOS-3296, issue "Required
+implementation" §1).
+
+A closed, code-owned registry -- same ``frozenset``/``StrEnum`` posture as
+``PLAN_REGISTRY``/``SourceClass`` -- naming, for every :class:`SourceClass`,
+whether that source is a *direct* or *supporting* role and which
+relationship tokens a fact from that source may legitimately claim on a
+``dev_relationship_path.v1`` hop from a committed subject. An unapproved
+relationship token fails construction (:func:`approved_relationship` returns
+``False``, and the executor's path-minting never emits it), never merely a
+lint/review finding.
+
+Deliberately excludes ``PLAN_REGISTRY``/plan-execution concerns (CHAOS-3295)
+and team-direct-scope semantics (CHAOS-3301) -- this module only answers "is
+this (source_class, relationship) pair one the platform has proven it can
+verify," independent of which plan or subject kind asked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..contracts_v2.base import SourceClass
+from ..work_graph_neighbors_service import ALLOWED_RELATIONSHIP_TYPES
+
+__all__ = [
+    "MIN_RELATIONSHIP_CONFIDENCE",
+    "RelationshipMatrixEntry",
+    "RELATIONSHIP_MATRIX",
+    "approved_relationship",
+]
+
+#: A path minted below this confidence is treated the same as an unapproved
+#: relationship type: never emitted. Distinguishes a "stale/low-confidence
+#: edge" (acceptance criterion) from a genuinely absent one -- the edge may
+#: still appear in ``content`` (the adapter's own bounded output is
+#: untouched), it simply never contributes a verified relationship path.
+MIN_RELATIONSHIP_CONFIDENCE = 0.3
+
+Role = Literal["direct", "supporting"]
+Requirement = Literal["required", "conditional", "not_applicable"]
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipMatrixEntry:
+    source_class: SourceClass
+    role: Role
+    requirement: Requirement
+    #: Closed vocabulary of relationship tokens a fact from this source may
+    #: carry on a minted ``DevRelationshipPath.relationship``. Empty means
+    #: this source class mints no per-fact relationship path at all (its
+    #: facts are either not entity-linked -- source health -- or no adapter
+    #: registered against the six core plans populates it yet).
+    approved_relationship_types: frozenset[str]
+    freshness_policy: str
+    evidence_expansion_capability: bool
+
+
+def _entry(
+    source_class: SourceClass,
+    *,
+    role: Role,
+    requirement: Requirement,
+    approved_relationship_types: frozenset[str] = frozenset(),
+    freshness_policy: str,
+    evidence_expansion_capability: bool,
+) -> RelationshipMatrixEntry:
+    return RelationshipMatrixEntry(
+        source_class=source_class,
+        role=role,
+        requirement=requirement,
+        approved_relationship_types=approved_relationship_types,
+        freshness_policy=freshness_policy,
+        evidence_expansion_capability=evidence_expansion_capability,
+    )
+
+
+#: One entry per :class:`SourceClass` member -- completeness is asserted at
+#: import time below, not left to a test to eventually notice drift.
+RELATIONSHIP_MATRIX: dict[SourceClass, RelationshipMatrixEntry] = {
+    entry.source_class: entry
+    for entry in (
+        _entry(
+            SourceClass.STATUS_CHANGE,
+            role="direct",
+            requirement="required",
+            # "status_assessment" covers the flattened declared/child/blocker
+            # facts status_snapshot.v1 wires into content.status_facts (v1's
+            # own wire shape already merges those three categories into one
+            # list -- the executor cannot recover which sub-kind a flattened
+            # fact came from, so it mints one honest, non-overclaiming label
+            # rather than a fabricated finer-grained one). "required_child"
+            # is reserved for content.required_children, which *does* stay
+            # separately typed end to end. status.entity.v2's single
+            # status_snapshot step is also the (only, today) adapter that
+            # mints the linked_pull_request/linked_ci_run/linked_deployment/
+            # linked_incident facts -- under a STATUS_CHANGE source
+            # requirement, not a dedicated one -- so those tokens are
+            # approved here too; the standalone PULL_REQUEST/CI_RUN/
+            # DEPLOYMENT/INCIDENT entries below stay reserved for a future
+            # *dedicated* adapter minting the same tokens under their own
+            # source requirement.
+            approved_relationship_types=frozenset(
+                {
+                    "status_assessment",
+                    "required_child",
+                    "observed_change",
+                    "linked_pull_request",
+                    "linked_ci_run",
+                    "linked_deployment",
+                    "linked_incident",
+                }
+            ),
+            freshness_policy="status_snapshot_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.WORK_ITEM,
+            role="supporting",
+            requirement="conditional",
+            approved_relationship_types=frozenset({"metric_scoped_to_subject"}),
+            freshness_policy="metric_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.WORK_GRAPH,
+            role="supporting",
+            requirement="conditional",
+            # Reuses the exact vocabulary work_graph_neighbors_service already
+            # validates a request against (ALLOWED_RELATIONSHIP_TYPES) --
+            # imported, not re-declared, so the two cannot drift apart.
+            approved_relationship_types=frozenset(ALLOWED_RELATIONSHIP_TYPES),
+            freshness_policy="work_graph_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.PULL_REQUEST,
+            role="supporting",
+            requirement="conditional",
+            approved_relationship_types=frozenset({"linked_pull_request"}),
+            freshness_policy="status_snapshot_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.CI_RUN,
+            role="supporting",
+            requirement="conditional",
+            approved_relationship_types=frozenset({"linked_ci_run"}),
+            freshness_policy="status_snapshot_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.DEPLOYMENT,
+            role="supporting",
+            requirement="conditional",
+            approved_relationship_types=frozenset({"linked_deployment"}),
+            freshness_policy="status_snapshot_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.INCIDENT,
+            role="supporting",
+            requirement="conditional",
+            approved_relationship_types=frozenset({"linked_incident"}),
+            freshness_policy="status_snapshot_freshness.v1",
+            evidence_expansion_capability=True,
+        ),
+        _entry(
+            SourceClass.SOURCE_HEALTH,
+            role="supporting",
+            requirement="required",
+            # Source health describes a *source's* freshness/availability, not
+            # a fact about the subject -- it never carries a relationship path
+            # of its own (no DevSourceContent slot exists for it either; see
+            # that contract's own docstring).
+            freshness_policy="data_health_freshness.v1",
+            evidence_expansion_capability=False,
+        ),
+        # Not yet minted by any of the six core plans' registered steps. Kept
+        # in the matrix (drift test requires every SourceClass present) with
+        # an honest empty vocabulary rather than a fabricated one --
+        # CHAOS-3303's/3304's/3305's own adapters amend these entries when
+        # they land, the same way they extend PLAN_REGISTRY.
+        _entry(
+            SourceClass.CODE_CHANGE,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
+        _entry(
+            SourceClass.REVIEW,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
+        _entry(
+            SourceClass.TEST_REPORT,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
+        _entry(
+            SourceClass.OPERATIONAL_CONTROL,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
+    )
+}
+
+_missing = set(SourceClass) - set(RELATIONSHIP_MATRIX)
+if _missing:
+    raise RuntimeError(
+        f"relationship_matrix.v1 is missing entries for: {sorted(_missing)}"
+    )
+
+
+def approved_relationship(source_class: SourceClass, relationship: str) -> bool:
+    """Whether ``relationship`` is a token this source class may mint.
+
+    ``False`` for any source class not in the matrix is unreachable (the
+    import-time completeness check above guarantees every member has an
+    entry), so this never needs a default/fallback branch of its own.
+    """
+
+    return relationship in RELATIONSHIP_MATRIX[source_class].approved_relationship_types

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -252,6 +252,16 @@ def approved_relationship(source_class: SourceClass, relationship: str) -> bool:
 #: is a visible, reviewed edit here too (the same posture as
 #: ``PLAN_ID_BY_INTENT``'s written-out mapping), not a silently-included slot
 #: no ``SourceClass`` entry below has judged yet.
+#:
+#: Dual-purpose (CHAOS-3296 Codex finding, HIGH, 2026-08-01): the order here
+#: is ALSO ``executor._budgeted_observation``'s truncation priority --
+#: issue body Section 6 "Evidence prioritization and bounds" ranks direct
+#: verdict > required incomplete work > blocking/delivery gates > optional
+#: context, which maps onto this exact field order (earliest = highest
+#: priority = dropped last; ``metric_refs`` at the tail is dropped first).
+#: One deliberate list rather than two that could silently drift apart --
+#: a future field addition here is reviewed for BOTH its approved-slot
+#: membership and where it ranks under budget pressure in the same edit.
 CONTENT_SLOT_FIELDS: tuple[str, ...] = (
     "status_facts",
     "required_children",

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -49,6 +49,8 @@ from .builtin_steps import (
     _bind_content,
     _ci_check_source_version,
     _ci_evidence_identity,
+    _claim_projection,
+    _metric_ref_id,
 )
 
 __all__ = [
@@ -455,31 +457,37 @@ def _status_entity(fact: Any) -> tuple[str, str]:
 
 def _identity_status_fact(fact: Any) -> tuple[str, str, str, str]:
     """``status_facts`` -- wired by ``_wire_status_snapshot_content``'s
-    ``mint_status``/``wire_status_fact``, which mints against the raw
+    ``wire_status_fact``, which mints against the raw
     ``StatusFact.entity_type``/``entity_id`` pair the wire fact's own
-    ``fact_id`` encodes as ``f"{entity_type}:{entity_id}"``, with
-    ``source_version`` binding the SAME composed ``"{label}: {status}"``
-    string ``wire_status_fact`` writes verbatim onto ``DevStatusFactV2.text``
-    (round 5) -- recovered here with no parsing, since that field already
-    IS the bound claim."""
-
-    entity_type, entity_id = _status_entity(fact)
-    source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
-    source_version = _bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=fact.text)
-    return source_system, source_version, entity_type, entity_id
-
-
-def _identity_required_child(fact: Any) -> tuple[str, str, str, str]:
-    """``required_children`` -- the same ``mint_status`` as ``status_facts``,
-    but ``wire_required_child`` splits the composed claim across TWO wire
-    fields instead of one (``text`` = ``display_label`` alone,
-    ``status`` separate) -- reconstruct the identical
-    ``"{label}: {status}"`` string ``mint_status`` bound from the two."""
+    ``fact_id`` encodes as ``f"{entity_type}:{entity_id}"``.
+    ``source_version`` binds :func:`~.builtin_steps._claim_projection` of
+    ``fact`` itself (round 6: every ``DevStatusFactV2`` field except
+    ``schema_version``/``evidence_ref_ids``, derived programmatically --
+    never a hand-picked subset)."""
 
     entity_type, entity_id = _status_entity(fact)
     source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
     source_version = _bind_content(
-        _STATUS_EVIDENCE_SOURCE_VERSION, claim=f"{fact.text}: {fact.status}"
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(fact)
+    )
+    return source_system, source_version, entity_type, entity_id
+
+
+def _identity_required_child(fact: Any) -> tuple[str, str, str, str]:
+    """``required_children`` -- the same raw ``StatusFact`` source as
+    ``status_facts``, wired to a DIFFERENT shape (``DevRequiredChildFactV2``
+    keeps ``text``=label and ``status`` as two SEPARATE fields, rather than
+    one composed string). Projecting THIS model binds them as separate
+    JSON keys, not a delimiter-joined string -- a forged fact cannot
+    re-split a genuine "Repo: Alpha"/"blocked" claim into "Repo"/
+    "Alpha: blocked" (or any other split producing the same composed
+    string) and still verify, the collision round 6 specifically asked to
+    rule out."""
+
+    entity_type, entity_id = _status_entity(fact)
+    source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
+    source_version = _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(fact)
     )
     return source_system, source_version, entity_type, entity_id
 
@@ -487,15 +495,12 @@ def _identity_required_child(fact: Any) -> tuple[str, str, str, str]:
 def _identity_pull_request(fact: Any) -> tuple[str, str, str, str]:
     """``wire_pull_request`` -> ``mint_delivery(source_system="pull_requests",
     entity_type="pull_request", entity_id=fact.entity_id)``, ``source_version``
-    binding ``DevPullRequestFactV2``'s own claim fields (round 5)."""
+    binding :func:`~.builtin_steps._claim_projection` of ``fact`` (round 6:
+    every ``DevPullRequestFactV2`` field except schema_version/
+    evidence_ref_ids)."""
 
     source_version = _bind_content(
-        _STATUS_EVIDENCE_SOURCE_VERSION,
-        state=fact.state,
-        review_state=fact.review_state,
-        changes_requested=fact.changes_requested,
-        merged=fact.merged,
-        required=fact.required,
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(fact)
     )
     return "pull_requests", source_version, "pull_request", fact.entity_id
 
@@ -507,60 +512,49 @@ def _identity_ci_check(fact: Any) -> tuple[str, str, str, str]:
     ``builtin_steps._ci_check_source_version`` this cell calls -- never a
     parallel reimplementation. That shared function embeds the FULL,
     uncoarsened id (round 4: distinguishes two checks on the same run) and a
-    canonical digest of the fact's own asserted claim (round 5: distinguishes
-    two different CLAIMS about the SAME check -- a genuine handle for a
-    failing check can no longer verify a fabricated passing claim for that
-    same check, because the two claims mint different, non-interchangeable
-    handles in the first place)."""
+    canonical digest of :func:`~.builtin_steps._claim_projection` of ``fact``
+    (round 6: every ``DevCIFactV2`` field, programmatically derived --
+    round 5 hand-picked only conclusion/required/skipped_required_work)."""
 
     lookup_entity_id = _ci_evidence_identity(fact.entity_id)
     source_version = _ci_check_source_version(
-        fact.entity_id,
-        conclusion=fact.conclusion,
-        required=fact.required,
-        skipped_required_work=fact.skipped_required_work,
+        fact.entity_id, claim=_claim_projection(fact)
     )
     return "ci_runs", source_version, "ci_run", lookup_entity_id
 
 
 def _identity_deployment(fact: Any) -> tuple[str, str, str, str]:
-    """``source_version`` binds ``DevDeploymentFactV2``'s own claim fields
-    (round 5)."""
+    """``source_version`` binds :func:`~.builtin_steps._claim_projection`
+    of ``fact`` (round 6: every ``DevDeploymentFactV2`` field)."""
 
     source_version = _bind_content(
-        _STATUS_EVIDENCE_SOURCE_VERSION,
-        status=fact.status,
-        environment=fact.environment,
-        required=fact.required,
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(fact)
     )
     return "deployments", source_version, "deployment", fact.entity_id
 
 
 def _identity_incident(fact: Any) -> tuple[str, str, str, str]:
-    """``source_version`` binds ``DevIncidentFactV2``'s own claim fields
-    (round 5)."""
+    """``source_version`` binds :func:`~.builtin_steps._claim_projection`
+    of ``fact`` (round 6: every ``DevIncidentFactV2`` field)."""
 
     source_version = _bind_content(
-        _STATUS_EVIDENCE_SOURCE_VERSION,
-        status=fact.status,
-        active=fact.active,
-        blocking=fact.blocking,
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(fact)
     )
     return "incidents", source_version, "incident", fact.entity_id
 
 
 def _identity_observed_change(change: Any) -> tuple[str, str, str, str]:
-    """Mirrors ``_wire_change_summary_content``'s ``change_evidence_identity``
+    """Mirrors ``_wire_change_summary_content``'s ``change_base_identity``
     closure exactly: a ``"relationship"``-category change mints against its
     own ``change_id`` (never ``entity_id``); a collision-prone category
     (``status``/``metric``) embeds ``change_id`` into ``source_version`` on
     top of minting against ``entity_id``; every other category mints
     straight against ``entity_id`` with the base source_version -- THEN
-    (round 5) every branch binds ``before``/``after``, the only
-    ``ObservedChange`` claim fields that survive onto ``DevObservedChangeV2``
-    at all. Every input (``category``, ``change_id``, ``entity_id``,
-    ``entity_type``, ``before``, ``after``) survives unchanged onto the wire
-    type, so this is fully reconstructible from the wire fact alone."""
+    every branch binds :func:`~.builtin_steps._claim_projection` of
+    ``change`` (round 6: every ``DevObservedChangeV2`` field -- ``before``/
+    ``after`` remain the only ones that actually vary meaningfully, since
+    ``claim_kind``/``relationship_chain``/``metric_value``/
+    ``metric_comparison_value`` never survive onto the wire type at all)."""
 
     category = change.category
     source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
@@ -573,9 +567,7 @@ def _identity_observed_change(change: Any) -> tuple[str, str, str, str]:
     else:
         base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
         entity_id = change.entity_id
-    source_version = _bind_content(
-        base_source_version, before=change.before, after=change.after
-    )
+    source_version = _bind_content(base_source_version, _claim_projection(change))
     return source_system, source_version, change.entity_type, entity_id
 
 
@@ -583,31 +575,44 @@ def _identity_graph_edge(edge: Any) -> tuple[str, str, str, str]:
     """``wire_edge`` mints against ``item.edge_id`` -- CHAOS-3296 round-4
     adds ``DevGraphEdgeV2.edge_id`` specifically so this identity survives
     to the wire; round 1-3 could not implement this cell at all.
-    ``source_version`` binds ``DevGraphEdgeV2``'s own claim fields (round
-    5): a genuine handle for edge_id X must never authenticate a fabricated
-    relationship/orientation for that same edge_id."""
+    ``source_version`` binds :func:`~.builtin_steps._claim_projection` of
+    ``edge`` (round 6: every ``DevGraphEdgeV2`` field, including
+    ``provenance``/``confidence``/``observed_at`` -- round 5 hand-picked
+    only relationship/orientation and Codex forged the rest on a genuine
+    handle)."""
 
     source_version = _bind_content(
-        _GRAPH_EVIDENCE_SOURCE_VERSION,
-        relationship=edge.relationship,
-        source_entity_id=edge.source_entity_id,
-        target_entity_id=edge.target_entity_id,
+        _GRAPH_EVIDENCE_SOURCE_VERSION, _claim_projection(edge)
     )
     return "work_graph", source_version, "work_graph_edge", edge.edge_id
 
 
 def _identity_metric_ref(ref: Any) -> tuple[str, str, str, str]:
-    """``source_version`` binds ``DevMetricRefV2``'s own claim fields
-    (round 5): a genuine handle for one metric value must never
-    authenticate a fabricated different value for the same
-    ``metric_ref_id``."""
+    """``entity_id`` is INDEPENDENTLY RECOMPUTED from ``ref``'s own
+    ``metric_id``/``dimensions``/``current_window`` via the exact same
+    :func:`~.builtin_steps._metric_ref_id` mint used -- never trusted as a
+    free-form ``ref.metric_ref_id`` the wire fact merely claims (round 6
+    ask: "recompute/validate metric_ref_id from the same inputs"). A fact
+    whose claimed ``metric_ref_id`` does not match what its OWN claimed
+    metric_id/dimensions/window would genuinely hash to fails verification
+    here structurally: the candidate's entity_id (this recomputed value)
+    would not equal what a genuine handle for THAT metric_ref_id was ever
+    signed against. ``source_version`` binds
+    :func:`~.builtin_steps._claim_projection` of ``ref`` (round 6: every
+    ``DevMetricRefV2`` field -- round 5 hand-picked only value/
+    comparison_value, so Codex re-labeled the metric and forged its series
+    while leaving those two fields untouched)."""
 
-    source_version = _bind_content(
-        _METRIC_EVIDENCE_SOURCE_VERSION,
-        value=ref.value,
-        comparison_value=ref.comparison_value,
+    entity_id = _metric_ref_id(
+        metric_id=ref.metric_id.value,
+        dimensions=ref.dimensions,
+        window_start=ref.current_window.start.isoformat(),
+        window_end=ref.current_window.end.isoformat(),
     )
-    return "metrics", source_version, "metric", ref.metric_ref_id
+    source_version = _bind_content(
+        _METRIC_EVIDENCE_SOURCE_VERSION, _claim_projection(ref)
+    )
+    return "metrics", source_version, "metric", entity_id
 
 
 EVIDENCE_IDENTITY_TABLE: dict[str, EvidenceIdentityCell] = {

--- a/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/relationship_matrix.py
@@ -42,11 +42,13 @@ from .builtin_steps import (
     _CHANGE_CATEGORY_SOURCE_SYSTEM,
     _CHANGE_COLLISION_PRONE_CATEGORIES,
     _CHANGE_EVIDENCE_SOURCE_VERSION,
-    _CI_ACCEPTANCE_CHECK_MARKER,
     _GRAPH_EVIDENCE_SOURCE_VERSION,
     _METRIC_EVIDENCE_SOURCE_VERSION,
     _STATUS_ENTITY_SOURCE_SYSTEM,
     _STATUS_EVIDENCE_SOURCE_VERSION,
+    _bind_content,
+    _ci_check_source_version,
+    _ci_evidence_identity,
 )
 
 __all__ = [
@@ -251,6 +253,30 @@ RELATIONSHIP_MATRIX: dict[SourceClass, RelationshipMatrixEntry] = {
             freshness_policy="unversioned",
             evidence_expansion_capability=False,
         ),
+        # CHAOS-3304 merge reconciliation (SourceClass reconciliation,
+        # 2026-08-02): COGNITIVE_LOAD/INVESTMENT_ALLOCATION landed on
+        # ``contracts_v2.base.SourceClass`` via #1374, which never touched
+        # this module -- 3304's health rules/adapters are wired directly
+        # against ``user_metrics_daily``/``team_metrics_daily``/
+        # ``investment_metrics_daily``, not through PLAN_REGISTRY/this
+        # investigation-plan executor. Same "not yet landed here, honest
+        # empty vocabulary" posture as CODE_CHANGE/REVIEW/TEST_REPORT/
+        # OPERATIONAL_CONTROL above -- amend when a plan step actually
+        # mints content under one of these classes.
+        _entry(
+            SourceClass.COGNITIVE_LOAD,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
+        _entry(
+            SourceClass.INVESTMENT_ALLOCATION,
+            role="supporting",
+            requirement="not_applicable",
+            freshness_policy="unversioned",
+            evidence_expansion_capability=False,
+        ),
     )
 }
 
@@ -342,6 +368,10 @@ APPROVED_CONTENT_SLOTS: dict[SourceClass, frozenset[str]] = {
     SourceClass.REVIEW: frozenset(),
     SourceClass.TEST_REPORT: frozenset(),
     SourceClass.OPERATIONAL_CONTROL: frozenset(),
+    # CHAOS-3304 merge reconciliation -- see the matching RELATIONSHIP_MATRIX
+    # entries above for the full rationale.
+    SourceClass.COGNITIVE_LOAD: frozenset(),
+    SourceClass.INVESTMENT_ALLOCATION: frozenset(),
 }
 
 _missing_content_slots = set(SourceClass) - set(APPROVED_CONTENT_SLOTS)
@@ -418,54 +448,105 @@ class EvidenceIdentityCell:
     rationale: str | None = None
 
 
-def _identity_status_like(fact: Any) -> tuple[str, str, str, str]:
-    """``status_facts`` / ``required_children`` -- both wired by
-    ``_wire_status_snapshot_content``'s ``mint_status``, which mints against
-    the raw ``StatusFact.entity_type``/``entity_id`` pair the wire fact's own
-    ``fact_id`` encodes as ``f"{entity_type}:{entity_id}"``."""
-
+def _status_entity(fact: Any) -> tuple[str, str]:
     entity_type, _sep, entity_id = fact.fact_id.partition(":")
+    return entity_type, entity_id
+
+
+def _identity_status_fact(fact: Any) -> tuple[str, str, str, str]:
+    """``status_facts`` -- wired by ``_wire_status_snapshot_content``'s
+    ``mint_status``/``wire_status_fact``, which mints against the raw
+    ``StatusFact.entity_type``/``entity_id`` pair the wire fact's own
+    ``fact_id`` encodes as ``f"{entity_type}:{entity_id}"``, with
+    ``source_version`` binding the SAME composed ``"{label}: {status}"``
+    string ``wire_status_fact`` writes verbatim onto ``DevStatusFactV2.text``
+    (round 5) -- recovered here with no parsing, since that field already
+    IS the bound claim."""
+
+    entity_type, entity_id = _status_entity(fact)
     source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
-    return source_system, _STATUS_EVIDENCE_SOURCE_VERSION, entity_type, entity_id
+    source_version = _bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=fact.text)
+    return source_system, source_version, entity_type, entity_id
+
+
+def _identity_required_child(fact: Any) -> tuple[str, str, str, str]:
+    """``required_children`` -- the same ``mint_status`` as ``status_facts``,
+    but ``wire_required_child`` splits the composed claim across TWO wire
+    fields instead of one (``text`` = ``display_label`` alone,
+    ``status`` separate) -- reconstruct the identical
+    ``"{label}: {status}"`` string ``mint_status`` bound from the two."""
+
+    entity_type, entity_id = _status_entity(fact)
+    source_system = _STATUS_ENTITY_SOURCE_SYSTEM.get(entity_type, "work_items")
+    source_version = _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION, claim=f"{fact.text}: {fact.status}"
+    )
+    return source_system, source_version, entity_type, entity_id
 
 
 def _identity_pull_request(fact: Any) -> tuple[str, str, str, str]:
     """``wire_pull_request`` -> ``mint_delivery(source_system="pull_requests",
-    entity_type="pull_request", entity_id=fact.entity_id)`` with the default
-    (unoverridden) ``source_version``."""
+    entity_type="pull_request", entity_id=fact.entity_id)``, ``source_version``
+    binding ``DevPullRequestFactV2``'s own claim fields (round 5)."""
 
-    return (
-        "pull_requests",
+    source_version = _bind_content(
         _STATUS_EVIDENCE_SOURCE_VERSION,
-        "pull_request",
-        fact.entity_id,
+        state=fact.state,
+        review_state=fact.review_state,
+        changes_requested=fact.changes_requested,
+        merged=fact.merged,
+        required=fact.required,
     )
+    return "pull_requests", source_version, "pull_request", fact.entity_id
 
 
 def _identity_ci_check(fact: Any) -> tuple[str, str, str, str]:
-    """``wire_ci`` coarsens ``fact.entity_id`` (strip the
-    ``#check...`` acceptance-check suffix) for the minted ``entity_id``, but
-    -- when coarsening actually changed anything -- embeds the FULL,
-    uncoarsened id into ``source_version`` specifically so two checks on the
-    same run mint distinct, non-interchangeable handles. Losing that
-    discriminator (round 2's gap) let one check's handle verify another's
-    fabricated fact; comparing ``source_version`` too closes it."""
+    """``wire_ci`` coarsens ``fact.entity_id`` (strip the ``#check...``
+    acceptance-check suffix) for the minted ``entity_id``, and mints against
+    a ``source_version`` built by the exact same
+    ``builtin_steps._ci_check_source_version`` this cell calls -- never a
+    parallel reimplementation. That shared function embeds the FULL,
+    uncoarsened id (round 4: distinguishes two checks on the same run) and a
+    canonical digest of the fact's own asserted claim (round 5: distinguishes
+    two different CLAIMS about the SAME check -- a genuine handle for a
+    failing check can no longer verify a fabricated passing claim for that
+    same check, because the two claims mint different, non-interchangeable
+    handles in the first place)."""
 
-    lookup_entity_id = fact.entity_id.split(_CI_ACCEPTANCE_CHECK_MARKER, 1)[0]
-    source_version = (
-        f"{_STATUS_EVIDENCE_SOURCE_VERSION}:{fact.entity_id}"
-        if lookup_entity_id != fact.entity_id
-        else _STATUS_EVIDENCE_SOURCE_VERSION
+    lookup_entity_id = _ci_evidence_identity(fact.entity_id)
+    source_version = _ci_check_source_version(
+        fact.entity_id,
+        conclusion=fact.conclusion,
+        required=fact.required,
+        skipped_required_work=fact.skipped_required_work,
     )
     return "ci_runs", source_version, "ci_run", lookup_entity_id
 
 
 def _identity_deployment(fact: Any) -> tuple[str, str, str, str]:
-    return "deployments", _STATUS_EVIDENCE_SOURCE_VERSION, "deployment", fact.entity_id
+    """``source_version`` binds ``DevDeploymentFactV2``'s own claim fields
+    (round 5)."""
+
+    source_version = _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION,
+        status=fact.status,
+        environment=fact.environment,
+        required=fact.required,
+    )
+    return "deployments", source_version, "deployment", fact.entity_id
 
 
 def _identity_incident(fact: Any) -> tuple[str, str, str, str]:
-    return "incidents", _STATUS_EVIDENCE_SOURCE_VERSION, "incident", fact.entity_id
+    """``source_version`` binds ``DevIncidentFactV2``'s own claim fields
+    (round 5)."""
+
+    source_version = _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION,
+        status=fact.status,
+        active=fact.active,
+        blocking=fact.blocking,
+    )
+    return "incidents", source_version, "incident", fact.entity_id
 
 
 def _identity_observed_change(change: Any) -> tuple[str, str, str, str]:
@@ -474,51 +555,65 @@ def _identity_observed_change(change: Any) -> tuple[str, str, str, str]:
     own ``change_id`` (never ``entity_id``); a collision-prone category
     (``status``/``metric``) embeds ``change_id`` into ``source_version`` on
     top of minting against ``entity_id``; every other category mints
-    straight against ``entity_id`` with the base source_version. Every input
-    (``category``, ``change_id``, ``entity_id``, ``entity_type``) survives
-    unchanged onto ``DevObservedChangeV2``, so this is fully reconstructible
-    from the wire fact alone."""
+    straight against ``entity_id`` with the base source_version -- THEN
+    (round 5) every branch binds ``before``/``after``, the only
+    ``ObservedChange`` claim fields that survive onto ``DevObservedChangeV2``
+    at all. Every input (``category``, ``change_id``, ``entity_id``,
+    ``entity_type``, ``before``, ``after``) survives unchanged onto the wire
+    type, so this is fully reconstructible from the wire fact alone."""
 
     category = change.category
     source_system = _CHANGE_CATEGORY_SOURCE_SYSTEM.get(category, "work_items")
     if category == "relationship":
-        return (
-            source_system,
-            _CHANGE_EVIDENCE_SOURCE_VERSION,
-            change.entity_type,
-            change.change_id,
-        )
-    if category in _CHANGE_COLLISION_PRONE_CATEGORIES:
-        return (
-            source_system,
-            f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{change.change_id}",
-            change.entity_type,
-            change.entity_id,
-        )
-    return (
-        source_system,
-        _CHANGE_EVIDENCE_SOURCE_VERSION,
-        change.entity_type,
-        change.entity_id,
+        base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
+        entity_id = change.change_id
+    elif category in _CHANGE_COLLISION_PRONE_CATEGORIES:
+        base_source_version = f"{_CHANGE_EVIDENCE_SOURCE_VERSION}:{change.change_id}"
+        entity_id = change.entity_id
+    else:
+        base_source_version = _CHANGE_EVIDENCE_SOURCE_VERSION
+        entity_id = change.entity_id
+    source_version = _bind_content(
+        base_source_version, before=change.before, after=change.after
     )
+    return source_system, source_version, change.entity_type, entity_id
 
 
 def _identity_graph_edge(edge: Any) -> tuple[str, str, str, str]:
     """``wire_edge`` mints against ``item.edge_id`` -- CHAOS-3296 round-4
     adds ``DevGraphEdgeV2.edge_id`` specifically so this identity survives
-    to the wire; round 1-3 could not implement this cell at all."""
+    to the wire; round 1-3 could not implement this cell at all.
+    ``source_version`` binds ``DevGraphEdgeV2``'s own claim fields (round
+    5): a genuine handle for edge_id X must never authenticate a fabricated
+    relationship/orientation for that same edge_id."""
 
-    return "work_graph", _GRAPH_EVIDENCE_SOURCE_VERSION, "work_graph_edge", edge.edge_id
+    source_version = _bind_content(
+        _GRAPH_EVIDENCE_SOURCE_VERSION,
+        relationship=edge.relationship,
+        source_entity_id=edge.source_entity_id,
+        target_entity_id=edge.target_entity_id,
+    )
+    return "work_graph", source_version, "work_graph_edge", edge.edge_id
 
 
 def _identity_metric_ref(ref: Any) -> tuple[str, str, str, str]:
-    return "metrics", _METRIC_EVIDENCE_SOURCE_VERSION, "metric", ref.metric_ref_id
+    """``source_version`` binds ``DevMetricRefV2``'s own claim fields
+    (round 5): a genuine handle for one metric value must never
+    authenticate a fabricated different value for the same
+    ``metric_ref_id``."""
+
+    source_version = _bind_content(
+        _METRIC_EVIDENCE_SOURCE_VERSION,
+        value=ref.value,
+        comparison_value=ref.comparison_value,
+    )
+    return "metrics", source_version, "metric", ref.metric_ref_id
 
 
 EVIDENCE_IDENTITY_TABLE: dict[str, EvidenceIdentityCell] = {
-    "status_facts": EvidenceIdentityCell(mode="required", derive=_identity_status_like),
+    "status_facts": EvidenceIdentityCell(mode="required", derive=_identity_status_fact),
     "required_children": EvidenceIdentityCell(
-        mode="required", derive=_identity_status_like
+        mode="required", derive=_identity_required_child
     ),
     "pull_requests": EvidenceIdentityCell(
         mode="required", derive=_identity_pull_request

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -208,7 +208,25 @@ _STAGE_STATUSES = frozenset({"started", "completed", "failed", "skipped"})
 _INTENT_PAYLOAD_MAX_BYTES = 16 * 1024
 _RESOLUTION_PAYLOAD_MAX_BYTES = 8 * 1024
 _SUBJECT_SET_PAYLOAD_MAX_BYTES = 16 * 1024
-_SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES = 16 * 1024
+# Codex finding (HIGH, 2026-08-01): a dense-but-valid `status.entity.v2`
+# observation (status_facts + up to 100 required_children + pull_requests +
+# ci_checks + deployments + incidents, each fact carrying its own
+# evidence_ref_ids/observed_at/display_label) observed ~19.6KB serialized --
+# comfortably past the prior 16KB bound, which raised
+# DevPersistenceValidationError at persist time and turned a real, already-
+# validated answer into an internal_error. The content-bearing collections
+# are already hard-capped at the contract layer (DevSourceContent's own
+# max_length=25/100 per field, contracts_v2/result.py) and every string
+# field is itself bounded (OpaqueID/Label/ShortText/EvidenceHandle), so
+# raising this envelope does not make the payload unbounded -- it aligns the
+# persistence-layer defense-in-depth check with what the contract already
+# allows to be legitimately dense, rather than truncating real evidence-
+# linked facts (which would either fabricate a shorter-than-real answer or
+# require a second, undisclosed truncation notion on top of the contract's
+# own TRUNCATED state). 64KB keeps meaningful headroom above the observed
+# dense case while staying well under the 128KB frame-payload envelope this
+# same module already trusts for the strictly larger synthesized answer.
+_SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES = 64 * 1024
 _PLAN_STEP_PARTITION_MAX_BYTES = 8 * 1024
 _PLAN_STEP_LIST_MAX_ITEMS = 25
 _FRAME_PAYLOAD_MAX_BYTES = 128 * 1024

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1210,6 +1210,41 @@ class _ProductionPlanExecutorRuntime:
     metric_service: MetricQueryService
     work_graph_service: WorkGraphNeighborsService
     data_health_service: DataHealthService
+    #: CHAOS-3296: the same signer the proven v1 tool-call evidence-minting
+    #: path (``mint_status_evidence``/``mint_delivery_evidence`` below) uses
+    #: -- never a second, parallel evidence-issuing mechanism.
+    evidence_signer: EvidenceReferenceSigner
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        ref = _mint_evidence(
+            self.evidence_signer,
+            org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+        return ref.evidence_ref_id
 
     async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
         return await self.status_service.status_snapshot(
@@ -2103,6 +2138,7 @@ async def _assemble_production_runtime(
                     metric_service=metric_service,
                     work_graph_service=work_graph_service,
                     data_health_service=data_health_service,
+                    evidence_signer=evidence_signer,
                 )
             )
         )

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -104,7 +104,6 @@ from .evidence_service import (
 from .investigation_plans import (
     PlanExecutor,
     build_default_registry,
-    wrap_runtime_with_mint_receipts,
 )
 from .investigation_plans.plan_documents import CORE_PLANS_BY_INTENT
 from .metrics.clickhouse import ClickHouseMetricSource
@@ -2136,24 +2135,24 @@ async def _assemble_production_runtime(
     # is committed, and only the preflight commits one.
     plan_executor = (
         PlanExecutor(
-            # CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): wrapping the
-            # runtime here -- the one place it is baked into every builtin
-            # step closure -- plus ``verify_mint_receipts=True`` is what
-            # actually turns on executor-side evidence-handle provenance
-            # checking; either half alone verifies nothing. See
-            # ``investigation_plans.executor.wrap_runtime_with_mint_receipts``.
+            # CHAOS-3296 round 5 (structural inversion, 2026-08-02): passing
+            # the exact ``EvidenceReferenceSigner`` every builtin step's
+            # ``mint_evidence`` already signs through is what turns on
+            # executor-side evidence-provenance checking -- the executor
+            # recomputes the real signature itself (see
+            # ``investigation_plans.executor._evidence_signature_failures``)
+            # rather than trusting a receipt of what this run minted, so no
+            # runtime-wrapping step is needed here anymore.
             registry=build_default_registry(
-                wrap_runtime_with_mint_receipts(
-                    _ProductionPlanExecutorRuntime(
-                        status_service=status_service,
-                        metric_service=metric_service,
-                        work_graph_service=work_graph_service,
-                        data_health_service=data_health_service,
-                        evidence_signer=evidence_signer,
-                    )
+                _ProductionPlanExecutorRuntime(
+                    status_service=status_service,
+                    metric_service=metric_service,
+                    work_graph_service=work_graph_service,
+                    data_health_service=data_health_service,
+                    evidence_signer=evidence_signer,
                 )
             ),
-            verify_mint_receipts=True,
+            evidence_signer=evidence_signer,
         )
         if wave_3_1_enabled
         else None

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -101,7 +101,11 @@ from .evidence_service import (
     EvidenceReferenceSigner,
     EvidenceService,
 )
-from .investigation_plans import PlanExecutor, build_default_registry
+from .investigation_plans import (
+    PlanExecutor,
+    build_default_registry,
+    wrap_runtime_with_mint_receipts,
+)
 from .investigation_plans.plan_documents import CORE_PLANS_BY_INTENT
 from .metrics.clickhouse import ClickHouseMetricSource
 from .metrics.service import MetricQueryRequest, MetricQueryService
@@ -2132,15 +2136,24 @@ async def _assemble_production_runtime(
     # is committed, and only the preflight commits one.
     plan_executor = (
         PlanExecutor(
+            # CHAOS-3296 Codex finding (MEDIUM, 2026-08-01): wrapping the
+            # runtime here -- the one place it is baked into every builtin
+            # step closure -- plus ``verify_mint_receipts=True`` is what
+            # actually turns on executor-side evidence-handle provenance
+            # checking; either half alone verifies nothing. See
+            # ``investigation_plans.executor.wrap_runtime_with_mint_receipts``.
             registry=build_default_registry(
-                _ProductionPlanExecutorRuntime(
-                    status_service=status_service,
-                    metric_service=metric_service,
-                    work_graph_service=work_graph_service,
-                    data_health_service=data_health_service,
-                    evidence_signer=evidence_signer,
+                wrap_runtime_with_mint_receipts(
+                    _ProductionPlanExecutorRuntime(
+                        status_service=status_service,
+                        metric_service=metric_service,
+                        work_graph_service=work_graph_service,
+                        data_health_service=data_health_service,
+                        evidence_signer=evidence_signer,
+                    )
                 )
-            )
+            ),
+            verify_mint_receipts=True,
         )
         if wave_3_1_enabled
         else None

--- a/tests/_chaos_3295_plan_executor.py
+++ b/tests/_chaos_3295_plan_executor.py
@@ -55,6 +55,7 @@ __all__ = [
     "fixed_now",
     "project_scope",
     "sign_evidence",
+    "sign_evidence_for_scope",
     "step_context_for",
 ]
 
@@ -106,6 +107,39 @@ def sign_evidence(
         repository_ids=tuple(repository_ids),
     )
     return TEST_EVIDENCE_SIGNER.issue(org_id, record)
+
+
+def sign_evidence_for_scope(
+    *, scope: DevScope, org_id: str = ORG_ID, source_version: str, **mint_kwargs
+) -> str:
+    """Like :func:`sign_evidence`, but routes through the exact same
+    ``builtin_steps._scope_bound_mint`` wrap every real ``wire_*_content``
+    call applies (CHAOS-3296 round 6) -- appends the SAME authorization-
+    scope digest suffix to ``source_version`` that a genuine mint call
+    under this ``scope`` would, so a test-constructed handle is genuinely
+    indistinguishable from a production one and verifies under
+    ``PlanExecutor``'s round-6 scope-fingerprint check. Callers pass the
+    CONTENT-bound (but not yet scope-bound) ``source_version`` -- e.g. the
+    output of ``_bind_content``/``_ci_check_source_version`` -- exactly as
+    they would to a raw ``mint_evidence`` call inside a ``wire_*`` helper.
+
+    ``repository_ids`` defaults to ``tuple(scope.repositories)`` -- exactly
+    what every real ``builtin_steps.py`` mint call derives via
+    ``_scope_evidence_binding(scope)`` -- unless the caller passes an
+    explicit override (e.g. to construct a deliberately cross-repository
+    forged handle in a RED test)."""
+
+    from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
+        _scope_bound_mint,
+    )
+
+    mint_kwargs.setdefault("repository_ids", tuple(scope.repositories))
+
+    def _raw_mint(**kwargs: object) -> str:
+        return sign_evidence(org_id=org_id, **kwargs)  # type: ignore[arg-type]
+
+    wrapped = _scope_bound_mint(_raw_mint, scope)
+    return wrapped(source_version=source_version, **mint_kwargs)
 
 
 def project_scope(*, entity_id: str = "project-ask-dev") -> DevScope:

--- a/tests/_chaos_3295_plan_executor.py
+++ b/tests/_chaos_3295_plan_executor.py
@@ -24,8 +24,10 @@ from dev_health_ops.api.dev.investigation_plans import (
 )
 from dev_health_ops.api.dev.metrics.definitions import MetricDefinition
 from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
     ChangeSummaryResult,
     ChangeWindow,
+    CompletionState,
     StatusResultState,
     StatusSnapshotResult,
 )
@@ -105,7 +107,22 @@ def _status_result(
         scope=None,  # type: ignore[arg-type]  # never read by any registered step
         as_of=fixed_now(),
         declared=None,
-        actual=None,  # type: ignore[arg-type]
+        # CHAOS-3296: content-minting reads ``actual.required_children`` on
+        # every queried status_snapshot outcome, so this can no longer be
+        # ``None`` (that was always a fixture shortcut -- production's
+        # ``StatusChangeService._assess`` never returns one) -- an
+        # intentionally empty, real ``ActualCompletion``, still "nothing to
+        # wire" for this shared empty-facts fixture.
+        actual=ActualCompletion(
+            state=CompletionState.NOT_READY,
+            rule_id="actual-completion",
+            rule_version="unversioned",
+            reason_codes=(),
+            required_children=(),
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
         children=(),
         blockers=(),
         pull_requests=(),
@@ -221,6 +238,32 @@ class FakePlanExecutorRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         self.data_health_calls += 1
         return _data_health(self._data_health_state)
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        # Every fixture this shared double serves returns all-empty
+        # canonical results (no declared fact, no children, no edges), so no
+        # registered step's content-wiring loop ever actually reaches this --
+        # it exists only so ``runtime.mint_evidence`` is a valid attribute
+        # access (Protocol conformance). Suites that need real minted
+        # evidence build their own richer double (see
+        # ``test_chaos_3296_evidence_minting.py``).
+        raise AssertionError(
+            "mint_evidence should not be reachable from an all-empty fixture result"
+        )
 
 
 class InvestigationRecorder(Recorder):

--- a/tests/_chaos_3295_plan_executor.py
+++ b/tests/_chaos_3295_plan_executor.py
@@ -16,6 +16,10 @@ from dev_health_ops.api.dev.data_health_service import (
     DataHealthSource,
     DataHealthState,
 )
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceRecord,
+    EvidenceReferenceSigner,
+)
 from dev_health_ops.api.dev.investigation_plans import (
     PlanExecutor,
     StepContext,
@@ -46,13 +50,62 @@ from tests._chaos_3292_preflight import Recorder
 __all__ = [
     "FakePlanExecutorRuntime",
     "InvestigationRecorder",
+    "TEST_EVIDENCE_SIGNER",
     "executor_for",
     "fixed_now",
     "project_scope",
+    "sign_evidence",
     "step_context_for",
 ]
 
 ORG_ID = "org_fullchaos"
+
+#: A fixed, valid (>=32 byte) test secret. CHAOS-3296 round 5's
+#: signature-verification tests need a REAL ``EvidenceReferenceSigner`` --
+#: the exact class ``production_runtime.py`` wires into
+#: ``PlanExecutor(evidence_signer=...)`` -- rather than a fabricated handle
+#: string, so a forged/reused/cross-tenant/wrong-content handle genuinely
+#: fails ``signer.verify`` the same way it would in production, and a
+#: genuine handle genuinely passes.
+TEST_EVIDENCE_SIGNER = EvidenceReferenceSigner(
+    b"chaos-3296-round5-signature-test-secret"
+)
+
+
+def sign_evidence(
+    *,
+    org_id: str,
+    source_system: str,
+    source_version: str,
+    entity_type: str,
+    entity_id: str,
+    display_label: str,
+    observed_at: datetime,
+    freshness,
+    confidence: float = 1.0,
+    repository_ids=(),
+) -> str:
+    """Mint a real, :data:`TEST_EVIDENCE_SIGNER`-verifiable handle -- the
+    exact ``EvidenceRecord``/``issue`` call
+    ``production_runtime._mint_evidence`` makes for every real evidence
+    handle in production -- so a test double's ``mint_evidence`` hands back
+    a handle that genuinely passes ``PlanExecutor``'s round-5 signature
+    check, rather than an opaque counter string no verifier would ever
+    accept."""
+
+    record = EvidenceRecord(
+        source_system=source_system,
+        source_version=source_version,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        display_label=display_label,
+        observed_at=observed_at,
+        freshness=freshness,
+        provenance=source_system,
+        confidence=confidence,
+        repository_ids=tuple(repository_ids),
+    )
+    return TEST_EVIDENCE_SIGNER.issue(org_id, record)
 
 
 def project_scope(*, entity_id: str = "project-ask-dev") -> DevScope:

--- a/tests/api/dev/test_chaos_3296_content_integrity.py
+++ b/tests/api/dev/test_chaos_3296_content_integrity.py
@@ -63,8 +63,12 @@ from dev_health_ops.api.dev.investigation_plans import (
 from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
     _STATUS_EVIDENCE_SOURCE_VERSION,
     _bind_content,
+    _claim_projection,
 )
-from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
+from tests._chaos_3295_plan_executor import (
+    TEST_EVIDENCE_SIGNER,
+    sign_evidence_for_scope,
+)
 
 ORG_ID = "org_fullchaos"
 ROOT_ENTITY_ID = "project-1"
@@ -286,7 +290,12 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return sign_evidence(
+        # CHAOS-3296 round 6: route through the scope-bound helper (using
+        # THIS file's fixed ``_scope()``) so a handle minted here carries
+        # the same authorization-scope digest suffix a genuine
+        # ``_scope_bound_mint``-wrapped mint call would.
+        return sign_evidence_for_scope(
+            scope=_scope(),
             org_id=org_id,
             source_system=source_system,
             source_version=source_version,
@@ -298,6 +307,20 @@ class _MintOnlyRuntime:
             confidence=confidence,
             repository_ids=repository_ids,
         )
+
+
+def _status_fact_source_version(*, fact_id: str, text: str) -> str:
+    """The exact ``source_version`` a genuine ``wire_status_fact`` mint
+    computes for a ``DevStatusFactV2`` with this fact_id/text (round 6:
+    ``_identity_status_fact`` projects the WHOLE wire model programmatically,
+    not just ``text``)."""
+
+    provisional = DevStatusFactV2(
+        fact_id=fact_id, text=text, evidence_ref_ids=("ev1_" + "0" * 40,)
+    )
+    return _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+    )
 
 
 @pytest.mark.asyncio
@@ -335,7 +358,9 @@ async def test_verify_mint_receipts_accepts_a_genuinely_minted_handle():
         handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text),
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-1", text=text
+            ),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -387,8 +412,8 @@ async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
         genuine = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION, claim=genuine_text
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-1", text=genuine_text
             ),
             entity_type="issue",
             entity_id="issue-1",

--- a/tests/api/dev/test_chaos_3296_content_integrity.py
+++ b/tests/api/dev/test_chaos_3296_content_integrity.py
@@ -179,6 +179,7 @@ async def test_content_shaped_for_a_different_source_class_is_rejected_structura
     persistence -- demoted to unmeasured, closure disclosed False."""
 
     edge = DevGraphEdgeV2(
+        edge_id="edge-1",
         source_entity_id=ROOT_ENTITY_ID,
         relationship="references",
         target_entity_id="pr-9",

--- a/tests/api/dev/test_chaos_3296_content_integrity.py
+++ b/tests/api/dev/test_chaos_3296_content_integrity.py
@@ -323,8 +323,12 @@ async def test_verify_mint_receipts_accepts_a_genuinely_minted_handle():
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
+        # fact_id follows the real convention builtin_steps.py wires
+        # (``f"{entity_type}:{entity_id}"``) so the identity a genuine
+        # verification check derives from the fact matches exactly what
+        # was minted -- see ``executor._content_fact_claims``.
         fact = DevStatusFactV2(
-            fact_id="issue:1",
+            fact_id="issue:issue-1",
             text="Issue one is in_progress",
             evidence_ref_ids=(handle,),
         )
@@ -366,7 +370,7 @@ async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
             freshness=FreshnessState.FRESH,
         )
         genuine_fact = DevStatusFactV2(
-            fact_id="issue:1",
+            fact_id="issue:issue-1",
             text="Issue one is in_progress",
             evidence_ref_ids=(genuine,),
         )

--- a/tests/api/dev/test_chaos_3296_content_integrity.py
+++ b/tests/api/dev/test_chaos_3296_content_integrity.py
@@ -1,0 +1,393 @@
+"""Content-integrity controls at observation construction (CHAOS-3296 Codex
+finding, MEDIUM, 2026-08-01).
+
+``PlanExecutor._to_observation`` previously accepted a step's
+``StepOutcome.content`` unconditionally: (1) nothing checked that the
+populated ``DevSourceContent`` slot(s) actually matched the observation's own
+``source_class`` (a step registered for one source class could return content
+shaped for a different one), and (2) nothing checked that a fact's
+``evidence_ref_ids`` were handles this exact step run actually minted through
+``PlanExecutorRuntime.mint_evidence`` -- pydantic's ``EvidenceHandle`` pattern
+only proves a string is *shaped* like ``ev1_...``, never that it is genuine.
+Both gaps only flipped ``relationship_closure_verified`` False at best;
+mismatched or forged content was still minted, persisted, and presented like
+legitimate evidence.
+
+Fix (``investigation_plans/executor.py`` + ``relationship_matrix.py``):
+
+* ``relationship_matrix.APPROVED_CONTENT_SLOTS`` is a closed, import-time-
+  total mapping of which ``DevSourceContent`` field(s) each ``SourceClass``
+  may ever populate; ``_to_observation`` rejects a mismatch structurally
+  (demotes to an unmeasured observation, drops the content, flips closure
+  False) rather than passing it through.
+* ``wrap_runtime_with_mint_receipts`` + ``PlanExecutor(verify_mint_receipts=
+  True)`` (opt-in -- off by default, so every pre-3296 test/harness that
+  hand-builds content is unaffected) let the executor verify every evidence
+  handle in a step's content was actually minted during that exact step's
+  own run, never merely shape-valid.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    FreshnessState,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2, DevStatusFactV2
+from dev_health_ops.api.dev.contracts_v2.plan import (
+    DevInvestigationPlan,
+    DevSourceRequirement,
+)
+from dev_health_ops.api.dev.contracts_v2.result import DevSourceContent
+from dev_health_ops.api.dev.investigation_plans import (
+    PlanExecutor,
+    PlanStepDefinition,
+    StepContext,
+    StepOutcome,
+    StepRegistry,
+    wrap_runtime_with_mint_receipts,
+)
+
+ORG_ID = "org_fullchaos"
+ROOT_ENTITY_ID = "project-1"
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _now() -> datetime:
+    return OBSERVED_AT
+
+
+def _scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": ROOT_ENTITY_ID,
+                "display_label": "Project One",
+                "repository_id": None,
+            }
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 7, 1, tzinfo=UTC),
+            end=datetime(2026, 7, 31, tzinfo=UTC),
+            timezone="UTC",
+        ),
+    )
+
+
+def _context() -> StepContext:
+    return StepContext(
+        org_id=ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=_scope(),
+        run_id="run-1",
+        now=_now(),
+    )
+
+
+def _plan(source_class: SourceClass) -> DevInvestigationPlan:
+    return DevInvestigationPlan(
+        schema_version="dev_investigation_plan.v1",
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        supported_subject_kinds=(EntityKind.PROJECT,),
+        supported_cardinalities=(Cardinality.SINGULAR, Cardinality.ORGANIZATION_WIDE),
+        mandatory_steps=("one",),
+        conditional_steps=(),
+        step_dependencies=(),
+        source_requirements=(
+            DevSourceRequirement(
+                schema_version="dev_source_requirement.v1",
+                source_class=source_class,
+                adapter_id="test.one.v1",
+                requirement_level="mandatory",
+                freshness_policy="p.v1",
+                minimum_usable_facts=0,
+            ),
+        ),
+        batch_strategy="single",
+        per_step_timeout_seconds=5,
+        max_rows_per_step=10,
+        max_bytes_per_step=1_000,
+        enrichment_allowed=False,
+        completion_rule_id="test.rule",
+        completion_rule_version="1",
+    )
+
+
+async def _run_single_step(
+    *,
+    source_class: SourceClass,
+    run,
+    verify_mint_receipts: bool = False,
+) -> tuple:
+    plan = _plan(source_class)
+    registry = StepRegistry()
+    registry.register(
+        PlanStepDefinition(
+            step_id="one",
+            plan_id=plan.plan_id,
+            source_class=source_class,
+            adapter_id="test.one.v1",
+            requirement_level="mandatory",
+            run=run,
+        )
+    )
+    executor = PlanExecutor(
+        registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
+    )
+    result = await executor.run(
+        plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
+    )
+    assert len(result.observations) == 1
+    return result, result.observations[0]
+
+
+def _queried_outcome(content: DevSourceContent) -> StepOutcome:
+    return StepOutcome(
+        observed_state=SourceRequirementState.AVAILABLE_CURRENT,
+        data_semantics="measured_zero",
+        usable_fact_count=1,
+        content=content,
+    )
+
+
+# -- SourceClass -> content-slot matrix ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_shaped_for_a_different_source_class_is_rejected_structurally():
+    """A step registered under STATUS_CHANGE returning WORK_GRAPH-shaped
+    content (graph_edges) must never reach relationship-path minting or
+    persistence -- demoted to unmeasured, closure disclosed False."""
+
+    edge = DevGraphEdgeV2(
+        source_entity_id=ROOT_ENTITY_ID,
+        relationship="references",
+        target_entity_id="pr-9",
+        provenance="work_graph",
+        confidence=1.0,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=("ev1_" + "a" * 40,),
+    )
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1", graph_edges=(edge,)
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("content_source_class_mismatch:")
+    assert "graph_edges" in observation.limitation
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_content_matching_its_own_source_class_is_accepted():
+    """Positive control: the matrix must not over-reject legitimate content."""
+
+    fact = DevStatusFactV2(
+        fact_id="issue:1",
+        text="Issue one is in_progress",
+        evidence_ref_ids=("ev1_" + "b" * 40,),
+    )
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1", status_facts=(fact,)
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 1
+    assert len(observation.relationship_paths) == 1
+    assert result.relationship_closure_verified is True
+
+
+# -- executor-verified mint receipts ---------------------------------------
+
+
+class _MintOnlyRuntime:
+    """A minimal ``PlanExecutorRuntime`` double: only ``mint_evidence`` is
+    ever exercised by the tests below, the rest exist purely for structural
+    protocol conformance."""
+
+    def __init__(self) -> None:
+        self.mint_calls = 0
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def list_metrics(self, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        self.mint_calls += 1
+        return "ev1_" + f"{self.mint_calls:040x}"
+
+
+@pytest.mark.asyncio
+async def test_verify_mint_receipts_off_by_default_accepts_a_forged_handle_unverified():
+    """Backward compatibility: with ``verify_mint_receipts`` off (the
+    default -- every pre-3296 test/harness), a hand-fabricated handle that
+    was never minted at all still passes through exactly as before."""
+
+    fact = DevStatusFactV2(
+        fact_id="issue:1",
+        text="Issue one is in_progress",
+        evidence_ref_ids=("ev1_" + "f" * 40,),  # never minted anywhere
+    )
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1", status_facts=(fact,)
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=False
+    )
+
+    assert observation.content is not None
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_mint_receipts_accepts_a_genuinely_minted_handle():
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = DevStatusFactV2(
+            fact_id="issue:1",
+            text="Issue one is in_progress",
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", status_facts=(fact,)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 1
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 1
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
+    """The forgery this finding names: a step embeds a syntactically valid
+    ``ev1_...`` handle it fabricated inline rather than obtaining through
+    ``mint_evidence`` -- with verification on, this must never reach
+    persistence, and the run must still terminate cleanly (never raise)."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        genuine = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_fact = DevStatusFactV2(
+            fact_id="issue:1",
+            text="Issue one is in_progress",
+            evidence_ref_ids=(genuine,),
+        )
+        forged_fact = DevStatusFactV2(
+            fact_id="issue:2",
+            text="Issue two is in_progress",
+            evidence_ref_ids=("ev1_" + "c" * 40,),  # fabricated, never minted
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                status_facts=(genuine_fact, forged_fact),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 1
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation == "unminted_evidence_handle"
+    assert result.relationship_closure_verified is False

--- a/tests/api/dev/test_chaos_3296_content_integrity.py
+++ b/tests/api/dev/test_chaos_3296_content_integrity.py
@@ -20,11 +20,12 @@ Fix (``investigation_plans/executor.py`` + ``relationship_matrix.py``):
   may ever populate; ``_to_observation`` rejects a mismatch structurally
   (demotes to an unmeasured observation, drops the content, flips closure
   False) rather than passing it through.
-* ``wrap_runtime_with_mint_receipts`` + ``PlanExecutor(verify_mint_receipts=
-  True)`` (opt-in -- off by default, so every pre-3296 test/harness that
-  hand-builds content is unaffected) let the executor verify every evidence
-  handle in a step's content was actually minted during that exact step's
-  own run, never merely shape-valid.
+* ``PlanExecutor(evidence_signer=...)`` (opt-in -- ``None`` by default, so
+  every pre-3296 test/harness that hand-builds content is unaffected) lets
+  the executor verify every evidence handle in a step's content by
+  recomputing the real signature (CHAOS-3296 round 5 -- see
+  ``executor._evidence_signature_failures``), never merely trusting that a
+  string is shaped like ``ev1_...``.
 """
 
 from __future__ import annotations
@@ -58,8 +59,12 @@ from dev_health_ops.api.dev.investigation_plans import (
     StepContext,
     StepOutcome,
     StepRegistry,
-    wrap_runtime_with_mint_receipts,
 )
+from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
+    _STATUS_EVIDENCE_SOURCE_VERSION,
+    _bind_content,
+)
+from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
 
 ORG_ID = "org_fullchaos"
 ROOT_ENTITY_ID = "project-1"
@@ -151,7 +156,9 @@ async def _run_single_step(
         )
     )
     executor = PlanExecutor(
-        registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
+        registry=registry,
+        now=_now,
+        evidence_signer=TEST_EVIDENCE_SIGNER if verify_mint_receipts else None,
     )
     result = await executor.run(
         plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
@@ -279,7 +286,18 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return "ev1_" + f"{self.mint_calls:040x}"
+        return sign_evidence(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            repository_ids=repository_ids,
+        )
 
 
 @pytest.mark.asyncio
@@ -311,13 +329,13 @@ async def test_verify_mint_receipts_off_by_default_accepts_a_forged_handle_unver
 @pytest.mark.asyncio
 async def test_verify_mint_receipts_accepts_a_genuinely_minted_handle():
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle = wrapped.mint_evidence(
+        text = "Issue one is in_progress"
+        handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -327,10 +345,13 @@ async def test_verify_mint_receipts_accepts_a_genuinely_minted_handle():
         # fact_id follows the real convention builtin_steps.py wires
         # (``f"{entity_type}:{entity_id}"``) so the identity a genuine
         # verification check derives from the fact matches exactly what
-        # was minted -- see ``executor._content_fact_claims``.
+        # was minted -- see ``executor._evidence_signature_failures``.
+        # ``text`` must match the ``claim`` bound above verbatim (round 5):
+        # ``_identity_status_fact`` recomputes the content digest straight
+        # from this same field.
         fact = DevStatusFactV2(
             fact_id="issue:issue-1",
-            text="Issue one is in_progress",
+            text=text,
             evidence_ref_ids=(handle,),
         )
         return _queried_outcome(
@@ -354,16 +375,21 @@ async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
     """The forgery this finding names: a step embeds a syntactically valid
     ``ev1_...`` handle it fabricated inline rather than obtaining through
     ``mint_evidence`` -- with verification on, this must never reach
-    persistence, and the run must still terminate cleanly (never raise)."""
+    persistence, and the run must still terminate cleanly (never raise).
+    CHAOS-3296 round 5: a handle that was never genuinely signed for ANY
+    identity fails ``signer.verify`` the same way a handle signed for the
+    WRONG identity does -- both report ``evidence_signature_invalid``."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        genuine = wrapped.mint_evidence(
+        genuine_text = "Issue one is in_progress"
+        genuine = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION, claim=genuine_text
+            ),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -372,7 +398,7 @@ async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
         )
         genuine_fact = DevStatusFactV2(
             fact_id="issue:issue-1",
-            text="Issue one is in_progress",
+            text=genuine_text,
             evidence_ref_ids=(genuine,),
         )
         forged_fact = DevStatusFactV2(
@@ -394,5 +420,5 @@ async def test_verify_mint_receipts_rejects_a_handle_this_step_never_minted():
     assert runtime.mint_calls == 1
     assert observation.content is None
     assert observation.observed_state is SourceRequirementState.UNAVAILABLE
-    assert observation.limitation == "unminted_evidence_handle"
+    assert observation.limitation == "evidence_signature_invalid:2"
     assert result.relationship_closure_verified is False

--- a/tests/api/dev/test_chaos_3296_evidence_minting.py
+++ b/tests/api/dev/test_chaos_3296_evidence_minting.py
@@ -1,0 +1,484 @@
+"""Evidence-minting controls (CHAOS-3296): ``DevSourceObservation.content``.
+
+CHAOS-3295 landed ``DevSourceContent`` as a typed slot every builtin step's
+``StepOutcome`` can fill, but no step actually minted it -- every
+``content`` field was structurally always ``None`` (``StepOutcome.content``
+default, never overridden by any of the six core plans' step closures in
+``investigation_plans/builtin_steps.py``). This is this issue's first
+deliverable: populate it from the exact canonical-service results the steps
+already fetch, with real signer-issued evidence (never a fabricated/forged
+handle), reusing the same ``EvidenceReferenceSigner``/``_mint_evidence``
+primitive ``production_runtime.py``'s proven v1 tool-call path already uses
+-- never a second, parallel evidence-issuing mechanism.
+
+Positive: a queried, non-empty canonical result mints exactly the matching
+``DevSourceContent`` slot, every fact carries at least one real
+``ev1_``-shaped evidence handle, and every other slot stays an empty tuple
+(never omitted -- the CHAOS-3295 docstring's own invariant).
+Negative: an unmeasured/empty/failed step never carries content, and a
+metric with zero returned values mints no metric refs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    ClaimKind,
+    DevEntityRef,
+    DevScope,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
+from dev_health_ops.api.dev.investigation_plans import (
+    StepRegistry,
+    register_builtin_steps,
+)
+from dev_health_ops.api.dev.metrics.definitions import MetricDefinition
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+    MetricSourceRef,
+)
+from dev_health_ops.api.dev.production_runtime import _mint_evidence
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    ChangeCategory,
+    ChangeSummaryResult,
+    ChangeWindow,
+    CIFact,
+    CompletionState,
+    DeploymentFact,
+    IncidentFact,
+    ObservedChange,
+    PullRequestFact,
+    StatusFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    QUERY_VERSION as WORK_GRAPH_QUERY_VERSION,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    SCHEMA_VERSION as WORK_GRAPH_SCHEMA_VERSION,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    GraphDirection,
+    WorkGraphNeighborEdge,
+    WorkGraphNeighborsResult,
+    WorkGraphResultState,
+)
+from tests._chaos_3295_plan_executor import (
+    FakePlanExecutorRuntime,
+    project_scope,
+    step_context_for,
+)
+
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+_SIGNER = EvidenceReferenceSigner("chaos-3296-test-secret-0123456789abcdef")
+
+
+def _evidence_handle_shaped(value: str) -> bool:
+    return value.startswith("ev1_") and len(value) == 44
+
+
+class ContentFakeRuntime(FakePlanExecutorRuntime):
+    """Extends the shared 3295 fake with real signer-issued evidence.
+
+    Reuses ``production_runtime._mint_evidence`` -- the exact primitive the
+    proven v1 tool-call path issues evidence through -- rather than a second
+    fabricated stub, so a collision or malformed-handle bug in the real
+    minting code would show up here too.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.mint_evidence_calls = 0
+        self.status_result: StatusSnapshotResult | None = None
+        self.change_result: ChangeSummaryResult | None = None
+        self.work_graph_result: WorkGraphNeighborsResult | None = None
+        self.metric_results: list[MetricQueryResult] = []
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        self.status_snapshot_calls += 1
+        if self._status_snapshot_fails:
+            raise RuntimeError("status source unavailable")
+        assert self.status_result is not None
+        return self.status_result
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        self.change_summary_calls += 1
+        assert self.change_result is not None
+        return self.change_result
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        self.work_graph_calls += 1
+        assert self.work_graph_result is not None
+        return self.work_graph_result
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        self.query_metric_calls += 1
+        for result in self.metric_results:
+            if result.definition.metric_id.value == metric_id:
+                return result
+        raise AssertionError(f"no fixture metric result for {metric_id!r}")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        self.mint_evidence_calls += 1
+        ref = _mint_evidence(
+            _SIGNER,
+            org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            valid_entity_ids=valid_entity_ids,
+            repository_ids=repository_ids,
+        )
+        return ref.evidence_ref_id
+
+
+def _registry(runtime: ContentFakeRuntime) -> StepRegistry:
+    registry = StepRegistry()
+    register_builtin_steps(registry, runtime)
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_mints_content_across_every_matching_slot():
+    runtime = ContentFakeRuntime()
+    runtime.status_result = StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.COMPLETE,
+        scope=project_scope(),
+        as_of=OBSERVED_AT,
+        declared=StatusFact(
+            entity_type="project",
+            entity_id="project-ask-dev",
+            display_label="Ask Dev",
+            status="in_progress",
+            observed_at=OBSERVED_AT,
+            source_ref_id="ref-declared",
+            evidence_ref_ids=(),
+        ),
+        actual=ActualCompletion(
+            state=CompletionState.NOT_READY,
+            rule_id="actual-completion",
+            rule_version="v4",
+            reason_codes=("required_child_incomplete",),
+            required_children=(
+                StatusFact(
+                    entity_type="issue",
+                    entity_id="issue-1",
+                    display_label="Issue One",
+                    status="open",
+                    observed_at=OBSERVED_AT,
+                    source_ref_id="ref-child",
+                    evidence_ref_ids=(),
+                ),
+            ),
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
+        children=(),
+        blockers=(),
+        pull_requests=(
+            PullRequestFact(
+                entity_id="pr-1",
+                display_label="Fix bug",
+                state="open",
+                review_state="approved",
+                changes_requested=0,
+                merged=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-pr",
+                evidence_ref_ids=(),
+                required=True,
+            ),
+        ),
+        ci=(
+            CIFact(
+                entity_id="ci-1#check123",
+                display_label="build",
+                conclusion="success",
+                required=True,
+                skipped_required_work=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-ci",
+                evidence_ref_ids=(),
+            ),
+        ),
+        deployments=(
+            DeploymentFact(
+                entity_id="deploy-1",
+                display_label="prod",
+                status="succeeded",
+                environment="production",
+                required=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-deploy",
+                evidence_ref_ids=(),
+            ),
+        ),
+        incidents=(
+            IncidentFact(
+                entity_id="incident-1",
+                display_label="Outage",
+                status="resolved",
+                active=False,
+                blocking=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-incident",
+                evidence_ref_ids=(),
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+    )
+    registry = _registry(runtime)
+    ctx = step_context_for()
+    outcome = await registry.get("status.entity.v2", "status_snapshot").run(ctx)
+
+    assert outcome.content is not None
+    content = outcome.content
+    assert (
+        len(content.status_facts) == 1
+    )  # declared only (children/blockers empty here)
+    assert len(content.required_children) == 1
+    assert len(content.pull_requests) == 1
+    assert len(content.ci_checks) == 1
+    assert len(content.deployments) == 1
+    assert len(content.incidents) == 1
+    # Every populated fact carries at least one real, signer-issued handle.
+    for group in (
+        content.status_facts,
+        content.required_children,
+        content.pull_requests,
+        content.ci_checks,
+        content.deployments,
+        content.incidents,
+    ):
+        for fact in group:
+            assert fact.evidence_ref_ids
+            for evidence_id in fact.evidence_ref_ids:
+                assert _evidence_handle_shaped(evidence_id)
+    # Every non-matching slot stays an empty tuple, never omitted.
+    assert content.graph_edges == ()
+    assert content.observed_changes == ()
+    assert content.metric_refs == ()
+    assert runtime.mint_evidence_calls > 0
+
+
+@pytest.mark.asyncio
+async def test_change_summary_mints_observed_changes_not_status_facts():
+    runtime = ContentFakeRuntime()
+    runtime.change_result = ChangeSummaryResult(
+        contract_version="change_summary.v1",
+        state=StatusResultState.COMPLETE,
+        current_window=ChangeWindow(OBSERVED_AT, OBSERVED_AT),
+        comparison_window=ChangeWindow(OBSERVED_AT, OBSERVED_AT),
+        changes=(
+            ObservedChange(
+                change_id="change-1",
+                category=ChangeCategory.STATUS,
+                entity_type="project",
+                entity_id="project-ask-dev",
+                display_label="Ask Dev",
+                before="planned",
+                after="in_progress",
+                observed_at=OBSERVED_AT,
+                claim_kind=ClaimKind.OBSERVED,
+                relationship_chain=(),
+                metric_id=None,
+                metric_value=None,
+                metric_comparison_value=None,
+                source_ref_ids=(),
+                evidence_ref_ids=(),
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+    )
+    scope = project_scope()
+    scope = scope.model_copy(
+        update={
+            "comparison_range": scope.time_range,
+        }
+    )
+    ctx = step_context_for(scope=scope)
+    registry = _registry(runtime)
+    outcome = await registry.get("change.observed.v1", "change_summary").run(ctx)
+
+    assert outcome.content is not None
+    assert len(outcome.content.observed_changes) == 1
+    assert outcome.content.status_facts == ()
+    change = outcome.content.observed_changes[0]
+    assert change.evidence_ref_ids
+    assert all(_evidence_handle_shaped(v) for v in change.evidence_ref_ids)
+
+
+@pytest.mark.asyncio
+async def test_work_graph_expansion_mints_graph_edges():
+    runtime = ContentFakeRuntime()
+    runtime.work_graph_result = WorkGraphNeighborsResult(
+        schema_version=WORK_GRAPH_SCHEMA_VERSION,
+        state=WorkGraphResultState.COMPLETE,
+        nodes=(),
+        edges=(
+            WorkGraphNeighborEdge(
+                edge_id="edge-1",
+                source_type="issue",
+                source_id="issue-1",
+                target_type="pr",
+                target_id="pr-1",
+                relationship_type="references",
+                direction=GraphDirection.BOTH,
+                provenance="persisted",
+                confidence=0.9,
+                source_ref_id="ref-edge",
+                observed_at=OBSERVED_AT,
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+        total_count=1,
+        returned_count=1,
+        truncated=False,
+        depth=1,
+        query_version=WORK_GRAPH_QUERY_VERSION,
+        watermark=None,
+    )
+    base = project_scope()
+    scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=base.organization_id,
+        direct_scope=DirectScope.ISSUE,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id="issue-1",
+                display_label="Issue One",
+            )
+        ],
+        time_range=base.time_range,
+    )
+    ctx = step_context_for(scope=scope)
+    registry = _registry(runtime)
+    outcome = await registry.get("status.entity.v2", "work_graph_expansion").run(ctx)
+
+    assert outcome.content is not None
+    assert len(outcome.content.graph_edges) == 1
+    edge = outcome.content.graph_edges[0]
+    assert edge.source_entity_id == "issue-1"
+    assert edge.target_entity_id == "pr-1"
+    assert edge.evidence_ref_ids
+    assert all(_evidence_handle_shaped(v) for v in edge.evidence_ref_ids)
+
+
+@pytest.mark.asyncio
+async def test_registered_metric_query_mints_metric_refs():
+    definition = MetricDefinition(
+        metric_id=MetricID.CYCLE_TIME_P50_HOURS,
+        label="Cycle Time",
+        owner="ask-dev",
+        description="desc",
+        definition_version="v1",
+        source_table="work_items",
+        source_version="v1",
+        query_version="v1",
+        unit="days",
+        aggregation="avg",
+        display_precision=1,
+        null_semantics="no_data",
+        zero_semantics="measured_zero",
+        supported_scopes=(),
+        supports_team_filter=False,
+        supported_dimensions=(),
+        min_range_days=1,
+        max_range_days=90,
+        supported_presets=(),
+        supported_time_grains=("day",),
+        comparison_rule="prior_period",
+        freshness_policy="p.v1",
+        expected_materialization="daily",
+        upstream_sources=("work_items",),
+        sensitivity="internal",
+        entitlement="community",
+    )
+    metric_result = MetricQueryResult(
+        definition=definition,
+        state=MetricDataState.VALUE,
+        freshness=FreshnessState.FRESH,
+        values=(
+            MetricQueryValue(
+                dimensions=(),
+                value=3.5,
+                comparison_value=None,
+                series=(),
+            ),
+        ),
+        coverage=1.0,
+        current_window_start=OBSERVED_AT,
+        current_window_end=OBSERVED_AT,
+        comparison_window_start=None,
+        comparison_window_end=None,
+        watermark=OBSERVED_AT,
+        source_refs=(
+            MetricSourceRef(
+                ref_id="ref-metric",
+                source_table="work_items",
+                source_version="v1",
+                watermark=OBSERVED_AT,
+                query_version="v1",
+            ),
+        ),
+    )
+    runtime = ContentFakeRuntime(metric_definitions=(definition,))
+    runtime.metric_results = [metric_result]
+    ctx = step_context_for(requested_metric_ids=(MetricID.CYCLE_TIME_P50_HOURS.value,))
+    registry = _registry(runtime)
+    outcome = await registry.get("metric.comparison.v1", "registered_metric_query").run(
+        ctx
+    )
+
+    assert outcome.content is not None
+    assert len(outcome.content.metric_refs) == 1
+    ref = outcome.content.metric_refs[0]
+    assert ref.evidence_ref_ids
+    assert all(_evidence_handle_shaped(v) for v in ref.evidence_ref_ids)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_status_snapshot_never_carries_content():
+    runtime = ContentFakeRuntime(status_snapshot_fails=True)
+    registry = _registry(runtime)
+    ctx = step_context_for()
+
+    with pytest.raises(RuntimeError):
+        await registry.get("status.entity.v2", "status_snapshot").run(ctx)
+    assert runtime.mint_evidence_calls == 0

--- a/tests/api/dev/test_chaos_3296_persistence_envelope.py
+++ b/tests/api/dev/test_chaos_3296_persistence_envelope.py
@@ -1,0 +1,378 @@
+"""The observation persistence envelope must fit a real dense result
+(CHAOS-3296 Codex finding, HIGH, 2026-08-01).
+
+``status.entity.v2``'s ``status_snapshot`` step can legitimately mint content
+across six categories at once (status_facts, required_children,
+pull_requests, ci_checks, deployments, incidents -- see
+``relationship_matrix.APPROVED_CONTENT_SLOTS[SourceClass.STATUS_CHANGE]``),
+each already bounded by the contract layer
+(``DevSourceContent``'s own ``max_length`` per field, ``contracts_v2/
+result.py``). A dense-but-otherwise-valid observation of this shape
+serializes to comfortably more than the persistence layer's prior 16KB
+defense-in-depth bound, which turned an already-contract-valid result into
+``DevPersistenceValidationError`` at persist time -- an ``internal_error`` on
+a real answer, never disclosed to the caller as anything but a platform
+failure.
+
+This is an end-to-end proof through ``PersistenceRunRecorder.
+record_investigation_result`` -- the exact orchestrator-owned persistence
+path a real run takes (``orchestrator.py`` calls it once investigation
+completes) -- against a real (aiosqlite) ``DevPersistenceService``, not a
+unit assertion on the content builder alone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import dev_health_ops.api.dev.persistence.service as persistence_service_module
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass, SourceRequirementState
+from dev_health_ops.api.dev.contracts_v2.embedded import (
+    DevCIFactV2,
+    DevDeploymentFactV2,
+    DevIncidentFactV2,
+    DevPullRequestFactV2,
+    DevRequiredChildFactV2,
+    DevStatusFactV2,
+)
+from dev_health_ops.api.dev.contracts_v2.result import (
+    DevInvestigationResult,
+    DevSourceContent,
+    DevSourceObservation,
+)
+from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
+from dev_health_ops.api.dev.persistence import (
+    DevPersistenceService,
+    DevPersistenceValidationError,
+)
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunIntent,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunStageDiagnostic,
+)
+
+# The prior bound this fixture must exceed to actually prove the finding
+# (rather than merely proving *some* oversized payload fails).
+_PRE_FIX_ENVELOPE_BYTES = 16 * 1024
+
+
+@pytest_asyncio.fixture
+async def persistence(tmp_path: Path):
+    database = tmp_path / "ask-dev-3296-persistence-envelope.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev-3296", name="Ask Dev 3296"),
+                User(id=user_id, email="ask-dev-3296@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+async def _accepted_run(
+    service: DevPersistenceService, *, org_id: uuid.UUID, user_id: uuid.UUID
+) -> tuple[uuid.UUID, uuid.UUID]:
+    conversation = await service.create_conversation(
+        org_id=org_id, user_id=user_id, current_scope={}
+    )
+    accepted = await service.append_user_message_and_run(
+        org_id=org_id,
+        user_id=user_id,
+        conversation_id=conversation.id,
+        client_message_id=uuid.uuid4(),
+        question="What is the status of this project?",
+        scope_snapshot={},
+    )
+    return conversation.id, accepted.run.id
+
+
+def _dense_status_snapshot_content() -> DevSourceContent:
+    """Every category ``status_snapshot`` can populate at once, each near
+    its own contract-layer cap -- the realistic shape of the ~19.6KB dense
+    case named in the finding, not an artificially padded blob."""
+
+    def evidence(prefix: str, index: int) -> str:
+        return f"ev1_{prefix}{index:0{40 - len(prefix)}x}"
+
+    status_facts = tuple(
+        DevStatusFactV2(
+            fact_id=f"issue:status-{i}",
+            text=f"Issue status-{i} is in_progress, blocked on review",
+            evidence_ref_ids=(evidence("a", i),),
+        )
+        for i in range(25)
+    )
+    required_children = tuple(
+        DevRequiredChildFactV2(
+            fact_id=f"issue:child-{i}",
+            text=f"Required child issue-{i}: implement the remaining subtask",
+            status="open",
+            evidence_ref_ids=(evidence("b", i),),
+        )
+        for i in range(100)
+    )
+    pull_requests = tuple(
+        DevPullRequestFactV2(
+            entity_id=f"pr-{i}",
+            display_label=f"Fix subtask {i} in the affected service",
+            state="open",
+            review_state="approved",
+            changes_requested=0,
+            merged=False,
+            required=True,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(evidence("c", i),),
+        )
+        for i in range(25)
+    )
+    ci_checks = tuple(
+        DevCIFactV2(
+            entity_id=f"ci-{i}",
+            display_label=f"build-and-test-{i}",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(evidence("d", i),),
+        )
+        for i in range(25)
+    )
+    deployments = tuple(
+        DevDeploymentFactV2(
+            entity_id=f"deploy-{i}",
+            display_label=f"production-release-{i}",
+            status="succeeded",
+            environment="production",
+            required=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(evidence("e", i),),
+        )
+        for i in range(25)
+    )
+    incidents = tuple(
+        DevIncidentFactV2(
+            entity_id=f"incident-{i}",
+            display_label=f"Elevated error rate incident-{i}",
+            status="resolved",
+            active=False,
+            blocking=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(evidence("f", i),),
+        )
+        for i in range(25)
+    )
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=status_facts,
+        required_children=required_children,
+        pull_requests=pull_requests,
+        ci_checks=ci_checks,
+        deployments=deployments,
+        incidents=incidents,
+    )
+
+
+def _dense_observation() -> DevSourceObservation:
+    return DevSourceObservation(
+        schema_version="dev_source_observation.v1",
+        observation_id=str(uuid.uuid4()),
+        source_class=SourceClass.STATUS_CHANGE,
+        adapter_id="status_change_service.status_snapshot.v1",
+        requirement_level="mandatory",
+        observed_state=SourceRequirementState.AVAILABLE_CURRENT,
+        data_semantics="measured_zero",
+        subject_coverage=1.0,
+        usable_fact_count=201,
+        relationship_paths=(),
+        evidence_ref_ids=(),
+        observed_at=OBSERVED_AT,
+        query_version="status-snapshot.v1",
+        content=_dense_status_snapshot_content(),
+    )
+
+
+def _dense_result(observation: DevSourceObservation) -> DevInvestigationResult:
+    return DevInvestigationResult(
+        schema_version="dev_investigation_result.v1",
+        result_id=str(uuid.uuid4()),
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        run_id=str(uuid.uuid4()),
+        subject_entity_id="project-1",
+        observations=(observation,),
+        completed_steps=("status_snapshot",),
+        skipped_steps=(),
+        failed_steps=(),
+        relationship_closure_verified=True,
+        completed_at=OBSERVED_AT,
+    )
+
+
+def test_the_dense_fixture_actually_exceeds_the_pre_fix_envelope() -> None:
+    """Sanity check on the fixture itself: if this ever stops being true the
+    test below would pass for the wrong reason (nothing dense enough to
+    exercise the bound at all)."""
+
+    import json
+
+    payload = _dense_observation().model_dump(mode="json")
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    assert len(encoded.encode("utf-8")) > _PRE_FIX_ENVELOPE_BYTES
+
+
+@pytest.mark.asyncio
+async def test_pre_fix_envelope_would_have_rejected_this_exact_dense_payload(
+    persistence, monkeypatch
+) -> None:
+    """RED: with the prior 16KB bound restored, the exact dense-but-valid
+    payload below is rejected -- proving the finding was real, not that some
+    unrelated oversized blob fails."""
+
+    maker, org_id, user_id = persistence
+    monkeypatch.setattr(
+        persistence_service_module,
+        "_SOURCE_OBSERVATION_PAYLOAD_MAX_BYTES",
+        _PRE_FIX_ENVELOPE_BYTES,
+    )
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        observation = _dense_observation()
+
+        with pytest.raises(DevPersistenceValidationError):
+            await service.append_source_observation(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=0,
+                observation_id=uuid.UUID(observation.observation_id),
+                source_class=observation.source_class.value,
+                requirement_level=observation.requirement_level,
+                observed_state=observation.observed_state.value,
+                data_semantics=observation.data_semantics,
+                usable_fact_count=observation.usable_fact_count,
+                sample_count=observation.sample_count,
+                subject_coverage=observation.subject_coverage,
+                observed_at=observation.observed_at,
+                payload=observation.model_dump(mode="json"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_dense_status_snapshot_result_persists_through_record_investigation_result(
+    persistence,
+) -> None:
+    """GREEN: the real, unpatched persistence layer -- driven through the
+    orchestrator's own ``record_investigation_result`` path, not a direct
+    unit call -- accepts the exact same dense-but-valid result end to end."""
+
+    maker, org_id, user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        recorder = PersistenceRunRecorder(
+            service,
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conv_id,
+            run_id=run_id,
+            provider_source="platform",
+        )
+        observation = _dense_observation()
+        result = _dense_result(observation)
+
+        await recorder.record_investigation_result(result)
+
+        rows = (
+            (
+                await session.execute(
+                    select(DevRunSourceObservation).where(
+                        DevRunSourceObservation.run_id == run_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        stored = rows[0]
+        assert stored.source_class == "status_change"
+        assert stored.usable_fact_count == 201
+        stored_content = stored.payload["content"]
+        assert len(stored_content["status_facts"]) == 25
+        assert len(stored_content["required_children"]) == 100
+        assert len(stored_content["pull_requests"]) == 25
+        assert len(stored_content["ci_checks"]) == 25
+        assert len(stored_content["deployments"]) == 25
+        assert len(stored_content["incidents"]) == 25
+
+        run = (
+            await session.execute(select(DevRun).where(DevRun.id == run_id))
+        ).scalar_one()
+        assert run.relationship_closure_verified is True
+        assert run.plan_step_partition == {
+            "completed": ["status_snapshot"],
+            "skipped": [],
+            "failed": [],
+        }

--- a/tests/api/dev/test_chaos_3296_relationship_closure.py
+++ b/tests/api/dev/test_chaos_3296_relationship_closure.py
@@ -35,7 +35,11 @@ from dev_health_ops.api.dev.contracts_v2.base import (
     SourceClass,
     SourceRequirementState,
 )
-from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
+from dev_health_ops.api.dev.contracts_v2.embedded import (
+    DevGraphEdgeV2,
+    DevRequiredChildFactV2,
+    DevStatusFactV2,
+)
 from dev_health_ops.api.dev.contracts_v2.plan import (
     DevInvestigationPlan,
     DevSourceRequirement,
@@ -49,6 +53,7 @@ from dev_health_ops.api.dev.investigation_plans import (
     StepRegistry,
 )
 from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
+    MAX_RELATIONSHIP_PATHS,
     MIN_RELATIONSHIP_CONFIDENCE,
 )
 
@@ -368,6 +373,95 @@ async def test_a_mixed_batch_with_one_bad_edge_marks_closure_unverified_but_neve
     assert len(observation.relationship_paths) == 1
     assert observation.relationship_paths[0].target_entity_id == "pr-9"
     assert result.relationship_closure_verified is False
+
+
+def _status_fact(index: int) -> DevStatusFactV2:
+    return DevStatusFactV2(
+        fact_id=f"issue:status-{index}",
+        text=f"Status fact {index}",
+        evidence_ref_ids=("ev1_" + f"{index:040x}",),
+    )
+
+
+def _required_child_fact(index: int) -> DevRequiredChildFactV2:
+    return DevRequiredChildFactV2(
+        fact_id=f"issue:child-{index}",
+        text=f"Required child {index}",
+        status="open",
+        evidence_ref_ids=("ev1_" + f"{index:040x}",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_exactly_the_relationship_path_budget_mints_every_path_and_closes():
+    """At the boundary (``MAX_RELATIONSHIP_PATHS`` distinct facts): every one
+    mints a path, nothing is dropped, closure can still be True."""
+
+    assert MAX_RELATIONSHIP_PATHS == 25
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=tuple(_status_fact(i) for i in range(MAX_RELATIONSHIP_PATHS)),
+    )
+    outcome = _queried_outcome(content)
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == MAX_RELATIONSHIP_PATHS
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_one_past_the_relationship_path_budget_truncates_deterministically_and_never_raises():
+    """Codex finding (HIGH, 2026-08-01): a dense-but-valid result minting one
+    more than the contract's ``relationship_paths`` bound (25) previously hit
+    a pydantic ``too_long`` deep inside ``DevSourceObservation`` construction
+    -- an uncaught exception that turned the whole run into
+    ``internal_error`` instead of a disclosed, partial answer. The executor
+    must budget deterministically instead: cap at 25, mark closure False,
+    never raise."""
+
+    assert MAX_RELATIONSHIP_PATHS == 25
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=tuple(_status_fact(i) for i in range(MAX_RELATIONSHIP_PATHS)),
+        required_children=(_required_child_fact(0),),
+    )
+    outcome = _queried_outcome(content)
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == MAX_RELATIONSHIP_PATHS
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_relationship_path_truncation_is_deterministic_across_runs():
+    """The same over-budget input must select the same 25 paths every time
+    (sorted by ``(relationship, target_entity_id)``), never dict/set order."""
+
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=tuple(_status_fact(i) for i in range(MAX_RELATIONSHIP_PATHS)),
+        required_children=(_required_child_fact(0),),
+    )
+    outcome = _queried_outcome(content)
+    _result_a, observation_a = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, outcome=outcome
+    )
+    _result_b, observation_b = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, outcome=outcome
+    )
+
+    targets_a = [path.target_entity_id for path in observation_a.relationship_paths]
+    targets_b = [path.target_entity_id for path in observation_b.relationship_paths]
+    assert targets_a == targets_b
+    # required_child sorts before status_assessment (lexicographic on
+    # relationship token), so the single required_children fact survives the
+    # budget and one status fact is dropped from the tail.
+    assert "issue:child-0" in targets_a
+    assert len(targets_a) == MAX_RELATIONSHIP_PATHS
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3296_relationship_closure.py
+++ b/tests/api/dev/test_chaos_3296_relationship_closure.py
@@ -143,8 +143,10 @@ def _edge(
     relationship: str = "references",
     confidence: float = 1.0,
     evidence_ref_ids: tuple[str, ...] = ("ev1_" + "a" * 40,),
+    edge_id: str | None = None,
 ) -> DevGraphEdgeV2:
     return DevGraphEdgeV2(
+        edge_id=edge_id or f"edge:{source_entity_id}:{relationship}:{target_entity_id}",
         source_entity_id=source_entity_id,
         relationship=relationship,
         target_entity_id=target_entity_id,

--- a/tests/api/dev/test_chaos_3296_relationship_closure.py
+++ b/tests/api/dev/test_chaos_3296_relationship_closure.py
@@ -1,0 +1,390 @@
+"""Relationship-closed evidence controls (CHAOS-3296).
+
+The executor comment left by CHAOS-3295 (``investigation_plans/executor.py``)
+names this issue's job precisely: "3296 populates DevSourceObservation.
+relationship_paths and owns the actual closure check." These controls prove
+that job at the layer it actually runs -- the executor's own
+``DevSourceObservation``/``DevInvestigationResult`` construction -- using
+hand-built ``StepOutcome.content`` the same way
+``test_chaos_3295_investigation_plans_executor.py`` hand-builds outcomes,
+never a full orchestrator/frame stack that does not exist yet.
+
+Positive: every content fact from a committed single-subject scope mints a
+verified path back to that subject, and the result-level
+``relationship_closure_verified`` flag turns on.
+
+Negative (issue acceptance criteria, verbatim): cross-tenant/forged entity
+ID, stale (low-confidence) link, duplicate edge, and path-cycle inputs must
+each fail *closed* -- no relationship path minted for the offending fact,
+``relationship_closure_verified`` stays ``False`` -- never a silent path
+fabricated from an unrelated or self-referential edge, and never an
+unhandled exception.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
+from dev_health_ops.api.dev.contracts_v2.plan import (
+    DevInvestigationPlan,
+    DevSourceRequirement,
+)
+from dev_health_ops.api.dev.contracts_v2.result import DevSourceContent
+from dev_health_ops.api.dev.investigation_plans import (
+    PlanExecutor,
+    PlanStepDefinition,
+    StepContext,
+    StepOutcome,
+    StepRegistry,
+)
+from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
+    MIN_RELATIONSHIP_CONFIDENCE,
+)
+
+ORG_ID = "org_fullchaos"
+ROOT_ENTITY_ID = "project-1"
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _now() -> datetime:
+    return OBSERVED_AT
+
+
+def _scope(*, direct_scope: DirectScope = DirectScope.PROJECT) -> DevScope:
+    time_range = DevTimeRange(
+        start=datetime(2026, 7, 1, tzinfo=UTC),
+        end=datetime(2026, 7, 31, tzinfo=UTC),
+        timezone="UTC",
+    )
+    if direct_scope is DirectScope.ORGANIZATION:
+        return DevScope(
+            schema_version="dev_scope.v1",
+            organization_id=ORG_ID,
+            direct_scope=DirectScope.ORGANIZATION,
+            time_range=time_range,
+        )
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=direct_scope,
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": ROOT_ENTITY_ID,
+                "display_label": "Project One",
+                "repository_id": None,
+            }
+        ],
+        time_range=time_range,
+    )
+
+
+def _context(*, direct_scope: DirectScope = DirectScope.PROJECT) -> StepContext:
+    return StepContext(
+        org_id=ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=_scope(direct_scope=direct_scope),
+        run_id="run-1",
+        now=_now(),
+    )
+
+
+def _plan(source_class: SourceClass) -> DevInvestigationPlan:
+    return DevInvestigationPlan(
+        schema_version="dev_investigation_plan.v1",
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        supported_subject_kinds=(EntityKind.PROJECT,),
+        supported_cardinalities=(Cardinality.SINGULAR, Cardinality.ORGANIZATION_WIDE),
+        mandatory_steps=("one",),
+        conditional_steps=(),
+        step_dependencies=(),
+        source_requirements=(
+            DevSourceRequirement(
+                schema_version="dev_source_requirement.v1",
+                source_class=source_class,
+                adapter_id="test.one.v1",
+                requirement_level="mandatory",
+                freshness_policy="p.v1",
+                minimum_usable_facts=0,
+            ),
+        ),
+        batch_strategy="single",
+        per_step_timeout_seconds=5,
+        max_rows_per_step=10,
+        max_bytes_per_step=1_000,
+        enrichment_allowed=False,
+        completion_rule_id="test.rule",
+        completion_rule_version="1",
+    )
+
+
+def _edge(
+    *,
+    source_entity_id: str,
+    target_entity_id: str,
+    relationship: str = "references",
+    confidence: float = 1.0,
+    evidence_ref_ids: tuple[str, ...] = ("ev1_" + "a" * 40,),
+) -> DevGraphEdgeV2:
+    return DevGraphEdgeV2(
+        source_entity_id=source_entity_id,
+        relationship=relationship,
+        target_entity_id=target_entity_id,
+        provenance="work_graph",
+        confidence=confidence,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=evidence_ref_ids,
+    )
+
+
+def _content(edges: tuple[DevGraphEdgeV2, ...]) -> DevSourceContent:
+    return DevSourceContent(schema_version="dev_source_content.v1", graph_edges=edges)
+
+
+async def _run_single_step(
+    *,
+    source_class: SourceClass,
+    outcome: StepOutcome,
+    direct_scope: DirectScope = DirectScope.PROJECT,
+) -> tuple:
+    plan = _plan(source_class)
+    registry = StepRegistry()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return outcome
+
+    registry.register(
+        PlanStepDefinition(
+            step_id="one",
+            plan_id=plan.plan_id,
+            source_class=source_class,
+            adapter_id="test.one.v1",
+            requirement_level="mandatory",
+            run=run,
+        )
+    )
+    executor = PlanExecutor(registry=registry, now=_now)
+    result = await executor.run(
+        plan=plan,
+        context=_context(direct_scope=direct_scope),
+        run_id="run-1",
+        subject_entity_id=ROOT_ENTITY_ID
+        if direct_scope is not DirectScope.ORGANIZATION
+        else None,
+    )
+    assert len(result.observations) == 1
+    return result, result.observations[0]
+
+
+def _queried_outcome(content: DevSourceContent) -> StepOutcome:
+    return StepOutcome(
+        observed_state=SourceRequirementState.AVAILABLE_CURRENT,
+        data_semantics="measured_zero",
+        usable_fact_count=1,
+        content=content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_real_edge_touching_the_subject_mints_a_verified_relationship_path():
+    outcome = _queried_outcome(
+        _content((_edge(source_entity_id=ROOT_ENTITY_ID, target_entity_id="pr-9"),))
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == 1
+    path = observation.relationship_paths[0]
+    assert path.source_entity_id == ROOT_ENTITY_ID
+    assert path.target_entity_id == "pr-9"
+    assert path.relationship == "references"
+    assert path.evidence_ref_ids == ("ev1_" + "a" * 40,)
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_an_edge_oriented_target_to_root_is_normalized_to_source_equals_root():
+    outcome = _queried_outcome(
+        _content((_edge(source_entity_id="pr-9", target_entity_id=ROOT_ENTITY_ID),))
+    )
+    _result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == 1
+    path = observation.relationship_paths[0]
+    assert path.source_entity_id == ROOT_ENTITY_ID
+    assert path.target_entity_id == "pr-9"
+
+
+@pytest.mark.asyncio
+async def test_organization_wide_scope_has_no_root_and_is_vacuously_closed():
+    """No committed single subject -- broad facts are legitimately unfiltered
+    (PRD v2 §3.2/§7), so there is nothing to enforce closure against."""
+
+    outcome = _queried_outcome(
+        _content((_edge(source_entity_id="pr-1", target_entity_id="pr-2"),))
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH,
+        outcome=outcome,
+        direct_scope=DirectScope.ORGANIZATION,
+    )
+
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_an_edge_unrelated_to_the_committed_subject_fails_closed():
+    """Cross-tenant/forged-ID acceptance criterion: neither end of the edge
+    is the committed subject -- must never mint a path claiming otherwise."""
+
+    outcome = _queried_outcome(
+        _content(
+            (_edge(source_entity_id="unrelated-a", target_entity_id="unrelated-b"),)
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_a_self_loop_edge_is_rejected_as_a_path_cycle():
+    outcome = _queried_outcome(
+        _content(
+            (_edge(source_entity_id=ROOT_ENTITY_ID, target_entity_id=ROOT_ENTITY_ID),)
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_a_low_confidence_edge_is_rejected_as_a_stale_link():
+    below_floor = MIN_RELATIONSHIP_CONFIDENCE - 0.01
+    assert below_floor >= 0.0
+    outcome = _queried_outcome(
+        _content(
+            (
+                _edge(
+                    source_entity_id=ROOT_ENTITY_ID,
+                    target_entity_id="pr-9",
+                    confidence=below_floor,
+                ),
+            )
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_an_unapproved_relationship_type_is_rejected_never_forged():
+    """A relationship token outside the closed matrix vocabulary must never
+    reach the wire, even if every other field looks legitimate."""
+
+    outcome = _queried_outcome(
+        _content(
+            (
+                _edge(
+                    source_entity_id=ROOT_ENTITY_ID,
+                    target_entity_id="pr-9",
+                    relationship="fabricated_relationship_type",
+                ),
+            )
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_duplicate_edges_mint_exactly_one_path_never_double_counted():
+    outcome = _queried_outcome(
+        _content(
+            (
+                _edge(source_entity_id=ROOT_ENTITY_ID, target_entity_id="pr-9"),
+                _edge(
+                    source_entity_id=ROOT_ENTITY_ID,
+                    target_entity_id="pr-9",
+                    evidence_ref_ids=("ev1_" + "b" * 40,),
+                ),
+            )
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == 1
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_a_mixed_batch_with_one_bad_edge_marks_closure_unverified_but_never_raises():
+    outcome = _queried_outcome(
+        _content(
+            (
+                _edge(source_entity_id=ROOT_ENTITY_ID, target_entity_id="pr-9"),
+                _edge(source_entity_id="unrelated-a", target_entity_id="unrelated-b"),
+            )
+        )
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert len(observation.relationship_paths) == 1
+    assert observation.relationship_paths[0].target_entity_id == "pr-9"
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_unmeasured_observation_has_no_content_and_no_relationship_paths():
+    outcome = StepOutcome(
+        observed_state=SourceRequirementState.UNAVAILABLE,
+        data_semantics="not_measured",
+        usable_fact_count=0,
+        limitation="step_execution_failed",
+    )
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, outcome=outcome
+    )
+
+    assert observation.content is None
+    assert observation.relationship_paths == ()
+    # An unmeasured source contributes nothing to close over -- closure
+    # verification is about facts that *were* found, not sources that never
+    # ran (that gap is disclosed separately via source coverage).
+    assert result.relationship_closure_verified is True

--- a/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
+++ b/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
@@ -1,0 +1,1029 @@
+"""Round-2 hardening (CHAOS-3296 Codex round 2, 2026-08-02): disclosed
+byte-budget truncation at observation construction, and identity-bound
+mint receipts.
+
+Round 1 fixed three findings (relationship-path budget, a raised
+persistence envelope, content-slot/mint-receipt structural checks). A
+scoped re-review confirmed two of round 1's own fixes were incomplete:
+
+1. [HIGH] Raising the persistence envelope to 64KiB only moved the
+   "valid run becomes internal_error" bug to a higher threshold -- a
+   genuinely contract-valid observation (every category at its own
+   ``max_length``, every string at its own bound) still serializes past
+   64KiB by an order of magnitude. The fix here is a deterministic,
+   DISCLOSED byte budget applied at construction (``PlanExecutor.
+   _budgeted_observation``): drop items in a documented priority order,
+   mark the contract's own truncation semantics, and keep the persistence
+   envelope only as an unreachable hard backstop.
+2. [MEDIUM] Round 1's mint-receipt check proved only that a handle was
+   minted *somewhere* during a step, not that it was minted *for the fact
+   citing it* -- a step could mint once for a real entity and reuse that
+   exact handle to "prove" an arbitrary number of fabricated facts.
+   ``_MintedReceipt`` now binds each handle to the identity it was
+   actually minted against; verification checks every fact's own claimed
+   identity against its cited handle's receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.contracts import (
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import (
+    DevCIFactV2,
+    DevDeploymentFactV2,
+    DevIncidentFactV2,
+    DevMetricPoint,
+    DevMetricRefV2,
+    DevPullRequestFactV2,
+    DevRequiredChildFactV2,
+    DevScopeV2,
+    DevStatusFactV2,
+)
+from dev_health_ops.api.dev.contracts_v2.plan import (
+    DevInvestigationPlan,
+    DevSourceRequirement,
+)
+from dev_health_ops.api.dev.contracts_v2.result import (
+    DevInvestigationResult,
+    DevSourceContent,
+    DevSourceObservation,
+)
+from dev_health_ops.api.dev.investigation_plans import (
+    PlanExecutor,
+    PlanStepDefinition,
+    StepContext,
+    StepOutcome,
+    StepRegistry,
+    wrap_runtime_with_mint_receipts,
+)
+from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
+    CONTENT_SLOT_FIELDS,
+)
+from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunIntent,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+ORG_ID = "org_fullchaos"
+ROOT_ENTITY_ID = "project-1"
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+
+# Real production default -- the fixture-actually-exceeds-it sanity checks
+# below prove against this value, not an artificially small stand-in.
+_PERSISTENCE_ENVELOPE_BYTES = 64 * 1024
+
+_PERSISTENCE_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunStageDiagnostic,
+)
+
+
+@pytest_asyncio.fixture
+async def persistence(tmp_path: Path):
+    database = tmp_path / "ask-dev-3296-round2.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_PERSISTENCE_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(
+                    id=org_id, slug="ask-dev-3296-round2", name="Ask Dev 3296 R2"
+                ),
+                User(id=user_id, email="ask-dev-3296-round2@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+async def _persist_observation(
+    maker, org_id: uuid.UUID, user_id: uuid.UUID, observation: DevSourceObservation
+) -> None:
+    """Drive ``observation`` through the exact real persistence path a
+    production run takes (``PersistenceRunRecorder.record_investigation_
+    result``) -- never a direct/synthetic call -- so success here proves
+    the persistence backstop is genuinely unreachable end to end, not just
+    that the executor's own byte estimate matches its own budget check."""
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="What is the status of this project?",
+            scope_snapshot={},
+        )
+        recorder = PersistenceRunRecorder(
+            service,
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            run_id=accepted.run.id,
+            provider_source="platform",
+        )
+        result = DevInvestigationResult(
+            schema_version="dev_investigation_result.v1",
+            result_id=str(uuid.uuid4()),
+            plan_id="status.entity.v2",
+            plan_version="status.entity.v2.1",
+            run_id=str(uuid.uuid4()),
+            subject_entity_id=ROOT_ENTITY_ID,
+            observations=(observation,),
+            completed_steps=("one",),
+            skipped_steps=(),
+            failed_steps=(),
+            relationship_closure_verified=False,
+            completed_at=OBSERVED_AT,
+        )
+        await recorder.record_investigation_result(result)
+
+
+def _now() -> datetime:
+    return OBSERVED_AT
+
+
+def _scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": ROOT_ENTITY_ID,
+                "display_label": "Project One",
+                "repository_id": None,
+            }
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 7, 1, tzinfo=UTC),
+            end=datetime(2026, 7, 31, tzinfo=UTC),
+            timezone="UTC",
+        ),
+    )
+
+
+def _context() -> StepContext:
+    return StepContext(
+        org_id=ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=_scope(),
+        run_id="run-1",
+        now=_now(),
+    )
+
+
+def _plan(source_class: SourceClass) -> DevInvestigationPlan:
+    return DevInvestigationPlan(
+        schema_version="dev_investigation_plan.v1",
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        supported_subject_kinds=(EntityKind.PROJECT,),
+        supported_cardinalities=(Cardinality.SINGULAR, Cardinality.ORGANIZATION_WIDE),
+        mandatory_steps=("one",),
+        conditional_steps=(),
+        step_dependencies=(),
+        source_requirements=(
+            DevSourceRequirement(
+                schema_version="dev_source_requirement.v1",
+                source_class=source_class,
+                adapter_id="test.one.v1",
+                requirement_level="mandatory",
+                freshness_policy="p.v1",
+                minimum_usable_facts=0,
+            ),
+        ),
+        batch_strategy="single",
+        per_step_timeout_seconds=5,
+        max_rows_per_step=10,
+        max_bytes_per_step=1_000,
+        enrichment_allowed=False,
+        completion_rule_id="test.rule",
+        completion_rule_version="1",
+    )
+
+
+async def _run_single_step(
+    *,
+    source_class: SourceClass,
+    run,
+    verify_mint_receipts: bool = False,
+    content_byte_budget: int | None = None,
+) -> tuple:
+    plan = _plan(source_class)
+    registry = StepRegistry()
+    registry.register(
+        PlanStepDefinition(
+            step_id="one",
+            plan_id=plan.plan_id,
+            source_class=source_class,
+            adapter_id="test.one.v1",
+            requirement_level="mandatory",
+            run=run,
+        )
+    )
+    executor = (
+        PlanExecutor(
+            registry=registry,
+            now=_now,
+            verify_mint_receipts=verify_mint_receipts,
+            content_byte_budget=content_byte_budget,
+        )
+        if content_byte_budget is not None
+        else PlanExecutor(
+            registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
+        )
+    )
+    result = await executor.run(
+        plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
+    )
+    assert len(result.observations) == 1
+    return result, result.observations[0]
+
+
+def _queried_outcome(
+    content: DevSourceContent,
+    *,
+    state: SourceRequirementState = SourceRequirementState.AVAILABLE_CURRENT,
+) -> StepOutcome:
+    return StepOutcome(
+        observed_state=state,
+        data_semantics="measured_zero",
+        usable_fact_count=1,
+        content=content,
+    )
+
+
+def _status_fact(index: int) -> DevStatusFactV2:
+    return DevStatusFactV2(
+        fact_id=f"issue:issue-{index}",
+        text=f"Issue {index} is in_progress, blocked on review from teammate",
+        evidence_ref_ids=("ev1_" + f"{index:040x}",),
+    )
+
+
+def _observation_json_bytes(observation) -> int:
+    """Byte-for-byte the same encoding ``executor._observation_json_bytes``
+    (and ``persistence.service._bounded_json``) measure with -- a test-side
+    oracle independent of, but consistent with, the production code path.
+    """
+
+    encoded = json.dumps(
+        observation.model_dump(mode="json"), separators=(",", ":"), sort_keys=True
+    )
+    return len(encoded.encode("utf-8"))
+
+
+# -- byte-budget truncation: boundary tests --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_small_content_is_never_truncated():
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1", status_facts=(_status_fact(0),)
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 1
+    assert observation.observed_state is SourceRequirementState.AVAILABLE_CURRENT
+    assert observation.limitation is None
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_status_observation_exactly_at_budget_is_untouched():
+    """Drive the same 10-fact content through two executors: one with an
+    effectively unlimited budget (to measure its real byte cost), one
+    pinned to EXACTLY that measured cost. At the boundary, ``<=`` must
+    still accept -- no truncation."""
+
+    content = DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=tuple(_status_fact(i) for i in range(10)),
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _unbudgeted_result, unbudgeted_observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, content_byte_budget=10**9
+    )
+    exact_budget = _observation_json_bytes(unbudgeted_observation)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        content_byte_budget=exact_budget,
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 10
+    assert observation.observed_state is SourceRequirementState.AVAILABLE_CURRENT
+    assert observation.limitation is None
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_status_observation_over_budget_truncates_deterministically_and_discloses():
+    """One byte less than the natural (unbudgeted) size of an 11-fact
+    observation must force at least one drop. The exact number dropped is
+    not asserted as a fixed constant -- the disclosure fields the executor
+    adds once truncation triggers (a non-null ``limitation``, a downgraded
+    ``observed_state``) cost real bytes too, so how many items fit is a
+    function of that overhead, not a simple per-item division. What must
+    hold, and what this test proves instead: the result is deterministic
+    across repeated runs, survivors are always the lowest-priority-index
+    PREFIX of the original facts (never dict/set order), the final payload
+    actually fits the budget, and the truncation is disclosed, never
+    silent."""
+
+    eleven_facts = tuple(_status_fact(i) for i in range(11))
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", status_facts=eleven_facts
+            )
+        )
+
+    _r, natural = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, content_byte_budget=10**9
+    )
+    budget = _observation_json_bytes(natural) - 1
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, content_byte_budget=budget
+    )
+    _result_again, observation_again = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, content_byte_budget=budget
+    )
+
+    assert observation.content is not None
+    survivors = observation.content.status_facts
+    assert 0 < len(survivors) < 11
+    assert [f.fact_id for f in survivors] == [
+        f.fact_id for f in eleven_facts[: len(survivors)]
+    ]
+    assert _observation_json_bytes(observation) <= budget
+    assert observation.observed_state is SourceRequirementState.AVAILABLE_STALE
+    assert observation.limitation is not None
+    dropped_count = 11 - len(survivors)
+    assert observation.limitation == f"budget_truncated:status_facts:{dropped_count}"
+    assert observation.usable_fact_count == len(survivors)
+    assert result.relationship_closure_verified is False
+    # Same input, same budget -> byte-identical outcome every time.
+    assert [f.fact_id for f in observation_again.content.status_facts] == [
+        f.fact_id for f in survivors
+    ]
+    assert observation_again.limitation == observation.limitation
+
+
+def _metric_ref(index: int, *, series_points: int = 366) -> DevMetricRefV2:
+    scope_v2 = DevScopeV2.model_validate(_scope().model_dump(mode="json"))
+    return DevMetricRefV2(
+        schema_version="dev_metric_ref.v1",
+        metric_ref_id=f"metric:ref-{index}",
+        metric_id=MetricID.CYCLE_TIME_P50_HOURS,
+        label=f"Cycle Time {index}",
+        definition_version="v1",
+        unit="hours",
+        aggregation="avg",
+        display_precision=1,
+        resolved_scope=scope_v2,
+        dimensions=(f"team=team-{index}",),
+        current_window=_scope().time_range,
+        comparison_window=None,
+        value=12.5,
+        comparison_value=None,
+        series=tuple(
+            DevMetricPoint(timestamp=datetime(2026, 1, 1, tzinfo=UTC), value=float(p))
+            for p in range(series_points)
+        ),
+        query_version="v1",
+        source_version="v1",
+        freshness=FreshnessState.FRESH,
+        coverage=1.0,
+        evidence_ref_ids=("ev1_" + f"{index:040x}",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_metric_observation_exactly_at_budget_is_untouched():
+    refs = tuple(_metric_ref(i) for i in range(3))
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", metric_refs=refs)
+        )
+
+    _r, unbudgeted = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=10**9
+    )
+    exact_budget = _observation_json_bytes(unbudgeted)
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=exact_budget
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.metric_refs) == 3
+    assert observation.limitation is None
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_metric_observation_over_budget_truncates_deterministically_and_discloses():
+    """Same reasoning as the status-observation equivalent: the disclosure
+    fields cost bytes once truncation triggers, so the exact survivor count
+    is not asserted as a hardcoded constant -- determinism, priority-order
+    survival, budget compliance, and disclosure are."""
+
+    four_refs = tuple(_metric_ref(i) for i in range(4))
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", metric_refs=four_refs
+            )
+        )
+
+    _r, natural = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=10**9
+    )
+    budget = _observation_json_bytes(natural) - 1
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=budget
+    )
+    _result_again, observation_again = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=budget
+    )
+
+    assert observation.content is not None
+    survivors = observation.content.metric_refs
+    assert 0 < len(survivors) < 4
+    assert [r.metric_ref_id for r in survivors] == [
+        r.metric_ref_id for r in four_refs[: len(survivors)]
+    ]
+    assert _observation_json_bytes(observation) <= budget
+    assert observation.limitation is not None
+    dropped_count = 4 - len(survivors)
+    assert observation.limitation == f"budget_truncated:metric_refs:{dropped_count}"
+    assert result.relationship_closure_verified is False
+    assert [r.metric_ref_id for r in observation_again.content.metric_refs] == [
+        r.metric_ref_id for r in survivors
+    ]
+
+
+# -- the persistence backstop must become unreachable ----------------------
+
+
+def _contract_max_status_content() -> DevSourceContent:
+    """Every bound the STATUS_CHANGE contract slots actually allow, maxed
+    out simultaneously -- the independently-verified ~615KiB true worst
+    case from the round-2 Codex finding."""
+
+    def evidence(prefix: str, index: int) -> tuple[str, ...]:
+        return tuple(
+            f"ev1_{prefix}{n:0{40 - len(prefix)}x}" for n in range(index, index + 25)
+        )
+
+    status_facts = tuple(
+        DevStatusFactV2(
+            fact_id="i" * 128, text="t" * 2048, evidence_ref_ids=evidence("a", i)
+        )
+        for i in range(25)
+    )
+    required_children = tuple(
+        DevRequiredChildFactV2(
+            fact_id="i" * 128,
+            text="t" * 2048,
+            status="s" * 128,
+            evidence_ref_ids=evidence("b", i),
+        )
+        for i in range(100)
+    )
+    pull_requests = tuple(
+        DevPullRequestFactV2(
+            entity_id="i" * 128,
+            display_label="d" * 256,
+            state="s" * 128,
+            review_state="r" * 128,
+            changes_requested=1000,
+            merged=False,
+            required=True,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=evidence("c", i),
+        )
+        for i in range(25)
+    )
+    ci_checks = tuple(
+        DevCIFactV2(
+            entity_id="i" * 128,
+            display_label="d" * 256,
+            conclusion="c" * 128,
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=evidence("d", i),
+        )
+        for i in range(25)
+    )
+    deployments = tuple(
+        DevDeploymentFactV2(
+            entity_id="i" * 128,
+            display_label="d" * 256,
+            status="s" * 128,
+            environment="e" * 128,
+            required=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=evidence("e", i),
+        )
+        for i in range(25)
+    )
+    incidents = tuple(
+        DevIncidentFactV2(
+            entity_id="i" * 128,
+            display_label="d" * 256,
+            status="s" * 128,
+            active=False,
+            blocking=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=evidence("f", i),
+        )
+        for i in range(25)
+    )
+    return DevSourceContent(
+        schema_version="dev_source_content.v1",
+        status_facts=status_facts,
+        required_children=required_children,
+        pull_requests=pull_requests,
+        ci_checks=ci_checks,
+        deployments=deployments,
+        incidents=incidents,
+    )
+
+
+@pytest.mark.asyncio
+async def test_contract_max_status_shape_never_exceeds_the_persistence_envelope():
+    """The independently-verified ~615KiB true contract maximum, driven
+    through the real (default-budget) executor, must fit the real 64KiB
+    persistence envelope -- disclosed as TRUNCATED, never raising."""
+
+    content = _contract_max_status_content()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _r, unbudgeted = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, content_byte_budget=10**9
+    )
+    unbudgeted_bytes = _observation_json_bytes(unbudgeted)
+    assert unbudgeted_bytes > _PERSISTENCE_ENVELOPE_BYTES, (
+        "fixture must actually exceed the real envelope to prove anything"
+    )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert _observation_json_bytes(observation) <= _PERSISTENCE_ENVELOPE_BYTES
+    assert observation.observed_state in (
+        SourceRequirementState.AVAILABLE_STALE,
+        SourceRequirementState.TRUNCATED,
+    )
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_codex_dense_metric_shape_never_exceeds_the_persistence_envelope():
+    """Codex's own round-2 counterexample: eight metric refs each with a
+    full 366-point series serialized to 150,740 bytes in isolation."""
+
+    refs = tuple(_metric_ref(i, series_points=366) for i in range(8))
+    content = DevSourceContent(schema_version="dev_source_content.v1", metric_refs=refs)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _r, unbudgeted = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, content_byte_budget=10**9
+    )
+    unbudgeted_bytes = _observation_json_bytes(unbudgeted)
+    assert unbudgeted_bytes > _PERSISTENCE_ENVELOPE_BYTES, (
+        "fixture must actually exceed the real envelope to prove anything"
+    )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run
+    )
+
+    assert _observation_json_bytes(observation) <= _PERSISTENCE_ENVELOPE_BYTES
+    del result
+
+
+@pytest.mark.asyncio
+async def test_truncation_never_leaves_a_dangling_relationship_path():
+    """Fabrication-by-omission control: every relationship path in a
+    truncated observation must cite a fact that is still actually present
+    in the (shrunk) content -- never a path left over from a dropped fact."""
+
+    content = _contract_max_status_content()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+    assert observation.content is not None
+
+    surviving_targets = {
+        field: {
+            getattr(item, "fact_id", getattr(item, "entity_id", None))
+            for item in getattr(observation.content, field)
+        }
+        for field in CONTENT_SLOT_FIELDS
+    }
+    all_surviving_ids = {
+        i for ids in surviving_targets.values() for i in ids if i is not None
+    }
+    for path in observation.relationship_paths:
+        assert path.target_entity_id in all_surviving_ids, (
+            f"relationship path {path.path_id} cites {path.target_entity_id!r}, "
+            "which is not present in the truncated content"
+        )
+
+
+# -- identity-bound mint receipts -------------------------------------------
+
+
+class _MintOnlyRuntime:
+    def __init__(self) -> None:
+        self.mint_calls = 0
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def list_metrics(self, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        self.mint_calls += 1
+        return "ev1_" + f"{self.mint_calls:040x}"
+
+
+@pytest.mark.asyncio
+async def test_reused_handle_across_unrelated_facts_is_rejected():
+    """RED: the exact Codex round-2 repro. A step mints one real handle for
+    issue-1, then reuses that same handle to "prove" a wholly fabricated
+    fact about issue-999. Must be rejected -- never raise, closure False."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        real_handle = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        real_fact = DevStatusFactV2(
+            fact_id="issue:issue-1",
+            text="Issue one really is in_progress",
+            evidence_ref_ids=(real_handle,),
+        )
+        forged_fact = DevStatusFactV2(
+            fact_id="issue:issue-999-fabricated",
+            text="Issue 999 is DEFINITELY DONE (fabricated)",
+            evidence_ref_ids=(real_handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                status_facts=(real_fact, forged_fact),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 1
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert "issue-999-fabricated" in observation.limitation
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_correct_handle_on_correct_fact_is_accepted():
+    """Positive control: a handle cited by the exact fact it was minted for
+    passes identity verification."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = DevStatusFactV2(
+            fact_id="issue:issue-1",
+            text="Issue one is in_progress",
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", status_facts=(fact,)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 1
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
+    """Cross-fact control: two DIFFERENT facts, each citing a handle
+    genuinely minted for that fact's own entity -- neither is a reuse of
+    the other's handle, so both must be accepted."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle_a = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        handle_b = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version="status-snapshot-evidence.v1",
+            entity_type="issue",
+            entity_id="issue-2",
+            display_label="Issue Two",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact_a = DevStatusFactV2(
+            fact_id="issue:issue-1",
+            text="Issue one is in_progress",
+            evidence_ref_ids=(handle_a,),
+        )
+        fact_b = DevStatusFactV2(
+            fact_id="issue:issue-2",
+            text="Issue two is done",
+            evidence_ref_ids=(handle_b,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", status_facts=(fact_a, fact_b)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 2
+    assert observation.content is not None
+    assert len(observation.content.status_facts) == 2
+    assert result.relationship_closure_verified is True
+
+
+@pytest.mark.asyncio
+async def test_graph_edge_handle_reuse_is_caught_only_by_existence_not_identity():
+    """Documented residual gap: ``DevGraphEdgeV2`` never preserves the
+    ``edge_id`` minting bound identity to, so a handle genuinely minted for
+    one edge, reused verbatim on a second, different edge, is NOT caught by
+    identity comparison here -- only a wholly-unminted handle would be. This
+    test exists to keep that gap honest and visible (never silently assumed
+    closed) rather than to assert it is fixed."""
+
+    from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_graph",
+            source_version="work-graph-evidence.v1",
+            entity_type="work_graph_edge",
+            entity_id="edge-1",
+            display_label="issue-1 references pr-1",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        edge_a = DevGraphEdgeV2(
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-1",
+            provenance="work_graph",
+            confidence=1.0,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        edge_b_reusing_handle = DevGraphEdgeV2(
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-2-unrelated",
+            provenance="work_graph",
+            confidence=1.0,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                graph_edges=(edge_a, edge_b_reusing_handle),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, run=run, verify_mint_receipts=True
+    )
+
+    # Both edges pass -- the existence check sees the handle in the receipt
+    # map (it WAS minted, just for a different edge); identity comparison
+    # never runs for graph_edges at all. This is the known, tested gap.
+    assert observation.content is not None
+    assert len(observation.content.graph_edges) == 2
+    del result
+
+
+# -- end to end through the real persistence path ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_contract_max_status_shape_persists_through_the_real_service(persistence):
+    """The full loop: contract-max content -> real (default-budget)
+    executor -> real PersistenceRunRecorder.record_investigation_result ->
+    real aiosqlite DevPersistenceService. Must complete without raising."""
+
+    maker, org_id, user_id = persistence
+    content = _contract_max_status_content()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    await _persist_observation(maker, org_id, user_id, observation)
+
+
+@pytest.mark.asyncio
+async def test_codex_dense_metric_shape_persists_through_the_real_service(persistence):
+    """Codex's own round-2 counterexample, driven through the same real
+    persistence path."""
+
+    maker, org_id, user_id = persistence
+    refs = tuple(_metric_ref(i, series_points=366) for i in range(8))
+    content = DevSourceContent(schema_version="dev_source_content.v1", metric_refs=refs)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(content)
+
+    _result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run
+    )
+
+    await _persist_observation(maker, org_id, user_id, observation)

--- a/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
+++ b/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
@@ -927,13 +927,16 @@ async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
 
 
 @pytest.mark.asyncio
-async def test_graph_edge_handle_reuse_is_caught_only_by_existence_not_identity():
-    """Documented residual gap: ``DevGraphEdgeV2`` never preserves the
-    ``edge_id`` minting bound identity to, so a handle genuinely minted for
-    one edge, reused verbatim on a second, different edge, is NOT caught by
-    identity comparison here -- only a wholly-unminted handle would be. This
-    test exists to keep that gap honest and visible (never silently assumed
-    closed) rather than to assert it is fixed."""
+async def test_graph_edge_handle_reuse_is_rejected():
+    """RED (CHAOS-3296 Codex round 3, [HIGH]): round 2 excluded graph_edges
+    from identity comparison because ``DevGraphEdgeV2`` never preserved the
+    ``edge_id`` minting bound identity to -- a handle genuinely minted for
+    edge-1, reused verbatim on a fabricated second edge, passed both the
+    existence check (the handle really was minted) and (vacuously) identity
+    comparison (which never ran for this category at all). Round 4 adds
+    ``DevGraphEdgeV2.edge_id`` and a real identity cell for graph_edges --
+    this must now be rejected exactly like the round-2 status-fact reuse
+    repro."""
 
     from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
 
@@ -952,6 +955,7 @@ async def test_graph_edge_handle_reuse_is_caught_only_by_existence_not_identity(
             freshness=FreshnessState.FRESH,
         )
         edge_a = DevGraphEdgeV2(
+            edge_id="edge-1",
             source_entity_id=ROOT_ENTITY_ID,
             relationship="references",
             target_entity_id="pr-1",
@@ -961,6 +965,7 @@ async def test_graph_edge_handle_reuse_is_caught_only_by_existence_not_identity(
             evidence_ref_ids=(handle,),
         )
         edge_b_reusing_handle = DevGraphEdgeV2(
+            edge_id="edge-2-fabricated",
             source_entity_id=ROOT_ENTITY_ID,
             relationship="references",
             target_entity_id="pr-2-unrelated",
@@ -980,12 +985,80 @@ async def test_graph_edge_handle_reuse_is_caught_only_by_existence_not_identity(
         source_class=SourceClass.WORK_GRAPH, run=run, verify_mint_receipts=True
     )
 
-    # Both edges pass -- the existence check sees the handle in the receipt
-    # map (it WAS minted, just for a different edge); identity comparison
-    # never runs for graph_edges at all. This is the known, tested gap.
+    assert runtime.mint_calls == 1
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert "edge-2-fabricated" in observation.limitation
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_two_graph_edges_each_citing_their_own_handle_are_both_accepted():
+    """Cross-edge positive control, mirroring the status-fact equivalent."""
+
+    from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle_a = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_graph",
+            source_version="work-graph-evidence.v1",
+            entity_type="work_graph_edge",
+            entity_id="edge-1",
+            display_label="issue-1 references pr-1",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        handle_b = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="work_graph",
+            source_version="work-graph-evidence.v1",
+            entity_type="work_graph_edge",
+            entity_id="edge-2",
+            display_label="issue-1 references pr-2",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        edge_a = DevGraphEdgeV2(
+            edge_id="edge-1",
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-1",
+            provenance="work_graph",
+            confidence=1.0,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle_a,),
+        )
+        edge_b = DevGraphEdgeV2(
+            edge_id="edge-2",
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-2",
+            provenance="work_graph",
+            confidence=1.0,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle_b,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                graph_edges=(edge_a, edge_b),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 2
     assert observation.content is not None
     assert len(observation.content.graph_edges) == 2
-    del result
+    assert result.relationship_closure_verified is True
 
 
 # -- end to end through the real persistence path ---------------------------

--- a/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
+++ b/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
@@ -54,6 +54,7 @@ from dev_health_ops.api.dev.contracts_v2.base import (
 from dev_health_ops.api.dev.contracts_v2.embedded import (
     DevCIFactV2,
     DevDeploymentFactV2,
+    DevGraphEdgeV2,
     DevIncidentFactV2,
     DevMetricPoint,
     DevMetricRefV2,
@@ -82,6 +83,7 @@ from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
     _GRAPH_EVIDENCE_SOURCE_VERSION,
     _STATUS_EVIDENCE_SOURCE_VERSION,
     _bind_content,
+    _claim_projection,
 )
 from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
     CONTENT_SLOT_FIELDS,
@@ -105,7 +107,10 @@ from dev_health_ops.models.dev_persistence import (
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.users import Organization, User
-from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
+from tests._chaos_3295_plan_executor import (
+    TEST_EVIDENCE_SIGNER,
+    sign_evidence_for_scope,
+)
 from tests._helpers import tables_of
 
 ORG_ID = "org_fullchaos"
@@ -782,7 +787,12 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return sign_evidence(
+        # CHAOS-3296 round 6: route through the scope-bound helper (using
+        # THIS file's fixed ``_scope()``) so a handle minted here carries
+        # the same authorization-scope digest suffix a genuine
+        # ``_scope_bound_mint``-wrapped mint call would.
+        return sign_evidence_for_scope(
+            scope=_scope(),
             org_id=org_id,
             source_system=source_system,
             source_version=source_version,
@@ -794,6 +804,49 @@ class _MintOnlyRuntime:
             confidence=confidence,
             repository_ids=repository_ids,
         )
+
+
+def _status_fact_source_version(*, fact_id: str, text: str) -> str:
+    """The exact ``source_version`` a genuine ``wire_status_fact`` mint
+    computes for a ``DevStatusFactV2`` with this fact_id/text -- built from
+    the SAME construct-then-project pattern production uses (round 6:
+    ``_identity_status_fact`` projects the WHOLE wire model, not just
+    ``text``), over a placeholder-handle provisional (excluded from the
+    digest regardless of its value)."""
+
+    provisional = DevStatusFactV2(
+        fact_id=fact_id, text=text, evidence_ref_ids=("ev1_" + "0" * 40,)
+    )
+    return _bind_content(
+        _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional)
+    )
+
+
+def _graph_edge_source_version(
+    *,
+    edge_id: str,
+    source_entity_id: str,
+    relationship: str,
+    target_entity_id: str,
+) -> str:
+    """The exact ``source_version`` a genuine ``wire_edge`` mint computes
+    for a ``DevGraphEdgeV2`` with these fields (provenance="work_graph",
+    confidence=1.0 fixed, matching every edge this file's permanent REDs
+    construct) -- built from the SAME construct-then-project pattern
+    production uses (round 6: ``_identity_graph_edge`` projects the WHOLE
+    wire model, including provenance/confidence/observed_at)."""
+
+    provisional = DevGraphEdgeV2(
+        edge_id=edge_id,
+        source_entity_id=source_entity_id,
+        relationship=relationship,
+        target_entity_id=target_entity_id,
+        provenance="work_graph",
+        confidence=1.0,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=("ev1_" + "0" * 40,),
+    )
+    return _bind_content(_GRAPH_EVIDENCE_SOURCE_VERSION, _claim_projection(provisional))
 
 
 @pytest.mark.asyncio
@@ -809,8 +862,8 @@ async def test_reused_handle_across_unrelated_facts_is_rejected():
         real_handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION, claim=real_text
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-1", text=real_text
             ),
             entity_type="issue",
             entity_id="issue-1",
@@ -860,7 +913,9 @@ async def test_correct_handle_on_correct_fact_is_accepted():
         handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text),
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-1", text=text
+            ),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -901,7 +956,9 @@ async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
         handle_a = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text_a),
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-1", text=text_a
+            ),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -911,7 +968,9 @@ async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
         handle_b = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text_b),
+            source_version=_status_fact_source_version(
+                fact_id="issue:issue-2", text=text_b
+            ),
             entity_type="issue",
             entity_id="issue-2",
             display_label="Issue Two",
@@ -956,18 +1015,16 @@ async def test_graph_edge_handle_reuse_is_rejected():
     this must now be rejected exactly like the round-2 status-fact reuse
     repro."""
 
-    from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
-
     runtime = _MintOnlyRuntime()
 
     async def run(_ctx: StepContext) -> StepOutcome:
         handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version=_bind_content(
-                _GRAPH_EVIDENCE_SOURCE_VERSION,
-                relationship="references",
+            source_version=_graph_edge_source_version(
+                edge_id="edge-1",
                 source_entity_id=ROOT_ENTITY_ID,
+                relationship="references",
                 target_entity_id="pr-1",
             ),
             entity_type="work_graph_edge",
@@ -1020,18 +1077,16 @@ async def test_graph_edge_handle_reuse_is_rejected():
 async def test_two_graph_edges_each_citing_their_own_handle_are_both_accepted():
     """Cross-edge positive control, mirroring the status-fact equivalent."""
 
-    from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
-
     runtime = _MintOnlyRuntime()
 
     async def run(_ctx: StepContext) -> StepOutcome:
         handle_a = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version=_bind_content(
-                _GRAPH_EVIDENCE_SOURCE_VERSION,
-                relationship="references",
+            source_version=_graph_edge_source_version(
+                edge_id="edge-1",
                 source_entity_id=ROOT_ENTITY_ID,
+                relationship="references",
                 target_entity_id="pr-1",
             ),
             entity_type="work_graph_edge",
@@ -1043,10 +1098,10 @@ async def test_two_graph_edges_each_citing_their_own_handle_are_both_accepted():
         handle_b = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version=_bind_content(
-                _GRAPH_EVIDENCE_SOURCE_VERSION,
-                relationship="references",
+            source_version=_graph_edge_source_version(
+                edge_id="edge-2",
                 source_entity_id=ROOT_ENTITY_ID,
+                relationship="references",
                 target_entity_id="pr-2",
             ),
             entity_type="work_graph_edge",

--- a/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
+++ b/tests/api/dev/test_chaos_3296_round2_budget_and_receipts.py
@@ -77,7 +77,11 @@ from dev_health_ops.api.dev.investigation_plans import (
     StepContext,
     StepOutcome,
     StepRegistry,
-    wrap_runtime_with_mint_receipts,
+)
+from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
+    _GRAPH_EVIDENCE_SOURCE_VERSION,
+    _STATUS_EVIDENCE_SOURCE_VERSION,
+    _bind_content,
 )
 from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
     CONTENT_SLOT_FIELDS,
@@ -101,6 +105,7 @@ from dev_health_ops.models.dev_persistence import (
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.users import Organization, User
+from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
 from tests._helpers import tables_of
 
 ORG_ID = "org_fullchaos"
@@ -297,17 +302,16 @@ async def _run_single_step(
             run=run,
         )
     )
+    evidence_signer = TEST_EVIDENCE_SIGNER if verify_mint_receipts else None
     executor = (
         PlanExecutor(
             registry=registry,
             now=_now,
-            verify_mint_receipts=verify_mint_receipts,
+            evidence_signer=evidence_signer,
             content_byte_budget=content_byte_budget,
         )
         if content_byte_budget is not None
-        else PlanExecutor(
-            registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
-        )
+        else PlanExecutor(registry=registry, now=_now, evidence_signer=evidence_signer)
     )
     result = await executor.run(
         plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
@@ -778,7 +782,18 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return "ev1_" + f"{self.mint_calls:040x}"
+        return sign_evidence(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            repository_ids=repository_ids,
+        )
 
 
 @pytest.mark.asyncio
@@ -788,13 +803,15 @@ async def test_reused_handle_across_unrelated_facts_is_rejected():
     fact about issue-999. Must be rejected -- never raise, closure False."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        real_handle = wrapped.mint_evidence(
+        real_text = "Issue one really is in_progress"
+        real_handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION, claim=real_text
+            ),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -803,7 +820,7 @@ async def test_reused_handle_across_unrelated_facts_is_rejected():
         )
         real_fact = DevStatusFactV2(
             fact_id="issue:issue-1",
-            text="Issue one really is in_progress",
+            text=real_text,
             evidence_ref_ids=(real_handle,),
         )
         forged_fact = DevStatusFactV2(
@@ -826,7 +843,7 @@ async def test_reused_handle_across_unrelated_facts_is_rejected():
     assert observation.content is None
     assert observation.observed_state is SourceRequirementState.UNAVAILABLE
     assert observation.limitation is not None
-    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert observation.limitation.startswith("evidence_signature_invalid:")
     assert "issue-999-fabricated" in observation.limitation
     assert result.relationship_closure_verified is False
 
@@ -837,13 +854,13 @@ async def test_correct_handle_on_correct_fact_is_accepted():
     passes identity verification."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle = wrapped.mint_evidence(
+        text = "Issue one is in_progress"
+        handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
@@ -852,7 +869,7 @@ async def test_correct_handle_on_correct_fact_is_accepted():
         )
         fact = DevStatusFactV2(
             fact_id="issue:issue-1",
-            text="Issue one is in_progress",
+            text=text,
             evidence_ref_ids=(handle,),
         )
         return _queried_outcome(
@@ -877,23 +894,24 @@ async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
     the other's handle, so both must be accepted."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle_a = wrapped.mint_evidence(
+        text_a = "Issue one is in_progress"
+        text_b = "Issue two is done"
+        handle_a = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text_a),
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
-        handle_b = wrapped.mint_evidence(
+        handle_b = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_items",
-            source_version="status-snapshot-evidence.v1",
+            source_version=_bind_content(_STATUS_EVIDENCE_SOURCE_VERSION, claim=text_b),
             entity_type="issue",
             entity_id="issue-2",
             display_label="Issue Two",
@@ -902,12 +920,12 @@ async def test_two_facts_each_citing_their_own_handle_are_both_accepted():
         )
         fact_a = DevStatusFactV2(
             fact_id="issue:issue-1",
-            text="Issue one is in_progress",
+            text=text_a,
             evidence_ref_ids=(handle_a,),
         )
         fact_b = DevStatusFactV2(
             fact_id="issue:issue-2",
-            text="Issue two is done",
+            text=text_b,
             evidence_ref_ids=(handle_b,),
         )
         return _queried_outcome(
@@ -941,13 +959,17 @@ async def test_graph_edge_handle_reuse_is_rejected():
     from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle = wrapped.mint_evidence(
+        handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version="work-graph-evidence.v1",
+            source_version=_bind_content(
+                _GRAPH_EVIDENCE_SOURCE_VERSION,
+                relationship="references",
+                source_entity_id=ROOT_ENTITY_ID,
+                target_entity_id="pr-1",
+            ),
             entity_type="work_graph_edge",
             entity_id="edge-1",
             display_label="issue-1 references pr-1",
@@ -989,7 +1011,7 @@ async def test_graph_edge_handle_reuse_is_rejected():
     assert observation.content is None
     assert observation.observed_state is SourceRequirementState.UNAVAILABLE
     assert observation.limitation is not None
-    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert observation.limitation.startswith("evidence_signature_invalid:")
     assert "edge-2-fabricated" in observation.limitation
     assert result.relationship_closure_verified is False
 
@@ -1001,23 +1023,32 @@ async def test_two_graph_edges_each_citing_their_own_handle_are_both_accepted():
     from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle_a = wrapped.mint_evidence(
+        handle_a = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version="work-graph-evidence.v1",
+            source_version=_bind_content(
+                _GRAPH_EVIDENCE_SOURCE_VERSION,
+                relationship="references",
+                source_entity_id=ROOT_ENTITY_ID,
+                target_entity_id="pr-1",
+            ),
             entity_type="work_graph_edge",
             entity_id="edge-1",
             display_label="issue-1 references pr-1",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
-        handle_b = wrapped.mint_evidence(
+        handle_b = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="work_graph",
-            source_version="work-graph-evidence.v1",
+            source_version=_bind_content(
+                _GRAPH_EVIDENCE_SOURCE_VERSION,
+                relationship="references",
+                source_entity_id=ROOT_ENTITY_ID,
+                target_entity_id="pr-2",
+            ),
             entity_type="work_graph_edge",
             entity_id="edge-2",
             display_label="issue-1 references pr-2",

--- a/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
+++ b/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
@@ -88,6 +88,7 @@ from tests._chaos_3295_plan_executor import (
     TEST_EVIDENCE_SIGNER,
     project_scope,
     sign_evidence,
+    sign_evidence_for_scope,
     step_context_for,
 )
 
@@ -183,13 +184,23 @@ def _registry(spy: _SpyRuntime) -> StepRegistry:
 
 def _minted_identity(spy: _SpyRuntime, fact) -> tuple[str, str, str, str]:
     """The real minted identity for ``fact``'s (assumed single) evidence
-    handle, straight from the spy's recorded mint-call kwargs."""
+    handle, straight from the spy's recorded mint-call kwargs.
+
+    CHAOS-3296 round 6: the recorded ``source_version`` carries a
+    ``#scope:...`` suffix -- ``_scope_bound_mint`` (applied inside the real
+    ``wire_*_content`` functions, upstream of this spy) appends it to EVERY
+    mint call, but ``EVIDENCE_IDENTITY_TABLE`` cells' ``derive`` never
+    include it (the executor appends it centrally, once per verification
+    pass, not per-cell -- see ``executor._evidence_signature_failures``).
+    Stripped here so this test compares content-identity apples to apples;
+    the scope suffix itself is proven correct separately (round-6 tests in
+    ``test_chaos_3296_round5_signature_verification.py``)."""
 
     assert len(fact.evidence_ref_ids) == 1
     call = spy.mint_calls[fact.evidence_ref_ids[0]]
     return (
         call["source_system"],
-        call["source_version"],
+        call["source_version"].split("#scope:", 1)[0],
         call["entity_type"],
         call["entity_id"],
     )
@@ -653,6 +664,7 @@ from dev_health_ops.api.dev.investigation_plans import (  # noqa: E402
 )
 from dev_health_ops.api.dev.investigation_plans.builtin_steps import (  # noqa: E402
     _ci_check_source_version,
+    _claim_projection,
 )
 
 ROOT_ENTITY_ID = "project-1"
@@ -870,7 +882,13 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return sign_evidence(
+        # CHAOS-3296 round 6: route through the scope-bound helper (using
+        # THIS file's fixed ``_scope()``) so a handle minted here carries
+        # the same authorization-scope digest suffix a genuine
+        # ``_scope_bound_mint``-wrapped mint call would, and verifies
+        # under PlanExecutor's round-6 scope-fingerprint check.
+        return sign_evidence_for_scope(
+            scope=_scope(),
             org_id=org_id,
             source_system=source_system,
             source_version=source_version,
@@ -882,6 +900,29 @@ class _MintOnlyRuntime:
             confidence=confidence,
             repository_ids=repository_ids,
         )
+
+
+def _ci_claim(
+    *, entity_id: str, display_label: str, conclusion: str
+) -> dict[str, object]:
+    """The EXACT projection a genuine ``wire_ci`` mint computes for a CI
+    fact with these fields (required=True, skipped_required_work=False,
+    observed_at=OBSERVED_AT fixed, matching every CI fact this file's
+    permanent REDs construct) -- built from the SAME provisional-then-
+    project pattern production uses, over the SAME entity_id/display_label
+    the corresponding genuine ``DevCIFactV2`` will carry (the projection
+    binds those too -- they are real wire fields, not excluded)."""
+
+    provisional = DevCIFactV2(
+        entity_id=entity_id,
+        display_label=display_label,
+        conclusion=conclusion,
+        required=True,
+        skipped_required_work=False,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=("ev1_" + "0" * 40,),
+    )
+    return _claim_projection(provisional)
 
 
 @pytest.mark.asyncio
@@ -903,9 +944,11 @@ async def test_red_ci_check_a_handle_reused_on_check_b_is_rejected():
             source_system="ci_runs",
             source_version=_ci_check_source_version(
                 "repo#ci7#checkA",
-                conclusion="success",
-                required=True,
-                skipped_required_work=False,
+                claim=_ci_claim(
+                    entity_id="repo#ci7#checkA",
+                    display_label="checkA really succeeded",
+                    conclusion="success",
+                ),
             ),
             entity_type="ci_run",
             entity_id="repo#ci7",
@@ -965,9 +1008,11 @@ async def test_ci_check_a_and_check_b_each_with_their_own_handle_are_both_accept
             source_system="ci_runs",
             source_version=_ci_check_source_version(
                 "repo#ci7#checkA",
-                conclusion="success",
-                required=True,
-                skipped_required_work=False,
+                claim=_ci_claim(
+                    entity_id="repo#ci7#checkA",
+                    display_label="checkA",
+                    conclusion="success",
+                ),
             ),
             entity_type="ci_run",
             entity_id="repo#ci7",
@@ -980,9 +1025,11 @@ async def test_ci_check_a_and_check_b_each_with_their_own_handle_are_both_accept
             source_system="ci_runs",
             source_version=_ci_check_source_version(
                 "repo#ci7#checkB",
-                conclusion="failure",
-                required=True,
-                skipped_required_work=False,
+                claim=_ci_claim(
+                    entity_id="repo#ci7#checkB",
+                    display_label="checkB",
+                    conclusion="failure",
+                ),
             ),
             entity_type="ci_run",
             entity_id="repo#ci7",

--- a/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
+++ b/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
@@ -1,0 +1,1136 @@
+"""Round-4 closure (CHAOS-3296 Codex round 3, 2026-08-02): the evidence
+identity table, require-known-good verification, and the three permanent
+RED tests for round 3's confirmed findings.
+
+Round 3 found the mint-receipt verification built in rounds 1-2 was
+reject-known-bad (flag a handle only if PRESENT and wrong) rather than
+require-known-good (every evidence-capable fact MUST cite >=1 receipted
+handle whose FULL identity matches):
+
+1. [HIGH] A fact citing zero evidence handles skipped every check entirely
+   -- no mint call needed at all to fabricate a fully-believed fact.
+2. [HIGH] graph_edges was excluded from identity comparison because
+   ``DevGraphEdgeV2`` never preserved the ``edge_id`` minting bound
+   identity to -- CHAOS-3296 round 4 adds that field.
+3. [MEDIUM] CI-check identity collapsed to the run level, discarding the
+   check-specific discriminator the real signer's HMAC actually binds into
+   ``source_version`` -- one check's handle could "verify" a different
+   check's fabricated fact on the same run.
+
+``relationship_matrix.EVIDENCE_IDENTITY_TABLE`` closes all three: one
+import-time-total cell per ``CONTENT_SLOT_FIELDS`` entry, each deriving the
+exact ``(source_system, source_version, entity_type, entity_id)`` its own
+``builtin_steps.py`` minting call site uses. This file's "source-anchored"
+tests prove each cell against the REAL production step (via
+``register_builtin_steps`` + a spy ``mint_evidence``), not a hand-authored
+fixture -- if a minting call site's identity derivation ever changes shape,
+these tests (not just the table's own import-time totality check) catch it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    ClaimKind,
+    DevEntityRef,
+    DevScope,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+    MetricID,
+)
+from dev_health_ops.api.dev.investigation_plans import (
+    StepRegistry,
+    register_builtin_steps,
+)
+from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
+    CONTENT_SLOT_FIELDS,
+    EVIDENCE_IDENTITY_TABLE,
+)
+from dev_health_ops.api.dev.metrics.definitions import MetricDefinition
+from dev_health_ops.api.dev.metrics.service import (
+    MetricDataState,
+    MetricQueryResult,
+    MetricQueryValue,
+    MetricSourceRef,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ActualCompletion,
+    ChangeCategory,
+    ChangeSummaryResult,
+    ChangeWindow,
+    CIFact,
+    CompletionState,
+    DeploymentFact,
+    IncidentFact,
+    ObservedChange,
+    PullRequestFact,
+    StatusFact,
+    StatusResultState,
+    StatusSnapshotResult,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    QUERY_VERSION as WORK_GRAPH_QUERY_VERSION,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    SCHEMA_VERSION as WORK_GRAPH_SCHEMA_VERSION,
+)
+from dev_health_ops.api.dev.work_graph_neighbors_service import (
+    GraphDirection,
+    WorkGraphNeighborEdge,
+    WorkGraphNeighborsResult,
+    WorkGraphResultState,
+)
+from tests._chaos_3295_plan_executor import project_scope, step_context_for
+
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+ORG_ID = "org_fullchaos"
+
+
+# -- shared spy runtime: source-anchors every test in this file against the
+# real production wiring, never a hand-authored shortcut. ------------------
+
+
+class _SpyRuntime:
+    def __init__(self, **kwargs: object) -> None:
+        self.mint_calls: dict[str, dict[str, str]] = {}
+        self._counter = 0
+        self.status_result: StatusSnapshotResult | None = None
+        self.change_result: ChangeSummaryResult | None = None
+        self.work_graph_result: WorkGraphNeighborsResult | None = None
+        self.metric_results: list[MetricQueryResult] = []
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        assert self.status_result is not None
+        return self.status_result
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        assert self.change_result is not None
+        return self.change_result
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        assert self.work_graph_result is not None
+        return self.work_graph_result
+
+    def list_metrics(self, scope):
+        return [result.definition for result in self.metric_results]
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        for result in self.metric_results:
+            if result.definition.metric_id.value == metric_id:
+                return result
+        raise AssertionError(f"no fixture metric result for {metric_id!r}")
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        self._counter += 1
+        handle = "ev1_" + f"{self._counter:040x}"
+        self.mint_calls[handle] = {
+            "source_system": source_system,
+            "source_version": source_version,
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+        }
+        return handle
+
+
+def _registry(spy: _SpyRuntime) -> StepRegistry:
+    registry = StepRegistry()
+    register_builtin_steps(registry, spy)
+    return registry
+
+
+def _minted_identity(spy: _SpyRuntime, fact) -> tuple[str, str, str, str]:
+    """The real minted identity for ``fact``'s (assumed single) evidence
+    handle, straight from the spy's recorded mint-call kwargs."""
+
+    assert len(fact.evidence_ref_ids) == 1
+    call = spy.mint_calls[fact.evidence_ref_ids[0]]
+    return (
+        call["source_system"],
+        call["source_version"],
+        call["entity_type"],
+        call["entity_id"],
+    )
+
+
+def _assert_cell_matches_minting(field: str, fact, spy: _SpyRuntime) -> None:
+    cell = EVIDENCE_IDENTITY_TABLE[field]
+    assert cell.mode == "required"
+    assert cell.derive is not None
+    assert cell.derive(fact) == _minted_identity(spy, fact)
+
+
+# -- source-anchored tests: one per CONTENT_SLOT_FIELDS cell -----------------
+
+
+def _status_snapshot_result(
+    *,
+    declared: StatusFact | None = None,
+    children: tuple[StatusFact, ...] = (),
+    required_children: tuple[StatusFact, ...] = (),
+    pull_requests: tuple[PullRequestFact, ...] = (),
+    ci: tuple[CIFact, ...] = (),
+    deployments: tuple[DeploymentFact, ...] = (),
+    incidents: tuple[IncidentFact, ...] = (),
+) -> StatusSnapshotResult:
+    return StatusSnapshotResult(
+        contract_version="status_snapshot.v1",
+        state=StatusResultState.COMPLETE,
+        scope=project_scope(),
+        as_of=OBSERVED_AT,
+        declared=declared,
+        actual=ActualCompletion(
+            state=CompletionState.NOT_READY,
+            rule_id="actual-completion",
+            rule_version="v1",
+            reason_codes=(),
+            required_children=required_children,
+            conflicts=(),
+            source_ref_ids=(),
+            evidence_ref_ids=(),
+        ),
+        children=children,
+        blockers=(),
+        pull_requests=pull_requests,
+        ci=ci,
+        deployments=deployments,
+        incidents=incidents,
+        source_refs=(),
+        warnings=(),
+    )
+
+
+async def _run_status_snapshot(spy: _SpyRuntime):
+    registry = _registry(spy)
+    ctx = step_context_for()
+    return await registry.get("status.entity.v2", "status_snapshot").run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_status_facts_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        declared=StatusFact(
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            status="in_progress",
+            observed_at=OBSERVED_AT,
+            source_ref_id="ref-declared",
+            evidence_ref_ids=(),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.status_facts) == 1
+    _assert_cell_matches_minting("status_facts", outcome.content.status_facts[0], spy)
+
+
+@pytest.mark.asyncio
+async def test_required_children_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        required_children=(
+            StatusFact(
+                entity_type="issue",
+                entity_id="issue-child-1",
+                display_label="Child",
+                status="open",
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-child",
+                evidence_ref_ids=(),
+            ),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.required_children) == 1
+    _assert_cell_matches_minting(
+        "required_children", outcome.content.required_children[0], spy
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_requests_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        pull_requests=(
+            PullRequestFact(
+                entity_id="pr-1",
+                display_label="Fix bug",
+                state="open",
+                review_state="approved",
+                changes_requested=0,
+                merged=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-pr",
+                evidence_ref_ids=(),
+                required=True,
+            ),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.pull_requests) == 1
+    _assert_cell_matches_minting("pull_requests", outcome.content.pull_requests[0], spy)
+
+
+@pytest.mark.asyncio
+async def test_ci_checks_identity_cell_matches_real_minting_including_check_discriminator():
+    """The cell most directly implicated in round-3 finding 3: a check-level
+    entity_id (with the "#check..." acceptance-check suffix) must derive the
+    SAME coarsened entity_id AND the SAME check-specific source_version the
+    real mint call actually used."""
+
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        ci=(
+            CIFact(
+                entity_id="repo#ci7#checkA",
+                display_label="build",
+                conclusion="success",
+                required=True,
+                skipped_required_work=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-ci",
+                evidence_ref_ids=(),
+            ),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.ci_checks) == 1
+    fact = outcome.content.ci_checks[0]
+    _assert_cell_matches_minting("ci_checks", fact, spy)
+    # The discriminator itself, spelled out: source_version must embed the
+    # FULL check-specific id, not just the coarsened run id.
+    ci_derive = EVIDENCE_IDENTITY_TABLE["ci_checks"].derive
+    assert ci_derive is not None
+    _source_system, source_version, _entity_type, entity_id = ci_derive(fact)
+    assert entity_id == "repo#ci7"
+    assert source_version.endswith("repo#ci7#checkA")
+
+
+@pytest.mark.asyncio
+async def test_deployments_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        deployments=(
+            DeploymentFact(
+                entity_id="deploy-1",
+                display_label="prod",
+                status="succeeded",
+                environment="production",
+                required=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-deploy",
+                evidence_ref_ids=(),
+            ),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.deployments) == 1
+    _assert_cell_matches_minting("deployments", outcome.content.deployments[0], spy)
+
+
+@pytest.mark.asyncio
+async def test_incidents_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.status_result = _status_snapshot_result(
+        incidents=(
+            IncidentFact(
+                entity_id="incident-1",
+                display_label="Outage",
+                status="resolved",
+                active=False,
+                blocking=False,
+                observed_at=OBSERVED_AT,
+                source_ref_id="ref-incident",
+                evidence_ref_ids=(),
+            ),
+        )
+    )
+    outcome = await _run_status_snapshot(spy)
+    assert outcome.content is not None
+    assert len(outcome.content.incidents) == 1
+    _assert_cell_matches_minting("incidents", outcome.content.incidents[0], spy)
+
+
+@pytest.mark.asyncio
+async def test_observed_changes_identity_cell_matches_real_minting_all_three_branches():
+    """``_identity_observed_change`` branches three ways -- exercise all
+    three from one real ``change_summary`` run."""
+
+    spy = _SpyRuntime()
+    scope = project_scope()
+    scope = scope.model_copy(update={"comparison_range": scope.time_range})
+    window = ChangeWindow(OBSERVED_AT, OBSERVED_AT)
+    spy.change_result = ChangeSummaryResult(
+        contract_version="change_summary.v1",
+        state=StatusResultState.COMPLETE,
+        current_window=window,
+        comparison_window=window,
+        changes=(
+            ObservedChange(
+                change_id="change-relationship",
+                category=ChangeCategory.RELATIONSHIP,
+                entity_type="issue",
+                entity_id="issue-1",
+                display_label="Linked",
+                before=None,
+                after="pr-1",
+                observed_at=OBSERVED_AT,
+                claim_kind=ClaimKind.OBSERVED,
+                relationship_chain=(),
+                metric_id=None,
+                metric_value=None,
+                metric_comparison_value=None,
+                source_ref_ids=(),
+                evidence_ref_ids=(),
+            ),
+            ObservedChange(
+                change_id="change-status",
+                category=ChangeCategory.STATUS,
+                entity_type="project",
+                entity_id="project-ask-dev",
+                display_label="Ask Dev",
+                before="planned",
+                after="in_progress",
+                observed_at=OBSERVED_AT,
+                claim_kind=ClaimKind.OBSERVED,
+                relationship_chain=(),
+                metric_id=None,
+                metric_value=None,
+                metric_comparison_value=None,
+                source_ref_ids=(),
+                evidence_ref_ids=(),
+            ),
+            ObservedChange(
+                change_id="change-entity",
+                category=ChangeCategory.ENTITY,
+                entity_type="issue",
+                entity_id="issue-2",
+                display_label="Issue Two",
+                before=None,
+                after=None,
+                observed_at=OBSERVED_AT,
+                claim_kind=ClaimKind.OBSERVED,
+                relationship_chain=(),
+                metric_id=None,
+                metric_value=None,
+                metric_comparison_value=None,
+                source_ref_ids=(),
+                evidence_ref_ids=(),
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+    )
+    ctx = step_context_for(scope=scope)
+    registry = _registry(spy)
+    outcome = await registry.get("change.observed.v1", "change_summary").run(ctx)
+
+    assert outcome.content is not None
+    assert len(outcome.content.observed_changes) == 3
+    for change in outcome.content.observed_changes:
+        _assert_cell_matches_minting("observed_changes", change, spy)
+
+
+@pytest.mark.asyncio
+async def test_graph_edges_identity_cell_matches_real_minting():
+    spy = _SpyRuntime()
+    spy.work_graph_result = WorkGraphNeighborsResult(
+        schema_version=WORK_GRAPH_SCHEMA_VERSION,
+        state=WorkGraphResultState.COMPLETE,
+        nodes=(),
+        edges=(
+            WorkGraphNeighborEdge(
+                edge_id="edge-1",
+                source_type="issue",
+                source_id="issue-1",
+                target_type="pr",
+                target_id="pr-1",
+                relationship_type="references",
+                direction=GraphDirection.BOTH,
+                provenance="persisted",
+                confidence=0.9,
+                source_ref_id="ref-edge",
+                observed_at=OBSERVED_AT,
+            ),
+        ),
+        source_refs=(),
+        warnings=(),
+        total_count=1,
+        returned_count=1,
+        truncated=False,
+        depth=1,
+        query_version=WORK_GRAPH_QUERY_VERSION,
+        watermark=None,
+    )
+    base = project_scope()
+    scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=base.organization_id,
+        direct_scope=DirectScope.ISSUE,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id="issue-1",
+                display_label="Issue One",
+            )
+        ],
+        time_range=base.time_range,
+    )
+    ctx = step_context_for(scope=scope)
+    registry = _registry(spy)
+    outcome = await registry.get("status.entity.v2", "work_graph_expansion").run(ctx)
+
+    assert outcome.content is not None
+    assert len(outcome.content.graph_edges) == 1
+    _assert_cell_matches_minting("graph_edges", outcome.content.graph_edges[0], spy)
+
+
+@pytest.mark.asyncio
+async def test_metric_refs_identity_cell_matches_real_minting():
+    definition = MetricDefinition(
+        metric_id=MetricID.CYCLE_TIME_P50_HOURS,
+        label="Cycle Time",
+        owner="ask-dev",
+        description="desc",
+        definition_version="v1",
+        source_table="work_items",
+        source_version="v1",
+        query_version="v1",
+        unit="days",
+        aggregation="avg",
+        display_precision=1,
+        null_semantics="no_data",
+        zero_semantics="measured_zero",
+        supported_scopes=(),
+        supports_team_filter=False,
+        supported_dimensions=(),
+        min_range_days=1,
+        max_range_days=90,
+        supported_presets=(),
+        supported_time_grains=("day",),
+        comparison_rule="prior_period",
+        freshness_policy="p.v1",
+        expected_materialization="daily",
+        upstream_sources=("work_items",),
+        sensitivity="internal",
+        entitlement="community",
+    )
+    metric_result = MetricQueryResult(
+        definition=definition,
+        state=MetricDataState.VALUE,
+        freshness=FreshnessState.FRESH,
+        values=(
+            MetricQueryValue(
+                dimensions=(), value=3.5, comparison_value=None, series=()
+            ),
+        ),
+        coverage=1.0,
+        current_window_start=OBSERVED_AT,
+        current_window_end=OBSERVED_AT,
+        comparison_window_start=None,
+        comparison_window_end=None,
+        watermark=OBSERVED_AT,
+        source_refs=(
+            MetricSourceRef(
+                ref_id="ref-metric",
+                source_table="work_items",
+                source_version="v1",
+                watermark=OBSERVED_AT,
+                query_version="v1",
+            ),
+        ),
+    )
+    spy = _SpyRuntime(metric_results=[metric_result])
+    ctx = step_context_for(requested_metric_ids=(MetricID.CYCLE_TIME_P50_HOURS.value,))
+    registry = _registry(spy)
+    outcome = await registry.get("metric.comparison.v1", "registered_metric_query").run(
+        ctx
+    )
+
+    assert outcome.content is not None
+    assert len(outcome.content.metric_refs) == 1
+    _assert_cell_matches_minting("metric_refs", outcome.content.metric_refs[0], spy)
+
+
+def test_evidence_identity_table_is_total_over_content_slot_fields():
+    assert set(EVIDENCE_IDENTITY_TABLE) == set(CONTENT_SLOT_FIELDS)
+    for field, cell in EVIDENCE_IDENTITY_TABLE.items():
+        assert cell.mode == "required", (
+            f"{field}: every wire_* helper in builtin_steps.py mints "
+            "unconditionally today -- an accepted_risk cell here would be a "
+            "fabricated exemption, not an honest one; if this ever "
+            "legitimately changes, this assertion is the reminder to add a "
+            "real rationale rather than silently loosen the table."
+        )
+        assert cell.derive is not None
+
+
+# -- permanent RED tests: the three round-3 Codex repros, verbatim ----------
+#
+# Below this line uses a lower-level, hand-built-content harness (like the
+# round-1/round-2 suites) rather than the spy runtime above -- these tests
+# are about the EXECUTOR's verification decision given a step's content, not
+# about proving a table cell matches a real mint call (already covered
+# above).
+
+from dev_health_ops.api.dev.contracts import DevTimeRange  # noqa: E402
+from dev_health_ops.api.dev.contracts_v2.base import (  # noqa: E402
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import (  # noqa: E402
+    DevCIFactV2,
+    DevDeploymentFactV2,
+    DevIncidentFactV2,
+    DevMetricRefV2,
+    DevPullRequestFactV2,
+    DevRequiredChildFactV2,
+    DevScopeV2,
+    DevStatusFactV2,
+)
+from dev_health_ops.api.dev.contracts_v2.plan import (  # noqa: E402
+    DevInvestigationPlan,
+    DevSourceRequirement,
+)
+from dev_health_ops.api.dev.contracts_v2.result import DevSourceContent  # noqa: E402
+from dev_health_ops.api.dev.investigation_plans import (  # noqa: E402
+    PlanExecutor,
+    PlanStepDefinition,
+    StepContext,
+    StepOutcome,
+    wrap_runtime_with_mint_receipts,
+)
+
+ROOT_ENTITY_ID = "project-1"
+
+
+def _now() -> datetime:
+    return OBSERVED_AT
+
+
+def _scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": ROOT_ENTITY_ID,
+                "display_label": "Project One",
+                "repository_id": None,
+            }
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 7, 1, tzinfo=UTC),
+            end=datetime(2026, 7, 31, tzinfo=UTC),
+            timezone="UTC",
+        ),
+    )
+
+
+def _context() -> StepContext:
+    return StepContext(
+        org_id=ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=_scope(),
+        run_id="run-1",
+        now=_now(),
+    )
+
+
+def _plan(source_class: SourceClass) -> DevInvestigationPlan:
+    return DevInvestigationPlan(
+        schema_version="dev_investigation_plan.v1",
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        supported_subject_kinds=(EntityKind.PROJECT,),
+        supported_cardinalities=(Cardinality.SINGULAR, Cardinality.ORGANIZATION_WIDE),
+        mandatory_steps=("one",),
+        conditional_steps=(),
+        step_dependencies=(),
+        source_requirements=(
+            DevSourceRequirement(
+                schema_version="dev_source_requirement.v1",
+                source_class=source_class,
+                adapter_id="test.one.v1",
+                requirement_level="mandatory",
+                freshness_policy="p.v1",
+                minimum_usable_facts=0,
+            ),
+        ),
+        batch_strategy="single",
+        per_step_timeout_seconds=5,
+        max_rows_per_step=10,
+        max_bytes_per_step=1_000,
+        enrichment_allowed=False,
+        completion_rule_id="test.rule",
+        completion_rule_version="1",
+    )
+
+
+async def _run_single_step(
+    *, source_class: SourceClass, run, verify_mint_receipts: bool
+):
+    plan = _plan(source_class)
+    registry = StepRegistry()
+    registry.register(
+        PlanStepDefinition(
+            step_id="one",
+            plan_id=plan.plan_id,
+            source_class=source_class,
+            adapter_id="test.one.v1",
+            requirement_level="mandatory",
+            run=run,
+        )
+    )
+    executor = PlanExecutor(
+        registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
+    )
+    result = await executor.run(
+        plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
+    )
+    assert len(result.observations) == 1
+    return result, result.observations[0]
+
+
+def _queried_outcome(content: DevSourceContent) -> StepOutcome:
+    return StepOutcome(
+        observed_state=SourceRequirementState.AVAILABLE_CURRENT,
+        data_semantics="measured_zero",
+        usable_fact_count=1,
+        content=content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_red_evidence_free_ci_fact_is_rejected():
+    """RED (Codex round 3, [HIGH]): the exact repro -- a fully fabricated
+    ``DevCIFactV2`` with ``evidence_ref_ids=()`` and zero ``mint_evidence``
+    calls anywhere in the step. Pre-round-4 this was accepted as
+    ``available_current`` with a minted "verified" relationship path and
+    ``relationship_closure_verified=True``. Must now be rejected, never
+    raise."""
+
+    fabricated_ci = DevCIFactV2(
+        entity_id="fake-ci-run",
+        display_label="totally fabricated, no mint call ever happened",
+        conclusion="success",
+        required=True,
+        skipped_required_work=False,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=(),
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", ci_checks=(fabricated_ci,)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_required:")
+    assert "ci_checks" in observation.limitation
+    assert observation.relationship_paths == ()
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_red_evidence_free_fact_still_accepted_when_verification_is_off():
+    """Backward-compat control: ``verify_mint_receipts=False`` (every
+    pre-3296 test/harness, and the default) must remain completely
+    unaffected by the require-known-good check -- it only ever runs inside
+    the ``verify_mint_receipts`` gate."""
+
+    fabricated_ci = DevCIFactV2(
+        entity_id="fake-ci-run",
+        display_label="no evidence, verification off",
+        conclusion="success",
+        required=True,
+        skipped_required_work=False,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=(),
+    )
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", ci_checks=(fabricated_ci,)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=False
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.ci_checks) == 1
+    del result
+
+
+class _MintOnlyRuntime:
+    def __init__(self) -> None:
+        self.mint_calls = 0
+
+    async def status_snapshot(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def change_summary(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def list_metrics(self, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def query_metric(self, *, org_id, permission_fingerprint, metric_id, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def work_graph_neighbors(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("not exercised by this suite")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        self.mint_calls += 1
+        return "ev1_" + f"{self.mint_calls:040x}"
+
+
+@pytest.mark.asyncio
+async def test_red_ci_check_a_handle_reused_on_check_b_is_rejected():
+    """RED (Codex round 3, [MEDIUM]): a handle genuinely minted for
+    repo#ci7/checkA -- coarsened to entity_id "repo#ci7", source_version
+    embedding the full check-specific id -- reused verbatim on a fabricated
+    fact for repo#ci7/checkB. Round 2's entity_type/entity_id-only
+    comparison could not distinguish them (both coarsen to the same
+    entity_id); comparing source_version too must now catch it."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version="status-snapshot-evidence.v1:repo#ci7#checkA",
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_check_a = DevCIFactV2(
+            entity_id="repo#ci7#checkA",
+            display_label="checkA really succeeded",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        forged_check_b = DevCIFactV2(
+            entity_id="repo#ci7#checkB",
+            display_label="checkB fabricated success (really failing)",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                ci_checks=(genuine_check_a, forged_check_b),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 1
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert "repo#ci7" in observation.limitation
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_ci_check_a_and_check_b_each_with_their_own_handle_are_both_accepted():
+    """Positive control for the coarsening fix: two DIFFERENT checks on the
+    same run, each with its own genuinely-minted, check-specific handle,
+    must both be accepted."""
+
+    runtime = _MintOnlyRuntime()
+    wrapped = wrap_runtime_with_mint_receipts(runtime)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        handle_a = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version="status-snapshot-evidence.v1:repo#ci7#checkA",
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        handle_b = wrapped.mint_evidence(
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version="status-snapshot-evidence.v1:repo#ci7#checkB",
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkB",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        check_a = DevCIFactV2(
+            entity_id="repo#ci7#checkA",
+            display_label="checkA",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle_a,),
+        )
+        check_b = DevCIFactV2(
+            entity_id="repo#ci7#checkB",
+            display_label="checkB",
+            conclusion="failure",
+            required=True,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle_b,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1", ci_checks=(check_a, check_b)
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run, verify_mint_receipts=True
+    )
+
+    assert runtime.mint_calls == 2
+    assert observation.content is not None
+    assert len(observation.content.ci_checks) == 2
+    assert result.relationship_closure_verified is True
+
+
+# -- evidence_required coverage across every evidence-capable slot ----------
+
+
+def _fact_with_no_evidence(field: str):
+    # "status_facts" is deliberately absent: DevStatusFactV2.evidence_ref_ids
+    # already carries min_length=1 at the contract layer (inherited from v1's
+    # DevStatusFact) -- pydantic itself rejects an empty tuple before this
+    # fixture, let alone the executor, ever sees it. The require-known-good
+    # check is real defense-in-depth for that one category (unreachable
+    # today, not untested), not a gap; the other eight categories have no
+    # such contract-layer backstop, which is exactly what this parametrized
+    # test proves the executor itself now closes.
+    if field == "required_children":
+        return DevRequiredChildFactV2(
+            fact_id="issue:x", text="t", status="open", evidence_ref_ids=()
+        )
+    if field == "pull_requests":
+        return DevPullRequestFactV2(
+            entity_id="pr-x",
+            display_label="d",
+            state="open",
+            review_state=None,
+            changes_requested=0,
+            merged=False,
+            required=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "ci_checks":
+        return DevCIFactV2(
+            entity_id="ci-x",
+            display_label="d",
+            conclusion="success",
+            required=False,
+            skipped_required_work=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "deployments":
+        return DevDeploymentFactV2(
+            entity_id="deploy-x",
+            display_label="d",
+            status="succeeded",
+            environment=None,
+            required=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "incidents":
+        return DevIncidentFactV2(
+            entity_id="incident-x",
+            display_label="d",
+            status="resolved",
+            active=False,
+            blocking=False,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "graph_edges":
+        from dev_health_ops.api.dev.contracts_v2.embedded import DevGraphEdgeV2
+
+        return DevGraphEdgeV2(
+            edge_id="edge-x",
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-x",
+            provenance="work_graph",
+            confidence=1.0,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "observed_changes":
+        from dev_health_ops.api.dev.contracts_v2.result import DevObservedChangeV2
+
+        return DevObservedChangeV2(
+            change_id="change-x",
+            category="entity",
+            entity_type="issue",
+            entity_id="issue-x",
+            display_label="d",
+            before=None,
+            after=None,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+    if field == "metric_refs":
+        scope_v2 = DevScopeV2.model_validate(_scope().model_dump(mode="json"))
+        return DevMetricRefV2(
+            schema_version="dev_metric_ref.v1",
+            metric_ref_id="metric:x",
+            metric_id=MetricID.CYCLE_TIME_P50_HOURS,
+            label="l",
+            definition_version="v1",
+            unit="hours",
+            aggregation="avg",
+            display_precision=1,
+            resolved_scope=scope_v2,
+            dimensions=(),
+            current_window=_scope().time_range,
+            comparison_window=None,
+            value=1.0,
+            comparison_value=None,
+            series=(),
+            query_version="v1",
+            source_version="v1",
+            freshness=FreshnessState.FRESH,
+            coverage=1.0,
+            evidence_ref_ids=(),
+        )
+    raise AssertionError(f"no no-evidence builder for {field!r}")
+
+
+@pytest.mark.parametrize(
+    ("source_class", "field"),
+    [
+        (SourceClass.STATUS_CHANGE, "required_children"),
+        (SourceClass.STATUS_CHANGE, "pull_requests"),
+        (SourceClass.STATUS_CHANGE, "ci_checks"),
+        (SourceClass.STATUS_CHANGE, "deployments"),
+        (SourceClass.STATUS_CHANGE, "incidents"),
+        (SourceClass.WORK_GRAPH, "graph_edges"),
+        (SourceClass.STATUS_CHANGE, "observed_changes"),
+        (SourceClass.WORK_ITEM, "metric_refs"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_evidence_required_rejects_zero_evidence_across_every_slot(
+    source_class, field
+):
+    fact = _fact_with_no_evidence(field)
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", **{field: (fact,)})
+        )
+
+    result, observation = await _run_single_step(
+        source_class=source_class, run=run, verify_mint_receipts=True
+    )
+
+    assert observation.content is None
+    assert observation.limitation is not None
+    assert observation.limitation == f"evidence_required:{field}"
+    assert result.relationship_closure_verified is False
+
+
+def test_status_facts_ninth_slot_is_covered_by_the_contract_layer_itself():
+    """The ninth slot ``test_evidence_required_rejects_zero_evidence_
+    across_every_slot`` cannot parametrize: ``DevStatusFactV2.evidence_
+    ref_ids`` already carries ``min_length=1`` (inherited from v1's
+    ``DevStatusFact``), so pydantic itself rejects an empty tuple before
+    construction ever completes -- proven here directly, so this coverage
+    claim is a demonstrated fact, not an assumption. Every one of the other
+    eight ``CONTENT_SLOT_FIELDS`` categories has no such backstop, which is
+    exactly why the executor's own require-known-good check (the
+    parametrized test above) is load-bearing for them."""
+
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="too_short"):
+        DevStatusFactV2(fact_id="issue:x", text="t", evidence_ref_ids=())

--- a/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
+++ b/tests/api/dev/test_chaos_3296_round4_evidence_identity_table.py
@@ -84,7 +84,12 @@ from dev_health_ops.api.dev.work_graph_neighbors_service import (
     WorkGraphNeighborsResult,
     WorkGraphResultState,
 )
-from tests._chaos_3295_plan_executor import project_scope, step_context_for
+from tests._chaos_3295_plan_executor import (
+    TEST_EVIDENCE_SIGNER,
+    project_scope,
+    sign_evidence,
+    step_context_for,
+)
 
 OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
 ORG_ID = "org_fullchaos"
@@ -145,7 +150,22 @@ class _SpyRuntime:
         repository_ids=(),
     ):
         self._counter += 1
-        handle = "ev1_" + f"{self._counter:040x}"
+        # CHAOS-3296 round 5: a REAL, ``TEST_EVIDENCE_SIGNER``-verifiable
+        # handle -- not an opaque counter string -- so this spy's minted
+        # handles genuinely pass ``PlanExecutor``'s signature check wherever
+        # a test in this file exercises it (see ``_run_single_step``).
+        handle = sign_evidence(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            repository_ids=repository_ids,
+        )
         self.mint_calls[handle] = {
             "source_system": source_system,
             "source_version": source_version,
@@ -324,13 +344,14 @@ async def test_ci_checks_identity_cell_matches_real_minting_including_check_disc
     assert len(outcome.content.ci_checks) == 1
     fact = outcome.content.ci_checks[0]
     _assert_cell_matches_minting("ci_checks", fact, spy)
-    # The discriminator itself, spelled out: source_version must embed the
-    # FULL check-specific id, not just the coarsened run id.
+    # The discriminators themselves, spelled out: source_version must embed
+    # the FULL check-specific id (round 4), not just the coarsened run id,
+    # AND a digest of the check's own asserted content (round 5).
     ci_derive = EVIDENCE_IDENTITY_TABLE["ci_checks"].derive
     assert ci_derive is not None
     _source_system, source_version, _entity_type, entity_id = ci_derive(fact)
     assert entity_id == "repo#ci7"
-    assert source_version.endswith("repo#ci7#checkA")
+    assert ":repo#ci7#checkA#content:" in source_version
 
 
 @pytest.mark.asyncio
@@ -629,7 +650,9 @@ from dev_health_ops.api.dev.investigation_plans import (  # noqa: E402
     PlanStepDefinition,
     StepContext,
     StepOutcome,
-    wrap_runtime_with_mint_receipts,
+)
+from dev_health_ops.api.dev.investigation_plans.builtin_steps import (  # noqa: E402
+    _ci_check_source_version,
 )
 
 ROOT_ENTITY_ID = "project-1"
@@ -717,7 +740,9 @@ async def _run_single_step(
         )
     )
     executor = PlanExecutor(
-        registry=registry, now=_now, verify_mint_receipts=verify_mint_receipts
+        registry=registry,
+        now=_now,
+        evidence_signer=TEST_EVIDENCE_SIGNER if verify_mint_receipts else None,
     )
     result = await executor.run(
         plan=plan, context=_context(), run_id="run-1", subject_entity_id=ROOT_ENTITY_ID
@@ -845,26 +870,43 @@ class _MintOnlyRuntime:
         repository_ids=(),
     ):
         self.mint_calls += 1
-        return "ev1_" + f"{self.mint_calls:040x}"
+        return sign_evidence(
+            org_id=org_id,
+            source_system=source_system,
+            source_version=source_version,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            display_label=display_label,
+            observed_at=observed_at,
+            freshness=freshness,
+            confidence=confidence,
+            repository_ids=repository_ids,
+        )
 
 
 @pytest.mark.asyncio
 async def test_red_ci_check_a_handle_reused_on_check_b_is_rejected():
     """RED (Codex round 3, [MEDIUM]): a handle genuinely minted for
     repo#ci7/checkA -- coarsened to entity_id "repo#ci7", source_version
-    embedding the full check-specific id -- reused verbatim on a fabricated
-    fact for repo#ci7/checkB. Round 2's entity_type/entity_id-only
-    comparison could not distinguish them (both coarsen to the same
-    entity_id); comparing source_version too must now catch it."""
+    embedding the full check-specific id (round 4) plus a digest of checkA's
+    own asserted content (round 5) -- reused verbatim on a fabricated fact
+    for repo#ci7/checkB. Round 2's entity_type/entity_id-only comparison
+    could not distinguish them (both coarsen to the same entity_id);
+    recomputing the real signature from each fact's own derived identity
+    must now catch it."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle = wrapped.mint_evidence(
+        handle = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="ci_runs",
-            source_version="status-snapshot-evidence.v1:repo#ci7#checkA",
+            source_version=_ci_check_source_version(
+                "repo#ci7#checkA",
+                conclusion="success",
+                required=True,
+                skipped_required_work=False,
+            ),
             entity_type="ci_run",
             entity_id="repo#ci7",
             display_label="checkA",
@@ -904,7 +946,7 @@ async def test_red_ci_check_a_handle_reused_on_check_b_is_rejected():
     assert observation.content is None
     assert observation.observed_state is SourceRequirementState.UNAVAILABLE
     assert observation.limitation is not None
-    assert observation.limitation.startswith("evidence_entity_mismatch:")
+    assert observation.limitation.startswith("evidence_signature_invalid:")
     assert "repo#ci7" in observation.limitation
     assert result.relationship_closure_verified is False
 
@@ -916,23 +958,32 @@ async def test_ci_check_a_and_check_b_each_with_their_own_handle_are_both_accept
     must both be accepted."""
 
     runtime = _MintOnlyRuntime()
-    wrapped = wrap_runtime_with_mint_receipts(runtime)
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        handle_a = wrapped.mint_evidence(
+        handle_a = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="ci_runs",
-            source_version="status-snapshot-evidence.v1:repo#ci7#checkA",
+            source_version=_ci_check_source_version(
+                "repo#ci7#checkA",
+                conclusion="success",
+                required=True,
+                skipped_required_work=False,
+            ),
             entity_type="ci_run",
             entity_id="repo#ci7",
             display_label="checkA",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
-        handle_b = wrapped.mint_evidence(
+        handle_b = runtime.mint_evidence(
             org_id=ORG_ID,
             source_system="ci_runs",
-            source_version="status-snapshot-evidence.v1:repo#ci7#checkB",
+            source_version=_ci_check_source_version(
+                "repo#ci7#checkB",
+                conclusion="failure",
+                required=True,
+                skipped_required_work=False,
+            ),
             entity_type="ci_run",
             entity_id="repo#ci7",
             display_label="checkB",

--- a/tests/api/dev/test_chaos_3296_round5_signature_verification.py
+++ b/tests/api/dev/test_chaos_3296_round5_signature_verification.py
@@ -1,72 +1,51 @@
-"""Round-5 closure (CHAOS-3296 Codex round 4, 2026-08-02): recomputed-
-signature verification, replacing the per-run receipt comparison rounds
-1-4 all built.
+"""Round-5/6 closure (CHAOS-3296 Codex rounds 4-5, 2026-08-02): recomputed-
+signature verification, an authorization-scope snapshot, and PROGRAMMATIC
+content-projection binding -- replacing the per-run receipt comparison
+rounds 1-4 built, and the hand-picked claim-field lists round 5 built.
 
 Round 4's closure (the evidence identity table + require-known-good) still
 compared a re-derived SUBSET of a handle's identity -- (source_system,
 source_version, entity_type, entity_id) -- against a per-run RECEIPT this
-executor maintained itself. An adversary only had to vary whatever the
-receipt didn't carry:
+executor maintained itself:
 
 1. [HIGH] The receipt never recorded org_id/repository_ids, though the real
    ``EvidenceReferenceSigner``'s HMAC binds both. A handle genuinely minted
-   for a DIFFERENT tenant/repository scope verified clean as long as the
-   remaining four fields happened to match.
-2. [HIGH] No round bound the fact's own asserted CONTENT at all. A genuine
-   handle for a failing CI check verified a fabricated fact claiming it
-   passed.
+   for a DIFFERENT tenant/repository scope verified clean.
+2. [HIGH] No round bound a fact's own asserted CONTENT at all.
 
-The fix is a structural inversion, not a wider receipt: verification
-recomputes the ACTUAL signature via ``EvidenceReferenceSigner.verify`` --
-the exact code every real mint call already goes through -- from (a) the
-fact's own re-derived identity and (b) the CURRENT ``StepContext``'s
-already-authorized org_id/repositories, never from anything carried by the
-fact or the handle being checked.
+Round 5 replaced the receipt with recomputed-signature verification
+(``EvidenceReferenceSigner.verify``, never re-implemented) and folded a
+content digest into ``source_version`` -- but round 5's own content binding
+used HAND-PICKED claim-field lists, and its ambient-scope binding read
+``context.scope`` fresh at verify time. Codex round 5 review confirmed 3
+MORE findings, closed here:
 
-Content binding (finding 2) was NOT scoped to ``ci_checks`` -- a provisional
-first pass claimed it was the sole category with a collision-prone identity,
-but the underlying gap is general: ANY category whose minted identity tuple
-does not already uniquely determine its content lets a genuinely-minted
-handle for one claim "verify" a fabricated, different claim about the same
-identity (a status fact citing a real handle while asserting a DIFFERENT
-status than what was observed at mint; a deployment/incident/PR the same
-way; an observed change with swapped before/after; a graph edge with a
-forged relationship/orientation; a metric with a fabricated value). Every
-``builtin_steps.py`` ``wire_*``/mint call site now folds a digest of that
-category's own claim fields -- the exact fields that survive onto its
-``DevSourceContent`` wire type -- into the minted ``source_version`` via ONE
-shared ``builtin_steps._bind_content``, and every
-``relationship_matrix.EVIDENCE_IDENTITY_TABLE`` cell's ``derive`` recomputes
-the SAME claim fields from the wire fact and calls the SAME function. Two
-facts differing only in their claim mint different, non-interchangeable
-handles; there is no receipt to bind content to, because there is no
-receipt.
+1. [HIGH] ``DevScope`` is frozen, but its ``repositories``/``team_ids``
+   fields are mutable LIST values -- a step that mutated
+   ``context.scope.repositories`` in place mid-run, then minted against its
+   own self-chosen value, verified clean (verification re-read the SAME
+   mutated list AFTER the step had already run). And a TEAM-scoped
+   investigation has an EMPTY ``repositories`` with ``team_ids`` never
+   bound at all, so two DIFFERENT teams' investigations minted identical
+   handles for identical content. Fixed: ``PlanExecutor.run`` snapshots a
+   deeply immutable ``_AuthorizationScope`` (direct_scope/team_ids/
+   entity_ids/repositories) BEFORE any step runs; verification uses ONLY
+   this snapshot, never a fresh ``context.scope`` read; its team_ids/
+   direct_scope/entity_ids digest is folded into every minted
+   ``source_version`` via ``builtin_steps._scope_bound_mint``.
+2. [HIGH] ``metric_refs``' hand-picked claim list bound only value/
+   comparison_value -- Codex re-labeled a metric to ``avg_wip`` with a
+   forged 999-point series and it verified.
+3. [HIGH] ``graph_edges``' hand-picked claim list omitted provenance/
+   confidence/observed_at -- Codex forged all three on a genuine handle.
 
-This file:
-
-* Proves both round-4 findings closed (cross-tenant/cross-repository
-  handles; content-swapped CI claims) -- the checkA/checkB content-swap
-  repro and the three round-1/2/3 repros (evidence-free fact, graph-edge
-  reuse, checkA-on-checkB run-level coarsening) already live as permanent
-  REDs in ``test_chaos_3296_round4_evidence_identity_table.py`` and
-  ``test_chaos_3296_round2_budget_and_receipts.py``, updated in the same
-  commit as this file to mint through the real signer and assert the new
-  ``evidence_signature_invalid:`` limitation -- not duplicated here.
-* Adds the two NEW round-4 findings this round closes (cross-tenant,
-  cross-repository-scope) as permanent REDs.
-* Adds representative content-swap REDs for two NON-ci_checks categories
-  (status_facts, observed_changes) proving the generalized closure -- not
-  exhaustive over all 9 categories (that would duplicate
-  ``test_evidence_identity_table_is_total_over_content_slot_fields`` and the
-  source-anchored per-cell tests in the round-4 file, which already prove
-  every cell's ``derive`` matches its real mint call site, content fields
-  included), but enough to demonstrate the pattern holds outside CI.
-* Adds the drift guard: a structural identity assertion that every
-  category's mint and verify call the literal same shared content-digest
-  function, plus a mutation test proving that if
-  ``EvidenceReferenceSigner``'s payload construction ever drifts between
-  mint and verify time, the result is REJECTION (fail-closed), never a
-  silent accept.
+Fixed generally, not per-category: ``builtin_steps._claim_projection``
+derives a fact's bound claim fields PROGRAMMATICALLY from the wire model's
+own ``model_fields`` (minus schema_version/evidence_ref_ids) -- a future
+field addition is bound automatically, never silently missed the way a
+hand-picked list can be. Every ``wire_*`` helper now constructs its wire
+model FIRST (evidence_ref_ids still empty), projects, mints, then patches
+in the real handle -- the digest reflects EXACTLY what the wire presents.
 """
 
 from __future__ import annotations
@@ -81,6 +60,7 @@ from dev_health_ops.api.dev.contracts import (
     DevTimeRange,
     DirectScope,
     FreshnessState,
+    MetricID,
 )
 from dev_health_ops.api.dev.contracts_v2.base import (
     Cardinality,
@@ -89,7 +69,13 @@ from dev_health_ops.api.dev.contracts_v2.base import (
     SourceClass,
     SourceRequirementState,
 )
-from dev_health_ops.api.dev.contracts_v2.embedded import DevCIFactV2, DevStatusFactV2
+from dev_health_ops.api.dev.contracts_v2.embedded import (
+    DevCIFactV2,
+    DevGraphEdgeV2,
+    DevMetricRefV2,
+    DevScopeV2,
+    DevStatusFactV2,
+)
 from dev_health_ops.api.dev.contracts_v2.plan import (
     DevInvestigationPlan,
     DevSourceRequirement,
@@ -117,12 +103,22 @@ from dev_health_ops.api.dev.investigation_plans import (
 )
 from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
     _CHANGE_EVIDENCE_SOURCE_VERSION,
+    _GRAPH_EVIDENCE_SOURCE_VERSION,
+    _METRIC_EVIDENCE_SOURCE_VERSION,
     _STATUS_EVIDENCE_SOURCE_VERSION,
     _bind_content,
     _ci_check_source_version,
+    _claim_projection,
+    _metric_ref_id,
 )
 from dev_health_ops.api.dev.investigation_plans.executor import _CandidateIdentity
-from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
+from dev_health_ops.api.dev.investigation_plans.relationship_matrix import (
+    _identity_metric_ref,
+)
+from tests._chaos_3295_plan_executor import (
+    TEST_EVIDENCE_SIGNER,
+    sign_evidence_for_scope,
+)
 
 ORG_ID = "org_fullchaos"
 OTHER_ORG_ID = "org_intruder"
@@ -132,6 +128,14 @@ OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
 
 def _now() -> datetime:
     return OBSERVED_AT
+
+
+def _time_range() -> DevTimeRange:
+    return DevTimeRange(
+        start=datetime(2026, 7, 1, tzinfo=UTC),
+        end=datetime(2026, 7, 31, tzinfo=UTC),
+        timezone="UTC",
+    )
 
 
 def _scope(*, repositories: tuple[str, ...] = ()) -> DevScope:
@@ -148,19 +152,38 @@ def _scope(*, repositories: tuple[str, ...] = ()) -> DevScope:
                 "repository_id": None,
             }
         ],
-        time_range=DevTimeRange(
-            start=datetime(2026, 7, 1, tzinfo=UTC),
-            end=datetime(2026, 7, 31, tzinfo=UTC),
-            timezone="UTC",
-        ),
+        time_range=_time_range(),
     )
 
 
-def _context(*, repositories: tuple[str, ...] = ()) -> StepContext:
+def _team_scope(team_id: str) -> DevScope:
+    """A DirectScope.TEAM scope -- ``repositories`` must be empty (a team
+    direct scope has no repository list of its own; see ``DevScope.
+    validate_direct_scope``), which is exactly why ``team_ids`` needs its
+    own binding independent of ``repositories``."""
+
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.TEAM,
+        team_ids=[team_id],
+        entity_refs=[
+            {
+                "entity_type": "team",
+                "entity_id": team_id,
+                "display_label": team_id,
+                "repository_id": None,
+            }
+        ],
+        time_range=_time_range(),
+    )
+
+
+def _context(*, scope: DevScope | None = None) -> StepContext:
     return StepContext(
         org_id=ORG_ID,
         permission_fingerprint="fingerprint",
-        scope=_scope(repositories=repositories),
+        scope=scope or _scope(),
         run_id="run-1",
         now=_now(),
     )
@@ -246,12 +269,33 @@ def _ci_fact(*, entity_id: str, conclusion: str, handle: str) -> DevCIFactV2:
     )
 
 
-# -- round-4 finding 1: cross-tenant / cross-repository receipt -------------
+def _ci_claim(*, entity_id: str, conclusion: str) -> dict[str, object]:
+    """The exact projection a genuine ``wire_ci`` mint would compute for a
+    CI fact with this entity_id/conclusion (the rest of ``_ci_fact``'s
+    fields are fixed) -- built from the SAME provisional-then-project
+    pattern production uses, never a hand-picked subset. ``evidence_ref_ids``
+    stays empty (never ``("",)`` -- ``OpaqueID`` rejects an empty string):
+    :func:`_claim_projection` excludes it from the digest regardless, so its
+    placeholder value here can never matter."""
+
+    provisional = DevCIFactV2(
+        entity_id=entity_id,
+        display_label="build",
+        conclusion=conclusion,
+        required=True,
+        skipped_required_work=False,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=(),
+    )
+    return _claim_projection(provisional)
+
+
+# -- round-5 finding 1: cross-tenant / cross-repository receipt -------------
 
 
 @pytest.mark.asyncio
 async def test_red_cross_tenant_handle_is_rejected():
-    """RED (Codex round 4, [HIGH]): a handle genuinely minted for a
+    """RED (Codex round 4/5, [HIGH]): a handle genuinely minted for a
     DIFFERENT organization than the one running this step verifies clean
     under a receipt comparison that never carried org_id at all -- round 5
     supplies org_id fresh from the CURRENT ``StepContext`` on every check,
@@ -261,13 +305,12 @@ async def test_red_cross_tenant_handle_is_rejected():
     async def run(_ctx: StepContext) -> StepOutcome:
         source_version = _ci_check_source_version(
             "repo#ci7#checkA",
-            conclusion="success",
-            required=True,
-            skipped_required_work=False,
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
         )
         # Minted for OTHER_ORG_ID -- a different tenant than the one this
         # step actually runs under (ORG_ID, via ``_context()`` below).
-        forged_handle = sign_evidence(
+        forged_handle = sign_evidence_for_scope(
+            scope=_scope(),
             org_id=OTHER_ORG_ID,
             source_system="ci_runs",
             source_version=source_version,
@@ -297,21 +340,19 @@ async def test_red_cross_tenant_handle_is_rejected():
 
 @pytest.mark.asyncio
 async def test_red_cross_repository_scope_handle_is_rejected():
-    """RED (Codex round 4, [HIGH], repository-scope half): a handle
+    """RED (Codex round 4/5, [HIGH], repository-scope half): a handle
     genuinely minted for a DIFFERENT repository scope than the one this
-    step's own ``StepContext`` authorizes. ``repository_ids`` is bound into
-    the real signer's HMAC exactly like ``org_id`` -- round 5 supplies it
-    fresh from ``context.scope.repositories`` on every check, never from the
-    handle."""
+    step's own ``StepContext`` authorizes."""
 
     async def run(_ctx: StepContext) -> StepOutcome:
         source_version = _ci_check_source_version(
             "repo#ci7#checkA",
-            conclusion="success",
-            required=True,
-            skipped_required_work=False,
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
         )
-        forged_handle = sign_evidence(
+        forged_handle = sign_evidence_for_scope(
+            # Minted against a repository the CURRENT step's scope
+            # (``repo-authorized`` below) never authorized.
+            scope=_scope(repositories=("repo-unauthorized",)),
             org_id=ORG_ID,
             source_system="ci_runs",
             source_version=source_version,
@@ -320,9 +361,6 @@ async def test_red_cross_repository_scope_handle_is_rejected():
             display_label="checkA",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
-            # Minted against a repository the CURRENT step's scope
-            # (``repo-authorized`` below) never authorized.
-            repository_ids=("repo-unauthorized",),
         )
         fact = _ci_fact(
             entity_id="repo#ci7#checkA", conclusion="success", handle=forged_handle
@@ -334,7 +372,7 @@ async def test_red_cross_repository_scope_handle_is_rejected():
     result, observation = await _run_single_step(
         source_class=SourceClass.STATUS_CHANGE,
         run=run,
-        context=_context(repositories=("repo-authorized",)),
+        context=_context(scope=_scope(repositories=("repo-authorized",))),
     )
 
     assert observation.content is None
@@ -347,17 +385,17 @@ async def test_red_cross_repository_scope_handle_is_rejected():
 @pytest.mark.asyncio
 async def test_genuine_same_tenant_and_repository_handle_is_accepted():
     """Positive control: a handle minted for the SAME org and repository
-    scope the step actually runs under must still verify -- round 5 must
-    not over-reject legitimate same-tenant evidence."""
+    scope the step actually runs under must still verify."""
+
+    scope = _scope(repositories=("repo-authorized",))
 
     async def run(_ctx: StepContext) -> StepOutcome:
         source_version = _ci_check_source_version(
             "repo#ci7#checkA",
-            conclusion="success",
-            required=True,
-            skipped_required_work=False,
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
         )
-        handle = sign_evidence(
+        handle = sign_evidence_for_scope(
+            scope=scope,
             org_id=ORG_ID,
             source_system="ci_runs",
             source_version=source_version,
@@ -366,7 +404,6 @@ async def test_genuine_same_tenant_and_repository_handle_is_accepted():
             display_label="checkA",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
-            repository_ids=("repo-authorized",),
         )
         fact = _ci_fact(
             entity_id="repo#ci7#checkA", conclusion="success", handle=handle
@@ -378,7 +415,7 @@ async def test_genuine_same_tenant_and_repository_handle_is_accepted():
     result, observation = await _run_single_step(
         source_class=SourceClass.STATUS_CHANGE,
         run=run,
-        context=_context(repositories=("repo-authorized",)),
+        context=_context(scope=scope),
     )
 
     assert observation.content is not None
@@ -386,35 +423,180 @@ async def test_genuine_same_tenant_and_repository_handle_is_accepted():
     assert result.relationship_closure_verified is True
 
 
-# -- generalized content binding: representative non-ci_checks REDs ---------
+# -- round-6 finding 1: mutable ambient scope / unbound team_ids ------------
+
+
+@pytest.mark.asyncio
+async def test_red_mid_step_repository_mutation_does_not_verify():
+    """RED (Codex round 6, [HIGH]): a step mutates ``context.scope.
+    repositories`` IN PLACE mid-step (``DevScope`` is frozen, but the LIST
+    its ``repositories`` attribute points to is not), then mints against
+    that self-chosen value. Verification must use the snapshot captured
+    BEFORE this step ran, never a fresh ``context.scope`` re-read -- so the
+    step's own mutation can never make its own forged handle verify."""
+
+    async def run(ctx: StepContext) -> StepOutcome:
+        # Attacker-controlled: swap the authorized repo list to one this
+        # run was never actually authorized for, AFTER the executor already
+        # snapshotted the true scope.
+        ctx.scope.repositories.clear()
+        ctx.scope.repositories.append("repo-self-chosen")
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
+        )
+        handle = sign_evidence_for_scope(
+            scope=ctx.scope,  # the NOW-mutated scope
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        context=_context(scope=_scope(repositories=("repo-authorized",))),
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_red_cross_team_handle_is_rejected():
+    """RED (Codex round 6, [HIGH]): a TEAM-scoped investigation has an EMPTY
+    ``repositories`` (structurally -- see ``DevScope.validate_direct_scope``)
+    -- a handle genuinely minted under a DIFFERENT team's authorization
+    scope must not verify under this team's, even though ``repositories``
+    is identically empty for both and could never itself distinguish them."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
+        )
+        forged_handle = sign_evidence_for_scope(
+            scope=_team_scope("team-alpha"),  # a DIFFERENT team than team-beta
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=forged_handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        context=_context(scope=_team_scope("team-beta")),
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_genuine_team_scoped_handle_is_accepted():
+    """Positive control: a handle minted under a TEAM scope, cited within
+    the SAME team's investigation, must still verify -- round 6 must not
+    over-reject legitimate team-scoped evidence."""
+
+    scope = _team_scope("team-beta")
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
+        )
+        handle = sign_evidence_for_scope(
+            scope=scope,
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        context=_context(scope=scope),
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.ci_checks) == 1
+    assert result.relationship_closure_verified is True
+
+
+# -- generalized (round-6, programmatic) content binding: representative REDs
 
 
 @pytest.mark.asyncio
 async def test_red_status_fact_content_swap_is_rejected():
     """RED: a handle genuinely minted for a status fact asserting
     "in_progress" reused verbatim on a fabricated fact for the SAME entity
-    claiming "done" instead. Proves the generalized closure holds for
-    ``status_facts``, not just ``ci_checks`` -- a real handle for one status
-    claim can never verify a fabricated different status claim about the
-    same entity."""
+    claiming "done" instead."""
+
+    scope = _scope()
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        genuine_text = "Issue One: in_progress"
-        handle = sign_evidence(
+        # DevStatusFactV2.evidence_ref_ids carries min_length=1 at the
+        # contract layer -- a placeholder handle-shaped string, discarded
+        # by _claim_projection's exclusion regardless of its value.
+        genuine = DevStatusFactV2(
+            fact_id="issue:issue-1",
+            text="Issue One: in_progress",
+            evidence_ref_ids=("ev1_" + "0" * 40,),
+        )
+        source_version = _bind_content(
+            _STATUS_EVIDENCE_SOURCE_VERSION, _claim_projection(genuine)
+        )
+        handle = sign_evidence_for_scope(
+            scope=scope,
             org_id=ORG_ID,
             source_system="work_items",
-            source_version=_bind_content(
-                _STATUS_EVIDENCE_SOURCE_VERSION, claim=genuine_text
-            ),
+            source_version=source_version,
             entity_type="issue",
             entity_id="issue-1",
             display_label="Issue One",
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
-        genuine_fact = DevStatusFactV2(
-            fact_id="issue:issue-1", text=genuine_text, evidence_ref_ids=(handle,)
-        )
+        genuine_fact = genuine.model_copy(update={"evidence_ref_ids": (handle,)})
         forged_fact = DevStatusFactV2(
             fact_id="issue:issue-1",
             text="Issue One: done (fabricated)",
@@ -428,7 +610,7 @@ async def test_red_status_fact_content_swap_is_rejected():
         )
 
     result, observation = await _run_single_step(
-        source_class=SourceClass.STATUS_CHANGE, run=run
+        source_class=SourceClass.STATUS_CHANGE, run=run, context=_context(scope=scope)
     )
 
     assert observation.content is None
@@ -442,14 +624,27 @@ async def test_red_status_fact_content_swap_is_rejected():
 async def test_red_observed_change_before_after_swap_is_rejected():
     """RED: a handle genuinely minted for an observed change asserting
     before="open"/after="closed" reused verbatim on a fabricated change for
-    the SAME entity/change_id claiming a DIFFERENT before/after pair. Proves
-    the generalized closure holds for ``observed_changes``."""
+    the SAME entity/change_id claiming a DIFFERENT before/after pair."""
+
+    scope = _scope()
 
     async def run(_ctx: StepContext) -> StepOutcome:
-        source_version = _bind_content(
-            _CHANGE_EVIDENCE_SOURCE_VERSION, before="open", after="closed"
+        genuine = DevObservedChangeV2(
+            change_id="change-1",
+            category="entity",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One closed",
+            before="open",
+            after="closed",
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
         )
-        handle = sign_evidence(
+        source_version = _bind_content(
+            _CHANGE_EVIDENCE_SOURCE_VERSION, _claim_projection(genuine)
+        )
+        handle = sign_evidence_for_scope(
+            scope=scope,
             org_id=ORG_ID,
             source_system="work_items",
             source_version=source_version,
@@ -459,17 +654,7 @@ async def test_red_observed_change_before_after_swap_is_rejected():
             observed_at=OBSERVED_AT,
             freshness=FreshnessState.FRESH,
         )
-        genuine_change = DevObservedChangeV2(
-            change_id="change-1",
-            category="entity",
-            entity_type="issue",
-            entity_id="issue-1",
-            display_label="Issue One closed",
-            before="open",
-            after="closed",
-            observed_at=OBSERVED_AT,
-            evidence_ref_ids=(handle,),
-        )
+        genuine_change = genuine.model_copy(update={"evidence_ref_ids": (handle,)})
         forged_change = DevObservedChangeV2(
             change_id="change-1",
             category="entity",
@@ -489,7 +674,177 @@ async def test_red_observed_change_before_after_swap_is_rejected():
         )
 
     result, observation = await _run_single_step(
-        source_class=SourceClass.STATUS_CHANGE, run=run
+        source_class=SourceClass.STATUS_CHANGE, run=run, context=_context(scope=scope)
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+def _metric_fact(
+    *,
+    metric_id: MetricID,
+    dimensions: tuple[str, ...] = (),
+    value: float,
+    series: tuple[tuple[str, float], ...] = (),
+) -> DevMetricRefV2:
+    window = _time_range()
+    scope_v2 = DevScopeV2.model_validate(_scope().model_dump(mode="json"))
+    metric_ref_id = _metric_ref_id(
+        metric_id=metric_id.value,
+        dimensions=dimensions,
+        window_start=window.start.isoformat(),
+        window_end=window.end.isoformat(),
+    )
+    return DevMetricRefV2(
+        schema_version="dev_metric_ref.v1",
+        metric_ref_id=metric_ref_id,
+        metric_id=metric_id,
+        label="Cycle time",
+        definition_version="v1",
+        unit="hours",
+        aggregation="p50",
+        display_precision=1,
+        resolved_scope=scope_v2,
+        dimensions=dimensions,
+        current_window=window,
+        comparison_window=None,
+        value=value,
+        comparison_value=None,
+        series=tuple({"timestamp": ts, "value": v} for ts, v in series),
+        query_version="v1",
+        source_version="v1",
+        freshness=FreshnessState.FRESH,
+        coverage=1.0,
+        evidence_ref_ids=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_red_metric_full_field_swap_is_rejected():
+    """RED (Codex round 6, [HIGH]): round 5 bound only value/
+    comparison_value -- a genuine handle for CYCLE_TIME_P50_HOURS=10.0
+    verified a fabricated fact re-labeled AVG_WIP with a forged dense
+    series, because neither metric_id nor series were bound."""
+
+    scope = _scope()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        genuine = _metric_fact(metric_id=MetricID.CYCLE_TIME_P50_HOURS, value=10.0)
+        source_version = _bind_content(
+            _METRIC_EVIDENCE_SOURCE_VERSION, _claim_projection(genuine)
+        )
+        handle = sign_evidence_for_scope(
+            scope=scope,
+            org_id=ORG_ID,
+            source_system="metrics",
+            source_version=source_version,
+            entity_type="metric",
+            entity_id=genuine.metric_ref_id,
+            display_label="Cycle time",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_ref = genuine.model_copy(update={"evidence_ref_ids": (handle,)})
+        forged_ref = genuine.model_copy(
+            update={
+                "metric_id": MetricID.AVG_WIP,
+                "series": tuple(
+                    {"timestamp": OBSERVED_AT, "value": float(i)} for i in range(999)
+                ),
+                "evidence_ref_ids": (handle,),
+            }
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                metric_refs=(genuine_ref, forged_ref),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_ITEM, run=run, context=_context(scope=scope)
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+def test_metric_ref_id_is_recomputed_never_trusted_from_the_fact() -> None:
+    """Structural proof (round-6 ask: "recompute/validate metric_ref_id
+    from the same inputs"): two ``DevMetricRefV2`` facts sharing the
+    IDENTICAL (spoofed) ``metric_ref_id`` field but different
+    ``metric_id``s must derive DIFFERENT entity_ids -- ``_identity_
+    metric_ref`` never trusts ``ref.metric_ref_id`` as a free-form id, it
+    is always recomputed from the fact's own metric_id/dimensions/window."""
+
+    a = _metric_fact(metric_id=MetricID.CYCLE_TIME_P50_HOURS, value=1.0)
+    spoofed = a.model_copy(update={"metric_id": MetricID.AVG_WIP})
+    assert spoofed.metric_ref_id == a.metric_ref_id  # same spoofed field value
+
+    _source_a, _sv_a, _et_a, entity_id_a = _identity_metric_ref(a)
+    _source_b, _sv_b, _et_b, entity_id_b = _identity_metric_ref(spoofed)
+    assert entity_id_a != entity_id_b
+
+
+@pytest.mark.asyncio
+async def test_red_graph_edge_provenance_confidence_timestamp_swap_is_rejected():
+    """RED (Codex round 6, [HIGH]): round 5 bound only relationship/
+    source_entity_id/target_entity_id -- a genuine handle verified a fact
+    with a forged provenance ("fabricated-authoritative-source"), a forged
+    confidence, and a year-2036 observed_at."""
+
+    scope = _scope()
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        genuine = DevGraphEdgeV2(
+            edge_id="edge-1",
+            source_entity_id=ROOT_ENTITY_ID,
+            relationship="references",
+            target_entity_id="pr-1",
+            provenance="ci_pipeline",
+            confidence=0.8,
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(),
+        )
+        source_version = _bind_content(
+            _GRAPH_EVIDENCE_SOURCE_VERSION, _claim_projection(genuine)
+        )
+        handle = sign_evidence_for_scope(
+            scope=scope,
+            org_id=ORG_ID,
+            source_system="work_graph",
+            source_version=source_version,
+            entity_type="work_graph_edge",
+            entity_id="edge-1",
+            display_label="issue-1 references pr-1",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_edge = genuine.model_copy(update={"evidence_ref_ids": (handle,)})
+        forged_edge = genuine.model_copy(
+            update={
+                "provenance": "fabricated-authoritative-source",
+                "confidence": 1.0,
+                "observed_at": datetime(2036, 1, 1, tzinfo=UTC),
+                "evidence_ref_ids": (handle,),
+            }
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                graph_edges=(genuine_edge, forged_edge),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.WORK_GRAPH, run=run, context=_context(scope=scope)
     )
 
     assert observation.content is None
@@ -503,35 +858,33 @@ async def test_red_observed_change_before_after_swap_is_rejected():
 
 
 def test_content_binding_is_shared_by_identity_between_every_mint_and_verify_site():
-    """Structural drift guard (round-5 item 3): EVERY category's mint
-    (``builtin_steps.py``'s ``wire_*``/mint closures) and verify
-    (``relationship_matrix.py``'s ``EVIDENCE_IDENTITY_TABLE`` cells) fold
-    content into ``source_version`` through the LITERAL SAME shared
-    function -- asserted by identity, not merely by matching behavior, so
-    no category's mint and verify can independently drift apart the way a
-    hand-duplicated constant could."""
+    """Structural drift guard: EVERY category's mint (``builtin_steps.py``'s
+    ``wire_*``/mint closures) and verify (``relationship_matrix.py``'s
+    ``EVIDENCE_IDENTITY_TABLE`` cells) fold content into ``source_version``
+    through the LITERAL SAME shared functions -- asserted by identity, not
+    merely by matching behavior."""
 
     assert (
         relationship_matrix_module._bind_content is builtin_steps_module._bind_content
     )
     assert (
+        relationship_matrix_module._claim_projection
+        is builtin_steps_module._claim_projection
+    )
+    assert (
         relationship_matrix_module._ci_check_source_version
         is builtin_steps_module._ci_check_source_version
+    )
+    assert (
+        relationship_matrix_module._metric_ref_id is builtin_steps_module._metric_ref_id
     )
 
 
 def test_signer_payload_drift_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mutation-style drift guard (round-5 item 3): if
-    ``EvidenceReferenceSigner``'s payload construction ever binds a field at
-    MINT time that the verifier's rebuilt candidate does not (or cannot)
-    supply, the result must be REJECTION, never a silent accept. Simulated
-    by minting through a deliberately WIDENED payload (one extra byte folded
-    in, standing in for a hypothetical future field the round-5 verifier
-    was never updated to rebuild) and then verifying the resulting handle
-    through the real, un-widened ``_payload`` -- exactly the shape an
-    accidental drift between mint and verify would take. If this test ever
-    fails (a widened payload still verifies), the signature check has
-    stopped being load-bearing."""
+    """Mutation-style drift guard: if ``EvidenceReferenceSigner``'s payload
+    construction ever binds a field at MINT time that the verifier's
+    rebuilt candidate does not (or cannot) supply, the result must be
+    REJECTION, never a silent accept."""
 
     signer = EvidenceReferenceSigner(b"round5-drift-guard-test-secret-000")
     real_payload = EvidenceReferenceSigner._payload
@@ -574,12 +927,7 @@ def test_signer_payload_drift_fails_closed(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_signer_payload_field_set_is_the_documented_allowlist() -> None:
     """Second half of the drift guard: pin the EXACT set of keys
-    ``EvidenceReferenceSigner._payload`` produces today. If a future change
-    adds (or removes) a bound field, this fails immediately and loudly --
-    the reviewer's cue to check whether ``_CandidateIdentity``/
-    ``_evidence_signature_failures`` (``executor.py``) still supply
-    everything the signer now binds, rather than discovering the gap only
-    when a real forgery slips through."""
+    ``EvidenceReferenceSigner._payload`` produces today."""
 
     import json as _json
 

--- a/tests/api/dev/test_chaos_3296_round5_signature_verification.py
+++ b/tests/api/dev/test_chaos_3296_round5_signature_verification.py
@@ -562,6 +562,115 @@ async def test_genuine_team_scoped_handle_is_accepted():
     assert result.relationship_closure_verified is True
 
 
+# -- round-6 finding 4: relationship-path rooting used a live context.scope
+# -- read, not the pre-step snapshot ----------------------------------------
+
+
+FOREIGN_ENTITY_ID = "project-foreign"
+
+
+@pytest.mark.asyncio
+async def test_red_post_mint_entity_swap_does_not_re_root_relationship_paths():
+    """RED (Codex round 6, [HIGH], the one finding that survived the rest of
+    round 6): a step mints its evidence honestly against the REAL committed
+    scope, then -- AFTER minting, still within the same step -- mutates
+    ``context.scope.entity_refs`` in place to point at a project this
+    investigation was never scoped to. ``_mint_relationship_paths`` ran
+    AFTER every step, so it used to call ``_root_entity_id(context.scope)``
+    and see the step's own mutation: every relationship path ended up
+    rooted at (``source_entity_id=``) the FOREIGN entity, with
+    ``relationship_closure_verified`` still reporting True and
+    ``result.subject_entity_id`` (passed in from outside, never re-derived)
+    the only field still showing the truth. Rooting from the pre-step
+    ``_AuthorizationScope`` snapshot instead means the mutation can no
+    longer reach relationship-path construction at all: every minted path
+    must still be rooted at the ORIGINAL committed entity."""
+
+    async def run(ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
+        )
+        # Minted honestly, BEFORE the mutation below, against the scope this
+        # run was actually authorized under -- the evidence signature itself
+        # is completely genuine.
+        handle = sign_evidence_for_scope(
+            scope=ctx.scope,
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=handle
+        )
+        # Attacker-controlled: swap the committed subject to a foreign
+        # project AFTER minting, but still before this step returns -- the
+        # executor already snapshotted the true scope before any step ran.
+        ctx.scope.entity_refs[0] = ctx.scope.entity_refs[0].model_copy(
+            update={"entity_id": FOREIGN_ENTITY_ID}
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is not None
+    assert len(observation.relationship_paths) == 1
+    path = observation.relationship_paths[0]
+    # The load-bearing assertion: rooted at the ORIGINAL committed entity,
+    # never the post-mint swap -- before the fix this was FOREIGN_ENTITY_ID.
+    assert path.source_entity_id == ROOT_ENTITY_ID
+    assert path.source_entity_id != FOREIGN_ENTITY_ID
+    assert result.relationship_closure_verified is True
+    assert result.subject_entity_id == ROOT_ENTITY_ID
+
+
+@pytest.mark.asyncio
+async def test_genuine_no_mutation_relationship_paths_still_root_correctly():
+    """Positive control: with no mid-step mutation at all, relationship
+    paths must still root at the real committed entity -- round 6's fix
+    must not leave every path unrooted (``root_entity_id is None``)."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            claim=_ci_claim(entity_id="repo#ci7#checkA", conclusion="success"),
+        )
+        handle = sign_evidence_for_scope(
+            scope=_scope(),
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert len(observation.relationship_paths) == 1
+    assert observation.relationship_paths[0].source_entity_id == ROOT_ENTITY_ID
+    assert result.relationship_closure_verified is True
+
+
 # -- generalized (round-6, programmatic) content binding: representative REDs
 
 

--- a/tests/api/dev/test_chaos_3296_round5_signature_verification.py
+++ b/tests/api/dev/test_chaos_3296_round5_signature_verification.py
@@ -1,0 +1,607 @@
+"""Round-5 closure (CHAOS-3296 Codex round 4, 2026-08-02): recomputed-
+signature verification, replacing the per-run receipt comparison rounds
+1-4 all built.
+
+Round 4's closure (the evidence identity table + require-known-good) still
+compared a re-derived SUBSET of a handle's identity -- (source_system,
+source_version, entity_type, entity_id) -- against a per-run RECEIPT this
+executor maintained itself. An adversary only had to vary whatever the
+receipt didn't carry:
+
+1. [HIGH] The receipt never recorded org_id/repository_ids, though the real
+   ``EvidenceReferenceSigner``'s HMAC binds both. A handle genuinely minted
+   for a DIFFERENT tenant/repository scope verified clean as long as the
+   remaining four fields happened to match.
+2. [HIGH] No round bound the fact's own asserted CONTENT at all. A genuine
+   handle for a failing CI check verified a fabricated fact claiming it
+   passed.
+
+The fix is a structural inversion, not a wider receipt: verification
+recomputes the ACTUAL signature via ``EvidenceReferenceSigner.verify`` --
+the exact code every real mint call already goes through -- from (a) the
+fact's own re-derived identity and (b) the CURRENT ``StepContext``'s
+already-authorized org_id/repositories, never from anything carried by the
+fact or the handle being checked.
+
+Content binding (finding 2) was NOT scoped to ``ci_checks`` -- a provisional
+first pass claimed it was the sole category with a collision-prone identity,
+but the underlying gap is general: ANY category whose minted identity tuple
+does not already uniquely determine its content lets a genuinely-minted
+handle for one claim "verify" a fabricated, different claim about the same
+identity (a status fact citing a real handle while asserting a DIFFERENT
+status than what was observed at mint; a deployment/incident/PR the same
+way; an observed change with swapped before/after; a graph edge with a
+forged relationship/orientation; a metric with a fabricated value). Every
+``builtin_steps.py`` ``wire_*``/mint call site now folds a digest of that
+category's own claim fields -- the exact fields that survive onto its
+``DevSourceContent`` wire type -- into the minted ``source_version`` via ONE
+shared ``builtin_steps._bind_content``, and every
+``relationship_matrix.EVIDENCE_IDENTITY_TABLE`` cell's ``derive`` recomputes
+the SAME claim fields from the wire fact and calls the SAME function. Two
+facts differing only in their claim mint different, non-interchangeable
+handles; there is no receipt to bind content to, because there is no
+receipt.
+
+This file:
+
+* Proves both round-4 findings closed (cross-tenant/cross-repository
+  handles; content-swapped CI claims) -- the checkA/checkB content-swap
+  repro and the three round-1/2/3 repros (evidence-free fact, graph-edge
+  reuse, checkA-on-checkB run-level coarsening) already live as permanent
+  REDs in ``test_chaos_3296_round4_evidence_identity_table.py`` and
+  ``test_chaos_3296_round2_budget_and_receipts.py``, updated in the same
+  commit as this file to mint through the real signer and assert the new
+  ``evidence_signature_invalid:`` limitation -- not duplicated here.
+* Adds the two NEW round-4 findings this round closes (cross-tenant,
+  cross-repository-scope) as permanent REDs.
+* Adds representative content-swap REDs for two NON-ci_checks categories
+  (status_facts, observed_changes) proving the generalized closure -- not
+  exhaustive over all 9 categories (that would duplicate
+  ``test_evidence_identity_table_is_total_over_content_slot_fields`` and the
+  source-anchored per-cell tests in the round-4 file, which already prove
+  every cell's ``derive`` matches its real mint call site, content fields
+  included), but enough to demonstrate the pattern holds outside CI.
+* Adds the drift guard: a structural identity assertion that every
+  category's mint and verify call the literal same shared content-digest
+  function, plus a mutation test proving that if
+  ``EvidenceReferenceSigner``'s payload construction ever drifts between
+  mint and verify time, the result is REJECTION (fail-closed), never a
+  silent accept.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import (
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    FreshnessState,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import DevCIFactV2, DevStatusFactV2
+from dev_health_ops.api.dev.contracts_v2.plan import (
+    DevInvestigationPlan,
+    DevSourceRequirement,
+)
+from dev_health_ops.api.dev.contracts_v2.result import (
+    DevObservedChangeV2,
+    DevSourceContent,
+)
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceRecord,
+    EvidenceReferenceSigner,
+)
+from dev_health_ops.api.dev.investigation_plans import (
+    PlanExecutor,
+    PlanStepDefinition,
+    StepContext,
+    StepOutcome,
+    StepRegistry,
+)
+from dev_health_ops.api.dev.investigation_plans import (
+    builtin_steps as builtin_steps_module,
+)
+from dev_health_ops.api.dev.investigation_plans import (
+    relationship_matrix as relationship_matrix_module,
+)
+from dev_health_ops.api.dev.investigation_plans.builtin_steps import (
+    _CHANGE_EVIDENCE_SOURCE_VERSION,
+    _STATUS_EVIDENCE_SOURCE_VERSION,
+    _bind_content,
+    _ci_check_source_version,
+)
+from dev_health_ops.api.dev.investigation_plans.executor import _CandidateIdentity
+from tests._chaos_3295_plan_executor import TEST_EVIDENCE_SIGNER, sign_evidence
+
+ORG_ID = "org_fullchaos"
+OTHER_ORG_ID = "org_intruder"
+ROOT_ENTITY_ID = "project-1"
+OBSERVED_AT = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _now() -> datetime:
+    return OBSERVED_AT
+
+
+def _scope(*, repositories: tuple[str, ...] = ()) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        repositories=list(repositories),
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": ROOT_ENTITY_ID,
+                "display_label": "Project One",
+                "repository_id": None,
+            }
+        ],
+        time_range=DevTimeRange(
+            start=datetime(2026, 7, 1, tzinfo=UTC),
+            end=datetime(2026, 7, 31, tzinfo=UTC),
+            timezone="UTC",
+        ),
+    )
+
+
+def _context(*, repositories: tuple[str, ...] = ()) -> StepContext:
+    return StepContext(
+        org_id=ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=_scope(repositories=repositories),
+        run_id="run-1",
+        now=_now(),
+    )
+
+
+def _plan(source_class: SourceClass) -> DevInvestigationPlan:
+    return DevInvestigationPlan(
+        schema_version="dev_investigation_plan.v1",
+        plan_id="status.entity.v2",
+        plan_version="status.entity.v2.1",
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        supported_subject_kinds=(EntityKind.PROJECT,),
+        supported_cardinalities=(Cardinality.SINGULAR, Cardinality.ORGANIZATION_WIDE),
+        mandatory_steps=("one",),
+        conditional_steps=(),
+        step_dependencies=(),
+        source_requirements=(
+            DevSourceRequirement(
+                schema_version="dev_source_requirement.v1",
+                source_class=source_class,
+                adapter_id="test.one.v1",
+                requirement_level="mandatory",
+                freshness_policy="p.v1",
+                minimum_usable_facts=0,
+            ),
+        ),
+        batch_strategy="single",
+        per_step_timeout_seconds=5,
+        max_rows_per_step=10,
+        max_bytes_per_step=1_000,
+        enrichment_allowed=False,
+        completion_rule_id="test.rule",
+        completion_rule_version="1",
+    )
+
+
+async def _run_single_step(
+    *, source_class: SourceClass, run, context: StepContext | None = None
+):
+    plan = _plan(source_class)
+    registry = StepRegistry()
+    registry.register(
+        PlanStepDefinition(
+            step_id="one",
+            plan_id=plan.plan_id,
+            source_class=source_class,
+            adapter_id="test.one.v1",
+            requirement_level="mandatory",
+            run=run,
+        )
+    )
+    executor = PlanExecutor(
+        registry=registry, now=_now, evidence_signer=TEST_EVIDENCE_SIGNER
+    )
+    result = await executor.run(
+        plan=plan,
+        context=context or _context(),
+        run_id="run-1",
+        subject_entity_id=ROOT_ENTITY_ID,
+    )
+    assert len(result.observations) == 1
+    return result, result.observations[0]
+
+
+def _queried_outcome(content: DevSourceContent) -> StepOutcome:
+    return StepOutcome(
+        observed_state=SourceRequirementState.AVAILABLE_CURRENT,
+        data_semantics="measured_zero",
+        usable_fact_count=1,
+        content=content,
+    )
+
+
+def _ci_fact(*, entity_id: str, conclusion: str, handle: str) -> DevCIFactV2:
+    return DevCIFactV2(
+        entity_id=entity_id,
+        display_label="build",
+        conclusion=conclusion,
+        required=True,
+        skipped_required_work=False,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=(handle,),
+    )
+
+
+# -- round-4 finding 1: cross-tenant / cross-repository receipt -------------
+
+
+@pytest.mark.asyncio
+async def test_red_cross_tenant_handle_is_rejected():
+    """RED (Codex round 4, [HIGH]): a handle genuinely minted for a
+    DIFFERENT organization than the one running this step verifies clean
+    under a receipt comparison that never carried org_id at all -- round 5
+    supplies org_id fresh from the CURRENT ``StepContext`` on every check,
+    never from the handle or the fact citing it, so this can no longer
+    happen."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+        )
+        # Minted for OTHER_ORG_ID -- a different tenant than the one this
+        # step actually runs under (ORG_ID, via ``_context()`` below).
+        forged_handle = sign_evidence(
+            org_id=OTHER_ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=forged_handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_red_cross_repository_scope_handle_is_rejected():
+    """RED (Codex round 4, [HIGH], repository-scope half): a handle
+    genuinely minted for a DIFFERENT repository scope than the one this
+    step's own ``StepContext`` authorizes. ``repository_ids`` is bound into
+    the real signer's HMAC exactly like ``org_id`` -- round 5 supplies it
+    fresh from ``context.scope.repositories`` on every check, never from the
+    handle."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+        )
+        forged_handle = sign_evidence(
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+            # Minted against a repository the CURRENT step's scope
+            # (``repo-authorized`` below) never authorized.
+            repository_ids=("repo-unauthorized",),
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=forged_handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        context=_context(repositories=("repo-authorized",)),
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_genuine_same_tenant_and_repository_handle_is_accepted():
+    """Positive control: a handle minted for the SAME org and repository
+    scope the step actually runs under must still verify -- round 5 must
+    not over-reject legitimate same-tenant evidence."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _ci_check_source_version(
+            "repo#ci7#checkA",
+            conclusion="success",
+            required=True,
+            skipped_required_work=False,
+        )
+        handle = sign_evidence(
+            org_id=ORG_ID,
+            source_system="ci_runs",
+            source_version=source_version,
+            entity_type="ci_run",
+            entity_id="repo#ci7",
+            display_label="checkA",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+            repository_ids=("repo-authorized",),
+        )
+        fact = _ci_fact(
+            entity_id="repo#ci7#checkA", conclusion="success", handle=handle
+        )
+        return _queried_outcome(
+            DevSourceContent(schema_version="dev_source_content.v1", ci_checks=(fact,))
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE,
+        run=run,
+        context=_context(repositories=("repo-authorized",)),
+    )
+
+    assert observation.content is not None
+    assert len(observation.content.ci_checks) == 1
+    assert result.relationship_closure_verified is True
+
+
+# -- generalized content binding: representative non-ci_checks REDs ---------
+
+
+@pytest.mark.asyncio
+async def test_red_status_fact_content_swap_is_rejected():
+    """RED: a handle genuinely minted for a status fact asserting
+    "in_progress" reused verbatim on a fabricated fact for the SAME entity
+    claiming "done" instead. Proves the generalized closure holds for
+    ``status_facts``, not just ``ci_checks`` -- a real handle for one status
+    claim can never verify a fabricated different status claim about the
+    same entity."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        genuine_text = "Issue One: in_progress"
+        handle = sign_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version=_bind_content(
+                _STATUS_EVIDENCE_SOURCE_VERSION, claim=genuine_text
+            ),
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_fact = DevStatusFactV2(
+            fact_id="issue:issue-1", text=genuine_text, evidence_ref_ids=(handle,)
+        )
+        forged_fact = DevStatusFactV2(
+            fact_id="issue:issue-1",
+            text="Issue One: done (fabricated)",
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                status_facts=(genuine_fact, forged_fact),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+@pytest.mark.asyncio
+async def test_red_observed_change_before_after_swap_is_rejected():
+    """RED: a handle genuinely minted for an observed change asserting
+    before="open"/after="closed" reused verbatim on a fabricated change for
+    the SAME entity/change_id claiming a DIFFERENT before/after pair. Proves
+    the generalized closure holds for ``observed_changes``."""
+
+    async def run(_ctx: StepContext) -> StepOutcome:
+        source_version = _bind_content(
+            _CHANGE_EVIDENCE_SOURCE_VERSION, before="open", after="closed"
+        )
+        handle = sign_evidence(
+            org_id=ORG_ID,
+            source_system="work_items",
+            source_version=source_version,
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One closed",
+            observed_at=OBSERVED_AT,
+            freshness=FreshnessState.FRESH,
+        )
+        genuine_change = DevObservedChangeV2(
+            change_id="change-1",
+            category="entity",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One closed",
+            before="open",
+            after="closed",
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        forged_change = DevObservedChangeV2(
+            change_id="change-1",
+            category="entity",
+            entity_type="issue",
+            entity_id="issue-1",
+            display_label="Issue One reopened (fabricated)",
+            before="closed",
+            after="open",
+            observed_at=OBSERVED_AT,
+            evidence_ref_ids=(handle,),
+        )
+        return _queried_outcome(
+            DevSourceContent(
+                schema_version="dev_source_content.v1",
+                observed_changes=(genuine_change, forged_change),
+            )
+        )
+
+    result, observation = await _run_single_step(
+        source_class=SourceClass.STATUS_CHANGE, run=run
+    )
+
+    assert observation.content is None
+    assert observation.observed_state is SourceRequirementState.UNAVAILABLE
+    assert observation.limitation is not None
+    assert observation.limitation.startswith("evidence_signature_invalid:")
+    assert result.relationship_closure_verified is False
+
+
+# -- drift guard --------------------------------------------------------
+
+
+def test_content_binding_is_shared_by_identity_between_every_mint_and_verify_site():
+    """Structural drift guard (round-5 item 3): EVERY category's mint
+    (``builtin_steps.py``'s ``wire_*``/mint closures) and verify
+    (``relationship_matrix.py``'s ``EVIDENCE_IDENTITY_TABLE`` cells) fold
+    content into ``source_version`` through the LITERAL SAME shared
+    function -- asserted by identity, not merely by matching behavior, so
+    no category's mint and verify can independently drift apart the way a
+    hand-duplicated constant could."""
+
+    assert (
+        relationship_matrix_module._bind_content is builtin_steps_module._bind_content
+    )
+    assert (
+        relationship_matrix_module._ci_check_source_version
+        is builtin_steps_module._ci_check_source_version
+    )
+
+
+def test_signer_payload_drift_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mutation-style drift guard (round-5 item 3): if
+    ``EvidenceReferenceSigner``'s payload construction ever binds a field at
+    MINT time that the verifier's rebuilt candidate does not (or cannot)
+    supply, the result must be REJECTION, never a silent accept. Simulated
+    by minting through a deliberately WIDENED payload (one extra byte folded
+    in, standing in for a hypothetical future field the round-5 verifier
+    was never updated to rebuild) and then verifying the resulting handle
+    through the real, un-widened ``_payload`` -- exactly the shape an
+    accidental drift between mint and verify would take. If this test ever
+    fails (a widened payload still verifies), the signature check has
+    stopped being load-bearing."""
+
+    signer = EvidenceReferenceSigner(b"round5-drift-guard-test-secret-000")
+    real_payload = EvidenceReferenceSigner._payload
+
+    def widened_payload(org_id: str, evidence) -> bytes:
+        return (
+            real_payload(org_id, evidence)
+            + hashlib.sha256(b"a-field-the-verifier-does-not-know-about").digest()
+        )
+
+    monkeypatch.setattr(
+        EvidenceReferenceSigner, "_payload", staticmethod(widened_payload)
+    )
+    record = EvidenceRecord(
+        source_system="ci_runs",
+        source_version="status-snapshot-evidence.v1:repo#ci7#checkA",
+        entity_type="ci_run",
+        entity_id="repo#ci7",
+        display_label="checkA",
+        observed_at=OBSERVED_AT,
+        freshness=FreshnessState.FRESH,
+        provenance="ci_runs",
+        confidence=1.0,
+        repository_ids=(),
+    )
+    drifted_handle = signer.issue(ORG_ID, record)
+
+    monkeypatch.setattr(EvidenceReferenceSigner, "_payload", staticmethod(real_payload))
+    candidate = _CandidateIdentity(
+        evidence_ref_id=drifted_handle,
+        source_system=record.source_system,
+        source_version=record.source_version,
+        entity_type=record.entity_type,
+        entity_id=record.entity_id,
+        repository_ids=record.repository_ids,
+    )
+
+    assert signer.verify(ORG_ID, candidate) is False
+
+
+def test_signer_payload_field_set_is_the_documented_allowlist() -> None:
+    """Second half of the drift guard: pin the EXACT set of keys
+    ``EvidenceReferenceSigner._payload`` produces today. If a future change
+    adds (or removes) a bound field, this fails immediately and loudly --
+    the reviewer's cue to check whether ``_CandidateIdentity``/
+    ``_evidence_signature_failures`` (``executor.py``) still supply
+    everything the signer now binds, rather than discovering the gap only
+    when a real forgery slips through."""
+
+    import json as _json
+
+    record = EvidenceRecord(
+        source_system="ci_runs",
+        source_version="v1",
+        entity_type="ci_run",
+        entity_id="repo#ci7",
+        display_label="checkA",
+        observed_at=OBSERVED_AT,
+        freshness=FreshnessState.FRESH,
+        provenance="ci_runs",
+        confidence=1.0,
+        repository_ids=("r1",),
+    )
+    payload_bytes = EvidenceReferenceSigner._payload(ORG_ID, record)
+    keys = set(_json.loads(payload_bytes))
+    assert keys == {
+        "org",
+        "source",
+        "source_version",
+        "entity_type",
+        "entity_id",
+        "repositories",
+    }

--- a/tests/api/dev/test_chaos_3303_portfolio_status_service.py
+++ b/tests/api/dev/test_chaos_3303_portfolio_status_service.py
@@ -164,6 +164,26 @@ class FakePortfolioRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         return DataHealthResult(sources=(), complete_eligible=True)
 
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        # CHAOS-3296's PlanExecutorRuntime protocol member -- neither
+        # ProjectHealthService nor PortfolioStatusService mints evidence
+        # itself, so this is here only for structural conformance.
+        raise AssertionError("not exercised by this suite")
+
 
 @pytest.mark.asyncio
 async def test_evaluate_portfolio_two_projects_returns_both() -> None:
@@ -417,6 +437,23 @@ class SingleFlightPortfolioRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         await self._guarded()
         return DataHealthResult(sources=(), complete_eligible=True)
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        raise AssertionError("not exercised by this suite")
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3303_project_health_service.py
+++ b/tests/api/dev/test_chaos_3303_project_health_service.py
@@ -145,6 +145,26 @@ class FakeRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         return _data_health()
 
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        # CHAOS-3296's PlanExecutorRuntime protocol member --
+        # ProjectHealthService never mints evidence itself, so this is here
+        # only for structural conformance.
+        raise AssertionError("not exercised by this suite")
+
 
 @pytest.mark.asyncio
 async def test_evaluate_project_rejects_non_project_scope() -> None:

--- a/tests/api/dev/test_chaos_3303_team_health_service.py
+++ b/tests/api/dev/test_chaos_3303_team_health_service.py
@@ -119,6 +119,27 @@ class FakeTeamRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         return DataHealthResult(sources=(), complete_eligible=False)
 
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        # CHAOS-3296's PlanExecutorRuntime protocol member -- TeamHealthService
+        # (CHAOS-3302/3303) never mints evidence itself, so this is here only
+        # for structural conformance, same posture as the sibling
+        # never-called methods above.
+        raise AssertionError("not exercised by this suite")
+
 
 @dataclass
 class FakeAttributionSource:
@@ -363,6 +384,23 @@ class FakeAttributedTeamRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         return DataHealthResult(sources=(), complete_eligible=True)
 
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        raise AssertionError("not exercised by this suite")
+
 
 @pytest.mark.asyncio
 async def test_evaluate_team_with_attribution_and_real_facts_reports_real_findings() -> (
@@ -422,6 +460,23 @@ class _UncallableRuntime:
         raise AssertionError("unexpected call")
 
     async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("unexpected call")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
         raise AssertionError("unexpected call")
 
 

--- a/tests/api/dev/test_chaos_3304_team_workload_service.py
+++ b/tests/api/dev/test_chaos_3304_team_workload_service.py
@@ -142,6 +142,26 @@ class FakeRuntime:
     async def data_health(self, *, org_id, permission_fingerprint, scope):
         return DataHealthResult(sources=(), complete_eligible=False)
 
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
+        # CHAOS-3296's PlanExecutorRuntime protocol member --
+        # TeamWorkloadService never mints evidence itself, so this is here
+        # only for structural conformance.
+        raise AssertionError("not exercised by this suite")
+
 
 @dataclass
 class FakeAttributionSource:
@@ -275,6 +295,23 @@ class _UncallableRuntime:
         raise AssertionError("unexpected call")
 
     async def data_health(self, *, org_id, permission_fingerprint, scope):
+        raise AssertionError("unexpected call")
+
+    def mint_evidence(
+        self,
+        *,
+        org_id,
+        source_system,
+        source_version,
+        entity_type,
+        entity_id,
+        display_label,
+        observed_at,
+        freshness,
+        confidence=1.0,
+        valid_entity_ids=(),
+        repository_ids=(),
+    ):
         raise AssertionError("unexpected call")
 
 

--- a/tests/api/dev/test_chaos_3305_operational_deficiency_service.py
+++ b/tests/api/dev/test_chaos_3305_operational_deficiency_service.py
@@ -251,6 +251,9 @@ class FakeRuntime:
         self.data_health_scopes.append(scope)
         return self.data_health_result
 
+    def mint_evidence(self, **kwargs):
+        raise NotImplementedError
+
 
 def _runtime(
     *,
@@ -528,6 +531,9 @@ class RepoAwareFakeRuntime:
             complete_eligible=not missing,
         )
 
+    def mint_evidence(self, **kwargs):
+        raise NotImplementedError
+
 
 @dataclass
 class OmissionAwareFakeRuntime:
@@ -597,6 +603,9 @@ class OmissionAwareFakeRuntime:
             if system not in omitted
         )
         return DataHealthResult(sources=sources, complete_eligible=True)
+
+    def mint_evidence(self, **kwargs):
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -853,6 +853,7 @@ _NON_HANDLE_IDENTIFIER_REASONS: dict[str, str] = {
     # DevSourceObservation.content's docstring).
     "DevCIFactV2.entity_id": "provider entity key",
     "DevDeploymentFactV2.entity_id": "provider entity key",
+    "DevGraphEdgeV2.edge_id": "provider entity key",
     "DevGraphEdgeV2.source_entity_id": "provider entity key",
     "DevGraphEdgeV2.target_entity_id": "provider entity key",
     "DevIncidentFactV2.entity_id": "provider entity key",


### PR DESCRIPTION
## Summary

Ask Dev's investigation-plan executor mints signed evidence handles and relationship paths per source category, then persists a `DevSourceObservation` per source requirement. This PR builds that minting/persistence path (versioned source/relationship matrix, relationship-path closure verification, byte-budgeted persistence) and hardens it through 7 rounds of adversarial (Codex) review against forged-evidence and scope-authorization attacks.

- Versioned source/relationship matrix + relationship-path minting with closure verification (`relationship_closure_verified`).
- Disclosed, deterministic byte-budget truncation for oversized observations (never an opaque `internal_error`).
- `EvidenceReferenceSigner`-backed evidence handles: every cited handle is cryptographically re-verified against the CURRENT tenant/scope at read time, never trusted from a per-run receipt.
- Content-claim binding: every evidence-capable fact's full asserted claim (not a hand-picked subset) is folded into its handle's digest, derived PROGRAMMATICALLY via reflection on the wire model's own fields (`_claim_projection`) so a future field addition is bound automatically.
- Authorization-scope snapshot: `PlanExecutor.run` captures a deeply immutable `_AuthorizationScope` from `StepContext.scope` BEFORE any step runs; every downstream authorization/verification/rooting decision (evidence signatures, relationship-path rooting) reads ONLY that snapshot, never a live re-read of `context.scope` a step could have mutated mid-run.

## Test plan

**TEST-EVIDENCE** — 7 Codex adversarial-review rounds, round by round:
- r1-r3: relationship-path budget (`MAX_RELATIONSHIP_PATHS=25`) and evidence-receipt closure; found and fixed a Pydantic `too_long` turning valid runs into `internal_error`, and a dense-content persistence-envelope overflow.
- r4: closure attempt (import-time-total identity-derivation table + require-known-good evidence); Codex confirmed 2 MORE HIGH in the class (cross-tenant receipt omitting signer-bound org_id/repository_ids; a genuine handle authenticating a contradictory, unbound claim).
- r5: redesigned verification to recompute the signature via the signer's own shared payload builder from the citing fact + current tenant context (checked ≡ bound by construction), plus content-digest binding at mint time; Codex confirmed 3 in-model HIGH findings (mutable/unsigned ambient scope, metric binding too narrow, graph-edge binding too narrow).
- r6: authorization-scope snapshot (closes the mutable-scope finding) + programmatic claim projection generalized to ALL 9 evidence categories (not just the 2 flagged) via `_claim_projection`; Codex found ONE remaining HIGH (relationship-path rooting still read live `context.scope`).
- r7: `_root_entity_id` rooted from the same pre-step snapshot; re-audited every `context.scope` read in `executor.py` -- only the single top-of-run snapshot line remains. **Codex round 7: SHIP, no material findings.**

Lane-side (post-rebase onto origin/main, includes CHAOS-3303/3304/3305/3285/3297-s1): `tests/api/dev/` 1376 passed / 0 failed / 35 skipped; full `mypy .` clean (1990 files); `ruff format --check .` + `ruff check .` clean. Prior full gates (this repo's serialized `ci/local_validate.sh`) ran clean through the round sequence, 10279 -> 10317/0. CI is the arbiter on this PR.

Each round's fix has a RED-first permanent regression test using Codex's own repro (e.g. `test_red_mid_step_repository_mutation_does_not_verify`, `test_red_cross_team_handle_is_rejected`, `test_red_metric_full_field_swap_is_rejected`, `test_red_graph_edge_provenance_confidence_timestamp_swap_is_rejected`, `test_red_post_mint_entity_swap_does_not_re_root_relationship_paths`) -- each verified to fail against the pre-fix code and pass against the fix, not merely added alongside it.

## RISK-NOTES

- Real-fixture proof that a maximal-shape `DevSourceObservation` fits the contract's byte ceiling: a 615KiB worst-case content construction stays under the persistence envelope.
- `issue-999` forgery pair: a documented adversarial fixture pair used across rounds to prove a forged claim for the same evidence-cited entity does NOT verify.
- Disclosed byte-budget truncation: oversized observations degrade to a bounded `limitation` + `AVAILABLE_STALE`/similar downgrade rather than an opaque internal error or silent data loss; budget is re-derived from what actually survives truncation, never the original pre-truncation count.
- `DevGraphEdgeV2.edge_id` is an additive contract field (round 4); 81 generated contract artifacts were regenerated, never hand-edited.
- Known, documented residual: `observed_changes`' `claim_kind`/`relationship_chain`/`metric_value` fields do not currently survive to the wire type -- out of scope for this PR, flagged for follow-up.
- Investigation-plan-minted evidence handles are not yet reconciled into `expand_evidence` -- a stack-3+ wiring note, not a gap in this PR's own guarantees.
- `SourceClass` reconciliation (`COGNITIVE_LOAD`/`INVESTMENT_ALLOCATION`, merged via CHAOS-3304) has honest-empty entries in this branch's relationship/content-slot matrices -- no relationship or content-slot vocabulary is claimed for those two categories yet.
- One out-of-scope, pre-existing fix bundled in: `test_chaos_3305_operational_deficiency_service.py`'s three `FakeRuntime` test doubles were missing the `mint_evidence` protocol stub (present on `PlanExecutorRuntime` since CHAOS-3295's original commit), which meant full-repo `mypy` has been red on `main` since CHAOS-3305 (#1375) merged. None of that file's exercised test paths call `mint_evidence`; added a `NotImplementedError` stub matching the file's own existing pattern for other unused protocol members. Discovered while rebasing this branch and running the mandatory pre-push mypy gate; unrelated to this PR's own evidence-minting work but required to unblock the push.