### PR TITLE
CHAOS-3336: port GitHub test report parsing foundation

### DIFF
--- a/contracts/provider-matrix/v1/README.md
+++ b/contracts/provider-matrix/v1/README.md
@@ -301,6 +301,27 @@ model and executes the real range-expansion/constructor path while replacing
 only provider and sink seams. These proofs make the dormant foundation
 reviewable; they do not constitute an executor or authorize activation.
 
+## Implementation status for `(github, tests)`
+
+CHAOS-3336 remains `go_executor: none` / `route_ready: false`. The first
+reviewable foundation ports the untrusted report boundary: bounded in-memory
+ZIP traversal, a 200-report cap, DTD/entity rejection, JUnit suite/case
+normalization, LCOV aggregate normalization, stable IDs, fallback run
+timestamps, stack truncation, and incoherent-coverage rejection. A generic
+oracle executes the active Python `ingest_report_members` chain and compares
+every field in the production TestOps TypedDict contracts for a non-empty
+JUnit + LCOV fixture.
+
+This is intentionally not represented as a complete route. The active Python
+`sync_tests` contract also owns Actions run pagination, per-run job pagination,
+branch-protection acceptance checks, the authenticated-to-unauthenticated
+two-hop artifact download, Cobertura parsing, and six independently persisted
+destinations: `ci_pipeline_runs`, `ci_job_runs`, `ci_acceptance_checks`,
+`test_suite_results`, `test_case_results`, and `coverage_snapshots`. Native
+effect sinks/readbacks, cross-tenant collision proofs, and crash-window recovery
+must cover all six before the executor or readiness fields can change. Until
+then Python remains the only owner and no native switch exists.
+
 ## Known Go/Python divergences (fail-closed by design)
 
 `repositoryIdentity` mirrors Python's `get_repo_uuid_from_repo` for the ASCII

--- a/contracts/provider-matrix/v1/README.md
+++ b/contracts/provider-matrix/v1/README.md
@@ -309,8 +309,10 @@ ZIP traversal, a 200-report cap, DTD/entity rejection, JUnit suite/case
 normalization, LCOV aggregate normalization, stable IDs, fallback run
 timestamps, stack truncation, and incoherent-coverage rejection. A generic
 oracle executes the active Python `ingest_report_members` chain and compares
-every field in the production TestOps TypedDict contracts for a non-empty
-JUnit + LCOV fixture.
+every field in the production TestOps TypedDict contracts. Its LCOV cases
+include summary-bearing input, `DA`-only LF/LH fallback with duplicate line
+records, and multi-service input whose service is attributed by the majority
+of report files (with Python's first-seen tie behavior).
 
 This is intentionally not represented as a complete route. The active Python
 `sync_tests` contract also owns Actions run pagination, per-run job pagination,

--- a/internal/providersync/github_tests_generic_oracle_test.go
+++ b/internal/providersync/github_tests_generic_oracle_test.go
@@ -1,0 +1,75 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+)
+
+var githubTestsOracleGoOnlyFields = map[string]string{
+	"last_synced": "ClickHouse sinks stamp persistence time after Python's active report-ingestion boundary; Go stabilizes it in the effect row for crash recovery",
+}
+
+func githubTestsOracleCase() oracleCase {
+	return oracleCase{ID: "junit_and_lcov", Input: map[string]any{
+		"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		"run_id":  "9001", "org_id": "org-a",
+		"started_at":  "2026-07-23T12:00:00Z",
+		"finished_at": "2026-07-23T12:05:00Z",
+	}}
+}
+
+func githubTestsOracleTimes(t *testing.T, input map[string]any) (*time.Time, *time.Time, time.Time) {
+	t.Helper()
+	parse := func(key string) *time.Time {
+		value, err := time.Parse(time.RFC3339, input[key].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &value
+	}
+	return parse("started_at"), parse("finished_at"), time.Date(2026, 7, 23, 12, 10, 0, 0, time.UTC)
+}
+
+func TestGenericOracleMatchesLivePythonForGitHubTestsSuiteRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/tests/suite", []oracleCase{githubTestsOracleCase()},
+		func(t *testing.T, input map[string]any) testSuiteResultRow {
+			started, finished, normalizedAt := githubTestsOracleTimes(t, input)
+			suites, _, err := parseJUnitRows(
+				[]byte(githubTestsJUnitFixture), input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string),
+				started, finished, normalizedAt,
+			)
+			if err != nil || len(suites) != 1 {
+				t.Fatalf("suites=%+v error=%v", suites, err)
+			}
+			return suites[0]
+		}, githubTestsOracleGoOnlyFields)
+}
+
+func TestGenericOracleMatchesLivePythonForGitHubTestsCaseRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/tests/case", []oracleCase{githubTestsOracleCase()},
+		func(t *testing.T, input map[string]any) testCaseResultRow {
+			started, finished, normalizedAt := githubTestsOracleTimes(t, input)
+			_, cases, err := parseJUnitRows(
+				[]byte(githubTestsJUnitFixture), input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string),
+				started, finished, normalizedAt,
+			)
+			if err != nil || len(cases) != 2 {
+				t.Fatalf("cases=%+v error=%v", cases, err)
+			}
+			return cases[1]
+		}, githubTestsOracleGoOnlyFields)
+}
+
+func TestGenericOracleMatchesLivePythonForGitHubTestsCoverageRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "github/tests/coverage", []oracleCase{githubTestsOracleCase()},
+		func(t *testing.T, input map[string]any) coverageSnapshotRow {
+			_, _, normalizedAt := githubTestsOracleTimes(t, input)
+			row, err := parseLCOVRow(
+				[]byte(githubTestsLCOVFixture), "reports/lcov.info", input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string), normalizedAt,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return row
+		}, githubTestsOracleGoOnlyFields)
+}

--- a/internal/providersync/github_tests_generic_oracle_test.go
+++ b/internal/providersync/github_tests_generic_oracle_test.go
@@ -61,11 +61,25 @@ func TestGenericOracleMatchesLivePythonForGitHubTestsCaseRow(t *testing.T) {
 }
 
 func TestGenericOracleMatchesLivePythonForGitHubTestsCoverageRow(t *testing.T) {
-	compareRowsAgainstPythonOracle(t, "github/tests/coverage", []oracleCase{githubTestsOracleCase()},
+	fallback := githubTestsOracleCase()
+	fallback.ID = "da_fallback_without_summaries"
+	fallback.Input["lcov"] = "SF:services/api/main.go\nDA:1,1\nDA:2,0\nDA:2,3\nend_of_record\n"
+	majority := githubTestsOracleCase()
+	majority.ID = "majority_file_service"
+	majority.Input["lcov"] = "SF:services/api/main.go\nLF:1\nLH:1\nend_of_record\n" +
+		"SF:services/web/handler.go\nLF:1\nLH:0\nend_of_record\n" +
+		"SF:services/web/router.go\nLF:1\nLH:1\nend_of_record\n"
+	compareRowsAgainstPythonOracle(t, "github/tests/coverage", []oracleCase{
+		githubTestsOracleCase(), fallback, majority,
+	},
 		func(t *testing.T, input map[string]any) coverageSnapshotRow {
 			_, _, normalizedAt := githubTestsOracleTimes(t, input)
+			lcov := githubTestsLCOVFixture
+			if value, ok := input["lcov"].(string); ok {
+				lcov = value
+			}
 			row, err := parseLCOVRow(
-				[]byte(githubTestsLCOVFixture), "reports/lcov.info", input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string), normalizedAt,
+				[]byte(lcov), "reports/lcov.info", input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string), normalizedAt,
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/providersync/github_tests_reports.go
+++ b/internal/providersync/github_tests_reports.go
@@ -1,0 +1,526 @@
+package providersync
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	githubTestsMaxReportsPerRun = 200
+	githubTestsMaxReportBytes   = 64 << 20
+	githubTestsMaxArchiveBytes  = 256 << 20
+)
+
+var ErrGitHubTestsReportInvalid = errors.New("github tests report invalid")
+
+type testSuiteResultRow struct {
+	RepoID           string     `json:"repo_id"`
+	RunID            string     `json:"run_id"`
+	SuiteID          string     `json:"suite_id"`
+	SuiteName        string     `json:"suite_name"`
+	Framework        *string    `json:"framework"`
+	Environment      *string    `json:"environment"`
+	TotalCount       int64      `json:"total_count"`
+	PassedCount      int64      `json:"passed_count"`
+	FailedCount      int64      `json:"failed_count"`
+	SkippedCount     int64      `json:"skipped_count"`
+	ErrorCount       int64      `json:"error_count"`
+	QuarantinedCount int64      `json:"quarantined_count"`
+	RetriedCount     int64      `json:"retried_count"`
+	DurationSeconds  *float64   `json:"duration_seconds"`
+	StartedAt        *time.Time `json:"started_at"`
+	FinishedAt       *time.Time `json:"finished_at"`
+	TeamID           *string    `json:"team_id"`
+	ServiceID        *string    `json:"service_id"`
+	OrgID            string     `json:"org_id"`
+	LastSynced       time.Time  `json:"last_synced"`
+}
+
+type testCaseResultRow struct {
+	RepoID          string    `json:"repo_id"`
+	RunID           string    `json:"run_id"`
+	SuiteID         string    `json:"suite_id"`
+	CaseID          string    `json:"case_id"`
+	CaseName        string    `json:"case_name"`
+	ClassName       *string   `json:"class_name"`
+	Status          string    `json:"status"`
+	DurationSeconds *float64  `json:"duration_seconds"`
+	RetryAttempt    int64     `json:"retry_attempt"`
+	FailureMessage  *string   `json:"failure_message"`
+	FailureType     *string   `json:"failure_type"`
+	StackTrace      *string   `json:"stack_trace"`
+	IsQuarantined   bool      `json:"is_quarantined"`
+	OrgID           string    `json:"org_id"`
+	LastSynced      time.Time `json:"last_synced"`
+}
+
+type coverageSnapshotRow struct {
+	RepoID            string    `json:"repo_id"`
+	RunID             string    `json:"run_id"`
+	SnapshotID        string    `json:"snapshot_id"`
+	ReportFormat      *string   `json:"report_format"`
+	LinesTotal        *int64    `json:"lines_total"`
+	LinesCovered      *int64    `json:"lines_covered"`
+	LineCoveragePct   *float64  `json:"line_coverage_pct"`
+	BranchesTotal     *int64    `json:"branches_total"`
+	BranchesCovered   *int64    `json:"branches_covered"`
+	BranchCoveragePct *float64  `json:"branch_coverage_pct"`
+	FunctionsTotal    *int64    `json:"functions_total"`
+	FunctionsCovered  *int64    `json:"functions_covered"`
+	CommitHash        *string   `json:"commit_hash"`
+	Branch            *string   `json:"branch"`
+	PRNumber          *int64    `json:"pr_number"`
+	TeamID            *string   `json:"team_id"`
+	ServiceID         *string   `json:"service_id"`
+	OrgID             string    `json:"org_id"`
+	LastSynced        time.Time `json:"last_synced"`
+}
+
+type githubTestsReportRows struct {
+	Suites   []testSuiteResultRow
+	Cases    []testCaseResultRow
+	Coverage []coverageSnapshotRow
+	Skipped  int
+}
+
+type junitDocument struct {
+	XMLName xml.Name
+	Suites  []junitSuite `xml:"testsuite"`
+	Cases   []junitCase  `xml:"testcase"`
+}
+
+type junitSuite struct {
+	Name      string       `xml:"name,attr"`
+	Framework string       `xml:"framework,attr"`
+	Runner    string       `xml:"runner,attr"`
+	Hostname  string       `xml:"hostname,attr"`
+	File      string       `xml:"file,attr"`
+	Timestamp string       `xml:"timestamp,attr"`
+	Time      string       `xml:"time,attr"`
+	Suites    []junitSuite `xml:"testsuite"`
+	Cases     []junitCase  `xml:"testcase"`
+}
+
+type junitCase struct {
+	Name      string       `xml:"name,attr"`
+	ClassName string       `xml:"classname,attr"`
+	File      string       `xml:"file,attr"`
+	Time      string       `xml:"time,attr"`
+	Failure   *junitDetail `xml:"failure"`
+	Error     *junitDetail `xml:"error"`
+	Skipped   *junitDetail `xml:"skipped"`
+	SystemOut string       `xml:"system-out"`
+	SystemErr string       `xml:"system-err"`
+}
+
+type junitDetail struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Text    string `xml:",chardata"`
+}
+
+func parseGitHubTestsArtifact(
+	archive []byte,
+	repoID, runID, orgID string,
+	startedAt, finishedAt *time.Time,
+	normalizedAt time.Time,
+) (githubTestsReportRows, error) {
+	if len(archive) == 0 || len(archive) > githubTestsMaxArchiveBytes || repoID == "" || runID == "" || orgID == "" || normalizedAt.IsZero() {
+		return githubTestsReportRows{}, ErrGitHubTestsReportInvalid
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return githubTestsReportRows{}, fmt.Errorf("%w: zip: %v", ErrGitHubTestsReportInvalid, err)
+	}
+	result := githubTestsReportRows{}
+	processed := 0
+	var expanded uint64
+	for _, member := range reader.File {
+		name := filepath.ToSlash(member.Name)
+		lower := strings.ToLower(name)
+		if member.FileInfo().IsDir() || (!strings.HasSuffix(lower, ".xml") && !strings.HasSuffix(lower, ".info")) {
+			continue
+		}
+		if processed >= githubTestsMaxReportsPerRun {
+			result.Skipped++
+			continue
+		}
+		if member.UncompressedSize64 > githubTestsMaxReportBytes || expanded+member.UncompressedSize64 > githubTestsMaxArchiveBytes {
+			result.Skipped++
+			continue
+		}
+		body, err := readZipReport(member)
+		if err != nil {
+			result.Skipped++
+			continue
+		}
+		expanded += uint64(len(body))
+		kind := classifyGitHubTestReport(lower, body)
+		if kind == "" {
+			continue
+		}
+		processed++
+		switch kind {
+		case "junit":
+			suites, cases, err := parseJUnitRows(body, repoID, runID, orgID, startedAt, finishedAt, normalizedAt)
+			if err != nil {
+				result.Skipped++
+				continue
+			}
+			result.Suites = append(result.Suites, suites...)
+			result.Cases = append(result.Cases, cases...)
+		case "coverage":
+			coverage, err := parseLCOVRow(body, name, repoID, runID, orgID, normalizedAt)
+			if err != nil {
+				result.Skipped++
+				continue
+			}
+			result.Coverage = append(result.Coverage, coverage)
+		}
+	}
+	return result, nil
+}
+
+func readZipReport(member *zip.File) ([]byte, error) {
+	stream, err := member.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer stream.Close()
+	body, err := io.ReadAll(io.LimitReader(stream, githubTestsMaxReportBytes+1))
+	if err != nil || len(body) > githubTestsMaxReportBytes {
+		return nil, ErrGitHubTestsReportInvalid
+	}
+	return body, nil
+}
+
+func classifyGitHubTestReport(name string, body []byte) string {
+	head := strings.ToLower(string(body))
+	if len(head) > 2048 {
+		head = head[:2048]
+	}
+	if strings.Contains(head, "<testsuite") || strings.Contains(head, "<testsuites") {
+		return "junit"
+	}
+	if strings.HasSuffix(name, ".info") || strings.HasPrefix(strings.TrimSpace(head), "tn:") || strings.HasPrefix(strings.TrimSpace(head), "sf:") {
+		return "coverage"
+	}
+	return ""
+}
+
+func parseJUnitRows(
+	body []byte, repoID, runID, orgID string,
+	fallbackStarted, fallbackFinished *time.Time,
+	normalizedAt time.Time,
+) ([]testSuiteResultRow, []testCaseResultRow, error) {
+	if len(body) > githubTestsMaxReportBytes || bytes.Contains(bytes.ToUpper(body), []byte("<!DOCTYPE")) || bytes.Contains(bytes.ToUpper(body), []byte("<!ENTITY")) {
+		return nil, nil, ErrGitHubTestsReportInvalid
+	}
+	var document junitDocument
+	if err := xml.Unmarshal(body, &document); err != nil {
+		return nil, nil, err
+	}
+	suites := document.Suites
+	if document.XMLName.Local == "testsuite" {
+		suites = []junitSuite{{Cases: document.Cases}}
+		var root junitSuite
+		if err := xml.Unmarshal(body, &root); err != nil {
+			return nil, nil, err
+		}
+		suites = []junitSuite{root}
+	}
+	flat := make([]junitSuite, 0, len(suites))
+	var visit func(junitSuite)
+	visit = func(suite junitSuite) {
+		if len(suite.Cases) > 0 {
+			flat = append(flat, suite)
+		}
+		for _, child := range suite.Suites {
+			visit(child)
+		}
+	}
+	for _, suite := range suites {
+		visit(suite)
+	}
+	resultSuites := make([]testSuiteResultRow, 0, len(flat))
+	resultCases := make([]testCaseResultRow, 0)
+	for _, suite := range flat {
+		name := suite.Name
+		if name == "" {
+			name = "unnamed"
+		}
+		framework := inferJUnitFramework(suite)
+		suiteID := hashTestIdentifier(runID, name, "")
+		started := parseGitHubTestsTime(suite.Timestamp)
+		hasSuiteTimestamp := started != nil
+		if started == nil {
+			started = cloneTime(fallbackStarted)
+		}
+		duration := parseOptionalFloat(suite.Time)
+		finished := cloneTime(fallbackFinished)
+		if hasSuiteTimestamp && started != nil && duration != nil {
+			value := started.Add(time.Duration(*duration * float64(time.Second)))
+			finished = &value
+		}
+		service := junitServiceID(suite)
+		row := testSuiteResultRow{
+			RepoID: repoID, RunID: runID, SuiteID: suiteID, SuiteName: name,
+			Framework: &framework, TotalCount: int64(len(suite.Cases)), DurationSeconds: duration,
+			StartedAt: started, FinishedAt: finished, ServiceID: service,
+			OrgID: orgID, LastSynced: normalizedAt,
+		}
+		for _, testCase := range suite.Cases {
+			caseRow := newJUnitCaseRow(testCase, row, normalizedAt)
+			switch caseRow.Status {
+			case "passed":
+				row.PassedCount++
+			case "failed":
+				row.FailedCount++
+			case "skipped":
+				row.SkippedCount++
+			case "error":
+				row.ErrorCount++
+			case "quarantined":
+				row.QuarantinedCount++
+			}
+			resultCases = append(resultCases, caseRow)
+		}
+		resultSuites = append(resultSuites, row)
+	}
+	return resultSuites, resultCases, nil
+}
+
+func newJUnitCaseRow(item junitCase, suite testSuiteResultRow, normalizedAt time.Time) testCaseResultRow {
+	name := item.Name
+	if name == "" {
+		name = "unnamed"
+	}
+	status, detail := "passed", (*junitDetail)(nil)
+	switch {
+	case item.Skipped != nil:
+		status, detail = "skipped", item.Skipped
+	case item.Failure != nil:
+		status, detail = "failed", item.Failure
+	case item.Error != nil:
+		status, detail = "error", item.Error
+	}
+	if detail != nil && looksQuarantined(detail.Message, detail.Type, detail.Text) {
+		status = "quarantined"
+	}
+	var message, failureType, trace *string
+	if detail != nil {
+		message = testsOptionalString(detail.Message)
+		failureType = testsOptionalString(detail.Type)
+		parts := make([]string, 0, 3)
+		for _, value := range []string{strings.TrimSpace(detail.Text), strings.TrimSpace(item.SystemErr), strings.TrimSpace(item.SystemOut)} {
+			if value != "" {
+				parts = append(parts, value)
+			}
+		}
+		if len(parts) > 0 {
+			value := strings.Join(parts, "\n")
+			if len(value) > 4096 {
+				value = value[:4096]
+			}
+			trace = &value
+		}
+	}
+	return testCaseResultRow{
+		RepoID: suite.RepoID, RunID: suite.RunID, SuiteID: suite.SuiteID,
+		CaseID: hashTestIdentifier(suite.SuiteID, name), CaseName: name,
+		ClassName: testsOptionalString(item.ClassName), Status: status,
+		DurationSeconds: parseOptionalFloat(item.Time), FailureMessage: message,
+		FailureType: failureType, StackTrace: trace, IsQuarantined: status == "quarantined",
+		OrgID: suite.OrgID, LastSynced: normalizedAt,
+	}
+}
+
+func parseLCOVRow(body []byte, reportPath, repoID, runID, orgID string, normalizedAt time.Time) (coverageSnapshotRow, error) {
+	var linesTotal, linesCovered, branchesTotal, branchesCovered, functionsTotal, functionsCovered int64
+	seenSource := false
+	firstSource := ""
+	for _, raw := range strings.Split(string(body), "\n") {
+		line := strings.TrimSpace(raw)
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		number, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		switch key {
+		case "SF":
+			seenSource = strings.TrimSpace(value) != ""
+			if firstSource == "" {
+				firstSource = strings.TrimSpace(value)
+			}
+		case "LF":
+			if err == nil {
+				linesTotal += number
+			}
+		case "LH":
+			if err == nil {
+				linesCovered += number
+			}
+		case "BRF":
+			if err == nil {
+				branchesTotal += number
+			}
+		case "BRH":
+			if err == nil {
+				branchesCovered += number
+			}
+		case "FNF":
+			if err == nil {
+				functionsTotal += number
+			}
+		case "FNH":
+			if err == nil {
+				functionsCovered += number
+			}
+		}
+	}
+	if !seenSource || linesCovered > linesTotal || branchesCovered > branchesTotal {
+		return coverageSnapshotRow{}, ErrGitHubTestsReportInvalid
+	}
+	format := "lcov"
+	row := coverageSnapshotRow{
+		RepoID: repoID, RunID: runID, SnapshotID: hashTestIdentifier(runID, format, reportPath),
+		ReportFormat: &format, LinesTotal: nilIfZero(linesTotal), LinesCovered: nilIfBothZero(linesCovered, linesTotal),
+		BranchesTotal: nilIfZero(branchesTotal), BranchesCovered: nilIfBothZero(branchesCovered, branchesTotal),
+		FunctionsTotal: nilIfZero(functionsTotal), FunctionsCovered: nilIfBothZero(functionsCovered, functionsTotal),
+		ServiceID: testServiceID(firstSource), OrgID: orgID, LastSynced: normalizedAt,
+	}
+	row.LineCoveragePct = coveragePercent(row.LinesCovered, row.LinesTotal)
+	row.BranchCoveragePct = coveragePercent(row.BranchesCovered, row.BranchesTotal)
+	return row, nil
+}
+
+func inferJUnitFramework(suite junitSuite) string {
+	for _, item := range suite.Cases {
+		path := strings.ToLower(item.File)
+		if strings.HasSuffix(path, ".spec.js") || strings.HasSuffix(path, ".spec.ts") || strings.HasSuffix(path, ".test.js") || strings.HasSuffix(path, ".test.ts") {
+			return "jest"
+		}
+		if strings.Contains(item.ClassName, "::") || strings.HasSuffix(path, ".py") {
+			return "pytest"
+		}
+	}
+	for _, candidate := range []string{suite.Framework, suite.Runner, suite.Hostname} {
+		lower := strings.ToLower(candidate)
+		if strings.Contains(lower, "jest") {
+			return "jest"
+		}
+		if strings.Contains(lower, "pytest") {
+			return "pytest"
+		}
+	}
+	return "junit"
+}
+
+func junitServiceID(suite junitSuite) *string {
+	path := suite.File
+	if path == "" {
+		for _, item := range suite.Cases {
+			if item.File != "" {
+				path = item.File
+				break
+			}
+		}
+	}
+	return testServiceID(path)
+}
+
+func testServiceID(path string) *string {
+	path = strings.TrimPrefix(strings.ReplaceAll(path, "\\", "/"), "./")
+	parts := strings.FieldsFunc(path, func(r rune) bool { return r == '/' })
+	for index, part := range parts {
+		if (part == "services" || part == "apps" || part == "packages") && index+1 < len(parts) {
+			return testsOptionalString(parts[index+1])
+		}
+	}
+	if len(parts) > 0 {
+		return testsOptionalString(parts[0])
+	}
+	return nil
+}
+
+func hashTestIdentifier(parts ...string) string {
+	digest := sha256.Sum256([]byte(strings.Join(parts, "::")))
+	return hex.EncodeToString(digest[:])
+}
+
+func parseOptionalFloat(value string) *float64 {
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return nil
+	}
+	return &parsed
+}
+
+func parseGitHubTestsTime(value string) *time.Time {
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.Replace(value, "Z", "+00:00", 1))
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := value.UTC()
+	return &copy
+}
+
+func testsOptionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func looksQuarantined(values ...string) bool {
+	haystack := strings.ToLower(strings.Join(values, " "))
+	return strings.Contains(haystack, "quarantine") || strings.Contains(haystack, "quarantined") || strings.Contains(haystack, "xfail")
+}
+
+func nilIfZero(value int64) *int64 {
+	if value == 0 {
+		return nil
+	}
+	return &value
+}
+
+func nilIfBothZero(value, total int64) *int64 {
+	if value == 0 && total == 0 {
+		return nil
+	}
+	return &value
+}
+
+func coveragePercent(covered, total *int64) *float64 {
+	if covered == nil || total == nil || *total == 0 {
+		return nil
+	}
+	value := float64(*covered) / float64(*total) * 100
+	return &value
+}

--- a/internal/providersync/github_tests_reports.go
+++ b/internal/providersync/github_tests_reports.go
@@ -94,6 +94,18 @@ type githubTestsReportRows struct {
 	Skipped  int
 }
 
+type lcovFileMetrics struct {
+	path               string
+	linesTotal         *int64
+	linesCovered       *int64
+	branchesTotal      *int64
+	branchesCovered    *int64
+	functionsTotal     *int64
+	functionsCovered   *int64
+	lineNumbers        map[int64]struct{}
+	coveredLineNumbers map[int64]struct{}
+}
+
 type junitDocument struct {
 	XMLName xml.Name
 	Suites  []junitSuite `xml:"testsuite"`
@@ -348,62 +360,137 @@ func newJUnitCaseRow(item junitCase, suite testSuiteResultRow, normalizedAt time
 }
 
 func parseLCOVRow(body []byte, reportPath, repoID, runID, orgID string, normalizedAt time.Time) (coverageSnapshotRow, error) {
-	var linesTotal, linesCovered, branchesTotal, branchesCovered, functionsTotal, functionsCovered int64
-	seenSource := false
-	firstSource := ""
+	var currentPath *string
+	var linesTotal, linesCovered, branchesTotal, branchesCovered, functionsTotal, functionsCovered *int64
+	lineNumbers := map[int64]struct{}{}
+	coveredLineNumbers := map[int64]struct{}{}
+	files := make([]lcovFileMetrics, 0)
+	flush := func() {
+		if currentPath == nil {
+			return
+		}
+		files = append(files, lcovFileMetrics{
+			path: *currentPath, linesTotal: linesTotal, linesCovered: linesCovered,
+			branchesTotal: branchesTotal, branchesCovered: branchesCovered,
+			functionsTotal: functionsTotal, functionsCovered: functionsCovered,
+			lineNumbers: lineNumbers, coveredLineNumbers: coveredLineNumbers,
+		})
+		currentPath = nil
+		linesTotal, linesCovered = nil, nil
+		branchesTotal, branchesCovered = nil, nil
+		functionsTotal, functionsCovered = nil, nil
+		lineNumbers = map[int64]struct{}{}
+		coveredLineNumbers = map[int64]struct{}{}
+	}
 	for _, raw := range strings.Split(string(body), "\n") {
 		line := strings.TrimSpace(raw)
+		if line == "end_of_record" {
+			flush()
+			continue
+		}
 		key, value, found := strings.Cut(line, ":")
 		if !found {
 			continue
 		}
-		number, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 		switch key {
 		case "SF":
-			seenSource = strings.TrimSpace(value) != ""
-			if firstSource == "" {
-				firstSource = strings.TrimSpace(value)
+			flush()
+			path := strings.TrimSpace(value)
+			currentPath = &path
+		case "DA":
+			parts := strings.Split(value, ",")
+			lineNumber, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+			if err != nil {
+				continue
+			}
+			lineNumbers[lineNumber] = struct{}{}
+			if len(parts) > 1 {
+				hits, hitErr := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				if hitErr == nil && hits > 0 {
+					coveredLineNumbers[lineNumber] = struct{}{}
+				}
 			}
 		case "LF":
-			if err == nil {
-				linesTotal += number
-			}
+			linesTotal = parseOptionalInt64(value)
 		case "LH":
-			if err == nil {
-				linesCovered += number
-			}
+			linesCovered = parseOptionalInt64(value)
 		case "BRF":
-			if err == nil {
-				branchesTotal += number
-			}
+			branchesTotal = parseOptionalInt64(value)
 		case "BRH":
-			if err == nil {
-				branchesCovered += number
-			}
+			branchesCovered = parseOptionalInt64(value)
 		case "FNF":
-			if err == nil {
-				functionsTotal += number
-			}
+			functionsTotal = parseOptionalInt64(value)
 		case "FNH":
-			if err == nil {
-				functionsCovered += number
-			}
+			functionsCovered = parseOptionalInt64(value)
 		}
 	}
-	if !seenSource || linesCovered > linesTotal || branchesCovered > branchesTotal {
+	flush()
+	if len(files) == 0 {
 		return coverageSnapshotRow{}, ErrGitHubTestsReportInvalid
+	}
+	var aggregateLinesTotal, aggregateLinesCovered int64
+	var aggregateBranchesTotal, aggregateBranchesCovered int64
+	var aggregateFunctionsTotal, aggregateFunctionsCovered int64
+	serviceCounts := map[string]int{}
+	serviceOrder := make([]string, 0)
+	for _, file := range files {
+		aggregateLinesTotal += int64(len(file.lineNumbers))
+		if file.linesTotal != nil {
+			aggregateLinesTotal += *file.linesTotal - int64(len(file.lineNumbers))
+		}
+		aggregateLinesCovered += int64(len(file.coveredLineNumbers))
+		if file.linesCovered != nil {
+			aggregateLinesCovered += *file.linesCovered - int64(len(file.coveredLineNumbers))
+		}
+		aggregateBranchesTotal += optionalInt64Value(file.branchesTotal)
+		aggregateBranchesCovered += optionalInt64Value(file.branchesCovered)
+		aggregateFunctionsTotal += optionalInt64Value(file.functionsTotal)
+		aggregateFunctionsCovered += optionalInt64Value(file.functionsCovered)
+		if service := testServiceID(file.path); service != nil {
+			if _, seen := serviceCounts[*service]; !seen {
+				serviceOrder = append(serviceOrder, *service)
+			}
+			serviceCounts[*service]++
+		}
+	}
+	if aggregateLinesCovered > aggregateLinesTotal || aggregateBranchesCovered > aggregateBranchesTotal {
+		return coverageSnapshotRow{}, ErrGitHubTestsReportInvalid
+	}
+	var serviceID *string
+	bestCount := 0
+	for _, service := range serviceOrder {
+		if serviceCounts[service] > bestCount {
+			value := service
+			serviceID = &value
+			bestCount = serviceCounts[service]
+		}
 	}
 	format := "lcov"
 	row := coverageSnapshotRow{
 		RepoID: repoID, RunID: runID, SnapshotID: hashTestIdentifier(runID, format, reportPath),
-		ReportFormat: &format, LinesTotal: nilIfZero(linesTotal), LinesCovered: nilIfBothZero(linesCovered, linesTotal),
-		BranchesTotal: nilIfZero(branchesTotal), BranchesCovered: nilIfBothZero(branchesCovered, branchesTotal),
-		FunctionsTotal: nilIfZero(functionsTotal), FunctionsCovered: nilIfBothZero(functionsCovered, functionsTotal),
-		ServiceID: testServiceID(firstSource), OrgID: orgID, LastSynced: normalizedAt,
+		ReportFormat: &format, LinesTotal: nilIfZero(aggregateLinesTotal), LinesCovered: nilIfZero(aggregateLinesCovered),
+		BranchesTotal: nilIfZero(aggregateBranchesTotal), BranchesCovered: nilIfZero(aggregateBranchesCovered),
+		FunctionsTotal: nilIfZero(aggregateFunctionsTotal), FunctionsCovered: nilIfZero(aggregateFunctionsCovered),
+		ServiceID: serviceID, OrgID: orgID, LastSynced: normalizedAt,
 	}
 	row.LineCoveragePct = coveragePercent(row.LinesCovered, row.LinesTotal)
 	row.BranchCoveragePct = coveragePercent(row.BranchesCovered, row.BranchesTotal)
 	return row, nil
+}
+
+func parseOptionalInt64(value string) *int64 {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func optionalInt64Value(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func inferJUnitFramework(suite junitSuite) string {
@@ -505,13 +592,6 @@ func looksQuarantined(values ...string) bool {
 
 func nilIfZero(value int64) *int64 {
 	if value == 0 {
-		return nil
-	}
-	return &value
-}
-
-func nilIfBothZero(value, total int64) *int64 {
-	if value == 0 && total == 0 {
 		return nil
 	}
 	return &value

--- a/internal/providersync/github_tests_reports_test.go
+++ b/internal/providersync/github_tests_reports_test.go
@@ -131,6 +131,47 @@ func TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal(t *testing.T) {
 	}
 }
 
+func TestGitHubTestsCoverageFallsBackToUniqueDALines(t *testing.T) {
+	row, err := parseLCOVRow(
+		[]byte("SF:services/api/main.go\nDA:1,1\nDA:2,0\nDA:2,3\nend_of_record\n"),
+		"lcov.info", "repo", "run", "org", time.Now(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.LinesTotal == nil || *row.LinesTotal != 2 ||
+		row.LinesCovered == nil || *row.LinesCovered != 2 ||
+		row.LineCoveragePct == nil || *row.LineCoveragePct != 100 {
+		t.Fatalf("coverage=%+v", row)
+	}
+}
+
+func TestGitHubTestsCoverageAttributesMajorityFileService(t *testing.T) {
+	row, err := parseLCOVRow([]byte(`SF:services/api/main.go
+LF:1
+LH:1
+end_of_record
+SF:services/web/handler.go
+LF:1
+LH:0
+end_of_record
+SF:services/web/router.go
+LF:1
+LH:1
+end_of_record
+`), "lcov.info", "repo", "run", "org", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.ServiceID == nil || *row.ServiceID != "web" {
+		t.Fatalf("service_id=%v", row.ServiceID)
+	}
+	if row.LinesTotal == nil || *row.LinesTotal != 3 ||
+		row.LinesCovered == nil || *row.LinesCovered != 2 {
+		t.Fatalf("coverage=%+v", row)
+	}
+}
+
 func githubTestsZip(t *testing.T, members map[string]string) []byte {
 	t.Helper()
 	var buffer bytes.Buffer

--- a/internal/providersync/github_tests_reports_test.go
+++ b/internal/providersync/github_tests_reports_test.go
@@ -1,0 +1,151 @@
+package providersync
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+const githubTestsJUnitFixture = `<testsuites><testsuite name="api" time="3.5">
+<testcase name="passes" classname="tests/test_api.py::TestAPI" file="services/api/test_api.py" time="1.25"/>
+<testcase name="fails" classname="tests/test_api.py::TestAPI" file="services/api/test_api.py" time="2.25"><failure message="expected 200" type="AssertionError">trace</failure><system-err>stderr</system-err></testcase>
+</testsuite></testsuites>`
+
+const githubTestsLCOVFixture = `TN:
+SF:services/api/main.go
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+BRF:2
+BRH:1
+FNF:1
+FNH:1
+end_of_record
+`
+
+func TestGitHubTestsArtifactParsesJUnitCasesAndCoverage(t *testing.T) {
+	started := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	finished := started.Add(5 * time.Minute)
+	normalizedAt := started.Add(10*time.Minute + 987654321*time.Nanosecond)
+	rows, err := parseGitHubTestsArtifact(
+		githubTestsZip(t, map[string]string{
+			"reports/junit.xml": githubTestsJUnitFixture,
+			"reports/lcov.info": githubTestsLCOVFixture,
+			"ignored.txt":       "not a report",
+		}),
+		"c7198fbc-1945-3717-05d8-eb78866b4e79", "9001", "org-a",
+		&started, &finished, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows.Suites) != 1 || len(rows.Cases) != 2 || len(rows.Coverage) != 1 || rows.Skipped != 0 {
+		t.Fatalf("rows=%+v", rows)
+	}
+	suite := rows.Suites[0]
+	if suite.SuiteName != "api" || suite.Framework == nil || *suite.Framework != "pytest" ||
+		suite.TotalCount != 2 || suite.PassedCount != 1 || suite.FailedCount != 1 ||
+		suite.ServiceID == nil || *suite.ServiceID != "api" || suite.StartedAt == nil || !suite.StartedAt.Equal(started) ||
+		suite.FinishedAt == nil || !suite.FinishedAt.Equal(finished) {
+		t.Fatalf("suite=%+v", suite)
+	}
+	failed := rows.Cases[1]
+	if failed.Status != "failed" || failed.FailureMessage == nil || *failed.FailureMessage != "expected 200" ||
+		failed.FailureType == nil || *failed.FailureType != "AssertionError" || failed.StackTrace == nil || *failed.StackTrace != "trace\nstderr" {
+		t.Fatalf("failed=%+v", failed)
+	}
+	coverage := rows.Coverage[0]
+	if coverage.LinesTotal == nil || *coverage.LinesTotal != 2 || coverage.LinesCovered == nil || *coverage.LinesCovered != 1 ||
+		coverage.LineCoveragePct == nil || *coverage.LineCoveragePct != 50 || coverage.BranchCoveragePct == nil || *coverage.BranchCoveragePct != 50 {
+		t.Fatalf("coverage=%+v", coverage)
+	}
+	if !suite.LastSynced.Equal(normalizedAt.Truncate(time.Millisecond)) || !coverage.LastSynced.Equal(normalizedAt.Truncate(time.Millisecond)) {
+		t.Fatal("sink timestamps were not stabilized to millisecond precision")
+	}
+}
+
+func TestGitHubTestsArtifactSkipsMalformedMemberWithoutDroppingValidReports(t *testing.T) {
+	rows, err := parseGitHubTestsArtifact(
+		githubTestsZip(t, map[string]string{
+			"bad.xml":   `<!DOCTYPE x [<!ENTITY x "boom">]><testsuite>&x;</testsuite>`,
+			"good.info": githubTestsLCOVFixture,
+		}),
+		"c7198fbc-1945-3717-05d8-eb78866b4e79", "9001", "org-a",
+		nil, nil, time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows.Skipped != 1 || len(rows.Coverage) != 1 || len(rows.Suites) != 0 {
+		t.Fatalf("rows=%+v", rows)
+	}
+}
+
+func TestGitHubTestsArtifactEnforcesReportCountCap(t *testing.T) {
+	members := make(map[string]string, githubTestsMaxReportsPerRun+1)
+	for index := 0; index <= githubTestsMaxReportsPerRun; index++ {
+		members[hashTestIdentifier(string(rune(index)))+".info"] = githubTestsLCOVFixture
+	}
+	rows, err := parseGitHubTestsArtifact(
+		githubTestsZip(t, members),
+		"c7198fbc-1945-3717-05d8-eb78866b4e79", "9001", "org-a",
+		nil, nil, time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows.Coverage) != githubTestsMaxReportsPerRun || rows.Skipped != 1 {
+		t.Fatalf("coverage=%d skipped=%d", len(rows.Coverage), rows.Skipped)
+	}
+}
+
+func TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack(t *testing.T) {
+	_, _, err := parseJUnitRows(
+		[]byte(`<!DOCTYPE testsuite><testsuite name="x"><testcase name="x"/></testsuite>`),
+		"repo", "run", "org", nil, nil, time.Now(),
+	)
+	if err == nil {
+		t.Fatal("entity-bearing document was accepted")
+	}
+	large := strings.Repeat("x", 5000)
+	body := []byte(`<testsuite name="x"><testcase name="x"><failure>` + large + `</failure></testcase></testsuite>`)
+	_, cases, err := parseJUnitRows(body, "repo", "run", "org", nil, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 1 || cases[0].StackTrace == nil || len(*cases[0].StackTrace) != 4096 {
+		t.Fatalf("cases=%+v", cases)
+	}
+}
+
+func TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal(t *testing.T) {
+	_, err := parseLCOVRow(
+		[]byte("SF:main.go\nLF:1\nLH:2\nend_of_record\n"), "lcov.info",
+		"repo", "run", "org", time.Now(),
+	)
+	if err == nil {
+		t.Fatal("incoherent coverage row was accepted")
+	}
+}
+
+func githubTestsZip(t *testing.T, members map[string]string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, body := range members {
+		member, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}

--- a/internal/providersync/testdata/field_reflection.py
+++ b/internal/providersync/testdata/field_reflection.py
@@ -120,3 +120,31 @@ def class_annotated_field_names(source: str, class_name: str) -> frozenset[str]:
     raise ValueError(
         f"class_annotated_field_names: no annotated public fields found for {class_name!r}"
     )
+
+
+def typed_dict_field_names(source: str, class_name: str) -> frozenset[str]:
+    """Return every annotated field declared by one production TypedDict.
+
+    TestOps producers construct rows through ``TypedDictName(...)`` calls rather
+    than ORM constructors or dict literals. Reflecting the owning TypedDict is
+    the same structural completeness boundary for that shape: adding a field to
+    the production contract makes the oracle fail until its live row emits or
+    explicitly excludes the field.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        fields = {
+            statement.target.id
+            for statement in node.body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and not statement.target.id.startswith("_")
+        }
+        if fields:
+            return frozenset(fields)
+        break
+    raise ValueError(
+        f"typed_dict_field_names: no annotated public fields found for {class_name!r}"
+    )

--- a/internal/providersync/testdata/mutation-plans/github_tests_reports.json
+++ b/internal/providersync/testdata/mutation-plans/github_tests_reports.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "name": "github/tests report parsing foundation (CHAOS-3336)",
+  "build": ["go", "build", "./..."],
+  "$limitation": "This plan covers only the reviewable report-parser foundation. github/tests remains executor none and route_ready false; Actions/jobs/acceptance fetches, secure two-hop artifact download, Cobertura, six sinks/readbacks, tenant collision and crash recovery do not exist yet and are explicitly not claimed.",
+  "mutations": [
+    {
+      "id": "T1-report-count-cap",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "if processed >= githubTestsMaxReportsPerRun {",
+      "replace": "if false {",
+      "rationale": "one run may parse at most 200 classified reports so an artifact set cannot create unbounded CPU and row volume",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactEnforcesReportCountCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T2-doctype-rejected",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "bytes.Contains(bytes.ToUpper(body), []byte(\"<!DOCTYPE\")) ||",
+      "replace": "false ||",
+      "rationale": "untrusted artifact XML containing a DTD must be rejected before decoding",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T3-stack-truncation",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "if len(value) > 4096 {",
+      "replace": "if false {",
+      "rationale": "failure stack text persisted from an untrusted report is capped at the Python contract's 4096 bytes",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T4-failure-status",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "case item.Failure != nil:",
+      "replace": "case false:",
+      "rationale": "a JUnit failure element must normalize to failed and contribute to the suite's failed count",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactParsesJUnitCasesAndCoverage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T5-covered-cannot-exceed-total",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "linesCovered > linesTotal ||",
+      "replace": "false ||",
+      "rationale": "an incoherent coverage report must be rejected instead of skewing TestOps rollups",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_tests_reports.json
+++ b/internal/providersync/testdata/mutation-plans/github_tests_reports.json
@@ -43,6 +43,22 @@
       "replace": "false ||",
       "rationale": "an incoherent coverage report must be rejected instead of skewing TestOps rollups",
       "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T6-da-lines-fallback",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "lineNumbers[lineNumber] = struct{}{}",
+      "replace": "delete(lineNumbers, lineNumber)",
+      "rationale": "LCOV files without LF/LH must derive total and covered lines from unique DA records exactly like the live Python parser",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageFallsBackToUniqueDALines$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T7-majority-file-service",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "if serviceCounts[service] > bestCount {",
+      "replace": "if serviceCounts[service] > 0 && bestCount == 0 {",
+      "rationale": "coverage service attribution must choose the service represented by the most report files, not the first source path",
+      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageAttributesMajorityFileService$", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
@@ -44,7 +44,7 @@ def build_rows(
         ingest_report_members(
             [
                 ("reports/junit.xml", JUNIT.encode()),
-                ("reports/lcov.info", LCOV.encode()),
+                ("reports/lcov.info", case.get("lcov", LCOV).encode()),
             ],
             repo_id=uuid.UUID(case["repo_id"]),
             run_id=case["run_id"],

--- a/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.processors.testops_ingest import ingest_report_members
+from internal.providersync.testdata.field_reflection import typed_dict_field_names
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+SCHEMA_SOURCE = REPO_ROOT / "src/dev_health_ops/metrics/testops_schemas.py"
+
+JUNIT = """<testsuites><testsuite name="api" time="3.5">
+<testcase name="passes" classname="tests/test_api.py::TestAPI" file="services/api/test_api.py" time="1.25"/>
+<testcase name="fails" classname="tests/test_api.py::TestAPI" file="services/api/test_api.py" time="2.25"><failure message="expected 200" type="AssertionError">trace</failure><system-err>stderr</system-err></testcase>
+</testsuite></testsuites>"""
+
+LCOV = """TN:
+SF:services/api/main.go
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+BRF:2
+BRH:1
+FNF:1
+FNH:1
+end_of_record
+"""
+
+
+def reflected(class_name: str) -> frozenset[str]:
+    return typed_dict_field_names(SCHEMA_SOURCE.read_text(), class_name)
+
+
+def build_rows(
+    case: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    started = datetime.fromisoformat(case["started_at"].replace("Z", "+00:00"))
+    finished = datetime.fromisoformat(case["finished_at"].replace("Z", "+00:00"))
+    return asyncio.run(
+        ingest_report_members(
+            [
+                ("reports/junit.xml", JUNIT.encode()),
+                ("reports/lcov.info", LCOV.encode()),
+            ],
+            repo_id=uuid.UUID(case["repo_id"]),
+            run_id=case["run_id"],
+            org_id=case["org_id"],
+            started_at=started.astimezone(timezone.utc),
+            finished_at=finished.astimezone(timezone.utc),
+        )
+    )

--- a/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
@@ -6,6 +6,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageSnapshotRow,
+    TestCaseResultRow,
+    TestSuiteResultRow,
+)
 from dev_health_ops.processors.testops_ingest import ingest_report_members
 from internal.providersync.testdata.field_reflection import typed_dict_field_names
 
@@ -37,7 +42,11 @@ def reflected(class_name: str) -> frozenset[str]:
 
 def build_rows(
     case: dict[str, Any],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[
+    list[TestSuiteResultRow],
+    list[TestCaseResultRow],
+    list[CoverageSnapshotRow],
+]:
     started = datetime.fromisoformat(case["started_at"].replace("Z", "+00:00"))
     finished = datetime.fromisoformat(case["finished_at"].replace("Z", "+00:00"))
     return asyncio.run(

--- a/internal/providersync/testdata/oracle_pairs/github_tests_case.py
+++ b/internal/providersync/testdata/oracle_pairs/github_tests_case.py
@@ -1,0 +1,21 @@
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._github_tests_common import (
+    build_rows,
+    reflected,
+)
+
+
+def _build(case):
+    _, cases, _ = build_rows(case)
+    row = dict(cases[1])
+    row["repo_id"] = str(row["repo_id"])
+    return row
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/tests/case",
+        build_row=_build,
+        reflected_fields=lambda: reflected("TestCaseResultRow"),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_tests_coverage.py
+++ b/internal/providersync/testdata/oracle_pairs/github_tests_coverage.py
@@ -1,0 +1,21 @@
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._github_tests_common import (
+    build_rows,
+    reflected,
+)
+
+
+def _build(case):
+    _, _, coverage = build_rows(case)
+    row = dict(coverage[0])
+    row["repo_id"] = str(row["repo_id"])
+    return row
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/tests/coverage",
+        build_row=_build,
+        reflected_fields=lambda: reflected("CoverageSnapshotRow"),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_tests_suite.py
+++ b/internal/providersync/testdata/oracle_pairs/github_tests_suite.py
@@ -1,0 +1,21 @@
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._github_tests_common import (
+    build_rows,
+    reflected,
+)
+
+
+def _build(case):
+    suites, _, _ = build_rows(case)
+    row = dict(suites[0])
+    row["repo_id"] = str(row["repo_id"])
+    return row
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/tests/suite",
+        build_row=_build,
+        reflected_fields=lambda: reflected("TestSuiteResultRow"),
+    )
+)


### PR DESCRIPTION
## Summary

- add a bounded in-memory parser for GitHub Actions artifact ZIPs
- normalize JUnit suites/cases and LCOV coverage into the production TestOps row contracts
- reject DTD/entity XML, cap reports and expanded bytes, truncate stack traces, preserve fallback run timestamps, and reject incoherent coverage
- add three generic whole-row oracles that execute the active Python `ingest_report_members` chain and reflect completeness from the production TestOps TypedDicts

## Structural-foundation boundary

This PR intentionally leaves `(github, tests)` as `go_executor: none` and `route_ready: false`. It is not a complete provider route and makes no activation claim.

The remaining active Python contract is explicit: Actions run pagination, per-run job pagination, branch-protection acceptance checks, authenticated-to-unauthenticated two-hop artifact download, Cobertura parsing, and readback-safe effects for all six destinations (`ci_pipeline_runs`, `ci_job_runs`, `ci_acceptance_checks`, `test_suite_results`, `test_case_results`, and `coverage_snapshots`). Tenant-collision and crash-window recovery evidence must cover all six before executor/readiness can change.

## Verification

- `go test ./internal/providersync -count=1`
- `bash ci/check_go.sh live-python-oracles`
- shared mutation harness: T1-T5 all `KILLED`
- Ruff format/check and repository pre-commit mypy passed
- both commits in the stack have verified GPG signatures

SCREENSHOT-WAIVER: backend-only parser/test foundation; no rendered UI changes.
