### PR TITLE
feat(scheduler): port scheduled sync planner foundation (CHAOS-3145)

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -22,7 +22,8 @@ Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|inte
   test   Run go test ./... in every Go module.
   race   Run go test -race ./... in every Go module.
   live-python-oracles
-         Run `go test -count=1 ./internal/providersync/...` unconditionally
+         Run the provider-sync and scheduled-planner live-Python oracle packages
+         with `go test -count=1` unconditionally
          (cache lookup disabled by -count=1 itself, not by any assumption
          about cache state). Separate from `test` because that package
          executes real production Python files (src/dev_health_ops/**.py)
@@ -190,7 +191,7 @@ check_race() {
 }
 
 check_live_python_oracles() {
-  # internal/providersync executes REAL production Python files
+  # internal/providersync and internal/scheduler/sync execute REAL production Python files
   # (src/dev_health_ops/**.py, via testdata/python_oracle_loader.py)
   # directly at test time -- not test fixtures, the actual functions this
   # repo ships. `//go:embed` cannot reach outside its own package
@@ -219,6 +220,8 @@ check_live_python_oracles() {
   # coverage possible again by construction.
   printf 'go test -count=1: internal/providersync (live Python oracle sources are outside the Go embed/cache boundary)\n'
   (cd "${ROOT}" && GOWORK=off go test -mod=readonly -count=1 ./internal/providersync/...)
+  printf 'go test -count=1: internal/scheduler/sync (live Python planner source is outside the Go embed/cache boundary)\n'
+  (cd "${ROOT}" && GOWORK=off go test -mod=readonly -count=1 ./internal/scheduler/sync/...)
 }
 
 check_build() {

--- a/internal/scheduler/sync/planner.go
+++ b/internal/scheduler/sync/planner.go
@@ -1,0 +1,301 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	SyncModeIncremental = "incremental"
+	SyncModeFullResync  = "full_resync"
+	SyncModeBackfill    = "backfill"
+
+	defaultInitialSyncDepthDays = 30
+	canonicalWorkItemsDataset   = "work-items"
+	familyDatasetFlagPrefix     = "family_dataset_"
+)
+
+var (
+	ErrInvalidPlan       = errors.New("invalid scheduled sync plan")
+	ErrBackfillScheduled = errors.New("scheduled sync backfill is not supported")
+)
+
+// PlanSource is the secret-free source state consumed by the pure planner.
+type PlanSource struct {
+	ID         string
+	ExternalID string
+	Provider   string
+	FullName   string
+}
+
+// PlanDataset is the secret-free dataset state consumed by the pure planner.
+type PlanDataset struct {
+	Key              string
+	InitialDepthDays *int
+}
+
+// WatermarkKey is the canonical incremental-watermark identity.
+type WatermarkKey struct {
+	SourceID string
+	Dataset  string
+}
+
+// PlannerInput contains only already-authorized, enabled rows. Loading and
+// locking those rows remains the PostgreSQL materializer's responsibility.
+type PlannerInput struct {
+	OrgID                string
+	IntegrationID        string
+	Mode                 string
+	Now                  time.Time
+	Before               *time.Time
+	IntegrationDepthDays *int
+	TierBackfillDaysCap  *int
+	WatermarkOverlap     time.Duration
+	Sources              []PlanSource
+	Datasets             []PlanDataset
+	Watermarks           map[WatermarkKey]time.Time
+}
+
+// PlannedUnit is the complete secret-free unit row prior to persistence.
+type PlannedUnit struct {
+	OrgID          string          `json:"org_id"`
+	IntegrationID  string          `json:"integration_id"`
+	SourceID       string          `json:"source_id"`
+	Provider       string          `json:"provider"`
+	Dataset        string          `json:"dataset_key"`
+	CostClass      string          `json:"cost_class"`
+	Mode           string          `json:"mode"`
+	WindowStart    *time.Time      `json:"window_start"`
+	WindowEnd      *time.Time      `json:"window_end"`
+	ProcessorFlags map[string]bool `json:"processor_flags"`
+}
+
+type datasetSpec struct {
+	CostClass      string
+	Incremental    bool
+	ProcessorFlags map[string]bool
+	LegacyTargets  []string
+}
+
+var workItemFamilyOrder = []string{
+	"work-items",
+	"work-item-labels",
+	"work-item-projects",
+	"work-item-history",
+	"work-item-comments",
+}
+
+var supportedProviderDatasets = map[string]map[string]struct{}{
+	"github":       setOf("repo-metadata", "commits", "commit-stats", "files", "blame", "prs", "pr-reviews", "pr-comments", "cicd", "tests", "deployments", "security", "work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments"),
+	"gitlab":       setOf("repo-metadata", "commits", "commit-stats", "files", "blame", "prs", "pr-reviews", "pr-comments", "cicd", "tests", "deployments", "incidents", "security", "work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments", "feature-flags"),
+	"jira":         setOf("incidents", "work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments"),
+	"linear":       setOf("work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments"),
+	"launchdarkly": setOf("feature-flags"),
+	"pagerduty":    setOf("services", "business-services", "escalation-policies", "schedules", "on-calls", "users", "teams", "incidents", "incident-alerts", "incident-log-entries", "incident-notes"),
+}
+
+var lightDatasets = setOf(
+	"repo-metadata", "incidents", "work-item-labels", "work-item-projects",
+	"services", "business-services", "escalation-policies", "schedules", "users", "teams",
+)
+var heavyDatasets = setOf("commit-stats", "files", "blame", "tests")
+var noWatermarkDatasets = setOf(
+	"repo-metadata", "services", "business-services", "escalation-policies",
+	"schedules", "on-calls", "users", "teams",
+)
+
+var processorFlagsByDataset = map[string]map[string]bool{
+	"commits":      {"sync_git": true, "sync_commits": true},
+	"commit-stats": {"sync_git": true, "sync_commit_stats": true},
+	"files":        {"sync_git": true, "sync_files": true},
+	"blame":        {"blame_only": true, "sync_blame": true},
+	"prs":          {"sync_prs": true},
+	"pr-reviews":   {"sync_prs": true},
+	"pr-comments":  {"sync_prs": true},
+	"cicd":         {"sync_cicd": true},
+	"tests":        {"sync_tests": true},
+	"deployments":  {"sync_deployments": true},
+	"incidents":    {"sync_incidents": true},
+	"security":     {"sync_security": true},
+}
+
+var legacyTargetsByDataset = map[string][]string{
+	"repo-metadata": {"git"}, "commits": {"git"}, "commit-stats": {"git"}, "files": {"git"},
+	"blame": {"blame"}, "prs": {"prs"}, "pr-reviews": {"prs"}, "pr-comments": {"prs"},
+	"cicd": {"cicd"}, "tests": {"tests"}, "deployments": {"deployments"},
+	"incidents": {"incidents"}, "security": {"security"},
+	"work-items": {"work-items"}, "work-item-labels": {"work-items"},
+	"work-item-projects": {"work-items"}, "work-item-history": {"work-items"},
+	"work-item-comments": {"work-items"}, "feature-flags": {"feature-flags"},
+	"services": {"operational"}, "business-services": {"operational"},
+	"escalation-policies": {"operational"}, "schedules": {"operational"},
+	"on-calls": {"operational"}, "users": {"operational"}, "teams": {"operational"},
+	"incident-alerts": {"operational"}, "incident-log-entries": {"operational"},
+	"incident-notes": {"operational"},
+}
+
+// BuildScheduledPlan is the pure scheduled planner. It deliberately rejects
+// backfill: scheduled occurrences may be incremental or full-resync only.
+func BuildScheduledPlan(input PlannerInput) ([]PlannedUnit, error) {
+	if input.Mode == SyncModeBackfill {
+		return nil, ErrBackfillScheduled
+	}
+	if input.Mode != SyncModeIncremental && input.Mode != SyncModeFullResync {
+		return nil, fmt.Errorf("%w: unsupported sync run mode %q", ErrInvalidPlan, input.Mode)
+	}
+	if input.OrgID == "" || input.IntegrationID == "" || input.Now.IsZero() {
+		return nil, ErrInvalidPlan
+	}
+	now := input.Now.UTC()
+	before := now
+	if input.Before != nil {
+		before = input.Before.UTC()
+	}
+	units := make([]PlannedUnit, 0, len(input.Sources)*len(input.Datasets))
+	for _, source := range input.Sources {
+		provider := strings.ToLower(source.Provider)
+		prsEnabled := false
+		family := make([]PlanDataset, 0, len(workItemFamilyOrder))
+		for _, dataset := range input.Datasets {
+			spec, ok := datasetSpecification(provider, dataset.Key)
+			if !ok {
+				continue
+			}
+			if slices.Contains(spec.LegacyTargets, "prs") {
+				prsEnabled = true
+			}
+			if slices.Contains(workItemFamilyOrder, dataset.Key) {
+				family = append(family, dataset)
+				continue
+			}
+			start := resolveWindowStart(input, source, dataset, spec, now)
+			units = append(units, newPlannedUnit(input, source, dataset.Key, spec, start, before))
+		}
+		if len(family) == 0 {
+			continue
+		}
+		canonical, ok := datasetSpecification(provider, canonicalWorkItemsDataset)
+		if !ok {
+			continue
+		}
+		var earliest *time.Time
+		flags := cloneFlags(canonical.ProcessorFlags)
+		for _, dataset := range family {
+			spec, ok := datasetSpecification(provider, dataset.Key)
+			if !ok {
+				continue
+			}
+			start := resolveWindowStart(input, source, dataset, spec, now)
+			if start == nil {
+				earliest = nil
+				break
+			}
+			if earliest == nil || start.Before(*earliest) {
+				copy := *start
+				earliest = &copy
+			}
+		}
+		for _, dataset := range family {
+			flags[familyDatasetFlag(dataset.Key)] = true
+		}
+		if provider == "github" {
+			flags["sync_prs"] = prsEnabled
+		}
+		unit := newPlannedUnit(input, source, canonicalWorkItemsDataset, canonical, earliest, before)
+		unit.ProcessorFlags = flags
+		units = append(units, unit)
+	}
+	return units, nil
+}
+
+func resolveWindowStart(input PlannerInput, source PlanSource, dataset PlanDataset, spec datasetSpec, now time.Time) *time.Time {
+	if input.Mode == SyncModeIncremental {
+		if !spec.Incremental {
+			return nil
+		}
+		if watermark, ok := input.Watermarks[WatermarkKey{SourceID: source.ExternalID, Dataset: dataset.Key}]; ok {
+			value := watermark.UTC().Add(-max(input.WatermarkOverlap, 0))
+			return &value
+		}
+	}
+	depth := resolveInitialSyncDepth(dataset.InitialDepthDays, input.IntegrationDepthDays, input.TierBackfillDaysCap)
+	value := now.AddDate(0, 0, -depth)
+	return &value
+}
+
+func resolveInitialSyncDepth(dataset, integration, tierCap *int) int {
+	depth := defaultInitialSyncDepthDays
+	if integration != nil {
+		depth = *integration
+	}
+	if dataset != nil {
+		depth = *dataset
+	}
+	if tierCap != nil && *tierCap < depth {
+		depth = *tierCap
+	}
+	if depth < 1 {
+		return 1
+	}
+	return depth
+}
+
+func newPlannedUnit(input PlannerInput, source PlanSource, dataset string, spec datasetSpec, start *time.Time, end time.Time) PlannedUnit {
+	end = end.UTC()
+	return PlannedUnit{
+		OrgID: input.OrgID, IntegrationID: input.IntegrationID, SourceID: source.ID,
+		Provider: strings.ToLower(source.Provider), Dataset: dataset, CostClass: spec.CostClass,
+		Mode: input.Mode, WindowStart: start, WindowEnd: &end, ProcessorFlags: cloneFlags(spec.ProcessorFlags),
+	}
+}
+
+func datasetSpecification(provider, dataset string) (datasetSpec, bool) {
+	supported, ok := supportedProviderDatasets[strings.ToLower(provider)]
+	if !ok {
+		return datasetSpec{}, false
+	}
+	if _, ok := supported[dataset]; !ok {
+		return datasetSpec{}, false
+	}
+	cost := "medium"
+	if _, ok := lightDatasets[dataset]; ok {
+		cost = "light"
+	} else if _, ok := heavyDatasets[dataset]; ok {
+		cost = "heavy"
+	}
+	flags := cloneFlags(processorFlagsByDataset[dataset])
+	targets := slices.Clone(legacyTargetsByDataset[dataset])
+	if provider == "pagerduty" && dataset == "incidents" {
+		targets = []string{"operational"}
+	}
+	if provider == "jira" && dataset == "incidents" {
+		cost = "medium"
+		flags = map[string]bool{}
+		targets = []string{"operational"}
+	}
+	_, noWatermark := noWatermarkDatasets[dataset]
+	return datasetSpec{CostClass: cost, Incremental: !noWatermark, ProcessorFlags: flags, LegacyTargets: targets}, true
+}
+
+func familyDatasetFlag(dataset string) string {
+	return familyDatasetFlagPrefix + strings.ReplaceAll(dataset, "-", "_")
+}
+
+func cloneFlags(flags map[string]bool) map[string]bool {
+	result := make(map[string]bool, len(flags))
+	for key, value := range flags {
+		result[key] = value
+	}
+	return result
+}
+
+func setOf(values ...string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}

--- a/internal/scheduler/sync/planner_oracle_test.go
+++ b/internal/scheduler/sync/planner_oracle_test.go
@@ -1,0 +1,184 @@
+package sync
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type plannerOracleSource struct {
+	ID         string `json:"id"`
+	ExternalID string `json:"external_id"`
+	Provider   string `json:"provider"`
+	FullName   string `json:"full_name"`
+}
+
+type plannerOracleDataset struct {
+	DatasetKey   string `json:"dataset_key"`
+	InitialDepth *int   `json:"initial_depth,omitempty"`
+}
+
+type plannerOracleWatermark struct {
+	SourceID   string `json:"source_id"`
+	DatasetKey string `json:"dataset_key"`
+	At         string `json:"at"`
+}
+
+type plannerOracleCase struct {
+	ID                      string                   `json:"id"`
+	OrgID                   string                   `json:"org_id"`
+	IntegrationID           string                   `json:"integration_id"`
+	Provider                string                   `json:"provider"`
+	Mode                    string                   `json:"mode"`
+	Now                     string                   `json:"now"`
+	Before                  *string                  `json:"before,omitempty"`
+	IntegrationDepth        *int                     `json:"integration_depth,omitempty"`
+	TierCap                 *int                     `json:"tier_cap,omitempty"`
+	WatermarkOverlapSeconds int                      `json:"watermark_overlap_seconds"`
+	Sources                 []plannerOracleSource    `json:"sources"`
+	Datasets                []plannerOracleDataset   `json:"datasets"`
+	Watermarks              []plannerOracleWatermark `json:"watermarks"`
+}
+
+func TestBuildScheduledPlanMatchesLivePythonPlanner(t *testing.T) {
+	depth120, depth60, cap30 := 120, 60, 30
+	before := "2026-07-30T11:30:00Z"
+	cases := []plannerOracleCase{
+		{
+			ID: "github_incremental_family", OrgID: "org-a", IntegrationID: "integration-a", Provider: "github",
+			Mode: SyncModeIncremental, Now: "2026-07-30T12:00:00Z", Before: &before,
+			IntegrationDepth: &depth60, TierCap: &cap30, WatermarkOverlapSeconds: 300,
+			Sources: []plannerOracleSource{
+				{ID: "source-z", ExternalID: "owner/z", Provider: "github", FullName: "owner/z"},
+				{ID: "source-a", ExternalID: "owner/a", Provider: "github", FullName: "owner/a"},
+			},
+			Datasets: []plannerOracleDataset{
+				{DatasetKey: "repo-metadata"}, {DatasetKey: "commits", InitialDepth: &depth120},
+				{DatasetKey: "prs"}, {DatasetKey: "work-item-labels"}, {DatasetKey: "work-items"},
+			},
+			Watermarks: []plannerOracleWatermark{
+				{SourceID: "owner/a", DatasetKey: "commits", At: "2026-07-29T10:00:00Z"},
+				{SourceID: "owner/a", DatasetKey: "work-items", At: "2026-07-28T10:00:00Z"},
+				{SourceID: "owner/a", DatasetKey: "work-item-labels", At: "2026-07-29T10:00:00Z"},
+			},
+		},
+		{
+			ID: "pagerduty_full_resync", OrgID: "org-b", IntegrationID: "integration-b", Provider: "pagerduty",
+			Mode: SyncModeFullResync, Now: "2026-07-30T12:00:00Z", IntegrationDepth: &depth60, TierCap: &cap30,
+			Sources:  []plannerOracleSource{{ID: "source-pd", ExternalID: "account", Provider: "pagerduty", FullName: "account"}},
+			Datasets: []plannerOracleDataset{{DatasetKey: "services"}, {DatasetKey: "incidents"}, {DatasetKey: "incident-notes"}},
+		},
+		{
+			ID: "jira_incident_override", OrgID: "org-c", IntegrationID: "integration-c", Provider: "jira",
+			Mode: SyncModeIncremental, Now: "2026-07-30T12:00:00Z", TierCap: &cap30,
+			Sources:  []plannerOracleSource{{ID: "source-jira", ExternalID: "project", Provider: "jira", FullName: "project"}},
+			Datasets: []plannerOracleDataset{{DatasetKey: "incidents"}},
+		},
+	}
+	allDatasets := []string{
+		"repo-metadata", "commits", "commit-stats", "files", "blame", "prs", "pr-reviews", "pr-comments",
+		"cicd", "tests", "deployments", "incidents", "security", "work-items", "work-item-labels",
+		"work-item-projects", "work-item-history", "work-item-comments", "feature-flags", "services",
+		"business-services", "escalation-policies", "schedules", "on-calls", "users", "teams",
+		"incident-alerts", "incident-log-entries", "incident-notes",
+	}
+	for _, provider := range []string{"github", "gitlab", "jira", "launchdarkly", "linear", "pagerduty"} {
+		datasets := make([]plannerOracleDataset, 0, len(allDatasets))
+		for _, dataset := range allDatasets {
+			datasets = append(datasets, plannerOracleDataset{DatasetKey: dataset})
+		}
+		cases = append(cases, plannerOracleCase{
+			ID: "provider_matrix_" + provider, OrgID: "org-matrix", IntegrationID: "integration-matrix",
+			Provider: provider, Mode: SyncModeIncremental, Now: "2026-07-30T12:00:00Z", TierCap: &cap30,
+			Sources:  []plannerOracleSource{{ID: "source", ExternalID: "external", Provider: provider, FullName: "source"}},
+			Datasets: datasets,
+		})
+	}
+
+	want := runPythonPlannerOracle(t, cases)
+	for _, test := range cases {
+		now, err := time.Parse(time.RFC3339, test.Now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var parsedBefore *time.Time
+		if test.Before != nil {
+			value, err := time.Parse(time.RFC3339, *test.Before)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parsedBefore = &value
+		}
+		input := PlannerInput{
+			OrgID: test.OrgID, IntegrationID: test.IntegrationID, Mode: test.Mode, Now: now,
+			Before: parsedBefore, IntegrationDepthDays: test.IntegrationDepth,
+			TierBackfillDaysCap: test.TierCap, WatermarkOverlap: time.Duration(test.WatermarkOverlapSeconds) * time.Second,
+			Watermarks: make(map[WatermarkKey]time.Time),
+		}
+		for _, source := range test.Sources {
+			input.Sources = append(input.Sources, PlanSource(source))
+		}
+		for _, dataset := range test.Datasets {
+			input.Datasets = append(input.Datasets, PlanDataset{Key: dataset.DatasetKey, InitialDepthDays: dataset.InitialDepth})
+		}
+		for _, watermark := range test.Watermarks {
+			value, err := time.Parse(time.RFC3339, watermark.At)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input.Watermarks[WatermarkKey{SourceID: watermark.SourceID, Dataset: watermark.DatasetKey}] = value
+		}
+		got, err := BuildScheduledPlan(input)
+		if err != nil {
+			t.Fatalf("%s: BuildScheduledPlan: %v", test.ID, err)
+		}
+		gotJSON, err := json.Marshal(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var normalized []map[string]any
+		if err := json.Unmarshal(gotJSON, &normalized); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(normalized, want[test.ID]) {
+			prettyGot, _ := json.MarshalIndent(normalized, "", "  ")
+			prettyWant, _ := json.MarshalIndent(want[test.ID], "", "  ")
+			t.Errorf("%s Go plan:\n%s\nPython plan:\n%s", test.ID, prettyGot, prettyWant)
+		}
+		if strings.HasPrefix(test.ID, "provider_matrix_") && len(normalized) == 0 {
+			t.Fatalf("%s produced no units; provider matrix parity did not execute", test.ID)
+		}
+	}
+}
+
+func runPythonPlannerOracle(t *testing.T, cases []plannerOracleCase) map[string][]map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(cases)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate Python planner oracle")
+	}
+	command := exec.Command("python3", filepath.Join(filepath.Dir(currentFile), "testdata", "python_planner_oracle.py"))
+	command.Stdin = bytes.NewReader(encoded)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute live Python planner oracle: %v\n%s", err, output)
+	}
+	var result map[string][]map[string]any
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode live Python planner oracle: %v\n%s", err, output)
+	}
+	if len(result) != len(cases) {
+		t.Fatalf("Python planner oracle returned %d cases for %d inputs", len(result), len(cases))
+	}
+	return result
+}

--- a/internal/scheduler/sync/planner_test.go
+++ b/internal/scheduler/sync/planner_test.go
@@ -1,0 +1,57 @@
+package sync
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBuildScheduledPlanRejectsBackfill(t *testing.T) {
+	_, err := BuildScheduledPlan(PlannerInput{
+		OrgID: "org", IntegrationID: "integration", Mode: SyncModeBackfill, Now: time.Now(),
+	})
+	if !errors.Is(err, ErrBackfillScheduled) {
+		t.Fatalf("BuildScheduledPlan(backfill) = %v, want ErrBackfillScheduled", err)
+	}
+}
+
+func TestBuildScheduledPlanCollapsesWorkItemFamilyAndUsesEarliestWatermark(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	labels := now.Add(-24 * time.Hour)
+	items := now.Add(-48 * time.Hour)
+	units, err := BuildScheduledPlan(PlannerInput{
+		OrgID: "org", IntegrationID: "integration", Mode: SyncModeIncremental, Now: now,
+		Sources:  []PlanSource{{ID: "source", ExternalID: "owner/repo", Provider: "github", FullName: "owner/repo"}},
+		Datasets: []PlanDataset{{Key: "work-item-labels"}, {Key: "prs"}, {Key: "work-items"}},
+		Watermarks: map[WatermarkKey]time.Time{
+			{SourceID: "owner/repo", Dataset: "work-items"}:       items,
+			{SourceID: "owner/repo", Dataset: "work-item-labels"}: labels,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(units) != 2 {
+		t.Fatalf("len(units) = %d, want 2: %+v", len(units), units)
+	}
+	family := units[1]
+	if family.Dataset != canonicalWorkItemsDataset || family.WindowStart == nil || !family.WindowStart.Equal(items) {
+		t.Fatalf("family unit = %+v, want canonical work-items at earliest watermark", family)
+	}
+	for _, flag := range []string{"family_dataset_work_items", "family_dataset_work_item_labels", "sync_prs"} {
+		if !family.ProcessorFlags[flag] {
+			t.Errorf("family flag %q missing from %+v", flag, family.ProcessorFlags)
+		}
+	}
+}
+
+func TestResolveInitialSyncDepthMatchesOverridePrecedenceAndFloor(t *testing.T) {
+	dataset, integration, cap := 120, 60, 30
+	if got := resolveInitialSyncDepth(&dataset, &integration, &cap); got != 30 {
+		t.Fatalf("resolveInitialSyncDepth() = %d, want 30", got)
+	}
+	zero := 0
+	if got := resolveInitialSyncDepth(&zero, nil, nil); got != 1 {
+		t.Fatalf("resolveInitialSyncDepth(zero) = %d, want 1", got)
+	}
+}

--- a/internal/scheduler/sync/testdata/python_planner_oracle.py
+++ b/internal/scheduler/sync/testdata/python_planner_oracle.py
@@ -1,0 +1,180 @@
+"""Execute the live Python scheduled-plan producer for Go parity cases."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[4]
+SOURCE = ROOT / "src/dev_health_ops"
+
+
+def _package(name: str) -> None:
+    module = ModuleType(name)
+    module.__path__ = []
+    sys.modules[name] = module
+
+
+def _module(name: str, **values: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in values.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _SyncRunMode(str, Enum):
+    INCREMENTAL = "incremental"
+    BACKFILL = "backfill"
+    FULL_RESYNC = "full_resync"
+
+
+class _Placeholder:
+    pass
+
+
+_package("dev_health_ops")
+_package("dev_health_ops.backfill")
+_package("dev_health_ops.credentials")
+_package("dev_health_ops.sync")
+_module(
+    "dev_health_ops.backfill.chunker",
+    chunk_date_range=lambda **_kwargs: (),
+)
+_module(
+    "dev_health_ops.credentials.fingerprint",
+    AUTH_SOURCE_ENVIRONMENT="environment",
+    AUTH_SOURCE_INTEGRATION_CREDENTIAL="integration_credential",
+    credential_fingerprint=lambda *_args, **_kwargs: "unused",
+)
+_module(
+    "dev_health_ops.models",
+    Integration=_Placeholder,
+    IntegrationDataset=_Placeholder,
+    IntegrationSource=_Placeholder,
+    SyncRun=_Placeholder,
+    SyncRunMode=_SyncRunMode,
+    SyncRunReferenceDiscovery=_Placeholder,
+    SyncRunStatus=_Placeholder,
+    SyncRunUnit=_Placeholder,
+    SyncRunUnitStatus=_Placeholder,
+)
+_module(
+    "dev_health_ops.sync.canonical_incident_gate",
+    require_canonical_incident_feature_sync=lambda *_args, **_kwargs: None,
+    sync_datasets_require_canonical_incident_feature=lambda *_args, **_kwargs: False,
+)
+datasets = _load("dev_health_ops.sync.datasets", SOURCE / "sync/datasets.py")
+_module(
+    "dev_health_ops.sync.dispatch_outbox",
+    OUTBOX_KIND_DISCOVERY="reference_discovery",
+    upsert_outbox_wakeup=lambda *_args, **_kwargs: None,
+)
+_module("dev_health_ops.sync.guard", _resolve_total_unit_cap=lambda *_args: 1000)
+_module(
+    "dev_health_ops.sync.pagerduty_repair",
+    repair_pagerduty_operational_integration=lambda *_args: None,
+)
+_module(
+    "dev_health_ops.sync.watermarks",
+    get_watermark_with_overlap=lambda *_args: None,
+)
+planner = _load("dev_health_ops.sync.planner", SOURCE / "sync/planner.py")
+
+
+def _instant(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _encode_instant(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _planned(case: dict[str, object]) -> list[dict[str, object]]:
+    now = _instant(str(case["now"]))
+    assert now is not None
+    watermarks = {
+        (str(row["source_id"]), str(row["dataset_key"])): _instant(str(row["at"]))
+        for row in (case.get("watermarks") or [])
+    }
+    overlap = int(case.get("watermark_overlap_seconds", 0))
+
+    def watermark(
+        _session: object, _org_id: str, source_id: str, dataset_key: str
+    ) -> datetime | None:
+        value = watermarks.get((source_id, dataset_key))
+        return value - timedelta(seconds=overlap) if value is not None else None
+
+    planner.get_watermark_with_overlap = watermark
+    planner._get_tier_backfill_days_cap = lambda *_args: case.get("tier_cap")
+    integration = SimpleNamespace(
+        id=case["integration_id"],
+        org_id=case["org_id"],
+        provider=case["provider"],
+        config={"initial_sync_depth": case["integration_depth"]}
+        if case.get("integration_depth") is not None
+        else {},
+    )
+    sources = [SimpleNamespace(**source) for source in case["sources"]]
+    plan_datasets = [
+        SimpleNamespace(
+            dataset_key=row["dataset_key"],
+            options={"initial_sync_depth": row["initial_depth"]}
+            if row.get("initial_depth") is not None
+            else {},
+        )
+        for row in case["datasets"]
+    ]
+    request = planner.SyncPlanRequest(
+        integration_id=str(case["integration_id"]),
+        org_id=str(case["org_id"]),
+        mode=str(case["mode"]),
+        triggered_by="schedule",
+        before=_instant(case.get("before")),
+    )
+    units = planner._build_planned_units(
+        session=object(),
+        request=request,
+        integration=integration,
+        sources=sources,
+        datasets=plan_datasets,
+        mode=str(case["mode"]),
+        now=now,
+    )
+    return [
+        {
+            "org_id": unit.org_id,
+            "integration_id": unit.integration_id,
+            "source_id": unit.source_id,
+            "provider": unit.provider,
+            "dataset_key": unit.dataset_key,
+            "cost_class": unit.cost_class,
+            "mode": unit.mode,
+            "window_start": _encode_instant(unit.window_start),
+            "window_end": _encode_instant(unit.window_end),
+            "processor_flags": dict(unit.processor_flags),
+        }
+        for unit in units
+    ]
+
+
+json.dump({case["id"]: _planned(case) for case in json.load(sys.stdin)}, sys.stdout)


### PR DESCRIPTION
## Summary

- ports the secret-free scheduled-sync planner foundation from the live Python implementation
- covers provider/dataset specs, window modes, tier/depth caps, watermark overlap, work-item-family collapse, and explicit scheduled-backfill rejection
- adds a fresh live-Python differential oracle to the Go gate

## Stack

Bottom of GitHub Stack #1406. Base: `feat/go-worker-runtime-migration`. Followed by PR #1405.

## Scope

Planner layer only. It does not flip `goOwnsMarkers`, activate workers, or run migration 0066. PR #1405 adds the still-dormant persistence/materialization layer and crash/readiness proofs.

## Test Evidence

- `go test -count=1 ./internal/scheduler/sync/...`
- `bash ci/check_go.sh live-python-oracles`
- `go vet ./internal/scheduler/sync`
- focused Ruff and format checks
- commit-hook Ruff and mypy
- independent focused rerun passed with a writable Go cache

TEST-EVIDENCE: Live production-Python planner output is compared with Go across incremental, full-resync, and provider-matrix cases.

RISK-NOTES: No activation or persistence wiring in this layer; full local gate later hit the repository host temporary-file limitation after Go/build/contract stages.

SCREENSHOT-WAIVER: backend planner and test-only change; no rendered UI.

Linear: https://linear.app/fullchaos/issue/CHAOS-3145
