### PR TITLE
fix(go): isolate live oracles and align storage authorization

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,8 +91,8 @@ jobs:
         with:
           python-version: '3.13.14'
 
-      - name: Install pinned repository-model oracle dependencies
-        run: python -m pip install GitPython==3.1.54 SQLAlchemy==2.0.49
+      - name: Install live provider oracle application environment
+        run: python -m pip install .
 
       - name: Prepare base job contracts
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -218,10 +218,47 @@ check_live_python_oracles() {
   # `test` run) on every package in the tree instead of only the one that
   # structurally needs it, and it would make skipping this specific
   # coverage possible again by construction.
+  local proof_dir proof_file
+  proof_dir="$(mktemp -d "${TMPDIR:-/tmp}/dev-health-live-python-oracles.XXXXXX")"
+
   printf 'go test -count=1: internal/providersync (live Python oracle sources are outside the Go embed/cache boundary)\n'
-  (cd "${ROOT}" && GOWORK=off go test -mod=readonly -count=1 ./internal/providersync/...)
+  if ! (
+    cd "${ROOT}"
+    GOWORK=off \
+      DEV_HEALTH_LIVE_PYTHON_ORACLES=1 \
+      DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR="${proof_dir}" \
+      PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+      go test -mod=readonly -count=1 ./internal/providersync/...
+  ); then
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+  proof_file="${proof_dir}/providersync"
+  if [ ! -f "${proof_file}" ] || [ "$(cat "${proof_file}")" != "executed" ]; then
+    printf 'ERROR: providersync live Python oracle measurement did not occur\n' >&2
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+
   printf 'go test -count=1: internal/scheduler/sync (live Python planner source is outside the Go embed/cache boundary)\n'
-  (cd "${ROOT}" && GOWORK=off go test -mod=readonly -count=1 ./internal/scheduler/sync/...)
+  if ! (
+    cd "${ROOT}"
+    GOWORK=off \
+      DEV_HEALTH_LIVE_PYTHON_ORACLES=1 \
+      DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR="${proof_dir}" \
+      PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+      go test -mod=readonly -count=1 ./internal/scheduler/sync/...
+  ); then
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+  proof_file="${proof_dir}/scheduler-sync"
+  if [ ! -f "${proof_file}" ] || [ "$(cat "${proof_file}")" != "executed" ]; then
+    printf 'ERROR: scheduler/sync live Python oracle measurement did not occur\n' >&2
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+  rm -rf -- "${proof_dir}"
 }
 
 check_build() {

--- a/internal/providersync/capabilities_test.go
+++ b/internal/providersync/capabilities_test.go
@@ -12,6 +12,22 @@ import (
 	"testing"
 )
 
+const (
+	livePythonOraclesEnv      = "DEV_HEALTH_LIVE_PYTHON_ORACLES"
+	livePythonOracleProofDir  = "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR"
+	livePythonOracleProofFile = "providersync"
+)
+
+func requireLivePythonOracles(t *testing.T) {
+	t.Helper()
+	if os.Getenv(livePythonOraclesEnv) != "1" {
+		t.Skip("live Python oracles run only through ci/check_go.sh live-python-oracles")
+	}
+	if os.Getenv(livePythonOracleProofDir) == "" {
+		t.Fatal("live Python oracle opt-in requires a proof directory from ci/check_go.sh")
+	}
+}
+
 func TestCapabilitiesMatchPythonProviderRegistry(t *testing.T) {
 	python := pythonExecutable(t)
 	_, currentFile, _, _ := runtime.Caller(0)
@@ -61,6 +77,14 @@ type registryEntry struct {
 
 func pythonExecutable(t *testing.T) string {
 	t.Helper()
+	requireLivePythonOracles(t)
+	// The shell gate checks this only after the package succeeds. Recording the
+	// proof here makes it impossible for a standalone marker test to pass after
+	// every real Python oracle invocation has been removed or renamed.
+	proof := filepath.Join(os.Getenv(livePythonOracleProofDir), livePythonOracleProofFile)
+	if err := os.WriteFile(proof, []byte("executed\n"), 0o600); err != nil {
+		t.Fatalf("write live Python oracle proof: %v", err)
+	}
 	if configured := os.Getenv("PYTHON"); configured != "" {
 		return configured
 	}

--- a/internal/scheduler/sync/planner_oracle_test.go
+++ b/internal/scheduler/sync/planner_oracle_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,41 @@ import (
 	"testing"
 	"time"
 )
+
+const (
+	livePythonOraclesEnv      = "DEV_HEALTH_LIVE_PYTHON_ORACLES"
+	livePythonOracleProofDir  = "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR"
+	livePythonOracleProofFile = "scheduler-sync"
+)
+
+func requireLivePythonOracles(t *testing.T) {
+	t.Helper()
+	if os.Getenv(livePythonOraclesEnv) != "1" {
+		t.Skip("live Python oracles run only through ci/check_go.sh live-python-oracles")
+	}
+	if os.Getenv(livePythonOracleProofDir) == "" {
+		t.Fatal("live Python oracle opt-in requires a proof directory from ci/check_go.sh")
+	}
+}
+
+func livePythonExecutable(t *testing.T) string {
+	t.Helper()
+	requireLivePythonOracles(t)
+	// The shell gate checks this only after the package succeeds. Recording the
+	// proof here makes a missing real Python oracle invocation fail closed.
+	proof := filepath.Join(os.Getenv(livePythonOracleProofDir), livePythonOracleProofFile)
+	if err := os.WriteFile(proof, []byte("executed\n"), 0o600); err != nil {
+		t.Fatalf("write live Python oracle proof: %v", err)
+	}
+	if configured := os.Getenv("PYTHON"); configured != "" {
+		return configured
+	}
+	if path, err := exec.LookPath("python3"); err == nil {
+		return path
+	}
+	t.Fatal("python3 is required for the live scheduled planner oracle")
+	return ""
+}
 
 type plannerOracleSource struct {
 	ID         string `json:"id"`
@@ -198,6 +234,7 @@ func TestBuildScheduledPlanMatchesLivePythonPlanner(t *testing.T) {
 
 func runPythonPlannerOracle(t *testing.T, cases []plannerOracleCase) map[string][]map[string]any {
 	t.Helper()
+	python := livePythonExecutable(t)
 	encoded, err := json.Marshal(cases)
 	if err != nil {
 		t.Fatal(err)
@@ -206,7 +243,7 @@ func runPythonPlannerOracle(t *testing.T, cases []plannerOracleCase) map[string]
 	if !ok {
 		t.Fatal("cannot locate Python planner oracle")
 	}
-	command := exec.Command("python3", filepath.Join(filepath.Dir(currentFile), "testdata", "python_planner_oracle.py"))
+	command := exec.Command(python, filepath.Join(filepath.Dir(currentFile), "testdata", "python_planner_oracle.py"))
 	command.Stdin = bytes.NewReader(encoded)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/internal/storage/postgres/domain_authorization_integration_test.go
+++ b/internal/storage/postgres/domain_authorization_integration_test.go
@@ -90,8 +90,9 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		"CREATE ROLE " + authorizedDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + domainAuthorizationPass + "'",
 		"GRANT CONNECT ON DATABASE worker_test TO " + authorizedDomainRole,
 		"GRANT USAGE ON SCHEMA public TO " + authorizedDomainRole,
-		"GRANT SELECT ON TABLE public.integrations, public.integration_sources, public.integration_datasets, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + authorizedDomainRole,
-		"GRANT SELECT, UPDATE ON TABLE public.sync_runs, public.sync_run_units, public.report_runs, public.saved_reports TO " + authorizedDomainRole,
+		"GRANT SELECT ON TABLE public.integrations, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + authorizedDomainRole,
+		"GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources, public.integration_datasets, public.sync_runs, public.sync_run_units TO " + authorizedDomainRole,
+		"GRANT SELECT, UPDATE ON TABLE public.report_runs, public.saved_reports TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.worker_job_outbox, public.external_ingest_recompute_jobs, public.external_ingest_rejections TO " + authorizedDomainRole,
 		"GRANT SELECT, DELETE ON TABLE public.external_ingest_batch_payloads TO " + authorizedDomainRole,
@@ -114,6 +115,16 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 	assertDomainAuthorized(t, ctx, domain)
 	if _, err := domain.Exec(ctx, "SELECT id FROM public.integrations"); err != nil {
 		t.Fatalf("domain SELECT-only inventory access failed: %v", err)
+	}
+	for name, statement := range map[string]string{
+		"integration source":  "INSERT INTO public.integration_sources (id) VALUES (1)",
+		"integration dataset": "INSERT INTO public.integration_datasets (id) VALUES (1)",
+		"sync run":            "INSERT INTO public.sync_runs (id) VALUES (1)",
+		"sync run unit":       "INSERT INTO public.sync_run_units (id, state) VALUES (1, 'planned')",
+	} {
+		if _, err := domain.Exec(ctx, statement); err != nil {
+			t.Fatalf("domain materializer %s INSERT failed: %v", name, err)
+		}
 	}
 	if _, err := domain.Exec(ctx, "UPDATE public.sync_run_units SET state = 'ready'"); err != nil {
 		t.Fatalf("domain sync-run-unit UPDATE failed: %v", err)
@@ -154,6 +165,26 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 			name:   "missing SELECT-only privilege",
 			grant:  "REVOKE SELECT ON TABLE public.integrations FROM " + authorizedDomainRole,
 			revoke: "GRANT SELECT ON TABLE public.integrations TO " + authorizedDomainRole,
+		},
+		{
+			name:   "missing integration-source INSERT",
+			grant:  "REVOKE INSERT ON TABLE public.integration_sources FROM " + authorizedDomainRole,
+			revoke: "GRANT INSERT ON TABLE public.integration_sources TO " + authorizedDomainRole,
+		},
+		{
+			name:   "missing integration-dataset INSERT",
+			grant:  "REVOKE INSERT ON TABLE public.integration_datasets FROM " + authorizedDomainRole,
+			revoke: "GRANT INSERT ON TABLE public.integration_datasets TO " + authorizedDomainRole,
+		},
+		{
+			name:   "missing sync-run INSERT",
+			grant:  "REVOKE INSERT ON TABLE public.sync_runs FROM " + authorizedDomainRole,
+			revoke: "GRANT INSERT ON TABLE public.sync_runs TO " + authorizedDomainRole,
+		},
+		{
+			name:   "missing sync-run-unit INSERT",
+			grant:  "REVOKE INSERT ON TABLE public.sync_run_units FROM " + authorizedDomainRole,
+			revoke: "GRANT INSERT ON TABLE public.sync_run_units TO " + authorizedDomainRole,
 		},
 		{
 			name:   "missing sync-run-unit UPDATE",

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 const (
@@ -87,8 +88,9 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"CREATE ROLE " + runtimeAuthorizationQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + runtimeAuthorizationQueuePass + "'",
 		"GRANT CONNECT ON DATABASE worker_test TO " + runtimeAuthorizationDomainRole + ", " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE ON SCHEMA public TO " + runtimeAuthorizationDomainRole + ", " + runtimeAuthorizationQueueRole,
-		"GRANT SELECT ON TABLE public.integrations, public.integration_sources, public.integration_datasets, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + runtimeAuthorizationDomainRole,
-		"GRANT SELECT, UPDATE ON TABLE public.sync_runs, public.sync_run_units, public.report_runs, public.saved_reports TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT ON TABLE public.integrations, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources, public.integration_datasets, public.sync_runs, public.sync_run_units TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT, UPDATE ON TABLE public.report_runs, public.saved_reports TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.worker_job_outbox, public.external_ingest_recompute_jobs, public.external_ingest_rejections TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, DELETE ON TABLE public.external_ingest_batch_payloads TO " + runtimeAuthorizationDomainRole,
@@ -119,6 +121,14 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 	}
 	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); err != nil {
 		t.Fatalf("queue authorization failed: %v", err)
+	}
+	if _, err := domain.Exec(ctx, "INSERT INTO public.sync_run_units (id, state) VALUES (1, 'planned')"); err != nil {
+		t.Fatalf("domain materializer cannot insert sync-run-unit state: %v", err)
+	}
+	_, err = queue.Exec(ctx, "INSERT INTO public.sync_run_units (id, state) VALUES (2, 'forbidden')")
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "42501" {
+		t.Fatalf("queue domain materializer write-boundary error = %v, want 42501 insufficient_privilege", err)
 	}
 	if _, err := admin.Exec(ctx, "GRANT TEMPORARY ON DATABASE worker_test TO PUBLIC"); err != nil {
 		t.Fatal(err)

--- a/internal/storage/river/migrate_integration_test.go
+++ b/internal/storage/river/migrate_integration_test.go
@@ -443,13 +443,22 @@ func assertRuntimePrivileges(t *testing.T, ctx context.Context, domainURI, queue
 		t.Fatalf("domain role cannot UPDATE sync-dispatch outbox state: %v", err)
 	}
 	for _, statement := range []string{
+		"INSERT INTO public.integration_sources (id) VALUES ('00000000-0000-0000-0000-000000000010')",
+		"INSERT INTO public.integration_datasets (id) VALUES ('00000000-0000-0000-0000-000000000011')",
+		"INSERT INTO public.sync_runs (id) VALUES ('00000000-0000-0000-0000-000000000012')",
+		"INSERT INTO public.sync_run_units (id, state) VALUES ('00000000-0000-0000-0000-000000000013', 'planned')",
+	} {
+		if _, err := domainPool.Exec(ctx, statement); err != nil {
+			t.Fatalf("domain materializer privilege for %q: %v", statement, err)
+		}
+	}
+	for _, statement := range []string{
 		"SELECT count(*) FROM public.domain_runtime_probe",
 		"INSERT INTO public.domain_runtime_probe (value) VALUES ('forbidden')",
 		"UPDATE public.domain_runtime_probe SET value='forbidden'",
 		"DELETE FROM public.domain_runtime_probe",
 		"SELECT nextval('public.domain_runtime_probe_id_seq')",
 		"INSERT INTO public.integrations (id) VALUES ('00000000-0000-0000-0000-000000000010')",
-		"INSERT INTO public.sync_run_units (id, state) VALUES ('00000000-0000-0000-0000-000000000011', 'forbidden')",
 		"DELETE FROM public.sync_run_units",
 		"DELETE FROM public.sync_watermarks",
 		"DELETE FROM public.sync_dispatch_outbox",


### PR DESCRIPTION
## Summary
- keep live Python provider and scheduler oracles out of ordinary and integration Go test verbs
- align PostgreSQL authorization integration contracts with the scheduler materializer
- require exact domain INSERT grants while retaining queue, write/delete, coordinator, and per-table revocation boundaries

Linear: https://linear.app/fullchaos/issue/CHAOS-3345/restore-cumulative-go-worker-ci-after-hosted-runner-backlog

## Stack
1. #1423 — planner oracle input validation
2. this PR — coupled live-oracle isolation and storage authorization contracts
3. #1424 — non-vacuous dedicated live-oracle CI proof

These two signed commits share one layer because either one alone triggers a cumulative Go lane that requires the other. All layers target only feat/go-worker-runtime-migration.

## TEST-EVIDENCE
- real PostgreSQL/River integration packages passed locally
- ordinary/race/integration Go tests skip live Python subprocess tests
- cumulative Ruff, mypy, Go, live-oracle, build, and contract gates passed locally
- both commits are GitHub-verified; hosted cumulative CI is required before stack merge

## RISK-NOTES
- execution/test-contract boundary only; production grants already changed with the scheduler materializer
- no migration 0066, deployment, cutover, or scheduler ownership activation
- goOwnsMarkers remains false

SCREENSHOT-WAIVER: backend CI/test-contract correction; no rendered UI change