### PR TITLE
CHAOS-3189: fail closed on GitHub files traversal

### DIFF
--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -318,8 +318,8 @@ def _run_github_dataset(
     # though the raise unwinds through run_async below.
     usage_sink: list[dict[str, Any]] = []
 
-    async def _handler(store: Any) -> None:
-        await process_github_repo(
+    async def _handler(store: Any) -> Any:
+        return await process_github_repo(
             store=store,
             owner=owner,
             repo_name=repo_name,
@@ -345,7 +345,9 @@ def _run_github_dataset(
         )
 
     try:
-        run_async(_run_with_reused_or_new_store(context, runtime, _handler))
+        inventory_status = run_async(
+            _run_with_reused_or_new_store(context, runtime, _handler)
+        )
     except Exception as exc:
         _attach_usage_sink_to_exception(exc, usage_sink)
         raise
@@ -366,6 +368,9 @@ def _run_github_dataset(
     }
     if usage_sink:
         result["observations"] = {PROVIDER_USAGE_OBSERVATION_KEY: list(usage_sink)}
+    if context.dataset_key == DatasetKey.FILES.value:
+        if inventory_status is not None:
+            result["inventory_status"] = str(inventory_status)
     return result
 
 

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import zipfile
 from datetime import datetime, timezone
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol
 
 from dev_health_ops.analytics.complexity import (
@@ -100,6 +101,18 @@ else:
 
 
 # --- GitHub Sync Helpers ---
+
+
+class GitHubFilesInventoryStatus(StrEnum):
+    """Proven outcomes for a completed GitHub files inventory traversal."""
+
+    COMPLETE = "complete"
+    EMPTY = "empty"
+    NO_COMMIT_AT_BOUND = "no_commit_at_bound"
+
+
+class GitHubFilesTraversalFailed(RuntimeError):
+    """The files inventory could not be proven complete for this unit."""
 
 
 def _repository_from_code_repo(repo: "GitHubRepositoryData") -> Repository:
@@ -1097,12 +1110,10 @@ async def _fetch_scannable_contents(
 
     Only paths matching the complexity scanner's include/exclude globs are
     fetched, keeping API volume proportional to what the metrics jobs can
-    actually use. A non-rate-limit fetch failure degrades to a paths-only
-    backfill (contents stay NULL) rather than failing the sync; a
-    ``RateLimitException``/``RateLimitExceededException`` propagates so the
-    caller's deferral semantics apply, mirroring the commit-stats fetch path
-    (CHAOS-2773 CS7 -- previously this degraded a rate limit to empty too,
-    silently masking it for the files dataset).
+    actually use. Any fetch failure leaves the inventory unproven: rate-limit
+    exceptions retain their existing deferral semantics and every other error
+    becomes ``GitHubFilesTraversalFailed`` so the unit cannot report success or
+    advance its watermark (CHAOS-3189).
     """
     scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
     scannable: list[str] = []
@@ -1129,8 +1140,9 @@ async def _fetch_scannable_contents(
     except (RateLimitException, RateLimitExceededException):
         raise
     except Exception as e:
-        logging.warning("Failed to fetch file contents for %s: %s", repo_full_name, e)
-        return {}
+        raise GitHubFilesTraversalFailed(
+            f"github files content fetch failed for {repo_full_name}"
+        ) from e
 
 
 async def _backfill_github_missing_data(
@@ -1149,7 +1161,7 @@ async def _backfill_github_missing_data(
     until: datetime | None = None,
     usage_sink: list[dict[str, Any]] | None = None,
     metrics_sink: Any | None = None,
-) -> None:
+) -> GitHubFilesInventoryStatus | None:
     # Logic matches the CLI sync orchestration.
     logging.info(
         "Backfilling data for %s...",
@@ -1191,7 +1203,7 @@ async def _backfill_github_missing_data(
     )
     needs_commit_stats = needs.commit_stats and include_commit_stats
     if not (needs_files or needs_blame or needs_commit_stats):
-        return
+        return None
 
     gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
 
@@ -1206,6 +1218,7 @@ async def _backfill_github_missing_data(
     if needs_files or needs_blame:
         code_client = _github_code_client_from_connector(connector)
     tree_ref = default_branch
+    inventory_status: GitHubFilesInventoryStatus | None = None
     try:
         if needs_files or needs_blame:
             try:
@@ -1216,6 +1229,10 @@ async def _backfill_github_missing_data(
                         owner, repo_name, ref=default_branch, until=until
                     )
                     if resolved_ref is None:
+                        if needs_files:
+                            inventory_status = (
+                                GitHubFilesInventoryStatus.NO_COMMIT_AT_BOUND
+                            )
                         logging.warning(
                             "No GitHub commit found for %s at or before %s; "
                             "skipping file backfill",
@@ -1267,11 +1284,20 @@ async def _backfill_github_missing_data(
                             ref_value=tree_ref,
                             contents_by_path=contents_by_path,
                         )
+                        inventory_status = GitHubFilesInventoryStatus.COMPLETE
+                    elif needs_files:
+                        inventory_status = GitHubFilesInventoryStatus.EMPTY
             except (RateLimitException, RateLimitExceededException):
                 raise
+            except GitHubFilesTraversalFailed:
+                raise
             except Exception as e:
+                if needs_files:
+                    raise GitHubFilesTraversalFailed(
+                        f"github files traversal failed for {repo_full_name}"
+                    ) from e
                 logging.warning(
-                    f"Failed to backfill GitHub files for {repo_full_name}: {e}"
+                    "Failed to traverse GitHub blame for %s: %s", repo_full_name, e
                 )
 
         if needs_commit_stats:
@@ -1399,6 +1425,7 @@ async def _backfill_github_missing_data(
                     "observations",
                     len(observations),
                 )
+    return inventory_status
 
 
 async def _sync_github_commits(
@@ -1781,7 +1808,7 @@ async def process_github_repo(
     sync_files: bool | None = None,
     sync_blame: bool | None = None,
     usage_sink: list[dict[str, Any]] | None = None,
-) -> None:
+) -> GitHubFilesInventoryStatus | None:
     """
     Process a GitHub repository using the GitHub connector.
 
@@ -1807,6 +1834,7 @@ async def process_github_repo(
     run_commit_stats = sync_git if sync_commit_stats is None else sync_commit_stats
     run_files = (backfill_missing and sync_git) if sync_files is None else sync_files
     run_blame = (backfill_missing and sync_git) if sync_blame is None else sync_blame
+    inventory_status: GitHubFilesInventoryStatus | None = None
 
     connector = (
         GitHubConnector(credentials=token)
@@ -1845,7 +1873,7 @@ async def process_github_repo(
             logging.info(f"Repository stored: {db_repo.repo} ({db_repo.id})")
 
             if blame_only:
-                await _backfill_github_missing_data(
+                inventory_status = await _backfill_github_missing_data(
                     store=store,
                     ingestion_sink=ingestion_sink,
                     connector=connector,
@@ -1863,7 +1891,7 @@ async def process_github_repo(
                     owner,
                     repo_name,
                 )
-                return
+                return inventory_status
 
             raw_commits: list[Any] | None = None
             window_truncated = False
@@ -2003,7 +2031,7 @@ async def process_github_repo(
             # (CHAOS-2376).
             if run_files or run_blame:
                 try:
-                    await _backfill_github_missing_data(
+                    inventory_status = await _backfill_github_missing_data(
                         store=store,
                         ingestion_sink=ingestion_sink,
                         connector=connector,
@@ -2018,7 +2046,17 @@ async def process_github_repo(
                         until=until,
                         usage_sink=usage_sink,
                     )
+                except (
+                    RateLimitException,
+                    RateLimitExceededException,
+                    GitHubFilesTraversalFailed,
+                ):
+                    raise
                 except Exception as e:
+                    if run_files:
+                        raise GitHubFilesTraversalFailed(
+                            f"github files traversal failed for {repo_info.full_name}"
+                        ) from e
                     logging.warning(
                         "Backfill failed for GitHub repo %s: %s",
                         repo_info.full_name,
@@ -2030,6 +2068,7 @@ async def process_github_repo(
                 owner,
                 repo_name,
             )
+            return inventory_status
 
     except ConnectorException as e:
         logging.error(f"Connector error: {e}")

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -91,7 +91,7 @@ def test_github_code_datasets_call_repo_processor_with_explicit_flags(
     dataset_key: str, flags: dict[str, bool]
 ) -> None:
     ctx = _context(dataset_key=dataset_key, processor_flags=flags)
-    processor = AsyncMock()
+    processor = AsyncMock(return_value=None)
 
     with patch("dev_health_ops.processors.github.process_github_repo", processor):
         result = run_dataset_unit(ctx, _runtime())
@@ -142,6 +142,39 @@ def test_github_prs_unit_does_not_over_fetch_deployments_incidents_or_security()
     assert kwargs["sync_incidents"] is False
     assert kwargs["sync_cicd"] is False
     assert kwargs["sync_tests"] is False
+
+
+def test_github_files_unit_persists_proven_inventory_status() -> None:
+    from dev_health_ops.processors.github import GitHubFilesInventoryStatus
+
+    ctx = _context(
+        dataset_key="files",
+        processor_flags=_flags(sync_git=True, sync_files=True),
+    )
+    processor = AsyncMock(return_value=GitHubFilesInventoryStatus.EMPTY)
+
+    with patch("dev_health_ops.processors.github.process_github_repo", processor):
+        result = run_dataset_unit(ctx, _runtime())
+
+    assert result["inventory_status"] == "empty"
+
+
+def test_github_files_traversal_failure_propagates_from_adapter() -> None:
+    from dev_health_ops.processors.github import GitHubFilesTraversalFailed
+
+    ctx = _context(
+        dataset_key="files",
+        processor_flags=_flags(sync_git=True, sync_files=True),
+    )
+    processor = AsyncMock(
+        side_effect=GitHubFilesTraversalFailed("github files traversal failed")
+    )
+
+    with (
+        patch("dev_health_ops.processors.github.process_github_repo", processor),
+        pytest.raises(GitHubFilesTraversalFailed),
+    ):
+        run_dataset_unit(ctx, _runtime())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -21,9 +22,11 @@ import pytest
 import dev_health_ops.connectors  # noqa: F401
 import dev_health_ops.metrics.job_complexity_db as job
 from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.models.git import Repo
 from dev_health_ops.processors.base_git import backfill_file_records
 from dev_health_ops.processors.github import (
     CONTENT_FETCH_MAX_BYTES,
+    GitHubFilesTraversalFailed,
     _fetch_scannable_contents,
 )
 from tests._complexity_readiness_fixtures import (
@@ -155,14 +158,15 @@ class TestFetchScannableContents:
         assert client.file_content_calls == []
 
     @pytest.mark.asyncio
-    async def test_api_error_degrades_to_empty(self):
+    async def test_api_error_fails_inventory(self):
         client = _FakeCodeClient(side_effect=RuntimeError("boom"))
 
-        result = await _fetch_scannable_contents(
-            client, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
-        )
-
-        assert result == {}
+        with pytest.raises(
+            GitHubFilesTraversalFailed, match="github files content fetch failed"
+        ):
+            await _fetch_scannable_contents(
+                client, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
+            )
 
     @pytest.mark.asyncio
     async def test_rate_limit_propagates_without_degrading(self):
@@ -340,6 +344,113 @@ class _FakeTreeEntry:
         self.path = path
         self.size = size
         self.type = type_
+
+
+def _missing_files_store() -> Mock:
+    store = Mock()
+    store.has_any_git_files = AsyncMock(return_value=False)
+    store.has_any_git_commit_stats = AsyncMock(return_value=True)
+    store.has_any_git_blame = AsyncMock(return_value=True)
+    return store
+
+
+def _github_backfill_connector(gh_repo: Mock) -> Mock:
+    connector = Mock()
+    connector.github.get_repo.return_value = gh_repo
+    return connector
+
+
+class TestFilesInventoryCompleteness:
+    @pytest.mark.asyncio
+    async def test_tree_failure_is_not_a_successful_empty_inventory(self, monkeypatch):
+        from dev_health_ops.processors import github
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        gh_repo = Mock()
+        gh_repo.get_branch.side_effect = RuntimeError("tree fetch failed")
+        connector = _github_backfill_connector(gh_repo)
+        code_client = _FakeCodeClient()
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
+
+        with pytest.raises(
+            GitHubFilesTraversalFailed, match="github files traversal failed"
+        ):
+            await _backfill_github_missing_data(
+                store=_missing_files_store(),
+                ingestion_sink=Mock(),
+                connector=connector,
+                db_repo=cast(Repo, SimpleNamespace(id=uuid.uuid4())),
+                repo_full_name="octo/repo",
+                default_branch="main",
+                max_commits=None,
+                include_files=True,
+                include_blame=False,
+                include_commit_stats=False,
+            )
+
+        code_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_completed_empty_tree_is_explicitly_empty(self, monkeypatch):
+        from dev_health_ops.processors import github
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        gh_repo = Mock()
+        gh_repo.get_branch.return_value = Mock(commit=Mock(sha="tree-sha"))
+        gh_repo.get_git_tree.return_value = Mock(tree=[])
+        connector = _github_backfill_connector(gh_repo)
+        code_client = _FakeCodeClient()
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
+
+        result = await _backfill_github_missing_data(
+            store=_missing_files_store(),
+            ingestion_sink=Mock(),
+            connector=connector,
+            db_repo=cast(Repo, SimpleNamespace(id=uuid.uuid4())),
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=True,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        assert result == "empty"
+        code_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_historical_bound_without_commit_is_explicit(self, monkeypatch):
+        from dev_health_ops.processors import github
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        gh_repo = Mock()
+        connector = _github_backfill_connector(gh_repo)
+        code_client = _FakeCodeClient(latest_commit_sha=None)
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
+
+        result = await _backfill_github_missing_data(
+            store=_missing_files_store(),
+            ingestion_sink=Mock(),
+            connector=connector,
+            db_repo=cast(Repo, SimpleNamespace(id=uuid.uuid4())),
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=True,
+            include_blame=False,
+            include_commit_stats=False,
+            until=datetime(2026, 1, 10, tzinfo=timezone.utc),
+        )
+
+        assert result == "no_commit_at_bound"
+        gh_repo.get_git_tree.assert_not_called()
+        code_client.close.assert_awaited_once()
 
 
 class TestPathsOnlyUpgrade:

--- a/tests/test_processor_split.py
+++ b/tests/test_processor_split.py
@@ -4,6 +4,8 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from dev_health_ops.processors import github, gitlab
 
 
@@ -201,6 +203,43 @@ def test_github_commits_run_does_not_fetch_stats_files_or_blame(monkeypatch):
     assert calls == {"commits": 1, "stats": 0, "backfill": []}
     assert store.sink.commits == ["commit-row"]
     assert store.sink.stats == []
+
+
+def test_github_files_run_does_not_swallow_traversal_failure(monkeypatch):
+    monkeypatch.setattr(github, "CONNECTORS_AVAILABLE", True)
+    monkeypatch.setattr(github, "GitHubConnector", _FakeGitHubConnector)
+    monkeypatch.setattr(github, "Repository", _SimpleRepository)
+    monkeypatch.setattr(github, "IngestionSink", _FakeSink)
+    monkeypatch.setattr(
+        github, "_fetch_github_repo_info_async", _fake_fetch_github_repo_info
+    )
+
+    traversal_failure = github.GitHubFilesTraversalFailed(
+        "github files traversal failed"
+    )
+
+    async def fail_backfill(**_kwargs):
+        raise traversal_failure
+
+    monkeypatch.setattr(github, "_backfill_github_missing_data", fail_backfill)
+
+    with pytest.raises(github.GitHubFilesTraversalFailed) as caught:
+        asyncio.run(
+            github.process_github_repo(
+                _FakeStore(),
+                "org",
+                "repo",
+                "token",
+                sync_git=False,
+                sync_commits=False,
+                sync_commit_stats=False,
+                sync_files=True,
+                sync_blame=False,
+                **_disable_non_git_flags(),
+            )
+        )
+
+    assert caught.value is traversal_failure
 
 
 def test_github_granular_stats_files_blame_and_legacy_bundle(monkeypatch):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -1152,6 +1152,75 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
+def test_github_files_traversal_failure_cannot_succeed_or_advance_watermark(
+    db_session, monkeypatch
+):
+    """CHAOS-3189: exercise the real swallowed traversal boundary through the worker."""
+    from unittest.mock import AsyncMock, Mock
+
+    from dev_health_ops.processors import dataset_adapters, github
+    from dev_health_ops.processors.github import _backfill_github_missing_data
+    from dev_health_ops.workers.async_runner import run_async
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(
+        db_session,
+        dataset_key="files",
+        processor_flags={"sync_git": True, "sync_files": True},
+    )
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    store = Mock()
+    store.has_any_git_files = AsyncMock(return_value=False)
+    store.has_any_git_commit_stats = AsyncMock(return_value=True)
+    store.has_any_git_blame = AsyncMock(return_value=True)
+    gh_repo = Mock()
+    gh_repo.get_branch.side_effect = RuntimeError("tree fetch failed")
+    connector = Mock()
+    connector.github.get_repo.return_value = gh_repo
+    code_client = Mock()
+    code_client.drain_usage_observations.return_value = []
+    code_client.close = AsyncMock()
+    monkeypatch.setattr(
+        github, "_github_code_client_from_connector", lambda _connector: code_client
+    )
+
+    def run_files_dataset(_ctx, _runtime):
+        inventory_status = run_async(
+            _backfill_github_missing_data(
+                store=store,
+                ingestion_sink=Mock(),
+                connector=connector,
+                db_repo=Mock(id=uuid.uuid4()),
+                repo_full_name="full-chaos/dev-health",
+                default_branch="main",
+                max_commits=None,
+                include_files=True,
+                include_blame=False,
+                include_commit_stats=False,
+            )
+        )
+        return {"inventory_status": inventory_status}
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_files_dataset)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "failed"
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error is not None
+    assert unit.error.startswith("GitHubFilesTraversalFailed:")
+    assert db_session.query(SyncWatermark).count() == 0
+    assert finalize_calls == [((str(run.id),), "sync")]
+
+
 def test_run_sync_unit_failure_sanitizes_credential_material(db_session, monkeypatch):
     """Mirrors CHAOS-2758's live-verify case B: a provider exception whose
     message embeds an Authorization header (e.g. "403 rate limited --


### PR DESCRIPTION
## Summary

- Turn non-rate-limit GitHub file-content and tree traversal failures into a stable GitHubFilesTraversalFailed error instead of a successful empty inventory.
- Propagate the typed failure through the backfill, processor, and dataset-adapter boundaries so run_sync_unit records FAILED and cannot advance the watermark.
- Preserve explicit successful inventory outcomes: complete, empty, and no_commit_at_bound. Rate-limit deferral and blame-only degradation remain unchanged.

## Evidence

- Untouched #1384 baseline: 5 intended failures; content/tree errors did not raise, explicit outcomes returned None, and the real worker path reported success/would watermark.
- Focused post-fix suite: 114 passed, including outer exception-identity and zero-watermark assertions.
- Full stack gate: ruff, mypy, uncached Go tests and live Python oracles, River compatibility, 10,822 Python tests, all 81 scratch ClickHouse migrations, and live argMax execution.

Linear: https://linear.app/fullchaos/issue/CHAOS-3189/github-files-traversal-failures-silently-advance-python-sync

SCREENSHOT-WAIVER: backend-only sync error semantics and tests; no rendered UI change.

This PR is stacked on #1384, whose root targets only feat/go-worker-runtime-migration. It does not alter deployment, routing activation, migration 0066, or retry policy.