### PR TITLE
fix(tests): update 0066 workflow guard for the renamed postgres migration step

### DIFF
--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -60,22 +60,21 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
     postgres_step = next(
         step
         for step in workflow["jobs"]["test-matrix"]["steps"]
-        if step.get("name") == "Run PostgreSQL 0066 migration tests"
+        if step.get("name") == "Run PostgreSQL migration tests"
     )
     assert postgres_step["env"][_POSTGRES_TEST_URI_ENV] == (
         "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
     )
-    assert postgres_step["run"] == (
-        "pytest -q tests/test_0066_celery_river_cutover_postgres.py"
-    )
+    assert "tests/test_0066_celery_river_cutover_postgres.py" in postgres_step["run"]
 
     unit_step = next(
         step
         for step in workflow["jobs"]["test-matrix"]["steps"]
         if step.get("name") == "Run parallel unit test contract"
     )
-    assert unit_step["env"]["PYTEST_ADDOPTS"] == (
+    assert (
         "--ignore=tests/test_0066_celery_river_cutover_postgres.py"
+        in (unit_step["env"]["PYTEST_ADDOPTS"])
     )
 
     coverage_step = next(


### PR DESCRIPTION
#1415 renamed the test-matrix step "Run PostgreSQL 0066 migration tests" to "Run PostgreSQL migration tests" and widened its file list, but the workflow guard test still looked the old name up with next(), dying with StopIteration on every PR (first seen on #1403's re-run after #1415 merged).

Updates test_github_unit_job_enables_real_postgres_migration_tests to the new step name, and asserts the 0066 file is present in the step's run block and ignore list (containment, not exact match) so future additive file-list changes don't re-break the guard while the guarded property -- 0066 runs against real Postgres and is excluded from the unit contract -- stays pinned.

Verified: file passes locally against main's workflow (5 passed); the old assertion's StopIteration is exactly the failure CI shows on #1403 run 30820328825.