### PR TITLE
fix(github): keep capped Go CI/CD units retryable (CHAOS-3196)

### DIFF
--- a/internal/providersync/github_cicd_route.go
+++ b/internal/providersync/github_cicd_route.go
@@ -91,6 +91,9 @@ func (handler GitHubCICDRouteHandler) Collect(
 	if err != nil {
 		return CompleteRouteBatch{}, err
 	}
+	if page.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
 	items := page.Items
 	if len(items) > maxRuns {
 		items = items[:maxRuns]

--- a/internal/providersync/github_cicd_route_test.go
+++ b/internal/providersync/github_cicd_route_test.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -117,6 +118,50 @@ func TestGitHubCICDRouteEmitsOnlyWindowedPipelineRuns(t *testing.T) {
 		second.RetryCount != 0 || second.QueuedAt == nil ||
 		!second.StartedAt.Equal(*second.QueuedAt) || second.FinishedAt != nil {
 		t.Fatalf("second row=%+v", second)
+	}
+}
+
+type gitHubCICDCappedDoer struct{ t *testing.T }
+
+func (doer gitHubCICDCappedDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	body := gitHubRepositoryFixture
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if request.URL.Path == "/repos/acme/api/actions/runs" {
+		body = gitHubCICDWorkflowRunsFixture
+		header.Set(
+			"Link",
+			`<https://api.github.com/repos/acme/api/actions/runs?per_page=100&page=2>; rel="next"`,
+		)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestGitHubCICDRouteDoesNotCompleteOrAdvanceWatermarkAtResultCap(
+	t *testing.T,
+) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	client := gitHubRepositoryClient(
+		t,
+		gitHubCICDCappedDoer{t: t},
+		"https://api.github.com",
+	)
+	claim := nativeTestClaim("github", "cicd")
+
+	batch, err := (GitHubCICDRouteHandler{MaxRuns: 100}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, now,
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("error=%v want ErrPaginationCapExceeded", err)
+	}
+	if batch.Watermark != nil || len(batch.Effects) != 0 {
+		t.Fatalf("incomplete batch must be empty, got %+v", batch)
 	}
 }
 

--- a/internal/providersync/request_plan.go
+++ b/internal/providersync/request_plan.go
@@ -4,6 +4,7 @@ import "sort"
 
 const (
 	BudgetRESTCore           = "rest_core"
+	BudgetContentsBlob       = "contents_blob"
 	BudgetSearch             = "search"
 	BudgetGraphQLCost        = "graphql_cost"
 	BudgetSecondaryAbuseRisk = "secondary_abuse_risk"
@@ -30,6 +31,8 @@ func ProviderRequestPlan(
 	}
 	var estimates []RequestEstimate
 	switch provider {
+	case "github":
+		estimates = githubRequestPlan(dataset, spanDays)
 	case "linear":
 		estimates = linearRequestPlan(dataset, spanDays)
 	case "jira":
@@ -51,6 +54,16 @@ func ProviderRequestPlan(
 		return estimates[left].RouteFamily < estimates[right].RouteFamily
 	})
 	return estimates
+}
+
+func githubRequestPlan(dataset string, spanDays int) []RequestEstimate {
+	if dataset != "cicd" {
+		return nil
+	}
+	return []RequestEstimate{
+		{BudgetRESTCore, 4 * spanDays, "low", "cicd"},
+		{BudgetContentsBlob, 2 * spanDays, "low", "cicd"},
+	}
 }
 
 func linearRequestPlan(dataset string, spanDays int) []RequestEstimate {

--- a/internal/providersync/request_plan_test.go
+++ b/internal/providersync/request_plan_test.go
@@ -17,6 +17,7 @@ func TestProviderRequestPlansMatchLivePythonBudgetFunctions(t *testing.T) {
 	output, err := exec.Command(
 		python,
 		filepath.Join(packageDir, "testdata", "python_provider_budget_oracle.py"),
+		filepath.Join(root, "src", "dev_health_ops", "providers", "github", "budget.py"),
 		filepath.Join(root, "src", "dev_health_ops", "providers", "linear", "budget.py"),
 		filepath.Join(root, "src", "dev_health_ops", "providers", "jira", "budget.py"),
 		filepath.Join(root, "src", "dev_health_ops", "providers", "launchdarkly", "budget.py"),

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -34,6 +34,7 @@ _BUDGET_TYPES_SOURCE = _source("dev_health_ops/sync/budget_types.py")
 _DATASETS_SOURCE = _source("dev_health_ops/sync/datasets.py")
 _USAGE_SOURCE = _source("dev_health_ops/providers/usage.py")
 _LAUNCHDARKLY_PROCESSOR_SOURCE = _source("dev_health_ops/processors/launchdarkly.py")
+_GITHUB_BUDGET_SOURCE = _source("dev_health_ops/providers/github/budget.py")
 _LINEAR_BUDGET_SOURCE = _source("dev_health_ops/providers/linear/budget.py")
 _JIRA_BUDGET_SOURCE = _source("dev_health_ops/providers/jira/budget.py")
 _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/budget.py")
@@ -461,6 +462,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
         "dev_health_ops.processors.launchdarkly",
         _LAUNCHDARKLY_PROCESSOR_SOURCE,
         _target_launchdarkly_processor,
+    ),
+    _GITHUB_BUDGET_SOURCE: (
+        "dev_health_ops.providers.github.budget",
+        _GITHUB_BUDGET_SOURCE,
+        _target_budget,
     ),
     _LINEAR_BUDGET_SOURCE: (
         "dev_health_ops.providers.linear.budget",

--- a/internal/providersync/testdata/python_provider_budget_oracle.py
+++ b/internal/providersync/testdata/python_provider_budget_oracle.py
@@ -67,6 +67,28 @@ def _linear_cases(linear: Any) -> list[dict[str, object]]:
     return cases
 
 
+def _github_cases(github: Any) -> list[dict[str, object]]:
+    return [
+        {
+            "provider": "github",
+            "dataset": "cicd",
+            "span_days": span_days,
+            "flags": {},
+            "estimates": _render(
+                github._dataset_estimates(
+                    dataset_key="cicd",
+                    flags={},
+                    org_id="org",
+                    host="fixture.example",
+                    credential_fingerprint="fingerprint",
+                    span_days=span_days,
+                )
+            ),
+        }
+        for span_days in (1, 3)
+    ]
+
+
 def _jira_cases(jira: Any) -> list[dict[str, object]]:
     cases: list[dict[str, object]] = []
     for span_days in (1, 3):
@@ -117,6 +139,8 @@ def _launchdarkly_cases(launchdarkly: Any) -> list[dict[str, object]]:
 
 def _provider_cases(provider: str, source: pathlib.Path) -> list[dict[str, object]]:
     module = _namespace(source)
+    if provider == "github":
+        return _github_cases(module)
     if provider == "linear":
         return _linear_cases(module)
     if provider == "jira":
@@ -152,14 +176,16 @@ def main() -> int:
         child_cases = _provider_cases(sys.argv[2], pathlib.Path(sys.argv[3]))
         json.dump(child_cases, sys.stdout, sort_keys=True, separators=(",", ":"))
         return 0
-    if len(sys.argv) != 4:
+    if len(sys.argv) != 5:
         return 2
 
-    linear = _provider_subprocess("linear", pathlib.Path(sys.argv[1]))
-    jira = _provider_subprocess("jira", pathlib.Path(sys.argv[2]))
-    launchdarkly = _provider_subprocess("launchdarkly", pathlib.Path(sys.argv[3]))
+    github = _provider_subprocess("github", pathlib.Path(sys.argv[1]))
+    linear = _provider_subprocess("linear", pathlib.Path(sys.argv[2]))
+    jira = _provider_subprocess("jira", pathlib.Path(sys.argv[3]))
+    launchdarkly = _provider_subprocess("launchdarkly", pathlib.Path(sys.argv[4]))
     cases: list[dict[str, object]] = []
     for span_days in (1, 3):
+        cases.extend(case for case in github if case["span_days"] == span_days)
         cases.extend(case for case in linear if case["span_days"] == span_days)
         cases.extend(case for case in jira if case["span_days"] == span_days)
     cases.extend(launchdarkly)

--- a/internal/providersync/work_item_contract_test.go
+++ b/internal/providersync/work_item_contract_test.go
@@ -212,6 +212,7 @@ func TestParityOraclesRunWithoutSQLAlchemy(t *testing.T) {
 			name:   "provider budget parity",
 			script: "python_provider_budget_oracle.py",
 			source: []string{
+				filepath.Join(root, "src", "dev_health_ops", "providers", "github", "budget.py"),
 				filepath.Join(root, "src", "dev_health_ops", "providers", "linear", "budget.py"),
 				filepath.Join(root, "src", "dev_health_ops", "providers", "jira", "budget.py"),
 				filepath.Join(root, "src", "dev_health_ops", "providers", "launchdarkly", "budget.py"),


### PR DESCRIPTION
## Summary
- returns ErrPaginationCapExceeded before Go effects or watermark construction
- ports github/cicd request estimates from the live Python budget implementation
- extends the uncached live-Python budget differential oracle to GitHub

## Stack
Top of GitHub Stack #1390. Base: #1388, which itself targets feat/go-worker-runtime-migration.

## Test evidence
- go test -count=1 ./internal/providersync/...
- bash ci/check_go.sh live-python-oracles
- repository Go fast gate passed outside the sandbox
- independent uncached provider-sync rerun passed with a writable Go cache
- Ruff and mypy commit hooks passed

TEST-EVIDENCE: A capped Go page returns an error with an empty batch, no effects, and no watermark.
RISK-NOTES: Durable pagination continuation is still future work; retry history retains the typed cap error while unit state uses the generic retryable category.
SCREENSHOT-WAIVER: Backend and test-only change; no rendered UI.

Linear: https://linear.app/fullchaos/issue/CHAOS-3196