### PR TITLE
fix(ci): run the CHAOS-3337 PostgreSQL migration tests in the step that has a database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,17 +116,29 @@ jobs:
           # 4 vCPUs, so this matches `-n auto` there while staying predictable on
           # larger runners. Override PYTEST_XDIST_WORKERS to tune.
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --ignore=tests/test_chaos_3337_source_class_postgres_migration.py
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
           ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
 
-      - name: Run PostgreSQL 0066 migration tests
+      # These files carry their own `isolated_postgres`/`require_postgres_test_uri`
+      # fixtures that pytest.fail() (not skip) when CI/GITHUB_ACTIONS is set but
+      # the needed URI is missing, so they cannot run in "Run parallel unit test
+      # contract" above (no admin-privileged Postgres URI there) and are ignored
+      # from it instead. DEV_HEALTH_TEST_POSTGRES_ADMIN_URI's database component
+      # must be literally `postgres`: the fixture connects to it to CREATE/DROP a
+      # throwaway per-test database on the same server.
+      - name: Run PostgreSQL migration tests
         env:
           DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-        run: pytest -q tests/test_0066_celery_river_cutover_postgres.py
+          DEV_HEALTH_TEST_POSTGRES_ADMIN_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
+        run: |
+          pytest -q \
+            tests/test_0066_celery_river_cutover_postgres.py \
+            tests/test_chaos_3337_source_class_postgres_migration.py \
+            tests/test_canonical_incident_feature_flag_postgres_migration.py
 
       - name: Upload junit test reports
         if: always()
@@ -209,6 +221,12 @@ jobs:
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
           COVERAGE_THRESHOLD: "70"
           DEV_HEALTH_POSTGRES_TEST_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+          # ci_tests() (ci/run_tests.sh) does not --ignore the postgres-gated
+          # migration test files, so they run inline here; without the admin
+          # URI they would pytest.fail() under CI (see the dedicated
+          # "Run PostgreSQL migration tests" step above for why `postgres` is
+          # required as the database component).
+          DEV_HEALTH_TEST_POSTGRES_ADMIN_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
           OTEL_ENABLED: "false"
           PYTEST_XDIST_WORKERS: "4"
         run: |


### PR DESCRIPTION
## Root cause

PR #1402 merged `tests/test_chaos_3337_source_class_postgres_migration.py`. Its `isolated_postgres` fixture calls `pytest.fail(...)` when `DEV_HEALTH_TEST_POSTGRES_ADMIN_URI` is unset and `CI`/`GITHUB_ACTIONS` is set — the same fail-loud pattern already used by `tests/test_0066_celery_river_cutover_postgres.py`. The `test-matrix` job's "Run parallel unit test contract" step never set that variable, so all 4 tests failed at fixture setup there, turning `main` red and propagating to every open PR.

## Change

- `test-matrix` / "Run parallel unit test contract": added `--ignore=tests/test_chaos_3337_source_class_postgres_migration.py` to `PYTEST_ADDOPTS` (same treatment already given to the 0066 file).
- `test-matrix`: renamed the dedicated step to "Run PostgreSQL migration tests", added `DEV_HEALTH_TEST_POSTGRES_ADMIN_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres` (the fixture requires the database component to be literally `postgres` — it creates/drops a throwaway database per test), and now runs three files there: `test_0066_celery_river_cutover_postgres.py`, `test_chaos_3337_source_class_postgres_migration.py`, and `test_canonical_incident_feature_flag_postgres_migration.py`.
- `test_canonical_incident_feature_flag_postgres_migration.py` uses the same admin-URI fixture but only plain-`pytest.skip`s without it, so it has been silently skipping in CI indefinitely. Verified locally against a real PostgreSQL that it passes, so it's now included in the dedicated step instead of continuing to skip unnoticed.
- `coverage` job: `ci/run_tests.sh ci` (`ci_tests()`) does not `--ignore` any of these files, so it would hit the same `pytest.fail()` under CI. Added `DEV_HEALTH_TEST_POSTGRES_ADMIN_URI` to that job's env too so the tests execute inline there as well.

The fail-loud guard (`pytest.fail` when `CI` is set and the URI is missing) is unchanged — this PR supplies the URI, it does not silence the guard.

## Verification

All commands run from a fresh worktree off `origin/main` (`uv sync --all-extras --dev`), against a real PostgreSQL 18 on `localhost:5555`:

**Tests pass for real (not skipped) against a real Postgres:**
```
DEV_HEALTH_TEST_POSTGRES_ADMIN_URI=postgresql+asyncpg://postgres:postgres@localhost:5555/postgres \
  .venv/bin/python -m pytest tests/test_chaos_3337_source_class_postgres_migration.py tests/test_canonical_incident_feature_flag_postgres_migration.py -q
# 5 passed, 1 warning in 16.09s
```

**Combined run matching the new CI step exactly (both URIs set):**
```
DEV_HEALTH_POSTGRES_TEST_URI=... DEV_HEALTH_TEST_POSTGRES_ADMIN_URI=... \
  .venv/bin/python -m pytest -q tests/test_0066_celery_river_cutover_postgres.py tests/test_chaos_3337_source_class_postgres_migration.py tests/test_canonical_incident_feature_flag_postgres_migration.py
# 11 passed, 1 warning in 16.89s
```

**Local skip path still works (no CI, no env var):**
```
env -u CI -u GITHUB_ACTIONS .venv/bin/python -m pytest tests/test_chaos_3337_source_class_postgres_migration.py -q
# 4 skipped, exit 0
```

**Fail-loud guard still fires (CI=1, no admin URI):**
```
CI=1 .venv/bin/python -m pytest tests/test_chaos_3337_source_class_postgres_migration.py -q
# 4 errors (Failed: DEV_HEALTH_TEST_POSTGRES_ADMIN_URI must be configured...), pytest exit code 1
```

**Workflow YAML parses:**
```
python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"
# OK
```

**Unit contract no longer collects the ignored 3337 postgres-migration file:**
```
pytest tests --collect-only -q --ignore=tests/test_0066_celery_river_cutover_postgres.py --ignore=tests/test_chaos_3337_source_class_postgres_migration.py 2>&1 | grep -c test_chaos_3337_source_class_postgres_migration
# 0
```
(Note: a naive `grep -c chaos_3337` on that output returns 13 — that's two unrelated, correctly-collected files, `tests/api/dev/test_chaos_3337_source_class_persistence_allowlist.py` and `tests/test_chaos_3337_source_class_allowlist_parity.py`, which are not postgres-gated and out of scope for this fix.)

Only `.github/workflows/test.yml` was changed.