### PR TITLE
fix(ask-dev): CHAOS-3358 platform provider certification is advisory and self-healing

### DIFF
--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -22,6 +22,7 @@ from dev_health_ops.api.admin.middleware import (
     require_superuser,
 )
 from dev_health_ops.api.dev.production_runtime import (
+    certify_platform_resolution,
     resolve_platform_certification_provider,
 )
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
@@ -32,15 +33,12 @@ from dev_health_ops.llm.agent.readiness import (
     PLATFORM_READINESS_SETTING_KEY,
     PLATFORM_SETTINGS_ORG_ID,
     AgentReadinessOutcome,
-    AgentReadinessService,
     ReadinessState,
     SettingsAgentReadinessStore,
     readiness_failure_state,
 )
-from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
 from dev_health_ops.llm.agent.roles import (
     PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
-    AgentRole,
     SettingsRoleCertificationStore,
 )
 
@@ -254,63 +252,20 @@ async def run_platform_ask_dev_readiness(
         current_user,
         detail="Platform Ask Dev administrative actions are unavailable while impersonating",
     )
+    # CHAOS-3358: this button is now a FORCE-REFRESH, not a requirement --
+    # a stale record re-certifies itself automatically (see
+    # dev_health_ops.api.dev.platform_auto_certification), and a stale record
+    # no longer blocks anyone's run either way. The button still certifies
+    # unconditionally and synchronously, so an operator who has just changed
+    # something can see the verdict immediately instead of waiting for the
+    # next Ask Dev question to trigger the automatic path.
+    #
+    # The certify sequence itself lives in production_runtime so this route
+    # and the automatic path are one implementation writing one record shape,
+    # not two that have to be kept in agreement.
     try:
         resolution = await resolve_platform_certification_provider()
     except DevRuntimeUnavailable:
         return await _platform_readiness_response(session)
-    try:
-        await AgentReadinessService(_platform_store(session)).certify(
-            resolution.provider,
-            provider_name=resolution.family,
-            model=resolution.model,
-            fingerprint=resolution.readiness_fingerprint,
-        )
-        try:
-            # CHAOS-3285: certify the legacy_agent role in the new per-role
-            # store too, on the same already-resolved provider, so the
-            # per-role projection reflects real preflight results rather
-            # than staying "not_yet_certified" forever. Best-effort: a bug
-            # here must never regress the existing (tested, relied-upon)
-            # binary certify() call above -- certify_legacy_agent already
-            # turns every AgentProviderError into a FAILED/INCOMPATIBLE
-            # record internally, so only a genuinely unexpected failure
-            # (e.g. store I/O) reaches this except.
-            #
-            # CHAOS-3285 round 2 (Codex MEDIUM): the whole attempt runs
-            # inside a SAVEPOINT (begin_nested), never bare. A DB error
-            # caught by a plain except -- without a rollback or savepoint --
-            # leaves the session's transaction unable to accept further
-            # operations; the NEXT query on it raises PendingRollbackError,
-            # and when the request's own session dependency later tries to
-            # commit, THAT failure rolls back the whole transaction --
-            # silently discarding the binary certify() write just above,
-            # despite this being "caught". begin_nested()'s __aexit__ rolls
-            # back only to the savepoint on an exception, leaving the outer
-            # transaction (and the binary write already flushed into it)
-            # intact and the session usable for the rest of this request.
-            async with session.begin_nested():
-                await RoleReadinessService(_platform_role_store(session)).certify_role(
-                    AgentRole.LEGACY_AGENT,
-                    resolution.provider,
-                    certification_key=resolution.readiness_fingerprint,
-                )
-        except Exception:
-            logger.warning(
-                "Failed to certify the legacy_agent role during platform "
-                "Ask Dev preflight",
-                exc_info=True,
-            )
-    finally:
-        try:
-            await resolution.provider.aclose()
-        except Exception:
-            # Best-effort cleanup only: the certify() call above has already
-            # persisted the readiness result (or its own failure state), so a
-            # transport-close error here must never mask that outcome or fail
-            # this request. Still worth knowing about (a leaked connection is
-            # an operational signal), so log it rather than swallow it.
-            logger.warning(
-                "Failed to close platform Ask Dev provider connection after preflight",
-                exc_info=True,
-            )
+    await certify_platform_resolution(session, resolution)
     return await _platform_readiness_response(session)

--- a/src/dev_health_ops/api/dev/platform_auto_certification.py
+++ b/src/dev_health_ops/api/dev/platform_auto_certification.py
@@ -1,0 +1,180 @@
+"""Automatic re-certification of the platform-owned Ask Dev provider.
+
+CHAOS-3358. The platform provider's stored certification is invalidated by
+construction on every ``READINESS_VERSION`` bump and every change to the
+readiness-fingerprint formula, and also whenever the operator rotates a
+credential, model, organization, project, or custom header. Before this,
+recovering from any of those required a superadmin to open Platform Admin and
+press the preflight button; until they did, the readiness badge sat on
+"stale". Requiring a human button-press for a condition the system creates
+for itself is the bug.
+
+So the system re-certifies itself. When a production resolution observes that
+the platform record has gone stale (or was never written), it schedules a
+background re-certification that runs the SAME code path the button runs and
+writes the SAME record, so the badge self-heals to ready -- or to a real
+failure state with a reason -- with no human action.
+
+Three properties this module exists to guarantee:
+
+* **It never blocks a run.** Certification performs several live provider
+  round-trips with their own timeouts. Doing that inline would turn "the
+  fingerprint changed" into a multi-second stall on somebody's question, and
+  a broken operator endpoint into a stall for its full timeout -- a softer
+  version of exactly the block CHAOS-3358 removes. The work is scheduled onto
+  a background task and the caller returns immediately. Failure is logged and
+  left in the record; it is never raised at the caller.
+
+* **It never stampedes the provider.** ``schedule`` is single-flight (at most
+  one attempt in flight) AND throttled (at most one attempt per
+  ``_MIN_ATTEMPT_INTERVAL_SECONDS``). Both checks run synchronously with no
+  ``await`` between the test and the set, so concurrent resolutions on one
+  event loop cannot interleave past them. The throttle -- not just the
+  single-flight -- is what bounds a FAILING endpoint: without it, every
+  request after a failed attempt would immediately start another one.
+
+* **It never writes a lying record.** It does not reuse a caller's candidate
+  or fingerprint. ``certify_platform_provider`` re-resolves the platform
+  provider itself and writes the fingerprint of the resolution it actually
+  probed.
+
+Scope bound, stated because it is easy to over-read: the single-flight and
+throttle are per process. In a multi-worker deployment the bound is one
+attempt per worker per interval, not one globally. That is deliberate -- a
+global bound would need a distributed lock -- and it is sized so the
+worst case (a fleet restarting into a fingerprint change) is a handful of
+certifications, not a per-request flood.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.db import get_postgres_session
+
+logger = logging.getLogger(__name__)
+
+# How long to wait before another automatic attempt. Applies to successes and
+# failures alike: a successful attempt makes the record current so nothing
+# re-schedules anyway, while a failing one is exactly the case that needs the
+# ceiling.
+_MIN_ATTEMPT_INTERVAL_SECONDS = 300.0
+
+SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+
+
+class PlatformAutoCertifier:
+    """Single-flight, throttled scheduler for platform re-certification."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: SessionFactory | None = None,
+        min_interval_seconds: float = _MIN_ATTEMPT_INTERVAL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._session_factory = session_factory
+        self._min_interval_seconds = min_interval_seconds
+        self._clock = clock
+        self._in_flight: asyncio.Task[None] | None = None
+        self._last_attempt_at: float | None = None
+
+    def schedule(self) -> asyncio.Task[None] | None:
+        """Start a re-certification attempt unless one is suppressed.
+
+        Returns the task so callers that need determinism (tests, a startup
+        hook) can await it. Returns ``None`` when single-flight or the
+        throttle suppressed this call -- ``None`` is a normal outcome, not an
+        error.
+
+        Deliberately NOT a coroutine: every decision below is a plain
+        attribute read/write with no ``await`` in between, which is what makes
+        the check-then-set atomic with respect to the event loop. Making this
+        ``async`` would introduce the very interleaving the single-flight
+        exists to prevent.
+        """
+
+        if self._in_flight is not None and not self._in_flight.done():
+            return None
+        now = self._clock()
+        if (
+            self._last_attempt_at is not None
+            and now - self._last_attempt_at < self._min_interval_seconds
+        ):
+            return None
+        self._last_attempt_at = now
+        task = asyncio.create_task(self._attempt())
+        self._in_flight = task
+        return task
+
+    async def _attempt(self) -> None:
+        # Its own session: the caller's request session is committed and
+        # closed by the request's dependency well before this task finishes,
+        # and writing through a closed session would lose the record (or
+        # poison the caller's transaction on the way out).
+        try:
+            async with self._open_session() as session:
+                from .production_runtime import certify_platform_provider
+
+                await certify_platform_provider(session)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Certification's own failures are already persisted as a FAILED
+            # record by AgentReadinessService.certify. Reaching here means
+            # something around it broke (database unavailable, provider
+            # construction). There is nothing to escalate to: the run this was
+            # scheduled from has long since returned, and by ruling a
+            # certification failure must not affect it.
+            logger.warning(
+                "Automatic platform Ask Dev re-certification failed",
+                exc_info=True,
+            )
+
+    @contextlib.asynccontextmanager
+    async def _open_session(self) -> AsyncIterator[AsyncSession]:
+        factory = self._session_factory
+        if factory is None:
+            async with get_postgres_session() as session:
+                yield session
+            return
+        async with factory() as session:
+            yield session
+
+
+_certifier = PlatformAutoCertifier()
+
+
+def schedule_platform_recertification() -> asyncio.Task[None] | None:
+    """Schedule automatic platform re-certification on the process certifier."""
+
+    return _certifier.schedule()
+
+
+def set_platform_auto_certifier(certifier: PlatformAutoCertifier) -> None:
+    """Replace the process certifier. For tests and for a startup hook that
+    needs its own throttle/clock; production code uses the module default."""
+
+    global _certifier
+    _certifier = certifier
+
+
+def reset_platform_auto_certifier() -> None:
+    """Restore a pristine process certifier (test isolation)."""
+
+    set_platform_auto_certifier(PlatformAutoCertifier())
+
+
+__all__ = [
+    "PlatformAutoCertifier",
+    "reset_platform_auto_certifier",
+    "schedule_platform_recertification",
+    "set_platform_auto_certifier",
+]

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -118,7 +118,6 @@ from .native_team_workload import ClickHouseTeamWorkloadSource
 from .operational_deficiency_service import OperationalDeficiencyService
 from .orchestrator import DevRunLimits
 from .org_policy import load_ask_dev_org_policy
-from .platform_auto_certification import schedule_platform_recertification
 from .project_health_service import ProjectHealthService
 from .prompts import LEGACY_PROMPT_VERSION, PROMPT_VERSION
 from .question_interpreter import QuestionInterpreter
@@ -198,6 +197,15 @@ class ProductionProviderResolution:
     provider_label: str
     model_label: str
     readiness_fingerprint: str = ""
+    #: CHAOS-3358. True when the SELECTED provider is the platform one and its
+    #: stored certification is not current. Deliberately a fact, not a side
+    #: effect: resolution runs on unauthenticated-adjacent read paths (the
+    #: capabilities projection resolves a provider before Ask Dev entitlement
+    #: or emergency-disable is checked), and automatic re-certification spends
+    #: real operator provider calls. Only an authorized run that actually
+    #: selected the platform provider acts on this -- see the dev router's
+    #: message path. Codex CHAOS-3358 review, CONFIRMED reachable.
+    platform_certification_stale: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,15 +322,6 @@ async def resolve_production_provider(
         byo_role_profile=byo_role_profile,
         platform_role_profile=platform_role_profile,
     )
-    # CHAOS-3358: a stale platform record no longer blocks this run, so
-    # nothing else would ever notice it had gone stale -- the operator badge
-    # would sit on "stale, run preflight" until a human pressed the button.
-    # Heal it instead. Scheduling is non-blocking, single-flight and
-    # throttled; see platform_auto_certification. Gated on ``usable`` so a
-    # platform provider that is not configured at all (no credentials,
-    # uncertified family, operator "none") never triggers a pointless probe.
-    if platform is not None and platform.usable and not platform.readiness_current:
-        schedule_platform_recertification()
     return _resolve_provider_selection(
         byo=byo,
         platform=platform,
@@ -686,6 +685,19 @@ def _resolve_provider_selection(
         provider_label="OpenAI compatible",
         model_label=selected.model.replace("\r", "").replace("\n", "")[:256],
         readiness_fingerprint=_readiness_fingerprint(selected),
+        # The source check is redundant TODAY and deliberately kept: a BYO
+        # candidate is only ever selectable while readiness_current is true
+        # (AgentProviderCandidate.usable still requires it for BYO, and
+        # selection only returns candidates that are usable), so dropping it
+        # is currently an equivalent mutation -- no reachable input
+        # distinguishes the two. It is written explicitly anyway so this flag
+        # does not silently start meaning something else if BYO's own gate
+        # ever changes. Stated rather than claimed as covered: no test kills
+        # that mutant, because none can.
+        platform_certification_stale=(
+            selected.source is AgentProviderSource.PLATFORM
+            and not selected.readiness_current
+        ),
     )
 
 
@@ -2318,6 +2330,7 @@ async def _assemble_production_runtime(
         registry=registry,
         scope_resolver=scope_resolver,
         versions=versions,
+        platform_certification_stale=provider.platform_certification_stale,
         preflight=preflight,
         # CHAOS-3297 stack #3: the combined ten-plan lookup -- orchestrator.py's
         # own plan_registry.get(intent.intent_id) is intent-generic and needs

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import hashlib
 import json
+import logging
 import os
 import uuid
 from collections.abc import Mapping, Sequence
@@ -43,8 +44,10 @@ from dev_health_ops.llm.agent.probes.legacy_agent import _probe_registry, _probe
 from dev_health_ops.llm.agent.readiness import (
     PLATFORM_READINESS_SETTING_KEY,
     PLATFORM_SETTINGS_ORG_ID,
+    AgentReadinessService,
     SettingsAgentReadinessStore,
 )
+from dev_health_ops.llm.agent.role_readiness import RoleReadinessService
 from dev_health_ops.llm.agent.roles import (
     PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
     AgentRole,
@@ -115,6 +118,7 @@ from .native_team_workload import ClickHouseTeamWorkloadSource
 from .operational_deficiency_service import OperationalDeficiencyService
 from .orchestrator import DevRunLimits
 from .org_policy import load_ask_dev_org_policy
+from .platform_auto_certification import schedule_platform_recertification
 from .project_health_service import ProjectHealthService
 from .prompts import LEGACY_PROMPT_VERSION, PROMPT_VERSION
 from .question_interpreter import QuestionInterpreter
@@ -162,6 +166,8 @@ from .work_graph_neighbors_service import (
 from .work_graph_neighbors_service import (
     SCHEMA_VERSION as _WORK_GRAPH_SCHEMA_VERSION,
 )
+
+logger = logging.getLogger(__name__)
 
 _LLM_CATEGORY = SettingCategory.LLM.value
 _METRIC_REGISTRY_VERSION = "ask-dev-metrics.v1"
@@ -308,6 +314,15 @@ async def resolve_production_provider(
         byo_role_profile=byo_role_profile,
         platform_role_profile=platform_role_profile,
     )
+    # CHAOS-3358: a stale platform record no longer blocks this run, so
+    # nothing else would ever notice it had gone stale -- the operator badge
+    # would sit on "stale, run preflight" until a human pressed the button.
+    # Heal it instead. Scheduling is non-blocking, single-flight and
+    # throttled; see platform_auto_certification. Gated on ``usable`` so a
+    # platform provider that is not configured at all (no credentials,
+    # uncertified family, operator "none") never triggers a pointless probe.
+    if platform is not None and platform.usable and not platform.readiness_current:
+        schedule_platform_recertification()
     return _resolve_provider_selection(
         byo=byo,
         platform=platform,
@@ -369,6 +384,104 @@ async def resolve_platform_certification_provider() -> ProductionProviderResolut
     raise DevRuntimeUnavailable(
         "provider_not_configured", "No certified Ask Dev model is ready."
     )
+
+
+async def certify_platform_resolution(
+    session: AsyncSession, resolution: ProductionProviderResolution
+) -> None:
+    """Probe an already-resolved platform provider and persist the verdict.
+
+    This is the ONE implementation of "certify the platform-owned provider
+    and write the record". Both callers share it deliberately: the Platform
+    Admin preflight button (a force-refresh) and the automatic
+    re-certification that CHAOS-3358 triggers when the stored record has gone
+    stale. Two copies of this sequence would be two things to keep in
+    agreement, and the whole point of the automatic path is that the record
+    it writes is indistinguishable from the one the button writes -- same
+    binary ``AgentReadinessRecord``, same per-role ``legacy_agent`` record,
+    same fingerprint.
+
+    The provider probed and the fingerprint written both come off the SAME
+    ``ProductionProviderResolution``, so the record cannot claim a
+    configuration other than the one actually exercised.
+    """
+
+    try:
+        await AgentReadinessService(_platform_readiness_store(session)).certify(
+            resolution.provider,
+            provider_name=resolution.family,
+            model=resolution.model,
+            fingerprint=resolution.readiness_fingerprint,
+        )
+        try:
+            # CHAOS-3285: certify the legacy_agent role in the new per-role
+            # store too, on the same already-resolved provider, so the
+            # per-role projection reflects real preflight results rather
+            # than staying "not_yet_certified" forever. Best-effort: a bug
+            # here must never regress the existing (tested, relied-upon)
+            # binary certify() call above -- certify_legacy_agent already
+            # turns every AgentProviderError into a FAILED/INCOMPATIBLE
+            # record internally, so only a genuinely unexpected failure
+            # (e.g. store I/O) reaches this except.
+            #
+            # CHAOS-3285 round 2 (Codex MEDIUM): the whole attempt runs
+            # inside a SAVEPOINT (begin_nested), never bare. A DB error
+            # caught by a plain except -- without a rollback or savepoint --
+            # leaves the session's transaction unable to accept further
+            # operations; the NEXT query on it raises PendingRollbackError,
+            # and when the request's own session dependency later tries to
+            # commit, THAT failure rolls back the whole transaction --
+            # silently discarding the binary certify() write just above,
+            # despite this being "caught". begin_nested()'s __aexit__ rolls
+            # back only to the savepoint on an exception, leaving the outer
+            # transaction (and the binary write already flushed into it)
+            # intact and the session usable for the rest of this request.
+            async with session.begin_nested():
+                await RoleReadinessService(_platform_role_store(session)).certify_role(
+                    AgentRole.LEGACY_AGENT,
+                    resolution.provider,
+                    certification_key=resolution.readiness_fingerprint,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to certify the legacy_agent role during platform "
+                "Ask Dev preflight",
+                exc_info=True,
+            )
+    finally:
+        try:
+            await resolution.provider.aclose()
+        except Exception:
+            # Best-effort cleanup only: the certify() call above has already
+            # persisted the readiness result (or its own failure state), so a
+            # transport-close error here must never mask that outcome or fail
+            # this request. Still worth knowing about (a leaked connection is
+            # an operational signal), so log it rather than swallow it.
+            logger.warning(
+                "Failed to close platform Ask Dev provider connection after preflight",
+                exc_info=True,
+            )
+
+
+async def certify_platform_provider(session: AsyncSession) -> bool:
+    """Resolve the platform provider and certify it. False when there was
+    nothing to certify.
+
+    The entry point for automatic re-certification (CHAOS-3358), which -- unlike
+    the admin route -- has no request to answer and so resolves the provider
+    itself. A provider that will not resolve at all (unconfigured, or an
+    explicit operator "none") leaves the stored record untouched: the badge
+    already reports that state from the resolution failure itself, and
+    overwriting a real prior verdict with a synthetic one would lose
+    information.
+    """
+
+    try:
+        resolution = await resolve_platform_certification_provider()
+    except DevRuntimeUnavailable:
+        return False
+    await certify_platform_resolution(session, resolution)
+    return True
 
 
 async def resolve_byo_certification_provider(

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -79,6 +79,7 @@ from .persistence.service import (
     DevRateLimitExceeded,
     TranscriptRecord,
 )
+from .platform_auto_certification import schedule_platform_recertification
 from .production_runtime import (
     build_production_runtime,
     expand_production_evidence,
@@ -1210,6 +1211,24 @@ async def create_message(
             SettingsService(service.session, user.org_id)
         )
         provider_source = runtime.provider_source if runtime is not None else None
+        # CHAOS-3358: heal a stale platform certification automatically, so an
+        # operator never has to press the preflight button to recover from a
+        # READINESS_VERSION bump or a fingerprint-format change.
+        #
+        # This is the ONLY place that triggers it, and deliberately so. It sits
+        # after _require_ask_dev (entitlement AND emergency-disable both
+        # checked) and behind provider_source == "platform", so a run that
+        # selected BYO, a disabled or non-entitled organization, and the
+        # capabilities projection -- which resolves a provider before any Ask
+        # Dev authorization runs -- can never spend operator provider calls.
+        # Codex CHAOS-3358 review CONFIRMED that reachable path when this was
+        # scheduled from provider resolution instead.
+        if (
+            runtime is not None
+            and provider_source == "platform"
+            and runtime.platform_certification_stale
+        ):
+            schedule_platform_recertification()
         accepted = await service.append_user_message_and_run(
             org_id=org_id,
             user_id=user_id,

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -41,6 +41,11 @@ class BoundedDevRuntime:
     registry: AskDevToolRegistry
     scope_resolver: ScopeResolver
     versions: DevContractVersions
+    #: CHAOS-3358. Carried from ProductionProviderResolution so the authorized
+    #: run path can heal a stale platform certification. Never acted on during
+    #: runtime construction itself -- construction happens on read paths that
+    #: have not checked Ask Dev authorization yet.
+    platform_certification_stale: bool = False
     #: ``None`` when ``ask_dev_wave_3_1`` is off for this organization, which
     #: is the pre-CHAOS-3292 run path.
     preflight: SubjectPreflight | None = None

--- a/src/dev_health_ops/llm/agent/policy.py
+++ b/src/dev_health_ops/llm/agent/policy.py
@@ -60,15 +60,30 @@ class AgentProviderCandidate:
             )
             if self.provider in _LOCAL_PLATFORM_PROVIDERS:
                 credentials_present = bool(self.credentials.base_url)
+            # CHAOS-3358: the platform provider is operator-owned and assumed
+            # to work, so its stored certification is an operator-facing
+            # DIAGNOSTIC (the Platform Admin readiness badge and its "run
+            # preflight" copy) rather than a runtime gate. Requiring
+            # ``readiness_current`` here meant every READINESS_VERSION bump and
+            # every readiness-fingerprint format change -- both of which
+            # invalidate the stored certification by construction -- hard-blocked
+            # Ask Dev for every organization without BYO until a superadmin
+            # manually re-ran platform preflight. The remaining conjuncts still
+            # apply: an uncertified provider family, a missing operator
+            # credential, or an unsafe operator base URL keeps the candidate
+            # unusable. BYO keeps the strict gate below: a customer-supplied
+            # endpoint has demonstrated nothing until it is certified.
+            readiness_required = False
         else:
             valid_url, _ = validate_llm_base_url(self.credentials.base_url)
             credentials_present = bool(self.credentials.api_key)
+            readiness_required = True
         return (
             self.certified
             and bool(self.model)
             and credentials_present
             and valid_url
-            and self.readiness_current
+            and (self.readiness_current or not readiness_required)
         )
 
 

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -287,7 +287,11 @@ async def test_post_succeeds_and_logs_when_provider_close_fails(
     mask the readiness result the caller already committed (CHAOS-3265 /
     CodeQL empty-except finding) -- and must be logged, not silently
     swallowed. Deleting the try/except's log call (or reverting it to a bare
-    `pass`) makes this test fail on the caplog assertion below."""
+    `pass`) makes this test fail on the caplog assertion below.
+
+    CHAOS-3358 moved the certify sequence (and therefore this log call) into
+    production_runtime.certify_platform_resolution, shared with automatic
+    re-certification; the logger name below follows it."""
 
     class CloseFailsProvider(FakeReadinessProvider):
         async def aclose(self) -> None:
@@ -303,9 +307,7 @@ async def test_post_succeeds_and_logs_when_provider_close_fails(
         platform_ask_dev, "resolve_platform_certification_provider", resolve
     )
 
-    with caplog.at_level(
-        "WARNING", logger="dev_health_ops.api.admin.routers.platform_ask_dev"
-    ):
+    with caplog.at_level("WARNING", logger="dev_health_ops.api.dev.production_runtime"):
         posted = await platform_context.client.post(
             "/api/v1/admin/platform/ask-dev/readiness"
         )

--- a/tests/api/dev/test_platform_auto_certification.py
+++ b/tests/api/dev/test_platform_auto_certification.py
@@ -1,0 +1,576 @@
+"""CHAOS-3358: the platform provider re-certifies itself.
+
+The advisory change stops a stale platform certification from blocking runs.
+On its own that would leave the operator badge parked on "stale, run
+preflight" forever, because nothing else ever noticed. These controls cover
+the other half: the record heals itself, without a human pressing a button,
+and without stampeding the provider while it does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev import platform_auto_certification, production_runtime
+from dev_health_ops.api.dev.platform_auto_certification import PlatformAutoCertifier
+from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentProviderCapabilities,
+    AgentToolRequest,
+    AgentUsage,
+    StreamingMode,
+    StructuredOutputMode,
+    ToolDecisionMode,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
+from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    PLATFORM_SETTINGS_ORG_ID,
+    READINESS_ECHO_TOOL_ID,
+    AgentReadinessOutcome,
+    SettingsAgentReadinessStore,
+)
+from dev_health_ops.llm.agent.roles import (
+    PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    AgentRole,
+    RoleCertificationState,
+    SettingsRoleCertificationStore,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import Setting
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+_TABLES = tables_of(User, Organization, Setting)
+_FINGERPRINT = "platform-readiness-fingerprint"
+
+
+class FakeReadinessProvider:
+    """Satisfies both probes the platform certification runs: the binary
+    transport echo (calls 1-2) and the production-sized legacy_agent role
+    probe (calls 3-6). Mirrors the fake the Platform Admin route's own tests
+    use, on purpose -- the two callers must be able to certify the same
+    provider to the same verdict."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.closed = False
+
+    @property
+    def capabilities(self) -> AgentProviderCapabilities:
+        return AgentProviderCapabilities(
+            structured_output=StructuredOutputMode.JSON_SCHEMA,
+            tool_decisions=ToolDecisionMode.NATIVE,
+            streaming=StreamingMode.BUFFERED,
+            supports_cancellation=True,
+            context_window_tokens=16_384,
+            max_output_tokens=1_024,
+            readiness_version=READINESS_VERSION,
+            disclosure_key="openai-compatible",
+        )
+
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        self.calls += 1
+        if self.calls % 2 == 1:
+            tool_id = READINESS_ECHO_TOOL_ID if self.calls == 1 else "query_metric.v1"
+            arguments = (
+                {"nonce": "ready-v1"} if tool_id == READINESS_ECHO_TOOL_ID else {}
+            )
+            return AgentDecisionResult(
+                decision=AgentToolRequest(tool_id, arguments, f"call-{self.calls}"),
+                usage=AgentUsage(input_tokens=3, output_tokens=2),
+                latency_ms=1,
+                provider_fingerprint="provider",
+                model_fingerprint="model",
+            )
+        value = (
+            {"nonce": "ready-v1"}
+            if self.calls == 2
+            else {"status": "complete", "direct_summary": "Stub role probe answer."}
+        )
+        return AgentDecisionResult(
+            decision=AgentFinalAnswer(value=value),
+            usage=AgentUsage(input_tokens=4, output_tokens=1),
+            latency_ms=1,
+            provider_fingerprint="provider",
+            model_fingerprint="model",
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FailingReadinessProvider(FakeReadinessProvider):
+    async def decide(self, *_args: Any, **_kwargs: Any) -> AgentDecisionResult:
+        raise AgentProviderError(AgentProviderErrorCode.INVALID_RESPONSE)
+
+
+def _resolution(provider: Any) -> ProductionProviderResolution:
+    return ProductionProviderResolution(
+        provider=provider,
+        source=AgentProviderSource.PLATFORM,
+        family="openai",
+        model="platform-model",
+        provider_label="OpenAI compatible",
+        model_label="platform-model",
+        readiness_fingerprint=_FINGERPRINT,
+    )
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest_asyncio.fixture
+async def settings_maker(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'platform-auto-certification.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield maker
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_certifier():
+    platform_auto_certification.reset_platform_auto_certifier()
+    yield
+    platform_auto_certification.reset_platform_auto_certifier()
+
+
+def _session_factory(maker: async_sessionmaker[AsyncSession]):
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[AsyncSession]:
+        async with maker() as session:
+            yield session
+            await session.commit()
+
+    return factory
+
+
+async def _write_stale_record(maker: async_sessionmaker[AsyncSession]) -> None:
+    async with maker() as session:
+        await SettingsService(session, PLATFORM_SETTINGS_ORG_ID).set(
+            PLATFORM_READINESS_SETTING_KEY,
+            json.dumps(
+                {
+                    "fingerprint": "fingerprint-from-the-previous-readiness-version",
+                    "readiness_version": "ask-dev-readiness.v0",
+                    "checked_at": "2026-07-29T12:00:00+00:00",
+                    "outcome": "ready",
+                    "safe_error_code": None,
+                }
+            ),
+            category="llm",
+            description="Safe Ask Dev provider certification result",
+        )
+        await session.commit()
+
+
+async def _load_record(maker: async_sessionmaker[AsyncSession]):
+    async with maker() as session:
+        return await SettingsAgentReadinessStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_READINESS_SETTING_KEY,
+        ).load()
+
+
+async def _load_role_record(maker: async_sessionmaker[AsyncSession]):
+    async with maker() as session:
+        profile = await SettingsRoleCertificationStore(
+            SettingsService(session, PLATFORM_SETTINGS_ORG_ID),
+            key=PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+        ).load()
+    return profile.for_role(AgentRole.LEGACY_AGENT)
+
+
+@pytest.mark.asyncio
+async def test_stale_record_self_heals_with_no_admin_action(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline control: a stale stored certification plus a working
+    provider becomes a CURRENT record after one scheduled attempt, with
+    nobody pressing preflight. Observed by reading the store, not by
+    trusting a return value."""
+
+    provider = FakeReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+    await _write_stale_record(settings_maker)
+
+    stale = await _load_record(settings_maker)
+    assert stale is not None
+    assert (
+        stale.is_current(fingerprint=_FINGERPRINT, readiness_version=READINESS_VERSION)
+        is False
+    )
+
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=FakeClock()
+    )
+    task = certifier.schedule()
+    assert task is not None
+    await task
+
+    healed = await _load_record(settings_maker)
+    assert healed is not None
+    assert healed.outcome is AgentReadinessOutcome.READY
+    assert (
+        healed.is_current(fingerprint=_FINGERPRINT, readiness_version=READINESS_VERSION)
+        is True
+    )
+    # The per-role certification the runtime and the badge both read must
+    # heal too -- a binary-only heal would leave the badge stale forever.
+    role_record = await _load_role_record(settings_maker)
+    assert role_record is not None
+    assert role_record.state is RoleCertificationState.COMPATIBLE
+    assert role_record.is_current(certification_key=_FINGERPRINT) is True
+    assert provider.closed is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resolutions_certify_the_provider_once(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No stampede: eight concurrent schedule() calls -- what a burst of Ask
+    Dev questions right after a deploy looks like -- must produce exactly one
+    certification, not eight sets of live provider round-trips."""
+
+    resolves = 0
+    release = asyncio.Event()
+
+    async def resolve() -> ProductionProviderResolution:
+        nonlocal resolves
+        resolves += 1
+        # Hold the attempt open so every sibling schedule() below runs while
+        # this one is genuinely in flight; without that the test could pass
+        # on timing rather than on the single-flight guard.
+        await release.wait()
+        return _resolution(FakeReadinessProvider())
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    # min_interval_seconds=0 disables the throttle deliberately. With the
+    # throttle active, the throttle alone suppresses every sibling call on a
+    # frozen clock and this test passes whether or not single-flight exists --
+    # it would be testing the wrong guard. Zero leaves single-flight as the
+    # only thing that can suppress these.
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker),
+        min_interval_seconds=0.0,
+        clock=FakeClock(),
+    )
+
+    first = certifier.schedule()
+    assert first is not None
+    await asyncio.sleep(0)  # let the task reach the awaited resolve
+
+    suppressed = [certifier.schedule() for _ in range(7)]
+    assert suppressed == [None] * 7
+
+    release.set()
+    await first
+    assert resolves == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_attempt_is_throttled_before_it_retries(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-flight alone does not bound a FAILING provider: once the
+    attempt finishes, the record is still not current, so the very next
+    request would schedule another one. The throttle is what turns that into
+    a bounded retry rate."""
+
+    attempts = 0
+
+    async def resolve() -> ProductionProviderResolution:
+        nonlocal attempts
+        attempts += 1
+        return _resolution(FailingReadinessProvider())
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    clock = FakeClock()
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker),
+        min_interval_seconds=300.0,
+        clock=clock,
+    )
+
+    first = certifier.schedule()
+    assert first is not None
+    await first
+    assert attempts == 1
+
+    # Attempt finished, record still not current, nothing in flight -- only
+    # the throttle stands between here and a retry per request.
+    clock.advance(299.0)
+    assert certifier.schedule() is None
+    assert attempts == 1
+
+    clock.advance(2.0)
+    later = certifier.schedule()
+    assert later is not None
+    await later
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_a_failing_provider_records_the_failure_and_raises_nothing(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-certification failure is a diagnostic, never an exception the
+    caller has to survive: the task completes, the record shows the failure
+    with a reason, and the run that scheduled it is unaffected."""
+
+    provider = FailingReadinessProvider()
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(provider)
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=FakeClock()
+    )
+    task = certifier.schedule()
+    assert task is not None
+    await task
+    assert task.exception() is None
+
+    record = await _load_record(settings_maker)
+    assert record is not None
+    assert record.outcome is AgentReadinessOutcome.FAILED
+    assert record.safe_error_code == "invalid_response"
+    assert (
+        record.is_current(fingerprint=_FINGERPRINT, readiness_version=READINESS_VERSION)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_infrastructure_failure_never_escapes_the_task(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failure AROUND certification (database down, provider construction
+    blowing up) is not persisted by certify() itself, so it has to be caught
+    here or it would surface as an unretrieved task exception."""
+
+    async def resolve() -> ProductionProviderResolution:
+        raise RuntimeError("postgres is unreachable")
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=FakeClock()
+    )
+    with caplog.at_level(
+        "WARNING", logger="dev_health_ops.api.dev.platform_auto_certification"
+    ):
+        task = certifier.schedule()
+        assert task is not None
+        await task
+
+    assert task.exception() is None
+    assert any(
+        "Automatic platform Ask Dev re-certification failed" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_platform_leaves_the_stored_record_untouched(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing to certify (no operator provider, or an explicit "none") must
+    not overwrite a real prior verdict with a synthetic one -- and must be a
+    clean "nothing to do", not an error the caller has to absorb."""
+
+    async def resolve() -> ProductionProviderResolution:
+        raise DevRuntimeUnavailable(
+            "provider_not_configured", "No certified Ask Dev model is ready."
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+    await _write_stale_record(settings_maker)
+    before = await _load_record(settings_maker)
+
+    # Asserted directly on certify_platform_provider, not only through the
+    # scheduler: the scheduler's blanket except would swallow a propagating
+    # DevRuntimeUnavailable and this would read as "untouched" for the wrong
+    # reason -- an unconfigured platform is an expected state, not a failure.
+    async with settings_maker() as session:
+        assert await production_runtime.certify_platform_provider(session) is False
+        await session.commit()
+    assert await _load_record(settings_maker) == before
+
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=FakeClock()
+    )
+    task = certifier.schedule()
+    assert task is not None
+    await task
+
+    assert await _load_record(settings_maker) == before
+
+
+@pytest.mark.asyncio
+async def test_automatic_and_manual_certification_write_the_same_record(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Differential control on the two callers of the shared certify path.
+
+    The whole premise of making the button optional is that the record the
+    automatic path writes is the record the button writes. If these two ever
+    diverge -- a different fingerprint, a missing role row, a different
+    outcome -- the badge would report one thing after a button press and
+    another after a self-heal. Compared field by field except checked_at,
+    which is a timestamp and must differ.
+    """
+
+    async def resolve() -> ProductionProviderResolution:
+        return _resolution(FakeReadinessProvider())
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    # The manual path: exactly what the Platform Admin POST route runs.
+    async with settings_maker() as session:
+        await production_runtime.certify_platform_resolution(
+            session, _resolution(FakeReadinessProvider())
+        )
+        await session.commit()
+    manual = await _load_record(settings_maker)
+    manual_role = await _load_role_record(settings_maker)
+
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=FakeClock()
+    )
+    task = certifier.schedule()
+    assert task is not None
+    await task
+    automatic = await _load_record(settings_maker)
+    automatic_role = await _load_role_record(settings_maker)
+
+    assert manual is not None and automatic is not None
+    assert manual.fingerprint == automatic.fingerprint == _FINGERPRINT
+    assert manual.readiness_version == automatic.readiness_version
+    assert manual.outcome is automatic.outcome
+    assert manual.safe_error_code == automatic.safe_error_code
+
+    assert manual_role is not None and automatic_role is not None
+    assert manual_role.role is automatic_role.role
+    assert manual_role.certification_key == automatic_role.certification_key
+    assert manual_role.readiness_version == automatic_role.readiness_version
+    assert manual_role.state is automatic_role.state
+    assert manual_role.safe_error_code == automatic_role.safe_error_code
+
+
+@pytest.mark.asyncio
+async def test_the_record_reflects_the_configuration_actually_probed(
+    settings_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """It must be impossible for the automatic path to certify one
+    configuration and file the result under another -- a "lying record"
+    would read as green for a configuration that was never exercised. The
+    fingerprint written comes off the same resolution whose provider was
+    probed, so a resolution change between attempts changes the record."""
+
+    resolutions = [
+        _resolution(FakeReadinessProvider()),
+        ProductionProviderResolution(
+            provider=FakeReadinessProvider(),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="rotated-model",
+            provider_label="OpenAI compatible",
+            model_label="rotated-model",
+            readiness_fingerprint="fingerprint-after-the-operator-rotated-the-model",
+        ),
+    ]
+
+    async def resolve() -> ProductionProviderResolution:
+        return resolutions.pop(0)
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_platform_certification_provider", resolve
+    )
+
+    clock = FakeClock()
+    certifier = PlatformAutoCertifier(
+        session_factory=_session_factory(settings_maker), clock=clock
+    )
+    first = certifier.schedule()
+    assert first is not None
+    await first
+    record = await _load_record(settings_maker)
+    assert record is not None and record.fingerprint == _FINGERPRINT
+
+    clock.advance(1_000.0)
+    second = certifier.schedule()
+    assert second is not None
+    await second
+    rotated = await _load_record(settings_maker)
+    assert rotated is not None
+    assert rotated.fingerprint == "fingerprint-after-the-operator-rotated-the-model"
+    # And the previously-current fingerprint is no longer claimed.
+    assert (
+        rotated.is_current(
+            fingerprint=_FINGERPRINT, readiness_version=READINESS_VERSION
+        )
+        is False
+    )

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -20,9 +20,13 @@ from dev_health_ops.api.dev.tool_registry import (
 from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
-from dev_health_ops.llm.agent.readiness import PLATFORM_READINESS_SETTING_KEY
+from dev_health_ops.llm.agent.readiness import (
+    PLATFORM_READINESS_SETTING_KEY,
+    READINESS_SETTING_KEY,
+)
 from dev_health_ops.llm.agent.roles import (
     PLATFORM_ROLE_CERTIFICATION_SETTING_KEY,
+    ROLE_CERTIFICATION_SETTING_KEY,
     AgentRole,
 )
 from dev_health_ops.llm.credentials import LLMCredentials
@@ -59,6 +63,7 @@ def _fingerprint(
     organization: str = "",
     project: str = "",
     custom_headers: tuple[tuple[str, str], ...] = (),
+    source: str = "platform",
 ) -> str:
     # CHAOS-3285: mirrors production_runtime._readiness_fingerprint's
     # extended formula. Every fixture in this file that builds a "current"
@@ -81,7 +86,7 @@ def _fingerprint(
     return hashlib.sha256(
         "\0".join(
             (
-                "platform",
+                source,
                 provider,
                 model,
                 base_url,
@@ -496,11 +501,16 @@ async def test_wire_policy_change_invalidates_stored_certification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """End-to-end: a certification stored under today's wire policy must be
-    invalidated -- selection fails closed -- once the policy changes for
-    this model, even though the candidate itself (model/provider/base_url)
-    never changed. Closes the loop codex asked for: fingerprint changes ->
-    stored certification invalidated, not just a digest changing in
-    isolation."""
+    invalidated once the policy changes for this model, even though the
+    candidate itself (model/provider/base_url) never changed. Closes the loop
+    codex asked for: fingerprint changes -> stored certification invalidated,
+    not just a digest changing in isolation.
+
+    CHAOS-3358: for the PLATFORM source that invalidation is now an
+    operator-facing diagnostic rather than a runtime block, so the assertion
+    is on the certification state itself; selection deliberately keeps
+    working. The equivalent BYO invalidation still fails closed -- see
+    test_byo_role_certification_is_still_a_hard_runtime_gate."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -532,17 +542,20 @@ async def test_wire_policy_change_invalidates_stored_certification(
         session, org_id="org_01"
     )
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     from dev_health_ops.llm.agent import openai_compatible
 
     monkeypatch.setattr(openai_compatible, "supports_temperature", lambda _model: False)
     production_runtime._wire_request_digest.cache_clear()
     try:
-        with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        assert await _platform_certification_is_current(session) is False
+        # Advisory, not a gate: the run still resolves.
+        assert (
             await production_runtime.resolve_production_provider(
                 session, org_id="org_01"
             )
-        assert exc_info.value.code == "provider_not_configured"
+        ).model == "certified-model"
     finally:
         production_runtime._wire_request_digest.cache_clear()
 
@@ -553,12 +566,14 @@ async def test_credential_rotation_invalidates_certification(
 ) -> None:
     """CHAOS-3285 round 5 (Codex HIGH), codex's exact repro: certify
     provider key A, then rotate to key B for the exact same
-    provider/model/base_url -- selection must fail closed until B is
-    re-certified. Before this fix, the certification key never depended on
-    WHICH credential was actually tested, so B's rotation silently
-    inherited A's certification while every real request already carried
-    B's Authorization header, never having demonstrated B can handle the
-    production request shape at all."""
+    provider/model/base_url -- the stored certification must not carry over.
+    Before that fix, the certification key never depended on WHICH credential
+    was actually tested, so B's rotation silently inherited A's certification
+    while every real request already carried B's Authorization header, never
+    having demonstrated B can handle the production request shape at all.
+
+    CHAOS-3358: on the operator-owned PLATFORM source this now reports as a
+    stale certification rather than a hard block."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -588,13 +603,12 @@ async def test_credential_rotation_invalidates_certification(
         session, org_id="org_01"
     )
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     # Rotate to key B -- same provider/model/base_url, a different
     # credential -- without re-running preflight.
     monkeypatch.setenv("OPENAI_API_KEY", "key-b")
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    assert await _platform_certification_is_current(session) is False
 
 
 @pytest.mark.asyncio
@@ -603,8 +617,8 @@ async def test_organization_rotation_invalidates_certification(
 ) -> None:
     """Same guard as credential (api_key) rotation, for organization:
     certify under org A, flip OPENAI_ORG_ID to org B for the exact same
-    provider/model/base_url/api_key -- selection must fail closed until B
-    is re-certified."""
+    provider/model/base_url/api_key -- the stored certification must not
+    carry over (CHAOS-3358: advisory on the platform source)."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -634,11 +648,10 @@ async def test_organization_rotation_invalidates_certification(
         session, org_id="org_01"
     )
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     monkeypatch.setenv("OPENAI_ORG_ID", "org-b")
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    assert await _platform_certification_is_current(session) is False
 
 
 @pytest.mark.asyncio
@@ -649,7 +662,7 @@ async def test_project_rotation_invalidates_certification(
     another for the exact same provider/model/base_url/api_key must
     invalidate certification -- previously this left the fingerprint
     byte-for-byte identical while the real OpenAI-Project wire header
-    changed."""
+    changed (CHAOS-3358: advisory on the platform source)."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -679,11 +692,10 @@ async def test_project_rotation_invalidates_certification(
         session, org_id="org_01"
     )
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     monkeypatch.setenv("OPENAI_PROJECT_ID", "project-b")
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    assert await _platform_certification_is_current(session) is False
 
 
 @pytest.mark.asyncio
@@ -692,7 +704,8 @@ async def test_custom_header_rotation_invalidates_certification(
 ) -> None:
     """Same guard, for custom identity headers: changing
     OPENAI_CUSTOM_HEADERS for the exact same provider/model/base_url/
-    api_key must invalidate certification."""
+    api_key must invalidate certification (CHAOS-3358: advisory on the
+    platform source)."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -722,11 +735,10 @@ async def test_custom_header_rotation_invalidates_certification(
         session, org_id="org_01"
     )
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "X-Tenant: tenant-b")
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    assert await _platform_certification_is_current(session) is False
 
 
 def test_credential_fingerprint_never_leaks_the_raw_api_key() -> None:
@@ -793,9 +805,15 @@ def test_credential_fingerprint_has_no_concatenation_ambiguity() -> None:
 
 
 @pytest.mark.asyncio
-async def test_provider_resolution_requires_current_certification(
+async def test_platform_certification_tracks_the_live_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The platform certification must follow the configuration it was taken
+    against: changing the model, or storing a fingerprint from a different
+    configuration, leaves it non-current. CHAOS-3358 makes that an operator
+    diagnostic rather than a runtime block, so selection keeps working
+    throughout."""
+
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
         production_runtime,
@@ -826,11 +844,13 @@ async def test_provider_resolution_requires_current_certification(
     assert resolved.source is AgentProviderSource.PLATFORM
     assert resolved.family == "openai"
     assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is True
 
     monkeypatch.setenv("LLM_MODEL", "changed-model")
-    with pytest.raises(DevRuntimeUnavailable) as model_change:
+    assert await _platform_certification_is_current(session) is False
+    assert (
         await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert model_change.value.code == "provider_not_configured"
+    ).model == "changed-model"
     monkeypatch.setenv("LLM_MODEL", "certified-model")
 
     FakeSettingsService.values[PLATFORM_READINESS_SETTING_KEY] = json.dumps(
@@ -842,13 +862,54 @@ async def test_provider_resolution_requires_current_certification(
             "safe_error_code": None,
         }
     )
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+    assert await _platform_certification_is_current(session) is False
+    assert (
         await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    ).model == "certified-model"
 
 
 @pytest.mark.asyncio
-async def test_echo_only_certification_does_not_restore_live_selection(
+def _byo_settings(*, role_state: str | None) -> dict[str, str]:
+    """A BYO organization whose binary readiness is CURRENT, parameterised on
+    the legacy_agent role certification: absent (``None``) or present with the
+    given state. Platform fallback is switched off so the BYO verdict is the
+    only thing under test."""
+
+    byo_fingerprint = _fingerprint(
+        source="byo",
+        provider="openai",
+        model="gpt-5-mini",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-org",
+    )
+    values = {
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+        "ask_dev_platform_fallback": "fail_closed",
+        READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": byo_fingerprint,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+    }
+    if role_state is not None:
+        role_key, role_value = _role_certification_setting(
+            key_prefix=ROLE_CERTIFICATION_SETTING_KEY,
+            certification_key=byo_fingerprint,
+            state=role_state,
+        )
+        values[role_key] = role_value
+    return values
+
+
+@pytest.mark.asyncio
+async def test_echo_only_certification_does_not_restore_live_byo_selection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """CHAOS-3285 (Codex HIGH): the old binary AgentReadinessRecord being
@@ -857,9 +918,70 @@ async def test_echo_only_certification_does_not_restore_live_selection(
     ever runs the old 512-token echo probe (or the new role probe simply
     never having run at all), the binary store would read current, and this
     candidate would become selectable for real traffic having never
-    demonstrated it can handle the production request shape. This is the RED
-    half: binary readiness alone, with NO legacy_agent role certification on
-    record, must fail closed."""
+    demonstrated it can handle the production request shape.
+
+    CHAOS-3358 moved this gate off the operator-owned platform source, so the
+    control now runs where it is still a runtime gate: a customer's BYO
+    endpoint, whose binary readiness is current but which has NO legacy_agent
+    role certification on record, must fail closed."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setattr(
+        production_runtime, "attach_agent_budget_guard", lambda value, **_: value
+    )
+    FakeSettingsService.values = _byo_settings(role_state=None)
+
+    session = cast(Any, object())
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+    # The GREEN half: the same configuration with a compatible legacy_agent
+    # role certification does resolve -- so the block above is the role gate
+    # firing, not the fixture failing to configure BYO at all.
+    FakeSettingsService.values = _byo_settings(role_state="compatible")
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+    assert resolved.source is AgentProviderSource.BYO
+    assert resolved.model == "gpt-5-mini"
+
+
+@pytest.mark.asyncio
+async def test_incompatible_legacy_agent_role_does_not_restore_live_byo_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same gate, with a role record present but INCOMPATIBLE (e.g. the
+    production-sized probe reproduced output exhaustion) rather than absent
+    -- an INCOMPATIBLE verdict must never be silently treated as good
+    enough for live BYO selection either."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setattr(
+        production_runtime, "attach_agent_budget_guard", lambda value, **_: value
+    )
+    FakeSettingsService.values = _byo_settings(role_state="incompatible")
+
+    session = cast(Any, object())
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_platform_role_certification_is_advisory_not_a_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3358: the platform-side counterpart of the two BYO controls
+    above -- binary readiness current, legacy_agent role certification absent
+    -- reports as a stale certification to the operator while the run
+    proceeds."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
@@ -882,47 +1004,12 @@ async def test_echo_only_certification_does_not_restore_live_selection(
     }
 
     session = cast(Any, object())
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
-
-
-@pytest.mark.asyncio
-async def test_incompatible_legacy_agent_role_does_not_restore_live_selection(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The same gate, with a role record present but INCOMPATIBLE (e.g. the
-    production-sized probe reproduced output exhaustion) rather than absent
-    -- an INCOMPATIBLE verdict must never be silently treated as good
-    enough for live selection either."""
-
-    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
-    monkeypatch.setattr(
-        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    assert await _platform_certification_is_current(session) is False
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
     )
-    monkeypatch.setenv("LLM_PROVIDER", "openai")
-    monkeypatch.setenv("LLM_MODEL", "certified-model")
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    role_key, role_value = _role_certification_setting(
-        certification_key=_fingerprint(), state="incompatible"
-    )
-    FakeSettingsService.values = {
-        PLATFORM_READINESS_SETTING_KEY: json.dumps(
-            {
-                "fingerprint": _fingerprint(),
-                "readiness_version": READINESS_VERSION,
-                "checked_at": "2026-07-29T12:00:00+00:00",
-                "outcome": "ready",
-                "safe_error_code": None,
-            }
-        ),
-        role_key: role_value,
-    }
-
-    session = cast(Any, object())
-    with pytest.raises(DevRuntimeUnavailable) as exc_info:
-        await production_runtime.resolve_production_provider(session, org_id="org_01")
-    assert exc_info.value.code == "provider_not_configured"
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.model == "certified-model"
 
 
 @pytest.mark.asyncio
@@ -1304,3 +1391,261 @@ async def test_runtime_construction_failure_closes_provider(
             clickhouse=cast(Any, object()),
         )
     assert provider.closed is True
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3358: the platform provider's stored certification is an operator
+# diagnostic, not a runtime gate.
+#
+# The platform provider is operator-owned and assumed to work. Every
+# READINESS_VERSION bump and every readiness-fingerprint format change
+# invalidates the stored PLATFORM certification by construction, and before
+# this change that invalidation hard-blocked Ask Dev for every organization
+# without BYO ("No certified Ask Dev model is ready.") until a superadmin
+# re-ran platform preflight. The stored record still drives the Platform Admin
+# readiness badge and its "run preflight" copy -- it just no longer decides
+# whether a run may select the platform endpoint. BYO gating is unchanged.
+# ---------------------------------------------------------------------------
+
+
+async def _platform_certification_is_current(session: Any) -> bool:
+    """The operator-facing diagnostic on its own: is the stored platform
+    certification still current for today's fingerprint?
+
+    This is what the Platform Admin badge reports. Since CHAOS-3358 it is no
+    longer the same question as "may a run use the platform provider", so the
+    invalidation tests below assert it directly instead of inferring it from a
+    runtime block that no longer happens.
+    """
+
+    readiness = await production_runtime._platform_readiness_store(session).load()
+    role_profile = await production_runtime._platform_role_store(session).load()
+    candidate, _ = production_runtime._platform_candidate(
+        readiness=readiness, role_profile=role_profile
+    )
+    assert candidate is not None
+    # The whole point of CHAOS-3358: a stale certification never costs the
+    # candidate its usability.
+    assert candidate.usable is True
+    return candidate.readiness_current
+
+
+def _certified_platform_settings(fingerprint: str) -> dict[str, str]:
+    role_key, role_value = _role_certification_setting(certification_key=fingerprint)
+    return {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": fingerprint,
+                "readiness_version": READINESS_VERSION,
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        ),
+        role_key: role_value,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stale_platform_certification_does_not_block_an_org_without_byo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3358 primary control: a platform certification stored under an
+    older fingerprint/readiness version -- exactly what every READINESS_VERSION
+    bump produces -- must not hard-block an organization that has no BYO
+    configuration."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {
+        PLATFORM_READINESS_SETTING_KEY: json.dumps(
+            {
+                "fingerprint": "fingerprint-from-the-previous-readiness-version",
+                "readiness_version": "ask-dev-readiness.v0",
+                "checked_at": "2026-07-29T12:00:00+00:00",
+                "outcome": "ready",
+                "safe_error_code": None,
+            }
+        )
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.family == "openai"
+    assert resolved.model == "certified-model"
+    # The operator diagnostic still reads "stale" -- the badge and the "run
+    # preflight" copy are unchanged; only the runtime block is gone.
+    assert await _platform_certification_is_current(session) is False
+
+
+@pytest.mark.asyncio
+async def test_absent_platform_certification_does_not_block_an_org_without_byo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same control for a platform provider that was never certified at
+    all (fresh deploy, or the readiness slot cleared): still selectable."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {}
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.model == "certified-model"
+    assert await _platform_certification_is_current(session) is False
+
+
+@pytest.mark.asyncio
+async def test_stale_platform_certification_still_serves_the_byo_fallback_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An org WITH BYO whose own certification is stale, under the default
+    platform-fallback policy, lands on the platform provider rather than
+    hard-blocking -- the platform's own stale certification is irrelevant."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setattr(
+        production_runtime, "attach_agent_budget_guard", lambda value, **_: value
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {
+        # BYO is configured but has no certification on record.
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+        "ask_dev_platform_fallback": "platform",
+    }
+    session = cast(Any, object())
+
+    resolved = await production_runtime.resolve_production_provider(
+        session, org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.model == "certified-model"
+
+
+@pytest.mark.asyncio
+async def test_byo_certification_is_still_a_hard_runtime_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control: BYO gating is unchanged. An uncertified BYO
+    configuration under an explicit fail-closed policy still blocks, and it
+    blocks even though the PLATFORM candidate beside it is fully certified --
+    so the block is demonstrably BYO's, not a side effect of platform state."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {
+        **_certified_platform_settings(_fingerprint()),
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+        "ask_dev_platform_fallback": "fail_closed",
+    }
+    session = cast(Any, object())
+
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_platform_without_operator_credentials_is_still_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control -- the gate that remains, observed failing: dropping
+    the readiness conjunct must not admit a platform provider that has no
+    operator credentials at all."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    for name in (
+        "OPENAI_API_KEY",
+        "LLM_API_KEY",
+        "OPENAI_BASE_URL",
+        "LLM_BASE_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    FakeSettingsService.values = {}
+    session = cast(Any, object())
+
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_operator_none_provider_is_still_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control: the operator's explicit "no LLM" switch still
+    disables Ask Dev outright."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "none")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {}
+    session = cast(Any, object())
+
+    with pytest.raises(DevRuntimeUnavailable) as exc_info:
+        await production_runtime.resolve_production_provider(session, org_id="org_01")
+    assert exc_info.value.code == "provider_not_configured"
+
+
+def test_acceptance_candidate_still_fails_closed_without_current_readiness() -> None:
+    """Negative control: the deterministic acceptance stack's pre-admitted
+    endpoint keeps its strict readiness requirement -- it exists to fail
+    closed, and CHAOS-3358 must not relax it via the shared base class."""
+
+    def acceptance(*, readiness_current: bool) -> Any:
+        return production_runtime._AcceptanceOpenAICandidate(
+            provider="openai",
+            model=production_runtime.ACCEPTANCE_OPENAI_MODEL,
+            credentials=LLMCredentials(
+                api_key="acceptance-key", base_url="http://127.0.0.1:8001/v1"
+            ),
+            source=AgentProviderSource.PLATFORM,
+            readiness_current=readiness_current,
+        )
+
+    assert acceptance(readiness_current=False).usable is False
+    assert acceptance(readiness_current=True).usable is True

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -1649,3 +1649,124 @@ def test_acceptance_candidate_still_fails_closed_without_current_readiness() -> 
 
     assert acceptance(readiness_current=False).usable is False
     assert acceptance(readiness_current=True).usable is True
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3358 (second half): a stale platform record heals itself. The
+# mechanism -- single-flight, throttle, what it writes -- is covered in
+# tests/api/dev/test_platform_auto_certification.py. These are the wiring
+# controls: does live provider resolution actually trigger it, and only when
+# it should.
+# ---------------------------------------------------------------------------
+
+
+def _record_scheduling(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    scheduled: list[int] = []
+
+    def schedule() -> None:
+        scheduled.append(1)
+        return None
+
+    monkeypatch.setattr(
+        production_runtime, "schedule_platform_recertification", schedule
+    )
+    return scheduled
+
+
+@pytest.mark.asyncio
+async def test_a_stale_platform_record_schedules_recertification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    scheduled = _record_scheduling(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {}
+
+    await production_runtime.resolve_production_provider(
+        cast(Any, object()), org_id="org_01"
+    )
+
+    assert scheduled == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_current_platform_record_schedules_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No pointless probes: a certification that is already current must not
+    re-certify on every question."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    scheduled = _record_scheduling(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = _certified_platform_settings(_fingerprint())
+
+    resolved = await production_runtime.resolve_production_provider(
+        cast(Any, object()), org_id="org_01"
+    )
+
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_platform_candidate_schedules_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A platform provider with no operator credentials cannot be certified,
+    so scheduling an attempt would just burn a throttle window on a probe
+    that is guaranteed to fail for a reason certification cannot fix."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    scheduled = _record_scheduling(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    for name in ("OPENAI_API_KEY", "LLM_API_KEY", "OPENAI_BASE_URL", "LLM_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+    FakeSettingsService.values = {}
+
+    with pytest.raises(DevRuntimeUnavailable):
+        await production_runtime.resolve_production_provider(
+            cast(Any, object()), org_id="org_01"
+        )
+
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_certification_paths_never_schedule_recertification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The preflight/certification resolution paths pass certification=True,
+    which makes every candidate read as current -- but they must not be the
+    thing that triggers automatic re-certification either, or a readiness
+    page load would kick off a probe."""
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    monkeypatch.setattr(
+        production_runtime, "_provider", lambda _candidate: FakeProvider()
+    )
+    scheduled = _record_scheduling(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "certified-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = {}
+
+    await production_runtime.resolve_certification_provider(
+        cast(Any, object()), org_id="org_01"
+    )
+
+    assert scheduled == []

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -8,9 +8,12 @@ from typing import Any, cast
 
 import pytest
 
-from dev_health_ops.api.dev import production_runtime
+from dev_health_ops.api.dev import platform_auto_certification, production_runtime
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevScope, DevToolRequest, ToolID
+from dev_health_ops.api.dev.platform_auto_certification import (
+    PlatformAutoCertifier,
+)
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
 from dev_health_ops.api.dev.tool_registry import (
@@ -52,6 +55,13 @@ class FakeSettingsService:
     async def get(self, key: str, category: str, default=None):
         del category
         return self.values.get(key, default)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_certifier():
+    platform_auto_certification.reset_platform_auto_certifier()
+    yield
+    platform_auto_certification.reset_platform_auto_certifier()
 
 
 def _fingerprint(
@@ -1654,58 +1664,65 @@ def test_acceptance_candidate_still_fails_closed_without_current_readiness() -> 
 # ---------------------------------------------------------------------------
 # CHAOS-3358 (second half): a stale platform record heals itself. The
 # mechanism -- single-flight, throttle, what it writes -- is covered in
-# tests/api/dev/test_platform_auto_certification.py. These are the wiring
-# controls: does live provider resolution actually trigger it, and only when
-# it should.
+# tests/api/dev/test_platform_auto_certification.py; the authorized trigger
+# is covered in tests/api/dev/test_router.py. What belongs HERE is that
+# provider resolution reports staleness as a FACT and performs no side
+# effect of its own.
+#
+# Codex CHAOS-3358 review, CONFIRMED: scheduling from resolution was
+# reachable from GET /api/v1/dev/capabilities, which resolves a provider
+# before Ask Dev entitlement or emergency-disable is checked -- so any
+# authenticated user, including one from a disabled organization, could
+# initiate operator-paid provider probes from a read-only request, and a run
+# that ultimately selected BYO could too. Resolution is now side-effect free
+# and only the authorized run path acts on the flag.
 # ---------------------------------------------------------------------------
 
 
-def _record_scheduling(monkeypatch: pytest.MonkeyPatch) -> list[int]:
-    scheduled: list[int] = []
-
-    def schedule() -> None:
-        scheduled.append(1)
-        return None
-
-    monkeypatch.setattr(
-        production_runtime, "schedule_platform_recertification", schedule
-    )
-    return scheduled
-
-
 @pytest.mark.asyncio
-async def test_a_stale_platform_record_schedules_recertification(
+async def test_resolution_reports_platform_staleness_without_side_effects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # A recording certifier on the process singleton, NOT a monkeypatched name
+    # on this module. production_runtime deliberately no longer imports the
+    # scheduler at all, so patching a name here would assert against an
+    # attribute nothing reads -- the control would pass whatever resolution
+    # did. Everything that can schedule goes through the certifier.
+    scheduled: list[int] = []
+
+    class RecordingCertifier(PlatformAutoCertifier):
+        def schedule(self):
+            scheduled.append(1)
+            return None
+
+    platform_auto_certification.set_platform_auto_certifier(RecordingCertifier())
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
         production_runtime, "_provider", lambda _candidate: FakeProvider()
     )
-    scheduled = _record_scheduling(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "certified-model")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     FakeSettingsService.values = {}
 
-    await production_runtime.resolve_production_provider(
+    resolved = await production_runtime.resolve_production_provider(
         cast(Any, object()), org_id="org_01"
     )
 
-    assert scheduled == [1]
+    assert resolved.source is AgentProviderSource.PLATFORM
+    assert resolved.platform_certification_stale is True
+    # The fact is reported; nothing is spent reporting it.
+    assert scheduled == []
 
 
 @pytest.mark.asyncio
-async def test_a_current_platform_record_schedules_nothing(
+async def test_a_current_platform_certification_is_not_reported_stale(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No pointless probes: a certification that is already current must not
-    re-certify on every question."""
-
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
         production_runtime, "_provider", lambda _candidate: FakeProvider()
     )
-    scheduled = _record_scheduling(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "certified-model")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -1716,57 +1733,92 @@ async def test_a_current_platform_record_schedules_nothing(
     )
 
     assert resolved.source is AgentProviderSource.PLATFORM
-    assert scheduled == []
+    assert resolved.platform_certification_stale is False
 
 
 @pytest.mark.asyncio
-async def test_an_unusable_platform_candidate_schedules_nothing(
+async def test_a_selected_byo_provider_is_never_reported_platform_stale(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A platform provider with no operator credentials cannot be certified,
-    so scheduling an attempt would just burn a throttle window on a probe
-    that is guaranteed to fail for a reason certification cannot fix."""
+    """The flag follows the SELECTED source. A run on a customer's own
+    endpoint must not carry a platform-staleness flag, or it would spend
+    operator provider calls on behalf of an organization that never touches
+    the platform provider (Codex CHAOS-3358, CONFIRMED)."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
         production_runtime, "_provider", lambda _candidate: FakeProvider()
     )
-    scheduled = _record_scheduling(monkeypatch)
+    monkeypatch.setattr(
+        production_runtime, "attach_agent_budget_guard", lambda value, **_: value
+    )
+    # Platform is configured but stale; BYO is certified and wins.
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "certified-model")
-    for name in ("OPENAI_API_KEY", "LLM_API_KEY", "OPENAI_BASE_URL", "LLM_BASE_URL"):
-        monkeypatch.delenv(name, raising=False)
-    FakeSettingsService.values = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    FakeSettingsService.values = _byo_settings(role_state="compatible")
 
-    with pytest.raises(DevRuntimeUnavailable):
-        await production_runtime.resolve_production_provider(
-            cast(Any, object()), org_id="org_01"
-        )
+    resolved = await production_runtime.resolve_production_provider(
+        cast(Any, object()), org_id="org_01"
+    )
 
-    assert scheduled == []
+    assert resolved.source is AgentProviderSource.BYO
+    assert resolved.platform_certification_stale is False
 
 
 @pytest.mark.asyncio
-async def test_certification_paths_never_schedule_recertification(
+async def test_certification_paths_never_report_staleness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The preflight/certification resolution paths pass certification=True,
-    which makes every candidate read as current -- but they must not be the
-    thing that triggers automatic re-certification either, or a readiness
-    page load would kick off a probe."""
+    which makes every candidate read as current -- so a readiness page load
+    can never look like a reason to re-certify."""
 
     monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
     monkeypatch.setattr(
         production_runtime, "_provider", lambda _candidate: FakeProvider()
     )
-    scheduled = _record_scheduling(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "certified-model")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     FakeSettingsService.values = {}
 
-    await production_runtime.resolve_certification_provider(
+    resolved = await production_runtime.resolve_certification_provider(
         cast(Any, object()), org_id="org_01"
     )
 
-    assert scheduled == []
+    assert resolved.platform_certification_stale is False
+
+
+@pytest.mark.asyncio
+async def test_the_runtime_carries_platform_staleness_to_the_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The router's authorized trigger reads the flag off BoundedDevRuntime,
+    so the plumb-through is load-bearing: drop it and a stale platform
+    certification would silently never heal."""
+
+    async def resolve_provider(_session, *, org_id: str):
+        return ProductionProviderResolution(
+            provider=cast(Any, FakeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+            platform_certification_stale=True,
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes")
+
+    runtime = await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id="org_01",
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+
+    assert runtime.platform_certification_stale is True

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -114,6 +114,9 @@ class DevApiContext:
 
 class FakeBoundedRuntime:
     provider_source = "platform"
+    # CHAOS-3358: BoundedDevRuntime carries this, so this double must too --
+    # the router's automatic-recertification trigger reads it on every run.
+    platform_certification_stale = False
 
     async def run(
         self,
@@ -2063,3 +2066,183 @@ async def test_org_policy_disables_both_surfaces_and_owns_retention(dev_api_cont
     )
     assert created.status_code == 201
     assert created.json()["retention_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3358: automatic platform re-certification is triggered from exactly
+# one place -- an authorized Ask Dev run that actually selected the platform
+# provider.
+#
+# Codex CHAOS-3358 review, CONFIRMED reachable: when this was scheduled from
+# provider resolution instead, GET /api/v1/dev/capabilities reached it before
+# Ask Dev entitlement or emergency-disable was ever checked, so any
+# authenticated user -- including one from a disabled organization -- could
+# initiate up to six unmetered operator-paid provider calls from a read-only
+# request, and a run that ultimately selected BYO could too. These are the
+# negative controls for that, plus the positive one that keeps the healing
+# working.
+# ---------------------------------------------------------------------------
+
+
+class _StalePlatformRuntime(FakeBoundedRuntime):
+    provider_source = "platform"
+    platform_certification_stale = True
+
+
+class _StaleButByoRuntime(FakeBoundedRuntime):
+    """A BYO-selected run. The platform record may well be stale, but this
+    organization is not using the platform provider and must never spend the
+    operator's provider calls."""
+
+    provider_source = "byo"
+    platform_certification_stale = False
+
+
+class _CurrentPlatformRuntime(FakeBoundedRuntime):
+    provider_source = "platform"
+    platform_certification_stale = False
+
+
+def _capture_scheduling(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    scheduled: list[int] = []
+    monkeypatch.setattr(
+        dev_router_module,
+        "schedule_platform_recertification",
+        lambda: scheduled.append(1),
+    )
+    return scheduled
+
+
+async def _new_conversation(context: Any) -> str:
+    created = await context.client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(context.org_id)},
+    )
+    assert created.status_code == 201
+    return created.json()["conversation_id"]
+
+
+async def _post_one_message(
+    context: Any, runtime: Any, conversation_id: str | None = None
+) -> Any:
+    context.app.dependency_overrides[dev_router_module.get_dev_execution_runtime] = (
+        lambda: dev_router_module.DevExecutionRuntimeResolution(
+            runtime=cast(Any, runtime)
+        )
+    )
+    if conversation_id is None:
+        conversation_id = await _new_conversation(context)
+    return await context.client.post(
+        f"/api/v1/dev/conversations/{conversation_id}/messages",
+        json={
+            "schema_version": "dev_message_request.v1",
+            "request_id": "request_recert_01",
+            "client_message_id": "client_recert_01",
+            "conversation_id": conversation_id,
+            "question": "What changed?",
+            "question_class": "observed_change",
+            "scope": _scope_payload(context.org_id),
+            "requested_metric_ids": [],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_authorized_platform_run_heals_a_stale_certification(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    scheduled = _capture_scheduling(monkeypatch)
+
+    response = await _post_one_message(dev_api_context, _StalePlatformRuntime())
+
+    assert response.status_code == 200
+    assert scheduled == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_byo_run_never_schedules_platform_recertification(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    scheduled = _capture_scheduling(monkeypatch)
+
+    response = await _post_one_message(dev_api_context, _StaleButByoRuntime())
+
+    assert response.status_code == 200
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_a_current_platform_run_schedules_nothing(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    scheduled = _capture_scheduling(monkeypatch)
+
+    response = await _post_one_message(dev_api_context, _CurrentPlatformRuntime())
+
+    assert response.status_code == 200
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_the_capabilities_projection_never_schedules_recertification(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    """The read-only capability request is the path codex CONFIRMED: it
+    resolves a provider before any Ask Dev authorization runs, so it must
+    stay entirely free of operator-paid side effects."""
+
+    scheduled = _capture_scheduling(monkeypatch)
+
+    response = await dev_api_context.client.get("/api/v1/dev/capabilities")
+
+    assert response.status_code == 200
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_a_disabled_organization_never_schedules_recertification(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    """Emergency-disabled: the run is rejected at _require_ask_dev, so the
+    trigger -- which lives after it -- is never reached."""
+
+    scheduled = _capture_scheduling(monkeypatch)
+    # Created while still enabled -- disabling blocks conversation creation
+    # too, and this test is about the MESSAGE path's trigger.
+    conversation_id = await _new_conversation(dev_api_context)
+    async with dev_api_context.maker() as session:
+        await SettingsService(session, str(dev_api_context.org_id)).set(
+            ASK_DEV_EMERGENCY_DISABLED_KEY, "true", category="ask_dev"
+        )
+        await session.commit()
+
+    response = await _post_one_message(
+        dev_api_context, _StalePlatformRuntime(), conversation_id
+    )
+
+    assert response.status_code == 403
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_a_non_entitled_organization_never_schedules_recertification(
+    dev_api_context, monkeypatch: pytest.MonkeyPatch
+):
+    scheduled = _capture_scheduling(monkeypatch)
+    conversation_id = await _new_conversation(dev_api_context)
+
+    async def _deny(self, _org_id: str) -> None:
+        raise dev_router_module.AskDevEntitlementDeniedError(
+            FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED
+        )
+
+    monkeypatch.setattr(
+        dev_router_module.CanonicalAskDevEntitlementAuthorizer, "require", _deny
+    )
+
+    response = await _post_one_message(
+        dev_api_context, _StalePlatformRuntime(), conversation_id
+    )
+
+    assert response.status_code == 403
+    assert scheduled == []

--- a/tests/llm/agent/test_contracts_and_policy.py
+++ b/tests/llm/agent/test_contracts_and_policy.py
@@ -176,3 +176,106 @@ def test_internal_scripted_adapter_is_not_a_product_provider_family() -> None:
             ),
         )
     assert caught.value.code is AgentProviderErrorCode.MODEL_NOT_SUPPORTED
+
+
+# CHAOS-3358: the platform provider is operator-owned and assumed to work, so
+# its stored certification is an operator-facing diagnostic and must not gate
+# runtime selection. Every other conjunct of `usable` -- and BYO's strict
+# readiness requirement -- is unchanged.
+
+
+def test_platform_candidate_is_usable_without_a_current_certification() -> None:
+    platform = candidate(source=AgentProviderSource.PLATFORM, ready=False)
+    assert platform.usable is True
+
+    selected = resolve_agent_provider_selection(
+        policy=AgentProviderPolicy(ask_dev_enabled=True),
+        byo=None,
+        platform=platform,
+    )
+    assert selected is platform
+
+
+def test_byo_candidate_still_requires_a_current_certification() -> None:
+    assert candidate(source=AgentProviderSource.BYO, ready=False).usable is False
+    assert candidate(source=AgentProviderSource.BYO, ready=True).usable is True
+
+
+@pytest.mark.parametrize("provider", ["openai", "local", "ollama", "lmstudio"])
+def test_platform_candidate_without_credentials_is_still_unusable(
+    provider: str,
+) -> None:
+    """The gate that remains, observed failing: no api_key and no base_url."""
+
+    platform = AgentProviderCandidate(
+        provider=provider,
+        model="agent-model",
+        credentials=LLMCredentials(),
+        source=AgentProviderSource.PLATFORM,
+        readiness_current=False,
+    )
+    assert platform.usable is False
+
+
+def test_platform_candidate_without_a_model_is_still_unusable() -> None:
+    platform = AgentProviderCandidate(
+        provider="openai",
+        model="",
+        credentials=LLMCredentials(api_key="operator-key"),
+        source=AgentProviderSource.PLATFORM,
+        readiness_current=False,
+    )
+    assert platform.usable is False
+
+
+def test_platform_candidate_of_an_uncertified_family_is_still_unusable() -> None:
+    platform = candidate(
+        provider="anthropic", source=AgentProviderSource.PLATFORM, ready=False
+    )
+    assert platform.certified is False
+    assert platform.usable is False
+
+    with pytest.raises(AgentProviderError) as caught:
+        resolve_agent_provider_selection(
+            policy=AgentProviderPolicy(ask_dev_enabled=True),
+            byo=None,
+            platform=platform,
+        )
+    assert caught.value.code is AgentProviderErrorCode.MODEL_NOT_SUPPORTED
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        AgentProviderPolicy(
+            ask_dev_enabled=True, denied_providers=frozenset({"openai"})
+        ),
+        AgentProviderPolicy(
+            ask_dev_enabled=True, denied_models=frozenset({"agent-model"})
+        ),
+    ],
+)
+def test_denied_platform_provider_or_model_still_blocks(
+    policy: AgentProviderPolicy,
+) -> None:
+    """Operator denylists outrank the platform's assumed-good status."""
+
+    platform = candidate(source=AgentProviderSource.PLATFORM, ready=False)
+    assert platform.usable is True
+
+    with pytest.raises(AgentProviderError) as caught:
+        resolve_agent_provider_selection(policy=policy, byo=None, platform=platform)
+    assert caught.value.code is AgentProviderErrorCode.MODEL_NOT_SUPPORTED
+
+
+def test_platform_unsafe_operator_base_url_is_still_unusable() -> None:
+    platform = AgentProviderCandidate(
+        provider="local",
+        model="local-agent-model",
+        credentials=LLMCredentials(
+            base_url="http://user:secret@host.docker.internal:1234/v1"
+        ),
+        source=AgentProviderSource.PLATFORM,
+        readiness_current=False,
+    )
+    assert platform.usable is False


### PR DESCRIPTION
Fixes the recurring outage where every READINESS_VERSION bump or fingerprint-format change (most recently CHAOS-3285's) invalidated the stored platform certification and hard-blocked every org without BYO ("No certified Ask Dev model is ready") until a superadmin manually re-ran preflight.

Three commits:
1. **Advisory, not a gate**: AgentProviderCandidate.usable requires readiness_current for BYO only. Platform keeps certified-family/model/credentials/sane-URL requirements; the acceptance-stack candidate keeps its strict readiness override. Sweep confirmed no other runtime gate existed -- every other reader of the readiness record is a display path (badge, preflight endpoint), all unchanged.
2. **Self-healing**: when the stored record is stale/absent, the system re-certifies automatically on a background task with its own session (never on the request path -- certification is six live provider round-trips). The certify sequence moved out of the admin router into production_runtime.certify_platform_resolution, shared by the button and the automatic path, with a differential control proving both write identical records. Failures are written (never raised) and throttled (300s). Single-flight and throttle are per process, not global -- a multi-worker fleet gets at most one attempt per worker per interval.
3. **Codex round 2 (NO-SHIP, MEDIUM, CONFIRMED)**: the trigger originally lived in provider resolution, reachable from GET /capabilities with no entitlement or emergency-disable check -- any authenticated user, including from a disabled org, could initiate operator-paid probes, and BYO-selected runs scheduled them too. Fixed: resolution reports staleness as a fact (ProductionProviderResolution.platform_certification_stale); the single trigger is in the Ask Dev message path after _require_ask_dev, behind provider_source == "platform". Capabilities, disabled/non-entitled orgs, and BYO runs are side-effect free by construction (six router-level controls).

Test plan: 3 RED-to-GREEN e2e controls (stale/absent platform cert + no BYO; stale BYO falling back); extensive negative controls observing every remaining gate fire; nine mutations -- eight killed, one documented as equivalent (BYO's own readiness gate makes the selected-source check unreachable; kept as defence in depth). Two first-pass mutation SURVIVORS exposed vacuous controls (a monkeypatch on a name the module no longer read; a blanket except masking a guard) -- both controls rewritten until the mutations died. Scoped suites: 1969 passed. The full local gate was repeatedly cut short by an environment-side local_validate wedge (CHAOS-3348) -- CI is the arbiter.