### PR TITLE
CHAOS-3146: grant coordinator sync dispatch outbox insert

### DIFF
--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -35,23 +35,24 @@ import (
 // These tests enforce the FIRST half of that sentence and not the second. They
 // make the flip visible and deliberate -- it cannot happen without editing a pin
 // in the same commit. They cannot verify that concrete delivery capability is
-// retained: set the flag and the pin together and everything here passes, 42501
-// and all. A reviewer supplies that evidence; see CHAOS-3146. Reviewed twice now
+// retained: set the flag and the pin together and everything here passes even if
+// a different runtime prerequisite is missing. A reviewer supplies that evidence.
+// Reviewed twice now
 // because the original wording claimed the whole sentence, and an overstated
 // comment is how a green test becomes read as permission to flip.
 //
-// Flipping syncMutation today also ships a known 42501: the Materializer runs on
-// the coordinator pool and inserts into public.sync_dispatch_outbox, which
-// coordinatorPosture() declares without INSERT (CHAOS-3146). So the pin's current
-// value is not merely "not yet" -- it is load-bearing.
+// CHAOS-3146 closed one concrete prerequisite by proving the restricted
+// coordinator can execute the Materializer's sync_dispatch_outbox INSERT. That
+// does not prove the whole mutation pipeline is ready to activate, so the pin
+// remains load-bearing until the complete delivery evidence is reviewed.
 //
 // What this file does NOT enforce, corrected after adversarial review pointed out
 // the original comment claimed otherwise: it cannot verify that flipping the seam
 // RETAINS concrete River delivery capability. Set the flag and the pin together
-// and both tests pass, 42501 and all. These tests prove the seam is dormant and
-// that changing it is deliberate; the capability evidence is a human's job at
-// review time, and CHAOS-3146 is the specific blocker. Do not let a green test
-// here be read as permission to flip.
+// and both tests pass without exercising that capability. These tests prove the
+// seam is dormant and that changing it is deliberate; the complete capability
+// evidence remains a human's job at review time. Do not let a green test here be
+// read as permission to flip.
 var checkedInReconcilerActivationPin = map[string]bool{
 	"syncMutation": false,
 }
@@ -172,8 +173,7 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 		t.Fatal(
 			"the PRODUCTION reconciler configuration built the sync MUTATION " +
 				"stepper. This process must observe, not mutate, until the seam is " +
-				"deliberately flipped -- and flipping it today ships a 42501 " +
-				"(CHAOS-3146). If activation is intended, that is a reviewed source " +
+				"deliberately flipped. If activation is intended, that is a reviewed source " +
 				"change: update the pin, record the capability evidence, and expect " +
 				"this test to need rewriting.",
 		)
@@ -389,8 +389,8 @@ func TestProductionSyncShadowBuilderReturnsTheShadowStepper(t *testing.T) {
 //     actually configured, because supplying one would turn this into an
 //     integration test.
 //   - That flipping the seam retains concrete River delivery capability. Set the
-//     flag and the pin together and everything here passes, 42501 and all
-//     (CHAOS-3146).
+//     flag and the pin together and everything here passes without exercising
+//     that capability. CHAOS-3146 proves the outbox INSERT grant only.
 //
 // A green run here therefore means "the seam is dormant and changing it is
 // deliberate", never "it is safe to flip".

--- a/internal/domaingrants/gate_enforcement_test.go
+++ b/internal/domaingrants/gate_enforcement_test.go
@@ -27,6 +27,13 @@ import (
 // prove the value reached the data structure while the loop that printed it was
 // deletable with everything still green.
 func TestAdvisoryReportCoversEveryCategory(t *testing.T) {
+	real := knownOpenCriticals
+	t.Cleanup(func() { knownOpenCriticals = real })
+	knownOpenCriticals = []KnownOpenCritical{{
+		Role: RoleCoordinator, Table: "sync_dispatch_outbox", Privilege: PrivInsert,
+		Ticket: "CHAOS-1111", Why: "synthetic known-open category fixture",
+	}}
+
 	var selectOnly PrivilegeSet
 	selectOnly.add(PrivSelect)
 

--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -84,21 +84,7 @@ type KnownOpenCritical struct {
 }
 
 // knownOpenCriticals is the accepted-and-ticketed set. See KnownOpenCritical.
-var knownOpenCriticals = []KnownOpenCritical{
-	{
-		Role:      RoleCoordinator,
-		Table:     "sync_dispatch_outbox",
-		Privilege: PrivInsert,
-		Ticket:    "CHAOS-3079",
-		Why: "syncreconciler.Materializer.Step runs on the coordinator pool " +
-			"(cmd/dev-health-reconciler/dependencies.go:208 NewMaterializer(coordinatorPool)) and executes four " +
-			"INSERT INTO public.sync_dispatch_outbox (materializer.go:125/235/345/450), but coordinatorPosture() " +
-			"declares {\"sync_dispatch_outbox\", false, true, false} -- allow_insert=false. Latent only because " +
-			"checkedInReconcilerActivation.syncMutation is false today; a 42501 the moment that flag flips. " +
-			"This gate's first run found it, independently confirming the CUT-06 lane's hand-derived row. " +
-			"The fix is a coordinatorPosture edit, which belongs to the posture lane, not to this checker.",
-	},
-}
+var knownOpenCriticals []KnownOpenCritical
 
 // matches reports whether f is this known-open entry.
 func (k KnownOpenCritical) matches(f Finding) bool {

--- a/internal/storage/postgres/coordinator_statement_privileges_integration_test.go
+++ b/internal/storage/postgres/coordinator_statement_privileges_integration_test.go
@@ -308,6 +308,39 @@ func TestCoordinatorStatementsArePermittedToTheCoordinatorRole(t *testing.T) {
 	}
 }
 
+// TestCoordinatorMaterializerCanInsertSyncDispatchOutbox is the CHAOS-3146
+// regression at the real trust boundary. The reconciler constructs its
+// Materializer with the restricted coordinator pool, so only a connection as
+// that login can prove the migration grants the INSERT that Step needs. The
+// statement is the production post_sync materialization shape, including its
+// conflict arbiter; a table owner or a one-column INSERT would miss the defect.
+//
+// The domain posture is checked in the same harness because sync_dispatch_outbox
+// is deliberately dual-role. Fixing the coordinator must not alter the domain
+// role's independently declared privileges.
+func TestCoordinatorMaterializerCanInsertSyncDispatchOutbox(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	_, uri := startGrantHarness(t, ctx)
+
+	statement := `INSERT INTO public.sync_dispatch_outbox (
+			id, org_id, sync_run_id, kind, status, available_at, attempts,
+			created_at, updated_at
+		) VALUES (
+			gen_random_uuid(), gen_random_uuid(), gen_random_uuid(),
+			'post_sync', 'pending', now(), 0, now(), now()
+		) ON CONFLICT (sync_run_id, kind) DO NOTHING`
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+	if err := execInRolledBackTransaction(t, ctx, coordinator, statement); err != nil {
+		t.Errorf("restricted coordinator cannot execute syncreconciler materializer INSERT: %v", err)
+	}
+
+	domain := connectAs(t, ctx, uri, grantDomainRole, grantDomainPass)
+	if err := CheckDomainAuthorization(ctx, domain, grantDomainRole, grantSchema); err != nil {
+		t.Errorf("coordinator grant changed the domain role's privilege posture: %v", err)
+	}
+}
+
 // TestCoordinatorReadinessAcceptsTheGrantsThePostureDescribes closes the loop
 // on the pair above: statements succeeding is worthless if readiness rejects
 // the same role, and readiness passing is worthless if it would also pass

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -687,7 +687,13 @@ func coordinatorPosture() RolePosture {
 			{"scheduled_jobs", false, true, false},
 			{"scheduled_sync_occurrences", true, true, false},
 			{"fixed_schedule_occurrences", true, true, false},
-			{"sync_dispatch_outbox", false, true, false},
+			// syncreconciler.Materializer.Step executes coordinator-pool INSERTs at
+			// internal/syncreconciler/materializer.go:125,
+			// internal/syncreconciler/materializer.go:235,
+			// internal/syncreconciler/materializer.go:345, and
+			// internal/syncreconciler/materializer.go:450. The first three also use
+			// ON CONFLICT DO UPDATE.
+			{"sync_dispatch_outbox", true, true, false},
 			{"sync_run_units", false, false, false},
 			{"sync_runs", false, true, false},
 			{"sync_dispatch_transport_routes", false, true, false},

--- a/internal/storage/postgres/domain_authorization_test.go
+++ b/internal/storage/postgres/domain_authorization_test.go
@@ -136,6 +136,36 @@ func TestDomainPostureInventoriesEachOriginalTableExactlyOnce(t *testing.T) {
 	}
 }
 
+func TestSyncDispatchOutboxPosturesKeepBothRolesLeastPrivilege(t *testing.T) {
+	t.Parallel()
+
+	find := func(t *testing.T, posture RolePosture) TablePrivilege {
+		t.Helper()
+		var matches []TablePrivilege
+		for _, table := range posture.RequiredTables {
+			if table.TableName == "sync_dispatch_outbox" {
+				matches = append(matches, table)
+			}
+		}
+		if len(matches) != 1 {
+			t.Fatalf("sync_dispatch_outbox posture rows = %d, want exactly 1", len(matches))
+		}
+		return matches[0]
+	}
+
+	coordinator := find(t, coordinatorPosture())
+	if !coordinator.AllowInsert || !coordinator.AllowUpdate || coordinator.AllowDelete {
+		t.Errorf("coordinator sync_dispatch_outbox = %+v, want SELECT+INSERT+UPDATE without DELETE", coordinator)
+	}
+
+	// The coordinator fix must not widen or narrow the independently required
+	// domain posture for provider-sync execution.
+	domain := find(t, domainPosture())
+	if !domain.AllowInsert || !domain.AllowUpdate || domain.AllowDelete {
+		t.Errorf("domain sync_dispatch_outbox = %+v, want unchanged SELECT+INSERT+UPDATE without DELETE", domain)
+	}
+}
+
 // unnest() does not error on mismatched array-parameter lengths; it silently
 // NULL-pads the shorter ones instead (confirmed empirically against a live
 // server — see CheckRolePosture's comment). This pins the Go-side guard that

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -277,7 +277,21 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 		)`,
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.sync_watermarks (id uuid PRIMARY KEY, state text NOT NULL)",
-		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		// Production-shaped enough for the reconciler materializer privilege proof:
+		// PostgreSQL resolves every named column and the ON CONFLICT arbiter before
+		// checking INSERT, so a one-column stand-in could only prove a 42703.
+		`CREATE TABLE public.sync_dispatch_outbox (
+			id uuid PRIMARY KEY,
+			org_id uuid NOT NULL,
+			sync_run_id uuid NOT NULL,
+			kind text NOT NULL,
+			status text NOT NULL,
+			available_at timestamptz NOT NULL,
+			attempts integer NOT NULL,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL,
+			UNIQUE (sync_run_id, kind)
+		)`,
 		// Production column shape, not a stub: the fixed-schedule engine's
 		// handoff INSERT names every one of these columns, and an undefined
 		// column (42703) is raised during parse analysis BEFORE the permission


### PR DESCRIPTION
## Summary

- Grant the coordinator posture INSERT on sync_dispatch_outbox for the four production materializer call sites.
- Keep the domain posture and syncMutation activation state unchanged.
- Replace the stale known-open grant advisory with real PostgreSQL and posture assertions.

## Evidence

- Untouched baseline reproduced SQLSTATE 42501 on the production-shaped coordinator insert.
- The same restricted-role PostgreSQL scenario passes with this change.
- Shared mutation harness changed AllowInsert true to false, killed at the same assertion, and verified restoration.
- bash ci/local_validate.sh passed: ruff, mypy, uncached Go tests and live Python oracles, River compatibility, 10,815 Python tests, 81 scratch ClickHouse migrations, and live argMax execution.

Linear: https://linear.app/fullchaos/issue/CHAOS-3146/coordinator-posture-lacks-insert-on-sync-dispatch-outbox-flipping

SCREENSHOT-WAIVER: backend-only authorization and tests; no rendered UI change.

This PR targets only feat/go-worker-runtime-migration. It does not activate syncMutation, migration 0066, or any deployment/cutover path.