### PR TITLE
fix(ask-dev): CHAOS-3337 -- SourceClass persistence allowlist for HEALTH_PROFILE/DEFICIENCY_INVENTORY

### DIFF
--- a/src/dev_health_ops/alembic/versions/0081_widen_source_observation_source_class.py
+++ b/src/dev_health_ops/alembic/versions/0081_widen_source_observation_source_class.py
@@ -1,4 +1,4 @@
-"""Widen dev_run_source_observations.source_class for CHAOS-3297 stack #3.
+"""Widen dev_run_source_observations.source_class for CHAOS-3297 stack #3 (install, NOT VALID).
 
 Revision ID: 0081
 Revises: 0080
@@ -16,17 +16,37 @@ INSERT: the database rejected the row with this CHECK constraint before
 the Python-level allowlist even got a chance to raise its own (also
 missing) validation error.
 
-No existing row can carry either new value (every attempt to write one
-failed at INSERT, by construction of the bug this migration closes), so
-the downgrade needs no data cleanup -- unlike 0072's widening of
-``ck_dev_runs_state``, which had to migrate live rows in the new states
-before narrowing back.
+Codex full-branch review (CHAOS-3337, 2026-08-03) HIGH finding: a plain
+``drop_constraint`` + ``create_check_constraint`` validates the replacement
+CHECK immediately, under the ``ACCESS EXCLUSIVE`` lock the drop+add already
+holds -- a full-table scan of ``dev_run_source_observations`` (an actively
+written, unbounded-growth table) blocking every concurrent read and write
+for the scan's duration. 0074/0075 already establish this repo's own
+precedent for exactly this shape (``ck_dev_runs_contract_generation``/
+``ck_dev_runs_public_outcome``): install the widened constraint ``NOT
+VALID`` here (metadata-only, no scan, brief lock), and validate it in a
+SEPARATE migration (0082) via ``VALIDATE CONSTRAINT``, which takes only a
+``SHARE UPDATE EXCLUSIVE`` lock and does not block concurrent reads/writes
+while it scans. SQLite has no ``NOT VALID``/``VALIDATE CONSTRAINT``
+concept -- ``batch_alter_table`` already fully validates a CHECK
+constraint at creation time, matching 0074's own SQLite arm.
+
+Codex HIGH finding 2: the original downgrade recreated the pre-widened
+constraint blind. That is only safe BEFORE any affected intent has ever
+run; once one has, rows carrying ``health_profile``/``deficiency_inventory``
+exist, and narrowing the CHECK back would either abort the migration (a
+CHECK violation on existing data) or -- worse -- require this migration to
+silently delete/mutate that data to make room for its own rollback, which
+is not this migration's call to make. Mirrors 0074's own downgrade posture
+exactly: preflight-and-refuse (raise) if any such row exists, rather than
+an authorized cleanup baked into a schema migration.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0081"
@@ -62,15 +82,44 @@ def _source_class_check(source_classes: Sequence[str]) -> str:
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
     op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
-    op.create_check_constraint(
-        _CONSTRAINT,
-        _TABLE,
-        _source_class_check((*_PRIOR_SOURCE_CLASSES, *_NEW_SOURCE_CLASSES)),
-    )
+    if is_postgres:
+        # Constraint name/body are module-level literals; DDL cannot take bound parameters.
+        op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+            f"ALTER TABLE {_TABLE} ADD CONSTRAINT {_CONSTRAINT} CHECK "
+            f"({_source_class_check((*_PRIOR_SOURCE_CLASSES, *_NEW_SOURCE_CLASSES))}) "
+            "NOT VALID"
+        )
+    else:
+        op.create_check_constraint(
+            _CONSTRAINT,
+            _TABLE,
+            _source_class_check((*_PRIOR_SOURCE_CLASSES, *_NEW_SOURCE_CLASSES)),
+        )
 
 
 def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.has_table(bind, _TABLE):
+        new_classes_list = ", ".join(f"'{c}'" for c in _NEW_SOURCE_CLASSES)
+        new_class_rows = bind.execute(
+            sa.text(
+                f"SELECT count(*) FROM {_TABLE} WHERE source_class IN "
+                f"({new_classes_list})"
+            )
+        ).scalar()
+        if new_class_rows:
+            raise RuntimeError(
+                f"refusing to downgrade {revision}: {_TABLE} has "
+                f"{new_class_rows} row(s) with source_class in "
+                f"{_NEW_SOURCE_CLASSES} -- narrowing the CHECK constraint "
+                "back would either abort on a violation or require this "
+                "migration to delete/mutate that data, which is not this "
+                "migration's call to make"
+            )
     op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
     op.create_check_constraint(
         _CONSTRAINT, _TABLE, _source_class_check(_PRIOR_SOURCE_CLASSES)

--- a/src/dev_health_ops/alembic/versions/0081_widen_source_observation_source_class.py
+++ b/src/dev_health_ops/alembic/versions/0081_widen_source_observation_source_class.py
@@ -1,0 +1,77 @@
+"""Widen dev_run_source_observations.source_class for CHAOS-3297 stack #3.
+
+Revision ID: 0081
+Revises: 0080
+Create Date: 2026-08-03 00:00:00
+
+CHAOS-3337: CHAOS-3297 stack #3 (merged #1387) wires four new plan-governed
+intents that emit ``SourceClass.HEALTH_PROFILE``/``SourceClass.
+DEFICIENCY_INVENTORY`` observations, but ``ck_dev_run_source_observations_
+source_class`` -- a hand-maintained mirror of the closed ``SourceClass``
+enum, separate from ``persistence.service._SOURCE_CLASSES`` (itself also
+missing these two values, fixed in the same changeset) -- was never
+updated. Every one of those four intents' plan-governed runs crashed the
+instant ``DevPersistenceService.append_source_observation`` tried to
+INSERT: the database rejected the row with this CHECK constraint before
+the Python-level allowlist even got a chance to raise its own (also
+missing) validation error.
+
+No existing row can carry either new value (every attempt to write one
+failed at INSERT, by construction of the bug this migration closes), so
+the downgrade needs no data cleanup -- unlike 0072's widening of
+``ck_dev_runs_state``, which had to migrate live rows in the new states
+before narrowing back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0081"
+down_revision: str | None = "0080"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_CONSTRAINT = "ck_dev_run_source_observations_source_class"
+_TABLE = "dev_run_source_observations"
+
+_PRIOR_SOURCE_CLASSES = (
+    "status_change",
+    "work_item",
+    "work_graph",
+    "pull_request",
+    "code_change",
+    "review",
+    "ci_run",
+    "test_report",
+    "deployment",
+    "incident",
+    "operational_control",
+    "source_health",
+)
+_NEW_SOURCE_CLASSES = ("health_profile", "deficiency_inventory")
+
+
+def _source_class_check(source_classes: Sequence[str]) -> str:
+    values = ", ".join(f"'{source_class}'" for source_class in source_classes)
+    return f"source_class IN ({values})"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        _source_class_check((*_PRIOR_SOURCE_CLASSES, *_NEW_SOURCE_CLASSES)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT, _TABLE, _source_class_check(_PRIOR_SOURCE_CLASSES)
+    )

--- a/src/dev_health_ops/alembic/versions/0082_validate_source_observation_source_class.py
+++ b/src/dev_health_ops/alembic/versions/0082_validate_source_observation_source_class.py
@@ -1,0 +1,50 @@
+"""Validate the NOT VALID dev_run_source_observations CHECK constraint added in 0081.
+
+Revision ID: 0082
+Revises: 0081
+Create Date: 2026-08-03 00:00:01
+
+``VALIDATE CONSTRAINT`` takes only a ``SHARE UPDATE EXCLUSIVE`` lock (does
+not block concurrent reads/writes) while it scans existing rows. Every
+pre-existing row in ``dev_run_source_observations`` already satisfies the
+widened constraint (it satisfied the NARROWER pre-0081 constraint, which
+0081's widened version is a strict superset of), so this step is expected
+to be fast -- but is kept as its own migration, mirroring 0075's own
+precedent for the 0074 ``dev_runs`` CHECK constraints, so a slow validation
+on an unexpectedly large table cannot block 0081's constraint install.
+
+No-op on non-PostgreSQL backends: SQLite's ``batch_alter_table`` (0081's
+SQLite arm) already fully validates a CHECK constraint at creation time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0082"
+down_revision: str | None = "0081"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_CONSTRAINT = "ck_dev_run_source_observations_source_class"
+_TABLE = "dev_run_source_observations"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    # Constraint/table names are module-level literals; DDL cannot take bound parameters.
+    op.execute(  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query, python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        f"ALTER TABLE {_TABLE} VALIDATE CONSTRAINT {_CONSTRAINT}"
+    )
+
+
+def downgrade() -> None:
+    # VALIDATE CONSTRAINT has no reversible state: the constraint remains
+    # installed (and valid) from 0081 either way. Nothing to undo here.
+    pass

--- a/src/dev_health_ops/api/dev/investigation_plans/wave_3_1_plans.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/wave_3_1_plans.py
@@ -32,6 +32,7 @@ into both ``builtin_steps.register_builtin_steps`` and this module's
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Protocol
 
@@ -52,6 +53,7 @@ from ..contracts_v2.health_rules import HealthRuleFinding
 from ..contracts_v2.plan import DevInvestigationPlan, DevSourceRequirement
 from ..contracts_v2.result import HEALTH_FINDING_SEVERITY_RANK, DevSourceContent
 from ..health_profile_synthesis import HealthProfileResult
+from ..persistence.service import _SOURCE_CLASSES as _PERSISTENCE_SOURCE_CLASSES
 from ..preflight_outcomes import PLAN_ID_BY_INTENT
 from .builtin_steps import PlanExecutorRuntime, register_builtin_steps
 from .plan_documents import CORE_PLANS_BY_INTENT, CORE_QUESTION_INTENT_IDS
@@ -67,6 +69,42 @@ __all__ = [
     "capped_health_findings",
     "register_wave_3_1_steps",
 ]
+
+
+def _source_classes_missing_from_persistence_allowlist(
+    plans_by_intent: Mapping[QuestionIntentID, DevInvestigationPlan],
+    *,
+    allowlist: frozenset[str],
+) -> frozenset[str]:
+    """Every ``SourceClass`` value any of ``plans_by_intent``'s steps can
+    emit that ``allowlist`` does not contain (CHAOS-3337).
+
+    ``persistence.service._SOURCE_CLASSES`` is a separate, hand-maintained
+    frozenset -- ``SourceClass`` being a closed pydantic enum only proves a
+    plan document's own ``source_requirements`` are internally consistent,
+    never that the persistence layer's own allowlist was updated to match.
+    A registered plan whose steps emit a ``SourceClass`` this table does
+    not carry crashes the FIRST live run that reaches
+    ``DevPersistenceService.append_source_observation`` with
+    ``DevPersistenceValidationError('invalid source_class')`` -- CHAOS-3337
+    was exactly this, for ``HEALTH_PROFILE``/``DEFICIENCY_INVENTORY``
+    (CHAOS-3297 stack #3), the third total-table to miss a ``SourceClass``
+    reconciliation (the CHAOS-3296/3297 relationship-matrix tables at
+    #1374's merge were the first two).
+
+    Pure and directly testable (see ``test_chaos_3337_source_class_
+    persistence_allowlist.py``), and also invoked below at THIS module's
+    own import time against the real registries and the real allowlist --
+    so the next ``SourceClass`` addition to a registered plan's
+    ``source_requirements`` fails at import, not live.
+    """
+
+    emitted = {
+        requirement.source_class.value
+        for plan in plans_by_intent.values()
+        for requirement in plan.source_requirements
+    }
+    return frozenset(emitted) - allowlist
 
 
 #: A finding-emitting service surface: exactly what this module's steps
@@ -554,6 +592,28 @@ _plan_id_mismatches = sorted(
 if _plan_id_mismatches:
     raise RuntimeError(
         f"wave_3_1 plan_id disagrees with PLAN_ID_BY_INTENT: {_plan_id_mismatches}"
+    )
+
+#: CHAOS-3337: every SourceClass the six core plans PLUS this module's four
+#: can emit, checked against persistence's own allowlist at THIS module's
+#: import time -- see ``_source_classes_missing_from_persistence_allowlist``'s
+#: own docstring. Covers both registries (not just this module's own) since
+#: either side could add a new SourceClass a plan's steps emit.
+_missing_from_persistence_allowlist = (
+    _source_classes_missing_from_persistence_allowlist(
+        {**CORE_PLANS_BY_INTENT, **WAVE_3_1_PLANS_BY_INTENT},
+        allowlist=_PERSISTENCE_SOURCE_CLASSES,
+    )
+)
+if _missing_from_persistence_allowlist:
+    raise RuntimeError(
+        "SourceClass(es) "
+        f"{sorted(_missing_from_persistence_allowlist)} are emitted by a "
+        "registered plan's source_requirements, but "
+        "persistence.service._SOURCE_CLASSES does not allow them -- every "
+        "observation for this source class would be rejected at write "
+        "time with DevPersistenceValidationError('invalid source_class') "
+        "(CHAOS-3337)"
     )
 
 #: The four question classes this module wires. ``PORTFOLIO_STATUS`` is

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -147,6 +147,18 @@ _RESOLUTION_OUTCOMES = frozenset(
 _ENTITY_KINDS = frozenset(
     {"repository", "project", "work_unit", "issue", "pull_request", "team"}
 )
+#: CHAOS-3337: this frozenset is a SEPARATE, hand-maintained mirror of
+#: ``contracts_v2.base.SourceClass`` -- that enum being closed only proves a
+#: plan document's own ``source_requirements`` are internally consistent,
+#: never that THIS allowlist was updated to match. A registered plan whose
+#: steps emit a SourceClass this table does not carry crashes the first
+#: live run that reaches ``append_source_observation`` below with
+#: ``DevPersistenceValidationError('invalid source_class')`` -- exactly
+#: what happened for ``health_profile``/``deficiency_inventory``
+#: (CHAOS-3297 stack #3, merged #1387) before this fix. Reconciliation is
+#: now also checked at ``investigation_plans.wave_3_1_plans`` import time
+#: (``_source_classes_missing_from_persistence_allowlist``), so the next
+#: SourceClass a registered plan's steps emit fails at import, not live.
 _SOURCE_CLASSES = frozenset(
     {
         "status_change",
@@ -161,6 +173,8 @@ _SOURCE_CLASSES = frozenset(
         "incident",
         "operational_control",
         "source_health",
+        "health_profile",
+        "deficiency_inventory",
     }
 )
 _REQUIREMENT_LEVELS = frozenset(

--- a/src/dev_health_ops/models/dev_persistence.py
+++ b/src/dev_health_ops/models/dev_persistence.py
@@ -613,7 +613,8 @@ class DevRunSourceObservation(Base):
         CheckConstraint(
             "source_class IN ('status_change', 'work_item', 'work_graph', "
             "'pull_request', 'code_change', 'review', 'ci_run', 'test_report', "
-            "'deployment', 'incident', 'operational_control', 'source_health')",
+            "'deployment', 'incident', 'operational_control', 'source_health', "
+            "'health_profile', 'deficiency_inventory')",
             name="ck_dev_run_source_observations_source_class",
         ),
         CheckConstraint(

--- a/tests/api/dev/test_chaos_3337_source_class_persistence_allowlist.py
+++ b/tests/api/dev/test_chaos_3337_source_class_persistence_allowlist.py
@@ -1,0 +1,401 @@
+"""CHAOS-3337: ``wave_3_1_plans.py`` uses ``SourceClass.HEALTH_PROFILE``/
+``SourceClass.DEFICIENCY_INVENTORY`` (CHAOS-3297 stack #3, merged in #1387),
+but ``persistence/service.py``'s own hand-maintained ``_SOURCE_CLASSES``
+frozenset allowlist was never updated -- every one of the four newly-wired
+intents (health.project.v1/health.team.v1/balance.team_workload.v1/
+deficiency.operational.v1) crashed live to a terminal error the instant the
+plan executor's REAL result reached ``DevPersistenceService.
+append_source_observation``: ``DevPersistenceValidationError('invalid
+source_class')``.
+
+This is the third total-table to miss a SourceClass reconciliation (the
+CHAOS-3296/3297 relationship-matrix tables at #1374's merge were the first
+two -- see ``investigation_plans/relationship_matrix.py``). Every unit test
+in the CHAOS-3297 s3 stack drove these two source classes through FAKE
+service doubles and asserted on ``StepOutcome``/``DevSourceContent``
+directly -- none of them ever reached the real
+``DevPersistenceService``/``PersistenceRunRecorder`` write path, which is
+the ONLY place ``_SOURCE_CLASSES`` is checked. That is the gap this suite
+closes: every test below drives a REAL ``PlanExecutor`` run through the
+REAL persistence layer (an in-memory SQLite-backed
+``DevPersistenceService``), for each of the four affected intents.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
+from dev_health_ops.api.dev.contracts_v2.base import QuestionIntentID
+from dev_health_ops.api.dev.contracts_v2.deficiency import (
+    DEFICIENCY_CATEGORIES,
+    DeficiencyCategoryStatus,
+    OperationalDeficiencyInventory,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import RuleApplicability
+from dev_health_ops.api.dev.health_profile_synthesis import HealthProfileResult
+from dev_health_ops.api.dev.investigation_plans.executor import PlanExecutor
+from dev_health_ops.api.dev.investigation_plans.plan_documents import (
+    CORE_PLANS_BY_INTENT,
+)
+from dev_health_ops.api.dev.investigation_plans.steps import StepContext
+from dev_health_ops.api.dev.investigation_plans.wave_3_1_plans import (
+    WAVE_3_1_PLANS_BY_INTENT,
+    _source_classes_missing_from_persistence_allowlist,
+    build_registry_with_wave_3_1,
+)
+from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.api.dev.persistence.service import (
+    _SOURCE_CLASSES as _PERSISTENCE_SOURCE_CLASSES,
+)
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunIntent,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+_ORG_ID = "org_fullchaos"
+_NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+
+_PERSISTENCE_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunStageDiagnostic,
+)
+
+
+@pytest_asyncio.fixture
+async def persistence(tmp_path: Path):
+    database = tmp_path / "ask-dev-3337.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_PERSISTENCE_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev-3337", name="Ask Dev 3337"),
+                User(id=user_id, email="ask-dev-3337@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+def _time_range() -> DevTimeRange:
+    return DevTimeRange(
+        start=datetime(2026, 7, 1, tzinfo=UTC),
+        end=datetime(2026, 7, 31, tzinfo=UTC),
+        timezone="UTC",
+    )
+
+
+def _project_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.PROJECT,
+        entity_refs=[
+            {
+                "entity_type": "project",
+                "entity_id": "proj-1",
+                "display_label": "Project",
+                "repository_id": None,
+            }
+        ],
+        time_range=_time_range(),
+    )
+
+
+def _team_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.TEAM,
+        entity_refs=[
+            {
+                "entity_type": "team",
+                "entity_id": "team-1",
+                "display_label": "Team",
+                "repository_id": None,
+            }
+        ],
+        team_ids=["team-1"],
+        time_range=_time_range(),
+    )
+
+
+def _step_context(scope: DevScope) -> StepContext:
+    return StepContext(
+        org_id=_ORG_ID,
+        permission_fingerprint="fingerprint",
+        scope=scope,
+        run_id="run-1",
+        now=_NOW,
+    )
+
+
+def _health_profile_result() -> HealthProfileResult:
+    return HealthProfileResult(
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        observations=(),
+        launch_findings=(),
+        shadow_findings=(),
+        suppressed_findings=(),
+        observations_by_rule={},
+    )
+
+
+def _deficiency_category_statuses() -> tuple[DeficiencyCategoryStatus, ...]:
+    return tuple(
+        DeficiencyCategoryStatus(
+            schema_version="deficiency_category_status.v1",
+            category=category,
+            evaluated=True,
+            finding_count=0,
+            applicability_states_observed=(),
+            limitation=None,
+        )
+        for category in DEFICIENCY_CATEGORIES
+    )
+
+
+def _deficiency_inventory() -> OperationalDeficiencyInventory:
+    return OperationalDeficiencyInventory(
+        schema_version="deficiency_operational_inventory.v1",
+        inventory_id="00000000-0000-0000-0000-00000000000f",
+        subject_kind=RuleApplicability.PROJECT,
+        subject_id="proj-1",
+        findings=(),
+        category_statuses=_deficiency_category_statuses(),
+        evaluated_at=_NOW,
+    )
+
+
+class _FakeHealth:
+    async def evaluate_project(self, *, org_id, permission_fingerprint, scope, now):
+        return _health_profile_result()
+
+    async def evaluate_team(
+        self, *, org_id, permission_fingerprint, scope, team_id, now
+    ):
+        return _health_profile_result()
+
+    async def evaluate_workload(
+        self, *, org_id, permission_fingerprint, scope, team_id, now
+    ):
+        return _health_profile_result()
+
+
+class _FakeOperationalDeficiency:
+    async def evaluate_project(self, *, org_id, permission_fingerprint, scope, now):
+        return _deficiency_inventory()
+
+    async def evaluate_team(
+        self, *, org_id, permission_fingerprint, scope, team_id, now
+    ):
+        return _deficiency_inventory()
+
+
+def _registry():
+    from tests._chaos_3295_plan_executor import FakePlanExecutorRuntime
+
+    fake = _FakeHealth()
+    return build_registry_with_wave_3_1(
+        FakePlanExecutorRuntime(),
+        project_health=fake,
+        team_health=fake,
+        team_workload=fake,
+        operational_deficiency=_FakeOperationalDeficiency(),
+    )
+
+
+async def _run_real_plan(intent_id: QuestionIntentID, scope: DevScope):
+    """Run a REAL PlanExecutor over a REAL registered plan (production
+    wiring end to end, fake CHAOS-3303/3304/3305 services only), producing
+    a genuine ``DevInvestigationResult`` -- never a hand-authored fixture.
+    """
+
+    plan = WAVE_3_1_PLANS_BY_INTENT[intent_id]
+    registry = _registry()
+    executor = PlanExecutor(registry=registry, now=lambda: _NOW)
+    return await executor.run(
+        plan=plan,
+        context=_step_context(scope),
+        run_id="run-1",
+        subject_entity_id="proj-1",
+    )
+
+
+async def _persist(maker, org_id, user_id, result) -> None:
+    """The exact real production write path
+    (``orchestrator.run()`` -> ``PersistenceRunRecorder.
+    record_investigation_result`` -> ``DevPersistenceService.
+    append_source_observation``) -- never a synthetic call, so success here
+    proves the fix genuinely closes the live crash, not just that the
+    executor's own in-memory objects look right.
+    """
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="What is the health of this project?",
+            scope_snapshot={},
+        )
+        recorder = PersistenceRunRecorder(
+            service,
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            run_id=accepted.run.id,
+            provider_source="platform",
+        )
+        await recorder.record_investigation_result(result)
+
+
+_INTENT_SCOPES = {
+    QuestionIntentID.PROJECT_HEALTH: _project_scope,
+    QuestionIntentID.TEAM_HEALTH: _team_scope,
+    QuestionIntentID.TEAM_WORKLOAD_BALANCE: _team_scope,
+    QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY: _project_scope,
+}
+
+
+_WAVE_3_1_INTENT_IDS: list[QuestionIntentID] = sorted(
+    WAVE_3_1_PLANS_BY_INTENT.keys(), key=lambda intent: intent.value
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("intent_id", _WAVE_3_1_INTENT_IDS)
+async def test_every_wave_3_1_intent_persists_through_the_real_write_path(
+    persistence, intent_id: QuestionIntentID
+) -> None:
+    """The live crash, reproduced and closed: a REAL plan-governed run for
+    each of the four newly-wired intents must persist cleanly through the
+    REAL DevPersistenceService, not raise DevPersistenceValidationError.
+    """
+
+    maker, org_id, user_id = persistence
+    scope_factory = _INTENT_SCOPES[intent_id]
+    result = await _run_real_plan(intent_id, scope_factory())
+
+    assert len(result.observations) >= 1
+    await _persist(maker, org_id, user_id, result)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# The totality gap itself: a pure, directly-testable function computing
+# "every SourceClass a registered plan's steps can emit that persistence's
+# allowlist does not contain" -- also run at wave_3_1_plans.py's own import
+# time (module-level RuntimeError), so the NEXT SourceClass addition fails
+# at import, not live.
+# ---------------------------------------------------------------------------
+
+
+def test_current_registry_has_no_gap_against_the_real_allowlist() -> None:
+    gap = _source_classes_missing_from_persistence_allowlist(
+        {**CORE_PLANS_BY_INTENT, **WAVE_3_1_PLANS_BY_INTENT},
+        allowlist=_PERSISTENCE_SOURCE_CLASSES,
+    )
+    assert gap == frozenset()
+
+
+def test_totality_function_detects_a_planted_gap() -> None:
+    """Plant defect: shrink the allowlist by one entry a registered plan
+    genuinely emits (health_profile) and confirm the totality function
+    reports exactly that gap -- proving it is a real, sensitive check, not
+    a vacuous one that would pass regardless of the allowlist's contents.
+    """
+
+    shrunk_allowlist = _PERSISTENCE_SOURCE_CLASSES - {"health_profile"}
+    gap = _source_classes_missing_from_persistence_allowlist(
+        {**CORE_PLANS_BY_INTENT, **WAVE_3_1_PLANS_BY_INTENT},
+        allowlist=shrunk_allowlist,
+    )
+    assert gap == frozenset({"health_profile"})
+
+
+@pytest.mark.asyncio
+async def test_production_write_path_fails_closed_under_the_same_planted_gap(
+    persistence, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same planted defect as above, proven against the REAL write path
+    this whole suite exists to protect: with health_profile removed from
+    the allowlist, the exact live crash (DevPersistenceValidationError)
+    must reproduce -- confirming the totality function and the real
+    persistence check agree on what "missing" means, not just in theory.
+    """
+
+    from dev_health_ops.api.dev.persistence import service as persistence_service_module
+
+    monkeypatch.setattr(
+        persistence_service_module,
+        "_SOURCE_CLASSES",
+        _PERSISTENCE_SOURCE_CLASSES - {"health_profile"},
+    )
+
+    maker, org_id, user_id = persistence
+    result = await _run_real_plan(QuestionIntentID.PROJECT_HEALTH, _project_scope())
+
+    from dev_health_ops.api.dev.persistence import DevPersistenceValidationError
+
+    with pytest.raises(DevPersistenceValidationError, match="invalid source_class"):
+        await _persist(maker, org_id, user_id, result)

--- a/tests/api/dev/test_chaos_3337_source_class_persistence_allowlist.py
+++ b/tests/api/dev/test_chaos_3337_source_class_persistence_allowlist.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
@@ -53,10 +53,12 @@ from dev_health_ops.api.dev.investigation_plans.wave_3_1_plans import (
     build_registry_with_wave_3_1,
 )
 from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
+from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.persistence import DevPersistenceService
 from dev_health_ops.api.dev.persistence.service import (
     _SOURCE_CLASSES as _PERSISTENCE_SOURCE_CLASSES,
 )
+from dev_health_ops.llm.agent.contracts import AgentUsage
 from dev_health_ops.models.dev_persistence import (
     DevAnswerFrame,
     DevConversation,
@@ -277,13 +279,26 @@ async def _run_real_plan(intent_id: QuestionIntentID, scope: DevScope):
     )
 
 
-async def _persist(maker, org_id, user_id, result) -> None:
+async def _persist(maker, org_id, user_id, result) -> uuid.UUID:
     """The exact real production write path
     (``orchestrator.run()`` -> ``PersistenceRunRecorder.
     record_investigation_result`` -> ``DevPersistenceService.
-    append_source_observation``) -- never a synthetic call, so success here
-    proves the fix genuinely closes the live crash, not just that the
-    executor's own in-memory objects look right.
+    append_source_observation``, followed by the terminal transition every
+    real run reaches) -- never a synthetic call, so success here proves the
+    fix genuinely closes the live crash, not just that the executor's own
+    in-memory objects look right.
+
+    Codex full-branch review (CHAOS-3337, 2026-08-03) MED finding: the
+    original version of this helper never called ``session.commit()`` --
+    the ``async with maker() as session`` block's exit closes the session
+    without committing, so the transaction rolled back and every assertion
+    that followed ("must not raise") proved only that the writes didn't
+    ERROR, never that they PERSISTED (rule 1: assert the state the system
+    exists to reach; rule 4: a measurement that did not happen must FAIL).
+    Fixed: commits here, and the caller re-opens a FRESH session
+    (``_load_persisted_state`` below) to query the committed rows back --
+    the only way to prove this is real persistence, not merely a
+    same-transaction round-trip an uncommitted INSERT would also satisfy.
     """
 
     async with maker() as session:
@@ -299,15 +314,60 @@ async def _persist(maker, org_id, user_id, result) -> None:
             question="What is the health of this project?",
             scope_snapshot={},
         )
+        run_id = accepted.run.id
         recorder = PersistenceRunRecorder(
             service,
             org_id=org_id,
             user_id=user_id,
             conversation_id=conversation.id,
-            run_id=accepted.run.id,
+            run_id=run_id,
             provider_source="platform",
         )
         await recorder.record_investigation_result(result)
+        # Every real run reaches a terminal state -- record_investigation_
+        # result alone never sets one (PersistenceRunRecorder.transition
+        # deliberately no-ops for terminal states; only orchestrator.
+        # finish()'s own terminal() call, mirrored here, actually persists
+        # one).
+        await recorder.terminal(
+            state=RunState.COMPLETED,
+            answer=None,
+            error=None,
+            usage=AgentUsage(),
+            tool_call_count=0,
+            provider_fingerprint=None,
+            model_fingerprint=None,
+            prompt_checksum=None,
+        )
+        await session.commit()
+    return run_id
+
+
+async def _load_persisted_state(maker, org_id, user_id, run_id):
+    """Re-open a FRESH session (never the one that wrote the data) and
+    query the committed rows back -- the only way to prove ``_persist``'s
+    writes are real persistence, not an uncommitted transaction a same-
+    session read would also satisfy."""
+
+    async with maker() as session:
+        run = await session.get(DevRun, run_id)
+        assert run is not None, "run must exist in a fresh session after commit"
+        observations = (
+            (
+                await session.execute(
+                    select(DevRunSourceObservation)
+                    .where(
+                        DevRunSourceObservation.run_id == run_id,
+                        DevRunSourceObservation.org_id == org_id,
+                        DevRunSourceObservation.user_id == user_id,
+                    )
+                    .order_by(DevRunSourceObservation.ordinal)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return run, observations
 
 
 _INTENT_SCOPES = {
@@ -322,6 +382,17 @@ _WAVE_3_1_INTENT_IDS: list[QuestionIntentID] = sorted(
     WAVE_3_1_PLANS_BY_INTENT.keys(), key=lambda intent: intent.value
 )
 
+#: The exact SourceClass every WAVE_3_1_PLANS_BY_INTENT plan's step(s) emit
+#: -- health.project.v1/health.team.v1/balance.team_workload.v1 all wire
+#: HealthProfileResult through HEALTH_PROFILE; deficiency.operational.v1
+#: wires OperationalDeficiencyInventory through DEFICIENCY_INVENTORY.
+_EXPECTED_SOURCE_CLASS = {
+    QuestionIntentID.PROJECT_HEALTH: "health_profile",
+    QuestionIntentID.TEAM_HEALTH: "health_profile",
+    QuestionIntentID.TEAM_WORKLOAD_BALANCE: "health_profile",
+    QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY: "deficiency_inventory",
+}
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("intent_id", _WAVE_3_1_INTENT_IDS)
@@ -330,7 +401,11 @@ async def test_every_wave_3_1_intent_persists_through_the_real_write_path(
 ) -> None:
     """The live crash, reproduced and closed: a REAL plan-governed run for
     each of the four newly-wired intents must persist cleanly through the
-    REAL DevPersistenceService, not raise DevPersistenceValidationError.
+    REAL DevPersistenceService, not raise DevPersistenceValidationError --
+    and (codex MED finding) the committed rows must be independently
+    re-readable afterward, with the exact observation source_class/count,
+    the completed step partition, and a terminal run state, not merely
+    "the write call didn't raise".
     """
 
     maker, org_id, user_id = persistence
@@ -338,7 +413,21 @@ async def test_every_wave_3_1_intent_persists_through_the_real_write_path(
     result = await _run_real_plan(intent_id, scope_factory())
 
     assert len(result.observations) >= 1
-    await _persist(maker, org_id, user_id, result)  # must not raise
+    run_id = await _persist(maker, org_id, user_id, result)
+
+    run, observations = await _load_persisted_state(maker, org_id, user_id, run_id)
+
+    assert len(observations) == len(result.observations)
+    expected_class = _EXPECTED_SOURCE_CLASS[intent_id]
+    assert {observation.source_class for observation in observations} == {
+        expected_class
+    }
+    assert run.state == "completed"
+    assert run.plan_step_partition is not None
+    assert sorted(run.plan_step_partition.get("completed", [])) == sorted(
+        result.completed_steps
+    )
+    assert run.relationship_closure_verified == result.relationship_closure_verified
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0080"}
+    assert _revisions(migrated_to_0065.engine) == {"0081"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0080"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0080"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0080"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0081"}
+    assert _revisions(migrated_to_0065.engine) == {"0082"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0082"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0082"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0081"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0082"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0081",)
+    assert heads == ("0082",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0080",)
+    assert heads == ("0081",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0081"}
+    assert set(heads) == {"0066", "0082"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0080"}
+    assert set(heads) == {"0066", "0081"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_chaos_3337_source_class_allowlist_parity.py
+++ b/tests/test_chaos_3337_source_class_allowlist_parity.py
@@ -1,0 +1,153 @@
+"""CHAOS-3337 codex full-branch review (2026-08-03), finding 4 (pre-authorized
+by team-lead regardless of verdict): three SEPARATE, hand-maintained
+definitions of the same closed ``source_class`` vocabulary can drift from
+each other independently of ``contracts_v2.base.SourceClass`` itself:
+
+1. ``persistence.service._SOURCE_CLASSES`` -- the Python-level allowlist
+   ``append_source_observation`` checks.
+2. ``models.dev_persistence.DevRunSourceObservation``'s own
+   ``ck_dev_run_source_observations_source_class`` CHECK constraint string
+   (``__table_args__``) -- what SQLite (every unit test's ``create_all``)
+   and a freshly-provisioned Postgres both enforce at the DB layer.
+3. Migration 0081's ``ADD CONSTRAINT ... CHECK (...) NOT VALID`` DDL text
+   -- what an EXISTING Postgres database's constraint actually becomes
+   after upgrading (0082 only validates 0081's constraint; it never
+   redefines the value list).
+
+CHAOS-3337 itself was exactly definitions 1 and 2 drifting from
+``contracts_v2.base.SourceClass`` independently, in two different ways, at
+the same time. This suite locks all three of the above together with each
+other (not merely against the enum, which ``test_chaos_3337_source_class_
+persistence_allowlist.py``'s import-time check already covers for the
+Python-importable side) -- so the next SourceClass this repo widens the
+allowlist for, but only in one or two of these three places, fails a test
+instead of live.
+
+Parses the model's and the migration's raw SQL/DDL text (never
+hand-transcribes the expected value list a second time) so this test
+cannot itself become a fourth, independently-driftable copy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from typing import cast
+
+from sqlalchemy import CheckConstraint, Table
+
+from dev_health_ops.api.dev.persistence.service import (
+    _SOURCE_CLASSES as _PERSISTENCE_SOURCE_CLASSES,
+)
+from dev_health_ops.models.dev_persistence import DevRunSourceObservation
+
+_CONSTRAINT_NAME = "ck_dev_run_source_observations_source_class"
+
+#: Matches every single-quoted SQL string literal in a
+#: ``source_class IN ('a', 'b', ...)`` CHECK constraint fragment. Deliberately
+#: general (any quoted literal, not anchored to "source_class IN" specifically)
+#: so it works unchanged against both the model's plain CHECK body and a
+#: migration's ``ALTER TABLE ... ADD CONSTRAINT ... CHECK (...) NOT VALID``
+#: DDL text, which wraps the same fragment in more SQL around it.
+_QUOTED_LITERAL_RE = re.compile(r"'([^']*)'")
+
+
+def _parse_quoted_values(sql: str) -> frozenset[str]:
+    """Every single-quoted string literal in ``sql`` -- the closed value
+    set a ``... IN (...)`` CHECK constraint fragment enumerates."""
+
+    return frozenset(_QUOTED_LITERAL_RE.findall(sql))
+
+
+def _model_check_constraint_sql() -> str:
+    table = cast(Table, DevRunSourceObservation.__table__)
+    for constraint in table.constraints:
+        if (
+            isinstance(constraint, CheckConstraint)
+            and constraint.name == _CONSTRAINT_NAME
+        ):
+            return str(constraint.sqltext)
+    raise AssertionError(
+        f"{_CONSTRAINT_NAME!r} not found on DevRunSourceObservation.__table_args__ "
+        "-- has it been renamed?"
+    )
+
+
+def _migration_0081_check_constraint_sql() -> str:
+    """0081's widened CHECK body, built the exact same way the migration's
+    own ``upgrade()`` builds it for the ``NOT VALID`` DDL -- never a second,
+    hand-copied literal list."""
+
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0081_widen_source_observation_source_class"
+    )
+    return migration._source_class_check(
+        (*migration._PRIOR_SOURCE_CLASSES, *migration._NEW_SOURCE_CLASSES)
+    )
+
+
+def test_model_check_constraint_matches_persistence_allowlist() -> None:
+    model_values = _parse_quoted_values(_model_check_constraint_sql())
+    assert model_values == _PERSISTENCE_SOURCE_CLASSES
+
+
+def test_migration_0081_constraint_matches_persistence_allowlist() -> None:
+    migration_values = _parse_quoted_values(_migration_0081_check_constraint_sql())
+    assert migration_values == _PERSISTENCE_SOURCE_CLASSES
+
+
+def test_model_and_migration_constraints_agree_with_each_other() -> None:
+    """Direct pairwise check (not merely implied by both matching
+    ``_SOURCE_CLASSES`` above): if a future change edits the model's CHECK
+    string and the persistence frozenset together but forgets the
+    migration DDL (or vice versa), THIS is the assertion that catches it,
+    independent of whether ``_SOURCE_CLASSES`` itself was touched.
+    """
+
+    model_values = _parse_quoted_values(_model_check_constraint_sql())
+    migration_values = _parse_quoted_values(_migration_0081_check_constraint_sql())
+    assert model_values == migration_values
+
+
+def test_parser_detects_a_planted_gap_on_the_model_side() -> None:
+    """Plant defect: a model CHECK constraint string missing one value the
+    persistence allowlist and the migration both still carry. Proves the
+    comparison is sensitive on the MODEL side specifically, not merely
+    reporting a passing/trivial result regardless of content.
+    """
+
+    shrunk_model_sql = _model_check_constraint_sql().replace("'health_profile', ", "")
+    assert "health_profile" not in _parse_quoted_values(shrunk_model_sql)
+    assert _parse_quoted_values(shrunk_model_sql) != _PERSISTENCE_SOURCE_CLASSES
+    assert _parse_quoted_values(shrunk_model_sql) != _parse_quoted_values(
+        _migration_0081_check_constraint_sql()
+    )
+
+
+def test_parser_detects_a_planted_gap_on_the_migration_side() -> None:
+    """Plant defect: a migration CHECK constraint string missing one value
+    the persistence allowlist and the model both still carry. Proves the
+    comparison is sensitive on the MIGRATION side specifically.
+    """
+
+    shrunk_migration_sql = _migration_0081_check_constraint_sql().replace(
+        "'deficiency_inventory'", ""
+    )
+    assert "deficiency_inventory" not in _parse_quoted_values(shrunk_migration_sql)
+    assert _parse_quoted_values(shrunk_migration_sql) != _PERSISTENCE_SOURCE_CLASSES
+    assert _parse_quoted_values(shrunk_migration_sql) != _parse_quoted_values(
+        _model_check_constraint_sql()
+    )
+
+
+def test_parser_detects_a_planted_gap_on_the_persistence_side() -> None:
+    """Plant defect: a persistence allowlist missing one value the model
+    and migration both still carry -- proves the comparison is sensitive
+    on the THIRD side too, not only the two SQL-text sides.
+    """
+
+    shrunk_allowlist = _PERSISTENCE_SOURCE_CLASSES - {"health_profile"}
+    assert _parse_quoted_values(_model_check_constraint_sql()) != shrunk_allowlist
+    assert (
+        _parse_quoted_values(_migration_0081_check_constraint_sql()) != shrunk_allowlist
+    )

--- a/tests/test_chaos_3337_source_class_postgres_migration.py
+++ b/tests/test_chaos_3337_source_class_postgres_migration.py
@@ -1,0 +1,322 @@
+"""CHAOS-3337 codex full-branch review (2026-08-03): real-Postgres proof for
+migrations 0081/0082 -- the NOT VALID install + separate VALIDATE CONSTRAINT
+split (mirroring 0074/0075's own precedent), and 0081's downgrade
+preflight-and-refuse when a row carries either newly-widened source_class.
+
+Gated exactly like ``test_0066_celery_river_cutover_postgres.py``/
+``test_canonical_incident_feature_flag_postgres_migration.py``: skips
+locally without a configured Postgres admin URI, but FAILS (never silently
+skips) in CI, so this real-lock-semantics proof cannot quietly disappear
+from the gate that gave it its name.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.dev_persistence import (
+    DevConversation,
+    DevRun,
+    DevRunSourceObservation,
+)
+from dev_health_ops.models.users import Organization, User
+
+_TEST_ADMIN_URI_ENV = "DEV_HEALTH_TEST_POSTGRES_ADMIN_URI"
+_ALEMBIC_SCRIPT_LOCATION = (
+    Path(__file__).parent / "src" / "dev_health_ops" / "alembic"
+).resolve()
+if not _ALEMBIC_SCRIPT_LOCATION.exists():
+    _ALEMBIC_SCRIPT_LOCATION = (
+        Path(__file__).parents[1] / "src" / "dev_health_ops" / "alembic"
+    )
+
+_CONSTRAINT = "ck_dev_run_source_observations_source_class"
+_TABLE = "dev_run_source_observations"
+
+
+@dataclass(frozen=True, slots=True)
+class PostgresMigrationHarness:
+    engine: Engine
+
+
+def _migration_config() -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(_ALEMBIC_SCRIPT_LOCATION))
+    return config
+
+
+@pytest.fixture
+def isolated_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[PostgresMigrationHarness]:
+    configured_uri = os.environ.get(_TEST_ADMIN_URI_ENV)
+    if configured_uri is None:
+        if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+            pytest.fail(
+                f"{_TEST_ADMIN_URI_ENV} must be configured for PostgreSQL "
+                "migration tests"
+            )
+        pytest.skip(
+            f"{_TEST_ADMIN_URI_ENV} is required for the PostgreSQL migration regression"
+        )
+
+    configured_url = make_url(configured_uri)
+    if configured_url.get_backend_name() != "postgresql":
+        pytest.skip(f"{_TEST_ADMIN_URI_ENV} must use PostgreSQL")
+    if configured_url.database != "postgres":
+        pytest.skip(f"{_TEST_ADMIN_URI_ENV} must target the postgres admin database")
+
+    database_name = f"test_3337_{uuid.uuid4().hex}"
+    admin_url = configured_url.set(
+        drivername="postgresql+psycopg2", database="postgres"
+    )
+    admin_engine = sa.create_engine(admin_url, isolation_level="AUTOCOMMIT")
+    database_created = False
+    engine: Engine | None = None
+
+    try:
+        with admin_engine.connect() as connection:
+            connection.exec_driver_sql(f'CREATE DATABASE "{database_name}"')
+            database_created = True
+
+        isolated_async_url = configured_url.set(database=database_name)
+        isolated_sync_url = isolated_async_url.set(drivername="postgresql+psycopg2")
+        engine = sa.create_engine(isolated_sync_url)
+        monkeypatch.setenv(
+            "POSTGRES_URI", isolated_async_url.render_as_string(hide_password=False)
+        )
+
+        yield PostgresMigrationHarness(engine=engine)
+    finally:
+        if engine is not None:
+            engine.dispose()
+        try:
+            if database_created:
+                with admin_engine.connect() as connection:
+                    connection.execute(
+                        sa.text(
+                            """
+                            SELECT pg_terminate_backend(pid)
+                            FROM pg_stat_activity
+                            WHERE datname = :database_name
+                              AND pid <> pg_backend_pid()
+                            """
+                        ),
+                        {"database_name": database_name},
+                    )
+                    connection.exec_driver_sql(f'DROP DATABASE "{database_name}"')
+        finally:
+            admin_engine.dispose()
+
+
+def _seed_run(session: Session, *, org_id, user_id) -> uuid.UUID:
+    """The minimal owner chain a ``dev_run_source_observations`` row's
+    composite FK (``run_id``, ``org_id``, ``user_id`` -> ``dev_runs``)
+    requires."""
+
+    session.add(Organization(id=org_id, slug=f"chaos-3337-{org_id.hex}", name="3337"))
+    session.add(User(id=user_id, email=f"chaos-3337-{user_id.hex}@example.com"))
+    session.flush()  # organizations/users rows must exist before dev_conversations
+    conversation_id = uuid.uuid4()
+    session.add(DevConversation(id=conversation_id, org_id=org_id, user_id=user_id))
+    session.flush()  # dev_conversations row must exist before dev_runs
+    run_id = uuid.uuid4()
+    session.add(
+        DevRun(
+            id=run_id,
+            request_id=uuid.uuid4(),
+            conversation_id=conversation_id,
+            org_id=org_id,
+            user_id=user_id,
+            state="completed",
+            started_at=datetime.now(UTC),
+        )
+    )
+    session.commit()
+    return run_id
+
+
+def _insert_observation(
+    session: Session, *, org_id, user_id, run_id, source_class: str
+) -> None:
+    session.add(
+        DevRunSourceObservation(
+            id=uuid.uuid4(),
+            run_id=run_id,
+            org_id=org_id,
+            user_id=user_id,
+            ordinal=0,
+            observation_id=uuid.uuid4(),
+            source_class=source_class,
+            requirement_level="mandatory",
+            observed_state="available_current",
+            data_semantics="measured_zero",
+            usable_fact_count=1,
+            sample_count=None,
+            subject_coverage=1.0,
+            payload={"schema_version": "dev_source_observation.v1"},
+            observed_at=datetime.now(UTC),
+        )
+    )
+    session.commit()
+
+
+def test_0081_installs_not_valid_and_0082_validates(
+    isolated_postgres: PostgresMigrationHarness,
+) -> None:
+    """Codex HIGH finding 1's exact claim, proven against a real Postgres
+    catalog: 0081 must leave the constraint UNvalidated (``pg_constraint.
+    convalidated = false``, the metadata-only, no-scan state), and only
+    0082's ``VALIDATE CONSTRAINT`` flips it to validated.
+    """
+
+    config = _migration_config()
+    command.upgrade(config, "0081")
+
+    with isolated_postgres.engine.connect() as connection:
+        convalidated_after_0081 = connection.execute(
+            sa.text("SELECT convalidated FROM pg_constraint WHERE conname = :name"),
+            {"name": _CONSTRAINT},
+        ).scalar_one()
+    assert convalidated_after_0081 is False
+
+    command.upgrade(config, "0082")
+
+    with isolated_postgres.engine.connect() as connection:
+        convalidated_after_0082 = connection.execute(
+            sa.text("SELECT convalidated FROM pg_constraint WHERE conname = :name"),
+            {"name": _CONSTRAINT},
+        ).scalar_one()
+    assert convalidated_after_0082 is True
+
+
+def test_every_prior_source_class_still_accepted_after_the_widen(
+    isolated_postgres: PostgresMigrationHarness,
+) -> None:
+    """Codex probe: 0081's recreate must list every previously-allowed
+    value, not just the two new ones -- proved by actually inserting one
+    row per PRIOR value (not just asserting the SQL string contains them)
+    after the widened constraint is installed and validated.
+    """
+
+    migration_0081 = importlib.import_module(
+        "dev_health_ops.alembic.versions.0081_widen_source_observation_source_class"
+    )
+    prior_source_classes = migration_0081._PRIOR_SOURCE_CLASSES
+
+    config = _migration_config()
+    command.upgrade(config, "0082")
+
+    with Session(isolated_postgres.engine) as session:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        run_id = _seed_run(session, org_id=org_id, user_id=user_id)
+        for index, source_class in enumerate(prior_source_classes):
+            session.add(
+                DevRunSourceObservation(
+                    id=uuid.uuid4(),
+                    run_id=run_id,
+                    org_id=org_id,
+                    user_id=user_id,
+                    ordinal=index,
+                    observation_id=uuid.uuid4(),
+                    source_class=source_class,
+                    requirement_level="mandatory",
+                    observed_state="available_current",
+                    data_semantics="measured_zero",
+                    usable_fact_count=1,
+                    sample_count=None,
+                    subject_coverage=1.0,
+                    payload={"schema_version": "dev_source_observation.v1"},
+                    observed_at=datetime.now(UTC),
+                )
+            )
+        session.commit()  # must not raise -- every prior value still valid
+
+    with isolated_postgres.engine.connect() as connection:
+        count = connection.execute(
+            sa.text(f"SELECT count(*) FROM {_TABLE} WHERE run_id = :run_id"),
+            {"run_id": run_id},
+        ).scalar_one()
+    assert count == len(prior_source_classes)
+
+
+def test_postgres_downgrade_refuses_when_new_source_classes_present(
+    isolated_postgres: PostgresMigrationHarness,
+) -> None:
+    """Codex HIGH finding 2, planted directly against real Postgres: a row
+    with source_class='health_profile' must block the downgrade to 0080
+    with the explicit refusal message, never a bare CHECK-violation
+    traceback and never a silent data-mutating rollback.
+    """
+
+    config = _migration_config()
+    command.upgrade(config, "0082")
+
+    with Session(isolated_postgres.engine) as session:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        run_id = _seed_run(session, org_id=org_id, user_id=user_id)
+        _insert_observation(
+            session,
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            source_class="health_profile",
+        )
+
+    with pytest.raises(Exception, match="refusing to downgrade 0081"):
+        command.downgrade(config, "0080")
+
+    with isolated_postgres.engine.connect() as connection:
+        version_after_refused_downgrade = connection.execute(
+            sa.text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+    # The refusal must abort BEFORE dropping/narrowing the constraint --
+    # the schema stays at 0082, not left half-migrated.
+    assert version_after_refused_downgrade == "0082"
+
+
+def test_postgres_downgrade_succeeds_when_no_new_source_classes_present(
+    isolated_postgres: PostgresMigrationHarness,
+) -> None:
+    config = _migration_config()
+    command.upgrade(config, "0082")
+
+    with Session(isolated_postgres.engine) as session:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        run_id = _seed_run(session, org_id=org_id, user_id=user_id)
+        _insert_observation(
+            session,
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            source_class="status_change",
+        )
+
+    command.downgrade(config, "0080")  # must not raise
+
+    with isolated_postgres.engine.connect() as connection:
+        version_after_downgrade = connection.execute(
+            sa.text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+    assert version_after_downgrade == "0080"
+
+    command.upgrade(config, "0082")  # re-upgrade must still succeed
+
+    with isolated_postgres.engine.connect() as connection:
+        version_after_reupgrade = connection.execute(
+            sa.text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+    assert version_after_reupgrade == "0082"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0080"}
+        assert set(heads) == {"0066", "0081"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0080"
+        assert script.get_revision("application_schema@head").revision == "0081"
         assert revisions
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0081"}
+        assert set(heads) == {"0066", "0082"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0081"
+        assert script.get_revision("application_schema@head").revision == "0082"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0080"}
-        assert scripts.get_revision("application_schema@head").revision == "0080"
-        assert _database_has_revision(cfg, ("0080",), "0065")
-        assert not _database_has_revision(cfg, ("0080",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0081"}
+        assert scripts.get_revision("application_schema@head").revision == "0081"
+        assert _database_has_revision(cfg, ("0081",), "0065")
+        assert not _database_has_revision(cfg, ("0081",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0081"}
-        assert scripts.get_revision("application_schema@head").revision == "0081"
-        assert _database_has_revision(cfg, ("0081",), "0065")
-        assert not _database_has_revision(cfg, ("0081",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0082"}
+        assert scripts.get_revision("application_schema@head").revision == "0082"
+        assert _database_has_revision(cfg, ("0082",), "0065")
+        assert not _database_has_revision(cfg, ("0082",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## Summary

CHAOS-3297 stack #3 (merged #1387) wired four intents (`health.project.v1`/`health.team.v1`/`balance.team_workload.v1`/`deficiency.operational.v1`) whose steps emit `SourceClass.HEALTH_PROFILE`/`SourceClass.DEFICIENCY_INVENTORY` -- but persistence was never updated to allow either. All four crashed live to a terminal error the instant a run's real result reached `DevPersistenceService.append_source_observation`, in **two separate places**:

1. `persistence/service.py`'s hand-maintained `_SOURCE_CLASSES` frozenset (Python-level check).
2. `dev_run_source_observations`' `ck_dev_run_source_observations_source_class` DB CHECK constraint (SQLAlchemy model + a live Postgres migration) -- this one fires first, an `IntegrityError` at INSERT, before the Python check even runs.

Both were only found by writing a genuinely production-shaped test that drives a real `PlanExecutor` run through the real `DevPersistenceService` write path -- every prior CHAOS-3297 s3 unit test stopped at fake service doubles and never reached persistence at all.

This is the third total-table to miss a `SourceClass` reconciliation (the CHAOS-3296/3297 relationship-matrix tables at #1374's merge were the first two).

## Fixes

- Added `health_profile`/`deficiency_inventory` to `_SOURCE_CLASSES` and to the model's `CheckConstraint` string.
- Migration 0081/0082 alters the live Postgres constraint, split per codex review (below) into a `NOT VALID` install + a separate `VALIDATE CONSTRAINT` step, mirroring this repo's own 0074/0075 precedent so the widen never holds an `ACCESS EXCLUSIVE` lock through a full-table scan. Bumped all five migration-head pin files to `"0082"`.
- `wave_3_1_plans._source_classes_missing_from_persistence_allowlist`: a pure function computing every `SourceClass` a registered plan's steps can emit that the allowlist doesn't contain, invoked at `wave_3_1_plans.py`'s own import time against both `CORE_PLANS_BY_INTENT` and `WAVE_3_1_PLANS_BY_INTENT` -- so the next `SourceClass` a plan adds fails at import, not live.
- A second set-compare test locks together all three hand-maintained copies of the `source_class` vocabulary (the Python allowlist, the model's `CheckConstraint` string, and migration 0081's DDL text), parsing the model's and migration's raw SQL rather than hand-transcribing the value list a second time.

## Codex full-branch review, round 2 -- four findings, all fixed

1. **HIGH**: the original migration validated the widened CHECK immediately under an `ACCESS EXCLUSIVE` lock (full-table scan on an actively written table). Split into 0081 (`NOT VALID` install) + 0082 (`VALIDATE CONSTRAINT`, `SHARE UPDATE EXCLUSIVE`, non-blocking).
2. **HIGH**: the downgrade recreated the narrower constraint blind -- unsafe once any row carries the new values. Fixed with an explicit preflight-and-refuse policy (raise if any `health_profile`/`deficiency_inventory` row exists), mirroring 0074's own downgrade posture.
3. **MED**: the production-shaped test's persistence helper flushed but never committed, so "didn't raise" proved nothing about actual persistence. Fixed: commits, calls the real `terminal()` transition, and a fresh session re-queries the committed rows, asserting exact observation classes/counts, the completed step partition, and terminal run state per intent.
4. **MED**: extended the set-compare test to lock all three definition sites together, with planted defects on each side.

## Test plan

- [x] RED-first for the original crash (both the Python allowlist AND the DB CHECK constraint reproduced independently) and for both codex-round-1 findings
- [x] A real-Postgres migration test suite (gated identically to `test_0066_celery_river_cutover_postgres.py`) proves against an actual Postgres instance: `pg_constraint.convalidated` is false after 0081 and true only after 0082; every previously-allowed value still inserts after the widen; the downgrade refuses cleanly (schema stays at 0082) with a new-class row present; downgrade+re-upgrade succeeds when none does -- executed for real against a local Postgres, not just collected
- [x] `tests/api/dev/` full suite: 1594 passed, 35 skipped, 1 xfailed, no failures
- [x] Contracts regenerated, no drift
- [x] ruff/mypy clean on every touched file, including all five migration-head pin files