### PR TITLE
fix(github): fail incomplete workflow-run pagination (CHAOS-3175)

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -393,12 +393,12 @@
       "notes": "Beat entry prune-external-ingest-batches, crontab(5,15) UTC"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:759",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:761",
       "surface": "dispatch_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 759
+        "line": 761
       },
       "queue_or_cadence": "sync",
       "dispatches": "run_sync_unit (per unit)",
@@ -417,12 +417,12 @@
       "notes": "transport-routes.json kind dispatch_sync_run, route=celery"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1150",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1152",
       "surface": "run_sync_unit",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1150
+        "line": 1152
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -441,12 +441,12 @@
       "notes": "only launchdarkly/feature-flags route-ready in Go"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1974",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1976",
       "surface": "finalize_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1974
+        "line": 1976
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2289,12 +2289,12 @@
       "notes": ""
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1046",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1048",
       "surface": "getattr(signature,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1046
+        "line": 1048
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2313,12 +2313,12 @@
       "notes": "grep-evading form; internal to dispatch_sync_run fan-out"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1609",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1611",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1609
+        "line": 1611
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2337,12 +2337,12 @@
       "notes": "grep-evading form; internal to unit completion"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2425",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2427",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2425
+        "line": 2427
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -329,15 +329,11 @@ async def _fetch_github_workflow_runs_async(
     runs: list[CiPipelineRun] = []
     client = _github_code_client_from_connector(connector)
     try:
-        try:
-            raw_runs = await client.get_workflow_runs(
-                owner,
-                repo_name,
-                max_runs=max_runs,
-            )
-        except Exception as exc:
-            logging.debug("Failed to fetch workflow runs: %s", exc)
-            return runs
+        raw_runs = await client.get_workflow_runs(
+            owner,
+            repo_name,
+            max_runs=max_runs,
+        )
 
         for run in raw_runs:
             started_at = run.started_at

--- a/src/dev_health_ops/providers/_http.py
+++ b/src/dev_health_ops/providers/_http.py
@@ -46,6 +46,7 @@ from dev_health_ops.exceptions import (
     APIException,
     AuthenticationException,
     NotFoundException,
+    PaginationException,
     RateLimitException,
 )
 from dev_health_ops.providers._ratelimit import resolve_retry_after_seconds
@@ -537,6 +538,7 @@ class InstrumentedRESTCore:
         headers: dict[str, str] | None = None,
         data_key: str | None = None,
         max_pages: int | None = 100,
+        require_complete: bool = False,
     ) -> list[Any]:
         """Paginate a GitHub-style endpoint via the RFC 5988 ``Link`` header.
 
@@ -547,6 +549,8 @@ class InstrumentedRESTCore:
         :param data_key: When the endpoint wraps its list in an envelope
             (e.g. GitHub Actions' ``{"workflow_runs": [...]}"``), the key to
             extract; ``None`` when the JSON payload IS the list.
+        :param require_complete: Raise instead of returning partial results
+            when the page cap is reached while a next page still exists.
         """
         items: list[Any] = []
         next_url: str | None = path
@@ -560,6 +564,11 @@ class InstrumentedRESTCore:
                     max_pages,
                     operation,
                 )
+                if require_complete:
+                    raise PaginationException(
+                        f"{self.provider} pagination incomplete after "
+                        f"{max_pages} pages for {operation}"
+                    )
                 break
             response = await self.request(
                 "GET",

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -858,6 +858,7 @@ class GitHubCodeClient:
             params={"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE},
             data_key="workflow_runs",
             max_pages=_page_cap_for_limit(max_runs),
+            require_complete=True,
         )
         return [
             _workflow_run_from_item(item)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -58,7 +58,7 @@ from sqlalchemy.orm import Session, SessionTransactionOrigin
 from dev_health_ops.api.services.sync_coverage import (
     invalidate_sync_coverage_projection_sync,
 )
-from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.exceptions import PaginationException, RateLimitException
 from dev_health_ops.models import (
     BackfillJob,
     JobRun,
@@ -267,6 +267,8 @@ def _classify_error(exc: BaseException) -> str:
     """
     if isinstance(exc, CanonicalIncidentFeatureDisabledError):
         return FEATURE_DISABLED_ERROR_CATEGORY
+    if isinstance(exc, PaginationException):
+        return "pagination_incomplete"
     msg = str(exc).lower()
     for pattern, category in _PROVIDER_ERROR_PATTERNS:
         if pattern in msg:

--- a/tests/providers/test_github_code_client_cicd.py
+++ b/tests/providers/test_github_code_client_cicd.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import PaginationException
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+
+
+def test_workflow_run_result_cap_fails_when_more_pages_exist() -> None:
+    asyncio.run(_test_workflow_run_result_cap_fails_when_more_pages_exist())
+
+
+async def _test_workflow_run_result_cap_fails_when_more_pages_exist() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"workflow_runs": [{"id": 1}]},
+            headers={"Link": f'<{request.url}&page=2>; rel="next"'},
+        )
+
+    client = GitHubCodeClient(
+        auth=GitHubAuth(token="unit-test-pat"),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(PaginationException, match="pagination incomplete"):
+            await client.get_workflow_runs("acme", "widgets", max_runs=1)
+    finally:
+        await client.close()

--- a/tests/providers/test_http_core.py
+++ b/tests/providers/test_http_core.py
@@ -21,6 +21,7 @@ from dev_health_ops.exceptions import (
     APIException,
     AuthenticationException,
     NotFoundException,
+    PaginationException,
     RateLimitException,
 )
 from dev_health_ops.providers._http import (
@@ -595,6 +596,27 @@ class TestPaginateLinkHeader:
             "/repos/a/b/commits", operation="git:GET commits", max_pages=3
         )
         assert len(items) == 3
+
+    @pytest.mark.asyncio
+    async def test_required_complete_fetch_raises_when_page_cap_has_more_data(
+        self,
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"workflow_runs": [{"id": 1}]},
+                headers={"Link": f'<{request.url}>; rel="next"'},
+            )
+
+        core = _core(transport=httpx.MockTransport(handler))
+        with pytest.raises(PaginationException, match="incomplete.*cicd:GET runs"):
+            await core.paginate_link_header(
+                "/repos/a/b/actions/runs",
+                operation="cicd:GET runs",
+                data_key="workflow_runs",
+                max_pages=1,
+                require_complete=True,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_pipeline_retry_count.py
+++ b/tests/test_ci_pipeline_retry_count.py
@@ -24,6 +24,7 @@ import pytest
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.exceptions import PaginationException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.processors.base_git import build_ci_pipeline_run
 from dev_health_ops.processors.github import (
@@ -164,6 +165,40 @@ async def test_github_workflow_run_async_drains_cicd_usage(monkeypatch):
     assert len(runs) == 1
     assert runs[0].run_id == "200"
     assert runs[0].retry_count == 2
+    assert usage_sink == [{"route_family": "cicd", "request_count": 1}]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_github_workflow_run_async_propagates_incomplete_pagination(
+    monkeypatch,
+):
+    class _IncompleteGitHubWorkflowRunClient(_GitHubWorkflowRunClient):
+        async def get_workflow_runs(
+            self, owner: str, repo: str, *, max_runs: int
+        ) -> list[GitHubWorkflowRunData]:
+            raise PaginationException(
+                "github pagination incomplete for cicd workflow runs"
+            )
+
+    client = _IncompleteGitHubWorkflowRunClient([])
+    monkeypatch.setattr(
+        "dev_health_ops.processors.github._github_code_client_from_connector",
+        lambda connector: client,
+    )
+    usage_sink: list[dict[str, object]] = []
+
+    with pytest.raises(PaginationException, match="pagination incomplete"):
+        await _fetch_github_workflow_runs_async(
+            object(),
+            "acme",
+            "widgets",
+            repo_id=None,
+            max_runs=10,
+            since=None,
+            usage_sink=usage_sink,
+        )
+
     assert usage_sink == [{"route_family": "cicd", "request_count": 1}]
     assert client.closed is True
 

--- a/tests/test_run_diagnostics.py
+++ b/tests/test_run_diagnostics.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from dev_health_ops.exceptions import PaginationException
 from dev_health_ops.models import (
     Base,
     Integration,
@@ -172,6 +173,13 @@ def test_classify_error_provider_error():
 
 def test_classify_error_adapter_error():
     assert _classify_error(Exception("unexpected NoneType")) == "adapter_error"
+
+
+def test_classify_error_incomplete_pagination():
+    assert (
+        _classify_error(PaginationException("pagination incomplete after 10 pages"))
+        == "pagination_incomplete"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- makes the active Python GitHub workflow-run path fail on incomplete capped pagination instead of returning a partial success
- stops converting provider fetch failures into successful empty batches
- records pagination_incomplete as an operator-facing failure category
- refreshes the authoritative transitional-inventory anchors changed by the source movement

## Stack
Bottom of GitHub Stack #1390. Base: feat/go-worker-runtime-migration. Followed by #1389.

## Test evidence
- baseline regression proved capped pagination returned partial data
- corrected affected Python and inventory suites: 83 passed
- independent focused rerun: 70 passed
- authoritative transitional inventory checker passed
- Ruff and mypy commit hooks passed

TEST-EVIDENCE: Capped pages with a next link raise, propagate through the active processor, and remain a failed/retryable unit.
RISK-NOTES: This is fail-closed recovery, not a durable cursor; dense windows may retry until subdivided.
SCREENSHOT-WAIVER: Backend and test-only change; no rendered UI.

Linear: https://linear.app/fullchaos/issue/CHAOS-3175