### PR TITLE
feat(providers): port Jira incidents to native Go (CHAOS-3127)

### DIFF
--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -287,12 +287,16 @@ func buildProviderSyncHandler(
 						errWorkerDependencyUnavailable
 				}
 				jiraSink := providersync.JiraIncidentClickHouseEffects{
+					Writer: clickhouseConnection, Lease: session,
+					Entitlement: jiraIncidentEntitlement,
+				}
+				jiraReadback := providersync.JiraIncidentClickHouseReadback{
 					Conn: clickhouseConnection, Lease: session,
 				}
 				routeHandler = providersync.JiraIncidentRouteHandler{
 					Entitlement: jiraIncidentEntitlement,
 				}
-				sink, readback = jiraSink, jiraSink
+				sink, readback = jiraSink, jiraReadback
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -142,6 +142,7 @@ func buildProviderSyncHandler(
 	clickhouseConnection driver.Conn,
 	valkeyClient valkeygo.Client,
 	domainPool *pgxpool.Pool,
+	jiraIncidentEntitlement providersync.JiraIncidentEntitlement,
 	collector *jobruntime.MetricsCollector,
 	logger *slog.Logger,
 ) (*providerunit.Handler, *providerfoundation.Metrics) {
@@ -281,10 +282,16 @@ func buildProviderSyncHandler(
 				sink, readback = ghCommitStatsSink, ghCommitStatsSink
 			case session.Claim.Provider == "jira" &&
 				session.Claim.Dataset == "incidents":
+				if jiraIncidentEntitlement == nil {
+					return providersync.CompleteRouteExecutor{},
+						errWorkerDependencyUnavailable
+				}
 				jiraSink := providersync.JiraIncidentClickHouseEffects{
 					Conn: clickhouseConnection, Lease: session,
 				}
-				routeHandler = providersync.JiraIncidentRouteHandler{}
+				routeHandler = providersync.JiraIncidentRouteHandler{
+					Entitlement: jiraIncidentEntitlement,
+				}
 				sink, readback = jiraSink, jiraSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
@@ -430,7 +437,9 @@ func constructProviderSyncWorkerWithDependencies(
 	collector, _ := observer.(*jobruntime.MetricsCollector)
 	handler, providerMetrics := buildProviderSyncHandler(
 		repository, workerRouteSwitches(cfg), decryptor, clickhouseConnection,
-		valkeyClient, postgresDatabase.pools.Domain, collector, logger,
+		valkeyClient, postgresDatabase.pools.Domain,
+		providersync.PostgresJiraIncidentEntitlement{Pool: postgresDatabase.pools.Domain},
+		collector, logger,
 	)
 	adapter, err := jobruntime.NewAdapter[jobruntime.ProviderUnitArgs](
 		registry, spec, handler, jobruntime.Dependencies{

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -192,9 +192,10 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Eight route-ready pairs can reach this closure today:
+			// Nine route-ready pairs can reach this closure today:
 			// launchdarkly/feature-flags plus github/repo-metadata, cicd,
-			// commits, deployments, security, files, and commit-stats. Each
+			// commits, deployments, security, files, commit-stats, and
+			// jira/incidents. Each
 			// has its own CompleteRouteHandler and effect sink. session.Claim
 			// is already known here — providerunit.Handler.Work only calls
 			// BuildExecutor after its own descriptor gate passed for THIS
@@ -278,6 +279,13 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubCommitStatsRouteHandler{}
 				sink, readback = ghCommitStatsSink, ghCommitStatsSink
+			case session.Claim.Provider == "jira" &&
+				session.Claim.Dataset == "incidents":
+				jiraSink := providersync.JiraIncidentClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.JiraIncidentRouteHandler{}
+				sink, readback = jiraSink, jiraSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
@@ -295,7 +303,12 @@ func buildProviderSyncHandler(
 					},
 					Decryptor: decryptor,
 				},
-				Doer:  &http.Client{Timeout: 45 * time.Second},
+				Doer: &http.Client{
+					Timeout: 45 * time.Second,
+					CheckRedirect: func(*http.Request, []*http.Request) error {
+						return http.ErrUseLastResponse
+					},
+				},
 				Retry: providerfoundation.DefaultRetryPolicy(),
 				Budget: providerfoundation.ValkeyBudgetStore{
 					Client:   valkeyClient,
@@ -463,7 +476,7 @@ func providerSyncWorkerEnabled(cfg config.Config) bool {
 		cfg.WorkerGithubPRsEnabled || cfg.WorkerGithubCICDEnabled ||
 		cfg.WorkerGithubCommitsEnabled || cfg.WorkerGithubDeploymentsEnabled ||
 		cfg.WorkerGithubSecurityEnabled || cfg.WorkerGithubFilesEnabled ||
-		cfg.WorkerGithubCommitStatsEnabled
+		cfg.WorkerGithubCommitStatsEnabled || cfg.WorkerJiraIncidentsEnabled
 }
 
 func providerSyncRiverConfig(

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -435,6 +435,30 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testin
 	}
 }
 
+func TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(
+		nil, providersync.CompleteRouteSwitches{JiraIncidents: true},
+		nil, nil, nil, nil, nil, slog.Default(),
+	)
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("provider sync handler is not constructed")
+	}
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "jira", Dataset: "incidents",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := executor.Handler.(providersync.JiraIncidentRouteHandler); !ok {
+		t.Fatalf("executor handler=%T", executor.Handler)
+	}
+	if _, ok := executor.Committer.Sink.(providersync.JiraIncidentClickHouseEffects); !ok {
+		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+}
+
 func TestBuildProviderSyncHandlerConstructsGitHubCICDCapability(t *testing.T) {
 	handler, _ := buildProviderSyncHandler(
 		nil,
@@ -543,6 +567,7 @@ func TestProviderSyncWorkerEnabledForEveryRouteReadySwitch(t *testing.T) {
 		"github_security":      {WorkerGithubSecurityEnabled: true},
 		"github_files":         {WorkerGithubFilesEnabled: true},
 		"github_commit_stats":  {WorkerGithubCommitStatsEnabled: true},
+		"jira_incidents":       {WorkerJiraIncidentsEnabled: true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if !providerSyncWorkerEnabled(cfg) {

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -443,7 +443,8 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testin
 }
 
 func TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability(t *testing.T) {
-	entitlement := providerSyncEntitlementFunc(func(context.Context, string) error { return nil })
+	entitlementFunc := providerSyncEntitlementFunc(func(context.Context, string) error { return nil })
+	entitlement := &entitlementFunc
 	handler, _ := buildProviderSyncHandler(
 		nil, providersync.CompleteRouteSwitches{JiraIncidents: true},
 		nil, nil, nil, nil, entitlement, nil, slog.Default(),
@@ -459,11 +460,19 @@ func TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := executor.Handler.(providersync.JiraIncidentRouteHandler); !ok {
+	route, ok := executor.Handler.(providersync.JiraIncidentRouteHandler)
+	if !ok {
 		t.Fatalf("executor handler=%T", executor.Handler)
 	}
-	if _, ok := executor.Committer.Sink.(providersync.JiraIncidentClickHouseEffects); !ok {
+	sink, ok := executor.Committer.Sink.(providersync.JiraIncidentClickHouseEffects)
+	if !ok {
 		t.Fatalf("executor sink=%T", executor.Committer.Sink)
+	}
+	if route.Entitlement != entitlement || sink.Entitlement != entitlement {
+		t.Fatal("Jira route and writer do not share the constructed entitlement")
+	}
+	if _, ok := executor.Committer.Readback.(providersync.JiraIncidentClickHouseReadback); !ok {
+		t.Fatalf("executor readback=%T", executor.Committer.Readback)
 	}
 }
 

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"path/filepath"
 	"testing"
@@ -15,6 +16,12 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 )
+
+type providerSyncEntitlementFunc func(context.Context, string) error
+
+func (require providerSyncEntitlementFunc) Require(ctx context.Context, orgID string) error {
+	return require(ctx, orgID)
+}
 
 // TestBuildProviderSyncHandlerSharesOneMetricsInstance is CHAOS-3118
 // mutation-tested evidence for dev_health_provider_*, not a behavioral
@@ -50,7 +57,7 @@ func TestBuildProviderSyncHandlerSharesOneMetricsInstance(t *testing.T) {
 	// Postgres connection.
 	handler, providerMetrics := buildProviderSyncHandler(
 		nil, providersync.CompleteRouteSwitches{}, nil, nil, nil, nil,
-		collector, slog.Default(),
+		nil, collector, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("buildProviderSyncHandler returned an incomplete handler")
@@ -234,7 +241,7 @@ func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			handler, _ := buildProviderSyncHandler(
-				nil, want, nil, nil, nil, nil, nil, slog.Default(),
+				nil, want, nil, nil, nil, nil, nil, nil, slog.Default(),
 			)
 			if handler == nil {
 				t.Fatal("buildProviderSyncHandler returned no handler")
@@ -414,7 +421,7 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testin
 	handler, _ := buildProviderSyncHandler(
 		nil,
 		providersync.CompleteRouteSwitches{GithubCommitStats: true},
-		nil, nil, nil, nil, nil, slog.Default(),
+		nil, nil, nil, nil, nil, nil, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
@@ -436,9 +443,10 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testin
 }
 
 func TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability(t *testing.T) {
+	entitlement := providerSyncEntitlementFunc(func(context.Context, string) error { return nil })
 	handler, _ := buildProviderSyncHandler(
 		nil, providersync.CompleteRouteSwitches{JiraIncidents: true},
-		nil, nil, nil, nil, nil, slog.Default(),
+		nil, nil, nil, nil, entitlement, nil, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
@@ -459,11 +467,26 @@ func TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability(t *testing.T)
 	}
 }
 
+func TestBuildProviderSyncHandlerRejectsJiraIncidentsWithoutEntitlement(t *testing.T) {
+	handler, _ := buildProviderSyncHandler(
+		nil, providersync.CompleteRouteSwitches{JiraIncidents: true},
+		nil, nil, nil, nil, nil, nil, slog.Default(),
+	)
+	_, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "jira", Dataset: "incidents",
+		}},
+	})
+	if !errors.Is(err, errWorkerDependencyUnavailable) {
+		t.Fatalf("error=%v want dependency unavailable", err)
+	}
+}
+
 func TestBuildProviderSyncHandlerConstructsGitHubCICDCapability(t *testing.T) {
 	handler, _ := buildProviderSyncHandler(
 		nil,
 		providersync.CompleteRouteSwitches{GithubCICD: true},
-		nil, nil, nil, nil, nil, slog.Default(),
+		nil, nil, nil, nil, nil, nil, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
@@ -488,7 +511,7 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitsCapability(t *testing.T)
 	handler, _ := buildProviderSyncHandler(
 		nil,
 		providersync.CompleteRouteSwitches{GithubCommits: true},
-		nil, nil, nil, nil, nil, slog.Default(),
+		nil, nil, nil, nil, nil, nil, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
@@ -510,7 +533,7 @@ func TestBuildProviderSyncHandlerConstructsGitHubCommitsCapability(t *testing.T)
 }
 
 func TestBuildProviderSyncHandlerConstructsGitHubDeploymentsCapability(t *testing.T) {
-	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubDeployments: true}, nil, nil, nil, nil, nil, slog.Default())
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubDeployments: true}, nil, nil, nil, nil, nil, nil, slog.Default())
 	executor, err := handler.BuildExecutor(&providersync.LeaseSession{Claim: providersync.Claim{Unit: providersync.Unit{Provider: "github", Dataset: "deployments"}}})
 	if err != nil {
 		t.Fatal(err)
@@ -524,7 +547,7 @@ func TestBuildProviderSyncHandlerConstructsGitHubDeploymentsCapability(t *testin
 }
 
 func TestBuildProviderSyncHandlerConstructsGitHubSecurityCapability(t *testing.T) {
-	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubSecurity: true}, nil, nil, nil, nil, nil, slog.Default())
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubSecurity: true}, nil, nil, nil, nil, nil, nil, slog.Default())
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
 	}
@@ -541,7 +564,7 @@ func TestBuildProviderSyncHandlerConstructsGitHubSecurityCapability(t *testing.T
 }
 
 func TestBuildProviderSyncHandlerConstructsGitHubFilesCapability(t *testing.T) {
-	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubFiles: true}, nil, nil, nil, nil, nil, slog.Default())
+	handler, _ := buildProviderSyncHandler(nil, providersync.CompleteRouteSwitches{GithubFiles: true}, nil, nil, nil, nil, nil, nil, slog.Default())
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("provider sync handler is not constructed")
 	}

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -792,13 +792,13 @@
         "operational"
       ],
       "processor_flags": {},
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "incidents",
       "route_destinations": [
         "operational_incidents"
       ],
-      "route_ready": false,
+      "route_ready": true,
       "credential_modes": [
         "basic_api_token",
         "oauth_bearer_token",

--- a/internal/providerfoundation/clients.go
+++ b/internal/providerfoundation/clients.go
@@ -76,6 +76,7 @@ func NewJiraClient(credential Credential, doer HTTPDoer, retry RetryPolicy, leas
 		}
 		request.SetBasicAuth(email.Reveal(), token.Reveal())
 		request.Header.Set("Accept", "application/json")
+		request.Header.Set("Content-Type", "application/json")
 		return nil
 	}
 	return NewHTTPClient("jira", credentialBaseURL(credential, ""), doer, auth, retry, lease)

--- a/internal/providerfoundation/clients_test.go
+++ b/internal/providerfoundation/clients_test.go
@@ -41,6 +41,17 @@ func TestExplicitProviderClientsApplyTypedAuthentication(t *testing.T) {
 			want:       "gitlab-token",
 		},
 		{
+			name: "jira basic auth",
+			credential: testCredential("jira", map[string]string{
+				"email": "dev@acme.test", "api_token": "jira-token",
+				"base_url": "https://acme.atlassian.net",
+			}),
+			newClient: NewJiraClient,
+			path:      "/rest/api/3/search/jql",
+			header:    "Authorization",
+			want:      "Basic ZGV2QGFjbWUudGVzdDpqaXJhLXRva2Vu",
+		},
+		{
 			name:       "linear",
 			credential: testCredential("linear", map[string]string{"api_key": "linear-key"}),
 			newClient:  NewLinearClient,
@@ -98,6 +109,11 @@ func TestExplicitProviderClientsApplyTypedAuthentication(t *testing.T) {
 			}
 			if test.credential.Provider == "pagerduty" && doer.header.Get("Accept") != pagerDutyAccept {
 				t.Fatalf("PagerDuty Accept=%q", doer.header.Get("Accept"))
+			}
+			if test.credential.Provider == "jira" &&
+				(doer.header.Get("Accept") != "application/json" ||
+					doer.header.Get("Content-Type") != "application/json") {
+				t.Fatalf("Jira JSON headers=%v", doer.header)
 			}
 		})
 	}

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -75,6 +75,8 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //     tenant-qualified FINAL readback.
 //   - github/commit-stats: CHAOS-3033, live producer oracle parity plus
 //     tenant-scoped FINAL readback and production-worker construction.
+//   - jira/incidents: CHAOS-3127, native JSM admission plus live whole-row
+//     OperationalIncident parity and tenant-scoped FINAL readback.
 //
 // github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
 // real CompleteRouteHandler and passing fixture-level parity evidence: codex
@@ -97,6 +99,7 @@ var routeReadyPairs = map[string]struct{}{
 	"github/security":            {},
 	"github/files":               {},
 	"github/commit-stats":        {},
+	"jira/incidents":             {},
 }
 
 // TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
@@ -250,6 +253,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 		"github/security":            GitHubSecurityRouteHandler{},
 		"github/files":               GitHubFilesRouteHandler{},
 		"github/commit-stats":        GitHubCommitStatsRouteHandler{},
+		"jira/incidents":             JiraIncidentRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -40,6 +40,7 @@ var providerExecutorRegistry = map[string]ExecutorKind{
 	"github/security":            ExecutorNativeGo,
 	"github/files":               ExecutorNativeGo,
 	"github/commit-stats":        ExecutorNativeGo,
+	"jira/incidents":             ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -178,6 +179,8 @@ func (switches CompleteRouteSwitches) Descriptor(
 		// handler is not wired yet. Preserve the manifest while failing closed.
 	case provider == "jira" && dataset == "incidents":
 		descriptor.Destinations = []string{"operational_incidents"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.JiraIncidents
 	case provider == "launchdarkly" && dataset == "feature-flags":
 		descriptor.Destinations = launchDarklyRouteDestinations()
 		descriptor.RouteReady = true

--- a/internal/providersync/execution_registry_test.go
+++ b/internal/providersync/execution_registry_test.go
@@ -56,8 +56,8 @@ func TestCompleteRouteSwitchesCollapseWorkItemAliasesAndRemainIndependent(t *tes
 	jiraWorkItems, _ := switches.Descriptor("jira", "work-items")
 	jiraIncidents, _ := switches.Descriptor("jira", "incidents")
 	launchDarkly, _ := switches.Descriptor("launchdarkly", "feature-flags")
-	if jiraWorkItems.RouteEnabled || jiraIncidents.RouteEnabled ||
-		launchDarkly.RouteEnabled {
+	if jiraWorkItems.RouteEnabled || !jiraIncidents.RouteReady ||
+		!jiraIncidents.RouteEnabled || launchDarkly.RouteEnabled {
 		t.Fatalf(
 			"independent routes jira_work=%+v jira_incidents=%+v ld=%+v",
 			jiraWorkItems, jiraIncidents, launchDarkly,

--- a/internal/providersync/jira_incident_entitlement.go
+++ b/internal/providersync/jira_incident_entitlement.go
@@ -18,12 +18,11 @@ var ErrJiraIncidentEntitlementDisabled = errors.New(
 	"canonical Jira incident ingestion entitlement is disabled",
 )
 
-// JiraIncidentEntitlement is checked twice for one Jira incident occurrence:
-// before provider fetch and immediately after collection before the batch is
-// handed to persistence. This deliberately mirrors Python's
-// _require_jira_incident_entitlement calls on both sides of
-// JsmIncidentProducer.collect so a revoked entitlement cannot be bypassed by a
-// long-running fetch.
+// A fresh Jira incident write checks JiraIncidentEntitlement before provider
+// fetch and again at the ClickHouse write boundary. This deliberately mirrors
+// Python's _require_jira_incident_entitlement calls on both sides of
+// JsmIncidentProducer.collect while also covering Go effect-ledger work between
+// collection and persistence.
 type JiraIncidentEntitlement interface {
 	Require(context.Context, string) error
 }

--- a/internal/providersync/jira_incident_entitlement.go
+++ b/internal/providersync/jira_incident_entitlement.go
@@ -1,0 +1,224 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const jiraIncidentFeatureKey = "canonical_incident_ingestion"
+
+var ErrJiraIncidentEntitlementDisabled = errors.New(
+	"canonical Jira incident ingestion entitlement is disabled",
+)
+
+// JiraIncidentEntitlement is checked twice for one Jira incident occurrence:
+// before provider fetch and immediately after collection before the batch is
+// handed to persistence. This deliberately mirrors Python's
+// _require_jira_incident_entitlement calls on both sides of
+// JsmIncidentProducer.collect so a revoked entitlement cannot be bypassed by a
+// long-running fetch.
+type JiraIncidentEntitlement interface {
+	Require(context.Context, string) error
+}
+
+type PostgresJiraIncidentEntitlement struct {
+	Pool *pgxpool.Pool
+	Now  func() time.Time
+}
+
+type jiraIncidentFeatureState struct {
+	Registered      bool
+	GloballyEnabled bool
+	MinTier         string
+	OrgTier         string
+	OrgOverride     *jiraIncidentFeatureOverride
+	LicenseOverride *bool
+	EvaluatedAt     time.Time
+}
+
+type jiraIncidentFeatureOverride struct {
+	Enabled   bool
+	ExpiresAt *time.Time
+}
+
+type jiraIncidentFeatureDecision struct {
+	FeatureKey string          `json:"feature_key"`
+	Allowed    bool            `json:"allowed"`
+	Reason     string          `json:"reason"`
+	ExpiresAt  *time.Time      `json:"expires_at"`
+	Config     *map[string]any `json:"config"`
+}
+
+func (entitlement PostgresJiraIncidentEntitlement) Require(
+	ctx context.Context, orgID string,
+) error {
+	parsedOrgID, err := uuid.Parse(strings.TrimSpace(orgID))
+	if ctx == nil || err != nil || entitlement.Pool == nil {
+		return ErrJiraIncidentEntitlementDisabled
+	}
+	evaluatedAt := time.Now().UTC()
+	if entitlement.Now != nil {
+		evaluatedAt = entitlement.Now().UTC()
+	}
+	state, err := loadJiraIncidentFeatureState(
+		ctx, entitlement.Pool, parsedOrgID.String(), evaluatedAt,
+	)
+	if err != nil || !jiraIncidentFeatureAllowed(state) {
+		return ErrJiraIncidentEntitlementDisabled
+	}
+	return nil
+}
+
+type jiraIncidentFeatureQueryer interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func loadJiraIncidentFeatureState(
+	ctx context.Context, queryer jiraIncidentFeatureQueryer,
+	orgID string, evaluatedAt time.Time,
+) (jiraIncidentFeatureState, error) {
+	state := jiraIncidentFeatureState{
+		MinTier: "community", OrgTier: "community", EvaluatedAt: evaluatedAt.UTC(),
+	}
+	var overrideEnabled *bool
+	var overrideExpiresAt *time.Time
+	var licenseTier, orgTier *string
+	var encodedOverrides []byte
+	// Read the complete policy input in one PostgreSQL statement. This gives
+	// one MVCC snapshot without requiring UPDATE privilege solely to take row
+	// locks, preserving the domain worker's read-only licensing posture.
+	err := queryer.QueryRow(ctx, `
+SELECT feature.min_tier, feature.is_enabled,
+       org_override.is_enabled, org_override.expires_at,
+       license.tier, license.features_override, organization.tier
+FROM feature_flags AS feature
+LEFT JOIN org_feature_overrides AS org_override
+  ON org_override.org_id = $2::uuid AND org_override.feature_id = feature.id
+LEFT JOIN org_licenses AS license ON license.org_id = $2::uuid
+LEFT JOIN organizations AS organization ON organization.id = $2::uuid
+WHERE feature.key = $1`, jiraIncidentFeatureKey, orgID).Scan(
+		&state.MinTier, &state.GloballyEnabled,
+		&overrideEnabled, &overrideExpiresAt,
+		&licenseTier, &encodedOverrides, &orgTier,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return state, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	state.Registered = true
+	if overrideEnabled != nil {
+		state.OrgOverride = &jiraIncidentFeatureOverride{
+			Enabled: *overrideEnabled, ExpiresAt: overrideExpiresAt,
+		}
+	}
+	if licenseTier != nil {
+		state.OrgTier = *licenseTier
+		var overrides map[string]any
+		if len(encodedOverrides) != 0 && json.Unmarshal(encodedOverrides, &overrides) != nil {
+			return state, ErrJiraIncidentEntitlementDisabled
+		}
+		if raw, ok := overrides[jiraIncidentFeatureKey]; ok {
+			value := pythonJSONTruth(raw)
+			state.LicenseOverride = &value
+		}
+	} else if orgTier != nil {
+		state.OrgTier = *orgTier
+	}
+	return state, nil
+}
+
+func jiraIncidentFeatureAllowed(state jiraIncidentFeatureState) bool {
+	return decideJiraIncidentFeature(state).Allowed
+}
+
+func decideJiraIncidentFeature(state jiraIncidentFeatureState) jiraIncidentFeatureDecision {
+	closed := func(reason string) jiraIncidentFeatureDecision {
+		return jiraIncidentFeatureDecision{FeatureKey: jiraIncidentFeatureKey, Reason: reason}
+	}
+	minTier, minOK := jiraLicenseTierIndex(state.MinTier)
+	orgTier, orgOK := jiraLicenseTierIndex(state.OrgTier)
+	if !minOK {
+		return closed("invalid_feature_state")
+	}
+	if !state.Registered {
+		return closed("feature_not_registered")
+	}
+	if !state.GloballyEnabled {
+		return closed("global_disabled")
+	}
+	if !orgOK {
+		orgTier = 0
+	}
+	if state.OrgOverride != nil {
+		expired := state.OrgOverride.ExpiresAt != nil &&
+			!state.OrgOverride.ExpiresAt.After(state.EvaluatedAt)
+		if !expired {
+			if !state.OrgOverride.Enabled {
+				return closed("org_override_disabled")
+			}
+			return jiraIncidentFeatureDecision{
+				FeatureKey: jiraIncidentFeatureKey, Allowed: true,
+				Reason: "enabled_by_org_override", ExpiresAt: state.OrgOverride.ExpiresAt,
+			}
+		}
+	}
+	if state.LicenseOverride != nil {
+		if !*state.LicenseOverride {
+			return closed("license_override_disabled")
+		}
+		return jiraIncidentFeatureDecision{
+			FeatureKey: jiraIncidentFeatureKey, Allowed: true,
+			Reason: "enabled_by_license_override",
+		}
+	}
+	if orgTier >= minTier {
+		return jiraIncidentFeatureDecision{
+			FeatureKey: jiraIncidentFeatureKey, Allowed: true,
+			Reason: "enabled_by_tier",
+		}
+	}
+	return closed("tier_required")
+}
+
+func jiraLicenseTierIndex(value string) (int, bool) {
+	switch value {
+	case "community":
+		return 0, true
+	case "team":
+		return 1, true
+	case "enterprise":
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func pythonJSONTruth(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return typed
+	case string:
+		return typed != ""
+	case float64:
+		return typed != 0
+	case []any:
+		return len(typed) != 0
+	case map[string]any:
+		return len(typed) != 0
+	default:
+		return false
+	}
+}
+
+var _ JiraIncidentEntitlement = PostgresJiraIncidentEntitlement{}

--- a/internal/providersync/jira_incident_entitlement_integration_test.go
+++ b/internal/providersync/jira_incident_entitlement_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresJiraIncidentEntitlementHonorsRevocation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	for _, statement := range []string{
+		`CREATE TABLE organizations (id uuid PRIMARY KEY, tier text NOT NULL)`,
+		`CREATE TABLE feature_flags (
+  id uuid PRIMARY KEY, key text UNIQUE NOT NULL, min_tier text NOT NULL,
+  is_enabled boolean NOT NULL)`,
+		`CREATE TABLE org_feature_overrides (
+  org_id uuid NOT NULL, feature_id uuid NOT NULL, is_enabled boolean NOT NULL,
+  expires_at timestamptz, PRIMARY KEY (org_id, feature_id))`,
+		`CREATE TABLE org_licenses (
+  org_id uuid PRIMARY KEY, tier text NOT NULL, features_override json)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orgID, featureID := uuid.NewString(), uuid.NewString()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, tier) VALUES ($1, 'community')`, orgID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO feature_flags (id, key, min_tier, is_enabled)
+VALUES ($1, 'canonical_incident_ingestion', 'community', true)`, featureID); err != nil {
+		t.Fatal(err)
+	}
+	entitlement := PostgresJiraIncidentEntitlement{
+		Pool: pool,
+		Now: func() time.Time {
+			return time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+		},
+	}
+	if err := entitlement.Require(ctx, orgID); err != nil {
+		t.Fatalf("tier grant: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO org_feature_overrides (org_id, feature_id, is_enabled)
+VALUES ($1, $2, false)`, orgID, featureID); err != nil {
+		t.Fatal(err)
+	}
+	if err := entitlement.Require(ctx, orgID); !errors.Is(err, ErrJiraIncidentEntitlementDisabled) {
+		t.Fatalf("revoked grant error=%v", err)
+	}
+}

--- a/internal/providersync/jira_incident_entitlement_oracle_test.go
+++ b/internal/providersync/jira_incident_entitlement_oracle_test.go
@@ -1,0 +1,78 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+)
+
+func buildJiraIncidentEntitlementDecisionForOracle(
+	t *testing.T, input map[string]any,
+) jiraIncidentFeatureDecision {
+	t.Helper()
+	state := jiraIncidentFeatureState{
+		Registered:      input["registered"].(bool),
+		GloballyEnabled: input["globally_enabled"].(bool),
+		MinTier:         input["min_tier"].(string), OrgTier: input["org_tier"].(string),
+		EvaluatedAt: time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	}
+	if raw := input["org_override"]; raw != nil {
+		value := raw.(map[string]any)
+		state.OrgOverride = &jiraIncidentFeatureOverride{Enabled: value["enabled"].(bool)}
+		if encoded, ok := value["expires_at"].(string); ok && encoded != "" {
+			parsed, err := time.Parse(time.RFC3339Nano, encoded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state.OrgOverride.ExpiresAt = &parsed
+		}
+	}
+	if raw := input["license_override"]; raw != nil {
+		value := raw.(bool)
+		state.LicenseOverride = &value
+	}
+	return decideJiraIncidentFeature(state)
+}
+
+func jiraIncidentEntitlementOracleCases() []oracleCase {
+	base := func() map[string]any {
+		return map[string]any{
+			"registered": true, "globally_enabled": true,
+			"min_tier": "community", "org_tier": "community",
+			"org_override": nil, "license_override": nil,
+		}
+	}
+	with := func(values map[string]any) map[string]any {
+		result := base()
+		for key, value := range values {
+			result[key] = value
+		}
+		return result
+	}
+	return []oracleCase{
+		{ID: "tier_enabled", Input: base()},
+		{ID: "tier_denied", Input: with(map[string]any{"min_tier": "enterprise", "org_tier": "team"})},
+		{ID: "global_kill_switch", Input: with(map[string]any{"globally_enabled": false})},
+		{ID: "missing_feature", Input: with(map[string]any{"registered": false})},
+		{ID: "invalid_min_tier", Input: with(map[string]any{"min_tier": "invalid"})},
+		{ID: "org_override_enabled", Input: with(map[string]any{
+			"min_tier": "enterprise", "org_override": map[string]any{"enabled": true, "expires_at": nil},
+		})},
+		{ID: "org_override_disabled", Input: with(map[string]any{
+			"org_override": map[string]any{"enabled": false, "expires_at": nil},
+		})},
+		{ID: "expired_override_falls_back", Input: with(map[string]any{
+			"org_override": map[string]any{"enabled": false, "expires_at": "2026-07-23T12:00:00Z"},
+		})},
+		{ID: "license_enabled", Input: with(map[string]any{
+			"min_tier": "enterprise", "license_override": true,
+		})},
+		{ID: "license_disabled", Input: with(map[string]any{"license_override": false})},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForJiraIncidentEntitlement(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "jira/incidents/entitlement", jiraIncidentEntitlementOracleCases(),
+		buildJiraIncidentEntitlementDecisionForOracle, nil,
+	)
+}

--- a/internal/providersync/jira_incidents_effects_clickhouse.go
+++ b/internal/providersync/jira_incidents_effects_clickhouse.go
@@ -1,0 +1,213 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/big"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const jiraIncidentColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,source_revision,source_conflict_key,ingest_revision,ordering_contract,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,service_external_id,escalation_policy_id,title,description,started_at,resolved_at,is_deleted,deleted_at"
+
+type JiraIncidentClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink JiraIncidentClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[jiraIncidentRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validateJiraIncidentScope(claim, rows); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incidents ("+jiraIncidentColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(jiraIncidentValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink JiraIncidentClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[jiraIncidentRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validateJiraIncidentScope(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectIncident(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink JiraIncidentClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "jira" || claim.Dataset != "incidents" ||
+		effect.Destination != "operational_incidents" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validateJiraIncidentScope(claim Claim, rows []jiraIncidentRow) error {
+	for _, row := range rows {
+		if row.OrgID != claim.OrgID || row.Provider != "jira" ||
+			row.ProviderInstanceID == "" || row.SourceEntityType != "jsm_incident" ||
+			row.ExternalID == "" || row.ID == "" || row.SourceRevision == nil ||
+			row.IngestRevision == nil || row.SourceConflictKey == "" ||
+			row.OrderingContract != 2 || row.SourceVersionAt.IsZero() ||
+			row.ObservedAt.IsZero() || row.LastSynced.IsZero() || row.Title == "" {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillJiraIncidentOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func jiraIncidentValues(row jiraIncidentRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceRevision, row.SourceConflictKey,
+		row.IngestRevision, row.OrderingContract, row.ID, row.SourceID,
+		row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt,
+		row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority,
+		row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority,
+		row.RelationshipProvenance, row.RelationshipConfidence, row.ServiceID,
+		row.ServiceExternalID, row.EscalationPolicyID, row.Title, row.Description,
+		row.StartedAt, row.ResolvedAt, row.IsDeleted, row.DeletedAt,
+	}
+}
+
+func (sink JiraIncidentClickHouseEffects) inspectIncident(
+	ctx context.Context, expected jiraIncidentRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+jiraIncidentColumns+" FROM operational_incidents FINAL WHERE org_id = ? AND id = ? LIMIT 1",
+		expected.OrgID, expected.ID,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual jiraIncidentRow
+	found := false
+	for rows.Next() {
+		var sourceRevision, ingestRevision big.Int
+		values := jiraIncidentScanValues(&actual, &sourceRevision, &ingestRevision)
+		if err := rows.Scan(values...); err != nil {
+			return EffectConflict, err
+		}
+		actual.SourceRevision = new(big.Int).Set(&sourceRevision)
+		actual.IngestRevision = new(big.Int).Set(&ingestRevision)
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareJiraIncidentVersion(expected, actual, found), nil
+}
+
+func jiraIncidentScanValues(row *jiraIncidentRow, sourceRevision, ingestRevision *big.Int) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, sourceRevision, &row.SourceConflictKey,
+		ingestRevision, &row.OrderingContract, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.ServiceID, &row.ServiceExternalID,
+		&row.EscalationPolicyID, &row.Title, &row.Description, &row.StartedAt,
+		&row.ResolvedAt, &row.IsDeleted, &row.DeletedAt,
+	}
+}
+
+func compareJiraIncidentVersion(
+	expected, actual jiraIncidentRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = JiraIncidentClickHouseEffects{}
+var _ EffectReadback = JiraIncidentClickHouseEffects{}

--- a/internal/providersync/jira_incidents_effects_clickhouse.go
+++ b/internal/providersync/jira_incidents_effects_clickhouse.go
@@ -13,8 +13,23 @@ import (
 const jiraIncidentColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,source_revision,source_conflict_key,ingest_revision,ordering_contract,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,service_external_id,escalation_policy_id,title,description,started_at,resolved_at,is_deleted,deleted_at"
 
 type JiraIncidentClickHouseEffects struct {
+	Writer      jiraIncidentBatchPreparer
+	Lease       providerfoundation.LeaseGuard
+	Entitlement JiraIncidentEntitlement
+}
+
+// JiraIncidentClickHouseReadback deliberately has no entitlement dependency.
+// Recovery must remain able to classify a write that was authorized when it
+// began even if the organization entitlement is revoked before a retry.
+type JiraIncidentClickHouseReadback struct {
 	Conn  driver.Conn
 	Lease providerfoundation.LeaseGuard
+}
+
+type jiraIncidentBatchPreparer interface {
+	PrepareBatch(
+		context.Context, string, ...driver.PrepareBatchOption,
+	) (driver.Batch, error)
 }
 
 func (sink JiraIncidentClickHouseEffects) WriteEffect(
@@ -30,13 +45,16 @@ func (sink JiraIncidentClickHouseEffects) WriteEffect(
 	if err := validateJiraIncidentScope(claim, rows); err != nil {
 		return err
 	}
+	// Preserve Python's second entitlement check at the actual persistence
+	// boundary. Provider collection and effect-ledger preparation can take long
+	// enough for an earlier grant to be revoked.
+	if err := sink.Entitlement.Require(ctx, claim.OrgID); err != nil {
+		return err
+	}
 	if len(rows) == 0 {
 		return nil
 	}
-	if sink.Conn == nil {
-		return ErrInvalidConfiguration
-	}
-	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incidents ("+jiraIncidentColumns+")")
+	batch, err := sink.Writer.PrepareBatch(ctx, "INSERT INTO operational_incidents ("+jiraIncidentColumns+")")
 	if err != nil {
 		return err
 	}
@@ -52,10 +70,10 @@ func (sink JiraIncidentClickHouseEffects) WriteEffect(
 	return batch.Send()
 }
 
-func (sink JiraIncidentClickHouseEffects) InspectEffect(
+func (readback JiraIncidentClickHouseReadback) InspectEffect(
 	ctx context.Context, claim Claim, effect EffectBatch,
 ) (EffectInspection, error) {
-	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+	if err := readback.validateRequest(ctx, claim, effect); err != nil {
 		return EffectConflict, err
 	}
 	expected, err := decodeEffectRows[jiraIncidentRow](effect)
@@ -68,12 +86,12 @@ func (sink JiraIncidentClickHouseEffects) InspectEffect(
 	if len(expected) == 0 {
 		return EffectAbsent, nil
 	}
-	if sink.Conn == nil {
+	if readback.Conn == nil {
 		return EffectConflict, ErrInvalidConfiguration
 	}
 	exact, absent := 0, 0
 	for _, row := range expected {
-		inspection, err := sink.inspectIncident(ctx, row)
+		inspection, err := readback.inspectIncident(ctx, row)
 		if err != nil {
 			return EffectConflict, err
 		}
@@ -100,10 +118,22 @@ func (sink JiraIncidentClickHouseEffects) validateRequest(
 ) error {
 	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
 		claim.Provider != "jira" || claim.Dataset != "incidents" ||
-		effect.Destination != "operational_incidents" {
+		effect.Destination != "operational_incidents" || sink.Writer == nil ||
+		sink.Entitlement == nil {
 		return ErrInvalidConfiguration
 	}
 	return sink.Lease.Assert(ctx)
+}
+
+func (readback JiraIncidentClickHouseReadback) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || readback.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "jira" || claim.Dataset != "incidents" ||
+		effect.Destination != "operational_incidents" {
+		return ErrInvalidConfiguration
+	}
+	return readback.Lease.Assert(ctx)
 }
 
 func validateJiraIncidentScope(claim Claim, rows []jiraIncidentRow) error {
@@ -145,10 +175,10 @@ func jiraIncidentValues(row jiraIncidentRow) []any {
 	}
 }
 
-func (sink JiraIncidentClickHouseEffects) inspectIncident(
+func (readback JiraIncidentClickHouseReadback) inspectIncident(
 	ctx context.Context, expected jiraIncidentRow,
 ) (EffectInspection, error) {
-	rows, err := sink.Conn.Query(
+	rows, err := readback.Conn.Query(
 		ctx, "SELECT "+jiraIncidentColumns+" FROM operational_incidents FINAL WHERE org_id = ? AND id = ? LIMIT 1",
 		expected.OrgID, expected.ID,
 	)
@@ -210,4 +240,4 @@ func compareJiraIncidentVersion(
 }
 
 var _ EffectSink = JiraIncidentClickHouseEffects{}
-var _ EffectReadback = JiraIncidentClickHouseEffects{}
+var _ EffectReadback = JiraIncidentClickHouseReadback{}

--- a/internal/providersync/jira_incidents_effects_integration_test.go
+++ b/internal/providersync/jira_incidents_effects_integration_test.go
@@ -31,7 +31,14 @@ CREATE TABLE operational_incidents (
 ) ENGINE = ReplacingMergeTree(source_revision) ORDER BY (org_id, id)`
 
 func TestJiraIncidentReadbackIsExactAndTenantScoped(t *testing.T) {
-	ctx, sink := newJiraIncidentIntegrationSink(t)
+	ctx, sink, readback := newJiraIncidentIntegrationSink(t)
+	revoked := false
+	sink.Entitlement = jiraIncidentEntitlementFunc(func(context.Context, string) error {
+		if revoked {
+			return ErrJiraIncidentEntitlementDisabled
+		}
+		return nil
+	})
 	claim := nativeTestClaim("jira", "incidents")
 	claim.SourceExternalID = "JSM"
 	row := jiraIncidentReadbackFixture(t)
@@ -46,20 +53,23 @@ func TestJiraIncidentReadbackIsExactAndTenantScoped(t *testing.T) {
 	if err := sink.WriteEffect(ctx, otherClaim, jiraIncidentEffect(t, otherRow)); err != nil {
 		t.Fatal(err)
 	}
-	inspection, err := sink.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
+	inspection, err := readback.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
 	if err != nil || inspection != EffectAbsent {
 		t.Fatalf("foreign-only inspection=%s error=%v", inspection, err)
 	}
 	if err := sink.WriteEffect(ctx, claim, jiraIncidentEffect(t, row)); err != nil {
 		t.Fatal(err)
 	}
-	inspection, err = sink.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
+	revoked = true
+	inspection, err = readback.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
 	if err != nil || inspection != EffectExact {
 		t.Fatalf("inspection=%s error=%v", inspection, err)
 	}
 }
 
-func newJiraIncidentIntegrationSink(t *testing.T) (context.Context, JiraIncidentClickHouseEffects) {
+func newJiraIncidentIntegrationSink(
+	t *testing.T,
+) (context.Context, JiraIncidentClickHouseEffects, JiraIncidentClickHouseReadback) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -82,10 +92,10 @@ func newJiraIncidentIntegrationSink(t *testing.T) (context.Context, JiraIncident
 	if err := conn.Exec(ctx, jiraIncidentsDDL); err != nil {
 		t.Fatal(err)
 	}
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
 	return ctx, JiraIncidentClickHouseEffects{
-		Conn:  conn,
-		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
-	}
+		Writer: conn, Lease: lease, Entitlement: allowJiraIncidentEntitlement,
+	}, JiraIncidentClickHouseReadback{Conn: conn, Lease: lease}
 }
 
 func jiraIncidentEffect(t *testing.T, row jiraIncidentRow) EffectBatch {

--- a/internal/providersync/jira_incidents_effects_integration_test.go
+++ b/internal/providersync/jira_incidents_effects_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const jiraIncidentsDDL = `
+CREATE TABLE operational_incidents (
+  org_id String, provider LowCardinality(String), provider_instance_id String,
+  source_entity_type String, external_id String, source_version_at DateTime64(6, 'UTC'),
+  source_revision UInt128, source_conflict_key String, ingest_revision UInt128,
+  ordering_contract UInt8, id String, source_id Nullable(UUID), source_url Nullable(String),
+  source_event_at Nullable(DateTime64(6, 'UTC')), source_event_id Nullable(String),
+  observed_at DateTime64(6, 'UTC'), last_synced DateTime64(6, 'UTC'),
+  raw_status Nullable(String), raw_severity Nullable(String), raw_priority Nullable(String),
+  normalized_status Nullable(String), normalized_severity Nullable(String),
+  normalized_priority Nullable(String), relationship_provenance Nullable(String),
+  relationship_confidence Nullable(Float64), service_id Nullable(String),
+  service_external_id Nullable(String), escalation_policy_id Nullable(String), title String,
+  description Nullable(String), started_at Nullable(DateTime64(6, 'UTC')),
+  resolved_at Nullable(DateTime64(6, 'UTC')), is_deleted Bool,
+  deleted_at Nullable(DateTime64(6, 'UTC'))
+) ENGINE = ReplacingMergeTree(source_revision) ORDER BY (org_id, id)`
+
+func TestJiraIncidentReadbackIsExactAndTenantScoped(t *testing.T) {
+	ctx, sink := newJiraIncidentIntegrationSink(t)
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	row := jiraIncidentReadbackFixture(t)
+	otherClaim, otherRow := claim, row
+	otherClaim.OrgID, otherRow.OrgID = "other-org", "other-org"
+	otherRow.ID, otherRow.SourceConflictKey = "", ""
+	otherRow.SourceRevision, otherRow.IngestRevision = nil, nil
+	otherRow.OrderingContract = 0
+	if err := fillJiraIncidentOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, jiraIncidentEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, jiraIncidentEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, jiraIncidentEffect(t, row))
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("inspection=%s error=%v", inspection, err)
+	}
+}
+
+func newJiraIncidentIntegrationSink(t *testing.T) (context.Context, JiraIncidentClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, jiraIncidentsDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, JiraIncidentClickHouseEffects{
+		Conn:  conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+}
+
+func jiraIncidentEffect(t *testing.T, row jiraIncidentRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(
+		"operational_incidents", EffectReadbackRequired, []jiraIncidentRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/jira_incidents_generic_oracle_test.go
+++ b/internal/providersync/jira_incidents_generic_oracle_test.go
@@ -1,0 +1,58 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var oracleJiraIncidentObservedAt = time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+
+func buildJiraIncidentRowForOracle(t *testing.T, input map[string]any) jiraIncidentRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["raw_issue"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var issue jiraIncidentPayload
+	if err := decoder.Decode(&issue); err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizeJiraIncident(
+		nativeTestClaim("jira", "incidents"), input["cloud_id"].(string),
+		input["base_url"].(string), issue, oracleJiraIncidentObservedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oracleJiraIncidentCases() []oracleCase {
+	return []oracleCase{
+		{ID: "active_with_priority", Input: map[string]any{
+			"cloud_id": "cloud-123", "base_url": "https://acme.atlassian.net",
+			"raw_issue": map[string]any{"id": "10001", "key": "JSM-1", "fields": map[string]any{
+				"summary": "API down", "created": "2026-07-22T10:00:00Z", "updated": "2026-07-22T10:05:00Z", "resolutiondate": nil,
+				"status":   map[string]any{"name": "Investigating", "statusCategory": map[string]any{"key": "indeterminate"}},
+				"priority": map[string]any{"name": "Highest"},
+			}},
+		}},
+		{ID: "resolved_without_priority", Input: map[string]any{
+			"cloud_id": "CLOUD-XYZ", "base_url": "https://team.atlassian.net/",
+			"raw_issue": map[string]any{"id": "10002", "key": "OPS-9", "fields": map[string]any{
+				"summary": "Recovered", "created": "2026-07-22T11:00:00.123456Z", "updated": "2026-07-22T11:05:00.654321Z", "resolutiondate": "2026-07-22T11:04:00Z",
+				"status": map[string]any{"name": "Done", "statusCategory": map[string]any{"key": "done"}}, "priority": nil,
+			}},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForJiraIncidentRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "jira/incidents/row", oracleJiraIncidentCases(), buildJiraIncidentRowForOracle, nil,
+	)
+}

--- a/internal/providersync/jira_incidents_readback_test.go
+++ b/internal/providersync/jira_incidents_readback_test.go
@@ -1,0 +1,78 @@
+package providersync
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+func jiraIncidentReadbackFixture(t *testing.T) jiraIncidentRow {
+	t.Helper()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	var issue jiraIncidentPayload
+	issue.ID, issue.Key = "10001", "JSM-1"
+	issue.Fields.Summary = "API down"
+	issue.Fields.Created = "2026-07-22T10:00:00Z"
+	issue.Fields.Updated = "2026-07-22T10:05:00Z"
+	issue.Fields.Status.Name = "Investigating"
+	issue.Fields.Status.StatusCategory.Key = "indeterminate"
+	row, err := normalizeJiraIncident(
+		claim, "cloud-123", "https://acme.atlassian.net", issue,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func TestJiraIncidentReadbackClassifiesVersionAndContent(t *testing.T) {
+	t.Parallel()
+	expected := jiraIncidentReadbackFixture(t)
+	older := expected
+	older.SourceRevision = new(big.Int).Sub(expected.SourceRevision, big.NewInt(1))
+	newer := expected
+	newer.SourceRevision = new(big.Int).Add(expected.SourceRevision, big.NewInt(1))
+	different := expected
+	different.Title = "Different incident"
+
+	for name, test := range map[string]struct {
+		actual jiraIncidentRow
+		found  bool
+		want   EffectInspection
+	}{
+		"missing":            {jiraIncidentRow{}, false, EffectAbsent},
+		"older":              {older, true, EffectAbsent},
+		"newer":              {newer, true, EffectConflict},
+		"same revision diff": {different, true, EffectConflict},
+		"exact":              {expected, true, EffectExact},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := compareJiraIncidentVersion(expected, test.actual, test.found); got != test.want {
+				t.Fatalf("inspection=%s want=%s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestJiraIncidentScopeRejectsCrossTenantRows(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	row := jiraIncidentReadbackFixture(t)
+	if err := validateJiraIncidentScope(claim, []jiraIncidentRow{row}); err != nil {
+		t.Fatal(err)
+	}
+	row.OrgID = "other-org"
+	row.ID, row.SourceConflictKey = "", ""
+	row.SourceRevision, row.IngestRevision = nil, nil
+	row.OrderingContract = 0
+	if err := fillJiraIncidentOrdering(&row); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateJiraIncidentScope(claim, []jiraIncidentRow{row}); err == nil {
+		t.Fatal("cross-tenant Jira incident row was accepted")
+	}
+}

--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -88,9 +88,10 @@ type jiraIncidentRow struct {
 }
 
 type JiraIncidentRouteHandler struct {
-	MaxPages int
-	MaxRows  int
-	PerPage  int
+	Entitlement JiraIncidentEntitlement
+	MaxPages    int
+	MaxRows     int
+	PerPage     int
 }
 
 func (handler JiraIncidentRouteHandler) limits() (int, int, int, error) {
@@ -121,8 +122,12 @@ func (handler JiraIncidentRouteHandler) Collect(
 	if ctx == nil || claim.Validate() != nil || claim.Provider != "jira" ||
 		claim.Dataset != "incidents" || client == nil || client.Provider != "jira" ||
 		client.BaseURL == nil || normalizedAt.IsZero() || claim.SinceAt == nil ||
-		claim.BeforeAt == nil || !claim.SinceAt.Before(*claim.BeforeAt) {
+		claim.BeforeAt == nil || !claim.SinceAt.Before(*claim.BeforeAt) ||
+		handler.Entitlement == nil {
 		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if err := handler.Entitlement.Require(ctx, claim.OrgID); err != nil {
+		return CompleteRouteBatch{}, err
 	}
 	maxPages, maxRows, perPage, err := handler.limits()
 	if err != nil {
@@ -188,6 +193,13 @@ func (handler JiraIncidentRouteHandler) Collect(
 	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, rows)
 	if err != nil {
 		return CompleteRouteBatch{}, err
+	}
+	// Mirror Python's second check after provider collection and immediately
+	// before handing the batch to the persistence pipeline. A grant may be
+	// revoked while Jira pagination is in flight.
+	writeAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)
+	if writeAuthorizationErr != nil {
+		return CompleteRouteBatch{}, writeAuthorizationErr
 	}
 	watermark := claim.BeforeAt.UTC()
 	return CompleteRouteBatch{

--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -194,13 +194,6 @@ func (handler JiraIncidentRouteHandler) Collect(
 	if err != nil {
 		return CompleteRouteBatch{}, err
 	}
-	// Mirror Python's second check after provider collection and immediately
-	// before handing the batch to the persistence pipeline. A grant may be
-	// revoked while Jira pagination is in flight.
-	writeAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)
-	if writeAuthorizationErr != nil {
-		return CompleteRouteBatch{}, writeAuthorizationErr
-	}
 	watermark := claim.BeforeAt.UTC()
 	return CompleteRouteBatch{
 		Effects:   []EffectBatch{effect},

--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -1,0 +1,621 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	jiraIncidentAPIOrigin = "https://api.atlassian.com"
+	jiraIncidentMaxPages  = 1_000
+	jiraIncidentMaxRows   = 100_000
+	jiraIncidentPerPage   = 100
+)
+
+type jiraIncidentPayload struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Summary        string  `json:"summary"`
+		Created        string  `json:"created"`
+		Updated        string  `json:"updated"`
+		ResolutionDate *string `json:"resolutiondate"`
+		Status         struct {
+			Name           string `json:"name"`
+			StatusCategory struct {
+				Key string `json:"key"`
+			} `json:"statusCategory"`
+		} `json:"status"`
+		Priority *struct {
+			Name string `json:"name"`
+		} `json:"priority"`
+	} `json:"fields"`
+}
+
+// jiraIncidentRow mirrors every dataclass field on Python's
+// OperationalIncident. The generic oracle reflects the live dataclass and
+// compares the entire row, including the UInt128 ordering values.
+type jiraIncidentRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *string    `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              *string    `json:"service_id"`
+	ServiceExternalID      *string    `json:"service_external_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	StartedAt              *time.Time `json:"started_at"`
+	ResolvedAt             *time.Time `json:"resolved_at"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+type JiraIncidentRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+func (handler JiraIncidentRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = jiraIncidentMaxPages
+	}
+	if rows == 0 {
+		rows = jiraIncidentMaxRows
+	}
+	if perPage == 0 {
+		perPage = jiraIncidentPerPage
+	}
+	if pages < 1 || pages > jiraIncidentMaxPages || rows < 1 ||
+		rows > jiraIncidentMaxRows || perPage < 1 || perPage > jiraIncidentPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler JiraIncidentRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "jira" ||
+		claim.Dataset != "incidents" || client == nil || client.Provider != "jira" ||
+		client.BaseURL == nil || normalizedAt.IsZero() || claim.SinceAt == nil ||
+		claim.BeforeAt == nil || !claim.SinceAt.Before(*claim.BeforeAt) {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	baseURL, err := trustedJiraCloudOrigin(client.BaseURL.String())
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	projectKey := strings.TrimSpace(claim.SourceExternalID)
+	if projectKey == "" || strings.ContainsAny(projectKey, ",()\"\r\n") {
+		return CompleteRouteBatch{}, providerfoundation.ErrInvalidScope
+	}
+
+	var tenant struct {
+		CloudID string `json:"cloudId"`
+	}
+	if err := jiraIncidentFetchObject(ctx, client, http.MethodGet, "/_edge/tenant_info", nil, &tenant); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	cloudID := strings.TrimSpace(tenant.CloudID)
+	if cloudID == "" {
+		return CompleteRouteBatch{}, providerfoundation.ErrInvalidScope
+	}
+	if configured := strings.TrimSpace(credential.Config["cloud_id"]); configured != "" && configured != cloudID {
+		return CompleteRouteBatch{}, providerfoundation.ErrInvalidScope
+	}
+
+	servicePages, serviceRequests, err := verifyJiraServiceProject(
+		ctx, client, projectKey, maxPages, maxRows, perPage,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	issues, searchPages, err := collectJiraIncidentIssues(
+		ctx, client, projectKey, *claim.SinceAt, *claim.BeforeAt,
+		maxPages, maxRows, perPage,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	admissionClient, err := jiraIncidentAdmissionClient(client, claim)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	rows := make([]jiraIncidentRow, 0, len(issues))
+	admissionRequests := 0
+	for _, issue := range issues {
+		admitted, err := admitJiraIncident(ctx, admissionClient, cloudID, issue.ID)
+		admissionRequests++
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		if !admitted {
+			continue
+		}
+		row, err := normalizeJiraIncident(claim, cloudID, baseURL, issue, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	watermark := claim.BeforeAt.UTC()
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{"incidents_synced": len(rows), "project_key": projectKey},
+		Watermark: &watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: 1 + serviceRequests + searchPages + admissionRequests,
+			Pages:    servicePages + searchPages, Records: len(rows),
+		},
+	}, nil
+}
+
+func trustedJiraCloudOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" ||
+		!strings.HasSuffix(strings.ToLower(parsed.Hostname()), ".atlassian.net") ||
+		parsed.User != nil || parsed.Port() != "" ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", providerfoundation.ErrInvalidScope
+	}
+	return "https://" + strings.ToLower(parsed.Hostname()), nil
+}
+
+func verifyJiraServiceProject(
+	ctx context.Context, client *providerfoundation.HTTPClient, projectKey string,
+	maxPages, maxRows, perPage int,
+) (int, int, error) {
+	start, pages, rowsSeen := 0, 0, 0
+	found := false
+	for {
+		if pages >= maxPages {
+			return pages, pages, ErrPaginationCapExceeded
+		}
+		var page struct {
+			Values     json.RawMessage `json:"values"`
+			IsLastPage *bool           `json:"isLastPage"`
+		}
+		path := "/rest/servicedeskapi/servicedesk?limit=" + strconv.Itoa(perPage) + "&start=" + strconv.Itoa(start)
+		if err := jiraIncidentFetchObject(ctx, client, http.MethodGet, path, nil, &page); err != nil {
+			return pages, pages + 1, err
+		}
+		pages++
+		if page.IsLastPage == nil {
+			return pages, pages, providerfoundation.ErrNormalizationInvalid
+		}
+		var values []json.RawMessage
+		if len(page.Values) == 0 || bytes.Equal(bytes.TrimSpace(page.Values), []byte("null")) ||
+			json.Unmarshal(page.Values, &values) != nil {
+			return pages, pages, providerfoundation.ErrNormalizationInvalid
+		}
+		rowsSeen += len(values)
+		if rowsSeen > maxRows {
+			return pages, pages, ErrPaginationCapExceeded
+		}
+		for _, raw := range values {
+			var desk struct {
+				ProjectKey string `json:"projectKey"`
+			}
+			if json.Unmarshal(raw, &desk) == nil && desk.ProjectKey == projectKey {
+				found = true
+			}
+		}
+		if *page.IsLastPage {
+			if !found {
+				return pages, pages, providerfoundation.ErrInvalidScope
+			}
+			return pages, pages, nil
+		}
+		if len(values) == 0 {
+			return pages, pages, ErrPaginationCapExceeded
+		}
+		next := start + len(values)
+		if next <= start {
+			return pages, pages, ErrPaginationCapExceeded
+		}
+		start = next
+	}
+}
+
+func collectJiraIncidentIssues(
+	ctx context.Context, client *providerfoundation.HTTPClient, projectKey string,
+	since, before time.Time, maxPages, maxRows, perPage int,
+) ([]jiraIncidentPayload, int, error) {
+	issues := make([]jiraIncidentPayload, 0)
+	token := ""
+	seen := map[string]struct{}{}
+	for pages := 0; ; pages++ {
+		if pages >= maxPages {
+			return nil, pages, ErrPaginationCapExceeded
+		}
+		body := map[string]any{
+			"jql": fmt.Sprintf(
+				`project in (%s) AND "Ticket category" = Incidents AND updated >= "%s" AND updated < "%s" ORDER BY updated ASC, key ASC`,
+				projectKey, since.Format(time.RFC3339Nano), before.Format(time.RFC3339Nano),
+			),
+			"maxResults": perPage,
+			"fields":     []string{"id", "key", "summary", "created", "updated", "resolutiondate", "status", "priority"},
+		}
+		if token != "" {
+			body["nextPageToken"] = token
+		}
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, pages, ErrInvalidConfiguration
+		}
+		var page struct {
+			Issues        json.RawMessage `json:"issues"`
+			IsLast        *bool           `json:"isLast"`
+			NextPageToken any             `json:"nextPageToken"`
+		}
+		if err := jiraIncidentFetchObject(ctx, client, http.MethodPost, "/rest/api/3/search/jql", bytes.NewReader(encoded), &page); err != nil {
+			return nil, pages + 1, err
+		}
+		var pageIssues []json.RawMessage
+		if page.IsLast == nil || len(page.Issues) == 0 ||
+			bytes.Equal(bytes.TrimSpace(page.Issues), []byte("null")) ||
+			json.Unmarshal(page.Issues, &pageIssues) != nil {
+			return nil, pages + 1, providerfoundation.ErrNormalizationInvalid
+		}
+		if len(issues)+len(pageIssues) > maxRows {
+			return nil, pages + 1, ErrPaginationCapExceeded
+		}
+		for _, raw := range pageIssues {
+			var issue jiraIncidentPayload
+			if err := decodeJiraIncidentJSON(raw, &issue); err != nil {
+				return nil, pages + 1, err
+			}
+			issues = append(issues, issue)
+		}
+		if *page.IsLast {
+			return issues, pages + 1, nil
+		}
+		next, ok := page.NextPageToken.(string)
+		if !ok || next == "" {
+			return nil, pages + 1, ErrPaginationCapExceeded
+		}
+		if _, duplicate := seen[next]; duplicate {
+			return nil, pages + 1, ErrPaginationCapExceeded
+		}
+		seen[next] = struct{}{}
+		token = next
+	}
+}
+
+func jiraIncidentAdmissionClient(
+	client *providerfoundation.HTTPClient, claim Claim,
+) (*providerfoundation.HTTPClient, error) {
+	admission, err := providerfoundation.NewHTTPClient(
+		"jira", jiraIncidentAPIOrigin, client.Doer, client.Auth, client.Retry, client.Lease,
+	)
+	if err != nil {
+		return nil, err
+	}
+	admission.Budget, admission.Gate, admission.Metrics = client.Budget, client.Gate, client.Metrics
+	admission.BudgetKey = client.BudgetKey
+	admission.BudgetKey.Provider = "jira"
+	admission.BudgetKey.OrgID = claim.OrgID
+	admission.BudgetKey.Host = "api.atlassian.com"
+	return admission, nil
+}
+
+func admitJiraIncident(
+	ctx context.Context, client *providerfoundation.HTTPClient, cloudID, issueID string,
+) (bool, error) {
+	if issueID == "" {
+		return false, providerfoundation.ErrNormalizationInvalid
+	}
+	for _, r := range issueID {
+		if r < '0' || r > '9' {
+			return false, providerfoundation.ErrNormalizationInvalid
+		}
+	}
+	path := "/jsm/incidents/cloudId/" + url.PathEscape(cloudID) + "/v1/incident/" + url.PathEscape(issueID)
+	var responseObject map[string]json.RawMessage
+	err := jiraIncidentFetchObject(ctx, client, http.MethodGet, path, nil, &responseObject)
+	if err == nil {
+		return responseObject != nil, nil
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr.Class == providerfoundation.ErrorNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func jiraIncidentFetchObject(
+	ctx context.Context, client *providerfoundation.HTTPClient, method, path string,
+	body io.Reader, target any,
+) error {
+	response, err := client.Do(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	limited, err := io.ReadAll(io.LimitReader(response.Body, nativeMaxObjectBytes+1))
+	if err != nil || len(limited) > nativeMaxObjectBytes || decodeJiraIncidentJSON(limited, target) != nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	return nil
+}
+
+func decodeJiraIncidentJSON(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	return nil
+}
+
+func normalizeJiraIncident(
+	claim Claim, cloudID, baseURL string, issue jiraIncidentPayload, normalizedAt time.Time,
+) (jiraIncidentRow, error) {
+	cloudID = strings.ToLower(strings.TrimSpace(cloudID))
+	issue.ID, issue.Key = strings.TrimSpace(issue.ID), strings.TrimSpace(issue.Key)
+	if claim.Validate() != nil || claim.Provider != "jira" || claim.Dataset != "incidents" ||
+		cloudID == "" || issue.ID == "" || issue.Key == "" || issue.Fields.Summary == "" ||
+		issue.Fields.Status.Name == "" || issue.Fields.Status.StatusCategory.Key == "" || normalizedAt.IsZero() {
+		return jiraIncidentRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	trustedBase, err := trustedJiraCloudOrigin(baseURL)
+	if err != nil {
+		return jiraIncidentRow{}, err
+	}
+	created, err := parseJiraIncidentTime(issue.Fields.Created)
+	if err != nil {
+		return jiraIncidentRow{}, err
+	}
+	updated, err := parseJiraIncidentTime(issue.Fields.Updated)
+	if err != nil {
+		return jiraIncidentRow{}, err
+	}
+	var resolution *time.Time
+	if issue.Fields.ResolutionDate != nil {
+		parsed, err := parseJiraIncidentTime(*issue.Fields.ResolutionDate)
+		if err != nil {
+			return jiraIncidentRow{}, err
+		}
+		resolution = &parsed
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	statusCategory := strings.ToLower(issue.Fields.Status.StatusCategory.Key)
+	normalizedStatus := map[string]string{
+		"new": "open", "open": "open", "indeterminate": "active", "done": "resolved",
+	}[statusCategory]
+	if normalizedStatus == "" {
+		normalizedStatus = "active"
+	}
+	rawStatus := issue.Fields.Status.Name
+	var rawPriority *string
+	if issue.Fields.Priority != nil {
+		value := issue.Fields.Priority.Name
+		rawPriority = &value
+	}
+	sourceURL := trustedBase + "/browse/" + issue.Key
+	sourceEventID := issue.Key
+	row := jiraIncidentRow{
+		OrgID: claim.OrgID, Provider: "jira", ProviderInstanceID: cloudID,
+		SourceEntityType: "jsm_incident", ExternalID: issue.ID,
+		SourceVersionAt: updated, SourceURL: &sourceURL, SourceEventAt: &created,
+		SourceEventID: &sourceEventID, ObservedAt: normalizedAt, LastSynced: normalizedAt,
+		RawStatus: &rawStatus, RawPriority: rawPriority, NormalizedStatus: &normalizedStatus,
+		Title: issue.Fields.Summary, StartedAt: &created, IsDeleted: false,
+	}
+	if statusCategory == "done" {
+		row.ResolvedAt = resolution
+	}
+	if err := fillJiraIncidentOrdering(&row); err != nil {
+		return jiraIncidentRow{}, err
+	}
+	return row, nil
+}
+
+func parseJiraIncidentTime(raw string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+type jiraOperationalField struct {
+	name  string
+	value any
+}
+
+func fillJiraIncidentOrdering(row *jiraIncidentRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	parts := []string{row.OrgID, row.Provider, row.ProviderInstanceID, "operational_incident", row.ExternalID}
+	for _, part := range parts {
+		if part == "" {
+			return providerfoundation.ErrNormalizationInvalid
+		}
+	}
+	quoted := make([]string, len(parts))
+	for index, part := range parts {
+		quoted[index] = strconv.QuoteToASCII(part)
+	}
+	idDigest := sha256.Sum256([]byte("[" + strings.Join(quoted, ",") + "]"))
+	row.ID = hex.EncodeToString(idDigest[:])
+	fields := []jiraOperationalField{
+		{"org_id", row.OrgID}, {"provider", row.Provider},
+		{"provider_instance_id", row.ProviderInstanceID}, {"source_entity_type", row.SourceEntityType},
+		{"external_id", row.ExternalID}, {"source_version_at", row.SourceVersionAt},
+		{"source_id", nil}, {"source_url", jiraStringValue(row.SourceURL)},
+		{"source_event_at", jiraTimeValue(row.SourceEventAt)}, {"source_event_id", jiraStringValue(row.SourceEventID)},
+		{"raw_status", jiraStringValue(row.RawStatus)}, {"raw_severity", nil},
+		{"raw_priority", jiraStringValue(row.RawPriority)}, {"normalized_status", jiraStringValue(row.NormalizedStatus)},
+		{"normalized_severity", nil}, {"normalized_priority", nil},
+		{"relationship_provenance", nil}, {"relationship_confidence", nil},
+		{"service_id", nil}, {"service_external_id", nil}, {"escalation_policy_id", nil},
+		{"title", row.Title}, {"description", nil}, {"started_at", jiraTimeValue(row.StartedAt)},
+		{"resolved_at", jiraTimeValue(row.ResolvedAt)}, {"is_deleted", row.IsDeleted}, {"deleted_at", nil},
+	}
+	conflict, err := encodeJiraOperationalConflict("operational_incident", fields)
+	if err != nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	row.SourceConflictKey = conflict
+	conflictBytes, _ := hex.DecodeString(conflict)
+	revisionDigest := sha256.Sum256(append([]byte("operational-source-revision-v1"), conflictBytes...))
+	sourceMicros, err := jiraOperationalMicros(row.SourceVersionAt)
+	if err != nil {
+		return err
+	}
+	row.SourceRevision = new(big.Int).Lsh(new(big.Int).SetUint64(sourceMicros), 64)
+	row.SourceRevision.Or(row.SourceRevision, new(big.Int).Lsh(big.NewInt(1), 56))
+	row.SourceRevision.Or(row.SourceRevision, new(big.Int).SetBytes(revisionDigest[:7]))
+	lastSyncedMicros, err := jiraOperationalMicros(row.LastSynced)
+	if err != nil {
+		return err
+	}
+	observedMicros, err := jiraOperationalMicros(row.ObservedAt)
+	if err != nil {
+		return err
+	}
+	row.IngestRevision = new(big.Int).Lsh(new(big.Int).SetUint64(lastSyncedMicros), 64)
+	row.IngestRevision.Or(row.IngestRevision, new(big.Int).SetUint64(observedMicros))
+	row.OrderingContract = 2
+	return nil
+}
+
+func encodeJiraOperationalConflict(family string, fields []jiraOperationalField) (string, error) {
+	var encoded bytes.Buffer
+	encoded.WriteString("operational-conflict-v1")
+	if err := encodeJiraOperationalField(&encoded, "entity_family", family); err != nil {
+		return "", err
+	}
+	for _, field := range fields {
+		if err := encodeJiraOperationalField(&encoded, field.name, field.value); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(encoded.Bytes()), nil
+}
+
+func encodeJiraOperationalField(out *bytes.Buffer, name string, value any) error {
+	valueType, marker, encoded, err := encodeJiraOperationalValue(value)
+	if err != nil || name == "" {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	writeJiraLength(out, []byte(name), 4)
+	writeJiraLength(out, []byte(valueType), 2)
+	out.WriteByte(marker)
+	writeJiraLength(out, encoded, 8)
+	return nil
+}
+
+func encodeJiraOperationalValue(value any) (string, byte, []byte, error) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", 0, nil, nil
+	case bool:
+		if typed {
+			return "bool", 1, []byte{1}, nil
+		}
+		return "bool", 1, []byte{0}, nil
+	case string:
+		return "string", 1, []byte(typed), nil
+	case time.Time:
+		if _, err := jiraOperationalMicros(typed); err != nil {
+			return "", 0, nil, err
+		}
+		return "datetime", 1, []byte(typed.UTC().Format("2006-01-02T15:04:05.000000Z")), nil
+	default:
+		return "", 0, nil, providerfoundation.ErrNormalizationInvalid
+	}
+}
+
+func writeJiraLength(out *bytes.Buffer, value []byte, width int) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], uint64(len(value)))
+	out.Write(encoded[8-width:])
+	out.Write(value)
+}
+
+func jiraOperationalMicros(value time.Time) (uint64, error) {
+	_, offset := value.Zone()
+	maximum := time.Date(2299, 12, 31, 23, 59, 59, 999999000, time.UTC)
+	if value.IsZero() || offset != 0 || value.Before(time.Unix(0, 0).UTC()) || value.After(maximum) {
+		return 0, providerfoundation.ErrNormalizationInvalid
+	}
+	return uint64(value.UTC().UnixMicro()), nil
+}
+
+func jiraStringValue(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func jiraTimeValue(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+var _ CompleteRouteHandler = JiraIncidentRouteHandler{}

--- a/internal/providersync/jira_incidents_route_test.go
+++ b/internal/providersync/jira_incidents_route_test.go
@@ -1,0 +1,182 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type jiraIncidentDoer struct {
+	t        *testing.T
+	requests []string
+}
+
+type jiraIncidentDoerFunc func(*http.Request) (*http.Response, error)
+
+func (doer jiraIncidentDoerFunc) Do(request *http.Request) (*http.Response, error) {
+	return doer(request)
+}
+
+func (doer *jiraIncidentDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	body := ""
+	switch request.URL.String() {
+	case "https://acme.atlassian.net/_edge/tenant_info":
+		body = `{"cloudId":"cloud-123"}`
+	case "https://acme.atlassian.net/rest/servicedeskapi/servicedesk?limit=100&start=0":
+		body = `{"values":[{"projectKey":"JSM"}],"isLastPage":true}`
+	case "https://acme.atlassian.net/rest/api/3/search/jql":
+		if request.Method != http.MethodPost || request.Header.Get("Content-Type") != "application/json" {
+			doer.t.Fatalf("JQL request method=%s content-type=%q", request.Method, request.Header.Get("Content-Type"))
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			doer.t.Fatal(err)
+		}
+		if !strings.Contains(payload["jql"].(string), `project in (JSM)`) {
+			doer.t.Fatalf("JQL=%q", payload["jql"])
+		}
+		body = `{"issues":[{"id":"10001","key":"JSM-1","fields":{"summary":"API down","created":"2026-07-22T10:00:00Z","updated":"2026-07-22T10:05:00Z","resolutiondate":null,"status":{"name":"Investigating","statusCategory":{"key":"indeterminate"}},"priority":{"name":"Highest"}}},{"id":"10002","key":"JSM-2","fields":{"summary":"Ordinary request","created":"2026-07-22T11:00:00Z","updated":"2026-07-22T11:05:00Z","resolutiondate":null,"status":{"name":"Open","statusCategory":{"key":"new"}},"priority":null}}],"isLast":true}`
+	case "https://api.atlassian.com/jsm/incidents/cloudId/cloud-123/v1/incident/10001":
+		body = `{}`
+	case "https://api.atlassian.com/jsm/incidents/cloudId/cloud-123/v1/incident/10002":
+		doer.requests = append(doer.requests, request.URL.String())
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+			Request:    request,
+		}, nil
+	default:
+		doer.t.Fatalf("unexpected Jira request %s", request.URL.String())
+	}
+	doer.requests = append(doer.requests, request.URL.String())
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestJiraIncidentsRouteCollectsOnlyNativelyAdmittedJSMIncidents(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	doer := &jiraIncidentDoer{t: t}
+	client, err := providerfoundation.NewHTTPClient(
+		"jira", "https://acme.atlassian.net", doer,
+		func(request *http.Request) error {
+			request.Header.Set("Accept", "application/json")
+			request.Header.Set("Content-Type", "application/json")
+			return nil
+		},
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := (JiraIncidentRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("jira", "incidents")
+	if !ok || !descriptor.RouteReady || descriptor.Executor != ExecutorNativeGo {
+		t.Fatalf("descriptor=%+v ok=%v", descriptor, ok)
+	}
+	if err := batch.validate(descriptor); err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark == nil || claim.BeforeAt == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v want=%v", batch.Watermark, claim.BeforeAt)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_incidents" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var row jiraIncidentRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	if row.OrgID != claim.OrgID || row.Provider != "jira" || row.ProviderInstanceID != "cloud-123" ||
+		row.ExternalID != "10001" || row.SourceEventID == nil || *row.SourceEventID != "JSM-1" ||
+		row.NormalizedStatus == nil || *row.NormalizedStatus != "active" || row.Title != "API down" {
+		t.Fatalf("row=%+v", row)
+	}
+	if got := len(doer.requests); got != 5 {
+		t.Fatalf("requests=%d want=5: %v", got, doer.requests)
+	}
+}
+
+func TestJiraIncidentsRouteFailsClosedBeforeWatermarkOnIncompleteTraversal(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	doer := jiraIncidentDoerFunc(func(request *http.Request) (*http.Response, error) {
+		body := `{"cloudId":"cloud-123"}`
+		if request.URL.Path == "/rest/servicedeskapi/servicedesk" {
+			body = `{"values":[{"projectKey":"JSM"}],"isLastPage":false}`
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+	})
+	client, err := providerfoundation.NewHTTPClient(
+		"jira", "https://acme.atlassian.net", doer, func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := (JiraIncidentRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err == nil || batch.Watermark != nil || len(batch.Effects) != 0 {
+		t.Fatalf("batch=%+v err=%v", batch, err)
+	}
+}
+
+func TestJiraIncidentsRouteRejectsNullIssueInventory(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	doer := jiraIncidentDoerFunc(func(request *http.Request) (*http.Response, error) {
+		body := `{"cloudId":"cloud-123"}`
+		switch request.URL.Path {
+		case "/rest/servicedeskapi/servicedesk":
+			body = `{"values":[{"projectKey":"JSM"}],"isLastPage":true}`
+		case "/rest/api/3/search/jql":
+			body = `{"issues":null,"isLast":true}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{},
+			Body: io.NopCloser(strings.NewReader(body)), Request: request,
+		}, nil
+	})
+	client, err := providerfoundation.NewHTTPClient(
+		"jira", "https://acme.atlassian.net", doer, func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := (JiraIncidentRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err == nil || batch.Watermark != nil || len(batch.Effects) != 0 {
+		t.Fatalf("batch=%+v err=%v", batch, err)
+	}
+}

--- a/internal/providersync/jira_incidents_route_test.go
+++ b/internal/providersync/jira_incidents_route_test.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -22,6 +23,16 @@ type jiraIncidentDoerFunc func(*http.Request) (*http.Response, error)
 func (doer jiraIncidentDoerFunc) Do(request *http.Request) (*http.Response, error) {
 	return doer(request)
 }
+
+type jiraIncidentEntitlementFunc func(context.Context, string) error
+
+func (require jiraIncidentEntitlementFunc) Require(ctx context.Context, orgID string) error {
+	return require(ctx, orgID)
+}
+
+var allowJiraIncidentEntitlement = jiraIncidentEntitlementFunc(
+	func(context.Context, string) error { return nil },
+)
 
 func (doer *jiraIncidentDoer) Do(request *http.Request) (*http.Response, error) {
 	doer.t.Helper()
@@ -85,7 +96,7 @@ func TestJiraIncidentsRouteCollectsOnlyNativelyAdmittedJSMIncidents(t *testing.T
 		t.Fatal(err)
 	}
 
-	batch, err := (JiraIncidentRouteHandler{}).Collect(
+	batch, err := (JiraIncidentRouteHandler{Entitlement: allowJiraIncidentEntitlement}).Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt,
 	)
 	if err != nil {
@@ -138,7 +149,9 @@ func TestJiraIncidentsRouteFailsClosedBeforeWatermarkOnIncompleteTraversal(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	batch, err := (JiraIncidentRouteHandler{MaxPages: 1}).Collect(
+	batch, err := (JiraIncidentRouteHandler{
+		Entitlement: allowJiraIncidentEntitlement, MaxPages: 1,
+	}).Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
 	)
@@ -172,11 +185,78 @@ func TestJiraIncidentsRouteRejectsNullIssueInventory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	batch, err := (JiraIncidentRouteHandler{}).Collect(
+	batch, err := (JiraIncidentRouteHandler{Entitlement: allowJiraIncidentEntitlement}).Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
 	)
 	if err == nil || batch.Watermark != nil || len(batch.Effects) != 0 {
 		t.Fatalf("batch=%+v err=%v", batch, err)
+	}
+}
+
+func TestJiraIncidentsRouteRejectsDisabledEntitlementBeforeProviderFetch(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	requests := 0
+	doer := jiraIncidentDoerFunc(func(*http.Request) (*http.Response, error) {
+		requests++
+		return nil, errors.New("provider fetch must not run")
+	})
+	client, err := providerfoundation.NewHTTPClient(
+		"jira", "https://acme.atlassian.net", doer, func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := (JiraIncidentRouteHandler{
+		Entitlement: jiraIncidentEntitlementFunc(func(context.Context, string) error {
+			return ErrJiraIncidentEntitlementDisabled
+		}),
+	}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrJiraIncidentEntitlementDisabled) || requests != 0 ||
+		batch.Watermark != nil || len(batch.Effects) != 0 {
+		t.Fatalf("requests=%d batch=%+v err=%v", requests, batch, err)
+	}
+}
+
+func TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("jira", "incidents")
+	claim.SourceExternalID = "JSM"
+	doer := &jiraIncidentDoer{t: t}
+	client, err := providerfoundation.NewHTTPClient(
+		"jira", "https://acme.atlassian.net", doer,
+		func(request *http.Request) error {
+			request.Header.Set("Accept", "application/json")
+			request.Header.Set("Content-Type", "application/json")
+			return nil
+		},
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := 0
+	entitlement := jiraIncidentEntitlementFunc(func(context.Context, string) error {
+		checks++
+		if checks > 1 {
+			return ErrJiraIncidentEntitlementDisabled
+		}
+		return nil
+	})
+	batch, err := (JiraIncidentRouteHandler{Entitlement: entitlement}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrJiraIncidentEntitlementDisabled) || checks != 2 ||
+		len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("entitlement checks=%d batch=%+v err=%v", checks, batch, err)
 	}
 }

--- a/internal/providersync/jira_incidents_route_test.go
+++ b/internal/providersync/jira_incidents_route_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
@@ -225,7 +226,18 @@ func TestJiraIncidentsRouteRejectsDisabledEntitlementBeforeProviderFetch(t *test
 	}
 }
 
-func TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff(t *testing.T) {
+type recordingJiraIncidentBatchPreparer struct {
+	prepared int
+}
+
+func (writer *recordingJiraIncidentBatchPreparer) PrepareBatch(
+	context.Context, string, ...driver.PrepareBatchOption,
+) (driver.Batch, error) {
+	writer.prepared++
+	return nil, errors.New("ClickHouse batch preparation must not run")
+}
+
+func TestJiraIncidentsRouteRechecksRevokedEntitlementAtClickHouseWrite(t *testing.T) {
 	t.Parallel()
 	claim := nativeTestClaim("jira", "incidents")
 	claim.SourceExternalID = "JSM"
@@ -244,9 +256,10 @@ func TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff(t 
 		t.Fatal(err)
 	}
 	checks := 0
+	revoked := false
 	entitlement := jiraIncidentEntitlementFunc(func(context.Context, string) error {
 		checks++
-		if checks > 1 {
+		if revoked {
 			return ErrJiraIncidentEntitlementDisabled
 		}
 		return nil
@@ -255,8 +268,17 @@ func TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff(t 
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
 	)
-	if !errors.Is(err, ErrJiraIncidentEntitlementDisabled) || checks != 2 ||
-		len(batch.Effects) != 0 || batch.Watermark != nil {
-		t.Fatalf("entitlement checks=%d batch=%+v err=%v", checks, batch, err)
+	if err != nil || checks != 1 || len(batch.Effects) != 1 || batch.Watermark == nil {
+		t.Fatalf("collect checks=%d batch=%+v err=%v", checks, batch, err)
+	}
+	revoked = true
+	writer := &recordingJiraIncidentBatchPreparer{}
+	err = (JiraIncidentClickHouseEffects{
+		Writer:      writer,
+		Lease:       providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		Entitlement: entitlement,
+	}).WriteEffect(context.Background(), claim, batch.Effects[0])
+	if !errors.Is(err, ErrJiraIncidentEntitlementDisabled) || checks != 2 || writer.prepared != 0 {
+		t.Fatalf("write checks=%d prepared=%d err=%v", checks, writer.prepared, err)
 	}
 }

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -376,6 +377,9 @@ func typedEncode(t *testing.T, v reflect.Value) any {
 	}
 	if timeValue, ok := v.Interface().(time.Time); ok {
 		return map[string]any{"t": "datetime", "v": timeValue.UTC().Format(time.RFC3339Nano)}
+	}
+	if integer, ok := v.Interface().(big.Int); ok {
+		return map[string]any{"t": "int", "v": integer.String()}
 	}
 	switch v.Kind() {
 	case reflect.String:

--- a/internal/providersync/testdata/mutation-plans/jira_incidents.json
+++ b/internal/providersync/testdata/mutation-plans/jira_incidents.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "jira/incidents native route (CHAOS-3127)",
   "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
-  "$limitation": "The plan pins native admission, whole-row normalization, tenant scope, readback content, and route readiness. The integration-tagged ClickHouse test separately proves the SQL schema and FINAL tenant-scoped readback against a real server.",
+  "$limitation": "The plan pins both entitlement checks, entitlement policy parity, native admission, whole-row normalization, tenant scope, readback content, and route readiness. Integration-tagged tests separately prove the Postgres atomic entitlement snapshot and ClickHouse FINAL tenant-scoped readback against real servers.",
   "mutations": [
     {
       "id": "admission-404-must-exclude",
@@ -35,6 +35,39 @@
       "replace": "\t\tif false || row.Provider != \"jira\" ||",
       "rationale": "the effect sink must reject a row whose tenant differs from the claimed unit",
       "proof": [["go", "test", "-run", "^TestJiraIncidentScopeRejectsCrossTenantRows$", "./internal/providersync/"]]
+    },
+    {
+      "id": "entitlement-before-fetch",
+      "file": "internal/providersync/jira_incidents_route.go",
+      "find": "\tif err := handler.Entitlement.Require(ctx, claim.OrgID); err != nil {\n\t\treturn CompleteRouteBatch{}, err\n\t}",
+      "replace": "\tif err := handler.Entitlement.Require(ctx, claim.OrgID); err != nil && false {\n\t\treturn CompleteRouteBatch{}, err\n\t}",
+      "rationale": "a disabled canonical-incident entitlement must fail before the first Jira request",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteRejectsDisabledEntitlementBeforeProviderFetch$", "./internal/providersync/"]]
+    },
+    {
+      "id": "entitlement-recheck-before-write",
+      "file": "internal/providersync/jira_incidents_route.go",
+      "find": "\twriteAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)\n\tif writeAuthorizationErr != nil {\n\t\treturn CompleteRouteBatch{}, writeAuthorizationErr\n\t}",
+      "replace": "\twriteAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)\n\tif writeAuthorizationErr != nil && false {\n\t\treturn CompleteRouteBatch{}, writeAuthorizationErr\n\t}",
+      "rationale": "an entitlement revoked during provider traversal must fail before the collected batch is handed to persistence",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff$", "./internal/providersync/"]]
+    },
+    {
+      "id": "entitlement-policy-org-override",
+      "file": "internal/providersync/jira_incident_entitlement.go",
+      "find": "\t\t\t\tFeatureKey: jiraIncidentFeatureKey, Allowed: true,\n\t\t\t\tReason: \"enabled_by_org_override\", ExpiresAt: state.OrgOverride.ExpiresAt,",
+      "replace": "\t\t\t\tFeatureKey: jiraIncidentFeatureKey, Allowed: false,\n\t\t\t\tReason: \"enabled_by_org_override\", ExpiresAt: state.OrgOverride.ExpiresAt,",
+      "rationale": "an active enabled org override must produce the same allowed decision as Python's canonical feature policy",
+      "proof": [["go", "test", "-run", "^TestGenericOracleMatchesLivePythonForJiraIncidentEntitlement$", "./internal/providersync/"]]
+    },
+    {
+      "id": "worker-builder-requires-entitlement",
+      "file": "cmd/dev-health-worker/provider_sync.go",
+      "find": "\t\t\t\tif jiraIncidentEntitlement == nil {",
+      "replace": "\t\t\t\tif false {",
+      "rationale": "a route-ready Jira incidents worker cannot be constructed without an entitlement dependency",
+      "build": ["go", "test", "-run", "^$", "./cmd/dev-health-worker/"],
+      "proof": [["go", "test", "-run", "^TestBuildProviderSyncHandlerRejectsJiraIncidentsWithoutEntitlement$", "./cmd/dev-health-worker/"]]
     },
     {
       "id": "readback-whole-row-content",

--- a/internal/providersync/testdata/mutation-plans/jira_incidents.json
+++ b/internal/providersync/testdata/mutation-plans/jira_incidents.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "name": "jira/incidents native route (CHAOS-3127)",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "The plan pins native admission, whole-row normalization, tenant scope, readback content, and route readiness. The integration-tagged ClickHouse test separately proves the SQL schema and FINAL tenant-scoped readback against a real server.",
+  "mutations": [
+    {
+      "id": "admission-404-must-exclude",
+      "file": "internal/providersync/jira_incidents_route.go",
+      "find": "\t\tif !admitted {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif admitted && false {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "an enhanced-JQL candidate is an incident only after the fixed-host JSM Incidents API admits it; a native 404 must be excluded",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteCollectsOnlyNativelyAdmittedJSMIncidents$", "./internal/providersync/"]]
+    },
+    {
+      "id": "indeterminate-status-parity",
+      "file": "internal/providersync/jira_incidents_route.go",
+      "find": "\t\t\"new\": \"open\", \"open\": \"open\", \"indeterminate\": \"active\", \"done\": \"resolved\",",
+      "replace": "\t\t\"new\": \"open\", \"open\": \"open\", \"indeterminate\": \"open\", \"done\": \"resolved\",",
+      "rationale": "Jira's stable indeterminate status category maps to canonical active exactly as the live Python producer does",
+      "proof": [["go", "test", "-run", "^TestGenericOracleMatchesLivePythonForJiraIncidentRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "null-issue-inventory-must-fail",
+      "file": "internal/providersync/jira_incidents_route.go",
+      "find": "\t\t\tbytes.Equal(bytes.TrimSpace(page.Issues), []byte(\"null\")) ||",
+      "replace": "\t\t\tfalse ||",
+      "rationale": "a null enhanced-JQL issues value is not an empty successful list and must never advance the watermark",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteRejectsNullIssueInventory$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effect-tenant-scope",
+      "file": "internal/providersync/jira_incidents_effects_clickhouse.go",
+      "find": "\t\tif row.OrgID != claim.OrgID || row.Provider != \"jira\" ||",
+      "replace": "\t\tif false || row.Provider != \"jira\" ||",
+      "rationale": "the effect sink must reject a row whose tenant differs from the claimed unit",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentScopeRejectsCrossTenantRows$", "./internal/providersync/"]]
+    },
+    {
+      "id": "readback-whole-row-content",
+      "file": "internal/providersync/jira_incidents_effects_clickhouse.go",
+      "find": "\tif expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {",
+      "replace": "\tif expectedErr != nil || actualErr != nil || (!bytes.Equal(expectedJSON, actualJSON) && false) {",
+      "rationale": "a row at the same source revision with different content must be a conflict, not an exact recovery",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentReadbackClassifiesVersionAndContent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "descriptor-route-ready",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "\t\tdescriptor.RouteReady = true\n\t\tdescriptor.RouteEnabled = switches.JiraIncidents",
+      "replace": "\t\tdescriptor.RouteReady = false\n\t\tdescriptor.RouteEnabled = switches.JiraIncidents",
+      "rationale": "the completed Jira incidents handler must remain represented as route-ready while the independent switch remains the second gate",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteCollectsOnlyNativelyAdmittedJSMIncidents$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/jira_incidents.json
+++ b/internal/providersync/testdata/mutation-plans/jira_incidents.json
@@ -46,11 +46,11 @@
     },
     {
       "id": "entitlement-recheck-before-write",
-      "file": "internal/providersync/jira_incidents_route.go",
-      "find": "\twriteAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)\n\tif writeAuthorizationErr != nil {\n\t\treturn CompleteRouteBatch{}, writeAuthorizationErr\n\t}",
-      "replace": "\twriteAuthorizationErr := handler.Entitlement.Require(ctx, claim.OrgID)\n\tif writeAuthorizationErr != nil && false {\n\t\treturn CompleteRouteBatch{}, writeAuthorizationErr\n\t}",
-      "rationale": "an entitlement revoked during provider traversal must fail before the collected batch is handed to persistence",
-      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteRechecksRevokedEntitlementBeforePersistenceHandoff$", "./internal/providersync/"]]
+      "file": "internal/providersync/jira_incidents_effects_clickhouse.go",
+      "find": "\tif err := sink.Entitlement.Require(ctx, claim.OrgID); err != nil {\n\t\treturn err\n\t}",
+      "replace": "\tif err := sink.Entitlement.Require(ctx, claim.OrgID); err != nil && false {\n\t\treturn err\n\t}",
+      "rationale": "an entitlement revoked after collection and ledger preparation must fail before ClickHouse batch preparation",
+      "proof": [["go", "test", "-run", "^TestJiraIncidentsRouteRechecksRevokedEntitlementAtClickHouseWrite$", "./internal/providersync/"]]
     },
     {
       "id": "entitlement-policy-org-override",
@@ -68,6 +68,15 @@
       "rationale": "a route-ready Jira incidents worker cannot be constructed without an entitlement dependency",
       "build": ["go", "test", "-run", "^$", "./cmd/dev-health-worker/"],
       "proof": [["go", "test", "-run", "^TestBuildProviderSyncHandlerRejectsJiraIncidentsWithoutEntitlement$", "./cmd/dev-health-worker/"]]
+    },
+    {
+      "id": "worker-wires-write-entitlement",
+      "file": "cmd/dev-health-worker/provider_sync.go",
+      "find": "\t\t\t\tjiraSink := providersync.JiraIncidentClickHouseEffects{\n\t\t\t\t\tWriter: clickhouseConnection, Lease: session,\n\t\t\t\t\tEntitlement: jiraIncidentEntitlement,",
+      "replace": "\t\t\t\tjiraSink := providersync.JiraIncidentClickHouseEffects{\n\t\t\t\t\tWriter: clickhouseConnection, Lease: session,\n\t\t\t\t\tEntitlement: nil,",
+      "rationale": "the Jira collector and ClickHouse writer must share the same entitlement dependency while recovery readback remains separate",
+      "build": ["go", "test", "-run", "^$", "./cmd/dev-health-worker/"],
+      "proof": [["go", "test", "-run", "^TestBuildProviderSyncHandlerConstructsJiraIncidentsCapability$", "./cmd/dev-health-worker/"]]
     },
     {
       "id": "readback-whole-row-content",

--- a/internal/providersync/testdata/oracle_pairs/jira_incidents_entitlement.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_incidents_entitlement.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from dataclasses import asdict, fields
+from datetime import datetime, timezone
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from dev_health_ops.licensing import feature_policy  # noqa: E402
+from dev_health_ops.licensing.types import LicenseTier  # noqa: E402
+
+_SOURCE = REPO_ROOT / "src/dev_health_ops/licensing/feature_policy.py"
+_EVALUATED_AT = datetime(2026, 7, 23, 12, 30, tzinfo=timezone.utc)
+
+
+def _reflected_fields() -> frozenset[str]:
+    if pathlib.Path(feature_policy.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("Jira entitlement oracle did not import the live policy")
+    return frozenset(field.name for field in fields(feature_policy.FeatureDecision))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    raw_override = case["org_override"]
+    override = None
+    if raw_override is not None:
+        expires_at = raw_override["expires_at"]
+        override = feature_policy.FeatureOverrideSnapshot(
+            is_enabled=raw_override["enabled"],
+            expires_at=(
+                datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                if expires_at is not None
+                else None
+            ),
+        )
+    try:
+        min_tier = LicenseTier(case["min_tier"])
+        storage_valid = True
+    except ValueError:
+        min_tier = LicenseTier.COMMUNITY
+        storage_valid = False
+    try:
+        org_tier = LicenseTier(case["org_tier"])
+    except ValueError:
+        org_tier = LicenseTier.COMMUNITY
+    decision = feature_policy.decide_feature(
+        feature_policy.FeatureDecisionContext(
+            feature_key="canonical_incident_ingestion",
+            is_registered=case["registered"],
+            is_storage_valid=storage_valid,
+            globally_enabled=case["globally_enabled"],
+            min_tier=min_tier,
+            org_tier=org_tier,
+            org_override=override,
+            license_override=case["license_override"],
+            evaluated_at=_EVALUATED_AT,
+        )
+    )
+    return asdict(decision)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/incidents/entitlement",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_incidents_row.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_incidents_row.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from dataclasses import asdict, fields
+from datetime import datetime, timezone
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/jira/jsm_incidents.py"
+_OBSERVED_AT = datetime(2026, 7, 23, 12, 30, tzinfo=timezone.utc)
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from dev_health_ops.providers.jira import jsm_incidents  # noqa: E402
+
+
+def _module() -> Any:
+    if pathlib.Path(jsm_incidents.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("Jira incident oracle did not import the live source")
+    return jsm_incidents
+
+
+def _reflected_fields() -> frozenset[str]:
+    module = _module()
+    return frozenset(field.name for field in fields(module.OperationalIncident))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    producer = module.JsmIncidentProducer(
+        client=None,
+        org_id="org-acme",
+        provider_instance_id=case["cloud_id"],
+        base_url=case["base_url"],
+        observed_at=_OBSERVED_AT,
+    )
+    return asdict(producer._incident(case["raw_issue"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/incidents/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -162,7 +162,7 @@ class ProviderUnitRouteSwitches:
         return switches
 
     def require_complete_routes(self) -> None:
-        if self.linear_work_items or self.jira_work_items or self.jira_incidents:
+        if self.linear_work_items or self.jira_work_items:
             raise ProviderUnitRouteError("enabled provider unit route is incomplete")
 
     def routes_to_river(self, provider: str, dataset: str) -> bool:

--- a/tests/workers/test_provider_matrix_contract.py
+++ b/tests/workers/test_provider_matrix_contract.py
@@ -206,13 +206,12 @@ def test_producer_gate_cannot_route_any_scope_outside_the_ready_set(
 def test_incomplete_route_switches_remain_forbidden(
     matrix: dict[str, Any],
 ) -> None:
-    """The linear/jira scaffolding switches must stay unusable for as long as
+    """The work-item scaffolding switches must stay unusable for as long as
     their Go descriptors are not route-ready."""
 
     scaffolding = {
         "linear_work_items": ("linear", "work-items"),
         "jira_work_items": ("jira", "work-items"),
-        "jira_incidents": ("jira", "incidents"),
     }
     ready = {
         (pair["provider"], pair["dataset"])

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -40,7 +40,6 @@ def test_route_switch_is_exact_and_independent() -> None:
     (
         "WORKER_LINEAR_WORK_ITEMS_ENABLED",
         "WORKER_JIRA_WORK_ITEMS_ENABLED",
-        "WORKER_JIRA_INCIDENTS_ENABLED",
     ),
 )
 def test_incomplete_routes_fail_closed(name: str) -> None:
@@ -55,6 +54,16 @@ def test_invalid_switch_fails_closed_without_echoing_value() -> None:
             {"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": value}
         )
     assert value not in str(raised.value)
+
+
+def test_jira_incidents_switch_is_the_second_required_key() -> None:
+    assert ProviderUnitRouteSwitches.is_route_ready("jira", "incidents")
+    assert not ProviderUnitRouteSwitches.from_environment({}).routes_to_river(
+        "jira", "incidents"
+    )
+    assert ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_JIRA_INCIDENTS_ENABLED": "true"}
+    ).routes_to_river("jira", "incidents")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n\n- Port the independent jira/incidents -> operational_incidents route to native Go.\n- Preserve Python Jira/JSM discovery, bounded enhanced-JQL pagination, fixed-host native admission, whole-row normalization, ClickHouse effect/readback, and tenant isolation.\n- Enforce canonical_incident_ingestion before provider fetch and again immediately before ClickHouse write; keep readback entitlement-independent for crash recovery.\n\n## Stack\n\n- Base/trunk: feat/go-worker-runtime-migration\n- This is the bottom PR in stack #1409.\n- Linked Linear issue: CHAOS-3127\n\n## Test Evidence\n\n- Full go test ./... -count=1 passed outside the sandbox.\n- Real PostgreSQL entitlement revocation + ClickHouse write/readback integration passed.\n- Domain grant-surface gate passed.\n- Live Python whole-row and entitlement decision oracles passed.\n- 43 targeted Python Jira/policy tests passed.\n- Shared mutation harness: 11/11 killed; restore verification clean.\n- Ruff, formatting, MyPy, hooks, and commit signatures passed.\n\nGitHub-hosted Actions were queued without runner assignment during this migration batch; this PR does not claim hosted CI green.\n\n## Risk and rollback\n\n- WORKER_JIRA_INCIDENTS_ENABLED remains default-off.\n- Global Go ownership activation is unchanged.\n- Migration 0066 is unchanged and remains guarded.\n- No database migration is included.\n- Rollback: disable the Jira incidents route flag or revert this PR from the migration feature branch.\n\nSCREENSHOT-WAIVER: backend-only provider runtime change.