### PR TITLE
feat(ask-dev): CHAOS-3366 bounded closest-matches fallback for unresolved named subjects

### DIFF
--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -51,6 +51,7 @@ from .question_interpreter import INTERPRETER_VERSION
 __all__ = [
     "CLARIFICATION_COPY",
     "LEGACY_ONLY_QUESTION_INTENTS",
+    "NOT_FOUND_CLOSE_MATCHES_KEY",
     "PLAN_ID_BY_INTENT",
     "PREFLIGHT_OUTCOME_BY_RESOLUTION",
     "TERMINAL_STATE_BY_OUTCOME",
@@ -136,6 +137,10 @@ TERMINAL_STATE_BY_OUTCOME: Mapping[PublicOutcome, RunState] = {
 #: contract's total field allowlist does not constrain its ``direct_answer``.
 #: Server-owned copy is supplied here instead, and — like the canonical
 #: no-answer table — it names nothing about the subject.
+#: CHAOS-3366's key into ``CLARIFICATION_COPY``. Named rather than spelled as
+#: a literal at both ends so the preflight and this table cannot drift apart.
+NOT_FOUND_CLOSE_MATCHES_KEY = "not_found_close_matches"
+
 CLARIFICATION_COPY: Mapping[str, str] = {
     "ambiguous": (
         "More than one authorized entity matches the name in this question. "
@@ -144,6 +149,16 @@ CLARIFICATION_COPY: Mapping[str, str] = {
     "uninterpretable": (
         "This question could not be interpreted confidently. Please rephrase "
         "it, naming the project, repository, or team you are asking about."
+    ),
+    # CHAOS-3366, provisional. The PRD sentence names the kind and the name
+    # back ("I couldn't find an authorized <kind> named 'X'"); interpolating
+    # request text into this table is a change to how public copy is governed,
+    # which is CHAOS-3367's contract to make, not this one's. Static
+    # server-owned text until then -- it says the same thing and, like every
+    # other value here, names nothing the catalog did not confirm.
+    NOT_FOUND_CLOSE_MATCHES_KEY: (
+        "I could not find an authorized entity of that kind with that name. "
+        "Here are the closest matches -- please ask again naming one of them."
     ),
 }
 

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -160,11 +160,15 @@ NOT_FOUND_FALLBACK_LIMIT = 5
 _UNAVAILABLE_WATERMARK = "catalog-watermark-unavailable"
 
 #: Why a fallback candidate is being offered. Distinct from the same-name
-#: ambiguity reason: these entities do **not** carry the name the user typed
-#: under the kind they typed, and saying so is the honest disclosure.
-_CLOSE_MATCH_REASON = (
-    "This is a close match to the name in the question, under a different kind."
-)
+#: ambiguity reason: nothing carried the typed name exactly, so what is being
+#: offered is a near miss rather than one of several equal readings.
+#:
+#: Deliberately silent about entity *kind* (Codex review, low). The obvious
+#: phrasing — "under a different kind" — is false on the context-ref path,
+#: where the mention's own kind was never fuzzy-searched and the closest match
+#: can legitimately be the same kind the user named. One reason string covers
+#: every candidate on the entry, so it must be true for all of them.
+_CLOSE_MATCH_REASON = "This is a close match to the name in the question."
 
 
 @dataclass(frozen=True, slots=True)
@@ -420,19 +424,6 @@ class SubjectPreflight:
             authorized_scope=authorized_scope,
             resolved_at=generated_at,
         )
-        # Last of the three amenders, and the only one that can *add*
-        # candidates rather than commit: it reads the outcomes the first two
-        # already settled, so a mention the catalog-reuse path just committed
-        # is never re-searched.
-        ledger, close_matched_ids = await self._apply_not_found_fallback(
-            ledger=ledger,
-            mentions=mentions,
-            org_id=org_id,
-            permission_fingerprint=permission_fingerprint,
-            untyped_ids=untyped_ids,
-            resolved_at=generated_at,
-        )
-
         latest = ledger.latest_by_mention()
         blocking_ids = frozenset(
             mention.mention_id
@@ -478,50 +469,87 @@ class SubjectPreflight:
             and len(blocking_committed_entities) >= 2
         )
         if not cohort_may_proceed_partial:
-            for mention in mentions:
-                if mention.mention_id not in blocking_ids:
-                    continue
-                entry = latest[mention.mention_id]
-                if entry.outcome in UNRESOLVED_OUTCOMES:
-                    # CHAOS-3366: a mention the fallback amended reaches this
-                    # loop as AMBIGUOUS_CANDIDATES like any other, so the
-                    # outcome mapping and the clarification channel are
-                    # untouched -- only the diagnostic and the copy key
-                    # distinguish "we found nothing under that name, here is
-                    # what is close" from genuine same-name ambiguity.
-                    is_close_match = mention.mention_id in close_matched_ids
-                    return self._terminate(
-                        interpretation=interpretation,
+            # The lowest-ordinal unresolved blocking mention — "the first
+            # thing you named" — is the one and only mention that can
+            # terminate this run. Selecting it *before* the CHAOS-3366
+            # fallback, rather than searching every unresolved mention and
+            # then discovering which one mattered, is what keeps the fallback
+            # at exactly one bounded catalog round trip per question instead
+            # of up to MAX_MENTIONS of them (Codex review, medium: a
+            # 25-mention question issued 25 serialized wide searches, 24 of
+            # whose results were then discarded unread).
+            #
+            # Selecting it here is safe because none of the three amenders can
+            # change *which* mention it is: the first two only ever produce
+            # EXACT_MATCH (removing a mention from contention, never adding
+            # one) and they have already run; the fallback only ever rewrites
+            # NO_AUTHORIZED_MATCH to AMBIGUOUS_CANDIDATES, and both are
+            # unresolved outcomes, so the selected mention stays selected.
+            terminating = next(
+                (
+                    mention
+                    for mention in mentions
+                    if mention.mention_id in blocking_ids
+                    and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+                ),
+                None,
+            )
+            if terminating is not None:
+                is_close_match = False
+                if (
+                    latest[terminating.mention_id].outcome
+                    is ResolutionOutcome.NO_AUTHORIZED_MATCH
+                ):
+                    # Last of the three ledger amenders, and the only one that
+                    # adds candidates rather than commits. Gated on
+                    # NO_AUTHORIZED_MATCH specifically: a mention that is
+                    # already ambiguous has real candidates, and one whose
+                    # catalog read failed has no successful answer to enrich.
+                    ledger, is_close_match = await self._apply_not_found_fallback(
                         ledger=ledger,
-                        outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
-                        diagnostic=(
-                            "unresolved_close_matches"
-                            if is_close_match
-                            else f"unresolved_{entry.outcome.value}"
-                        ),
-                        run_id=run_id,
-                        answer_id=answer_id,
-                        conversation_id=conversation_id,
-                        generated_at=generated_at,
-                        clarification_key=(
-                            NOT_FOUND_CLOSE_MATCHES_KEY
-                            if is_close_match
-                            else "ambiguous"
-                        ),
-                        # CHAOS-3325: only AMBIGUOUS_CANDIDATES carries real
-                        # candidates to persist/authorize (the other three
-                        # UNRESOLVED_OUTCOMES map to no-answer outcomes,
-                        # where clarification_candidates is ABSENT-forced
-                        # regardless) -- passing the whole entry, not just
-                        # its candidates, is what lets the orchestrator
-                        # persist the exact ledger row record_frame's new
-                        # cross-check authorizes against.
-                        terminating_resolution_entry=(
-                            entry
-                            if entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
-                            else None
-                        ),
+                        mention=terminating,
+                        org_id=org_id,
+                        permission_fingerprint=permission_fingerprint,
+                        resolved_at=generated_at,
                     )
+                    latest = ledger.latest_by_mention()
+                entry = latest[terminating.mention_id]
+                # CHAOS-3366: an amended mention reaches this point as
+                # AMBIGUOUS_CANDIDATES like any other, so the outcome mapping
+                # and the clarification channel are untouched -- only the
+                # diagnostic and the copy key distinguish "we found nothing
+                # under that name, here is what is close" from genuine
+                # same-name ambiguity.
+                return self._terminate(
+                    interpretation=interpretation,
+                    ledger=ledger,
+                    outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
+                    diagnostic=(
+                        "unresolved_close_matches"
+                        if is_close_match
+                        else f"unresolved_{entry.outcome.value}"
+                    ),
+                    run_id=run_id,
+                    answer_id=answer_id,
+                    conversation_id=conversation_id,
+                    generated_at=generated_at,
+                    clarification_key=(
+                        NOT_FOUND_CLOSE_MATCHES_KEY if is_close_match else "ambiguous"
+                    ),
+                    # CHAOS-3325: only AMBIGUOUS_CANDIDATES carries real
+                    # candidates to persist/authorize (the other three
+                    # UNRESOLVED_OUTCOMES map to no-answer outcomes,
+                    # where clarification_candidates is ABSENT-forced
+                    # regardless) -- passing the whole entry, not just
+                    # its candidates, is what lets the orchestrator
+                    # persist the exact ledger row record_frame's new
+                    # cross-check authorizes against.
+                    terminating_resolution_entry=(
+                        entry
+                        if entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+                        else None
+                    ),
+                )
 
         if unresolved_untyped:
             # A bare name we could not resolve is not proof of a subject, so
@@ -955,12 +983,11 @@ class SubjectPreflight:
         self,
         *,
         ledger: DevResolutionLedger,
-        mentions: Sequence[DevSubjectMention],
+        mention: DevSubjectMention,
         org_id: str,
         permission_fingerprint: str,
-        untyped_ids: frozenset[str],
         resolved_at: datetime,
-    ) -> tuple[DevResolutionLedger, frozenset[str]]:
+    ) -> tuple[DevResolutionLedger, bool]:
         """Offer the closest authorized matches instead of a bare not-found.
 
         CHAOS-3366. A *typed* mention that matched nothing under the kind the
@@ -969,70 +996,66 @@ class SubjectPreflight:
         titled ``Go workers…`` and no project of that name, so "the Go workers
         project" dead-ends today with nothing to act on.
 
-        Three properties are load-bearing, and each has its own test:
+        Four properties are load-bearing, and each has its own test:
 
-        * **Never a commit.** Every appended entry is
-          ``AMBIGUOUS_CANDIDATES`` — including a *sole* result whose label
+        * **Never a commit.** The appended entry is always
+          ``AMBIGUOUS_CANDIDATES`` — including for a *sole* result whose label
           equals the typed name outright. That result is still not what was
-          asked for (the user named a different kind), and auto-committing it
-          would be exactly the "answer about one entity under another's name"
-          defect this module exists to prevent. The invariant is structural:
-          there is no branch here that constructs ``EXACT_MATCH``.
-        * **Bounded and tenant-scoped.** One search per unresolved mention,
-          capped at ``NOT_FOUND_FALLBACK_LIMIT``, through the same
-          ``ScopeResolutionService.search`` seam every other caller uses — so
+          asked for (the user named a kind it does not have), and
+          auto-committing it would be exactly the "answer about one entity
+          under another's name" defect this module exists to prevent. The
+          invariant is structural: there is no branch here that constructs
+          ``EXACT_MATCH``.
+        * **Bounded and tenant-scoped.** Exactly one search, for exactly one
+          mention — the caller has already established that this is the
+          mention that terminates the run — capped at
+          ``NOT_FOUND_FALLBACK_LIMIT`` and issued through the same
+          ``ScopeResolutionService.search`` seam every other caller uses, so
           it inherits the ``org_id`` filter every ``scope_catalog`` query
-          applies in SQL. There is no organization fallback and no widening.
+          applies in SQL. No organization fallback, no widening.
         * **Never worse than today.** No candidates, or a catalog that fails
           under us, leaves the mention exactly as ``NO_AUTHORIZED_MATCH`` and
           the run terminates ``not_found`` unchanged.
-
-        Untyped (bare-name) mentions are deliberately excluded: they were
-        already resolved across every searchable kind, so a second identical
-        search proves nothing, and turning one into a termination would break
-        the org-wide questions the untyped path exists to keep working.
+        * **Append-only.** Like both amenders above it, the new entry goes
+          through ``_append``/``validate_ledger_extends``, so the original
+          ``no_authorized_match`` entry survives as history.
 
         The search covers *every* searchable kind, not only the other five.
         For an ordinary mention the named kind is provably empty already (it
         is why we are here), so re-including it costs one no-op query; for a
         context-ref mention, which is resolved with ``exact=True`` and so
         never ran a fuzzy search at all, it is the only way its own kind gets
-        searched.
+        searched — and that path can legitimately return a *same-kind*
+        candidate, which is why the offered reason below says nothing about
+        kinds.
         """
 
-        latest = ledger.latest_by_mention()
-        appended: list[DevResolutionEntry] = []
-        close_matched: set[str] = set()
-        next_ordinal = len(ledger.entries)
-        for mention in mentions:
-            if mention.mention_id in untyped_ids:
-                continue
-            if latest[mention.mention_id].outcome is not (
-                ResolutionOutcome.NO_AUTHORIZED_MATCH
-            ):
-                continue
-            resolution = await self._close_matches(
-                org_id=org_id,
-                permission_fingerprint=permission_fingerprint,
-                lookup_text=mention.normalized_lookup_text,
-            )
-            if resolution is None:
-                continue
-            appended.append(
-                self._entry(
-                    ordinal=next_ordinal,
-                    mention=mention,
-                    resolution=resolution,
-                    resolved_at=resolved_at,
-                    candidate_reason=_CLOSE_MATCH_REASON,
-                )
-            )
-            close_matched.add(mention.mention_id)
-            next_ordinal += 1
-        return (
-            self._append(ledger, appended, resolved_at=resolved_at),
-            frozenset(close_matched),
+        resolution = await self._close_matches(
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            lookup_text=mention.normalized_lookup_text,
         )
+        if resolution is None:
+            return ledger, False
+        if resolution.outcome is not ResolutionOutcome.AMBIGUOUS_CANDIDATES:
+            # The ratified invariant, stated where it can be violated rather
+            # than left to be discovered three layers down. Unreachable today
+            # -- ``_close_matches`` has no branch that builds anything else --
+            # but "never auto-commit a fuzzy match" is the whole reason this
+            # amender is allowed to exist, and an unreachable state that is
+            # merely *implied* by construction stops being implied the moment
+            # someone edits the constructor.
+            raise RuntimeError(  # pragma: no cover - guarded by _close_matches
+                "the not-found fallback may never commit a subject"
+            )
+        entry = self._entry(
+            ordinal=len(ledger.entries),
+            mention=mention,
+            resolution=resolution,
+            resolved_at=resolved_at,
+            candidate_reason=_CLOSE_MATCH_REASON,
+        )
+        return self._append(ledger, [entry], resolved_at=resolved_at), True
 
     async def _close_matches(
         self,

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -68,6 +68,7 @@ from .contracts_v2 import (
 from .contracts_v2.subject import UNRESOLVED_OUTCOMES
 from .orchestrator_states import RunState
 from .preflight_outcomes import (
+    NOT_FOUND_CLOSE_MATCHES_KEY,
     PREFLIGHT_OUTCOME_BY_RESOLUTION,
     build_preflight_answer,
 )
@@ -79,9 +80,11 @@ from .scope_service import (
     EntityKind,
     MentionResolution,
     ScopeResolutionService,
+    ScopeSearchRequest,
 )
 
 __all__ = [
+    "NOT_FOUND_FALLBACK_LIMIT",
     "PREFLIGHT_DIAGNOSTICS",
     "SUBJECT_BEARING_TOOLS",
     "CommittedSubjects",
@@ -139,6 +142,28 @@ PREFLIGHT_DIAGNOSTICS: tuple[str, ...] = (
     "cohort_unsupported_in_v1",
     "committed_cohort_v1_only",
     "proceeded_committed_subject",
+    "unresolved_close_matches",
+)
+
+#: CHAOS-3366: how many closest matches one not-found fallback may offer.
+#:
+#: A bound, not a page size — the list is read by a person deciding which thing
+#: they meant, and a twenty-five-entry list of substring matches is not a
+#: decision aid. Small enough that the search costs one bounded catalog round
+#: trip per unresolved mention and no more.
+NOT_FOUND_FALLBACK_LIMIT = 5
+
+#: ``DevResolutionEntry.query_version`` is a non-empty ``Version``. A catalog
+#: that returned candidates always returns a watermark too; this is the same
+#: content-free placeholder ``scope_service`` uses, kept local so a defensive
+#: empty value can never fail contract validation on the fallback path.
+_UNAVAILABLE_WATERMARK = "catalog-watermark-unavailable"
+
+#: Why a fallback candidate is being offered. Distinct from the same-name
+#: ambiguity reason: these entities do **not** carry the name the user typed
+#: under the kind they typed, and saying so is the honest disclosure.
+_CLOSE_MATCH_REASON = (
+    "This is a close match to the name in the question, under a different kind."
 )
 
 
@@ -395,6 +420,18 @@ class SubjectPreflight:
             authorized_scope=authorized_scope,
             resolved_at=generated_at,
         )
+        # Last of the three amenders, and the only one that can *add*
+        # candidates rather than commit: it reads the outcomes the first two
+        # already settled, so a mention the catalog-reuse path just committed
+        # is never re-searched.
+        ledger, close_matched_ids = await self._apply_not_found_fallback(
+            ledger=ledger,
+            mentions=mentions,
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            untyped_ids=untyped_ids,
+            resolved_at=generated_at,
+        )
 
         latest = ledger.latest_by_mention()
         blocking_ids = frozenset(
@@ -446,15 +483,31 @@ class SubjectPreflight:
                     continue
                 entry = latest[mention.mention_id]
                 if entry.outcome in UNRESOLVED_OUTCOMES:
+                    # CHAOS-3366: a mention the fallback amended reaches this
+                    # loop as AMBIGUOUS_CANDIDATES like any other, so the
+                    # outcome mapping and the clarification channel are
+                    # untouched -- only the diagnostic and the copy key
+                    # distinguish "we found nothing under that name, here is
+                    # what is close" from genuine same-name ambiguity.
+                    is_close_match = mention.mention_id in close_matched_ids
                     return self._terminate(
                         interpretation=interpretation,
                         ledger=ledger,
                         outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
-                        diagnostic=f"unresolved_{entry.outcome.value}",
+                        diagnostic=(
+                            "unresolved_close_matches"
+                            if is_close_match
+                            else f"unresolved_{entry.outcome.value}"
+                        ),
                         run_id=run_id,
                         answer_id=answer_id,
                         conversation_id=conversation_id,
                         generated_at=generated_at,
+                        clarification_key=(
+                            NOT_FOUND_CLOSE_MATCHES_KEY
+                            if is_close_match
+                            else "ambiguous"
+                        ),
                         # CHAOS-3325: only AMBIGUOUS_CANDIDATES carries real
                         # candidates to persist/authorize (the other three
                         # UNRESOLVED_OUTCOMES map to no-answer outcomes,
@@ -751,6 +804,7 @@ class SubjectPreflight:
         mention: DevSubjectMention,
         resolution: MentionResolution,
         resolved_at: datetime,
+        candidate_reason: str = "Multiple authorized entities match this name.",
     ) -> DevResolutionEntry:
         committed = (
             _entity_ref_v2(resolution.entity) if resolution.entity is not None else None
@@ -758,7 +812,7 @@ class SubjectPreflight:
         candidates = tuple(
             DevResolutionCandidate(
                 entity_ref=_entity_ref_v2(candidate),
-                reason="Multiple authorized entities match this name.",
+                reason=candidate_reason,
             )
             for candidate in resolution.candidates
         )
@@ -896,6 +950,141 @@ class SubjectPreflight:
             )
             next_ordinal += 1
         return self._append(ledger, appended, resolved_at=resolved_at)
+
+    async def _apply_not_found_fallback(
+        self,
+        *,
+        ledger: DevResolutionLedger,
+        mentions: Sequence[DevSubjectMention],
+        org_id: str,
+        permission_fingerprint: str,
+        untyped_ids: frozenset[str],
+        resolved_at: datetime,
+    ) -> tuple[DevResolutionLedger, frozenset[str]]:
+        """Offer the closest authorized matches instead of a bare not-found.
+
+        CHAOS-3366. A *typed* mention that matched nothing under the kind the
+        user named is the one case where the catalog may still hold the thing
+        they meant, one kind over: the live organization has 23 work items
+        titled ``Go workers…`` and no project of that name, so "the Go workers
+        project" dead-ends today with nothing to act on.
+
+        Three properties are load-bearing, and each has its own test:
+
+        * **Never a commit.** Every appended entry is
+          ``AMBIGUOUS_CANDIDATES`` — including a *sole* result whose label
+          equals the typed name outright. That result is still not what was
+          asked for (the user named a different kind), and auto-committing it
+          would be exactly the "answer about one entity under another's name"
+          defect this module exists to prevent. The invariant is structural:
+          there is no branch here that constructs ``EXACT_MATCH``.
+        * **Bounded and tenant-scoped.** One search per unresolved mention,
+          capped at ``NOT_FOUND_FALLBACK_LIMIT``, through the same
+          ``ScopeResolutionService.search`` seam every other caller uses — so
+          it inherits the ``org_id`` filter every ``scope_catalog`` query
+          applies in SQL. There is no organization fallback and no widening.
+        * **Never worse than today.** No candidates, or a catalog that fails
+          under us, leaves the mention exactly as ``NO_AUTHORIZED_MATCH`` and
+          the run terminates ``not_found`` unchanged.
+
+        Untyped (bare-name) mentions are deliberately excluded: they were
+        already resolved across every searchable kind, so a second identical
+        search proves nothing, and turning one into a termination would break
+        the org-wide questions the untyped path exists to keep working.
+
+        The search covers *every* searchable kind, not only the other five.
+        For an ordinary mention the named kind is provably empty already (it
+        is why we are here), so re-including it costs one no-op query; for a
+        context-ref mention, which is resolved with ``exact=True`` and so
+        never ran a fuzzy search at all, it is the only way its own kind gets
+        searched.
+        """
+
+        latest = ledger.latest_by_mention()
+        appended: list[DevResolutionEntry] = []
+        close_matched: set[str] = set()
+        next_ordinal = len(ledger.entries)
+        for mention in mentions:
+            if mention.mention_id in untyped_ids:
+                continue
+            if latest[mention.mention_id].outcome is not (
+                ResolutionOutcome.NO_AUTHORIZED_MATCH
+            ):
+                continue
+            resolution = await self._close_matches(
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                lookup_text=mention.normalized_lookup_text,
+            )
+            if resolution is None:
+                continue
+            appended.append(
+                self._entry(
+                    ordinal=next_ordinal,
+                    mention=mention,
+                    resolution=resolution,
+                    resolved_at=resolved_at,
+                    candidate_reason=_CLOSE_MATCH_REASON,
+                )
+            )
+            close_matched.add(mention.mention_id)
+            next_ordinal += 1
+        return (
+            self._append(ledger, appended, resolved_at=resolved_at),
+            frozenset(close_matched),
+        )
+
+    async def _close_matches(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        lookup_text: str,
+    ) -> MentionResolution | None:
+        """One bounded tenant-scoped search, or ``None`` for "nothing to offer".
+
+        A catalog failure here is deliberately *not* typed as
+        ``CATALOG_UNAVAILABLE``: the mention already has a real, successful
+        ``NO_AUTHORIZED_MATCH`` outcome from the resolution round, and
+        downgrading a definite answer to "temporarily unavailable" because an
+        optional enrichment failed would make the run's reported outcome worse
+        than it was before this method existed.
+        """
+
+        query = lookup_text.strip()[:256]
+        if not query:
+            return None
+        # Built outside the try, exactly as ``resolve_mention`` does: a
+        # malformed request is a caller defect, not a catalog outage.
+        #
+        # ``limit`` is the *only* place the bound is applied on this path, on
+        # purpose. ``search`` already truncates its own result to
+        # ``request.limit`` and the catalog applies it again in SQL, so a
+        # second slice here would be redundant defence that also makes the
+        # real clause unkillable: mutate the bound and an output-only
+        # assertion still passes. One clause, one witness.
+        request = ScopeSearchRequest(
+            query=query,
+            kinds=tuple(sorted(SEARCHABLE_ENTITY_KINDS, key=lambda kind: kind.value)),
+            limit=NOT_FOUND_FALLBACK_LIMIT,
+            allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+        )
+        try:
+            result = await self._scope_service.search(
+                org_id, permission_fingerprint, request
+            )
+        except Exception:
+            return None
+        candidates = result.candidates
+        if not candidates:
+            return None
+        return MentionResolution(
+            outcome=ResolutionOutcome.AMBIGUOUS_CANDIDATES,
+            entity=None,
+            candidates=candidates,
+            catalog_watermark=result.catalog_watermark or _UNAVAILABLE_WATERMARK,
+            query_version=result.query_version,
+        )
 
     @staticmethod
     def _reusable_entity(

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -474,6 +474,47 @@ async def test_the_fallback_appends_and_never_erases_the_not_found_entry() -> No
 
 
 @pytest.mark.asyncio
+async def test_the_persisted_entry_matches_the_pre_existing_ambiguity_shape() -> None:
+    """Codex confirmation review (medium), scoped: no NEW persistence gap.
+
+    The orchestrator persists exactly one resolution row -- the terminating
+    entry the frame's candidates are authorized against (CHAOS-3325) -- so a
+    durable ledger has never been a contiguous prefix. This pins that the
+    fallback lands in the same shape the pre-existing genuine-ambiguity path
+    already lands in, and that the two stay distinguishable durably: the
+    diagnostic on ``dev_runs.preflight_outcome`` is what says which happened.
+
+    Widening persistence to store the whole prefix would change what
+    ``_authorize_clarification_candidates`` compares against and belongs with
+    CHAOS-3325's contract, not here.
+    """
+
+    ambiguous = await _run(
+        _preflight(
+            [
+                (ORG_ID, ASK_DEV_PROJECT),
+                (ORG_ID, ATLAS_PROJECT_ONE),
+                (ORG_ID, ATLAS_PROJECT_TWO),
+            ]
+        ),
+        request_for("Compare project Ask Dev and project Atlas"),
+    )
+    fallback = await _run(
+        _preflight([(ORG_ID, issue) for issue in go_workers_issues(3)]),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    for result in (ambiguous, fallback):
+        assert result.ledger is not None
+        assert [entry.entry_ordinal for entry in result.ledger.entries] == [0, 1]
+        assert result.terminating_resolution_entry is not None
+        assert result.terminating_resolution_entry.entry_ordinal == 1
+
+    assert ambiguous.diagnostic == "unresolved_ambiguous_candidates"
+    assert fallback.diagnostic == "unresolved_close_matches"
+
+
+@pytest.mark.asyncio
 async def test_a_genuine_ambiguity_keeps_its_own_clarification_copy() -> None:
     """The close-matches copy must not swallow real same-name ambiguity."""
 

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -1,0 +1,451 @@
+"""CHAOS-3366: one bounded closest-matches search for an unresolved named subject.
+
+A *typed* named subject that resolves to ``NO_AUTHORIZED_MATCH`` terminates the
+run with ``not_found`` today, naming nothing back to the user. The live failure
+this closes: the organization has 23 work items titled ``Go workers…`` and no
+project of that name, so "the Go workers project" dead-ends even though the
+catalog holds the obvious closest matches one kind over.
+
+Every assertion here is about the *seam*, not the copy: candidates must reach
+``dev_answer_frame.v1.clarification_candidates`` through the existing
+``AMBIGUOUS_CANDIDATES`` → ``needs_clarification`` mapping, bounded, tenant
+scoped, and **never** auto-committed — not even a sole result whose label
+equals the name outright.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2 import (
+    PublicOutcome,
+    ResolutionOutcome,
+)
+from dev_health_ops.api.dev.preflight_outcomes import (
+    CLARIFICATION_COPY,
+    NOT_FOUND_CLOSE_MATCHES_KEY,
+)
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_service import (
+    MAX_CANDIDATES,
+    AuthorizedEntity,
+    EntityKind,
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import (
+    NOT_FOUND_FALLBACK_LIMIT,
+    PREFLIGHT_DIAGNOSTICS,
+    PreflightDecision,
+    SubjectPreflight,
+)
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
+    ORG_ID,
+    OTHER_ORG_ID,
+    SeededCatalog,
+    fixed_now,
+    request_for,
+    sequential_ids,
+    versions,
+)
+
+#: The question shape under test. Quoted rather than bare-capitalized because
+#: the kind-noun grammar's ``_NAME`` requires every word of an unquoted span to
+#: be capitalized -- "the Go workers project" would type no mention at all,
+#: which is a different (untyped) path entirely.
+GO_WORKERS_QUESTION = 'What is the status of the "Go workers" project?'
+
+
+def go_workers_issues(count: int) -> list[AuthorizedEntity]:
+    """Work items titled ``Go workers…``, mirroring the live organization."""
+
+    return [
+        AuthorizedEntity(
+            kind=EntityKind.ISSUE,
+            canonical_id=f"linear:CHAOS-{3000 + index}",
+            label=f"Go workers: stage {index:02d}",
+            repository_id=None,
+        )
+        for index in range(count)
+    ]
+
+
+class LimitRecordingCatalog(SeededCatalog):
+    """Records the ``limit`` every search was actually asked for.
+
+    The bound must be provable *at the query*, not only in the returned list:
+    asserting output length alone cannot tell a fallback that asked for five
+    from one that asked for twenty-five and happened to be handed five.
+    """
+
+    def __init__(self, entities: Any) -> None:
+        super().__init__(entities)
+        self.search_limits: list[tuple[int, int]] = []
+
+    async def search(
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+    ) -> list[AuthorizedEntity]:
+        self.search_limits.append((len(kinds), limit))
+        return await super().search(org_id, query, kinds, limit=limit)
+
+
+class CrossTenantLeakingCatalog(SeededCatalog):
+    """A catalog that ignores ``org_id`` on the wide fallback search.
+
+    Not a fixture for the happy path — it is the planted defect the tenant
+    test exists to catch, used only by the mutation harness.
+    """
+
+    async def search(
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+    ) -> list[AuthorizedEntity]:
+        if len(kinds) == 1:
+            return await super().search(org_id, query, kinds, limit=limit)
+        needle = query.casefold()
+        matched = [
+            entity
+            for _owner, entity in self.entities
+            if entity.kind in kinds and needle in entity.label.casefold()
+        ]
+        matched.sort(key=lambda entity: (entity.label.casefold(), entity.canonical_id))
+        return matched[:limit]
+
+
+class MultiKindFailingCatalog(SeededCatalog):
+    """Succeeds for a single-kind search, raises for the fallback's wide one.
+
+    The fallback must degrade to today's ``not_found``, never turn a resolvable
+    termination into an unhandled exception or a mistyped catalog outage.
+    """
+
+    async def search(
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+    ) -> list[AuthorizedEntity]:
+        if len(kinds) > 1:
+            raise RuntimeError("catalog unavailable for the fallback search")
+        return await super().search(org_id, query, kinds, limit=limit)
+
+
+def _preflight(
+    entities: Any, *, catalog_cls: Any = SeededCatalog, catalog: Any = None
+) -> SubjectPreflight:
+    mint = sequential_ids()
+    return SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            catalog if catalog is not None else catalog_cls(entities),
+            cache=ScopeRequestCache(),
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+
+async def _run(preflight: SubjectPreflight, request: Any, **kwargs: Any) -> Any:
+    return await preflight.run(
+        request=request,
+        org_id=kwargs.pop("org_id", ORG_ID),
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        **kwargs,
+    )
+
+
+def _latest_outcome(result: Any) -> ResolutionOutcome:
+    latest = result.ledger.latest_by_mention()
+    (entry,) = latest.values()
+    return entry.outcome
+
+
+# ---------------------------------------------------------------------------
+# RED -- the acceptance case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_named_project_with_no_match_offers_bounded_close_matches() -> None:
+    """The live case: 23 ``Go workers`` work items, no project of that name."""
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ASK_DEV_PROJECT)]
+            + [(ORG_ID, issue) for issue in go_workers_issues(23)]
+        ),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+
+    # The candidates reach the frame through the landed CHAOS-3325 channel --
+    # no new outcome plumbing.
+    assert result.answer is not None
+    candidates = result.answer.frame.clarification_candidates
+    assert candidates, "a close-matches termination must carry candidates"
+    assert len(candidates) == NOT_FOUND_FALLBACK_LIMIT
+    assert {candidate.entity_ref.entity_kind.value for candidate in candidates} == {
+        "issue"
+    }
+    assert all(
+        candidate.entity_ref.display_label.startswith("Go workers")
+        for candidate in candidates
+    )
+
+    # And the orchestrator gets the ledger row that authorizes them.
+    assert result.terminating_resolution_entry is not None
+    assert (
+        result.terminating_resolution_entry.candidates
+        == result.answer.frame.clarification_candidates
+    )
+    assert _latest_outcome(result) is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+    assert result.diagnostic == "unresolved_close_matches"
+    assert (
+        result.answer.frame.direct_answer
+        == CLARIFICATION_COPY[NOT_FOUND_CLOSE_MATCHES_KEY]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mutation targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_candidate_bound_holds_against_more_matches_than_the_limit() -> None:
+    """Plant more matches than the limit; the bound is what must survive.
+
+    Kills a mutation of the fallback's own ``limit=`` clause: with the bound
+    widened to ``MAX_CANDIDATES`` this run returns 23 candidates, not 5.
+    """
+
+    seeded = go_workers_issues(NOT_FOUND_FALLBACK_LIMIT * 3)
+    assert len(seeded) > NOT_FOUND_FALLBACK_LIMIT, "the fixture must exceed the bound"
+    catalog = LimitRecordingCatalog([(ORG_ID, issue) for issue in seeded])
+    result = await _run(
+        _preflight(None, catalog=catalog),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.answer is not None
+    assert len(result.answer.frame.clarification_candidates) == NOT_FOUND_FALLBACK_LIMIT
+
+    # And the bound was applied *at the query*, not after the fact.
+    wide_searches = [
+        limit for kind_count, limit in catalog.search_limits if kind_count > 1
+    ]
+    assert wide_searches == [NOT_FOUND_FALLBACK_LIMIT], (
+        "the fallback must ask the catalog for exactly the bound, once"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_tenant_assertion_would_catch_a_leaking_catalog() -> None:
+    """Negative control for the test below.
+
+    The ``org_id`` filter lives in ``scope_catalog``'s SQL, which the seeded
+    harness stands in for -- so "it stayed not_found" is only evidence if a
+    catalog that *did* leak would have been seen. Plant exactly that defect
+    and observe the difference: same fixture, same question, cross-tenant
+    matches now reach the frame.
+    """
+
+    entities = [(ORG_ID, ASK_DEV_PROJECT)] + [
+        (OTHER_ORG_ID, issue) for issue in go_workers_issues(23)
+    ]
+    leaked = await _run(
+        _preflight(None, catalog=CrossTenantLeakingCatalog(entities)),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert leaked.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert leaked.answer is not None
+    assert len(leaked.answer.frame.clarification_candidates) == NOT_FOUND_FALLBACK_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_close_matches_never_cross_the_tenant_boundary() -> None:
+    """The same ``Go workers`` work items, owned by another organization.
+
+    Cross-tenant is modelled as a *populated catalog owned by someone else*, so
+    a fallback that dropped ``org_id`` would surface them. It must stay
+    ``not_found``, exactly as today.
+    """
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ASK_DEV_PROJECT)]
+            + [(OTHER_ORG_ID, issue) for issue in go_workers_issues(23)]
+        ),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+    assert result.terminating_resolution_entry is None
+    assert _latest_outcome(result) is ResolutionOutcome.NO_AUTHORIZED_MATCH
+
+
+@pytest.mark.asyncio
+async def test_zero_close_matches_leaves_not_found_exactly_as_today() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for('What is the status of the "Nightfall" project?'),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+    assert result.answer is not None
+    assert result.answer.frame.clarification_candidates == ()
+    assert _latest_outcome(result) is ResolutionOutcome.NO_AUTHORIZED_MATCH
+
+
+@pytest.mark.asyncio
+async def test_a_sole_exactly_named_close_match_is_still_never_committed() -> None:
+    """The invariant at ``scope_service`` :706-711, one layer up.
+
+    The single work item's label equals the typed name outright. It is still
+    not what the user asked for -- they named a *project* -- so it is offered
+    back, never auto-committed. A fuzzy match must never become a subject.
+    """
+
+    exact_label_issue = AuthorizedEntity(
+        kind=EntityKind.ISSUE,
+        canonical_id="linear:CHAOS-3040",
+        label="Go workers",
+        repository_id=None,
+    )
+    result = await _run(
+        _preflight([(ORG_ID, exact_label_issue)]),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.committed_subjects is None
+    assert result.has_committed_subject is False
+    assert _latest_outcome(result) is not ResolutionOutcome.EXACT_MATCH
+    assert result.answer is not None
+    assert len(result.answer.frame.clarification_candidates) == 1
+
+
+# ---------------------------------------------------------------------------
+# Structural guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_appends_and_never_erases_the_not_found_entry() -> None:
+    result = await _run(
+        _preflight([(ORG_ID, issue) for issue in go_workers_issues(3)]),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.ledger is not None
+    outcomes = [entry.outcome for entry in result.ledger.entries]
+    assert outcomes == [
+        ResolutionOutcome.NO_AUTHORIZED_MATCH,
+        ResolutionOutcome.AMBIGUOUS_CANDIDATES,
+    ], "the original not-found entry must survive as history, not be rewritten"
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_ambiguity_keeps_its_own_clarification_copy() -> None:
+    """The close-matches copy must not swallow real same-name ambiguity."""
+
+    result = await _run(
+        _preflight([(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]),
+        request_for("What is the status of the Atlas project?"),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.diagnostic == "unresolved_ambiguous_candidates"
+    assert result.answer is not None
+    assert result.answer.frame.direct_answer == CLARIFICATION_COPY["ambiguous"]
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_bare_name_is_never_re_searched_by_the_fallback() -> None:
+    """The fallback is for *typed* mentions only, and this is what that buys.
+
+    A bare name is already resolved across every searchable kind, so the
+    fallback's search would be byte-identical to one that just returned
+    nothing. Asserting the run still proceeds organization-wide does **not**
+    prove the guard: an untyped mention is excluded from the terminate loop
+    and ``AMBIGUOUS_CANDIDATES`` is an unresolved outcome like any other, so
+    the *decision* is unchanged either way. What the guard actually prevents
+    is the redundant round trip -- and a candidate-bearing ledger entry for a
+    mention no clarification will ever act on -- so that is what is asserted.
+    """
+
+    catalog = LimitRecordingCatalog([(ORG_ID, issue) for issue in go_workers_issues(3)])
+    result = await _run(
+        _preflight(None, catalog=catalog),
+        request_for("How is Nightfall doing?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.legacy_guard_required is True
+    assert result.diagnostic == "proceeded_unresolved_bare_name"
+    assert [limit for _kinds, limit in catalog.search_limits] == [MAX_CANDIDATES], (
+        "the bare name's own all-kinds search is the only one this run may make"
+    )
+    assert result.ledger is not None
+    assert [entry.outcome for entry in result.ledger.entries] == [
+        ResolutionOutcome.NO_AUTHORIZED_MATCH
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fallback_search_degrades_to_not_found() -> None:
+    result = await _run(
+        _preflight(
+            [(ORG_ID, issue) for issue in go_workers_issues(3)],
+            catalog_cls=MultiKindFailingCatalog,
+        ),
+        request_for(GO_WORKERS_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+
+
+def test_every_preflight_diagnostic_fits_the_persisted_column() -> None:
+    """``dev_runs.preflight_outcome`` is a ``String(32)`` with no CHECK.
+
+    The closed tuple's own docstring claims this test exists; it did not. A
+    diagnostic over the bound is a real insert-time failure in production that
+    every unit test which never persists a run would pass.
+    """
+
+    assert len(set(PREFLIGHT_DIAGNOSTICS)) == len(PREFLIGHT_DIAGNOSTICS)
+    oversized = [name for name in PREFLIGHT_DIAGNOSTICS if len(name) > 32]
+    assert oversized == []

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -264,6 +264,103 @@ async def test_the_candidate_bound_holds_against_more_matches_than_the_limit() -
 
 
 @pytest.mark.asyncio
+async def test_one_question_costs_exactly_one_fallback_search() -> None:
+    """Codex review (medium): the amplification bound.
+
+    Only the lowest-ordinal unresolved mention can terminate the run, so only
+    that mention's fallback result is ever read. Searching every unresolved
+    mention meant a 25-mention question issued 25 serialized wide catalog
+    searches -- each one a watermark query plus six per-kind ClickHouse
+    queries -- and discarded 24 of the answers unread.
+    """
+
+    named = " and ".join(f'project "Ghost {index:02d}"' for index in range(8))
+    catalog = LimitRecordingCatalog([(ORG_ID, issue) for issue in go_workers_issues(3)])
+    result = await _run(
+        _preflight(None, catalog=catalog),
+        request_for(f"Compare {named}"),
+    )
+
+    assert len(result.interpretation.mentions) == 8, "the fixture must be multi-mention"
+    assert result.decision is PreflightDecision.TERMINATE
+    wide_searches = [
+        limit for kind_count, limit in catalog.search_limits if kind_count > 1
+    ]
+    assert len(wide_searches) <= 1, (
+        "at most one bounded fallback search may be issued per question, "
+        f"got {len(wide_searches)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_same_kind_close_match_is_not_described_as_another_kind() -> None:
+    """Codex review (low): the context-ref path returns same-kind candidates.
+
+    A stale context ref resolves with ``exact=True``, so the mention's own
+    kind never ran a fuzzy search -- and the fallback, which searches every
+    searchable kind, can then legitimately return a candidate of exactly the
+    kind the user named. A reason string asserting "under a different kind"
+    would be a false statement persisted onto canonical v2 state.
+    """
+
+    beacon = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-beacon-migration",
+        label="Beacon Migration",
+        repository_id=None,
+    )
+    result = await _run(
+        _preflight([(ORG_ID, beacon)]),
+        request_for(
+            'What is the status of the "beacon" project?',
+            scope_overrides={
+                "direct_scope": "project",
+                "entity_refs": [
+                    {
+                        "entity_type": "project",
+                        "entity_id": "beacon",
+                        "display_label": "Beacon",
+                        "repository_id": None,
+                    }
+                ],
+            },
+        ),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.answer is not None
+    (candidate,) = result.answer.frame.clarification_candidates
+    assert candidate.entity_ref.entity_kind.value == "project", (
+        "this fixture must exercise the same-kind path, or it proves nothing"
+    )
+    assert "kind" not in candidate.reason.casefold()
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_ambiguous_mention_is_never_re_searched() -> None:
+    """The fallback is gated on ``no_authorized_match`` specifically.
+
+    An ambiguous mention already holds real candidates; re-searching it would
+    replace the entities that actually carry the typed name with substring
+    near-misses, and spend a catalog round trip to do it.
+    """
+
+    catalog = LimitRecordingCatalog(
+        [(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)]
+    )
+    result = await _run(
+        _preflight(None, catalog=catalog),
+        request_for("What is the status of the Atlas project?"),
+    )
+
+    assert result.diagnostic == "unresolved_ambiguous_candidates"
+    # Both Atlas projects match on exact label, so ``resolve_mention`` never
+    # reaches its own fuzzy search either -- this run must issue no catalog
+    # ``search`` at all.
+    assert catalog.search_limits == []
+
+
+@pytest.mark.asyncio
 async def test_the_tenant_assertion_would_catch_a_leaking_catalog() -> None:
     """Negative control for the test below.
 


### PR DESCRIPTION
## What

A *typed* named subject that resolves to `NO_AUTHORIZED_MATCH` terminates the run with a bare `not_found` today. The live organization has 23 work items titled `Go workers…` and no project of that name, so *"the Go workers project"* dead-ends with nothing to act on.

This adds a third ledger amender, `_apply_not_found_fallback`, beside the landed `_apply_context_tiebreaker` / `_apply_catalog_reuse`: for the mention that is about to terminate the run, run **one** bounded tenant-scoped catalog search across every searchable kind and append an `AMBIGUOUS_CANDIDATES` entry carrying up to 5 candidates.

## Seam verification

Every claim in the blueprint was checked against the code before writing anything:

| Claim | Verdict |
|---|---|
| Terminate loop at `subject_preflight.py:443-471` is the seam | confirmed (restructured, see below) |
| Amenders at `:812-855` / `:857-898`, guarded by `validate_ledger_extends` at `:785-810` | confirmed |
| `preflight_outcomes.py:122` maps `AMBIGUOUS_CANDIDATES` → `needs_clarification` | confirmed |
| ISSUE catalog SQL is an `org_id`-scoped `work_items.title LIKE` at `scope_catalog.py:233-245` | confirmed |
| Never-auto-commit invariant at `scope_service.py:706-711` | confirmed, and re-stated one layer up |

**Candidate flow — proven, with one honest limit.** Candidates reach `dev_answer_frame.v1.clarification_candidates` through the existing CHAOS-3325 channel with zero new outcome plumbing: `_terminate` passes `terminating_resolution_entry.candidates` to `build_preflight_answer`, `orchestrator.run` persists the same ledger row via `append_resolution` immediately before `record_frame`, and `_authorize_clarification_candidates` cross-checks the frame against it.

**They do not yet reach a client.** `project_preflight_error` projects `needs_clarification` to a fixed `scope_ambiguous` v1 `DevError` that carries no candidates — as `preflight_outcomes`' own docstring states, serving the candidate block needs the v2 rendering surface (CHAOS-3298) and persisted clarification state (CHAOS-3299). So the **user-visible change on v1 today is the outcome only**: `scope_not_found` → `scope_ambiguous`. The closest matches are canonical server state waiting on 3298/3299.

## RED evidence

Probe on unmodified `origin/main`, same fixture:

```
mentions      : [('project', 'go workers')]
decision      : terminate
public outcome: not_found          <- RED
diagnostic    : unresolved_no_authorized_match
candidates    : 0
direct_answer : No matching subject was found for this question.
```

After: `needs_clarification`, 5 issue candidates, diagnostic `unresolved_close_matches`.

## Ratified decisions, and where each is enforced

- **Candidates always produce `needs_clarification`; never auto-commit.** Structural — no branch constructs `EXACT_MATCH` — plus an explicit `RuntimeError` at the amender boundary stating the invariant. A sole candidate whose label equals the typed name outright is still offered back, never committed.
- **0 candidates → `NOT_FOUND` unchanged.** Also true when the fallback search itself fails: a catalog error is swallowed rather than downgrading a definite answer to `temporarily_unavailable`.
- **No silent org fallback, no widening.** Goes through the same `ScopeResolutionService.search` seam every other caller uses, so it inherits the `org_id` filter every `scope_catalog` query applies in SQL. No other caller's allowlist changes.

## Mutations

Digest-verified harness: pristine bytes hashed before any write, re-hashed after every restore, run aborts and voids results if a restore does not reproduce the digest. Final digest matched. **7/7 killed**, plus an 8th planted at the catalog boundary.

| # | Planted defect | Died at |
|---|---|---|
| M1 | candidate bound → 25 | `wide_searches == [5]` (the bound asserted **at the query**, not the output) |
| M2 | zero-candidate branch disabled | `DevResolutionEntry` validator: `ambiguous_candidates requires candidates` |
| M3 | sole candidate auto-committed | the named invariant guard: *"the not-found fallback may never commit a subject"* |
| M4 | gate widened to all unresolved outcomes | `diagnostic == 'unresolved_ambiguous_candidates'` |
| M5 | catalog-failure degrade removed | planted `RuntimeError` propagated |
| M6 | one-search bound removed (old per-mention loop restored) | `at most one bounded fallback search…, got 8` |
| M7 | reason string claims "under a different kind" | `'kind' not in candidate.reason` |
| M8 | catalog double ignores `org_id` | control `not_found`/0 → planted `needs_clarification`/5 |

M2 and M3 die in a contract validator and a guard rather than a test assertion, because in both cases the wrong state is unrepresentable rather than merely unasserted — recorded here rather than claimed as an assertion kill.

Two mutations changed the design, not just proved it:

- **M6 was a real defect.** The first cut searched *every* unresolved typed mention. Only the lowest-ordinal one can terminate the run, so a 25-mention question issued 25 serialized wide searches — each a watermark query plus six per-kind ClickHouse queries — and discarded 24 answers unread. The terminating mention is now selected *before* the fallback and at most one search runs. Safe because no amender can change which mention is selected: the first two only ever produce `EXACT_MATCH` (removing a mention from contention, never adding one) and have already run, and the fallback only rewrites one unresolved outcome to another.
- **A vacuous test was found and replaced.** The first bare-name test asserted the run still proceeds organization-wide — which is true with *or without* the typed-only guard, since untyped mentions are excluded from the terminate loop and `AMBIGUOUS_CANDIDATES` is an unresolved outcome like any other. It now asserts what the guard actually buys: no redundant round trip, and no candidate-bearing ledger entry for a mention no clarification will act on.

## Codex adversarial review

Two rounds. Round 1 `needs-attention`, both findings fixed in `43da5ba20`: the amplification above (medium), and a candidate `reason` claiming "under a different kind" — false on the context-ref path, where a mention resolved with `exact=True` never fuzzy-searched its own kind and the closest match can legitimately be the same kind (low). Both now have their own regression test.

Round 2 raised one medium: a successful fallback persists ordinal 1 without ordinal 0. **Verified and scoped out, with evidence.** The orchestrator persists exactly one resolution row — the terminating entry the frame's candidates are authorized against — so a durable ledger has never been a contiguous prefix. The pre-existing genuine-ambiguity path lands in the identical shape:

```
pre-existing ambiguity : in-memory [0, 1]  persisted [1]  unresolved_ambiguous_candidates
CHAOS-3366 fallback    : in-memory [0, 1]  persisted [1]  unresolved_close_matches
```

`orchestrator.py` is not in this diff. The finding's claim that the fallback origin is lost is refuted by the second column: `dev_runs.preflight_outcome` distinguishes the two durably, and `test_the_persisted_entry_matches_the_pre_existing_ambiguity_shape` now pins both halves. Widening persistence to store the whole prefix changes what `_authorize_clarification_candidates` compares against and belongs with CHAOS-3325's contract — worth its own ticket, not this one.

## Gates

- `tests/api/dev` — **1783 passed**, 35 skipped, 1 xfailed. No existing expectation needed changing: `case_a2`/`a6`/`a8`/`r1` all name things that match nothing anywhere, so they stay `not_found`.
- `ruff check src tests` and `ruff format` — clean. Repo-wide `mypy` (2025 files, the literal `typecheck.yml` command) — clean.
- **`ci/local_validate.sh` was NOT run** — it wedges at the argMax here-doc on this machine. Full `tests/` was run instead: 11316 passed, 29 failed, 58 errors. Every failure is in a `*_live.py` suite needing ClickHouse/Postgres or another infra-dependent file; none are in `tests/api/dev`, none of the failing files reference `subject_preflight`, `preflight_outcomes`, `scope_service` or `scope_catalog`, and the two non-live ones (`test_feature_flags`, `test_recommendations_tombstone`) pass in isolation. CI is the real gate for those.

## Seams with other lanes

- **CHAOS-3367 (copy contract).** One key added to `CLARIFICATION_COPY` in `preflight_outcomes.py`, exported as `NOT_FOUND_CLOSE_MATCHES_KEY` so the preflight and the table cannot drift. The text is **provisional and static** — the PRD sentence names the kind and the name back (*"I couldn't find an authorized `<kind>` named 'X'"*), and interpolating request text into that table changes how public copy is governed, which is 3367's call. If 3367 lands first this is a one-line value change with no call-site churn.
- **CHAOS-3365 (Linear project sync).** No overlap; that lane changes what the catalog contains, this one changes what happens when it contains nothing matching.
