### PR TITLE
test(sync): restore PostgreSQL legacy dispatch coverage (CHAOS-3179)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,18 +117,12 @@ jobs:
           # 4 vCPUs, so this matches `-n auto` there while staying predictable on
           # larger runners. Override PYTEST_XDIST_WORKERS to tune.
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
           ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
-
-      - name: Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)
-        continue-on-error: true
-        env:
-          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-        run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
 
       - name: Run PostgreSQL 0066 migration tests
         env:
@@ -218,18 +212,12 @@ jobs:
           COVERAGE_THRESHOLD: "70"
           OTEL_ENABLED: "false"
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --deselect=tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
           ./ci/run_tests.sh ci 2>&1 | tee test-results/logs/ci-3.12.log
-
-      - name: Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)
-        continue-on-error: true
-        env:
-          DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-        run: pytest -q tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
 
       - name: Upload junit test reports
         if: always()

--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -75,9 +75,7 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
         if step.get("name") == "Run parallel unit test contract"
     )
     assert unit_step["env"]["PYTEST_ADDOPTS"] == (
-        "--ignore=tests/test_0066_celery_river_cutover_postgres.py "
-        "--deselect=tests/test_dispatch_outbox.py::"
-        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible"
+        "--ignore=tests/test_0066_celery_river_cutover_postgres.py"
     )
     assert unit_step["env"][_POSTGRES_TEST_URI_ENV] == (
         "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
@@ -95,24 +93,13 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
     assert coverage_step["env"]["PYTEST_ADDOPTS"] == unit_step["env"]["PYTEST_ADDOPTS"]
     assert "./ci/run_tests.sh ci" in coverage_step["run"]
 
-    quarantine_step = next(
-        step
-        for step in workflow["jobs"]["test-matrix"]["steps"]
-        if step.get("name")
-        == "Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)"
-    )
-    assert quarantine_step["continue-on-error"] is True
-    assert quarantine_step["env"][_POSTGRES_TEST_URI_ENV] == (
-        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
-    )
-    assert quarantine_step["run"] == (
-        "pytest -q tests/test_dispatch_outbox.py::"
-        "test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible"
-    )
-
     for job_name in ("test-matrix", "coverage"):
         assert all(
-            step.get("name") != "Run quarantined PostgreSQL planner test (CHAOS-3180)"
+            step.get("name")
+            not in {
+                "Run quarantined PostgreSQL planner test (CHAOS-3180)",
+                "Run quarantined PostgreSQL legacy dispatch test (CHAOS-3179)",
+            }
             for step in workflow["jobs"][job_name]["steps"]
         )
 

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import inspect
 import os
 import time
@@ -10,7 +11,9 @@ from datetime import datetime, timedelta, timezone
 from threading import Event
 
 import pytest
-from sqlalchemy import create_engine, event, update
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, event, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -63,6 +66,44 @@ def _postgres_engine():
     return create_engine(
         normalize_sync_postgres_uri(os.environ[_POSTGRES_TEST_URI_ENV])
     )
+
+
+@contextmanager
+def _postgres_0049_migrated_session():
+    """Yield an isolated session whose schema was upgraded by migration 0049.
+
+    ``Base.metadata.create_all`` installs the current constraints, but cannot
+    install PostgreSQL functions or triggers. Rewinding and replaying 0049 in a
+    private schema makes the compatibility test exercise the actual migration
+    contract without depending on state left in the shared test database.
+    """
+    engine = _postgres_engine()
+    schema = f"chaos_3179_{uuid.uuid4().hex}"
+    connection = engine.connect()
+    try:
+        connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+        connection.execute(text(f'SET search_path TO "{schema}"'))
+        connection.commit()
+        Base.metadata.create_all(connection)
+
+        migration = importlib.import_module(
+            "dev_health_ops.alembic.versions.0049_add_sync_dispatch_transport_fence"
+        )
+        context = MigrationContext.configure(connection)
+        with Operations.context(context):
+            migration.downgrade()
+            migration.upgrade()
+        connection.commit()
+
+        with Session(bind=connection) as session:
+            yield session
+    finally:
+        connection.rollback()
+        connection.execute(text("SET search_path TO public"))
+        connection.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+        connection.commit()
+        connection.close()
+        engine.dispose()
 
 
 @pytest.fixture
@@ -918,93 +959,71 @@ def test_backoff_seconds_sequence_is_capped():
 
 @pytest.mark.usefixtures("require_postgres_test_uri")
 def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible():
-    engine = _postgres_engine()
-    Base.metadata.create_all(engine)
-    run_id = None
-    integration_id = None
-    try:
-        with Session(engine) as session:
-            for kind in (
-                OUTBOX_KIND_DISPATCH,
-                OUTBOX_KIND_FINALIZE,
-                "post_sync",
-                "reference_discovery",
-            ):
-                if session.get(SyncDispatchTransportRoute, kind) is None:
-                    session.add(
-                        SyncDispatchTransportRoute(
-                            kind=kind,
-                            transport="celery",
-                            generation=1,
-                            paused=False,
-                            paused_at=None,
-                            rollback_transport="celery",
-                        )
-                    )
-            route = session.get(
-                SyncDispatchTransportRoute,
-                OUTBOX_KIND_DISPATCH,
-            )
-            assert route is not None
-            expected_generation = route.generation
-            now = datetime.now(timezone.utc)
-            row = _seed_outbox(session, available_at=now)
-            run_id = row.sync_run_id
-            run = session.get(SyncRun, run_id)
-            assert run is not None
-            integration_id = run.integration_id
-            session.flush()
-
-            # Simulate a pre-0049 worker: it writes only the original lease
-            # columns. The migration trigger binds the current Celery route.
-            session.execute(
-                update(SyncDispatchOutbox)
-                .where(SyncDispatchOutbox.id == row.id)
-                .values(
-                    claim_token="legacy-celery-token",
-                    claim_expires_at=now + timedelta(minutes=5),
+    with _postgres_0049_migrated_session() as session:
+        trigger_installed = session.execute(
+            text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_trigger
+                    WHERE tgrelid = 'sync_dispatch_outbox'::regclass
+                      AND tgname = 'trg_sync_dispatch_outbox_route_fence'
+                      AND NOT tgisinternal
                 )
+                """
             )
-            session.expire_all()
-            claimed = session.get(SyncDispatchOutbox, row.id)
-            assert claimed is not None
-            assert claimed.claim_transport == "celery"
-            assert claimed.claim_route_generation == expected_generation
+        ).scalar_one()
+        assert trigger_installed is True
 
-            # The same old worker clears only its original lease columns when
-            # marking success. The trigger copies the old binding into the
-            # dispatched audit columns before clearing the claim tuple.
-            session.execute(
-                update(SyncDispatchOutbox)
-                .where(SyncDispatchOutbox.id == row.id)
-                .values(
-                    status=OUTBOX_STATUS_DISPATCHED,
-                    dispatched_at=now,
-                    claim_token=None,
-                    claim_expires_at=None,
-                )
+        route = session.get(
+            SyncDispatchTransportRoute,
+            OUTBOX_KIND_DISPATCH,
+        )
+        assert route is not None
+        assert route.transport == "celery"
+        assert route.paused is False
+        expected_generation = route.generation
+        now = datetime.now(timezone.utc)
+        row = _seed_outbox(session, available_at=now)
+        session.flush()
+
+        # Simulate a pre-0049 worker: it writes only the original lease
+        # columns. The migration trigger binds the current Celery route before
+        # the claim-route coherence constraint is evaluated.
+        session.execute(
+            update(SyncDispatchOutbox)
+            .where(SyncDispatchOutbox.id == row.id)
+            .values(
+                claim_token="legacy-celery-token",
+                claim_expires_at=now + timedelta(minutes=5),
             )
-            session.expire_all()
-            dispatched = session.get(SyncDispatchOutbox, row.id)
-            assert dispatched is not None
-            assert dispatched.claim_transport is None
-            assert dispatched.claim_route_generation is None
-            assert dispatched.dispatched_transport == "celery"
-            assert dispatched.dispatched_route_generation == expected_generation
-            session.commit()
-    finally:
-        if run_id is not None:
-            with Session(engine) as cleanup_session:
-                cleanup_session.query(SyncDispatchOutbox).filter_by(
-                    sync_run_id=run_id
-                ).delete()
-                cleanup_session.query(SyncRun).filter_by(id=run_id).delete()
-                if integration_id is not None:
-                    cleanup_session.query(Integration).filter_by(
-                        id=integration_id
-                    ).delete()
-                cleanup_session.commit()
-        engine.dispose()
+        )
+        session.expire_all()
+        claimed = session.get(SyncDispatchOutbox, row.id)
+        assert claimed is not None
+        assert claimed.claim_transport == "celery"
+        assert claimed.claim_route_generation == expected_generation
+
+        # The same old worker clears only its original lease columns when
+        # marking success. The trigger copies the old binding into the
+        # dispatched audit columns before clearing the claim tuple.
+        session.execute(
+            update(SyncDispatchOutbox)
+            .where(SyncDispatchOutbox.id == row.id)
+            .values(
+                status=OUTBOX_STATUS_DISPATCHED,
+                dispatched_at=now,
+                claim_token=None,
+                claim_expires_at=None,
+            )
+        )
+        session.expire_all()
+        dispatched = session.get(SyncDispatchOutbox, row.id)
+        assert dispatched is not None
+        assert dispatched.claim_transport is None
+        assert dispatched.claim_route_generation is None
+        assert dispatched.dispatched_transport == "celery"
+        assert dispatched.dispatched_route_generation == expected_generation
 
 
 @pytest.mark.usefixtures("require_postgres_test_uri")


### PR DESCRIPTION
## Summary
- provisions an isolated PostgreSQL schema and replays real migration 0049
- proves the route-fence trigger binds legacy claim and dispatch metadata before coherence constraints
- removes only the CHAOS-3179 deselection and continue-on-error quarantine
- preserves the separate migration 0066 gate unchanged

## Stack
Bottom of GitHub Stack #1393. Base: feat/go-worker-runtime-migration. Followed by #1392.

## Test evidence
- untouched behavior reproduced ck_sync_dispatch_outbox_claim_route_coherence failure
- repaired PostgreSQL regression: 1 passed
- full dispatch-outbox module: 30 passed
- 0066 guard suite: 9 passed
- Ruff and mypy hooks passed

TEST-EVIDENCE: The test checks the actual installed trigger and both legacy claim and dispatched metadata transitions.
RISK-NOTES: No production migration or runtime activation change; host temporary-space exhaustion prevented the final integration-coverage/full-Python/ClickHouse tail of the broad gate.
SCREENSHOT-WAIVER: Test and CI-only change; no rendered UI.

Linear: https://linear.app/fullchaos/issue/CHAOS-3179