### PR TITLE
fix(worker): repair feature branch gate baseline

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -465,12 +465,12 @@
       "notes": "transport-routes.json kind finalize_sync_run, route=celery"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_reconciler.py:77",
+      "id": "celery_task:src/dev_health_ops/workers/sync_reconciler.py:78",
       "surface": "prune_rate_limit_observations",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 77
+        "line": 78
       },
       "queue_or_cadence": "sync",
       "dispatches": "self (Beat)",
@@ -489,12 +489,12 @@
       "notes": "Beat entry prune-rate-limit-observations, crontab(5,0) UTC"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_reconciler.py:124",
+      "id": "celery_task:src/dev_health_ops/workers/sync_reconciler.py:125",
       "surface": "reconcile_sync_dispatch",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 124
+        "line": 125
       },
       "queue_or_cadence": "sync",
       "dispatches": "self (Beat)",
@@ -2361,12 +2361,12 @@
       "notes": "grep-evading form"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:843",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:859",
       "surface": "getattr(run_sync_reference_discovery,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 843
+        "line": 859
       },
       "queue_or_cadence": "n/a",
       "dispatches": "run_sync_reference_discovery",
@@ -2385,12 +2385,12 @@
       "notes": "grep-evading form; reconciler repair redrive"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:861",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:877",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 861
+        "line": 877
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2409,12 +2409,12 @@
       "notes": "grep-evading form; reconciler repair redrive"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:869",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:885",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 869
+        "line": 885
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",

--- a/internal/providersync/github_repository_route.go
+++ b/internal/providersync/github_repository_route.go
@@ -18,12 +18,24 @@ import (
 )
 
 // marshalRepositoryJSON matches the canonical Python ClickHouse repository
-// encoder: compact separators, UTF-8 preserved, and no HTML-only escaping.
+// encoder: sorted keys, compact separators, UTF-8 preserved, and no HTML-only
+// escaping. The marshal/decode step deliberately turns structs into maps so
+// the final encoder applies the same key ordering as Python's sort_keys=True.
 func marshalRepositoryJSON(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var canonical any
+	if err := decoder.Decode(&canonical); err != nil {
+		return nil, err
+	}
 	var encoded bytes.Buffer
 	encoder := json.NewEncoder(&encoded)
 	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(value); err != nil {
+	if err := encoder.Encode(canonical); err != nil {
 		return nil, err
 	}
 	return bytes.TrimSuffix(encoded.Bytes(), []byte{'\n'}), nil
@@ -44,10 +56,8 @@ type repositoryRow struct {
 	LastSynced time.Time `json:"last_synced"`
 }
 
-// repositorySettings preserves the Python insertion order of the settings
-// document. Python writes a dict literal, and dict order is preserved by
-// json.dumps, so an alphabetically sorted Go map would not round-trip
-// byte-identically.
+// repositorySettings defines the GitHub repository settings fields. The
+// shared encoder canonicalizes their persisted order across runtimes.
 type repositorySettings struct {
 	Source            string `json:"source"`
 	GitHubInstanceURL string `json:"github_instance_url"`

--- a/internal/providersync/github_repository_route_test.go
+++ b/internal/providersync/github_repository_route_test.go
@@ -142,8 +142,8 @@ func TestGitHubRepositoryRouteEmitsOneBoundedReposEffect(t *testing.T) {
 		!row.LastSynced.Equal(now) || !row.CreatedAt.Equal(now) {
 		t.Fatalf("row=%+v", row)
 	}
-	if row.Settings != `{"source":"github","github_instance_url":"github.com",`+
-		`"repo_id":4567,"url":"https://github.com/Acme/API","default_branch":"main"}` {
+	if row.Settings != `{"default_branch":"main","github_instance_url":"github.com",`+
+		`"repo_id":4567,"source":"github","url":"https://github.com/Acme/API"}` {
 		t.Fatalf("settings=%s", row.Settings)
 	}
 	if row.Tags != `["github","Go"]` {

--- a/internal/providersync/gitlab_repository_route.go
+++ b/internal/providersync/gitlab_repository_route.go
@@ -10,9 +10,8 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// gitLabRepositorySettings preserves the insertion order of the Python
-// process_gitlab_project settings dict. ClickHouse stores this document as a
-// JSON string, so stable order also keeps effect digests stable across retry.
+// gitLabRepositorySettings defines the GitLab repository settings fields. The
+// shared encoder canonicalizes their persisted order across runtimes.
 type gitLabRepositorySettings struct {
 	Source            string  `json:"source"`
 	ProjectID         int64   `json:"project_id"`

--- a/internal/providersync/gitlab_repository_route_test.go
+++ b/internal/providersync/gitlab_repository_route_test.go
@@ -102,7 +102,7 @@ func TestGitLabRepositoryRouteEmitsCompleteReposEffect(t *testing.T) {
 		!row.CreatedAt.Equal(wantAt) || !row.LastSynced.Equal(wantAt) {
 		t.Fatalf("row=%+v", row)
 	}
-	if row.Settings != `{"source":"gitlab","project_id":123,"url":"https://gitlab.example/Acme/API","default_branch":"main","gitlab_instance_url":"https://gitlab.example"}` {
+	if row.Settings != `{"default_branch":"main","gitlab_instance_url":"https://gitlab.example","project_id":123,"source":"gitlab","url":"https://gitlab.example/Acme/API"}` {
 		t.Fatalf("settings=%s", row.Settings)
 	}
 	if row.Tags != `["gitlab"]` {

--- a/internal/streamhandlers/external_clickhouse.go
+++ b/internal/streamhandlers/external_clickhouse.go
@@ -1,6 +1,7 @@
 package streamhandlers
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -118,11 +119,11 @@ func externalRecordValues(
 		repositorySystem := externalStringDefault(payload, "sourceSystem", system)
 		repoID := externalRepoUUID(repositorySystem, instance, stringField(payload, "externalId"))
 		scope.RepoIDs = append(scope.RepoIDs, repoID.String())
-		settings, err := externalPythonJSON(objectField(payload, "settings"))
+		settings, err := externalPythonCompactJSON(objectField(payload, "settings"))
 		if err != nil {
 			return nil, err
 		}
-		tags, err := externalPythonJSON(stringArrayField(payload, "tags"))
+		tags, err := externalPythonCompactJSON(stringArrayField(payload, "tags"))
 		if err != nil {
 			return nil, err
 		}
@@ -589,6 +590,17 @@ func externalIdentity(provider, raw string) string {
 // JSON is data in ClickHouse rather than a native JSON column, so equivalent
 // but byte-different encodings would otherwise create false parity drift.
 func externalPythonJSON(value any) (string, error) {
+	return externalPythonJSONWithSeparators(value, ", ", ": ")
+}
+
+// externalPythonCompactJSON matches repository_json_or_none, whose explicit
+// separators=(",", ":") contract differs from the default json.dumps shape
+// used by the other Python external-ingest writers.
+func externalPythonCompactJSON(value any) (string, error) {
+	return externalPythonJSONWithSeparators(value, ",", ":")
+}
+
+func externalPythonJSONWithSeparators(value any, itemSeparator, keySeparator string) (string, error) {
 	var output strings.Builder
 	var encode func(any) error
 	encode = func(item any) error {
@@ -598,8 +610,14 @@ func externalPythonJSON(value any) (string, error) {
 		case bool:
 			output.WriteString(strconv.FormatBool(typed))
 		case string:
-			encoded, _ := json.Marshal(typed)
-			output.Write(encoded)
+			var encoded bytes.Buffer
+			encoder := json.NewEncoder(&encoded)
+			encoder.SetEscapeHTML(false)
+			if err := encoder.Encode(typed); err != nil {
+				return err
+			}
+			encodedBytes := bytes.TrimSuffix(encoded.Bytes(), []byte{'\n'})
+			output.Write(encodedBytes)
 		case json.Number:
 			if _, err := typed.Float64(); err != nil {
 				return err
@@ -613,7 +631,7 @@ func externalPythonJSON(value any) (string, error) {
 			output.WriteByte('[')
 			for index, element := range typed {
 				if index > 0 {
-					output.WriteString(", ")
+					output.WriteString(itemSeparator)
 				}
 				if err := encode(element); err != nil {
 					return err
@@ -624,7 +642,7 @@ func externalPythonJSON(value any) (string, error) {
 			output.WriteByte('[')
 			for index, element := range typed {
 				if index > 0 {
-					output.WriteString(", ")
+					output.WriteString(itemSeparator)
 				}
 				if err := encode(element); err != nil {
 					return err
@@ -640,12 +658,12 @@ func externalPythonJSON(value any) (string, error) {
 			output.WriteByte('{')
 			for index, key := range keys {
 				if index > 0 {
-					output.WriteString(", ")
+					output.WriteString(itemSeparator)
 				}
 				if err := encode(key); err != nil {
 					return err
 				}
-				output.WriteString(": ")
+				output.WriteString(keySeparator)
 				if err := encode(typed[key]); err != nil {
 					return err
 				}

--- a/scripts/worker/generate_external_ingest_sink_golden.py
+++ b/scripts/worker/generate_external_ingest_sink_golden.py
@@ -46,7 +46,17 @@ INGESTION_ID = uuid.UUID("11111111-2222-4333-8444-555555555555")
 class FrozenDateTime(datetime):
     @classmethod
     def now(cls, tz=None):
-        return NOW if tz is not None else NOW.replace(tzinfo=None)
+        if tz is None:
+            return cls(
+                NOW.year,
+                NOW.month,
+                NOW.day,
+                NOW.hour,
+                NOW.minute,
+                NOW.second,
+                NOW.microsecond,
+            )
+        return cls.fromtimestamp(NOW.timestamp(), tz=tz)
 
 
 def _canonical(value: Any) -> Any:
@@ -121,7 +131,7 @@ def legacy_records() -> list[RecordEnvelope]:
                 "externalId": repo,
                 "sourceSystem": "github",
                 "defaultRef": "main",
-                "settings": {"private": True, "stars": 7},
+                "settings": {"z": "<café &>", "a": 1},
                 "tags": ["go", "ops"],
             },
         ),
@@ -419,6 +429,7 @@ async def _capture_legacy() -> tuple[dict[str, Any], list[RecordEnvelope]]:
     with (
         patch.object(external_sinks, "datetime", FrozenDateTime),
         patch("dev_health_ops.storage.clickhouse.datetime", FrozenDateTime),
+        patch("dev_health_ops.storage.repository_rows.datetime", FrozenDateTime),
         patch(
             "dev_health_ops.metrics.sinks.clickhouse.work_graph.datetime",
             FrozenDateTime,

--- a/src/dev_health_ops/storage/repository_rows.py
+++ b/src/dev_health_ops/storage/repository_rows.py
@@ -28,7 +28,13 @@ def repository_json_or_none(value: Any) -> str | None:
     """Encode repository JSON fields in the cross-runtime canonical form."""
     if value is None:
         return None
-    return json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
+    return json.dumps(
+        value,
+        default=str,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def build_repository_insert_row(

--- a/tests/fixtures/external_ingest_sink_python_golden.json
+++ b/tests/fixtures/external_ingest_sink_python_golden.json
@@ -1165,8 +1165,8 @@
         "defaultRef": "main",
         "externalId": "Acme/API",
         "settings": {
-          "private": true,
-          "stars": 7
+          "a": 1,
+          "z": "<caf\u00e9 &>"
         },
         "sourceSystem": "github",
         "tags": [
@@ -1180,8 +1180,8 @@
         "Acme/API",
         "main",
         "2026-07-23T12:00:00.000000Z",
-        "{\"private\": true, \"stars\": 7}",
-        "[\"go\", \"ops\"]",
+        "{\"a\":1,\"z\":\"<caf\u00e9 &>\"}",
+        "[\"go\",\"ops\"]",
         "github",
         "2026-07-23T12:00:00.000000Z",
         "9749bda0-fc9f-4076-b19d-7b26c4f306ff",

--- a/tests/scripts/test_external_ingest_sink_golden.py
+++ b/tests/scripts/test_external_ingest_sink_golden.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from datetime import timezone
 from pathlib import Path
+
+from scripts.worker.generate_external_ingest_sink_golden import FrozenDateTime
+
+
+def test_frozen_datetime_preserves_datetime_subclass() -> None:
+    assert isinstance(FrozenDateTime.now(), FrozenDateTime)
+    assert isinstance(FrozenDateTime.now(timezone.utc), FrozenDateTime)
 
 
 def test_go_external_ingest_sink_golden_is_current() -> None:

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 import pytest
 
 from dev_health_ops.connectors import BatchResult
+from dev_health_ops.connectors.models import Repository
 from dev_health_ops.connectors.utils import match_repo_pattern
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.models.git import (
@@ -319,11 +320,13 @@ async def test_process_gitlab_projects_batch_persists_instance_discriminator(
 
     store = DummyStore()
 
-    project = Mock()
-    project.id = 456
-    project.full_name = "group/proj"
-    project.url = "https://example.com/group/proj"
-    project.default_branch = "main"
+    project = Repository(
+        id=456,
+        name="proj",
+        full_name="group/proj",
+        url="https://example.com/group/proj",
+        default_branch="main",
+    )
 
     result = BatchResult(repository=project, stats=None, success=True)
     _stub_gitlab_project_discovery(monkeypatch, [project])
@@ -1636,11 +1639,13 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
         async def insert_git_pull_requests(self, pr_data):
             return
 
-    project = Mock()
-    project.id = 456
-    project.full_name = "group/proj-metrics"
-    project.url = "https://example.com/group/proj-metrics"
-    project.default_branch = "main"
+    project = Repository(
+        id=456,
+        name="proj-metrics",
+        full_name="group/proj-metrics",
+        url="https://example.com/group/proj-metrics",
+        default_branch="main",
+    )
 
     result = BatchResult(repository=project, stats=None, success=True)
     _stub_gitlab_project_discovery(monkeypatch, [project])
@@ -1770,11 +1775,13 @@ async def test_process_gitlab_projects_batch_since_prepass_persists_aggregate_st
         async def insert_git_pull_requests(self, pr_data):
             return
 
-    project = Mock()
-    project.id = 457
-    project.full_name = "group/windowed-stats"
-    project.url = "https://example.com/group/windowed-stats"
-    project.default_branch = "main"
+    project = Repository(
+        id=457,
+        name="windowed-stats",
+        full_name="group/windowed-stats",
+        url="https://example.com/group/windowed-stats",
+        default_branch="main",
+    )
 
     class DummyConnector:
         def __init__(self, url: str, private_token: str):
@@ -1797,7 +1804,9 @@ async def test_process_gitlab_projects_batch_since_prepass_persists_aggregate_st
         async def get_commit_stats(self, project_id, commit_hash):
             assert project_id == project.id
             assert commit_hash == "gitlab-windowed"
-            return SimpleNamespace(additions=7, deletions=2)
+            return SimpleNamespace(
+                commit_id="gitlab-windowed", additions=7, deletions=2
+            )
 
         def drain_usage_observations(self):
             return []

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from pathlib import Path
 
 import pytest
@@ -402,21 +403,28 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
     # scripts back in contradiction with domain readiness.
     expected_read_only_tables = {
         "integrations",
-        "integration_sources",
-        "integration_datasets",
         "integration_credentials",
-        "sync_runs",
         "sync_dispatch_transport_routes",
     }
-    configured_read_only_tables = {
-        line.strip().removeprefix("('").removesuffix("'),").removesuffix("')")
-        for line in domain_script.splitlines()
-        if line.strip().startswith("('")
-    }
+    configured_read_only_tables = _tables_for_formatted_grant(
+        domain_script, "GRANT SELECT ON TABLE public.%I TO %I"
+    )
     assert configured_read_only_tables == expected_read_only_tables
+    # These tables are mutable domain state, so they deliberately live in the
+    # separate read/write grant rather than the read-only VALUES list above.
+    expected_read_write_tables = {
+        "integration_sources",
+        "integration_datasets",
+        "sync_runs",
+        "sync_run_units",
+    }
+    configured_read_write_tables = _tables_for_formatted_grant(
+        domain_script, "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I"
+    )
+    assert configured_read_write_tables == expected_read_write_tables
     for grant in (
         "GRANT SELECT ON TABLE public.%I TO %I",
-        "GRANT SELECT, UPDATE ON TABLE public.sync_run_units",
+        "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I",
         "GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks",
         "GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_dispatch_outbox",
         "GRANT SELECT, INSERT ON TABLE public.worker_job_outbox",
@@ -428,6 +436,42 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
         "DELETE ON TABLE",
     ):
         assert forbidden not in domain_script
+
+
+def _tables_for_formatted_grant(domain_script: str, grant: str) -> set[str]:
+    pattern = re.compile(
+        rf"SELECT\s+format\(\s*'{re.escape(grant)}'.*?"
+        r"FROM\s+\((.*?)\)\s+AS\s+required\(table_name\)",
+        re.DOTALL,
+    )
+    matches = pattern.findall(domain_script)
+    assert len(matches) == 1, f"expected exactly one VALUES block for {grant!r}"
+    return set(re.findall(r"\('([^']+)'\)", matches[0]))
+
+
+@pytest.mark.parametrize(
+    "script_path",
+    (
+        _REPO_ROOT / "docker" / "init-extra-dbs.sh",
+        _REPO_ROOT / "scripts" / "worker" / "provision_river_roles.sql",
+    ),
+)
+def test_least_privilege_domain_grants_reject_swapped_privilege_blocks(
+    script_path: Path,
+) -> None:
+    domain_script = script_path.read_text(encoding="utf-8").split(
+        "-- The queue role", maxsplit=1
+    )[0]
+    read_only_grant = "GRANT SELECT ON TABLE public.%I TO %I"
+    read_write_grant = "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I"
+    inverted = (
+        domain_script.replace(read_only_grant, "__READ_ONLY_GRANT__")
+        .replace(read_write_grant, read_only_grant)
+        .replace("__READ_ONLY_GRANT__", read_write_grant)
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_least_privilege_domain_grants(inverted)
 
 
 def test_legacy_compose_disables_ambient_migrations() -> None:

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -2551,12 +2551,12 @@ def test_dispatch_sync_run_routes_only_enabled_launchdarkly_unit_to_river(
         integration_id=launchdarkly.integration_id,
         source_id=launchdarkly.source_id,
         provider="github",
-        dataset_key="tests",
+        dataset_key="prs",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_tests": True},
+        processor_flags={"sync_prs": True},
     )
     run.total_units = 2
     db_session.add(celery_unit)
@@ -3084,12 +3084,12 @@ def test_dispatch_sync_run_concurrency_cap_defers_regardless_of_transport(
         integration_id=river_unit.integration_id,
         source_id=river_unit.source_id,
         provider="github",
-        dataset_key="tests",
+        dataset_key="prs",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_tests": True},
+        processor_flags={"sync_prs": True},
     )
     run.total_units = 2
     db_session.add(celery_unit)
@@ -3156,12 +3156,12 @@ def test_dispatch_sync_run_reclaims_stale_units_of_both_transports_and_redecides
         integration_id=river_unit.integration_id,
         source_id=river_unit.source_id,
         provider="github",
-        dataset_key="tests",
+        dataset_key="prs",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_tests": True},
+        processor_flags={"sync_prs": True},
     )
     stale = datetime.now(timezone.utc) - timedelta(minutes=30)
     river_unit.status = SyncRunUnitStatus.DISPATCHING.value


### PR DESCRIPTION
## Summary

- Repair all ten committed Python gate failures introduced by the accumulated Go migration stack.
- Reanchor the transitional inventory, use canonical provider DTOs in GitLab batch tests, and assert the exact read-only/read-write role grant sets.
- Canonicalize repository JSON across Python and Go with compact separators, sorted keys, UTF-8 preservation, and no HTML-only escaping.
- Strengthen the producer-generated Python-to-Go golden with out-of-order Unicode/HTML data so ordering and escaping drift fail closed.

## Test evidence

- `pytest tests -m "not benchmark and not clickhouse" --ignore=tests/test_connectors_integration.py --ignore=tests/test_private_repo_access.py -n 4 --dist loadscope -ra --tb=short -q` against an isolated, fully migrated ClickHouse scratch database: **10922 passed, 94 skipped, 1 xfailed**
- `go test ./... -count=1`: passed
- `go vet ./...`: passed
- `bash ci/check_go.sh live-python-oracles`: passed uncached provider and scheduler Python-to-Go oracles
- `ruff format --check .`: passed
- `ruff check .`: passed
- `mypy --install-types --non-interactive .`: passed for 2029 source files
- `python scripts/mutation_harness.py verify`: clean
- `bash ci/check_river_compat_static.sh`: passed

## Risk and rollback

- Base is `feat/go-worker-runtime-migration`; this PR must not merge to `main` independently.
- No deployment activation, scheduler activation, migration 0066, or Celery/River cutover.
- No schema migration or configuration change.
- Rollback is a revert of this commit on the feature branch.

## Tracking

- Linear: CHAOS-3359
- SCREENSHOT-WAIVER: backend/runtime validation only; no rendered UI changes.
