### PR TITLE
feat(ask-dev): CHAOS-3325 typed clarification-candidate block

### DIFF
--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.denied_with_narrative.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.denied_with_narrative.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": null,
     "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.frame_run_id_mismatch.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.frame_run_id_mismatch.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_completion_number_out_of_context.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_completion_number_out_of_context.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_number.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_number.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_readiness.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_readiness.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_recommendation.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_recommendation.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_subject.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_contradicts_subject.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_substring_subject.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_substring_subject.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_unbound_recommendation.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_unbound_recommendation.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_unrelated_comparison_number.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.narrative_unrelated_comparison_number.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [
       {
         "comparison_value": 82.0,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer.v2.outcome_mismatch_with_frame.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer.v2.outcome_mismatch_with_frame.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_with_clarification_candidates.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_with_clarification_candidates.json
@@ -1,5 +1,16 @@
 {
-  "clarification_candidates": [],
+  "clarification_candidates": [
+    {
+      "entity_ref": {
+        "display_label": "full-chaos/nightfall-public",
+        "entity_id": "repo_nightfall_public",
+        "entity_kind": "repository",
+        "repository_id": null,
+        "team_id": null
+      },
+      "reason": "Multiple authorized entities match this name."
+    }
+  ],
   "comparisons": [],
   "completion": {
     "calculable": true,
@@ -18,7 +29,7 @@
     "unavailable_required_sources": []
   },
   "deficiency_refs": [],
-  "direct_answer": "Scope resolution failed with scope_forbidden for this repository.",
+  "direct_answer": "Repository dev-health is on track; one required child issue remains open.",
   "evidence": [
     {
       "citation_text": "Repository status observed directly.",

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_with_disclosure.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_with_disclosure.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_without_versions.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.answered_without_versions.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.clarification_candidate_unknown_entity_kind.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.clarification_candidate_unknown_entity_kind.json
@@ -1,5 +1,16 @@
 {
-  "clarification_candidates": [],
+  "clarification_candidates": [
+    {
+      "entity_ref": {
+        "display_label": "full-chaos/nightfall-public",
+        "entity_id": "repo_nightfall_public",
+        "entity_kind": "malicious_kind",
+        "repository_id": null,
+        "team_id": null
+      },
+      "reason": "Multiple authorized entities match this name."
+    }
+  ],
   "comparisons": [],
   "completion": null,
   "conflicts": [],
@@ -11,7 +22,7 @@
     "unavailable_required_sources": []
   },
   "deficiency_refs": [],
-  "direct_answer": "You do not have access to ask about this.",
+  "direct_answer": "Repository dev-health is on track; one required child issue remains open.",
   "evidence": [],
   "facts": [],
   "finding_refs": [],
@@ -20,11 +31,13 @@
   "health_profile_refs": [],
   "limitations": [],
   "metrics": [],
-  "public_outcome": "denied",
+  "public_outcome": "needs_clarification",
   "readiness": null,
   "relationship_paths": [],
   "run_id": "0f1a2b3c-0001-4a00-8000-000000000001",
-  "safe_follow_up_questions": [],
+  "safe_follow_up_questions": [
+    "What changed since last week?"
+  ],
   "schema_version": "dev_answer_frame.v1",
   "sections": [],
   "source_observations": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.clarification_candidates_duplicate_entity_id.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.clarification_candidates_duplicate_entity_id.json
@@ -1,5 +1,26 @@
 {
-  "clarification_candidates": [],
+  "clarification_candidates": [
+    {
+      "entity_ref": {
+        "display_label": "full-chaos/nightfall-public",
+        "entity_id": "repo_nightfall_public",
+        "entity_kind": "repository",
+        "repository_id": null,
+        "team_id": null
+      },
+      "reason": "Multiple authorized entities match this name."
+    },
+    {
+      "entity_ref": {
+        "display_label": "full-chaos/nightfall (duplicate)",
+        "entity_id": "repo_nightfall_public",
+        "entity_kind": "repository",
+        "repository_id": null,
+        "team_id": null
+      },
+      "reason": "Multiple authorized entities match this name."
+    }
+  ],
   "comparisons": [],
   "completion": null,
   "conflicts": [],
@@ -11,7 +32,7 @@
     "unavailable_required_sources": []
   },
   "deficiency_refs": [],
-  "direct_answer": "You do not have access to ask about this.",
+  "direct_answer": "Repository dev-health is on track; one required child issue remains open.",
   "evidence": [],
   "facts": [],
   "finding_refs": [],
@@ -20,11 +41,13 @@
   "health_profile_refs": [],
   "limitations": [],
   "metrics": [],
-  "public_outcome": "denied",
+  "public_outcome": "needs_clarification",
   "readiness": null,
   "relationship_paths": [],
   "run_id": "0f1a2b3c-0001-4a00-8000-000000000001",
-  "safe_follow_up_questions": [],
+  "safe_follow_up_questions": [
+    "What changed since last week?"
+  ],
   "schema_version": "dev_answer_frame.v1",
   "sections": [],
   "source_observations": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.completion_without_denominator.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.completion_without_denominator.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.coverage_stale_source_outside_vocabulary.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.coverage_stale_source_outside_vocabulary.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.coverage_unavailable_source_outside_vocabulary.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.coverage_unavailable_source_outside_vocabulary.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_clarification_candidates.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_clarification_candidates.json
@@ -1,16 +1,19 @@
 {
-  "clarification_candidates": [],
-  "comparisons": [],
-  "completion": null,
-  "conflicts": [
+  "clarification_candidates": [
     {
-      "evidence_ref_ids": [
-        "ev1_5e6770d32646fba023ff686db7decc73d792e808",
-        "ev1_65678803ca13ee1c70bd07e33adbb03fcc9144dc"
-      ],
-      "summary": "Project Nightfall is marked private in one provider and public in another."
+      "entity_ref": {
+        "display_label": "full-chaos/nightfall-public",
+        "entity_id": "repo_nightfall_public",
+        "entity_kind": "repository",
+        "repository_id": null,
+        "team_id": null
+      },
+      "reason": "Multiple authorized entities match this name."
     }
   ],
+  "comparisons": [],
+  "completion": null,
+  "conflicts": [],
   "coverage": {
     "as_of": "2026-07-28T12:00:00Z",
     "available_source_count": 1,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_comparisons.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_comparisons.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [
     {
       "comparison_value": 9.0,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_completion.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_completion.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_deficiency_refs.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_deficiency_refs.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_evidence.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_evidence.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_finding_refs.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_finding_refs.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_follow_up_questions.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_follow_up_questions.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_health_profile_refs.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_health_profile_refs.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_limitations.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_limitations.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_metrics.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_metrics.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_producer_direct_answer.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_producer_direct_answer.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_readiness.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_readiness.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_relationship_paths.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_relationship_paths.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_source_observations.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_source_observations.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_subject_identity.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.denied_with_subject_identity.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.disclosures_duplicated.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.disclosures_duplicated.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.disclosures_out_of_order.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.disclosures_out_of_order.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.outcome_content_mismatch.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.outcome_content_mismatch.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": null,
   "conflicts": [],

--- a/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.relationship_outside_frame.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_answer_frame.v1.relationship_outside_frame.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/positive/dev_answer.v2.json
+++ b/contracts/ask-dev/v2/examples/positive/dev_answer.v2.json
@@ -2,6 +2,7 @@
   "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
   "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
   "frame": {
+    "clarification_candidates": [],
     "comparisons": [],
     "completion": {
       "calculable": true,

--- a/contracts/ask-dev/v2/examples/positive/dev_answer_frame.v1.json
+++ b/contracts/ask-dev/v2/examples/positive/dev_answer_frame.v1.json
@@ -1,4 +1,5 @@
 {
+  "clarification_candidates": [],
   "comparisons": [],
   "completion": {
     "calculable": true,

--- a/contracts/ask-dev/v2/examples/streams/invalid_answer_run_id_mismatch.json
+++ b/contracts/ask-dev/v2/examples/streams/invalid_answer_run_id_mismatch.json
@@ -18,6 +18,7 @@
       "answer_id": "0f1a2b3c-0004-4a00-8000-000000000001",
       "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
       "frame": {
+        "clarification_candidates": [],
         "comparisons": [],
         "completion": {
           "calculable": true,

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -168,141 +168,161 @@
         {
           "case": "internal_leakage",
           "path": "examples/negative/dev_answer_frame.v1.internal_leakage.json",
-          "sha256": "1c46fbf12497ac6f4d425e7cfae0572e4694178b7529cfe678e09c829bee7cd1"
+          "sha256": "a395bab06b52d5c5dd10da10e71834a6356d7d1428824ba0bf8b242540ee12b3"
         },
         {
           "case": "outcome_content_mismatch",
           "path": "examples/negative/dev_answer_frame.v1.outcome_content_mismatch.json",
-          "sha256": "b11b6273aeecfd6685e7463b141f097eb01da8e5cb691d3532849e35ea5df7b6"
+          "sha256": "f574d8ea763d393fe98fafe90eb80a39d0535e9c0af713bd4a64d96d4139fa8b"
         },
         {
           "case": "completion_without_denominator",
           "path": "examples/negative/dev_answer_frame.v1.completion_without_denominator.json",
-          "sha256": "609dcef1925faafb01f16917eaba05250d1980ec4dd428909a5ab53ad8251884"
+          "sha256": "6af99ad64a22be0280eed6ca5cc4e527258c525e6274fa440845331eb8b80025"
         },
         {
           "case": "relationship_outside_frame",
           "path": "examples/negative/dev_answer_frame.v1.relationship_outside_frame.json",
-          "sha256": "c50cb8ab4e4386c15a97744e41230ae244e515ad8ca351227bc3842e696b0d64"
+          "sha256": "19d469031b37cba1cfa5331bb0d58a5d6e0c07fdc4ae783c0db73bbbeec1dc4b"
         },
         {
           "case": "answered_without_versions",
           "path": "examples/negative/dev_answer_frame.v1.answered_without_versions.json",
-          "sha256": "f1546b8b77a01229f50a8ddfb91fff9cee2b9d5fdc566bd350b96a305defde46"
+          "sha256": "f9d2ffb735839332f53aaaa37f18c85210244d18d6739c6c2508e22220bb3678"
         },
         {
           "case": "answered_with_disclosure",
           "path": "examples/negative/dev_answer_frame.v1.answered_with_disclosure.json",
-          "sha256": "5d08ecdbd46a9ceb2f40d189a531b27f0524bfd2816fe369a9ae5588fd7b173e"
+          "sha256": "2b4cf375f97ddadfa79018c46a932c0f447a73835445b15a3064a49aad592afe"
         },
         {
           "case": "disclosures_out_of_order",
           "path": "examples/negative/dev_answer_frame.v1.disclosures_out_of_order.json",
-          "sha256": "a94b60cbd63b19d61ed1fcf47a4d6f7bbc12210fbe01ae3dd0e4b1fc7ba3c9f5"
+          "sha256": "43d887b7a113301da306b2af02038348b1676f8f0266695e9bf96a9f6cd9fbf6"
         },
         {
           "case": "disclosures_duplicated",
           "path": "examples/negative/dev_answer_frame.v1.disclosures_duplicated.json",
-          "sha256": "247536f5dd90cc8d9925f38399e7911c18329d69ce6ef2a6b8431451403eed79"
+          "sha256": "0a0bfc18e2e5232578f854c1bacd08ffbffd9e864a3a99079e18998f9e91a7ca"
+        },
+        {
+          "case": "answered_with_clarification_candidates",
+          "path": "examples/negative/dev_answer_frame.v1.answered_with_clarification_candidates.json",
+          "sha256": "611a560307e92f6d0e1d24e2a1917692b23a38a07f49cbbb55e80bffce32fb40"
+        },
+        {
+          "case": "clarification_candidate_unknown_entity_kind",
+          "path": "examples/negative/dev_answer_frame.v1.clarification_candidate_unknown_entity_kind.json",
+          "sha256": "d1f4789a7905d7471e31db6510c4197b09c2d656337ecaa417e480257eb553da"
+        },
+        {
+          "case": "clarification_candidates_duplicate_entity_id",
+          "path": "examples/negative/dev_answer_frame.v1.clarification_candidates_duplicate_entity_id.json",
+          "sha256": "710e79709d8e0ecef195a00d0874b17e4c263ff41073117c4cf3451bb896e2a9"
         },
         {
           "case": "denied_with_completion",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_completion.json",
-          "sha256": "69ce1a7ec5212f9d298a396b9488cdedc1d8bd5f9b13e43ab195f1de577a988a"
+          "sha256": "7d8f386de7e2f186a9c1509fe8545d7ec53fc4a7e12dbedf509b44d6fd5db29d"
         },
         {
           "case": "denied_with_readiness",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_readiness.json",
-          "sha256": "3d66a4d6c50a34ee58b2e20f77dd116bc9480b57cd3e38919043df8795d7d260"
+          "sha256": "35d27c2f3dae7a24b649de0fd768d70719acfbb0ff13a4c684eb37f9dd02f85e"
         },
         {
           "case": "denied_with_metrics",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_metrics.json",
-          "sha256": "72c451ee11d8afbda18f7e137f03ba9fd91d7eaa851e4e0fb8ce1e6bf77bedf9"
+          "sha256": "b737c1a7c1532d0d9265292ad1958fc900af549a6f214cb7251ec6308ced9b06"
         },
         {
           "case": "denied_with_comparisons",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_comparisons.json",
-          "sha256": "2474d03afdc6edb836a100b29c0cf8095caaa4cf81bbcaa33d0c428cbc4584c5"
+          "sha256": "29d538cafb197c516ebdbebee67f5bc1033fc964003da3caad31d1169c3745d7"
         },
         {
           "case": "denied_with_relationship_paths",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_relationship_paths.json",
-          "sha256": "aa3d8e3540e626cc72bb6b93ebc5b5a30bc0cb661949ed59306a8a5e198edbce"
+          "sha256": "c8568c1f98b6c0c2b8479683b9ee8c8ad9948197e1d2329a490f6000eac9a144"
+        },
+        {
+          "case": "denied_with_clarification_candidates",
+          "path": "examples/negative/dev_answer_frame.v1.denied_with_clarification_candidates.json",
+          "sha256": "a61a5b30d29e093ceff0c46be54b4e566aba8c9163e23e554db4c8ff668dae6d"
         },
         {
           "case": "denied_with_evidence",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_evidence.json",
-          "sha256": "fd93aad1159233731961133b6baf1a0e238ca3427b04f4c9e40bbd97bf031593"
+          "sha256": "b15750386cd3a265b799683e5aea9436b510b42efa55af53513d4257474815a1"
         },
         {
           "case": "denied_with_source_observations",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_source_observations.json",
-          "sha256": "ccddf97fab4ff6ffed852acc0e89224196596756337c9144670bca0efee40b45"
+          "sha256": "ace68eb16fbe73767090cb55e152ec6bda47ced98850839df76b495a043d30a8"
         },
         {
           "case": "denied_with_health_profile_refs",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_health_profile_refs.json",
-          "sha256": "8d1e26c67c47f4cd70aecb3ada0b9cad1ee0493f3316579f8e9695482e600b22"
+          "sha256": "2b5583599e30593d269f864ab5d7e13fe765f304b6dae358bd13189dcfe8dfd0"
         },
         {
           "case": "denied_with_finding_refs",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_finding_refs.json",
-          "sha256": "71442b17689cfc4bcb59c7363f1b9614eb9bc02c6d5b6aa51f93cd16de0bc27e"
+          "sha256": "053df8875f3999b429af6b382fb1aa07a8f07aa66dbb0f8130761caf0a7c7cac"
         },
         {
           "case": "denied_with_deficiency_refs",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_deficiency_refs.json",
-          "sha256": "46ac94908501245bd09df790264534150a33497fc1fd5f628859201e8e5ca35e"
+          "sha256": "a7751ac96b5ee9a36d10d6d6c7f0c19612df10d510dc48f9893f69894d607f54"
         },
         {
           "case": "denied_with_subject_identity",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_subject_identity.json",
-          "sha256": "8fdfc758481830e93708209b3567a0d1a654786119fe402987b1de514704fe33"
+          "sha256": "818f31e0b4869955ff02c49dea56282f09321ef0f5682e7cd7853b57f703b207"
         },
         {
           "case": "denied_with_conflicts",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_conflicts.json",
-          "sha256": "c428d89a6119d803964eaeb34e04b648ec157dcff3381e7ba97f323acdcefb19"
+          "sha256": "1c347d7eb7105b33715e94aeec917ca724e138f8f6d3c34323e95aabecef18ad"
         },
         {
           "case": "denied_with_limitations",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_limitations.json",
-          "sha256": "6294598e08bd18c7d7c3cd9dfc699e25ba05e1eb63cf4fef68b3e23b020cde41"
+          "sha256": "08ea9f453d8d368ae198fad8f0576fa8540dedbfce03cb28180e6da44d69c009"
         },
         {
           "case": "denied_with_follow_up_questions",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_follow_up_questions.json",
-          "sha256": "3d8be4a24b37cc390b51e01db64fa3703b2ee030c0cbfb07d11c3d75b936d374"
+          "sha256": "979248958858e44d7023dd5395badd079340e413981a380cb51736081d9588a6"
         },
         {
           "case": "denied_with_producer_direct_answer",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_producer_direct_answer.json",
-          "sha256": "863b5ade18df5c8e0286da8ada4da03b707abad6bf1ffacac1968cba52740d0b"
+          "sha256": "b0f88176fb7fac3fc381277666398632b038a6252f6106a3ececed61dbe42b37"
         },
         {
           "case": "denied_with_versions",
           "path": "examples/negative/dev_answer_frame.v1.denied_with_versions.json",
-          "sha256": "aee58489c89212b1b643001b30abfef3cc177e1af860945ac99ff328a92a748c"
+          "sha256": "0cb5356f3f1fd144840d881a9bd243632402d4bb77595946339d8b8fc072bbef"
         },
         {
           "case": "coverage_unavailable_source_outside_vocabulary",
           "path": "examples/negative/dev_answer_frame.v1.coverage_unavailable_source_outside_vocabulary.json",
-          "sha256": "20666cd7f28656c1ceba96830ad0a2e630eaacf9889a2c06683b289711524694"
+          "sha256": "3e1c761ed2cc2dc23d162ce652c3a42f6ab8d5f0409efee0b676b12e932c9a68"
         },
         {
           "case": "coverage_stale_source_outside_vocabulary",
           "path": "examples/negative/dev_answer_frame.v1.coverage_stale_source_outside_vocabulary.json",
-          "sha256": "e7d4abf56d9bf00059656562aac4625e58f0ca88b902904c311a9caa869bb602"
+          "sha256": "6504bc262de2d28ab0a0785376de46f3b5cf67de1c6dc89fd1da4ea3091829cc"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_answer_frame.v1.json",
-        "sha256": "8998c14a47d4025dfb9da67ecbd290870266c6e83693bc33f9b244cc45f9b356"
+        "sha256": "91855e2829f628d96d4579576698b5cd941188975b416e3561fc32b97156da6a"
       },
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "62d7a905ac47af0c851b913d26960d6d5ea4b7a7113ce15568ed89411aa16e75"
+        "sha256": "38382807a2793693652eaa7d3580a1749409be746d8126b26b60d0ec48c90f17"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -329,66 +349,66 @@
         {
           "case": "outcome_mismatch_with_frame",
           "path": "examples/negative/dev_answer.v2.outcome_mismatch_with_frame.json",
-          "sha256": "008bc1eb32383e815c136716023dac0843ad8f2ee64fa1345aeeb2df9f3216d2"
+          "sha256": "7a9366127b1ee918339aa5b7afaccca51e5e00d807d4dd2e92fb690e2d172d7f"
         },
         {
           "case": "frame_run_id_mismatch",
           "path": "examples/negative/dev_answer.v2.frame_run_id_mismatch.json",
-          "sha256": "594cc370974f9e824824f3fce14c10ce7c4cde597fb7a84e9f0efacd67bf23fb"
+          "sha256": "e76b0a494951a5b58e5b33824fd171982c3f1b46ffd0918c9260027cc6e5a5bf"
         },
         {
           "case": "narrative_contradicts_number",
           "path": "examples/negative/dev_answer.v2.narrative_contradicts_number.json",
-          "sha256": "4bcc19a20cf5c94a1d542a27a92390c366a04e73560db4eff4e429b93be3944e"
+          "sha256": "740dd8d99ec960c9aa20fc72d48b390b10191a71961fd394442f6e3932385408"
         },
         {
           "case": "narrative_contradicts_readiness",
           "path": "examples/negative/dev_answer.v2.narrative_contradicts_readiness.json",
-          "sha256": "5615600a9161d748af7a084a1999a27c09991371e358f6a5aea411541e5f7e6f"
+          "sha256": "c6a1ceceebab2363fd25906431c9f974d6d07021d3d721f76efeb1c2e0e844d6"
         },
         {
           "case": "narrative_contradicts_subject",
           "path": "examples/negative/dev_answer.v2.narrative_contradicts_subject.json",
-          "sha256": "27c7c470a505efc0f07c2ffa5c2c29530f8a5fe3b50b4e4633628997a75540ce"
+          "sha256": "04bc5ed8db694cb39959f3c9dfac200a5929db2f98dc1ffbf80b81a31f73594f"
         },
         {
           "case": "narrative_contradicts_recommendation",
           "path": "examples/negative/dev_answer.v2.narrative_contradicts_recommendation.json",
-          "sha256": "dd1e0ba5880679f68a8650d998c567bdd2662271081c2aa91ae095b5163690e2"
+          "sha256": "786d52e223ba4b3fa1259132f0420caaea947ccc17d610417c7b1123f4b06a62"
         },
         {
           "case": "denied_with_narrative",
           "path": "examples/negative/dev_answer.v2.denied_with_narrative.json",
-          "sha256": "ed40fc45004e453e132e0c7b03f849043e05a7305d0fb761bd9bd0d298c97678"
+          "sha256": "c8f781253d1c63214390cf413f8d787cc5275e30cb17ff65b7a710481cab4757"
         },
         {
           "case": "narrative_unrelated_comparison_number",
           "path": "examples/negative/dev_answer.v2.narrative_unrelated_comparison_number.json",
-          "sha256": "fdaf2f3a6fe014c1b4e6c15f980e77d9f027c66e251a8ae3690bbf5d26518cc9"
+          "sha256": "c2e311cf00a21017b289d2021191e4f1fdb8a3e01bdead47aa2b05dac007531c"
         },
         {
           "case": "narrative_substring_subject",
           "path": "examples/negative/dev_answer.v2.narrative_substring_subject.json",
-          "sha256": "9bb9055e73c9b94510a9567698f80d7fc34e965937e545a93260cd6048097c29"
+          "sha256": "db7082ada586094ec9ce7e6ee8c6ec4ce6e30e8691833c7ae1e2b4b5dbbd5967"
         },
         {
           "case": "narrative_unbound_recommendation",
           "path": "examples/negative/dev_answer.v2.narrative_unbound_recommendation.json",
-          "sha256": "c8eaa616366056c8fa5c38e980b9667de99b2648be858bfb5c628822f577d23d"
+          "sha256": "9281f7a703545a5b9389d6696e619a69b9b76275a1cdbf19c191ea86f45edc1d"
         },
         {
           "case": "narrative_completion_number_out_of_context",
           "path": "examples/negative/dev_answer.v2.narrative_completion_number_out_of_context.json",
-          "sha256": "e8bb2a3686a2c3ab21153c11e9297f0df0499ce5b929078f7a3d87c3592b8529"
+          "sha256": "444ea73bf6f20729ab6192a070b33a6b437aff7fd2d07ee9574cae4df99fb5af"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_answer.v2.json",
-        "sha256": "6ea9ca3b984ff0f987dc1291aa5ea9733243d5b8f3c6a6493f9c1d41cd75ee38"
+        "sha256": "07c91f4fab5284ab3f12766f181cf416386f93a48553605b9bbdd72acde06adf"
       },
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "b04f0bf09b22da88784a16048bf38360614c4ed4b1f4f0d13150bfedf5354b8e"
+        "sha256": "3f3129b4956d2dd3e1c03440b55fd1ec1bad00c2c48d5f39011cee7bd928bc44"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -406,7 +426,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "e5d2af956ed1e64bdced7631ba15ceb5b4c2a825d1e2708a4e21beb55c484850"
+        "sha256": "10e88e411727950ba03a8ded00e5fd9517d1551814e7efc3d10eb7f027dc7965"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
@@ -93,6 +93,14 @@
     "DevAnswerFrame": {
       "additionalProperties": false,
       "properties": {
+        "clarification_candidates": {
+          "items": {
+            "$ref": "#/$defs/DevResolutionCandidate"
+          },
+          "maxItems": 25,
+          "title": "Clarification Candidates",
+          "type": "array"
+        },
         "comparisons": {
           "items": {
             "$ref": "#/$defs/DevComparisonPoint"
@@ -1898,6 +1906,26 @@
         "status"
       ],
       "title": "DevRequiredChildFactV2",
+      "type": "object"
+    },
+    "DevResolutionCandidate": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_ref": {
+          "$ref": "#/$defs/DevEntityRefV2"
+        },
+        "reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_ref",
+        "reason"
+      ],
+      "title": "DevResolutionCandidate",
       "type": "object"
     },
     "DevScopeV2": {

--- a/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
@@ -1534,6 +1534,26 @@
       "title": "DevRequiredChildFactV2",
       "type": "object"
     },
+    "DevResolutionCandidate": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_ref": {
+          "$ref": "#/$defs/DevEntityRefV2"
+        },
+        "reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_ref",
+        "reason"
+      ],
+      "title": "DevResolutionCandidate",
+      "type": "object"
+    },
     "DevScopeV2": {
       "additionalProperties": false,
       "properties": {
@@ -2094,6 +2114,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "clarification_candidates": {
+      "items": {
+        "$ref": "#/$defs/DevResolutionCandidate"
+      },
+      "maxItems": 25,
+      "title": "Clarification Candidates",
+      "type": "array"
+    },
     "comparisons": {
       "items": {
         "$ref": "#/$defs/DevComparisonPoint"

--- a/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
@@ -93,6 +93,14 @@
     "DevAnswerFrame": {
       "additionalProperties": false,
       "properties": {
+        "clarification_candidates": {
+          "items": {
+            "$ref": "#/$defs/DevResolutionCandidate"
+          },
+          "maxItems": 25,
+          "title": "Clarification Candidates",
+          "type": "array"
+        },
         "comparisons": {
           "items": {
             "$ref": "#/$defs/DevComparisonPoint"

--- a/docs/contribute/architecture/ask-dev-contracts-v2.md
+++ b/docs/contribute/architecture/ask-dev-contracts-v2.md
@@ -157,6 +157,73 @@ declaration) order via `_disclosures_from_claim_flags`, so a v1 claim
 carrying `stale`/`uncertain`/`conflicting`/`untrusted_source` is no longer
 silently dropped when embedded into a frame.
 
+## Clarification candidates
+
+`DevAnswerFrame.clarification_candidates` (CHAOS-3325) is a typed block of
+real, authorized entities for a `needs_clarification` outcome, reusing
+`dev_resolution_ledger.v1`'s own `DevResolutionCandidate` shape
+(`entity_ref` + `reason`) rather than declaring a second one: it carries
+exactly what the resolution ledger already recorded for an
+`ambiguous_candidates` mention, never a re-derived or invented copy.
+`subject_preflight.SubjectPreflight._terminate` passes the terminating
+ledger entry's own `candidates` tuple straight through
+`build_preflight_answer` onto the frame -- empty for the other three
+`UNRESOLVED_OUTCOMES` (`DevResolutionEntry.validate_outcome_payload` already
+guarantees those carry none) and populated only for
+`ambiguous_candidates`.
+
+Classification is split across two mechanisms because
+`needs_clarification` is deliberately **not** one of `NO_ANSWER_OUTCOMES`
+(see "No-content outcomes are rebuilt from an allowlist" below):
+
+- `no_answer_policy.NO_ANSWER_FRAME_FIELD_POLICY` classifies the field
+  `ABSENT`, which governs the five true no-answer outcomes
+  (`not_found | temporarily_unavailable | unsupported | denied | failed`).
+- `validators.validate_outcome_consistency` carries a dedicated clause
+  forbidding it on `answered`/`answered_with_gaps` -- the two outcomes the
+  no-answer allowlist does not reach.
+
+Between the two, every outcome but `needs_clarification` is forced empty;
+`needs_clarification` itself is unconstrained -- it may carry zero
+candidates (e.g. the question could not be interpreted at all, before any
+mention was ever resolved) or several, and zero is a legal terminal payload
+in its own right, never backfilled with an invented candidate.
+`DevAnswerFrame.validate_frame_semantics` additionally requires every
+candidate's `entity_ref.entity_id` to be unique -- two candidates naming the
+same authorized entity are not two distinct options. There is no
+"unauthorized" flag on the wire shape: authorization is enforced entirely by
+construction (`subject_preflight._entity_ref_v2` only ever builds a
+candidate from an `AuthorizedEntity` the catalog itself returned), and the
+one wire-level rejection available for a malformed candidate is the closed
+`EntityKind` vocabulary on `entity_ref.entity_kind`.
+
+`contracts_v2/compat.py`'s `_project_needs_clarification` projects the block
+to v1 in priority order: real `clarification_candidates` (reported
+`ScopeResolutionOutcome.AMBIGUOUS`, matching v1's own "ambiguous requires
+candidates" invariant), else a single candidate derived from
+`frame.subject_ref` (pre-CHAOS-3325 behavior, unchanged -- never set by the
+preflight ambiguity path, which commits nothing), else
+`ScopeResolutionOutcome.UNRESOLVED` with no candidates at all. That third
+case replaces what the pre-3325 projector did instead: fabricate a single
+placeholder candidate (`entity_id="clarification_required"`,
+`display_label="Clarification required"`) to satisfy v1's
+AMBIGUOUS-requires-candidates invariant. `UNRESOLVED` carries no candidates
+by the same invariant's other half (`candidates are allowed only for
+ambiguous outcomes`), so the zero-candidate case is now represented
+honestly -- "not resolved, nothing to offer" -- rather than inventing an
+option that was never real.
+
+On the live preflight path this block does not yet reach a v1 client:
+`orchestrator.run` and the router's replay-reconstruction path both call
+`preflight_outcomes.project_preflight_error` for a preflight ambiguity,
+which returns the fixed `scope_ambiguous` `DevError` (CHAOS-3292's ratified
+design) and never carries candidates, whatever the frame holds. The
+`_project_needs_clarification` path above is exercised by any *other*
+caller that runs a `needs_clarification` `dev_answer.v2` through the general
+`project_answer_v2_to_v1` projector. Actually serving the candidate block to
+a user still needs the v2 rendering surface (CHAOS-3298) and persisted
+clarification state (CHAOS-3299).
+
 ## Public outcome vocabulary and the five semantic validators
 
 `dev_answer.v2`'s `public_outcome` is exactly: `answered`,

--- a/src/dev_health_ops/api/dev/contract_fixtures_v2.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures_v2.py
@@ -75,6 +75,29 @@ def _evidence() -> dict[str, Any]:
     }
 
 
+def _clarification_candidate(
+    *,
+    entity_id: str,
+    display_label: str,
+    entity_kind: str = "repository",
+) -> dict[str, Any]:
+    """CHAOS-3325: one real, authorized ``DevResolutionCandidate``-shaped
+    entry -- the same shape ``dev_resolution_ledger.v1``'s own candidates
+    already use (see ``_resolution_entry``), reused here rather than a
+    separate fixture vocabulary."""
+
+    return {
+        "entity_ref": {
+            "entity_kind": entity_kind,
+            "entity_id": entity_id,
+            "display_label": display_label,
+            "repository_id": None,
+            "team_id": None,
+        },
+        "reason": "Multiple authorized entities match this name.",
+    }
+
+
 def _relationship_path() -> dict[str, Any]:
     return {
         "path_id": "path_01",
@@ -286,6 +309,7 @@ def _frame() -> dict[str, Any]:
         "public_outcome": "answered",
         "subject_ref": _entity_ref(),
         "subject_set_ref": None,
+        "clarification_candidates": [],
         "direct_answer": (
             "Repository dev-health is on track; one required child issue remains open."
         ),
@@ -456,6 +480,65 @@ def _denied_answer_base() -> dict[str, Any]:
     return answer
 
 
+def _needs_clarification_frame_base() -> dict[str, Any]:
+    """A fully compliant, content-free ``needs_clarification`` frame.
+
+    Mirrors ``_denied_frame_base`` but for the one empty-content outcome the
+    no-answer allowlist projection does not govern --
+    ``needs_clarification`` is deliberately excluded from
+    ``NO_ANSWER_OUTCOMES`` (see ``no_answer_policy``'s module docstring), so
+    ``direct_answer``/``versions`` are unconstrained free text/provenance
+    here rather than pinned to the canonical no-answer table.
+    ``clarification_candidates`` starts empty -- CHAOS-3325: a legal
+    ``needs_clarification`` payload in its own right (e.g. the question
+    could not be interpreted at all, before any mention was ever resolved),
+    never backfilled with an invented candidate.
+    """
+
+    frame = deepcopy(_frame())
+    frame["public_outcome"] = "needs_clarification"
+    frame["subject_ref"] = None
+    frame["subject_set_ref"] = None
+    frame["clarification_candidates"] = []
+    frame["direct_answer"] = "Which repository did you mean?"
+    frame["completion"] = None
+    frame["readiness"] = None
+    frame["sections"] = []
+    frame["facts"] = []
+    frame["metrics"] = []
+    frame["comparisons"] = []
+    frame["relationship_paths"] = []
+    frame["health_profile_refs"] = []
+    frame["finding_refs"] = []
+    frame["deficiency_refs"] = []
+    frame["conflicts"] = []
+    frame["limitations"] = []
+    frame["source_observations"] = []
+    frame["evidence"] = []
+    frame["safe_follow_up_questions"] = []
+    return frame
+
+
+def needs_clarification_frame_with_candidates() -> dict[str, Any]:
+    """CHAOS-3325: a ``needs_clarification`` frame carrying real, authorized
+    clarification candidates -- the positive counterpart to the zero-
+    candidate base above. Two candidates, never one, to keep this fixture
+    distinct from (and not degenerate with) the zero-candidate case."""
+
+    frame = _needs_clarification_frame_base()
+    frame["clarification_candidates"] = [
+        _clarification_candidate(
+            entity_id="repo_nightfall_public",
+            display_label="full-chaos/nightfall-public",
+        ),
+        _clarification_candidate(
+            entity_id="repo_nightfall_internal",
+            display_label="full-chaos/nightfall-internal",
+        ),
+    ]
+    return frame
+
+
 def _no_answer_outcome_prohibited_field_cases() -> list[tuple[str, dict[str, Any]]]:
     """One negative fixture per field ``validate_no_answer_content_leaks`` forbids.
 
@@ -508,6 +591,20 @@ def _no_answer_outcome_prohibited_field_cases() -> list[tuple[str, dict[str, Any
         case(
             "denied_with_relationship_paths",
             lambda v: v.__setitem__("relationship_paths", [_relationship_path()]),
+        ),
+        # CHAOS-3325: clarification_candidates is ABSENT on every true
+        # no-answer outcome -- only needs_clarification may carry it.
+        case(
+            "denied_with_clarification_candidates",
+            lambda v: v.__setitem__(
+                "clarification_candidates",
+                [
+                    _clarification_candidate(
+                        entity_id="repo_nightfall_public",
+                        display_label="full-chaos/nightfall-public",
+                    )
+                ],
+            ),
         ),
         case(
             "denied_with_evidence",
@@ -770,6 +867,93 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
         "dev_answer_frame.v1",
         lambda value: value["facts"][0].__setitem__("disclosures", ["stale", "stale"]),
     )
+    # CHAOS-3325: validate_outcome_consistency's new clause -- an 'answered'
+    # frame whose only defect is a clarification candidate. Distinct from
+    # denied_with_clarification_candidates (the ABSENT no-answer-policy
+    # path): 'answered' is not one of NO_ANSWER_OUTCOMES, so that policy
+    # never reaches it -- this clause is what does.
+    frame_answered_with_clarification_candidates = changed(
+        "dev_answer_frame.v1",
+        lambda value: value.__setitem__(
+            "clarification_candidates",
+            [
+                _clarification_candidate(
+                    entity_id="repo_nightfall_public",
+                    display_label="full-chaos/nightfall-public",
+                )
+            ],
+        ),
+    )
+    # A candidate outside the closed EntityKind vocabulary -- the only
+    # "unauthorized-shaped" candidate expressible at the wire-type level.
+    # Real authorization is enforced by the builder using only
+    # preflight-resolved entities (subject_preflight._entity_ref_v2), never
+    # by a field on the wire shape itself.
+    frame_clarification_candidate_unknown_entity_kind = changed(
+        "dev_answer_frame.v1",
+        lambda value: (
+            value.__setitem__("public_outcome", "needs_clarification"),
+            value.__setitem__("subject_ref", None),
+            value.__setitem__("subject_set_ref", None),
+            value.__setitem__("sections", []),
+            value.__setitem__("facts", []),
+            value.__setitem__("completion", None),
+            value.__setitem__("readiness", None),
+            value.__setitem__("metrics", []),
+            value.__setitem__("comparisons", []),
+            value.__setitem__("relationship_paths", []),
+            value.__setitem__("evidence", []),
+            value.__setitem__("source_observations", []),
+            value.__setitem__("health_profile_refs", []),
+            value.__setitem__("finding_refs", []),
+            value.__setitem__("deficiency_refs", []),
+            value.__setitem__(
+                "clarification_candidates",
+                [
+                    _clarification_candidate(
+                        entity_id="repo_nightfall_public",
+                        display_label="full-chaos/nightfall-public",
+                        entity_kind="malicious_kind",
+                    )
+                ],
+            ),
+        ),
+    )
+    # DevAnswerFrame.validate_frame_semantics: two candidates naming the same
+    # authorized entity are not two distinct options.
+    frame_clarification_candidates_duplicate_entity_id = changed(
+        "dev_answer_frame.v1",
+        lambda value: (
+            value.__setitem__("public_outcome", "needs_clarification"),
+            value.__setitem__("subject_ref", None),
+            value.__setitem__("subject_set_ref", None),
+            value.__setitem__("sections", []),
+            value.__setitem__("facts", []),
+            value.__setitem__("completion", None),
+            value.__setitem__("readiness", None),
+            value.__setitem__("metrics", []),
+            value.__setitem__("comparisons", []),
+            value.__setitem__("relationship_paths", []),
+            value.__setitem__("evidence", []),
+            value.__setitem__("source_observations", []),
+            value.__setitem__("health_profile_refs", []),
+            value.__setitem__("finding_refs", []),
+            value.__setitem__("deficiency_refs", []),
+            value.__setitem__(
+                "clarification_candidates",
+                [
+                    _clarification_candidate(
+                        entity_id="repo_nightfall_public",
+                        display_label="full-chaos/nightfall-public",
+                    ),
+                    _clarification_candidate(
+                        entity_id="repo_nightfall_public",
+                        display_label="full-chaos/nightfall (duplicate)",
+                    ),
+                ],
+            ),
+        ),
+    )
     answer_frame_run_id_mismatch = changed(
         "dev_answer.v2",
         lambda value: value["frame"].__setitem__(
@@ -999,6 +1183,18 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
             ("answered_with_disclosure", frame_answered_with_disclosure),
             ("disclosures_out_of_order", frame_disclosures_out_of_order),
             ("disclosures_duplicated", frame_disclosures_duplicated),
+            (
+                "answered_with_clarification_candidates",
+                frame_answered_with_clarification_candidates,
+            ),
+            (
+                "clarification_candidate_unknown_entity_kind",
+                frame_clarification_candidate_unknown_entity_kind,
+            ),
+            (
+                "clarification_candidates_duplicate_entity_id",
+                frame_clarification_candidates_duplicate_entity_id,
+            ),
             *_no_answer_outcome_prohibited_field_cases(),
             *_coverage_source_vocabulary_cases(),
         ],
@@ -1176,6 +1372,7 @@ def stream_fixtures() -> dict[str, list[dict[str, Any]]]:
 
 
 __all__ = [
+    "needs_clarification_frame_with_candidates",
     "negative_fixtures",
     "no_answer_answer_fixture",
     "positive_fixtures",

--- a/src/dev_health_ops/api/dev/contracts_v2/compat.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/compat.py
@@ -88,6 +88,7 @@ from dev_health_ops.api.dev.contracts import (
 from .answer import DevAnswerV2
 from .base import EntityKind, FactDisclosure, OpaqueID, PublicOutcome
 from .frame import DevFrameVersions
+from .subject import DevResolutionCandidate
 from .validators import CANONICAL_NO_ANSWER_COPY, CANONICAL_NO_ANSWER_REMEDIATION
 
 __all__ = ["project_answer_v2_to_v1"]
@@ -164,6 +165,46 @@ _KIND_TO_ENTITY_TYPE: dict[EntityKind, EntityType] = {
     EntityKind.ISSUE: EntityType.ISSUE,
     EntityKind.PULL_REQUEST: EntityType.PULL_REQUEST,
 }
+
+#: Full ``EntityKind`` -> v1 ``EntityType`` mapping for a clarification
+#: candidate (CHAOS-3325), unlike ``_KIND_TO_ENTITY_TYPE`` above: that map
+#: intentionally omits ``TEAM`` because it backs ``_build_resolved_scope``,
+#: which never reaches a team kind at all (the team-subject guard in
+#: ``project_answer_v2_to_v1`` intercepts it first — v1 has no team
+#: *direct-scope* representation). A clarification candidate is never a
+#: resolved scope, only a named option in a list, and v1's own
+#: ``EntityType`` already has a ``TEAM`` member (``contracts.py``) — so a
+#: team candidate has a faithful v1 shape and this map is total over
+#: ``EntityKind`` rather than reusing the scope-building map's narrower one.
+_CANDIDATE_ENTITY_TYPE: dict[EntityKind, EntityType] = {
+    **_KIND_TO_ENTITY_TYPE,
+    EntityKind.TEAM: EntityType.TEAM,
+}
+
+
+def _project_clarification_candidate(
+    candidate: DevResolutionCandidate,
+) -> DevDisambiguationCandidate:
+    """One real, authorized ledger candidate -> its v1 wire shape.
+
+    Never invented: ``entity_ref``/``reason`` are carried straight across
+    from the ``DevResolutionCandidate`` the resolution ledger recorded (see
+    ``subject_preflight.SubjectPreflight._entry``) — the same object
+    ``build_preflight_answer`` places on ``frame.clarification_candidates``.
+    """
+
+    entity = candidate.entity_ref
+    return DevDisambiguationCandidate(
+        entity_ref=DevEntityRef(
+            entity_type=_CANDIDATE_ENTITY_TYPE[entity.entity_kind],
+            entity_id=entity.entity_id,
+            display_label=entity.display_label,
+            repository_id=entity.repository_id,
+        ),
+        repository_id=entity.repository_id,
+        reason=candidate.reason,
+    )
+
 
 _ERROR_OUTCOME_CODES: dict[PublicOutcome, tuple[str, bool]] = {
     PublicOutcome.NOT_FOUND: ("scope_not_found", False),
@@ -330,17 +371,45 @@ def _project_answered(
 def _project_needs_clarification(
     answer: DevAnswerV2, organization_id: OpaqueID, time_range: DevTimeRange
 ) -> DevAnswer:
+    """Project a ``needs_clarification`` v2 answer to a v1 ``DevAnswer``.
+
+    CHAOS-3325: candidates are now projected from ``frame.clarification_
+    candidates`` — the resolution ledger's own real, authorized entries — and
+    never fabricated. Three cases, in priority order:
+
+    1. ``frame.clarification_candidates`` is non-empty (the preflight
+       ambiguous-mention case): project each real candidate and report
+       ``ScopeResolutionOutcome.AMBIGUOUS``, matching v1's own invariant that
+       an ``AMBIGUOUS`` resolution carries candidates
+       (``DevScopeResolution.validate_outcome_payload``).
+    2. ``frame.subject_ref`` is set instead (pre-CHAOS-3325 behavior,
+       unchanged): a committed subject that itself needs narrowing on
+       something else — never set by the preflight ambiguity path, which
+       commits nothing (see ``build_preflight_answer``) — so this remains a
+       single derived candidate from the one real, committed entity.
+    3. Neither is present (e.g. the question could not be interpreted at all,
+       before any mention was ever resolved — no real candidate list exists
+       to report). The old code invented a placeholder entity
+       (``entity_id="clarification_required"``) here to satisfy v1's
+       ``AMBIGUOUS``-requires-candidates invariant; this reports
+       ``ScopeResolutionOutcome.UNRESOLVED`` instead, which carries no
+       candidates by the same invariant's other half
+       (``candidates are allowed only for ambiguous outcomes``) — an honest
+       "not resolved, nothing to offer" rather than a fabricated option.
+    """
+
     frame = answer.frame
     versions = _require_versions(frame.versions, answer.public_outcome)
     resolved = _build_resolved_scope(answer, organization_id, time_range)
-    resolution = DevScopeResolution(
-        schema_version="dev_scope_resolution.v1",
-        requested_scope=resolved,
-        resolved_scope=None,
-        outcome=ScopeResolutionOutcome.AMBIGUOUS,
-        authorized_repository_ids=[],
-        authorized_entity_ids=[],
-        candidates=[
+    if frame.clarification_candidates:
+        outcome = ScopeResolutionOutcome.AMBIGUOUS
+        candidates = [
+            _project_clarification_candidate(candidate)
+            for candidate in frame.clarification_candidates
+        ]
+    elif frame.subject_ref is not None:
+        outcome = ScopeResolutionOutcome.AMBIGUOUS
+        candidates = [
             DevDisambiguationCandidate(
                 entity_ref=DevEntityRef(
                     entity_type=_KIND_TO_ENTITY_TYPE.get(
@@ -353,17 +422,17 @@ def _project_needs_clarification(
                 reason="Clarification requested before continuing.",
             )
         ]
-        if frame.subject_ref is not None
-        else [
-            DevDisambiguationCandidate(
-                entity_ref=DevEntityRef(
-                    entity_type=EntityType.REPOSITORY,
-                    entity_id="clarification_required",
-                    display_label="Clarification required",
-                ),
-                reason="The question requires clarification before it can be answered.",
-            )
-        ],
+    else:
+        outcome = ScopeResolutionOutcome.UNRESOLVED
+        candidates = []
+    resolution = DevScopeResolution(
+        schema_version="dev_scope_resolution.v1",
+        requested_scope=resolved,
+        resolved_scope=None,
+        outcome=outcome,
+        authorized_repository_ids=[],
+        authorized_entity_ids=[],
+        candidates=candidates,
         fallbacks=[],
         warnings=[],
         resolved_at=answer.generated_at,

--- a/src/dev_health_ops/api/dev/contracts_v2/frame.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/frame.py
@@ -47,7 +47,7 @@ from .base import (
 from .embedded import DevCoverageV2, DevEvidenceRefV2, DevMetricRefV2
 from .plan import PlanRegistryID
 from .result import DevRelationshipPath, DevSourceObservation
-from .subject import DevEntityRefV2
+from .subject import DevEntityRefV2, DevResolutionCandidate
 
 __all__ = [
     "DevAnswerFact",
@@ -188,6 +188,21 @@ class DevAnswerFrame(ContractModelV2):
     public_outcome: PublicOutcome
     subject_ref: DevEntityRefV2 | None = None
     subject_set_ref: OpaqueID | None = None
+    #: CHAOS-3325: the real, authorized candidates a preflight ambiguity
+    #: resolved -- the same ``DevResolutionCandidate`` shape the resolution
+    #: ledger already records per mention (``subject.py``), reused here
+    #: rather than re-declared, so the frame carries exactly what preflight
+    #: resolution actually found and nothing a builder invented. Populated
+    #: only for ``needs_clarification`` (``validate_outcome_consistency``
+    #: forbids it on ``answered``/``answered_with_gaps``; the no-answer
+    #: allowlist projection forces it empty on every no-content outcome --
+    #: see ``no_answer_policy.NO_ANSWER_FRAME_FIELD_POLICY``). Empty is a
+    #: legal ``needs_clarification`` payload in its own right (e.g. the
+    #: question could not be interpreted at all, before any mention was ever
+    #: resolved) -- it is never backfilled with an invented candidate.
+    clarification_candidates: tuple[DevResolutionCandidate, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
     direct_answer: LongText
     completion: DevCompletionBlock | None = None
     readiness: DevReadinessBlock | None = None
@@ -233,6 +248,12 @@ class DevAnswerFrame(ContractModelV2):
         relationship_ids = [path.path_id for path in self.relationship_paths]
         if len(relationship_ids) != len(set(relationship_ids)):
             raise ValueError("relationship path IDs must be unique")
+        candidate_ids = [
+            candidate.entity_ref.entity_id
+            for candidate in self.clarification_candidates
+        ]
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("clarification candidate entity IDs must be unique")
         # Structural closure first: the five acceptance-criteria semantic
         # validators below assume a well-formed frame (unique, resolvable
         # fact/section/evidence IDs).

--- a/src/dev_health_ops/api/dev/contracts_v2/no_answer_policy.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/no_answer_policy.py
@@ -157,6 +157,13 @@ NO_ANSWER_FRAME_FIELD_POLICY: Mapping[str, NoAnswerFieldPolicy] = {
     "public_outcome": NoAnswerFieldPolicy.CLOSED_VOCABULARY,
     "subject_ref": NoAnswerFieldPolicy.ABSENT,
     "subject_set_ref": NoAnswerFieldPolicy.ABSENT,
+    # CHAOS-3325: real per-mention candidates, only ever populated for
+    # needs_clarification -- which is not one of NO_ANSWER_OUTCOMES (see the
+    # module docstring), so this ABSENT cell governs the five true no-answer
+    # outcomes; validators.validate_outcome_consistency separately forbids it
+    # on 'answered'/'answered_with_gaps', the two outcomes this policy does
+    # not reach.
+    "clarification_candidates": NoAnswerFieldPolicy.ABSENT,
     "direct_answer": NoAnswerFieldPolicy.CANONICAL,
     "completion": NoAnswerFieldPolicy.ABSENT,
     "readiness": NoAnswerFieldPolicy.ABSENT,

--- a/src/dev_health_ops/api/dev/contracts_v2/validators.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/validators.py
@@ -413,6 +413,16 @@ def validate_outcome_consistency(frame: _frame.DevAnswerFrame) -> None:
         raise ValueError(
             f"public outcome {outcome!r} requires answer sections and facts"
         )
+    # CHAOS-3325: clarification_candidates is ABSENT-classified for the five
+    # true no-answer outcomes (no_answer_policy.NO_ANSWER_FRAME_FIELD_POLICY),
+    # but 'answered'/'answered_with_gaps' are not in NO_ANSWER_OUTCOMES either
+    # (see that module's docstring), so this clause is what forbids it there
+    # -- only 'needs_clarification' may carry it.
+    if outcome in ANSWERED_CONTENT_OUTCOMES and frame.clarification_candidates:
+        raise ValueError(
+            f"public outcome {outcome!r} cannot carry clarification_candidates; "
+            "only 'needs_clarification' may"
+        )
     if outcome == "answered":
         if frame.limitations:
             raise ValueError(

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -73,6 +73,7 @@ from .contracts import (
 from .contracts_v2 import (
     Cardinality,
     DevInvestigationResult,
+    DevResolutionEntry,
     DevSubjectSet,
     QuestionIntentID,
 )
@@ -329,6 +330,21 @@ class RunRecorder(Protocol):
         """
         ...
 
+    async def append_resolution(self, entry: DevResolutionEntry) -> None:
+        """Persist one ``dev_resolution_ledger.v1`` entry (CHAOS-3325).
+
+        Called only for the terminating ``ambiguous_candidates`` entry of a
+        preflight ambiguity — the exact entry
+        ``SubjectPreflightResult.terminating_resolution_entry`` carries —
+        always immediately before ``record_frame`` for the same outcome, so
+        the persisted frame's ``clarification_candidates`` always has a
+        matching ledger row to be authorized against
+        (``persistence.service._authorize_clarification_candidates``, a
+        Codex-review NO-SHIP finding: a schema-valid frame could otherwise
+        name an entity the ledger never authorized).
+        """
+        ...
+
     async def record_frame(self, frame: DevAnswerFrame) -> None:
         """Persist one already-built ``dev_answer_frame.v1`` (CHAOS-3297).
 
@@ -406,6 +422,9 @@ class NullRunRecorder:
 
     async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
         del subject_set
+
+    async def append_resolution(self, entry: DevResolutionEntry) -> None:
+        del entry
 
     async def record_frame(self, frame: DevAnswerFrame) -> None:
         del frame
@@ -900,6 +919,18 @@ class DevOrchestrator:
                     # land together -- mirrors record_answer's placement
                     # ahead of terminal() on the completed-answer path.
                     try:
+                        # CHAOS-3325 Codex review (NO-SHIP, confirmed): the
+                        # terminating ledger entry -- the one that produced
+                        # the frame's own clarification_candidates -- is
+                        # persisted first, in the same try/rollback unit, so
+                        # record_frame's cross-check
+                        # (_authorize_clarification_candidates) always has a
+                        # real ledger row to authorize against rather than
+                        # racing it.
+                        if preflight_result.terminating_resolution_entry is not None:
+                            await self._recorder.append_resolution(
+                                preflight_result.terminating_resolution_entry
+                            )
                         await self._recorder.record_frame(preflight_result.answer.frame)
                     except Exception:
                         # A database-layer failure here (constraint

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -2425,6 +2425,17 @@ class DevPersistenceService:
         a schema-valid frame could name an entity the resolution ledger
         never authorized. Extends the same cross-check posture one field
         further: see ``_authorize_clarification_candidates``.
+
+        CHAOS-3325 confirmation review (MEDIUM): the row is built from
+        ``validated.model_dump(mode="json")`` -- the authorized snapshot --
+        never from ``payload``. Every check above runs against ``validated``,
+        an immutable contract object, while ``payload`` is the caller's
+        mapping and stays mutable throughout; building the row from it meant
+        anything that changed it after authorization returned was persisted
+        unchecked, which review demonstrated by mutating in that window.
+        Persisting what was actually authorized, rather than re-reading the
+        input, is the same row-binding lesson as CHAOS-3297 s1's payload-vs-
+        row identity closure.
         """
 
         run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
@@ -2465,7 +2476,7 @@ class DevPersistenceService:
         )
         record = await self._construct_validated_payload_row(
             model_cls=DevAnswerFrame,
-            payload_dict=payload,
+            payload_dict=validated.model_dump(mode="json"),
             field_name="frame_payload",
             max_bytes=_FRAME_PAYLOAD_MAX_BYTES,
             run_id=run.id,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -31,6 +31,9 @@ from dev_health_ops.api.dev.contracts_v2.frame import (
 from dev_health_ops.api.dev.contracts_v2.narrative import (
     DevNarrative as DevNarrativeContract,
 )
+from dev_health_ops.api.dev.contracts_v2.subject import (
+    DevResolutionEntry as DevResolutionEntryContract,
+)
 from dev_health_ops.api.dev.org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from dev_health_ops.models.dev_persistence import (
     DEV_RETENTION_DAYS,
@@ -964,6 +967,74 @@ def _guarded_bulk_update_mappings(
 Session.bulk_save_objects = _guarded_bulk_save_objects  # type: ignore[method-assign]
 Session.bulk_insert_mappings = _guarded_bulk_insert_mappings  # type: ignore[method-assign]
 Session.bulk_update_mappings = _guarded_bulk_update_mappings  # type: ignore[method-assign]
+
+
+async def _authorize_clarification_candidates(
+    session: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    validated: DevAnswerFrameContract,
+) -> None:
+    """CHAOS-3325 Codex review (NO-SHIP, confirmed medium): a schema-valid
+    ``clarification_candidates`` entry only proves *shape*, not provenance --
+    a frame naming an entity the resolution ledger never authorized (e.g.
+    another org's repository, ``entity_id="other-org-secret-repo"``) would
+    otherwise persist as canonical v2 state and be served verbatim by any
+    general ``project_answer_v2_to_v1`` caller or future CHAOS-3298 consumer.
+
+    A separate, independently monkeypatchable function -- the same posture
+    ``contracts_v2.validators`` uses for its guardrails -- so a RED/GREEN
+    test pair can prove this specific check, not the whole of
+    ``record_frame``, is what rejects an unauthorized candidate.
+
+    Non-empty ``clarification_candidates`` must equal, exactly and in the
+    same order, the owned run's persisted ``ambiguous_candidates``
+    resolution-ledger entry (``orchestrator.run`` persists it via
+    ``append_resolution`` immediately before calling ``record_frame`` for
+    this outcome -- see ``SubjectPreflightResult.terminating_resolution_
+    entry``); a missing ledger entry is rejected exactly like a mismatched
+    one, never treated as "nothing to check".
+
+    Empty candidates are never rejected here, regardless of what the ledger
+    holds for this run: a frame disclosing FEWER candidates than were
+    authorized is not a disclosure risk, only a mismatched or surplus one
+    is -- so this is a no-op whenever ``validated.clarification_candidates``
+    is empty (the honest "uninterpretable question" case CHAOS-3325 already
+    decided not to fabricate a placeholder for).
+    """
+
+    if not validated.clarification_candidates:
+        return
+    ledger_row = await session.scalar(
+        select(DevRunResolution)
+        .where(
+            DevRunResolution.run_id == run_id,
+            DevRunResolution.org_id == org_id,
+            DevRunResolution.user_id == user_id,
+            DevRunResolution.outcome == "ambiguous_candidates",
+        )
+        .order_by(DevRunResolution.entry_ordinal.desc())
+    )
+    if ledger_row is None:
+        raise DevPersistenceValidationError(
+            "frame_payload.clarification_candidates is non-empty but this "
+            "run has no recorded ambiguous_candidates resolution ledger "
+            "entry to authorize it"
+        )
+    try:
+        ledger_entry = DevResolutionEntryContract.model_validate(ledger_row.payload)
+    except PydanticValidationError as exc:
+        raise DevPersistenceValidationError(
+            "the run's recorded resolution ledger entry is not a valid "
+            f"dev_resolution_entry: {exc}"
+        ) from exc
+    if tuple(validated.clarification_candidates) != tuple(ledger_entry.candidates):
+        raise DevPersistenceValidationError(
+            "frame_payload.clarification_candidates does not match the "
+            "run's recorded ambiguous_candidates resolution ledger entry"
+        )
 
 
 class DevPersistenceService:
@@ -2322,6 +2393,12 @@ class DevPersistenceService:
         call's own arguments -- a caller passing a frame for a different
         run, or claiming a different outcome than it argues for, is a
         caller bug, not data to persist quietly.
+
+        CHAOS-3325 Codex review (NO-SHIP, confirmed medium): shape validation
+        alone did not prove *provenance* for ``clarification_candidates`` --
+        a schema-valid frame could name an entity the resolution ledger
+        never authorized. Extends the same cross-check posture one field
+        further: see ``_authorize_clarification_candidates``.
         """
 
         run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
@@ -2348,6 +2425,18 @@ class DevPersistenceService:
                 "frame_payload.public_outcome does not match the "
                 "public_outcome argument"
             )
+        # CHAOS-3325 Codex review (NO-SHIP, confirmed): the contract only
+        # enforces wire shape, not provenance -- see
+        # _authorize_clarification_candidates's own docstring. Runs before
+        # the row is constructed, so an unauthorized candidate list never
+        # reaches the payload-bearing row at all.
+        await _authorize_clarification_candidates(
+            self.session,
+            run_id=run_id,
+            org_id=org_id,
+            user_id=user_id,
+            validated=validated,
+        )
         record = await self._construct_validated_payload_row(
             model_cls=DevAnswerFrame,
             payload_dict=payload,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -989,24 +989,48 @@ async def _authorize_clarification_candidates(
     test pair can prove this specific check, not the whole of
     ``record_frame``, is what rejects an unauthorized candidate.
 
-    Non-empty ``clarification_candidates`` must equal, exactly and in the
-    same order, the owned run's persisted ``ambiguous_candidates``
-    resolution-ledger entry (``orchestrator.run`` persists it via
-    ``append_resolution`` immediately before calling ``record_frame`` for
-    this outcome -- see ``SubjectPreflightResult.terminating_resolution_
-    entry``); a missing ledger entry is rejected exactly like a mismatched
-    one, never treated as "nothing to check".
+    The run's ``ambiguous_candidates`` resolution-ledger entry is **always**
+    fetched, regardless of whether the frame's own
+    ``clarification_candidates`` is empty (Codex review round 2, confirmed
+    medium: the round-1 early return on an empty frame tuple let an internal
+    caller silently *downgrade* canonical state -- persist ``needs_
+    clarification`` with zero candidates for a run whose ledger genuinely
+    recorded several, hiding the real choices the resolver offered from
+    every future reader of this "canonical" v2 row):
 
-    Empty candidates are never rejected here, regardless of what the ledger
-    holds for this run: a frame disclosing FEWER candidates than were
-    authorized is not a disclosure risk, only a mismatched or surplus one
-    is -- so this is a no-op whenever ``validated.clarification_candidates``
-    is empty (the honest "uninterpretable question" case CHAOS-3325 already
-    decided not to fabricate a placeholder for).
+    * **No ledger entry recorded at all** (e.g. the question could not be
+      interpreted -- ``build_preflight_answer`` never calls
+      ``append_resolution`` for that case): the frame's candidates must be
+      empty too. Non-empty here means the frame is claiming candidates
+      nothing authorized, and is rejected exactly like a mismatch below.
+    * **A ledger entry exists**: the frame's candidates must equal it
+      exactly, in the same order, element for element -- including
+      non-emptiness. An empty frame against a non-empty ledger entry is now
+      rejected (the round-2 fix): under-disclosure is no longer assumed
+      safe once a real ledger row exists to compare against, because that
+      row is exactly the canonical-state-downgrade signal above.
+
+    ``orchestrator.run`` persists the ledger entry via ``append_resolution``
+    immediately before calling ``record_frame`` for this outcome (see
+    ``SubjectPreflightResult.terminating_resolution_entry``), so both fetch
+    outcomes above correspond to a real caller state, never an artifact of
+    query timing.
+
+    Residual risk (CHAOS-3325 Codex review round 2 finding 1, deferred by
+    ruling -- not fixed in this branch): a caller *inside* the trust
+    boundary that forges both a schema-valid ledger row (via
+    ``append_resolution``, itself unvalidated against the actual scope
+    catalog today) and a frame whose candidates happen to equal it defeats
+    this equality check -- it only proves the two objects agree with each
+    other, not that either was honestly produced by ``subject_preflight``'s
+    real resolution. Closing that "double-forge" seam requires validating
+    ``append_resolution``'s own payload against the authorized catalog,
+    which is CHAOS-3330's scope, not a persistence-layer-to-resolver-catalog
+    coupling here. See
+    ``test_record_frame_double_forged_ledger_and_frame_defeats_the_equality_check``
+    (``xfail(strict=True)``, flips loudly once CHAOS-3330 lands).
     """
 
-    if not validated.clarification_candidates:
-        return
     ledger_row = await session.scalar(
         select(DevRunResolution)
         .where(
@@ -1018,11 +1042,13 @@ async def _authorize_clarification_candidates(
         .order_by(DevRunResolution.entry_ordinal.desc())
     )
     if ledger_row is None:
-        raise DevPersistenceValidationError(
-            "frame_payload.clarification_candidates is non-empty but this "
-            "run has no recorded ambiguous_candidates resolution ledger "
-            "entry to authorize it"
-        )
+        if validated.clarification_candidates:
+            raise DevPersistenceValidationError(
+                "frame_payload.clarification_candidates is non-empty but this "
+                "run has no recorded ambiguous_candidates resolution ledger "
+                "entry to authorize it"
+            )
+        return
     try:
         ledger_entry = DevResolutionEntryContract.model_validate(ledger_row.payload)
     except PydanticValidationError as exc:

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -37,6 +37,7 @@ from .contracts_v2 import (
     DevAnswerV2,
     DevCoverageV2,
     DevFrameVersions,
+    DevResolutionCandidate,
     PublicOutcome,
     QuestionIntentID,
     ResolutionOutcome,
@@ -218,6 +219,7 @@ def build_preflight_answer(
     conversation_id: str,
     generated_at: datetime,
     clarification_key: str = "ambiguous",
+    clarification_candidates: tuple[DevResolutionCandidate, ...] = (),
 ) -> DevAnswerV2:
     """Build the v2 answer one preflight termination emits.
 
@@ -226,6 +228,15 @@ def build_preflight_answer(
     ``direct_answer`` is the canonical server sentence; the contract's own
     ``validate_no_answer_projection`` re-derives that from the same table, so
     an error here is a validation failure rather than a silent disclosure.
+
+    ``clarification_candidates`` (CHAOS-3325) is the resolution ledger's own
+    ``DevResolutionCandidate`` tuple for one ``ambiguous_candidates`` mention
+    — passed straight through from the ledger entry that terminated the run,
+    never re-derived or invented here. It is meaningless for every outcome
+    but ``needs_clarification`` (``validate_outcome_consistency`` /
+    ``NO_ANSWER_FRAME_FIELD_POLICY`` both forbid it elsewhere), so callers on
+    the four no-answer paths simply never pass it and the default empty tuple
+    is always the correct value there.
     """
 
     is_no_answer = outcome is not PublicOutcome.NEEDS_CLARIFICATION
@@ -240,6 +251,7 @@ def build_preflight_answer(
             if is_no_answer
             else CLARIFICATION_COPY[clarification_key]
         ),
+        clarification_candidates=clarification_candidates,
         coverage=DevCoverageV2(
             required_source_count=0,
             available_source_count=0,
@@ -278,20 +290,31 @@ def project_preflight_error(answer: DevAnswerV2, *, request_id: str) -> DevError
     canonical tables. That is what makes "the internal combined outcome never
     leaves the server" structural on the v1 surface too.
 
-    ``needs_clarification`` is handled separately and deliberately. The
-    projector maps it to a v1 ``DevAnswer`` carrying one **fabricated**
-    disambiguation candidate synthesised from ``frame.subject_ref`` — which a
-    preflight ambiguity does not have, since nothing was committed. Today's
-    orchestrator already terminates an ambiguous scope as
-    ``insufficient_evidence`` + ``scope_ambiguous``, and that is both the more
-    faithful statement and the shape the router and web client already handle.
-    The real candidate list is recorded on the resolution ledger, so "ambiguous
-    targets return stable authorized candidates" holds at the ledger and v2
-    level — but **not** on the v1 surface, which has no candidate field to
-    carry them. That gap is CHAOS-3325 (a candidate block on
-    ``dev_answer_frame.v1``); delivery to a user additionally needs the v2
-    rendering surface (CHAOS-3298) and persisted clarification state
-    (CHAOS-3299).
+    ``needs_clarification`` is handled separately and deliberately, on both
+    the live path (``orchestrator.run``) and the replay path (``router``'s
+    terminal-payload reconstruction): both call this function, not
+    ``compat.project_answer_v2_to_v1``, for a preflight ambiguity, and it
+    always returns the fixed ``scope_ambiguous`` ``DevError`` above — never a
+    v1 ``DevAnswer``, so it never carries candidates at all, whatever the
+    frame's own ``clarification_candidates`` holds. That is deliberate and
+    unchanged by CHAOS-3325: it is both the more faithful terminal-state
+    statement (the run genuinely produced no answer) and the shape the router
+    and web client already handle.
+
+    The real candidate list is carried one level up instead. CHAOS-3325 gave
+    ``dev_answer_frame.v1`` a typed ``clarification_candidates`` block — the
+    resolution ledger's own ``DevResolutionCandidate`` entries for the
+    mention that went ambiguous, passed straight through by
+    ``build_preflight_answer`` rather than invented — and
+    ``contracts_v2.compat``'s ``_project_needs_clarification`` now projects
+    those real candidates (or, when there are none, an honest
+    ``ScopeResolutionOutcome.UNRESOLVED`` rather than a fabricated
+    placeholder) for whichever *other* caller runs a ``needs_clarification``
+    answer through the general ``project_answer_v2_to_v1`` projector — this
+    function's own preflight-ambiguity path does not, and still routes
+    through ``scope_ambiguous`` as above. Actually serving the candidate
+    block to a v1/v2 client still additionally needs the v2 rendering
+    surface (CHAOS-3298) and persisted clarification state (CHAOS-3299).
     """
 
     if answer.public_outcome is PublicOutcome.NEEDS_CLARIFICATION:

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -446,6 +446,13 @@ class SubjectPreflight:
                         answer_id=answer_id,
                         conversation_id=conversation_id,
                         generated_at=generated_at,
+                        # CHAOS-3325: the ledger entry's own candidates --
+                        # populated only for AMBIGUOUS_CANDIDATES
+                        # (DevResolutionEntry.validate_outcome_payload),
+                        # empty for the other three UNRESOLVED_OUTCOMES, so
+                        # this is always the correct value to pass through
+                        # regardless of which one fired.
+                        clarification_candidates=entry.candidates,
                     )
 
         if unresolved_untyped:
@@ -925,6 +932,7 @@ class SubjectPreflight:
         generated_at: datetime,
         clarification_key: str = "ambiguous",
         subject_set: DevSubjectSet | None = None,
+        clarification_candidates: tuple[DevResolutionCandidate, ...] = (),
     ) -> SubjectPreflightResult:
         answer = build_preflight_answer(
             outcome=outcome,
@@ -935,6 +943,7 @@ class SubjectPreflight:
             conversation_id=conversation_id,
             generated_at=generated_at,
             clarification_key=clarification_key,
+            clarification_candidates=clarification_candidates,
         )
         return SubjectPreflightResult(
             decision=PreflightDecision.TERMINATE,

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -207,6 +207,15 @@ class SubjectPreflightResult:
     #: grammar only recognizes a name adjacent to an entity noun, so without
     #: these it cannot see the very names re-arming it is meant to guard.
     unresolved_name_spans: frozenset[str] = frozenset()
+    #: CHAOS-3325: the ledger entry that produced ``answer.frame.
+    #: clarification_candidates``, when the run terminated on an ambiguous
+    #: mention -- ``None`` for every other termination reason (nothing on
+    #: the frame to authorize) and for a non-terminal result. The caller
+    #: (``orchestrator.run``) persists this via ``recorder.append_resolution``
+    #: immediately before ``record_frame``, so the persistence layer has a
+    #: real ledger row to cross-check the frame's candidates against
+    #: (Codex review, CHAOS-3325 NO-SHIP finding).
+    terminating_resolution_entry: DevResolutionEntry | None = None
 
     @property
     def has_committed_subject(self) -> bool:
@@ -446,13 +455,19 @@ class SubjectPreflight:
                         answer_id=answer_id,
                         conversation_id=conversation_id,
                         generated_at=generated_at,
-                        # CHAOS-3325: the ledger entry's own candidates --
-                        # populated only for AMBIGUOUS_CANDIDATES
-                        # (DevResolutionEntry.validate_outcome_payload),
-                        # empty for the other three UNRESOLVED_OUTCOMES, so
-                        # this is always the correct value to pass through
-                        # regardless of which one fired.
-                        clarification_candidates=entry.candidates,
+                        # CHAOS-3325: only AMBIGUOUS_CANDIDATES carries real
+                        # candidates to persist/authorize (the other three
+                        # UNRESOLVED_OUTCOMES map to no-answer outcomes,
+                        # where clarification_candidates is ABSENT-forced
+                        # regardless) -- passing the whole entry, not just
+                        # its candidates, is what lets the orchestrator
+                        # persist the exact ledger row record_frame's new
+                        # cross-check authorizes against.
+                        terminating_resolution_entry=(
+                            entry
+                            if entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+                            else None
+                        ),
                     )
 
         if unresolved_untyped:
@@ -932,8 +947,13 @@ class SubjectPreflight:
         generated_at: datetime,
         clarification_key: str = "ambiguous",
         subject_set: DevSubjectSet | None = None,
-        clarification_candidates: tuple[DevResolutionCandidate, ...] = (),
+        terminating_resolution_entry: DevResolutionEntry | None = None,
     ) -> SubjectPreflightResult:
+        # CHAOS-3325: the frame's clarification_candidates and the result's
+        # terminating_resolution_entry are always derived from the same
+        # single entry -- never set independently -- so a caller cannot
+        # attach candidates to the frame without also giving the
+        # orchestrator the ledger row that authorizes them.
         answer = build_preflight_answer(
             outcome=outcome,
             intent_id=interpretation.intent.intent_id,
@@ -943,7 +963,11 @@ class SubjectPreflight:
             conversation_id=conversation_id,
             generated_at=generated_at,
             clarification_key=clarification_key,
-            clarification_candidates=clarification_candidates,
+            clarification_candidates=(
+                terminating_resolution_entry.candidates
+                if terminating_resolution_entry is not None
+                else ()
+            ),
         )
         return SubjectPreflightResult(
             decision=PreflightDecision.TERMINATE,
@@ -960,4 +984,5 @@ class SubjectPreflight:
             outcome=outcome,
             allowed_tools=frozenset(),
             diagnostic=diagnostic,
+            terminating_resolution_entry=terminating_resolution_entry,
         )

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -332,6 +332,12 @@ class Recorder:
         self.terminals: list[RunState] = []
         self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
         self.frames: list[Any] = []
+        self.resolutions: list[Any] = []
+        #: CHAOS-3325: the recorder-method call sequence, by name -- proves
+        #: append_resolution lands before record_frame, not just that both
+        #: were called (two same-length lists alone prove nothing about
+        #: order).
+        self.call_order: list[str] = []
 
     async def transition(self, state: RunState) -> None:
         self.transitions.append(state)
@@ -351,8 +357,13 @@ class Recorder:
         """No-op here; CHAOS-3301's SubjectSetRecorder subclass captures this."""
         del subject_set
 
+    async def append_resolution(self, entry: Any) -> None:
+        self.resolutions.append(entry)
+        self.call_order.append("append_resolution")
+
     async def record_frame(self, frame: Any) -> None:
         self.frames.append(frame)
+        self.call_order.append("record_frame")
 
     async def rollback(self) -> None:
         pass

--- a/tests/api/dev/test_chaos_3292_preflight_acceptance.py
+++ b/tests/api/dev/test_chaos_3292_preflight_acceptance.py
@@ -18,11 +18,14 @@ from typing import Any
 import pytest
 
 from dev_health_ops.api.dev.contracts import DirectScope, QuestionClass, ToolID
-from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome
+from dev_health_ops.api.dev.contracts_v2 import PublicOutcome, ResolutionOutcome
 from dev_health_ops.api.dev.contracts_v2.validators import scan_public_text
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator
 from dev_health_ops.api.dev.orchestrator_states import RunState
-from dev_health_ops.api.dev.subject_preflight import SUBJECT_BEARING_TOOLS
+from dev_health_ops.api.dev.subject_preflight import (
+    SUBJECT_BEARING_TOOLS,
+    PreflightDecision,
+)
 from dev_health_ops.llm.agent.contracts import (
     AgentFinalAnswer,
     AgentToolRequest,
@@ -199,6 +202,43 @@ async def test_a3_ledger_records_both_authorized_candidates() -> None:
         ATLAS_PROJECT_ONE.canonical_id,
         ATLAS_PROJECT_TWO.canonical_id,
     ]
+
+    # CHAOS-3325: the frame carries the same real candidates the ledger
+    # recorded (never fabricated), and the result exposes the exact
+    # terminating entry so the orchestrator can persist it via
+    # append_resolution before record_frame -- the ledger row
+    # persistence.service._authorize_clarification_candidates cross-checks
+    # the frame against.
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.terminating_resolution_entry == entry
+    assert result.answer is not None
+    assert result.answer.frame.clarification_candidates == entry.candidates
+
+
+@pytest.mark.asyncio
+async def test_a3_orchestrator_persists_the_ledger_entry_before_the_frame() -> None:
+    """CHAOS-3325 Codex review (NO-SHIP, confirmed medium): the full
+    ``orchestrator.run`` wiring, not just ``SubjectPreflight`` in isolation --
+    proves ``append_resolution`` is actually called, with the real
+    candidate-bearing entry, strictly before ``record_frame``, so
+    ``persistence.service._authorize_clarification_candidates`` always has a
+    matching ledger row to cross-check the persisted frame against."""
+
+    output = await case_a3()
+
+    assert output.recorder is not None
+    assert len(output.recorder.resolutions) == 1
+    assert len(output.recorder.frames) == 1
+    assert output.recorder.call_order == ["append_resolution", "record_frame"]
+
+    persisted_entry = output.recorder.resolutions[0]
+    persisted_frame = output.recorder.frames[0]
+    assert persisted_entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+    assert persisted_frame.clarification_candidates == persisted_entry.candidates
+    assert sorted(
+        candidate.entity_ref.entity_id for candidate in persisted_entry.candidates
+    ) == [ATLAS_PROJECT_ONE.canonical_id, ATLAS_PROJECT_TWO.canonical_id]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -58,6 +58,7 @@ from dev_health_ops.api.dev.contracts import DevAnswer as DevAnswerV1
 from dev_health_ops.api.dev.contracts import DevError as DevErrorV1
 from dev_health_ops.api.dev.contracts_v2 import compat as compat_module
 from dev_health_ops.api.dev.contracts_v2 import validators as validators_module
+from dev_health_ops.api.dev.contracts_v2.validators import ANSWERED_CONTENT_OUTCOMES
 from dev_health_ops.api.dev.export_contracts_v2 import (
     check_artifacts,
     expected_artifacts,
@@ -688,22 +689,97 @@ def test_needs_clarification_frame_may_carry_zero_or_many_clarification_candidat
     ]
 
 
-def test_clarification_candidates_forbidden_outside_needs_clarification() -> None:
-    """(f)/(b): ABSENT on the five true no-answer outcomes, and
-    validate_outcome_consistency's new clause on 'answered'/
-    'answered_with_gaps' -- only 'needs_clarification' may carry it."""
+#: Every outcome that may NOT carry clarification_candidates, derived from the
+#: enum rather than listed: a ninth PublicOutcome member is parametrized into
+#: the rejection test below the moment it is declared, and fails there until it
+#: is classified into one of the two guards.
+_CANDIDATE_GUARDED_OUTCOMES = tuple(
+    sorted(
+        outcome.value
+        for outcome in v2.PublicOutcome
+        if outcome is not v2.PublicOutcome.NEEDS_CLARIFICATION
+    )
+)
 
-    denied_payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
-        "denied_with_clarification_candidates"
-    ]
-    with pytest.raises(ValidationError, match="clarification_candidates"):
-        v2.DevAnswerFrame.model_validate(denied_payload)
 
-    answered_payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
-        "answered_with_clarification_candidates"
-    ]
+def _candidate_bearing_frame_for(outcome: str) -> dict[str, Any]:
+    """One valid-but-for-the-candidates frame, retargeted at ``outcome``.
+
+    Built by retargeting the two committed negative fixtures rather than
+    hand-authoring a payload, so the candidate block under test is the exact
+    one those fixtures pin (Verification rule: build from the real producer).
+    Every other field is made legal for the outcome, so the ValidationError
+    the test asserts is attributable to ``clarification_candidates`` and not
+    to some unrelated invariant the retargeting broke.
+    """
+
+    negatives = dict(negative_fixtures()["dev_answer_frame.v1"])
+    if outcome in v2.NO_ANSWER_OUTCOMES:
+        payload = deepcopy(negatives["denied_with_clarification_candidates"])
+        payload["public_outcome"] = outcome
+        payload["direct_answer"] = v2.CANONICAL_NO_ANSWER_COPY[outcome]
+        return payload
+    payload = deepcopy(negatives["answered_with_clarification_candidates"])
+    payload["public_outcome"] = outcome
+    if outcome == "answered_with_gaps":
+        # answered_with_gaps independently requires a disclosed gap, so give
+        # it one -- otherwise the rejection could be that missing gap rather
+        # than the candidates.
+        payload["limitations"] = ["A required source was stale at query time."]
+    return payload
+
+
+def test_clarification_candidate_guards_partition_every_public_outcome() -> None:
+    """The two guards partition ``PublicOutcome`` exactly, with no gap.
+
+    Guard A is the ``ABSENT`` cell in ``NO_ANSWER_FRAME_FIELD_POLICY``, which
+    only reaches ``NO_ANSWER_OUTCOMES``; guard B is
+    ``validate_outcome_consistency``'s clause, which only reaches
+    ``ANSWERED_CONTENT_OUTCOMES``. ``needs_clarification`` is in neither, by
+    design -- it is the one outcome permitted to carry candidates. Asserting
+    the three sets tile the enum is what makes "forbidden everywhere else"
+    a closure rather than a claim about the cells someone happened to test.
+    """
+
+    guard_a = set(v2.NO_ANSWER_OUTCOMES)
+    guard_b = set(ANSWERED_CONTENT_OUTCOMES)
+    every_outcome = {outcome.value for outcome in v2.PublicOutcome}
+
+    assert guard_a & guard_b == set(), "an outcome cannot be governed by both guards"
+    assert guard_a | guard_b == every_outcome - {"needs_clarification"}
+    assert set(_CANDIDATE_GUARDED_OUTCOMES) == guard_a | guard_b
+    assert (
+        v2.NO_ANSWER_FRAME_FIELD_POLICY["clarification_candidates"]
+        is v2.NoAnswerFieldPolicy.ABSENT
+    )
+
+
+@pytest.mark.parametrize("outcome", _CANDIDATE_GUARDED_OUTCOMES)
+def test_clarification_candidates_forbidden_outside_needs_clarification(
+    outcome: str,
+) -> None:
+    """(f)/(b): every outcome but ``needs_clarification`` rejects candidates.
+
+    Total over the enum, not a sample of two cells: the earlier version of
+    this test exercised only ``denied`` and ``answered``, so a regression
+    opening any of the other five would not have been observed.
+    """
+
+    payload = _candidate_bearing_frame_for(outcome)
+    assert payload["clarification_candidates"], "the case must actually carry some"
     with pytest.raises(ValidationError, match="clarification_candidates"):
-        v2.DevAnswerFrame.model_validate(answered_payload)
+        v2.DevAnswerFrame.model_validate(payload)
+
+
+def test_needs_clarification_is_the_one_outcome_that_accepts_candidates() -> None:
+    """The positive half of the partition -- without it the test above is
+    satisfied by a validator that rejects candidates unconditionally."""
+
+    frame = v2.DevAnswerFrame.model_validate(
+        needs_clarification_frame_with_candidates()
+    )
+    assert frame.public_outcome is v2.PublicOutcome.NEEDS_CLARIFICATION
+    assert len(frame.clarification_candidates) == 2
 
 
 def test_answered_clarification_candidates_clause_is_new_not_preexisting(

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -31,6 +31,8 @@ from dev_health_ops.api.dev.contract_fixtures import (
 )
 from dev_health_ops.api.dev.contract_fixtures_v2 import (
     NOW,
+    _needs_clarification_frame_base,
+    needs_clarification_frame_with_candidates,
     negative_fixtures,
     no_answer_answer_fixture,
     positive_fixtures,
@@ -40,13 +42,21 @@ from dev_health_ops.api.dev.contracts import (
     CONTRACT_MODELS,
     AnswerStatus,
     DevClaimFlags,
+    DevContractVersions,
     DevCoverage,
+    DevDisambiguationCandidate,
+    DevEntityRef,
     DevEvidenceRef,
+    DevModelMetadata,
     DevScope,
+    DevScopeResolution,
     DevTimeRange,
+    EntityType,
+    ScopeResolutionOutcome,
 )
 from dev_health_ops.api.dev.contracts import DevAnswer as DevAnswerV1
 from dev_health_ops.api.dev.contracts import DevError as DevErrorV1
+from dev_health_ops.api.dev.contracts_v2 import compat as compat_module
 from dev_health_ops.api.dev.contracts_v2 import validators as validators_module
 from dev_health_ops.api.dev.export_contracts_v2 import (
     check_artifacts,
@@ -270,7 +280,14 @@ _FRAME_VALIDATOR_CASES: dict[str, tuple[str, str]] = {
 #: has_content clause) -- both must flip when the validator is disabled, and
 #: neither should count as "a different guardrail" in the isolation loop below.
 _ADDITIONAL_CASES_SAME_VALIDATOR: dict[str, tuple[str, ...]] = {
-    "validate_outcome_consistency": ("answered_with_disclosure",),
+    # CHAOS-3325: answered_with_clarification_candidates is a second case
+    # validate_outcome_consistency alone rejects (its new clarification-
+    # candidates clause), alongside answered_with_disclosure (CHAOS-3297) and
+    # outcome_content_mismatch (the pre-existing has_content clause).
+    "validate_outcome_consistency": (
+        "answered_with_disclosure",
+        "answered_with_clarification_candidates",
+    ),
 }
 
 
@@ -456,9 +473,16 @@ def test_answered_disclosure_clause_is_new_not_preexisting(
     # must still be rejected under the RED replacement -- proving it is a
     # faithful full reproduction of the pre-changeset validator, not a stub
     # that happens to also let the disclosure fixture through by disabling
-    # everything.
+    # everything. CHAOS-3325's clarification-candidates clause is excluded
+    # too: this reproduction is frozen at the pre-3297 snapshot, which
+    # predates that clause as well, so it correctly passes that fixture for
+    # the same reason it passes the disclosure one -- not a different guard
+    # catching it.
     for other_case, other_payload in negative_fixtures()["dev_answer_frame.v1"]:
-        if other_case == "answered_with_disclosure":
+        if other_case in (
+            "answered_with_disclosure",
+            "answered_with_clarification_candidates",
+        ):
             continue
         with pytest.raises(ValidationError):
             v2.DevAnswerFrame.model_validate(other_payload)
@@ -627,6 +651,308 @@ def test_compat_projects_needs_clarification_to_insufficient_evidence() -> None:
     assert isinstance(projected, DevAnswerV1)
     assert projected.schema_version == "dev_answer.v1"
     assert projected.status is AnswerStatus.INSUFFICIENT_EVIDENCE
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3325: a typed clarification-candidate block on dev_answer_frame.v1,
+# carrying the resolution ledger's real authorized candidates instead of the
+# v1 projector's pre-3325 fabricated placeholder.
+# ---------------------------------------------------------------------------
+
+
+def _needs_clarification_answer_payload(
+    frame_payload: dict[str, Any],
+) -> dict[str, Any]:
+    payload = deepcopy(positive_fixtures()["dev_answer.v2"])
+    payload["frame"] = frame_payload
+    payload["public_outcome"] = "needs_clarification"
+    payload["outcome_display_label"] = "Needs clarification"
+    payload["narrative"] = None
+    return payload
+
+
+def test_needs_clarification_frame_may_carry_zero_or_many_clarification_candidates() -> (
+    None
+):
+    """Both shapes are legal on the contract: zero candidates (e.g. the
+    question could not be interpreted at all) is not an error state that
+    needs a placeholder to satisfy the type."""
+
+    zero = v2.DevAnswerFrame.model_validate(_needs_clarification_frame_base())
+    assert zero.clarification_candidates == ()
+
+    many = v2.DevAnswerFrame.model_validate(needs_clarification_frame_with_candidates())
+    assert [c.entity_ref.entity_id for c in many.clarification_candidates] == [
+        "repo_nightfall_public",
+        "repo_nightfall_internal",
+    ]
+
+
+def test_clarification_candidates_forbidden_outside_needs_clarification() -> None:
+    """(f)/(b): ABSENT on the five true no-answer outcomes, and
+    validate_outcome_consistency's new clause on 'answered'/
+    'answered_with_gaps' -- only 'needs_clarification' may carry it."""
+
+    denied_payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
+        "denied_with_clarification_candidates"
+    ]
+    with pytest.raises(ValidationError, match="clarification_candidates"):
+        v2.DevAnswerFrame.model_validate(denied_payload)
+
+    answered_payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
+        "answered_with_clarification_candidates"
+    ]
+    with pytest.raises(ValidationError, match="clarification_candidates"):
+        v2.DevAnswerFrame.model_validate(answered_payload)
+
+
+def test_answered_clarification_candidates_clause_is_new_not_preexisting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED/GREEN pair for the CHAOS-3325 'answered' clause on
+    validate_outcome_consistency, mirroring
+    test_answered_disclosure_clause_is_new_not_preexisting. The "old" body
+    below is byte-identical to the pre-3325 validator (copied, not imported
+    from history, so the RED half is self-contained)."""
+
+    payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
+        "answered_with_clarification_candidates"
+    ]
+
+    def _pre_3325_validate_outcome_consistency(frame: Any) -> None:
+        outcome = frame.public_outcome.value
+        has_content = bool(frame.sections) or bool(frame.facts)
+        if outcome in validators_module._EMPTY_CONTENT_OUTCOMES and has_content:
+            raise ValueError(
+                f"public outcome {outcome!r} cannot carry answer sections/facts"
+            )
+        if outcome in validators_module.ANSWERED_CONTENT_OUTCOMES and not has_content:
+            raise ValueError(
+                f"public outcome {outcome!r} requires answer sections and facts"
+            )
+        if outcome == "answered":
+            if frame.limitations:
+                raise ValueError(
+                    "'answered' cannot carry limitations; use answered_with_gaps"
+                )
+            if frame.completion is not None and frame.completion.calculable is False:
+                raise ValueError(
+                    "'answered' cannot carry a non-calculable completion block; "
+                    "use answered_with_gaps"
+                )
+            disclosed_facts = [fact.fact_id for fact in frame.facts if fact.disclosures]
+            if disclosed_facts:
+                raise ValueError(
+                    "'answered' cannot carry a fact disclosure (stale/uncertain/"
+                    f"conflicting/untrusted_source) on fact(s) {sorted(disclosed_facts)}; "
+                    "use answered_with_gaps"
+                )
+        if outcome == "answered_with_gaps" and not frame.limitations:
+            if frame.completion is None or frame.completion.calculable is not False:
+                raise ValueError(
+                    "'answered_with_gaps' requires disclosed limitations or a "
+                    "non-calculable completion block"
+                )
+
+    original_validator = validators_module.validate_outcome_consistency
+
+    # RED: the pre-changeset validator body has no clarification-candidates
+    # clause and accepts this fixture.
+    monkeypatch.setattr(
+        validators_module,
+        "validate_outcome_consistency",
+        _pre_3325_validate_outcome_consistency,
+    )
+    v2.DevAnswerFrame.model_validate(payload)  # must not raise
+
+    # Every other frame negative fixture is a different guardrail and must
+    # still be rejected -- proves the RED body is a faithful reproduction,
+    # not a stub that disables everything.
+    for other_case, other_payload in negative_fixtures()["dev_answer_frame.v1"]:
+        if other_case == "answered_with_clarification_candidates":
+            continue
+        with pytest.raises(ValidationError):
+            v2.DevAnswerFrame.model_validate(other_payload)
+
+    # GREEN: restore the real, current validator -- it rejects the same
+    # payload.
+    monkeypatch.setattr(
+        validators_module, "validate_outcome_consistency", original_validator
+    )
+    with pytest.raises(ValidationError, match="clarification_candidates"):
+        v2.DevAnswerFrame.model_validate(payload)
+
+
+def test_clarification_candidate_entity_ids_must_be_unique() -> None:
+    payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
+        "clarification_candidates_duplicate_entity_id"
+    ]
+    with pytest.raises(ValidationError, match="unique"):
+        v2.DevAnswerFrame.model_validate(payload)
+
+
+def test_clarification_candidate_entity_kind_is_a_closed_vocabulary() -> None:
+    """The only "unauthorized-shaped" candidate expressible at the wire-type
+    level: a candidate outside the closed EntityKind vocabulary. Real
+    authorization is enforced by the builder (subject_preflight only ever
+    constructs a candidate from an AuthorizedEntity the catalog itself
+    returned), never by a field on the wire shape -- there is no
+    "unauthorized" flag to smuggle a different value through."""
+
+    payload = dict(negative_fixtures()["dev_answer_frame.v1"])[
+        "clarification_candidate_unknown_entity_kind"
+    ]
+    with pytest.raises(ValidationError, match="entity_kind"):
+        v2.DevAnswerFrame.model_validate(payload)
+
+
+def test_compat_projects_real_clarification_candidates_not_a_placeholder() -> None:
+    """GREEN: the current projector carries the frame's own authorized
+    candidates -- the resolution ledger's real entries -- through to v1,
+    reporting AMBIGUOUS (matching DevScopeResolution's own "ambiguous
+    requires candidates" invariant)."""
+
+    answer = v2.DevAnswerV2.model_validate(
+        _needs_clarification_answer_payload(needs_clarification_frame_with_candidates())
+    )
+    projected = v2.project_answer_v2_to_v1(
+        answer, organization_id="org_fullchaos", time_range=_time_range_for_scope()
+    )
+    assert isinstance(projected, DevAnswerV1)
+    resolution = projected.resolved_scope
+    assert resolution.outcome is ScopeResolutionOutcome.AMBIGUOUS
+    assert [c.entity_ref.entity_id for c in resolution.candidates] == [
+        "repo_nightfall_public",
+        "repo_nightfall_internal",
+    ]
+    assert [c.entity_ref.display_label for c in resolution.candidates] == [
+        "full-chaos/nightfall-public",
+        "full-chaos/nightfall-internal",
+    ]
+    assert all(c.reason for c in resolution.candidates)
+    # v1 CONTRACT_MODELS accepts the projected object's own dict form too.
+    CONTRACT_MODELS["dev_answer.v1"].model_validate(projected.model_dump(mode="json"))
+
+
+def _pre_chaos_3325_project_needs_clarification(
+    answer: v2.DevAnswerV2, organization_id: str, time_range: DevTimeRange
+) -> DevAnswerV1:
+    """Byte-identical to ``compat._project_needs_clarification`` before
+    CHAOS-3325 -- copied, not imported from git history, so the RED half
+    below is self-contained. Fabricates a placeholder candidate
+    (``entity_id="clarification_required"``) whenever the frame carries
+    neither a real candidate list nor a ``subject_ref``."""
+
+    frame = answer.frame
+    versions = compat_module._require_versions(frame.versions, answer.public_outcome)
+    resolved = compat_module._build_resolved_scope(answer, organization_id, time_range)
+    resolution = DevScopeResolution(
+        schema_version="dev_scope_resolution.v1",
+        requested_scope=resolved,
+        resolved_scope=None,
+        outcome=ScopeResolutionOutcome.AMBIGUOUS,
+        authorized_repository_ids=[],
+        authorized_entity_ids=[],
+        candidates=[
+            DevDisambiguationCandidate(
+                entity_ref=DevEntityRef(
+                    entity_type=compat_module._KIND_TO_ENTITY_TYPE.get(
+                        frame.subject_ref.entity_kind, EntityType.REPOSITORY
+                    ),
+                    entity_id=frame.subject_ref.entity_id,
+                    display_label=frame.subject_ref.display_label,
+                    repository_id=frame.subject_ref.repository_id,
+                ),
+                reason="Clarification requested before continuing.",
+            )
+        ]
+        if frame.subject_ref is not None
+        else [
+            DevDisambiguationCandidate(
+                entity_ref=DevEntityRef(
+                    entity_type=EntityType.REPOSITORY,
+                    entity_id="clarification_required",
+                    display_label="Clarification required",
+                ),
+                reason="The question requires clarification before it can be answered.",
+            )
+        ],
+        fallbacks=[],
+        warnings=[],
+        resolved_at=answer.generated_at,
+    )
+    return DevAnswerV1(
+        schema_version="dev_answer.v1",
+        answer_id=answer.answer_id,
+        conversation_id=answer.conversation_id,
+        generated_at=answer.generated_at,
+        resolved_scope=resolution,
+        as_of=answer.generated_at,
+        status=AnswerStatus.INSUFFICIENT_EVIDENCE,
+        direct_summary=frame.direct_answer,
+        claims=[],
+        metrics=[],
+        evidence=[],
+        conflicts=[],
+        coverage=compat_module._as_v1(DevCoverage, frame.coverage),
+        warnings=list(frame.limitations),
+        suggested_follow_up_questions=list(frame.safe_follow_up_questions),
+        versions=DevContractVersions(
+            prompt_version=versions.prompt_version
+            or compat_module._DETERMINISTIC_VERSION_PLACEHOLDER,
+            tool_contract_version=versions.tool_contract_version,
+            metric_definition_version=versions.metric_definition_version,
+            query_version=versions.query_version,
+        ),
+        model=DevModelMetadata(
+            provider_source="platform",
+            provider_family="deterministic",
+            model_fingerprint=compat_module._DETERMINISTIC_VERSION_PLACEHOLDER,
+        ),
+    )
+
+
+def test_needs_clarification_zero_candidates_no_longer_fabricates_a_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED/GREEN pair: the pre-CHAOS-3325 projector invented a
+    ``clarification_required`` placeholder candidate for the zero-candidate,
+    no-subject_ref case (e.g. the question could not be interpreted at all).
+    The current projector reports UNRESOLVED with no candidates instead --
+    honest about "nothing to offer" rather than fabricating an option."""
+
+    answer = v2.DevAnswerV2.model_validate(
+        _needs_clarification_answer_payload(_needs_clarification_frame_base())
+    )
+    time_range = _time_range_for_scope()
+    original = compat_module._project_needs_clarification
+
+    # RED: the old projector fabricates a placeholder candidate and reports
+    # AMBIGUOUS, even though nothing was ever actually ambiguous.
+    monkeypatch.setattr(
+        compat_module,
+        "_project_needs_clarification",
+        _pre_chaos_3325_project_needs_clarification,
+    )
+    fabricated = v2.project_answer_v2_to_v1(
+        answer, organization_id="org_fullchaos", time_range=time_range
+    )
+    assert isinstance(fabricated, DevAnswerV1)
+    assert fabricated.resolved_scope.outcome is ScopeResolutionOutcome.AMBIGUOUS
+    assert len(fabricated.resolved_scope.candidates) == 1
+    assert (
+        fabricated.resolved_scope.candidates[0].entity_ref.entity_id
+        == "clarification_required"
+    )
+
+    # GREEN: restore the real projector -- no fabrication.
+    monkeypatch.setattr(compat_module, "_project_needs_clarification", original)
+    honest = v2.project_answer_v2_to_v1(
+        answer, organization_id="org_fullchaos", time_range=time_range
+    )
+    assert isinstance(honest, DevAnswerV1)
+    assert honest.resolved_scope.outcome is ScopeResolutionOutcome.UNRESOLVED
+    assert honest.resolved_scope.candidates == []
 
 
 @pytest.mark.parametrize(
@@ -1397,6 +1723,7 @@ def _frame_absent_field_samples() -> dict[str, object]:
     cases = dict(negative_fixtures()["dev_answer_frame.v1"])
     from_case = {
         "subject_ref": "denied_with_subject_identity",
+        "clarification_candidates": "denied_with_clarification_candidates",
         "completion": "denied_with_completion",
         "readiness": "denied_with_readiness",
         "metrics": "denied_with_metrics",

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -50,6 +50,7 @@ class Recorder:
         self.terminal_errors: list[Any] = []
         self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
         self.frames: list[Any] = []
+        self.resolutions: list[Any] = []
         self.rollbacks = 0
         self.fail_answer_write = fail_answer_write
         self.fail_frame_write = fail_frame_write
@@ -73,6 +74,9 @@ class Recorder:
 
     async def record_subject_set(self, subject_set: DevSubjectSet) -> None:
         del subject_set
+
+    async def append_resolution(self, entry: Any) -> None:
+        self.resolutions.append(entry)
 
     async def record_frame(self, frame: Any) -> None:
         if self.fail_frame_write:

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -37,6 +37,7 @@ from dev_health_ops.api.dev.contract_fixtures import (
     positive_fixtures as positive_fixtures_v1,
 )
 from dev_health_ops.api.dev.contract_fixtures_v2 import (
+    _clarification_candidate,
     _needs_clarification_frame_base,
 )
 from dev_health_ops.api.dev.contract_fixtures_v2 import (
@@ -962,20 +963,27 @@ async def test_record_frame_rejects_clarification_candidates_mismatching_the_led
 
 
 @pytest.mark.asyncio
-async def test_record_frame_allows_empty_clarification_candidates_regardless_of_ledger(
+async def test_record_frame_allows_empty_clarification_candidates_only_when_the_ledger_is_also_empty(
     persistence,
 ):
-    """Documents the empty-candidates decision: a frame disclosing FEWER
-    candidates than the ledger holds is not a disclosure risk, so it is
-    never rejected here -- only a mismatched or surplus one is. Covers both
-    "no ledger entry at all" (the uninterpretable-question case) and "a
-    ledger entry exists but the frame simply omits it"."""
+    """CHAOS-3325 Codex review round 2 (confirmed medium): the round-1
+    "empty is always allowed" rule let an internal caller downgrade
+    canonical state -- persist ``needs_clarification`` with zero candidates
+    for a run whose ledger genuinely recorded several, hiding the choices
+    the resolver actually offered. The ledger is now always fetched:
+
+    * no ledger entry at all (the uninterpretable-question case) -> an
+      empty frame is legitimate, nothing to authorize.
+    * a ledger entry exists -> the frame must match it exactly, including
+      non-emptiness; an empty frame against a non-empty ledger is now the
+      rejected counterexample, not an allowed one.
+    """
 
     maker, org_id, _other_org, user_id, _other_user = persistence
     async with maker() as session:
         service = DevPersistenceService(session)
 
-        # Case 1: no ledger entry at all.
+        # Case 1 (unchanged): no ledger entry at all -> empty is legitimate.
         _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
         empty_payload = _needs_clarification_frame_payload(
             run_id=run_id, with_candidates=False
@@ -991,8 +999,9 @@ async def test_record_frame_allows_empty_clarification_candidates_regardless_of_
         )
         assert record.public_outcome == "needs_clarification"
 
-        # Case 2: a real ambiguous ledger entry exists for this run, but the
-        # frame being persisted carries none.
+        # Case 2, the round-2 counterexample: a real ambiguous ledger entry
+        # exists for this run, but the frame being persisted carries none --
+        # a canonical-state downgrade, now rejected rather than allowed.
         _conv_id2, run_id2 = await _accepted_run(
             service, org_id=org_id, user_id=user_id
         )
@@ -1015,15 +1024,101 @@ async def test_record_frame_allows_empty_clarification_candidates_regardless_of_
         empty_payload_2 = _needs_clarification_frame_payload(
             run_id=run_id2, with_candidates=False
         )
-        record2 = await service.record_frame(
+        with pytest.raises(
+            DevPersistenceValidationError, match="clarification_candidates"
+        ):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id2,
+                frame_id=uuid.UUID(empty_payload_2["frame_id"]),
+                public_outcome="needs_clarification",
+                payload=empty_payload_2,
+            )
+        frame_count = await session.scalar(
+            select(func.count())
+            .select_from(DevAnswerFrame)
+            .where(DevAnswerFrame.run_id == run_id2)
+        )
+        assert frame_count == 0, (
+            "a canonical-state downgrade (empty frame vs. non-empty ledger) "
+            "must never be written"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason="CHAOS-3330: append_resolution validation closes the double-forge seam",
+)
+async def test_record_frame_double_forged_ledger_and_frame_defeats_the_equality_check(
+    persistence,
+):
+    """CHAOS-3325 Codex review round 2 finding 1 (deferred by ruling, NOT
+    fixed in this branch): an internal caller that forges BOTH a
+    schema-valid resolution-ledger row and a frame whose
+    ``clarification_candidates`` exactly match it defeats
+    ``_authorize_clarification_candidates`` -- the equality check only
+    proves the two objects agree with each other, not that either was
+    honestly produced by ``subject_preflight``'s real resolution against
+    the authorized catalog. ``append_resolution`` accepts any schema-valid
+    payload today with no check against the catalog, so a forged, mutually
+    consistent pair persists cleanly.
+
+    Ruling: the natural closure is CHAOS-3330's ``append_resolution``
+    payload validation (already escalated as authorization-load-bearing),
+    not a persistence-layer-to-resolver-catalog coupling in this branch.
+    This is the repro, held ``xfail(strict=True)`` so it flips loudly --
+    an unexpected pass fails the suite -- the moment CHAOS-3330 closes the
+    seam; until then it documents the residual risk rather than silently
+    passing over it.
+    """
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        mention_id = uuid.uuid4()
+
+        # Neither the ledger entry nor the frame candidate was ever offered
+        # by the real authorized catalog -- an internal caller fabricated
+        # both, in agreement with each other, so the equality check alone
+        # cannot tell this apart from a genuine resolution.
+        forged_candidates = [
+            _clarification_candidate(
+                entity_id="forged-entity-never-in-catalog",
+                display_label="Forged Entity",
+            )
+        ]
+        await service.append_resolution(
             org_id=org_id,
             user_id=user_id,
-            run_id=run_id2,
-            frame_id=uuid.UUID(empty_payload_2["frame_id"]),
-            public_outcome="needs_clarification",
-            payload=empty_payload_2,
+            run_id=run_id,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload=_ambiguous_ledger_entry_payload(
+                mention_id=mention_id, candidates=forged_candidates
+            ),
         )
-        assert record2.public_outcome == "needs_clarification"
+        forged_frame = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=False
+        )
+        forged_frame["clarification_candidates"] = forged_candidates
+
+        # This SHOULD raise once CHAOS-3330 validates append_resolution's
+        # payload against the authorized catalog. It does not today, which
+        # is exactly the residual seam this test documents.
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(forged_frame["frame_id"]),
+                public_outcome="needs_clarification",
+                payload=forged_frame,
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -909,6 +909,151 @@ async def test_record_frame_rejects_clarification_candidates_absent_from_the_led
 
 
 @pytest.mark.asyncio
+async def test_record_frame_persists_the_authorized_snapshot_not_the_caller_mapping(
+    persistence, monkeypatch
+):
+    """CHAOS-3325 confirmation-codex MEDIUM (in-model half), exact repro.
+
+    Every check in ``record_frame`` -- contract validation, the
+    frame_id/run_id/outcome cross-checks, and the ledger authorization --
+    runs against ``validated``, the immutable contract snapshot. The row
+    used to be constructed from ``payload``, the caller's *mutable*
+    mapping, so anything that changed that mapping after authorization
+    returned was persisted unchecked. Codex mutated it in exactly that
+    window and ``other-org-secret-repo`` reached the row.
+
+    The window is reproduced deterministically by wrapping the
+    authorization hook: it delegates to the real implementation (so the
+    frame genuinely is authorized) and then mutates the caller's mapping
+    before returning -- precisely the interleaving the fix must survive.
+    The fix is to build the row from ``validated.model_dump(mode="json")``;
+    with ``payload_dict=payload`` restored, this test fails.
+    """
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        mention_id = uuid.uuid4()
+
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        candidates = deepcopy(frame_payload["clarification_candidates"])
+        authorized_entity_id = candidates[0]["entity_ref"]["entity_id"]
+
+        await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload=_ambiguous_ledger_entry_payload(
+                mention_id=mention_id, candidates=candidates
+            ),
+        )
+
+        real_authorize = dev_persistence_service._authorize_clarification_candidates
+
+        async def _mutate_after_authorizing(session_arg, **kwargs):
+            await real_authorize(session_arg, **kwargs)
+            # Authorization has returned; the row is not constructed yet.
+            frame_payload["clarification_candidates"][0]["entity_ref"]["entity_id"] = (
+                "other-org-secret-repo"
+            )
+
+        monkeypatch.setattr(
+            dev_persistence_service,
+            "_authorize_clarification_candidates",
+            _mutate_after_authorizing,
+        )
+
+        record = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(frame_payload["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=frame_payload,
+        )
+
+        # The caller's mapping really was mutated -- otherwise the test is
+        # vacuous and would pass against the unfixed code too.
+        assert (
+            frame_payload["clarification_candidates"][0]["entity_ref"]["entity_id"]
+            == "other-org-secret-repo"
+        )
+        stored = record.payload["clarification_candidates"][0]["entity_ref"][
+            "entity_id"
+        ]
+        assert stored == authorized_entity_id
+        assert "other-org-secret-repo" not in json.dumps(record.payload)
+
+
+@pytest.mark.asyncio
+async def test_direct_orm_frame_write_is_not_ledger_checked_documented_residual(
+    persistence,
+):
+    """DOCUMENTED RESIDUAL -- asserts today's behavior, not a desired one.
+
+    CHAOS-3325 confirmation-codex MEDIUM (out-of-model half): a direct
+    ORM/Core write carrying a candidate-bearing frame with no authorizing
+    ledger row is NOT rejected. That is deliberate and matches where s1 put
+    the boundary: the ORM listener and the 0080 trigger validate contract
+    shape and payload/row identity, never cross-table provenance. Enforcing
+    ledger equality inside a trigger would be cross-table DB logic out of
+    proportion to the risk, so ledger provenance stays a service-layer
+    guarantee and non-``record_frame`` frame writes remain unsupported
+    paths.
+
+    This test exists so that stays a decision rather than an assumption: if
+    ledger provenance is ever moved to the boundary, this test fails and is
+    flipped deliberately, instead of the residual being rediscovered.
+    """
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        # No append_resolution for this run: nothing authorizes these
+        # candidates. record_frame would reject this exact payload -- see
+        # test_record_frame_rejects_clarification_candidates_absent_from_the_ledger.
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        frame_payload["clarification_candidates"][0]["entity_ref"]["entity_id"] = (
+            "other-org-secret-repo"
+        )
+        row = DevAnswerFrame(
+            run_id=run_id,
+            org_id=org_id,
+            user_id=user_id,
+            frame_id=uuid.UUID(frame_payload["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=frame_payload,
+        )
+        session.add(row)
+        await session.commit()
+
+    async with maker() as session:
+        stored = await session.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
+        )
+        assert stored is not None, (
+            "documented residual: the direct-ORM path is shape-checked and "
+            "identity-checked, but not ledger-checked -- if this now fails, "
+            "ledger provenance reached the boundary and the residual is closed"
+        )
+        assert (
+            stored.payload["clarification_candidates"][0]["entity_ref"]["entity_id"]
+            == "other-org-secret-repo"
+        )
+
+
+@pytest.mark.asyncio
 async def test_record_frame_rejects_clarification_candidates_mismatching_the_ledger(
     persistence,
 ):

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -37,6 +37,12 @@ from dev_health_ops.api.dev.contract_fixtures import (
     positive_fixtures as positive_fixtures_v1,
 )
 from dev_health_ops.api.dev.contract_fixtures_v2 import (
+    _needs_clarification_frame_base,
+)
+from dev_health_ops.api.dev.contract_fixtures_v2 import (
+    needs_clarification_frame_with_candidates as _needs_clarification_frame_with_candidates,
+)
+from dev_health_ops.api.dev.contract_fixtures_v2 import (
     positive_fixtures as positive_fixtures_v2,
 )
 from dev_health_ops.api.dev.contracts import DevAnswer, DevError
@@ -165,6 +171,44 @@ def _narrative_payload(
         "validation_warnings": [],
     }
     return payload, narrative_text, provider_fingerprint
+
+
+def _needs_clarification_frame_payload(
+    *, run_id: uuid.UUID, with_candidates: bool
+) -> dict[str, Any]:
+    """CHAOS-3325: a valid ``needs_clarification`` frame, with or without a
+    real ``clarification_candidates`` block, retargeted at ``run_id`` the
+    same way ``_frame_payload`` retargets the ``answered`` fixture."""
+
+    payload = deepcopy(
+        _needs_clarification_frame_with_candidates()
+        if with_candidates
+        else _needs_clarification_frame_base()
+    )
+    payload["run_id"] = str(run_id)
+    payload["frame_id"] = str(uuid.uuid5(uuid.NAMESPACE_URL, f"frame:{run_id}"))
+    return payload
+
+
+def _ambiguous_ledger_entry_payload(
+    *, mention_id: uuid.UUID, candidates: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """A valid ``dev_resolution_ledger.v1`` entry payload -- the shape
+    ``append_resolution`` stores and ``_authorize_clarification_candidates``
+    reads back and validates as ``DevResolutionEntry``."""
+
+    return {
+        "entry_ordinal": 0,
+        "mention_id": str(mention_id),
+        "outcome": "ambiguous_candidates",
+        "committed_entity_ref": None,
+        "candidates": candidates,
+        "repository_attribution": None,
+        "team_attribution": None,
+        "resolver_version": "resolver.v1",
+        "query_version": "resolve_scope.v1",
+        "resolved_at": datetime.now(UTC).isoformat(),
+    }
 
 
 _TABLES = tables_of(
@@ -765,6 +809,290 @@ async def test_record_frame_rejects_a_frame_id_mismatch(persistence):
         run = await session.get(DevRun, run_id)
         assert run is not None
         assert run.contract_generation == "v1"
+
+
+# -- CHAOS-3325: clarification_candidates must be authorized by the run's
+# own persisted resolution ledger, not merely schema-valid ------------------
+
+
+@pytest.mark.asyncio
+async def test_record_frame_accepts_clarification_candidates_matching_the_ledger(
+    persistence,
+):
+    """Positive control: real candidates that exactly match the run's own
+    persisted ``ambiguous_candidates`` ledger entry persist cleanly."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        mention_id = uuid.uuid4()
+
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        candidates = frame_payload["clarification_candidates"]
+        assert candidates, "fixture must actually carry candidates"
+
+        await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload=_ambiguous_ledger_entry_payload(
+                mention_id=mention_id, candidates=candidates
+            ),
+        )
+
+        record = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(frame_payload["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=frame_payload,
+        )
+        assert record.public_outcome == "needs_clarification"
+        assert record.payload["clarification_candidates"] == candidates
+
+
+@pytest.mark.asyncio
+async def test_record_frame_rejects_clarification_candidates_absent_from_the_ledger(
+    persistence,
+):
+    """CHAOS-3325 Codex review (NO-SHIP, confirmed medium), the exact repro:
+    a schema-valid ``clarification_candidates`` entry that the resolution
+    ledger never authorized (e.g. another org's repository) must never
+    persist as canonical v2 state -- no matching ledger row exists for this
+    run at all."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+
+        # No append_resolution call at all for this run -- the exact repro:
+        # a needs_clarification frame carrying a schema-valid candidate the
+        # ledger never recorded.
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        frame_payload["clarification_candidates"][0]["entity_ref"]["entity_id"] = (
+            "other-org-secret-repo"
+        )
+
+        with pytest.raises(
+            DevPersistenceValidationError, match="clarification_candidates"
+        ):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(frame_payload["frame_id"]),
+                public_outcome="needs_clarification",
+                payload=frame_payload,
+            )
+
+        frame_count = await session.scalar(
+            select(func.count())
+            .select_from(DevAnswerFrame)
+            .where(DevAnswerFrame.run_id == run_id)
+        )
+        assert frame_count == 0, "an unauthorized candidate must never be written"
+        run = await session.get(DevRun, run_id)
+        assert run is not None
+        assert run.contract_generation == "v1"
+
+
+@pytest.mark.asyncio
+async def test_record_frame_rejects_clarification_candidates_mismatching_the_ledger(
+    persistence,
+):
+    """The other half of the same guard: a ledger entry does exist for this
+    run, but the frame's candidates diverge from it (a different entity, or
+    a different order) -- rejected exactly like the missing-entry case."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        mention_id = uuid.uuid4()
+
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        ledger_candidates = deepcopy(frame_payload["clarification_candidates"])
+        # The ledger authorized a *different* entity than the frame claims.
+        ledger_candidates[0]["entity_ref"]["entity_id"] = "repo_authorized_only"
+
+        await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload=_ambiguous_ledger_entry_payload(
+                mention_id=mention_id, candidates=ledger_candidates
+            ),
+        )
+
+        with pytest.raises(
+            DevPersistenceValidationError, match="clarification_candidates"
+        ):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(frame_payload["frame_id"]),
+                public_outcome="needs_clarification",
+                payload=frame_payload,
+            )
+
+        frame_count = await session.scalar(
+            select(func.count())
+            .select_from(DevAnswerFrame)
+            .where(DevAnswerFrame.run_id == run_id)
+        )
+        assert frame_count == 0, "a mismatched candidate must never be written"
+
+
+@pytest.mark.asyncio
+async def test_record_frame_allows_empty_clarification_candidates_regardless_of_ledger(
+    persistence,
+):
+    """Documents the empty-candidates decision: a frame disclosing FEWER
+    candidates than the ledger holds is not a disclosure risk, so it is
+    never rejected here -- only a mismatched or surplus one is. Covers both
+    "no ledger entry at all" (the uninterpretable-question case) and "a
+    ledger entry exists but the frame simply omits it"."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        # Case 1: no ledger entry at all.
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        empty_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=False
+        )
+        assert empty_payload["clarification_candidates"] == []
+        record = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(empty_payload["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=empty_payload,
+        )
+        assert record.public_outcome == "needs_clarification"
+
+        # Case 2: a real ambiguous ledger entry exists for this run, but the
+        # frame being persisted carries none.
+        _conv_id2, run_id2 = await _accepted_run(
+            service, org_id=org_id, user_id=user_id
+        )
+        mention_id = uuid.uuid4()
+        real_candidates = _needs_clarification_frame_payload(
+            run_id=run_id2, with_candidates=True
+        )["clarification_candidates"]
+        await service.append_resolution(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id2,
+            entry_ordinal=0,
+            mention_id=mention_id,
+            outcome="ambiguous_candidates",
+            resolved_at=datetime.now(UTC),
+            payload=_ambiguous_ledger_entry_payload(
+                mention_id=mention_id, candidates=real_candidates
+            ),
+        )
+        empty_payload_2 = _needs_clarification_frame_payload(
+            run_id=run_id2, with_candidates=False
+        )
+        record2 = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id2,
+            frame_id=uuid.UUID(empty_payload_2["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=empty_payload_2,
+        )
+        assert record2.public_outcome == "needs_clarification"
+
+
+@pytest.mark.asyncio
+async def test_record_frame_clarification_candidates_check_is_new_not_preexisting(
+    persistence, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RED/GREEN pair: before this fix, ``record_frame`` had no notion of
+    ``_authorize_clarification_candidates`` at all and would have persisted
+    an unauthorized candidate verbatim as canonical v2 state."""
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        _conv_id, run_id = await _accepted_run(service, org_id=org_id, user_id=user_id)
+        frame_payload = _needs_clarification_frame_payload(
+            run_id=run_id, with_candidates=True
+        )
+        frame_payload["clarification_candidates"][0]["entity_ref"]["entity_id"] = (
+            "other-org-secret-repo"
+        )
+
+        async def _pre_3325_noop_authorization(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        # RED: the pre-3325 record_frame had no cross-check for this field
+        # at all -- reproduced here as a no-op, and shown to accept the
+        # exact same unauthorized payload the negative test above rejects.
+        monkeypatch.setattr(
+            dev_persistence_service,
+            "_authorize_clarification_candidates",
+            _pre_3325_noop_authorization,
+        )
+        record = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(frame_payload["frame_id"]),
+            public_outcome="needs_clarification",
+            payload=frame_payload,
+        )
+        assert (
+            record.payload["clarification_candidates"][0]["entity_ref"]["entity_id"]
+            == "other-org-secret-repo"
+        ), "RED: the unauthorized candidate persisted verbatim, unguarded"
+
+        # GREEN: restore the real check -- the identical payload on a fresh
+        # run is now rejected (proven by the dedicated negative test above;
+        # re-asserted here on monkeypatch teardown for the direct contrast).
+        monkeypatch.undo()
+        _conv_id2, run_id2 = await _accepted_run(
+            service, org_id=org_id, user_id=user_id
+        )
+        frame_payload_2 = _needs_clarification_frame_payload(
+            run_id=run_id2, with_candidates=True
+        )
+        frame_payload_2["clarification_candidates"][0]["entity_ref"]["entity_id"] = (
+            "other-org-secret-repo"
+        )
+        with pytest.raises(
+            DevPersistenceValidationError, match="clarification_candidates"
+        ):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id2,
+                frame_id=uuid.UUID(frame_payload_2["frame_id"]),
+                public_outcome="needs_clarification",
+                payload=frame_payload_2,
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -62,6 +62,7 @@ from dev_health_ops.models.dev_persistence import (
     DevFeedback,
     DevMessage,
     DevRun,
+    DevRunResolution,
     DevToolCall,
 )
 from dev_health_ops.models.git import Base
@@ -79,6 +80,15 @@ _TABLES = tables_of(
     DevFeedback,
     DevConversationTombstone,
     DevAnswerFrame,
+    # CHAOS-3325 Codex review round 2: record_frame's
+    # _authorize_clarification_candidates now always queries
+    # dev_run_resolutions (even for an empty-candidates frame), so every
+    # schema this fixture backs must provision it or the query itself
+    # raises and record_frame's failure path silently rolls back --
+    # exactly this table's prior absence broke every frame-persisting test
+    # in this module and its two dependents (test_chaos_3297_frame_e2e.py,
+    # test_chaos_3297_frame_reachability.py) that import dev_api_context.
+    DevRunResolution,
     Setting,
 )
 


### PR DESCRIPTION
Adds a typed clarification-candidate block to `dev_answer_frame.v1`, closing CHAOS-3325. `compat._project_needs_clarification` previously fabricated a single placeholder candidate because the frame had no channel carrying the resolution ledger's authorized candidate list, so the CHAOS-3292 acceptance criterion ("ambiguity produces authorized candidates and focused clarification") held only at the ledger level.

`DevAnswerFrame` gains `clarification_candidates`, bounded and deeply immutable, carrying typed entity refs with safe labels. The v1 projector now emits real `DevDisambiguationCandidate` entries instead of a placeholder. `needs_clarification` is the only outcome permitted to carry the block, and it may legitimately carry zero — the honest "the question could not be interpreted at all" case is represented rather than papered over with a fabricated candidate.

Provenance is enforced at the service layer: `record_frame` requires a non-empty candidate list to match the run's own persisted `ambiguous_candidates` resolution-ledger entry exactly and in order, with a missing ledger entry rejected exactly like a mismatched one rather than treated as "nothing to check". This wires `append_resolution`'s first production caller.

## TEST-EVIDENCE

- Two adversarial review rounds pre-rebase (ledger binding, then the canonical-state-downgrade seam), plus a confirmation round post-rebase whose in-model finding is fixed here.
- `tests/api/dev`: 1442 passed, 35 skipped, 1 xfailed, 0 failed. Repo-wide `ruff check` and `ruff format --check` clean; `mypy --install-types --non-interactive .` (the literal CI command) clean across 1990 source files. `export_contracts_v2 check` verifies 88 artifacts with no drift.
- Artifacts were regenerated **after** the rebase onto merged main, not carried across it; only the manifest index needed correcting, and the drift check above was run on the committed tree.
- The confirmation MEDIUM fix ships with a RED that reproduces the exact window by wrapping the authorization hook so it delegates to the real implementation and then mutates the caller's mapping. It asserts the mutation actually happened, so it cannot pass vacuously. With the defect restored it is the **only** failing test in `tests/api/dev` — the other 1441 pass with the bug present, so it closes a gap rather than sitting beside existing coverage.
- Both partition guards were observed failing before restore. Removing the `validate_outcome_consistency` clause fails `answered` and `answered_with_gaps`; reclassifying the policy cell fails the partition test. Guard files were restored from backups and verified with `git diff --exit-code` against HEAD.
- CI is the arbiter; no `local_validate` run on this branch.

## RISK-NOTES

- **Authorized-snapshot binding.** `record_frame` builds the row from `validated.model_dump(mode="json")`, never from the caller's `payload` mapping. Every check runs against the immutable snapshot while the caller's mapping stays mutable, so building the row from the input meant a post-authorization mutation persisted unchecked. Same row-binding lesson as CHAOS-3297 s1's payload-vs-row identity closure. A side effect worth knowing: stored frame payloads are now canonicalized by the contract serializer rather than stored as the caller spelled them, which makes persisted frames more deterministic, not less.
- **Ledger-provenance residual (accepted, documented, tested).** A direct ORM/Core write carrying a candidate-bearing frame with no authorizing ledger row is not rejected. This matches where s1 deliberately put the boundary — the ORM listener and the 0080 trigger validate contract shape and payload/row identity, never cross-table provenance — and enforcing ledger equality inside a trigger would be cross-table DB logic out of proportion to the risk. Non-`record_frame` frame writes are unsupported paths already guarded by s1's deny-by-default listener; ledger provenance is a service-layer guarantee. `test_direct_orm_frame_write_is_not_ledger_checked_documented_residual` asserts today's behavior with a comment, so if provenance ever moves to the boundary the test fails and is flipped deliberately instead of the residual being rediscovered.
- **Double-forge deferred to CHAOS-3330**, carried as an `xfail(strict=True)` test with a docstring rather than an untested comment, so the deferral cannot silently start passing or silently rot.
- **The policy-partition amendment is now test-total.** `needs_clarification` is excluded from `NO_ANSWER_OUTCOMES`, so the field is governed by two guards: the `ABSENT` policy cell over the five true no-answer outcomes, and a `validate_outcome_consistency` clause over the two answered outcomes. The partition was re-verified against merged main after the rebase and is now pinned by tests parametrized over `PublicOutcome` itself, so a ninth outcome member fails until classified. A separate test asserts the two guard sets tile the enum and pins the policy cell to `ABSENT` — needed because reclassifying `ABSENT → IDENTIFIER` still rejects prose candidates and would otherwise leave every rejection case green.
- Rebased onto merged main across CHAOS-3297 s1 and the flags PR. The one semantically load-bearing conflict was in `record_frame`, where s1 had rewritten row construction while this branch inserted its authorization call at the same line; authorization now runs before construction, so an unauthorized candidate list never reaches a payload-bearing row.
