### PR TITLE
fix(ask-dev): CHAOS-3338 team-scope golden fixture in both contract trees

### DIFF
--- a/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json
@@ -1,0 +1,28 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "project",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_with_repository_list.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_with_repository_list.json
@@ -1,0 +1,30 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [
+    "repo_dev_health"
+  ],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json
@@ -1,0 +1,26 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev/v1/examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json
@@ -1,0 +1,61 @@
+{
+  "authorized_entity_ids": [
+    "team_platform"
+  ],
+  "authorized_repository_ids": [],
+  "candidates": [],
+  "fallbacks": [],
+  "outcome": "exact",
+  "requested_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "organization",
+    "entity_refs": [],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "resolved_at": "2026-07-28T12:00:00Z",
+  "resolved_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [
+      "repo_dev_health"
+    ],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "schema_version": "dev_scope_resolution.v1",
+  "warnings": []
+}

--- a/contracts/ask-dev/v1/examples/positive/dev_scope.v1.team_direct_scope.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_scope.v1.team_direct_scope.json
@@ -1,0 +1,28 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev/v1/examples/positive/dev_scope_resolution.v1.team_direct_scope.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_scope_resolution.v1.team_direct_scope.json
@@ -1,0 +1,59 @@
+{
+  "authorized_entity_ids": [
+    "team_platform"
+  ],
+  "authorized_repository_ids": [],
+  "candidates": [],
+  "fallbacks": [],
+  "outcome": "exact",
+  "requested_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "organization",
+    "entity_refs": [],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "resolved_at": "2026-07-28T12:00:00Z",
+  "resolved_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "schema_version": "dev_scope_resolution.v1",
+  "warnings": []
+}

--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -13,6 +13,7 @@
         "path": "examples/positive/dev_capabilities.v1.json",
         "sha256": "c50f40db5b17e5542273bd9458260c85ea557ac2c561b1d74b8f2f145bfcd781"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_capabilities.v1.schema.json",
         "sha256": "66f9dd47b340f1ca3b3d545761912e69a0833b1550868a8f45a6ab2836ec2050"
@@ -31,6 +32,7 @@
         "path": "examples/positive/dev_conversation.v1.json",
         "sha256": "47be0516bbcaa870893952b97a0e4c8ab149976dbc7a61c2f3f0a011c8e697ab"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation.v1.schema.json",
         "sha256": "8cc7267de6d08f5a63d1ecef1b4a0b45856a925637ba780f6433856fa7d27bbb"
@@ -49,6 +51,7 @@
         "path": "examples/positive/dev_conversation_summary.v1.json",
         "sha256": "6304c4105dc11299fe840041c76453b0fd1eedecdbafbdb76d9b9f703a3f530b"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_summary.v1.schema.json",
         "sha256": "53f0fac1fef5801a794ed160b1904fc107c3647d60e52c7462ddeccdb8c6f167"
@@ -72,6 +75,7 @@
         "path": "examples/positive/dev_conversation_transcript.v1.json",
         "sha256": "7aa148b2e030d83df425a53144b2a72c1ce12f6a2fd4bf8ffe798a09239db72d"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
         "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
@@ -105,6 +109,7 @@
         "path": "examples/positive/dev_message_request.v1.json",
         "sha256": "bf3e37433e31bb6df754365523d22bcbcbdde51e5ac187d5c040805d989c2193"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
         "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
@@ -148,6 +153,7 @@
         "path": "examples/positive/dev_answer.v1.json",
         "sha256": "fba7cafc8b232b43e56c8385b2b58439e5a4b0b67cb3eb1da0ffc32f19733c21"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
         "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
@@ -166,6 +172,7 @@
         "path": "examples/positive/dev_claim.v1.json",
         "sha256": "d0ecc9782098c5b683e7002d8bf2b62dbf03cd19db5e49a8a6becb738d728b41"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_claim.v1.schema.json",
         "sha256": "4a8505fb87ccae4c4e63c17403410a18f543e54f1e46a79c0b8144d7b60b5481"
@@ -184,6 +191,7 @@
         "path": "examples/positive/dev_metric_ref.v1.json",
         "sha256": "e7ca0ef77b63d9f23812d96033004c1e799baad21f90c8f786b1fa3c6ae6fe1f"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_metric_ref.v1.schema.json",
         "sha256": "8038eef2144551ffd165681dd96a9541d0ae74925708250691f5674acbedde32"
@@ -202,6 +210,7 @@
         "path": "examples/positive/dev_evidence_ref.v1.json",
         "sha256": "736e3ddf1dea4a689d7853b6eeed317980f894aa99477aeb83b85cd5eaa17bb0"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_ref.v1.schema.json",
         "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
@@ -220,6 +229,7 @@
         "path": "examples/positive/dev_evidence_expansion.v1.json",
         "sha256": "a685babfe43af765fb48fd9c670c5b9236a5e5bf090f88fcba381fff615ef473"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_expansion.v1.schema.json",
         "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
@@ -232,12 +242,34 @@
           "case": "repository_scope_without_repository",
           "path": "examples/negative/dev_scope.v1.repository_scope_without_repository.json",
           "sha256": "9231bdb93fd8ca9071b94eddab8efe18117d779a36bd9c98a460645a53a913c7"
+        },
+        {
+          "case": "team_scope_with_repository_list",
+          "path": "examples/negative/dev_scope.v1.team_scope_with_repository_list.json",
+          "sha256": "9be0e272c2f64d88b3045fa75190d56291e306a6f16a12ffc70b11dddc607a71"
+        },
+        {
+          "case": "team_scope_without_matching_team_id",
+          "path": "examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json",
+          "sha256": "6ed6b7870fbbc05695b85b3b537f86427aa9cde17dbaab9b5038729842a3c84c"
+        },
+        {
+          "case": "team_scope_entity_ref_is_not_a_team",
+          "path": "examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json",
+          "sha256": "29d0ec2641b0605f52e377ecb19422a01a63f331da161472cf05c39a76032614"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_scope.v1.json",
         "sha256": "dde80325d67210773c48c173a87a10d28175cbfe749de68031ad0aea498b22a8"
       },
+      "positive_variants": [
+        {
+          "case": "team_direct_scope",
+          "path": "examples/positive/dev_scope.v1.team_direct_scope.json",
+          "sha256": "fcfa27343f3c8495cdb53bfedecad7563b88270397eb8510dbfa3a3a44e78689"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_scope.v1.schema.json",
         "sha256": "d968b133e6ebf1fde7851c9a3c7c650dddf6edc5bb3a4dca311c6302add5e1a8"
@@ -250,12 +282,24 @@
           "case": "ambiguous_without_candidates",
           "path": "examples/negative/dev_scope_resolution.v1.ambiguous_without_candidates.json",
           "sha256": "7fed2de44881a812e39df698ac9f70d17ad2687b5152c8deddfa16f0f49627b2"
+        },
+        {
+          "case": "team_resolution_scope_with_repository_list",
+          "path": "examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json",
+          "sha256": "ecac58395a2e44a2172dca0589fade71c71103fe8e91a0452af02242d5a48e27"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_scope_resolution.v1.json",
         "sha256": "c6b8c0117a8d43b2d9cb2307ff84790b09cef16dae6261b0a06bcecce47aa98e"
       },
+      "positive_variants": [
+        {
+          "case": "team_direct_scope",
+          "path": "examples/positive/dev_scope_resolution.v1.team_direct_scope.json",
+          "sha256": "7bba6a7be653b7c2fbc0889b29a3a5828683107a0c6a0fe2da5251b68980efdb"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_scope_resolution.v1.schema.json",
         "sha256": "6f0f9de88d78beb53b5d6e42b9e161cadaf947a2939a3215a810069600227b81"
@@ -274,6 +318,7 @@
         "path": "examples/positive/dev_tool_request.v1.json",
         "sha256": "6813cd3b14a8b89c3f53c636950052733936e92fc396e06a36652d4b02166fff"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_request.v1.schema.json",
         "sha256": "eed1f7ad4d5dac6f12680329eded654e7808fa78280e11280f4e3cf541a0bfe1"
@@ -297,6 +342,7 @@
         "path": "examples/positive/dev_tool_result.v1.json",
         "sha256": "31a956f4659f29f190346a7b873a219ffc85ccd2dfb9d7032937a4eb9c9ed653"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
         "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
@@ -315,6 +361,7 @@
         "path": "examples/positive/dev_feedback.v1.json",
         "sha256": "f4e15f005ae9314210900993a791b5ab358375997f7dc28b30d4d76487101ba0"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_feedback.v1.schema.json",
         "sha256": "9c792cd80995e4e6eba066d50e495d77e0337621dffaf12fd59ed468af69b545"
@@ -333,6 +380,7 @@
         "path": "examples/positive/dev_stream_event.v1.json",
         "sha256": "0a0f35ac4aa52b623cfce76eca11aca5c6fa186d1e66f3376cdfc5c90d0759b2"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
         "sha256": "694eeacf026c3c6abe6363625d1188fa59c3b1d194713acd8754babeeaa0dfad"
@@ -351,6 +399,7 @@
         "path": "examples/positive/dev_error.v1.json",
         "sha256": "c4536803fbb8259951bca9725d8594801169da9641177f2bd91fd87d124874ee"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_error.v1.schema.json",
         "sha256": "eb78a38684caab42ef2c88c6a33f558330855b86b9b847024560dfeb68581514"

--- a/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_entity_ref_is_not_a_team.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_entity_ref_is_not_a_team.json
@@ -1,0 +1,39 @@
+{
+  "client_message_id": "web-msg-2026-07-31-0001",
+  "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
+  "idempotency_key": "idem_01",
+  "question": "How is the Platform team doing?",
+  "question_class_hint": null,
+  "request_id": "web-req-2026-07-31-0001",
+  "requested_metric_ids": [],
+  "retry_of_run_id": "0f1a2b3c-0001-4a00-8000-000000000002",
+  "schema_version": "dev_message_request.v2",
+  "scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "project",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  }
+}

--- a/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_with_repository_list.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_with_repository_list.json
@@ -1,0 +1,41 @@
+{
+  "client_message_id": "web-msg-2026-07-31-0001",
+  "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
+  "idempotency_key": "idem_01",
+  "question": "How is the Platform team doing?",
+  "question_class_hint": null,
+  "request_id": "web-req-2026-07-31-0001",
+  "requested_metric_ids": [],
+  "retry_of_run_id": "0f1a2b3c-0001-4a00-8000-000000000002",
+  "schema_version": "dev_message_request.v2",
+  "scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [
+      "repo_dev_health"
+    ],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  }
+}

--- a/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_without_matching_team_id.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_message_request.v2.team_scope_without_matching_team_id.json
@@ -1,0 +1,37 @@
+{
+  "client_message_id": "web-msg-2026-07-31-0001",
+  "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
+  "idempotency_key": "idem_01",
+  "question": "How is the Platform team doing?",
+  "question_class_hint": null,
+  "request_id": "web-req-2026-07-31-0001",
+  "requested_metric_ids": [],
+  "retry_of_run_id": "0f1a2b3c-0001-4a00-8000-000000000002",
+  "schema_version": "dev_message_request.v2",
+  "scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  }
+}

--- a/contracts/ask-dev/v2/examples/positive/dev_message_request.v2.team_direct_scope.json
+++ b/contracts/ask-dev/v2/examples/positive/dev_message_request.v2.team_direct_scope.json
@@ -1,0 +1,39 @@
+{
+  "client_message_id": "web-msg-2026-07-31-0001",
+  "conversation_id": "0f1a2b3c-0005-4a00-8000-000000000001",
+  "idempotency_key": "idem_01",
+  "question": "How is the Platform team doing?",
+  "question_class_hint": null,
+  "request_id": "web-req-2026-07-31-0001",
+  "requested_metric_ids": [],
+  "retry_of_run_id": "0f1a2b3c-0001-4a00-8000-000000000002",
+  "schema_version": "dev_message_request.v2",
+  "scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  }
+}

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -7,12 +7,34 @@
           "case": "oversized_question",
           "path": "examples/negative/dev_message_request.v2.oversized_question.json",
           "sha256": "81efd3ddd7e22c8cf670f43f336858d0116d1506c9f615713c614a2d6333dc0a"
+        },
+        {
+          "case": "team_scope_with_repository_list",
+          "path": "examples/negative/dev_message_request.v2.team_scope_with_repository_list.json",
+          "sha256": "e1596a7ec462fde1e7122162fb38c5798368b46895ee26ead68e13b4329e0187"
+        },
+        {
+          "case": "team_scope_without_matching_team_id",
+          "path": "examples/negative/dev_message_request.v2.team_scope_without_matching_team_id.json",
+          "sha256": "f4b7eb1728a1e90b665cc73ec4defbaf3d46e212e8f37fbc6ecbe59b1c6305fd"
+        },
+        {
+          "case": "team_scope_entity_ref_is_not_a_team",
+          "path": "examples/negative/dev_message_request.v2.team_scope_entity_ref_is_not_a_team.json",
+          "sha256": "de8897c2283cd9d23e63553c4b73929e74bbac3c50d66d78e8359633d2f10bfd"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_message_request.v2.json",
         "sha256": "d8f99c9d4195c18ee6068ac9fa752d7617469f013ad4fb28d977852313cd0648"
       },
+      "positive_variants": [
+        {
+          "case": "team_direct_scope",
+          "path": "examples/positive/dev_message_request.v2.team_direct_scope.json",
+          "sha256": "f2fe4ecfc242c5d69c31e1a477294b0ada6ebe0f78276b6121b0230806e06fca"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_message_request.v2.schema.json",
         "sha256": "b36c98551b1905343f89a3435f899ddf51ae1a55123e39368438728cf0b86e7d"
@@ -31,6 +53,7 @@
         "path": "examples/positive/dev_question_intent.v1.json",
         "sha256": "ce47eebe099ff275e2bba158c26d3a127baa0b855de81c68d4eaf09b498e9599"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_question_intent.v1.schema.json",
         "sha256": "ab9aba605adc6d28366087aa1d543453e5fac7eae09b25adee806b63f62e492e"
@@ -49,6 +72,7 @@
         "path": "examples/positive/dev_subject_mention.v1.json",
         "sha256": "8084977cf007ef7c1bfd0f9fd346fc4e0df61555fb6c346fdfa92228655dbc32"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_subject_mention.v1.schema.json",
         "sha256": "2dd5ca6cc5e702e4a7777ee05149b998d3ad63afe65d9427d05d87b88d415b52"
@@ -67,6 +91,7 @@
         "path": "examples/positive/dev_resolution_ledger.v1.json",
         "sha256": "3278cc6345c352045132a724d8a50761e7d7eada6839b7f53182af191683ffef"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_resolution_ledger.v1.schema.json",
         "sha256": "e00c984352675b52678aa45d8a979c3d8112131c2e2923ea4b9e63a1e8bd16b9"
@@ -85,6 +110,7 @@
         "path": "examples/positive/dev_subject_set.v1.json",
         "sha256": "a74fb65e6be049eb1315d6a2308c1ae750a231b9d19b8eecf2b9a25c19997e15"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_subject_set.v1.schema.json",
         "sha256": "0f07946b84b605016db675d0c53a31a8dbd86e6db563886429ebfa55f53bb32e"
@@ -103,6 +129,7 @@
         "path": "examples/positive/dev_source_requirement.v1.json",
         "sha256": "2264235568e65602bc36315d5470fdb1d88177088274f666b3e15acac974a78d"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_source_requirement.v1.schema.json",
         "sha256": "50ee3376959280adbd82706fe9d35096d78d96c2ceeecf58a59701a24a1b19b7"
@@ -121,6 +148,7 @@
         "path": "examples/positive/dev_investigation_plan.v1.json",
         "sha256": "be5f6716a303ed6b92a5e6af553f885e16178d270224f9b61792c476fef0f3bb"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_investigation_plan.v1.schema.json",
         "sha256": "f483e4657f6527f51f42657028bc2d6603ac84699dde2b52d5b411d5d27d6415"
@@ -139,6 +167,7 @@
         "path": "examples/positive/dev_source_observation.v1.json",
         "sha256": "9bb4810aa32d1b032300ddd8817e981b543cbeabc36428e00f7e81ef272c4a01"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_source_observation.v1.schema.json",
         "sha256": "8afcc973ac4735763b2ddd50ccaea9eecb710aa6196dc1fbdfe0cbf366d2075c"
@@ -157,6 +186,7 @@
         "path": "examples/positive/dev_investigation_result.v1.json",
         "sha256": "70924280c51ffdd7788cfb3093a29f5ffb6df2c54b1ccffbd1686c1f5f5522f9"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_investigation_result.v1.schema.json",
         "sha256": "b085bcd237f8ba86151505c042f2e44061f07063435286e205f4bbb80dc57a66"
@@ -345,6 +375,7 @@
         "path": "examples/positive/dev_answer_frame.v1.json",
         "sha256": "91855e2829f628d96d4579576698b5cd941188975b416e3561fc32b97156da6a"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
         "sha256": "a75875a8d9b159cc07f6be98c2296c73e48f5d1fcfe8f60a4f21ee7e52ce0b50"
@@ -363,6 +394,7 @@
         "path": "examples/positive/dev_narrative.v1.json",
         "sha256": "edfe5ed285b34b6787f448218119d06fc2b0bf01702c60526c33a7dfed7d5588"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_narrative.v1.schema.json",
         "sha256": "371753c6f2e33469b12c49814b86b6fbbc50ba928ffc4991b55f63e53bfb6585"
@@ -431,6 +463,7 @@
         "path": "examples/positive/dev_answer.v2.json",
         "sha256": "07c91f4fab5284ab3f12766f181cf416386f93a48553605b9bbdd72acde06adf"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
         "sha256": "8cb9dd96139a9db09664785e8556a3f9f678f2ae0d3ded5ed4c0e174975ac5db"
@@ -449,6 +482,7 @@
         "path": "examples/positive/dev_stream_event.v2.json",
         "sha256": "adfc1fce5cb44346ae3aa0c4e902bace2465a0ae241366fb4f149f13bf420269"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
         "sha256": "4f9649b45d387d381d5e25de302ddc85e6e7e5c1092424f1c28acafb1f2370ab"

--- a/src/dev_health_ops/api/dev/contract_fixtures.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime
 from typing import Any
+
+from .contracts import DevScope, DevScopeResolution
+from .scope_service import AuthorizedEntity, EntityKind, ScopeResolutionService
 
 NOW = "2026-07-28T12:00:00Z"
 START = "2026-06-28T00:00:00Z"
 END = "2026-07-28T00:00:00Z"
 PREVIOUS_START = "2026-05-29T00:00:00Z"
+
+TEAM_ID = "team_platform"
+TEAM_LABEL = "Platform"
 
 
 def _time_range(start: str = START, end: str = END) -> dict[str, Any]:
@@ -54,6 +61,62 @@ def _scope_resolution() -> dict[str, Any]:
         "warnings": [],
         "resolved_at": NOW,
     }
+
+
+def committed_team_commit() -> DevScopeResolution:
+    """The one committed TEAM scope, built by the **real producer**.
+
+    CHAOS-3338. ``ScopeResolutionService.committed_resolution_for`` is the
+    single construction of an exact-match committed scope in production —
+    it is what the subject preflight itself calls
+    (``subject_preflight.py``) — so the team golden this module exports is
+    the real wire shape rather than hand-authored JSON free to drift from
+    it. Team became a real committed direct scope in CHAOS-3301, but no
+    positive example of one was ever exported, which left
+    ``dev-health-web``'s ``validateScope`` team arm with nothing to verify
+    against except a live call into this producer.
+
+    ``__new__`` skips ``__init__`` deliberately: ``committed_resolution_for``
+    touches neither the catalog nor the request cache, and a fixture module
+    has no ClickHouse client to hand it. Same construction
+    ``tests/api/dev/test_chaos_3332_tool_executor_faults.py`` already uses.
+
+    The requested scope is an organization scope, which is what the page
+    actually sends when a user names a team in the question rather than
+    navigating to it: the commit is what *narrows* it to that team.
+    """
+
+    base_scope = DevScope.model_validate(
+        {
+            "schema_version": "dev_scope.v1",
+            "organization_id": "org_fullchaos",
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "team_ids": [],
+            "time_range": _time_range(),
+            "comparison_range": _time_range(PREVIOUS_START, START),
+            "surface_context": None,
+        }
+    )
+    service = ScopeResolutionService.__new__(ScopeResolutionService)
+    return service.committed_resolution_for(
+        AuthorizedEntity(EntityKind.TEAM, TEAM_ID, TEAM_LABEL),
+        org_id="org_fullchaos",
+        base_scope=base_scope,
+        resolved_at=datetime.fromisoformat(NOW.replace("Z", "+00:00")),
+    )
+
+
+def _team_scope() -> dict[str, Any]:
+    resolved = committed_team_commit().resolved_scope
+    if resolved is None:  # pragma: no cover - an exact commit always resolves
+        raise RuntimeError("committed team resolution produced no resolved scope")
+    return resolved.model_dump(mode="json")
+
+
+def _team_scope_resolution() -> dict[str, Any]:
+    return committed_team_commit().model_dump(mode="json")
 
 
 def _evidence() -> dict[str, Any]:
@@ -344,13 +407,41 @@ def positive_fixtures() -> dict[str, dict[str, Any]]:
     }
 
 
+def positive_variant_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
+    """Extra *valid* payloads for contracts with more than one shipped shape.
+
+    ``positive_fixtures`` holds exactly one canonical payload per contract,
+    which is enough for schema coverage but silently under-describes any
+    contract whose invariants branch on a discriminator. ``dev_scope.v1``
+    branches on ``direct_scope``, and its canonical payload is a
+    ``repository`` scope, so nothing in the exported set showed a consumer
+    what a committed ``team`` scope looks like (CHAOS-3338). Variants are
+    exported as ``examples/positive/{schema}.{label}.json`` alongside the
+    canonical example and listed under ``positive_variants`` in the
+    manifest.
+    """
+
+    return {
+        "dev_scope.v1": [("team_direct_scope", _team_scope())],
+        "dev_scope_resolution.v1": [("team_direct_scope", _team_scope_resolution())],
+    }
+
+
 def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
     """Return intentional failures; case labels explain the invariant exercised."""
 
     positives = positive_fixtures()
+    variants = {
+        schema: dict(cases) for schema, cases in positive_variant_fixtures().items()
+    }
 
     def changed(schema: str, mutator: Any) -> dict[str, Any]:
         value = deepcopy(positives[schema])
+        mutator(value)
+        return value
+
+    def changed_variant(schema: str, label: str, mutator: Any) -> dict[str, Any]:
+        value = deepcopy(variants[schema][label])
         mutator(value)
         return value
 
@@ -541,7 +632,39 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                 changed(
                     "dev_scope.v1", lambda value: value.__setitem__("repositories", [])
                 ),
-            )
+            ),
+            # CHAOS-3338: one case per clause of the TEAM branch of
+            # ``DevScope.validate_direct_scope``, each mutating the shipped
+            # team golden rather than a hand-built payload, so a clause that
+            # stops rejecting is attributable to that clause alone.
+            (
+                "team_scope_with_repository_list",
+                changed_variant(
+                    "dev_scope.v1",
+                    "team_direct_scope",
+                    lambda value: value.__setitem__(
+                        "repositories", ["repo_dev_health"]
+                    ),
+                ),
+            ),
+            (
+                "team_scope_without_matching_team_id",
+                changed_variant(
+                    "dev_scope.v1",
+                    "team_direct_scope",
+                    lambda value: value.__setitem__("team_ids", []),
+                ),
+            ),
+            (
+                "team_scope_entity_ref_is_not_a_team",
+                changed_variant(
+                    "dev_scope.v1",
+                    "team_direct_scope",
+                    lambda value: value["entity_refs"][0].__setitem__(
+                        "entity_type", "project"
+                    ),
+                ),
+            ),
         ],
         "dev_scope_resolution.v1": [
             (
@@ -553,7 +676,17 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                         value.__setitem__("resolved_scope", None),
                     ),
                 ),
-            )
+            ),
+            (
+                "team_resolution_scope_with_repository_list",
+                changed_variant(
+                    "dev_scope_resolution.v1",
+                    "team_direct_scope",
+                    lambda value: value["resolved_scope"].__setitem__(
+                        "repositories", ["repo_dev_health"]
+                    ),
+                ),
+            ),
         ],
         "dev_tool_request.v1": [
             (
@@ -651,4 +784,10 @@ def stream_fixtures() -> dict[str, list[dict[str, Any]]]:
     }
 
 
-__all__ = ["negative_fixtures", "positive_fixtures", "stream_fixtures"]
+__all__ = [
+    "committed_team_commit",
+    "negative_fixtures",
+    "positive_fixtures",
+    "positive_variant_fixtures",
+    "stream_fixtures",
+]

--- a/src/dev_health_ops/api/dev/contract_fixtures_v2.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures_v2.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from .contract_fixtures import committed_team_commit
 from .contracts_v2.validators import CANONICAL_NO_ANSWER_COPY
 
 NOW = "2026-07-28T12:00:00Z"
@@ -34,6 +35,22 @@ def _scope() -> dict[str, Any]:
         "comparison_range": None,
         "surface_context": None,
     }
+
+
+def _team_scope() -> dict[str, Any]:
+    """The committed TEAM scope, from the same real producer v1 exports.
+
+    CHAOS-3338. ``DevScopeV2`` subclasses ``DevScope``, so the one payload
+    ``ScopeResolutionService.committed_resolution_for`` emits is the golden
+    for both trees; deriving it here rather than restating it keeps the two
+    exported team examples from drifting apart (asserted in
+    ``tests/api/dev/test_contracts_v2.py``).
+    """
+
+    resolved = committed_team_commit().resolved_scope
+    if resolved is None:  # pragma: no cover - an exact commit always resolves
+        raise RuntimeError("committed team resolution produced no resolved scope")
+    return resolved.model_dump(mode="json")
 
 
 def _entity_ref() -> dict[str, Any]:
@@ -903,13 +920,46 @@ def positive_fixtures() -> dict[str, dict[str, Any]]:
     }
 
 
+def _team_message_request() -> dict[str, Any]:
+    """A request whose committed scope is a TEAM subject (CHAOS-3338).
+
+    The canonical ``dev_message_request.v2`` carries a ``repository``
+    scope, so no exported v2 example showed a consumer the team arm of
+    ``DevScopeV2``'s inherited ``validate_direct_scope``.
+    """
+
+    request = _message_request()
+    request["question"] = "How is the Platform team doing?"
+    request["scope"] = _team_scope()
+    return request
+
+
+def positive_variant_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
+    """Extra *valid* payloads for contracts with more than one shipped shape.
+
+    Mirrors ``contract_fixtures.positive_variant_fixtures`` (v1); exported
+    as ``examples/positive/{schema}.{label}.json`` and listed under
+    ``positive_variants`` in the v2 manifest.
+    """
+
+    return {"dev_message_request.v2": [("team_direct_scope", _team_message_request())]}
+
+
 def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
     """Return intentional failures; case labels explain the invariant exercised."""
 
     positives = positive_fixtures()
+    variants = {
+        schema: dict(cases) for schema, cases in positive_variant_fixtures().items()
+    }
 
     def changed(schema: str, mutator: Any) -> dict[str, Any]:
         value = deepcopy(positives[schema])
+        mutator(value)
+        return value
+
+    def changed_variant(schema: str, label: str, mutator: Any) -> dict[str, Any]:
+        value = deepcopy(variants[schema][label])
         mutator(value)
         return value
 
@@ -1215,7 +1265,39 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                     "dev_message_request.v2",
                     lambda value: value.__setitem__("question", "é" * 4_097),
                 ),
-            )
+            ),
+            # CHAOS-3338: one case per clause of the TEAM branch of the
+            # inherited ``DevScope.validate_direct_scope``, mutating the
+            # shipped team golden so a clause that stops rejecting is
+            # attributable to that clause alone.
+            (
+                "team_scope_with_repository_list",
+                changed_variant(
+                    "dev_message_request.v2",
+                    "team_direct_scope",
+                    lambda value: value["scope"].__setitem__(
+                        "repositories", ["repo_dev_health"]
+                    ),
+                ),
+            ),
+            (
+                "team_scope_without_matching_team_id",
+                changed_variant(
+                    "dev_message_request.v2",
+                    "team_direct_scope",
+                    lambda value: value["scope"].__setitem__("team_ids", []),
+                ),
+            ),
+            (
+                "team_scope_entity_ref_is_not_a_team",
+                changed_variant(
+                    "dev_message_request.v2",
+                    "team_direct_scope",
+                    lambda value: value["scope"]["entity_refs"][0].__setitem__(
+                        "entity_type", "project"
+                    ),
+                ),
+            ),
         ],
         "dev_question_intent.v1": [
             (
@@ -1590,5 +1672,6 @@ __all__ = [
     "negative_fixtures",
     "no_answer_answer_fixture",
     "positive_fixtures",
+    "positive_variant_fixtures",
     "stream_fixtures",
 ]

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -272,7 +272,17 @@ class DevScope(ContractModel):
             # populated) and never carry any other id. An organization scope
             # carrying team_ids stays a filter, structurally — this branch
             # only fires for DirectScope.TEAM.
-            if self.team_ids != [self.entity_refs[0].entity_id]:
+            # CHAOS-3338: compared as tuples, not against a list literal.
+            # ``DevScopeV2`` (contracts_v2.embedded) re-declares ``team_ids``
+            # as a ``tuple[OpaqueID, ...]``, and ``("t",) != ["t"]`` is
+            # always True in Python -- so this branch rejected *every* v2
+            # team scope, including the one the real producer commits.
+            # ``investigation_plans.builtin_steps._wire_metric_content``
+            # revalidates the committed scope as a ``DevScopeV2``, so a
+            # committed team subject raised there for the whole metrics
+            # step. Found by exporting the first team golden into the v2
+            # tree, which had no positive team example until now.
+            if tuple(self.team_ids) != (self.entity_refs[0].entity_id,):
                 raise ValueError(
                     "team direct scope requires team_ids to name exactly that team"
                 )

--- a/src/dev_health_ops/api/dev/export_contracts.py
+++ b/src/dev_health_ops/api/dev/export_contracts.py
@@ -10,7 +10,12 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from .contract_fixtures import negative_fixtures, positive_fixtures, stream_fixtures
+from .contract_fixtures import (
+    negative_fixtures,
+    positive_fixtures,
+    positive_variant_fixtures,
+    stream_fixtures,
+)
 from .contracts import CONTRACT_MODELS, DevStreamEvent, validate_stream
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
@@ -34,6 +39,29 @@ def _schema(name: str) -> dict[str, Any]:
     }
 
 
+def _validate_positive_variants() -> None:
+    """CHAOS-3338: variants are additional *valid* payloads, held to the
+    same bar as the canonical positives plus a naming contract, since each
+    one claims its own ``examples/positive/{schema}.{label}.json`` path."""
+
+    variants = positive_variant_fixtures()
+    unregistered = sorted(set(variants) - set(CONTRACT_MODELS))
+    if unregistered:
+        raise RuntimeError(
+            f"positive variants name unregistered contracts: {unregistered}"
+        )
+    for name, cases in variants.items():
+        if not cases:
+            raise RuntimeError(f"{name} declares an empty positive variant list")
+        labels = [label for label, _ in cases]
+        if len(labels) != len(set(labels)):
+            raise RuntimeError(f"{name} has duplicate positive variant labels")
+        for label, payload in cases:
+            if not label:
+                raise RuntimeError(f"{name} has an unlabelled positive variant")
+            CONTRACT_MODELS[name].model_validate(payload)
+
+
 def _validate_fixtures() -> None:
     positives = positive_fixtures()
     negatives = negative_fixtures()
@@ -43,6 +71,7 @@ def _validate_fixtures() -> None:
         raise RuntimeError("negative fixture coverage does not match contract registry")
     for name, payload in positives.items():
         CONTRACT_MODELS[name].model_validate(payload)
+    _validate_positive_variants()
     for name, cases in negatives.items():
         if not cases:
             raise RuntimeError(f"{name} has no negative fixture")
@@ -71,6 +100,7 @@ def expected_artifacts() -> dict[str, str]:
     manifest_entries: list[dict[str, Any]] = []
     positives = positive_fixtures()
     negatives = negative_fixtures()
+    variants = positive_variant_fixtures()
     for name in CONTRACT_MODELS:
         schema_path = f"schemas/{name}.schema.json"
         positive_path = f"examples/positive/{name}.json"
@@ -78,6 +108,20 @@ def expected_artifacts() -> dict[str, str]:
         positive_contents = _json(positives[name])
         artifacts[schema_path] = schema_contents
         artifacts[positive_path] = positive_contents
+        variant_entries = []
+        for label, payload in variants.get(name, []):
+            variant_path = f"examples/positive/{name}.{label}.json"
+            if variant_path in artifacts:
+                raise RuntimeError(f"positive variant path collides: {variant_path}")
+            variant_contents = _json(payload)
+            artifacts[variant_path] = variant_contents
+            variant_entries.append(
+                {
+                    "case": label,
+                    "path": variant_path,
+                    "sha256": _sha256(variant_contents),
+                }
+            )
         negative_entries = []
         for label, payload in negatives[name]:
             negative_path = f"examples/negative/{name}.{label}.json"
@@ -98,6 +142,7 @@ def expected_artifacts() -> dict[str, str]:
                     "path": positive_path,
                     "sha256": _sha256(positive_contents),
                 },
+                "positive_variants": variant_entries,
                 "negative": negative_entries,
             }
         )

--- a/src/dev_health_ops/api/dev/export_contracts_v2.py
+++ b/src/dev_health_ops/api/dev/export_contracts_v2.py
@@ -17,7 +17,12 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from .contract_fixtures_v2 import negative_fixtures, positive_fixtures, stream_fixtures
+from .contract_fixtures_v2 import (
+    negative_fixtures,
+    positive_fixtures,
+    positive_variant_fixtures,
+    stream_fixtures,
+)
 from .contracts_v2 import CONTRACT_MODELS_V2, DevStreamEventV2, validate_stream_v2
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
@@ -41,6 +46,27 @@ def _schema(name: str) -> dict[str, Any]:
     }
 
 
+def _validate_positive_variants() -> None:
+    """CHAOS-3338: mirrors ``export_contracts._validate_positive_variants``."""
+
+    variants = positive_variant_fixtures()
+    unregistered = sorted(set(variants) - set(CONTRACT_MODELS_V2))
+    if unregistered:
+        raise RuntimeError(
+            f"positive variants name unregistered contracts: {unregistered}"
+        )
+    for name, cases in variants.items():
+        if not cases:
+            raise RuntimeError(f"{name} declares an empty positive variant list")
+        labels = [label for label, _ in cases]
+        if len(labels) != len(set(labels)):
+            raise RuntimeError(f"{name} has duplicate positive variant labels")
+        for label, payload in cases:
+            if not label:
+                raise RuntimeError(f"{name} has an unlabelled positive variant")
+            CONTRACT_MODELS_V2[name].model_validate(payload)
+
+
 def _validate_fixtures() -> None:
     positives = positive_fixtures()
     negatives = negative_fixtures()
@@ -50,6 +76,7 @@ def _validate_fixtures() -> None:
         raise RuntimeError("negative fixture coverage does not match contract registry")
     for name, payload in positives.items():
         CONTRACT_MODELS_V2[name].model_validate(payload)
+    _validate_positive_variants()
     for name, cases in negatives.items():
         if not cases:
             raise RuntimeError(f"{name} has no negative fixture")
@@ -87,6 +114,7 @@ def expected_artifacts() -> dict[str, str]:
     manifest_entries: list[dict[str, Any]] = []
     positives = positive_fixtures()
     negatives = negative_fixtures()
+    variants = positive_variant_fixtures()
     for name in CONTRACT_MODELS_V2:
         schema_path = f"schemas/{name}.schema.json"
         positive_path = f"examples/positive/{name}.json"
@@ -94,6 +122,20 @@ def expected_artifacts() -> dict[str, str]:
         positive_contents = _json(positives[name])
         artifacts[schema_path] = schema_contents
         artifacts[positive_path] = positive_contents
+        variant_entries = []
+        for label, payload in variants.get(name, []):
+            variant_path = f"examples/positive/{name}.{label}.json"
+            if variant_path in artifacts:
+                raise RuntimeError(f"positive variant path collides: {variant_path}")
+            variant_contents = _json(payload)
+            artifacts[variant_path] = variant_contents
+            variant_entries.append(
+                {
+                    "case": label,
+                    "path": variant_path,
+                    "sha256": _sha256(variant_contents),
+                }
+            )
         negative_entries = []
         for label, payload in negatives[name]:
             negative_path = f"examples/negative/{name}.{label}.json"
@@ -114,6 +156,7 @@ def expected_artifacts() -> dict[str, str]:
                     "path": positive_path,
                     "sha256": _sha256(positive_contents),
                 },
+                "positive_variants": variant_entries,
                 "negative": negative_entries,
             }
         )

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -354,6 +354,14 @@ def test_team_scope_negative_examples_fail_for_their_named_reason(
         DevScope.model_validate(payload)
 
 
+def test_team_resolution_negative_example_fails_for_its_named_reason() -> None:
+    payload = dict(negative_fixtures()["dev_scope_resolution.v1"])[
+        "team_resolution_scope_with_repository_list"
+    ]
+    with pytest.raises(ValidationError, match="cannot carry a repository list"):
+        DevScopeResolution.model_validate(payload)
+
+
 def test_checked_in_contract_artifacts_have_no_drift() -> None:
     check_artifacts(expected_artifacts())
 

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
+from datetime import datetime
 
 import pytest
 from pydantic import ValidationError
 
 from dev_health_ops.api.dev.contract_fixtures import (
+    TEAM_ID,
+    TEAM_LABEL,
     negative_fixtures,
     positive_fixtures,
+    positive_variant_fixtures,
     stream_fixtures,
 )
 from dev_health_ops.api.dev.contracts import (
@@ -24,11 +29,30 @@ from dev_health_ops.api.dev.export_contracts import (
     check_artifacts,
     expected_artifacts,
 )
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ScopeResolutionService,
+)
 
 
 @pytest.mark.parametrize("schema_version", CONTRACT_MODELS)
 def test_positive_fixture_validates(schema_version: str) -> None:
     CONTRACT_MODELS[schema_version].model_validate(positive_fixtures()[schema_version])
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "case", "payload"),
+    [
+        (schema_version, case, payload)
+        for schema_version, cases in positive_variant_fixtures().items()
+        for case, payload in cases
+    ],
+)
+def test_positive_variant_fixture_validates(
+    schema_version: str, case: str, payload: dict[str, object]
+) -> None:
+    CONTRACT_MODELS[schema_version].model_validate(payload)
 
 
 @pytest.mark.parametrize(
@@ -225,6 +249,109 @@ def test_organization_scope_with_a_team_filter_stays_a_filter() -> None:
     scope = DevScope.model_validate(org_scope)
 
     assert scope.team_ids == ["team_platform"]
+
+
+def _live_producer_team_scope() -> dict[str, object]:
+    """Re-derive the committed TEAM scope straight from the producer.
+
+    Deliberately does NOT go through ``contract_fixtures``: this is the
+    other half of a differential oracle, so it has to call
+    ``ScopeResolutionService.committed_resolution_for`` itself. If the
+    fixture module ever stops producing its golden from the producer (a
+    hand-edit, a copy-paste of the JSON), the comparison below breaks.
+    """
+
+    base_scope = DevScope.model_validate(
+        {
+            "schema_version": "dev_scope.v1",
+            "organization_id": "org_fullchaos",
+            "direct_scope": "organization",
+            "repositories": [],
+            "entity_refs": [],
+            "team_ids": [],
+            "time_range": {
+                "start": "2026-06-28T00:00:00Z",
+                "end": "2026-07-28T00:00:00Z",
+                "timezone": "America/Los_Angeles",
+            },
+            "comparison_range": {
+                "start": "2026-05-29T00:00:00Z",
+                "end": "2026-06-28T00:00:00Z",
+                "timezone": "America/Los_Angeles",
+            },
+            "surface_context": None,
+        }
+    )
+    service = ScopeResolutionService.__new__(ScopeResolutionService)
+    resolution = service.committed_resolution_for(
+        AuthorizedEntity(EntityKind.TEAM, TEAM_ID, TEAM_LABEL),
+        org_id="org_fullchaos",
+        base_scope=base_scope,
+        resolved_at=datetime.fromisoformat("2026-07-28T12:00:00+00:00"),
+    )
+    assert resolution.resolved_scope is not None
+    return resolution.resolved_scope.model_dump(mode="json")
+
+
+def test_team_scope_golden_is_exported_and_matches_the_live_producer() -> None:
+    """CHAOS-3338: the shipped team golden is producer output, not JSON.
+
+    Before this, ``contracts/ask-dev/v1`` shipped no positive example of a
+    TEAM ``DevScope`` at all, even though CHAOS-3301 made TEAM a real
+    committed direct scope -- so ``dev-health-web``'s ``validateScope``
+    team arm had nothing to verify against but a live call into this same
+    producer.
+    """
+
+    artifacts = expected_artifacts()
+    path = "examples/positive/dev_scope.v1.team_direct_scope.json"
+    assert path in artifacts, "team-scope golden is not in the exported artifact set"
+
+    payload = json.loads(artifacts[path])
+    assert payload["direct_scope"] == "team"
+    DevScope.model_validate(payload)
+    assert payload == _live_producer_team_scope()
+
+
+def test_team_scope_golden_is_listed_in_the_manifest() -> None:
+    """A file nobody can find from the manifest is not shipped, only present."""
+
+    manifest = json.loads(expected_artifacts()["manifest.json"])
+    entry = next(
+        item
+        for item in manifest["contracts"]
+        if item["schema_version"] == "dev_scope.v1"
+    )
+    variants = {case["case"]: case["path"] for case in entry["positive_variants"]}
+    assert variants == {
+        "team_direct_scope": "examples/positive/dev_scope.v1.team_direct_scope.json"
+    }
+
+
+@pytest.mark.parametrize(
+    ("case", "reason"),
+    [
+        ("team_scope_with_repository_list", "cannot carry a repository list"),
+        (
+            "team_scope_without_matching_team_id",
+            "team_ids to name exactly that team",
+        ),
+        (
+            "team_scope_entity_ref_is_not_a_team",
+            "direct entity scope requires one matching entity",
+        ),
+    ],
+)
+def test_team_scope_negative_examples_fail_for_their_named_reason(
+    case: str, reason: str
+) -> None:
+    """The generic negative sweep only asserts *some* error; each team
+    mutation has to be rejected by the clause its label names, or the
+    example documents an invariant it does not actually exercise."""
+
+    payload = dict(negative_fixtures()["dev_scope.v1"])[case]
+    with pytest.raises(ValidationError, match=reason):
+        DevScope.model_validate(payload)
 
 
 def test_checked_in_contract_artifacts_have_no_drift() -> None:

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -17,6 +17,7 @@ fails the contract suite" acceptance clause, made attributable per-guard.
 from __future__ import annotations
 
 import itertools
+import json
 import re
 from copy import deepcopy
 from enum import StrEnum
@@ -27,6 +28,10 @@ from pydantic import BaseModel, ValidationError
 
 from dev_health_ops.api.dev import contracts_v2 as v2
 from dev_health_ops.api.dev.contract_fixtures import (
+    TEAM_ID,
+    committed_team_commit,
+)
+from dev_health_ops.api.dev.contract_fixtures import (
     positive_fixtures as positive_fixtures_v1,
 )
 from dev_health_ops.api.dev.contract_fixtures_v2 import (
@@ -36,6 +41,7 @@ from dev_health_ops.api.dev.contract_fixtures_v2 import (
     negative_fixtures,
     no_answer_answer_fixture,
     positive_fixtures,
+    positive_variant_fixtures,
     stream_fixtures,
 )
 from dev_health_ops.api.dev.contracts import (
@@ -59,6 +65,9 @@ from dev_health_ops.api.dev.contracts import DevError as DevErrorV1
 from dev_health_ops.api.dev.contracts_v2 import compat as compat_module
 from dev_health_ops.api.dev.contracts_v2 import validators as validators_module
 from dev_health_ops.api.dev.contracts_v2.validators import ANSWERED_CONTENT_OUTCOMES
+from dev_health_ops.api.dev.export_contracts import (
+    expected_artifacts as expected_artifacts_v1,
+)
 from dev_health_ops.api.dev.export_contracts_v2 import (
     check_artifacts,
     expected_artifacts,
@@ -120,6 +129,94 @@ def test_stream_sequences_require_exactly_one_terminal_then_done() -> None:
             v2.validate_stream_v2(
                 [v2.DevStreamEventV2.model_validate(item) for item in payloads]
             )
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "case", "payload"),
+    [
+        (schema_version, case, payload)
+        for schema_version, cases in positive_variant_fixtures().items()
+        for case, payload in cases
+    ],
+)
+def test_positive_variant_fixture_validates(
+    schema_version: str, case: str, payload: dict[str, object]
+) -> None:
+    v2.CONTRACT_MODELS_V2[schema_version].model_validate(payload)
+
+
+def test_v2_team_golden_is_the_same_producer_output_v1_exports() -> None:
+    """CHAOS-3338: one committed TEAM scope, exported into both trees.
+
+    ``DevScopeV2`` subclasses ``DevScope``, so there is exactly one correct
+    team wire shape. Exporting it twice from one producer call is what
+    makes the two trees' team examples unable to drift apart.
+    """
+
+    v1_team = json.loads(
+        expected_artifacts_v1()["examples/positive/dev_scope.v1.team_direct_scope.json"]
+    )
+    v2_request = json.loads(
+        expected_artifacts()[
+            "examples/positive/dev_message_request.v2.team_direct_scope.json"
+        ]
+    )
+
+    assert v2_request["scope"] == v1_team
+    assert v2.DevScopeV2.model_validate(v1_team).direct_scope.value == "team"
+
+
+def test_v2_scope_accepts_the_committed_team_scope() -> None:
+    """CHAOS-3338 regression, fail-before/pass-after.
+
+    ``DevScopeV2`` re-declares ``team_ids`` as a ``tuple``, while the
+    inherited ``DevScope.validate_direct_scope`` compared it against a
+    ``list`` literal -- and ``("t",) != ["t"]`` is always True, so the
+    branch rejected *every* v2 team scope, the real producer's included.
+    ``investigation_plans.builtin_steps._wire_metric_content``
+    revalidates the committed scope as a ``DevScopeV2``, so a committed
+    team subject raised there for the entire metrics step. Restoring the
+    ``!= [ ... ]`` comparison fails this test while leaving every v1 team
+    test green, which is what makes the sequence-type mismatch the
+    attributable cause.
+    """
+
+    committed = committed_team_commit().resolved_scope
+    assert committed is not None
+
+    scope_v2 = v2.DevScopeV2.model_validate(committed.model_dump(mode="json"))
+
+    assert scope_v2.team_ids == (TEAM_ID,)
+    assert tuple(committed.team_ids) == scope_v2.team_ids
+
+    # The invariant itself must still bite on a v2 scope, not merely have
+    # been loosened into accepting anything.
+    mismatched = committed.model_dump(mode="json")
+    mismatched["team_ids"] = []
+    with pytest.raises(ValidationError, match="team_ids to name exactly that team"):
+        v2.DevScopeV2.model_validate(mismatched)
+
+
+@pytest.mark.parametrize(
+    ("case", "reason"),
+    [
+        ("team_scope_with_repository_list", "cannot carry a repository list"),
+        (
+            "team_scope_without_matching_team_id",
+            "team_ids to name exactly that team",
+        ),
+        (
+            "team_scope_entity_ref_is_not_a_team",
+            "direct entity scope requires one matching entity",
+        ),
+    ],
+)
+def test_v2_team_scope_negative_examples_fail_for_their_named_reason(
+    case: str, reason: str
+) -> None:
+    payload = dict(negative_fixtures()["dev_message_request.v2"])[case]
+    with pytest.raises(ValidationError, match=reason):
+        v2.DevMessageRequestV2.model_validate(payload)
 
 
 def test_checked_in_contract_artifacts_have_no_drift() -> None:


### PR DESCRIPTION
## What

CHAOS-3301 made TEAM a real committed direct scope, but neither `contracts/ask-dev/v1/` nor `v2/` ever shipped a positive example of one. `dev-health-web`'s `validateScope` team arm had nothing to verify against except a live call into the producer.

This ships the team golden into **both** trees, generated from the real producer.

## How the golden is produced

`contract_fixtures.committed_team_commit()` calls `ScopeResolutionService.committed_resolution_for` — the single construction of an exact-match committed scope in production, and what `subject_preflight.py` itself calls — and dumps its output. Nothing is hand-authored.

`contract_fixtures_v2._team_scope()` derives from that *same* call, so the two trees' team examples cannot drift apart (asserted in `test_v2_team_golden_is_the_same_producer_output_v1_exports`).

`test_team_scope_golden_is_exported_and_matches_the_live_producer` is a differential oracle: it re-derives the scope by calling `committed_resolution_for` itself, deliberately *not* through `contract_fixtures`, and asserts byte-equality with the exported artifact. If the fixture module ever stops producing its golden from the producer, that test breaks.

## Artifacts added

New `positive_variant_fixtures()` seam in both export pipelines — extra *valid* payloads for a contract whose invariants branch on a discriminator, exported as `examples/positive/{schema}.{label}.json` and listed under a new additive `positive_variants` manifest key.

**v1** (`contracts/ask-dev/v1/`)
- `examples/positive/dev_scope.v1.team_direct_scope.json`
- `examples/positive/dev_scope_resolution.v1.team_direct_scope.json`
- `examples/negative/dev_scope.v1.team_scope_with_repository_list.json`
- `examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json`
- `examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json`
- `examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json`

**v2** (`contracts/ask-dev/v2/`) — `dev_scope.v1` is not a registered v2 contract; the applicable carrier is `dev_message_request.v2`, whose `scope` is a `DevScopeV2`
- `examples/positive/dev_message_request.v2.team_direct_scope.json`
- `examples/negative/dev_message_request.v2.team_scope_with_repository_list.json`
- `examples/negative/dev_message_request.v2.team_scope_without_matching_team_id.json`
- `examples/negative/dev_message_request.v2.team_scope_entity_ref_is_not_a_team.json`

One negative per clause of the TEAM branch of `DevScope.validate_direct_scope`, each mutating the shipped team golden, so a clause that stops rejecting is attributable to that clause alone. Tests assert each is rejected by the clause its label names, not by some unrelated validator firing first.

All artifacts regenerated via `python -m dev_health_ops.api.dev.export_contracts write` and `export_contracts_v2 write`. Nothing under `contracts/` was hand-edited. **No schema file changed.**

## Production defect found and fixed

Exporting the first team golden into the v2 tree immediately failed, exposing a real, reachable bug:

`DevScopeV2` (`contracts_v2/embedded.py`) re-declares `team_ids` as a `tuple[OpaqueID, ...]`, while the inherited `DevScope.validate_direct_scope` compared it against a **list literal**. `("t",) != ["t"]` is always `True` in Python, so the branch rejected **every** v2 team scope — including the one the real producer commits.

`investigation_plans/builtin_steps.py:754` (`_wire_metric_content`) revalidates the committed scope as a `DevScopeV2`, so a committed team subject raised there for the entire metrics step.

Fix is one line: compare as tuples. Mutation-verified — restoring the `!= [...]` comparison fails 4 v2 tests including the dedicated regression, while all 85 v1 team tests stay green, which makes the sequence-type mismatch the attributable cause. The invariant still bites on a v2 scope (asserted), so it was not merely loosened.

## Verification

- `tests/api/dev/test_contracts.py` + `test_contracts_v2.py`: **361 passed**
- Full `tests/api/dev`: **1768 passed, 35 skipped, 1 xfailed**
- Codex adversarial review: **VERDICT: SHIP**, no findings — confirmed the golden is genuine producer output, the negatives fail on their named clauses, the tuple comparison preserves the invariant across v1 lists and v2 tuples, and the variant plumbing cannot silently drop a registered variant
- `ruff check` / `ruff format` / `mypy` clean (2024 source files)

### Gate note (honest)

`bash ci/local_validate.sh` was run plain from the worktree. **Every stage before `argMax live-exec proof` PASSED**, including the FULL unit suite (`11313 passed, 98 skipped, 1 xfailed`) and `ch-migrate (upgrade + status --check)`.

The `argMax live-exec proof (real engine)` stage wedges environmentally on this machine — the `run_stage` subshell sits at 0% CPU and never spawns the here-doc. It recurs on plain runs across multiple lanes and is unrelated to this change (tracked separately). The gate therefore did not run to completion locally; **CI is the arbiter.**