### PR TITLE
fix(launchdarkly): fail closed on code-reference normalization faults (CHAOS-3191)

### DIFF
--- a/internal/providersync/launchdarkly_route.go
+++ b/internal/providersync/launchdarkly_route.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -159,6 +160,10 @@ func (handler LaunchDarklyRouteHandler) Collect(
 		}
 		if leaseErr := client.Lease.Assert(ctx); leaseErr != nil {
 			return CompleteRouteBatch{}, leaseErr
+		}
+		var providerErr *providerfoundation.ProviderError
+		if !errors.As(codeReferenceErr, &providerErr) {
+			return CompleteRouteBatch{}, codeReferenceErr
 		}
 		codeReferencePayload = json.RawMessage(`{"items":[]}`)
 	}

--- a/internal/providersync/launchdarkly_route_test.go
+++ b/internal/providersync/launchdarkly_route_test.go
@@ -180,6 +180,57 @@ func TestLaunchDarklyRouteKeepsCodeReferencesBestEffort(t *testing.T) {
 	}
 }
 
+func TestLaunchDarklyRouteFailsClosedOnCodeReferencePayloadFaults(t *testing.T) {
+	oversized := `{"items":[],"padding":"` +
+		strings.Repeat("x", nativeMaxObjectBytes) + `"}`
+	tests := map[string]string{
+		"oversized":    oversized,
+		"invalid JSON": `{"items":`,
+		"non-object":   `[]`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			doer := &launchDarklyRouteDoer{responses: []launchDarklyRouteResponse{
+				{status: http.StatusOK, body: `{"items":[],"totalCount":0}`},
+				{status: http.StatusOK, body: `{"items":[]}`},
+				{status: http.StatusOK, body: body},
+			}}
+			client, err := providerfoundation.NewHTTPClient(
+				"launchdarkly",
+				"https://app.launchdarkly.com",
+				doer,
+				func(*http.Request) error { return nil },
+				providerfoundation.RetryPolicy{
+					MaxAttempts: 1,
+					InitialWait: time.Nanosecond,
+					MaxWait:     time.Nanosecond,
+				},
+				providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim := nativeTestClaim("launchdarkly", "feature-flags")
+			claim.DatasetOptions = map[string]any{"project_key": "payments"}
+			batch, err := (LaunchDarklyRouteHandler{
+				CodeReferences: staticLaunchDarklyReferenceResolver{},
+			}).Collect(
+				context.Background(),
+				claim,
+				providerfoundation.Credential{Provider: "launchdarkly"},
+				client,
+				time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+			)
+			if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+				t.Fatalf("error=%v want ErrNormalizationInvalid", err)
+			}
+			if len(batch.Effects) != 0 || batch.Watermark != nil {
+				t.Fatalf("failed collection returned effects or watermark: %+v", batch)
+			}
+		})
+	}
+}
+
 type staticLaunchDarklyReferenceResolver struct{}
 
 func (staticLaunchDarklyReferenceResolver) ResolveLaunchDarklyCodeReferences(


### PR DESCRIPTION
## Summary
- preserves best-effort code-reference handling only for typed provider/HTTP failures
- fails the unit on oversized, invalid-JSON, and non-object code-reference payloads
- returns before any effects or watermark on normalization failure

## Stack
Bottom LaunchDarkly layer. Base: feat/go-worker-runtime-migration. Followed by #1396.

## Test evidence
- all three payload faults reproduced red on the untouched baseline and green after the fix
- existing HTTP 403 best-effort test remains green
- focused LaunchDarkly and full provider-sync Go tests passed
- live Python normalization oracle passed
- independent adversarial review: no findings

TEST-EVIDENCE: Oversized, invalid JSON, and non-object bodies return ErrNormalizationInvalid with no effects or watermark.
RISK-NOTES: Transport/status failures intentionally remain best-effort to preserve the active Python ConnectorException contract.
SCREENSHOT-WAIVER: Backend and test-only change; no rendered UI.

Linear: https://linear.app/fullchaos/issue/CHAOS-3191