### PR TITLE
CHAOS-3354: preserve joined GitLab control-plane failures

### DIFF
--- a/internal/providersync/gitlab_commit_stats_route.go
+++ b/internal/providersync/gitlab_commit_stats_route.go
@@ -3,7 +3,6 @@ package providersync
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"math"
 	"net/url"
 	"strconv"
@@ -187,22 +186,24 @@ func gitLabCommitStatsFatalDetailError(ctx context.Context, err error) error {
 	if ctx != nil && ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+	// D16 preserves malformed individual detail payloads as soft degradation,
+	// but only when every leaf is that normalization sentinel. A joined budget,
+	// lease, context, or other control-plane error must still fail the unit.
+	if gitLabErrorTreeOnlyLeaves(err, func(leaf error) bool {
+		return leaf == providerfoundation.ErrNormalizationInvalid
+	}) {
 		return nil
 	}
-	var providerErr *providerfoundation.ProviderError
-	if !errors.As(err, &providerErr) {
-		return err
-	}
-	switch providerErr.Class {
-	case providerfoundation.ErrorNotFound,
+	if gitLabErrorTreeOnlyProviderClasses(
+		err,
+		providerfoundation.ErrorNotFound,
 		providerfoundation.ErrorConflict,
 		providerfoundation.ErrorTransient,
-		providerfoundation.ErrorPermanent:
+		providerfoundation.ErrorPermanent,
+	) {
 		return nil
-	default:
-		return err
 	}
+	return err
 }
 
 func normalizeGitLabCommitStats(

--- a/internal/providersync/gitlab_commit_stats_route_test.go
+++ b/internal/providersync/gitlab_commit_stats_route_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -295,8 +296,50 @@ func TestGitLabCommitStatsFatalDetailErrorClassification(t *testing.T) {
 		{"credential invalid", providerfoundation.ErrCredentialInvalid, true},
 		{"transient detail", &providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient}, false},
 		{"not found detail", &providerfoundation.ProviderError{Class: providerfoundation.ErrorNotFound}, false},
+		{"conflict detail", &providerfoundation.ProviderError{Class: providerfoundation.ErrorConflict}, false},
+		{"permanent detail", &providerfoundation.ProviderError{Class: providerfoundation.ErrorPermanent}, false},
 		{"malformed detail", providerfoundation.ErrNormalizationInvalid, false},
+		{
+			"wrapped malformed detail",
+			fmt.Errorf("decode detail: %w", providerfoundation.ErrNormalizationInvalid),
+			false,
+		},
+		{
+			"joined malformed details",
+			errors.Join(
+				providerfoundation.ErrNormalizationInvalid,
+				providerfoundation.ErrNormalizationInvalid,
+			),
+			false,
+		},
 		{"unknown provider class", &providerfoundation.ProviderError{Class: "future-control-plane-class"}, true},
+		{
+			"joined transient and budget",
+			errors.Join(
+				&providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient},
+				providerfoundation.ErrBudgetUnavailable,
+			),
+			true,
+		},
+		{
+			"nested not found and lease",
+			fmt.Errorf(
+				"detail request: %w",
+				errors.Join(
+					&providerfoundation.ProviderError{Class: providerfoundation.ErrorNotFound},
+					fmt.Errorf("release reservation: %w", providerfoundation.ErrLeaseLost),
+				),
+			),
+			true,
+		},
+		{
+			"joined normalization and budget",
+			errors.Join(
+				providerfoundation.ErrNormalizationInvalid,
+				providerfoundation.ErrBudgetUnavailable,
+			),
+			true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := gitLabCommitStatsFatalDetailError(context.Background(), test.err)

--- a/internal/providersync/gitlab_error_classification.go
+++ b/internal/providersync/gitlab_error_classification.go
@@ -1,0 +1,78 @@
+package providersync
+
+import (
+	"reflect"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type singleErrorUnwrapper interface {
+	Unwrap() error
+}
+
+type multiErrorUnwrapper interface {
+	Unwrap() []error
+}
+
+// gitLabErrorTreeOnlyProviderClasses reports whether every leaf in err's full
+// wrapping/join tree is a ProviderError whose class is explicitly allowed.
+// Inspecting only the first errors.As match is unsafe: HTTP reservation cleanup
+// can join a soft request failure with a fatal budget or lease failure.
+func gitLabErrorTreeOnlyProviderClasses(
+	err error,
+	allowedClasses ...providerfoundation.ErrorClass,
+) bool {
+	allowed := make(map[providerfoundation.ErrorClass]struct{}, len(allowedClasses))
+	for _, class := range allowedClasses {
+		allowed[class] = struct{}{}
+	}
+	return gitLabErrorTreeOnlyLeaves(err, func(leaf error) bool {
+		providerErr, ok := leaf.(*providerfoundation.ProviderError)
+		if !ok {
+			return false
+		}
+		_, ok = allowed[providerErr.Class]
+		return ok
+	})
+}
+
+func gitLabErrorTreeOnlyLeaves(err error, allowed func(error) bool) bool {
+	if gitLabErrorIsNil(err) || allowed == nil {
+		return false
+	}
+	switch wrapped := err.(type) {
+	case multiErrorUnwrapper:
+		children := wrapped.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !gitLabErrorTreeOnlyLeaves(child, allowed) {
+				return false
+			}
+		}
+		return true
+	case singleErrorUnwrapper:
+		if child := wrapped.Unwrap(); child != nil {
+			return gitLabErrorTreeOnlyLeaves(child, allowed)
+		}
+	}
+	return allowed(err)
+}
+
+// gitLabErrorIsNil rejects typed-nil error implementations before invoking
+// an Unwrap method on them. Interface comparison alone cannot detect a nil
+// pointer stored in an error interface, and a custom unwrapper may dereference
+// its receiver and panic instead of allowing the route to fail closed.
+func gitLabErrorIsNil(err error) bool {
+	if err == nil {
+		return true
+	}
+	value := reflect.ValueOf(err)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/providersync/gitlab_error_classification_test.go
+++ b/internal/providersync/gitlab_error_classification_test.go
@@ -1,0 +1,115 @@
+package providersync
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabTypedNilSingleUnwrapper struct{ cause error }
+
+func (err *gitLabTypedNilSingleUnwrapper) Error() string { return "typed nil single" }
+func (err *gitLabTypedNilSingleUnwrapper) Unwrap() error { return err.cause }
+
+type gitLabTypedNilMultiUnwrapper struct{ causes []error }
+
+func (err *gitLabTypedNilMultiUnwrapper) Error() string   { return "typed nil multi" }
+func (err *gitLabTypedNilMultiUnwrapper) Unwrap() []error { return err.causes }
+
+func TestGitLabErrorTreeOnlyProviderClasses(t *testing.T) {
+	t.Parallel()
+	soft := []providerfoundation.ErrorClass{
+		providerfoundation.ErrorNotFound,
+		providerfoundation.ErrorConflict,
+		providerfoundation.ErrorTransient,
+		providerfoundation.ErrorPermanent,
+	}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "direct allowed provider leaf",
+			err:  &providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient},
+			want: true,
+		},
+		{
+			name: "wrapped allowed provider leaf",
+			err: fmt.Errorf(
+				"detail: %w",
+				&providerfoundation.ProviderError{Class: providerfoundation.ErrorPermanent},
+			),
+			want: true,
+		},
+		{
+			name: "joined allowed provider leaves",
+			err: errors.Join(
+				&providerfoundation.ProviderError{Class: providerfoundation.ErrorNotFound},
+				&providerfoundation.ProviderError{Class: providerfoundation.ErrorConflict},
+			),
+			want: true,
+		},
+		{
+			name: "nested allowed provider leaves",
+			err: fmt.Errorf(
+				"detail: %w",
+				errors.Join(
+					&providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient},
+					fmt.Errorf(
+						"release: %w",
+						&providerfoundation.ProviderError{Class: providerfoundation.ErrorPermanent},
+					),
+				),
+			),
+			want: true,
+		},
+		{
+			name: "joined budget leaf",
+			err: errors.Join(
+				&providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient},
+				providerfoundation.ErrBudgetUnavailable,
+			),
+		},
+		{
+			name: "nested lease leaf",
+			err: fmt.Errorf(
+				"detail: %w",
+				errors.Join(
+					&providerfoundation.ProviderError{Class: providerfoundation.ErrorNotFound},
+					fmt.Errorf("release: %w", providerfoundation.ErrLeaseLost),
+				),
+			),
+		},
+		{
+			name: "authentication leaf",
+			err:  &providerfoundation.ProviderError{Class: providerfoundation.ErrorAuthentication},
+		},
+		{
+			name: "rate-limit leaf",
+			err:  &providerfoundation.ProviderError{Class: providerfoundation.ErrorRateLimited},
+		},
+		{
+			name: "cancelled leaf",
+			err:  &providerfoundation.ProviderError{Class: providerfoundation.ErrorCancelled},
+		},
+		{
+			name: "unknown provider leaf",
+			err:  &providerfoundation.ProviderError{Class: "future-control-plane-class"},
+		},
+		{name: "nil provider leaf", err: (*providerfoundation.ProviderError)(nil)},
+		{name: "typed nil single unwrapper", err: (*gitLabTypedNilSingleUnwrapper)(nil)},
+		{name: "typed nil multi unwrapper", err: (*gitLabTypedNilMultiUnwrapper)(nil)},
+		{name: "non-provider leaf", err: errors.New("transport failed")},
+		{name: "nil error", err: nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := gitLabErrorTreeOnlyProviderClasses(test.err, soft...); got != test.want {
+				t.Fatalf("soft=%t want %t for %v", got, test.want, test.err)
+			}
+		})
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_commit_stats.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_commit_stats.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "name": "GitLab commit stats native route structural closure (CHAOS-3349)",
+  "name": "GitLab commit stats native route and joined-error structural closure (CHAOS-3349, CHAOS-3354)",
   "build": ["go", "test", "-run", "^$", "./internal/providersync/", "./cmd/dev-health-worker/"],
-  "$limitation": "This plan directly targets the GitLab commit-stats claim/client guards, project binding, pagination and window boundaries, required commit identity, accepted per-detail failure semantics, aggregate row shape, Python selection limits, repository identity, tenant-scoped exact readback, accepted Python budget, route readiness, and worker activation. The tenant collision is an integration-tagged mutation proof shared with the existing GitHub commit-stat sink. The generic live-Python oracle executes the canonical GitLab detail normalizer plus the production row builder and reflects the complete production model field set. This plan does not claim live credentialed GitLab traffic, scheduler activation, schema redesign, provider-instance semantics, migration 0066, or deployment/cutover evidence.",
+  "$limitation": "This plan directly targets the GitLab commit-stats claim/client guards, project binding, pagination and window boundaries, required commit identity, full joined-error-tree classification, accepted per-detail failure semantics, aggregate row shape, Python selection limits, repository identity, tenant-scoped exact readback, accepted Python budget, route readiness, and worker activation. The tenant collision is an integration-tagged mutation proof shared with the existing GitHub commit-stat sink. The generic live-Python oracle executes the canonical GitLab detail normalizer plus the production row builder and reflects the complete production model field set. This plan does not claim live credentialed GitLab traffic, scheduler activation, schema redesign, provider-instance semantics, migration 0066, or deployment/cutover evidence.",
   "mutations": [
     {
       "id": "G1-claim-provider-guard",
@@ -71,8 +71,8 @@
     {
       "id": "G9-detail-rate-limit-propagates",
       "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "case providerfoundation.ErrorNotFound,",
-      "replace": "case providerfoundation.ErrorRateLimited,\n\t\tproviderfoundation.ErrorNotFound,",
+      "find": "\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
+      "replace": "\t\tproviderfoundation.ErrorRateLimited,\n\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
       "rationale": "a rate-limited detail request must fail the unit rather than being swallowed as an accepted soft detail failure",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsRouteFailsClosedOnListCapAndRateLimit$/detail_rate_limit$", "./internal/providersync/"]]
     },
@@ -160,8 +160,8 @@
     {
       "id": "G20-detail-authentication-propagates",
       "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "case providerfoundation.ErrorNotFound,",
-      "replace": "case providerfoundation.ErrorAuthentication,\n\t\tproviderfoundation.ErrorNotFound,",
+      "find": "\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
+      "replace": "\t\tproviderfoundation.ErrorAuthentication,\n\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
       "rationale": "a detail 401 or 403 must fail the unit without effects or watermark advancement",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsRoutePropagatesAuthenticationDetailFailure$", "./internal/providersync/"]]
     },
@@ -176,8 +176,8 @@
     {
       "id": "G26-provider-cancelled-class-propagates",
       "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "case providerfoundation.ErrorNotFound,",
-      "replace": "case providerfoundation.ErrorCancelled,\n\t\tproviderfoundation.ErrorNotFound,",
+      "find": "\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
+      "replace": "\t\tproviderfoundation.ErrorCancelled,\n\t\tproviderfoundation.ErrorNotFound,\n\t\tproviderfoundation.ErrorConflict,",
       "rationale": "the provider taxonomy's cancelled class is a fatal control-plane outcome",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/provider_cancelled$", "./internal/providersync/"]]
     },
@@ -191,35 +191,91 @@
     },
     {
       "id": "G29-unknown-provider-class-fails-closed",
-      "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "default:\n\t\treturn err\n\t}\n}",
-      "replace": "default:\n\t\treturn nil\n\t}\n}",
+      "file": "internal/providersync/gitlab_error_classification.go",
+      "find": "\t\t_, ok = allowed[providerErr.Class]\n\t\treturn ok",
+      "replace": "\t\t_, ok = allowed[providerErr.Class]\n\t\treturn true",
       "rationale": "a future unclassified provider control-plane class must fail closed rather than silently become accepted detail degradation",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/unknown_provider_class$", "./internal/providersync/"]]
     },
     {
       "id": "G30-transient-detail-soft-allowlist",
       "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "providerfoundation.ErrorTransient,\n\t\tproviderfoundation.ErrorPermanent:",
-      "replace": "providerfoundation.ErrorClass(\"mutated-transient\"),\n\t\tproviderfoundation.ErrorPermanent:",
+      "find": "\t\tproviderfoundation.ErrorTransient,\n\t\tproviderfoundation.ErrorPermanent,",
+      "replace": "\t\tproviderfoundation.ErrorClass(\"mutated-transient\"),\n\t\tproviderfoundation.ErrorPermanent,",
       "rationale": "HTTP transient detail failures remain an explicitly accepted soft class under D16 rather than an accidental default",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsRouteMirrorsPythonSoftDetailFailure$", "./internal/providersync/"]]
     },
     {
       "id": "G31-non-provider-control-plane-fallback",
-      "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "if !errors.As(err, &providerErr) {\n\t\treturn err\n\t}",
-      "replace": "if !errors.As(err, &providerErr) {\n\t\treturn nil\n\t}",
+      "file": "internal/providersync/gitlab_error_classification.go",
+      "find": "\t\tif !ok {\n\t\t\treturn false\n\t\t}",
+      "replace": "\t\tif !ok {\n\t\t\treturn true\n\t\t}",
       "rationale": "lease, budget, explicit context, credential, and other non-ProviderError control-plane failures must fail closed through one structural fallback",
       "proof": [["go", "test", "-count=1", "-run", "^(TestGitLabCommitStatsRoutePropagatesDetailLeaseLoss|TestGitLabCommitStatsRoutePropagatesDetailBudgetDenial|TestGitLabCommitStatsFatalDetailErrorClassification)$", "./internal/providersync/"]]
     },
     {
       "id": "G32-normalization-detail-soft-allowlist",
       "file": "internal/providersync/gitlab_commit_stats_route.go",
-      "find": "if errors.Is(err, providerfoundation.ErrNormalizationInvalid) {\n\t\treturn nil\n\t}",
-      "replace": "if errors.Is(err, providerfoundation.ErrNormalizationInvalid) {\n\t\treturn err\n\t}",
+      "find": "\t\treturn leaf == providerfoundation.ErrNormalizationInvalid",
+      "replace": "\t\treturn false",
       "rationale": "malformed individual detail payloads remain an explicit accepted soft normalization failure rather than relying on the fatal fallback",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/malformed_detail$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G33-full-joined-error-tree",
+      "file": "internal/providersync/gitlab_error_classification.go",
+      "find": "\t\tfor _, child := range children {\n\t\t\tif !gitLabErrorTreeOnlyLeaves(child, allowed) {\n\t\t\t\treturn false\n\t\t\t}\n\t\t}\n\t\treturn true",
+      "replace": "\t\treturn gitLabErrorTreeOnlyLeaves(children[0], allowed)",
+      "rationale": "classification must inspect every joined child; a soft provider request joined with budget or lease loss is fatal even when the soft child is first",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/(joined_transient_and_budget|nested_not_found_and_lease)$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G34-wrapped-error-tree",
+      "file": "internal/providersync/gitlab_error_classification.go",
+      "find": "\t\tif child := wrapped.Unwrap(); child != nil {",
+      "replace": "\t\tif child := wrapped.Unwrap(); false {",
+      "rationale": "ordinary wrapping layers must be traversed before leaf classification so wrapped allowed provider errors remain soft and nested fatal leaves remain visible",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabErrorTreeOnlyProviderClasses$/wrapped_allowed_provider_leaf$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G35-normalization-joined-control-plane-leaf",
+      "file": "internal/providersync/gitlab_commit_stats_route.go",
+      "find": "\t\treturn leaf == providerfoundation.ErrNormalizationInvalid",
+      "replace": "\t\treturn leaf == providerfoundation.ErrNormalizationInvalid || leaf == providerfoundation.ErrBudgetUnavailable",
+      "rationale": "the commit-stats normalization exception is leaf-exact and must not hide a joined budget failure",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/joined_normalization_and_budget$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G36-typed-nil-error-tree",
+      "file": "internal/providersync/gitlab_error_classification.go",
+      "find": "\tif gitLabErrorIsNil(err) || allowed == nil {",
+      "replace": "\tif err == nil || allowed == nil {",
+      "rationale": "typed-nil error implementations must fail closed before invoking single- or multi-Unwrap methods that may dereference a nil receiver",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabErrorTreeOnlyProviderClasses$/(nil_provider_leaf|typed_nil_single_unwrapper|typed_nil_multi_unwrapper)$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G37-not-found-detail-soft-allowlist",
+      "file": "internal/providersync/gitlab_commit_stats_route.go",
+      "find": "\t\tproviderfoundation.ErrorNotFound,",
+      "replace": "\t\tproviderfoundation.ErrorClass(\"mutated-not-found\"),",
+      "rationale": "not-found detail responses remain an explicit accepted soft class rather than depending on a broad fallback",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/not_found_detail$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G38-conflict-detail-soft-allowlist",
+      "file": "internal/providersync/gitlab_commit_stats_route.go",
+      "find": "\t\tproviderfoundation.ErrorConflict,",
+      "replace": "\t\tproviderfoundation.ErrorClass(\"mutated-conflict\"),",
+      "rationale": "conflict detail responses remain an explicit accepted soft class rather than depending on a broad fallback",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/conflict_detail$", "./internal/providersync/"]]
+    },
+    {
+      "id": "G39-permanent-detail-soft-allowlist",
+      "file": "internal/providersync/gitlab_commit_stats_route.go",
+      "find": "\t\tproviderfoundation.ErrorPermanent,",
+      "replace": "\t\tproviderfoundation.ErrorClass(\"mutated-permanent\"),",
+      "rationale": "ordinary permanent detail responses remain an explicit accepted soft class under D16",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabCommitStatsFatalDetailErrorClassification$/permanent_detail$", "./internal/providersync/"]]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- classify the complete GitLab error wrap/join tree instead of accepting the first soft `ProviderError`
- keep commit-stat normalization degradation soft only when every error leaf is the normalization sentinel
- fail closed on joined or nested budget, lease, context, authentication, rate-limit, cancellation, unknown, typed-nil, and non-provider failures
- add clause-level mutation coverage for the shared classifier contract

## Baseline reproduction

On feature baseline `ec1daa9b876fe1c428020f3b1dae23ca7ac9c9d5`, the commit-stat classifier returned soft success for:

- transient provider failure joined with budget denial
- not-found provider failure nested with lease loss
- normalization failure joined with budget denial

The pre-fix tests failed on all three exact cases. A reviewer also reproduced a typed-nil custom unwrapper panic; the final helper rejects typed-nil error implementations before invoking `Unwrap`.

## Verification

- focused classifier and commit-stat tests: pass
- full `internal/providersync` tests: pass
- full Go suite: pass
- Go vet: pass
- mutation harness: 16/16 affected mutations killed, zero survivors or invalid mutations
- mutation restore verification, JSON validation, and diff check: pass
- independent review: pass, including the original typed-nil counterexample
- commit is signed

## Landing boundary

Base is `feat/go-worker-runtime-migration`. This PR is a bottom stack layer and must merge only into that feature branch. It changes no deployment switch, scheduler ownership, migration 0066 behavior, or cutover state.

SCREENSHOT-WAIVER: backend-only error-classification and tests; no rendered UI change.
