### PR TITLE
fix(ci): avoid Go integration inventory deadlock

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -313,18 +313,18 @@ check_contract() {
 # "needs a live vendor credential CI does not provision."
 declare -A INTEGRATION_DENYLIST=()
 
-# discover_integration_packages populates INTEGRATION_PACKAGES_BY_MODULE
-# (module_dir -> newline-separated list of module-relative "./pkg/dir"
-# entries) with every package that has at least one tracked or untracked,
-# non-vendor *_test.go file whose leading build-constraint comment names the
-# "integration" tag. This is a repo-wide scan for the literal constraint
+# discover_integration_packages populates parallel module/package arrays with
+# every module-relative "./pkg/dir" entry that has at least one tracked or
+# untracked, non-vendor *_test.go file whose leading build-constraint comment
+# names the "integration" tag. This is a repo-wide scan for the literal constraint
 # every integration suite in this tree uses today
 # (`//go:build integration`), checked via git's own file listing so it
 # honours the same tracked/untracked/exclude-standard rules as the rest of
 # this script -- not `find`, and not a hand-maintained list.
 discover_integration_packages() {
   local module_dir go_file dir
-  declare -gA INTEGRATION_PACKAGES_BY_MODULE=()
+  declare -ga INTEGRATION_PACKAGE_MODULES=()
+  declare -ga INTEGRATION_PACKAGES=()
 
   for module_dir in "${MODULE_DIRS[@]}"; do
     local -a found=()
@@ -345,9 +345,12 @@ discover_integration_packages() {
     done < <(
       git -C "${ROOT}/${module_dir}" ls-files --cached --others --exclude-standard -z -- '*_test.go'
     )
-    if [ "${#found[@]}" -gt 0 ]; then
-      INTEGRATION_PACKAGES_BY_MODULE["${module_dir}"]="$(printf '%s\n' "${found[@]}" | sort -u)"
-    fi
+    [ "${#found[@]}" -gt 0 ] || continue
+    while IFS= read -r dir; do
+      [ -n "${dir}" ] || continue
+      INTEGRATION_PACKAGE_MODULES+=("${module_dir}")
+      INTEGRATION_PACKAGES+=("${dir}")
+    done < <(printf '%s\n' "${found[@]}" | sort -u)
   done
 }
 
@@ -371,25 +374,23 @@ integration_denylist_reason() {
 # Docker and belongs in the fast path.
 check_integration_coverage() {
   discover_integration_packages
-  local module_dir pkg key reason
+  local index module_dir pkg key reason
   local -a denylist_seen=()
   local total=0
 
   printf 'integration coverage: discovered packages (module: package)\n'
-  for module_dir in "${MODULE_DIRS[@]}"; do
-    [ -n "${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]:-}" ] || continue
-    while IFS= read -r pkg; do
-      [ -n "${pkg}" ] || continue
-      total=$((total + 1))
-      key="${module_dir}/${pkg#./}"
-      key="${key#./}"
-      if reason="$(integration_denylist_reason "${key}")"; then
-        denylist_seen+=("${key}")
-        printf '  SKIP %s: %s\n' "${key}" "${reason}"
-      else
-        printf '  RUN  %s\n' "${key}"
-      fi
-    done <<<"${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]}"
+  for index in "${!INTEGRATION_PACKAGES[@]}"; do
+    module_dir="${INTEGRATION_PACKAGE_MODULES[${index}]}"
+    pkg="${INTEGRATION_PACKAGES[${index}]}"
+    total=$((total + 1))
+    key="${module_dir}/${pkg#./}"
+    key="${key#./}"
+    if reason="$(integration_denylist_reason "${key}")"; then
+      denylist_seen+=("${key}")
+      printf '  SKIP %s: %s\n' "${key}" "${reason}"
+    else
+      printf '  RUN  %s\n' "${key}"
+    fi
   done
 
   if [ "${total}" -eq 0 ]; then
@@ -413,21 +414,21 @@ check_integration_coverage() {
 
 check_integration() {
   check_integration_coverage
-  local module_dir pkg key reason
+  local index module_dir pkg key reason
   local -a run_pkgs=()
 
   for module_dir in "${MODULE_DIRS[@]}"; do
-    [ -n "${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]:-}" ] || continue
     run_pkgs=()
-    while IFS= read -r pkg; do
-      [ -n "${pkg}" ] || continue
+    for index in "${!INTEGRATION_PACKAGES[@]}"; do
+      [ "${INTEGRATION_PACKAGE_MODULES[${index}]}" = "${module_dir}" ] || continue
+      pkg="${INTEGRATION_PACKAGES[${index}]}"
       key="${module_dir}/${pkg#./}"
       key="${key#./}"
       if reason="$(integration_denylist_reason "${key}")"; then
         continue
       fi
       run_pkgs+=("${pkg}")
-    done <<<"${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]}"
+    done
     [ "${#run_pkgs[@]}" -gt 0 ] || continue
 
     printf 'go test integration: %s -> %s\n' "${module_dir}" "${run_pkgs[*]}"

--- a/tests/tooling/test_check_go_integration_coverage.py
+++ b/tests/tooling/test_check_go_integration_coverage.py
@@ -1,0 +1,32 @@
+"""Regression coverage for the Go integration-package inventory gate."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_integration_coverage_inventory_completes_and_stays_nonempty() -> None:
+    """A large inventory must not deadlock before the first package is printed.
+
+    Bash implements a here-string as a producer that fills a pipe before the
+    consumer starts. In environments whose pipe capacity is smaller than this
+    repository's inventory, that producer blocks forever. Running the public
+    discovery verb exercises the real inventory size and the same shell seam
+    used by ``local_validate.sh``.
+    """
+
+    result = subprocess.run(
+        ["bash", "ci/check_go.sh", "integration-coverage"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "  RUN  internal/providersync" in result.stdout
+    assert "package(s) discovered, 0 denylisted" in result.stdout


### PR DESCRIPTION
## Summary

- remove the newline-scalar/here-string transport that deadlocks Go integration inventory discovery on small local pipe capacities
- store discovered module/package pairs in parallel arrays and iterate them directly
- preserve sorted discovery, denylist validation, fail-on-zero behavior, and per-module integration test grouping
- add a regression through the public `ci/check_go.sh integration-coverage` verb

Linear: https://linear.app/fullchaos/issue/CHAOS-3347/fix-local-go-integration-coverage-hang-in-local-validate

## Target

This repository-wide local-validation fix targets `main` directly. It is independent of the Go Worker Runtime Migration stack because the deadlock blocks every local validation run.

## TEST-EVIDENCE

- baseline `9decbcb1b`: `timeout 5 bash ci/check_go.sh integration-coverage` stops after the inventory header with exit 124
- fixed focused regression passes and the public discovery verb prints 24 discovered, 0 denylisted, 24 runnable packages in about 0.9 seconds
- full escalated `PYTHONPATH=$PWD/src bash ci/check_go.sh fast` exits 0 through Go tests, build, contracts, integration vet, inventory, and advisory
- Bash syntax, ShellCheck, Ruff, mypy, diff check, and mutation-harness clean verification pass
- commit is GPG-signed and independently approved; hosted CI is required before merge

## RISK-NOTES

- the existing `fix/skip-go-local-validate` workaround branch is untouched; this PR fixes the mechanism instead of skipping Go/River stages
- no timeout increase and no integration package denylisting
- no migration 0066, deployment, cutover, scheduler ownership activation, or `goOwnsMarkers` change

SCREENSHOT-WAIVER: local backend CI shell fix; no rendered UI change
