### PR TITLE
fix(ask-dev): project status snapshot reads the committed subject's work items

### DIFF
--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -468,6 +468,38 @@ FROM (
 WHERE g.repo_id IS NOT NULL
 """
 
+#: Re-derive one project's repository set from canonical work-item attribution.
+#:
+#: A committed PROJECT subject can never carry a repository list of its own,
+#: exactly like the TEAM subject above: ``DevScope.repositories`` is only ever
+#: populated for a REPOSITORY commit
+#: (``scope_service.ScopeResolutionService.committed_scope_for`` /
+#: ``_resolved_scope``), and the catalog row a project commit is built from
+#: selects ``NULL AS repository_id``
+#: (``scope_catalog.ClickHouseAuthorizedEntityCatalog._query_for``) because a
+#: project spans repositories and has no repository dimension. So
+#: ``_repository_ids(scope)`` returned an empty set for *every* production
+#: project subject, and ``status_snapshot``/``change_summary`` took the
+#: fail-closed "authorized repository set" branch before running a single
+#: project query -- an empty snapshot for a project whose work items match.
+#:
+#: Bounded by the same ``org_id`` tenant boundary
+#: ``_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL`` enforces, by the same
+#: ``updated_at <= as_of`` bound ``_WORK_ITEMS_SQL`` applies, and by the same
+#: ``project_id``/``project_key`` disjunction every project SQL arm uses -- so
+#: the derived set is exactly the repositories this project's own facts can be
+#: drawn from, never wider. Deliberately NOT joined against ``repos``: Linear
+#: work items carry no repository and land under a zero-UUID ``repo_id`` that
+#: has no ``repos`` row, so an existence join would re-empty the set for the
+#: provider this fix exists for.
+_PROJECT_REPOSITORIES_SQL = """
+SELECT DISTINCT toString(repo_id) AS repository_id
+FROM work_items FINAL
+WHERE org_id = {org_id:String}
+  AND updated_at <= {as_of:DateTime64(3, 'UTC')}
+  AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
+"""
+
 _TRANSITIONS_SQL = (
     """
 SELECT transition.work_item_id AS entity_id, item.title AS display_label,
@@ -908,6 +940,36 @@ class ClickHouseStatusChangeSource:
             self._team_repository_cache.popitem(last=False)
         return result
 
+    async def _project_repository_ids(
+        self, org_id: str, entity_id: str, *, as_of: datetime
+    ) -> list[str]:
+        """Repositories this project's canonical work items live in.
+
+        A failed query returns an empty set, which lands the caller on the
+        same fail-closed "authorized repository set" branch an unmeasured
+        team attribution already takes -- an unreadable attribution source is
+        never allowed to read as "this project spans no repositories".
+        """
+
+        if not entity_id:
+            return []
+        try:
+            async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
+                rows = await query_dicts(
+                    self._client,
+                    _PROJECT_REPOSITORIES_SQL,
+                    {
+                        "org_id": org_id,
+                        "entity_id": entity_id,
+                        "as_of": as_of.astimezone(UTC),
+                    },
+                )
+        except Exception:
+            return []
+        return sorted(
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+        )
+
     async def _authorized_repository_ids(
         self, org_id: str, scope: DevScope, *, as_of: datetime
     ) -> list[str]:
@@ -937,7 +999,21 @@ class ClickHouseStatusChangeSource:
         it), so without this branch every team subject would always resolve
         to an empty repository set and take the fail-closed path below,
         regardless of real ownership data.
+
+        A committed project *subject* (``direct_scope=PROJECT``) has the same
+        structural problem for a different reason -- the catalog resolves
+        projects with no repository dimension at all, so both
+        ``scope.repositories`` and ``entity_refs[0].repository_id`` are always
+        empty for a production project commit -- and is re-derived here from
+        canonical work-item project attribution
+        (``_PROJECT_REPOSITORIES_SQL``). Without this branch every project
+        subject failed closed below while its work items sat in ``work_items``
+        matching the very ``project_id`` the scope committed.
         """
+        if scope.direct_scope is DirectScope.PROJECT:
+            return await self._project_repository_ids(
+                org_id, self._entity_id(scope), as_of=as_of
+            )
         if scope.direct_scope is DirectScope.TEAM:
             # Unmeasured (failed lookup) and measured-but-empty both fall
             # through to the existing empty-repositories fail-closed branch

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -485,19 +485,42 @@ WHERE g.repo_id IS NOT NULL
 #:
 #: Bounded by the same ``org_id`` tenant boundary
 #: ``_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL`` enforces, by the same
-#: ``updated_at <= as_of`` bound ``_WORK_ITEMS_SQL`` applies, and by the same
-#: ``project_id``/``project_key`` disjunction every project SQL arm uses -- so
-#: the derived set is exactly the repositories this project's own facts can be
-#: drawn from, never wider. Deliberately NOT joined against ``repos``: Linear
-#: work items carry no repository and land under a zero-UUID ``repo_id`` that
-#: has no ``repos`` row, so an existence join would re-empty the set for the
-#: provider this fix exists for.
+#: ``updated_at <= as_of`` bound ``_WORK_ITEMS_SQL`` applies, and by the
+#: byte-identical ``project_id``/``project_key`` disjunction every project SQL
+#: arm uses (pinned by
+#: ``test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do``) --
+#: so the derived set can never admit a repository the fact queries it bounds
+#: would not themselves have drawn from.
+#:
+#: Codex adversarial review (HIGH, 2026-08-03): the first cut stopped there and
+#: trusted every ``work_items.repo_id`` outright. ClickHouse enforces no
+#: foreign key, so a repository revoked from ``repos`` -- de-authorized, and
+#: correctly invisible to the ORGANIZATION branch, which enumerates ``repos``
+#: itself -- can keep its ``work_items`` rows and would have become an admitted
+#: read bound for project scope alone. Every *real* repository id must therefore
+#: still resolve through the same org-scoped ``repos`` catalog.
+#:
+#: The zero UUID is admitted explicitly rather than by omitting that check.
+#: It is not a repository at all: it is the sentinel
+#: ``ClickHouseMetricsSink`` writes whenever a record has no repository
+#: (``metrics/sinks/clickhouse/core.py`` -- ``row.repo_id or uuid.UUID(int=0)``),
+#: which is every Linear work item (``providers/linear/normalize.py`` sets
+#: ``repo_id=None``). It has no ``repos`` row and never will, so a bare
+#: existence join would re-empty the set for the exact provider this fix exists
+#: for -- while a blanket "skip the catalog" would have de-authorized nothing
+#: and admitted everything. Naming the sentinel keeps both properties.
 _PROJECT_REPOSITORIES_SQL = """
 SELECT DISTINCT toString(repo_id) AS repository_id
 FROM work_items FINAL
 WHERE org_id = {org_id:String}
   AND updated_at <= {as_of:DateTime64(3, 'UTC')}
   AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
+  AND (
+    toString(repo_id) = '00000000-0000-0000-0000-000000000000'
+    OR toString(repo_id) IN (
+      SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}
+    )
+  )
 """
 
 _TRANSITIONS_SQL = (
@@ -1009,8 +1032,21 @@ class ClickHouseStatusChangeSource:
         (``_PROJECT_REPOSITORIES_SQL``). Without this branch every project
         subject failed closed below while its work items sat in ``work_items``
         matching the very ``project_id`` the scope committed.
+
+        A *team-filtered* project scope (``direct_scope=PROJECT`` alongside
+        ``scope.team_ids``, a filter -- ``DevScope`` permits the combination,
+        and ``ScopeResolutionService._resolved_scope`` populates ``team_ids``
+        from ``resolution.team_filters`` for any direct scope) is excluded
+        from that derivation for exactly the reason the team-filtered
+        ORGANIZATION case below is excluded, and the exclusion is checked
+        first: no project SQL arm applies a team filter, so deriving the
+        project's full repository set would silently answer a "project P, team
+        A only" request with team B's work from the same project. Falling
+        through to the caller's own (empty) bounded fields preserves the
+        fail-closed behavior such a request already had before this branch
+        existed. Codex adversarial review (HIGH, 2026-08-03).
         """
-        if scope.direct_scope is DirectScope.PROJECT:
+        if scope.direct_scope is DirectScope.PROJECT and not scope.team_ids:
             return await self._project_repository_ids(
                 org_id, self._entity_id(scope), as_of=as_of
             )

--- a/tests/api/dev/test_native_change_summary.py
+++ b/tests/api/dev/test_native_change_summary.py
@@ -136,7 +136,23 @@ _CLASS_FIXTURES = (
 )
 
 
+def _is_project_repository_derivation(sql: str) -> bool:
+    """The ``_PROJECT_REPOSITORIES_SQL`` round trip that precedes every read.
+
+    A committed PROJECT scope carries no repository dimension of its own (the
+    catalog selects ``NULL AS repository_id``), so ``_authorized_repository_ids``
+    re-derives the set from canonical work-item project attribution before any
+    delivery query runs. Fakes must answer it, and assertions about delivery
+    parameters must not mistake its parameters for a delivery query's.
+    """
+
+    return "FROM work_items FINAL" in sql and "SELECT DISTINCT" in sql
+
+
 def _fixture_for(sql: str) -> list[dict[str, Any]]:
+    if _is_project_repository_derivation(sql):
+        # Where production learns about ``repo-a`` for the scope below.
+        return [{"repository_id": "repo-a"}]
     for marker, _, _, row in _CLASS_FIXTURES:
         if marker in sql:
             return [row]
@@ -148,11 +164,15 @@ async def test_native_change_summary_emits_every_delivery_change_class(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed_params: list[dict[str, Any]] = []
+    derivation_params: list[dict[str, Any]] = []
 
     async def fake_query(
         _client: object, sql: str, params: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        observed_params.append(params)
+        if _is_project_repository_derivation(sql):
+            derivation_params.append(params)
+        else:
+            observed_params.append(params)
         return _fixture_for(sql)
 
     monkeypatch.setattr(
@@ -162,6 +182,12 @@ async def test_native_change_summary_emits_every_delivery_change_class(
         ClickHouseStatusChangeSource(object(), now=NOW)
     ).change_summary("org-a", "permission-v1", _request())
 
+    # The repository bound the delivery queries below are checked against is
+    # derived, not carried -- so assert it was derived from this org and this
+    # project rather than treating ["repo-a"] as a given.
+    assert [
+        (params["org_id"], params["entity_id"]) for params in derivation_params
+    ] == [("org-a", "project-a")]
     expected_categories = {fixture[2] for fixture in _CLASS_FIXTURES}
     assert {change.category for change in result.changes} == expected_categories
     assert all(change.claim_kind.value == "observed" for change in result.changes)
@@ -185,6 +211,8 @@ async def test_native_change_summary_preserves_blocker_category(
     async def fake_query(
         _client: object, sql: str, _params: dict[str, Any]
     ) -> list[dict[str, Any]]:
+        if _is_project_repository_derivation(sql):
+            return [{"repository_id": "repo-a"}]
         if "FROM work_graph_edges FINAL" in sql:
             return [
                 {
@@ -224,6 +252,8 @@ async def test_heuristic_deployment_incident_change_is_inferred_with_chain(
     async def fake_query(
         _client: object, sql: str, _params: dict[str, Any]
     ) -> list[dict[str, Any]]:
+        if _is_project_repository_derivation(sql):
+            return [{"repository_id": "repo-a"}]
         if "FROM operational_incidents AS incident" in sql:
             observed_incident_sql.append(sql)
             return [
@@ -330,7 +360,10 @@ async def test_native_change_summary_applies_one_global_deterministic_bound(
     async def fake_query(
         _client: object, sql: str, params: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        assert params["limit"] == 3
+        # The derivation query has no display bound of its own -- it resolves
+        # the repository set the bounded delivery queries are then run against.
+        if not _is_project_repository_derivation(sql):
+            assert params["limit"] == 3
         return _fixture_for(sql)
 
     monkeypatch.setattr(

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -1,0 +1,410 @@
+"""A committed PROJECT subject must read its own work items.
+
+Every pre-existing project-scope status test hand-builds a ``DevScope`` whose
+entity ref carries ``repository_id="repo-a"``. **Production can never produce
+that shape**: ``ClickHouseAuthorizedEntityCatalog._query_for(EntityKind.PROJECT)``
+selects ``NULL AS repository_id``, and
+``ScopeResolutionService.committed_scope_for``/``_resolved_scope`` populate
+``DevScope.repositories`` only for a REPOSITORY commit. So the hand-built
+scopes proved the project SQL arms work while the real committed scope failed
+closed in ``_authorized_repository_ids`` before reaching them -- coverage that
+read as coverage and was not.
+
+These tests build the scope with the **real producer**
+(``ScopeResolutionService`` over the real ``ClickHouseAuthorizedEntityCatalog``)
+and run the real ``ClickHouseStatusChangeSource`` SQL dispatch over it. Only the
+ClickHouse round trip is replaced, and the two things a fake could quietly
+invent are pinned:
+
+* ``test_catalog_project_rows_carry_no_repository`` pins the catalog's own
+  ``NULL AS repository_id``, so the committed-scope shape cannot drift; and
+* ``_FakeWorkItems`` **evaluates** the derivation SQL's ``org_id``, ``as_of``
+  and ``project_id``/``project_key`` predicates against a row store rather than
+  returning a canned answer -- dropping any one of them changes the derived
+  repository set and fails a test (mutation-checked).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev import native_status_change, scope_catalog
+from dev_health_ops.api.dev.contracts import DirectScope
+from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
+from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
+from dev_health_ops.api.dev.scope_service import (
+    EntityKind,
+    ScopeRef,
+    ScopeResolutionService,
+    ScopeResolveRequest,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    ChangeSummaryRequest,
+    StatusChangeService,
+    StatusSnapshotRequest,
+)
+
+NOW = datetime(2026, 8, 4, 1, 44, tzinfo=UTC)
+ORG_ID = "org-under-test"
+OTHER_ORG_ID = "org-other-tenant"
+PROJECT_ID = "13e65c04-40ec-4a95-8216-f7c2ce233244"
+PROJECT_NAME = "Ask Dev"
+
+#: Linear work items carry no repository: the sync lands them under the zero
+#: UUID, which has no ``repos`` row at all (verified against the live dev
+#: ClickHouse). The fix must derive the project's repository set from
+#: ``work_items`` itself, never from an existence check against ``repos``.
+LINEAR_NO_REPOSITORY_ID = "00000000-0000-0000-0000-000000000000"
+#: Reached only through the SQL's ``project_key`` arm.
+KEYED_REPOSITORY_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+#: Same project, another tenant -- must never enter this org's derived set.
+FOREIGN_REPOSITORY_ID = "bbbbbbbb-0000-0000-0000-000000000002"
+#: Same project and tenant, but updated strictly after ``as_of``.
+FUTURE_REPOSITORY_ID = "cccccccc-0000-0000-0000-000000000003"
+
+EXPECTED_DERIVED_REPOSITORY_IDS = sorted({LINEAR_NO_REPOSITORY_ID, KEYED_REPOSITORY_ID})
+
+NO_REPOSITORY_SET_WARNING = (
+    "Status reads require the complete authorized repository set; "
+    "scope was not widened."
+)
+NO_CHANGE_SET_WARNING = "Observed-change scope was not widened."
+
+
+def _row(
+    *,
+    work_item_id: str,
+    title: str,
+    status: str,
+    repository_id: str,
+    org_id: str = ORG_ID,
+    project_id: str = PROJECT_ID,
+    project_key: str = "",
+    updated_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "org_id": org_id,
+        "repository_id": repository_id,
+        "work_item_id": work_item_id,
+        "title": title,
+        "status": status,
+        "parent_id": "",
+        "project_id": project_id,
+        "project_key": project_key,
+        "updated_at": updated_at or (NOW - timedelta(days=4)),
+        "last_synced": NOW,
+    }
+
+
+#: One store, shared by the derivation query and the work-item read, so the
+#: two can never disagree about what exists.
+WORK_ITEM_STORE = [
+    _row(
+        work_item_id="linear:CHAOS-3367",
+        title="Outcome copy contract",
+        status="done",
+        repository_id=LINEAR_NO_REPOSITORY_ID,
+    ),
+    _row(
+        work_item_id="linear:CHAOS-3368",
+        title="Project status snapshot",
+        status="in_progress",
+        repository_id=LINEAR_NO_REPOSITORY_ID,
+    ),
+    # Attributed by project_key rather than project_id.
+    _row(
+        work_item_id="jira:ASK-9",
+        title="Keyed attribution",
+        status="in_progress",
+        repository_id=KEYED_REPOSITORY_ID,
+        project_id="",
+        project_key=PROJECT_ID,
+    ),
+    # Another tenant's item for the same project id.
+    _row(
+        work_item_id="linear:FOREIGN-1",
+        title="Other tenant",
+        status="done",
+        repository_id=FOREIGN_REPOSITORY_ID,
+        org_id=OTHER_ORG_ID,
+    ),
+    # This tenant, this project, but not yet visible at as_of.
+    _row(
+        work_item_id="linear:FUTURE-1",
+        title="Not yet at as_of",
+        status="todo",
+        repository_id=FUTURE_REPOSITORY_ID,
+        updated_at=NOW + timedelta(days=1),
+    ),
+]
+
+IN_SCOPE_WORK_ITEM_IDS = {
+    "linear:CHAOS-3367",
+    "linear:CHAOS-3368",
+    "jira:ASK-9",
+}
+
+
+class _FakeWorkItems:
+    """Evaluate the production SQL's predicates, don't fake past them.
+
+    A canned-answer fake makes the ``org_id`` / ``as_of`` / ``project_key``
+    predicates unfalsifiable -- deleting any of them from
+    ``_PROJECT_REPOSITORIES_SQL`` would still return the same rows. This reads
+    which predicates the SQL under test actually contains and applies exactly
+    those, so a dropped predicate changes the derived repository set and a
+    test fails.
+    """
+
+    def __init__(self) -> None:
+        self.sql: list[str] = []
+        self.params: list[dict[str, Any]] = []
+
+    def _matching(self, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        rows = list(WORK_ITEM_STORE)
+        if "org_id = {org_id:String}" in sql:
+            rows = [row for row in rows if row["org_id"] == params["org_id"]]
+        if "updated_at <= {as_of:DateTime64(3, 'UTC')}" in sql:
+            rows = [row for row in rows if row["updated_at"] <= params["as_of"]]
+        if "toString(repo_id) IN {repository_ids:Array(String)}" in sql:
+            rows = [
+                row for row in rows if row["repository_id"] in params["repository_ids"]
+            ]
+        entity_id = params["entity_id"]
+        arms = []
+        if "project_id = {entity_id:String}" in sql:
+            arms.append(lambda row: row["project_id"] == entity_id)
+        if "project_key = {entity_id:String}" in sql:
+            arms.append(lambda row: row["project_key"] == entity_id)
+        return [row for row in rows if any(arm(row) for arm in arms)]
+
+    async def __call__(
+        self, _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.sql.append(sql)
+        self.params.append(dict(params))
+        if "FROM work_items FINAL" in sql and "SELECT DISTINCT" in sql:
+            return [
+                {"repository_id": repository_id}
+                for repository_id in sorted(
+                    {row["repository_id"] for row in self._matching(sql, params)}
+                )
+            ]
+        if "FROM work_items FINAL" in sql and "parent_id" in sql:
+            return self._matching(sql, params)
+        if "FROM work_graph_projection_runs" in sql:
+            return [{"last_synced": NOW}]
+        return []
+
+    def work_item_read_params(self) -> dict[str, Any]:
+        for sql, params in zip(self.sql, self.params, strict=True):
+            if "FROM work_items FINAL" in sql and "parent_id" in sql:
+                return params
+        raise AssertionError("the work-item read was never issued")
+
+
+def _install_catalog_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serve the real catalog SQL the shapes production ClickHouse returns."""
+
+    async def fake_query(
+        _client: object, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "AS watermark" in sql:
+            return [{"watermark": NOW}]
+        if "FROM projects FINAL" in sql:
+            return [
+                {
+                    "canonical_id": PROJECT_ID,
+                    "label": PROJECT_NAME,
+                    # The production SQL selects ``NULL AS repository_id`` --
+                    # pinned by test_catalog_project_rows_carry_no_repository.
+                    "repository_id": None,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(scope_catalog, "query_dicts", fake_query)
+
+
+def _install_status_client(monkeypatch: pytest.MonkeyPatch) -> _FakeWorkItems:
+    fake = _FakeWorkItems()
+    monkeypatch.setattr(native_status_change, "query_dicts", fake)
+    return fake
+
+
+async def _committed_project_scope() -> Any:
+    """The committed scope, from the real producer -- never hand-built."""
+
+    service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(object()))
+    resolution = await service.resolve_contract(
+        ORG_ID,
+        "permission-fingerprint",
+        ScopeResolveRequest(explicit_refs=(ScopeRef(EntityKind.PROJECT, PROJECT_ID),)),
+        resolved_at=NOW,
+    )
+    assert resolution.outcome.value == "exact"
+    scope = resolution.resolved_scope
+    assert scope is not None
+    assert scope.direct_scope is DirectScope.PROJECT
+    return scope
+
+
+def test_catalog_project_rows_carry_no_repository() -> None:
+    """The production fact the fakes above stand in for.
+
+    If the catalog ever starts selecting a real ``repository_id`` for a
+    project, these tests would be asserting against a shape production no
+    longer produces -- so pin it here rather than letting the fake silently
+    become fiction.
+    """
+
+    sql = ClickHouseAuthorizedEntityCatalog._query_for(EntityKind.PROJECT, exact=True)
+    assert "NULL AS repository_id" in sql
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_carries_no_repository_dimension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The structural premise: nothing on the wire names a repository."""
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    assert scope.repositories == []
+    assert len(scope.entity_refs) == 1
+    assert scope.entity_refs[0].entity_id == PROJECT_ID
+    assert scope.entity_refs[0].repository_id is None
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_status_snapshot_reads_its_work_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED before the fix: the snapshot came back empty and fail-closed."""
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    # The work-item read must actually have been issued -- an assertion on
+    # the returned facts alone would pass for a snapshot that never queried.
+    fake.work_item_read_params()
+    assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
+
+
+@pytest.mark.asyncio
+async def test_derived_repository_set_is_exactly_the_projects_own_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The derived bound is neither too narrow nor too wide.
+
+    Asserted on the ``repository_ids`` the real ``_WORK_ITEMS_SQL`` read was
+    actually bound by -- the one observable that distinguishes a correct
+    derivation from one that dropped the tenant bound, the ``as_of`` bound, or
+    the ``project_key`` arm.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    bound = fake.work_item_read_params()["repository_ids"]
+    assert sorted(bound) == EXPECTED_DERIVED_REPOSITORY_IDS
+    assert FOREIGN_REPOSITORY_ID not in bound
+    assert FUTURE_REPOSITORY_ID not in bound
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_change_summary_is_not_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``change_summary`` shares the same repository-bounding helper."""
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+    assert scope.comparison_range is not None
+
+    _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    change = await service.change_summary(
+        ORG_ID,
+        "permission-fingerprint",
+        ChangeSummaryRequest(
+            scope=scope,
+            current_start=scope.time_range.start,
+            current_end=scope.time_range.end,
+            comparison_start=scope.comparison_range.start,
+            comparison_end=scope.comparison_range.end,
+        ),
+    )
+
+    assert NO_CHANGE_SET_WARNING not in change.warnings
+
+
+@pytest.mark.asyncio
+async def test_project_repository_derivation_failure_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable attribution source is never "spans no repositories".
+
+    Guard for the ``except`` arm of ``_project_repository_ids``: without it a
+    ClickHouse outage would surface as a confident empty project snapshot
+    instead of the disclosed fail-closed one.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    async def failing_query(
+        _client: object, _sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        raise RuntimeError("clickhouse unavailable")
+
+    monkeypatch.setattr(native_status_change, "query_dicts", failing_query)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+
+
+@pytest.mark.asyncio
+async def test_empty_project_id_never_issues_a_derivation_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty subject id must not widen to "every unkeyed work item".
+
+    ``DevScope.validate_direct_scope`` makes this unreachable through a
+    committed project scope today, which is exactly why the guard is asserted
+    directly: ``project_key`` is empty for every Linear work item, so an empty
+    ``entity_id`` reaching the SQL would match the entire organization through
+    the ``project_key`` arm.
+    """
+
+    fake = _install_status_client(monkeypatch)
+    source = ClickHouseStatusChangeSource(object(), now=NOW)
+
+    derived = await source._project_repository_ids(ORG_ID, "", as_of=NOW)
+
+    assert derived == []
+    assert fake.sql == []

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -52,6 +52,7 @@ ORG_ID = "org-under-test"
 OTHER_ORG_ID = "org-other-tenant"
 PROJECT_ID = "13e65c04-40ec-4a95-8216-f7c2ce233244"
 PROJECT_NAME = "Ask Dev"
+TEAM_ID = "5b0d3f61-3e5f-4a2f-9a1e-1d2c3b4a5f60"
 
 #: Linear work items carry no repository: the sync lands them under the zero
 #: UUID, which has no ``repos`` row at all (verified against the live dev
@@ -64,6 +65,18 @@ KEYED_REPOSITORY_ID = "aaaaaaaa-0000-0000-0000-000000000001"
 FOREIGN_REPOSITORY_ID = "bbbbbbbb-0000-0000-0000-000000000002"
 #: Same project and tenant, but updated strictly after ``as_of``.
 FUTURE_REPOSITORY_ID = "cccccccc-0000-0000-0000-000000000003"
+#: Still referenced by this project's work items, but no longer in ``repos`` --
+#: revoked/removed. ClickHouse enforces no foreign key, so the rows outlive the
+#: authorization. The ORGANIZATION branch enumerates ``repos`` and would never
+#: admit it; neither may the project branch.
+REVOKED_REPOSITORY_ID = "dddddddd-0000-0000-0000-000000000004"
+
+#: The org-scoped ``repos`` catalog. The zero UUID is deliberately absent: it
+#: is the repository-*less* sentinel, not a repository.
+REPOS_CATALOG = {
+    ORG_ID: {KEYED_REPOSITORY_ID, FUTURE_REPOSITORY_ID},
+    OTHER_ORG_ID: {FOREIGN_REPOSITORY_ID},
+}
 
 EXPECTED_DERIVED_REPOSITORY_IDS = sorted({LINEAR_NO_REPOSITORY_ID, KEYED_REPOSITORY_ID})
 
@@ -139,6 +152,14 @@ WORK_ITEM_STORE = [
         repository_id=FUTURE_REPOSITORY_ID,
         updated_at=NOW + timedelta(days=1),
     ),
+    # This tenant, this project, in window -- but its repository is gone from
+    # the authorization catalog.
+    _row(
+        work_item_id="linear:REVOKED-1",
+        title="Repository no longer authorized",
+        status="in_progress",
+        repository_id=REVOKED_REPOSITORY_ID,
+    ),
 ]
 
 IN_SCOPE_WORK_ITEM_IDS = {
@@ -151,12 +172,22 @@ IN_SCOPE_WORK_ITEM_IDS = {
 class _FakeWorkItems:
     """Evaluate the production SQL's predicates, don't fake past them.
 
-    A canned-answer fake makes the ``org_id`` / ``as_of`` / ``project_key``
-    predicates unfalsifiable -- deleting any of them from
+    A canned-answer fake makes the ``org_id`` / ``as_of`` / ``project_key`` /
+    ``repos`` predicates unfalsifiable -- deleting any of them from
     ``_PROJECT_REPOSITORIES_SQL`` would still return the same rows. This reads
     which predicates the SQL under test actually contains and applies exactly
     those, so a dropped predicate changes the derived repository set and a
     test fails.
+
+    What it deliberately does NOT do, so nobody reads more into a green run
+    than is there (Codex adversarial review, MEDIUM, 2026-08-03): it is a
+    predicate evaluator, not a SQL engine. It cannot see boolean precedence,
+    joins, or ``LIMIT`` -- flipping the project ``OR`` to ``AND`` or appending
+    ``LIMIT 1`` changes real ClickHouse behavior while every substring it
+    looks for is still present. Those two properties are pinned separately and
+    structurally by ``test_derivation_sql_structure_is_pinned``, and the SQL's
+    real-engine validity by the ``project_repositories`` entry in
+    ``tests/api/dev/test_status_change_clickhouse_live.py``.
     """
 
     def __init__(self) -> None:
@@ -172,6 +203,20 @@ class _FakeWorkItems:
         if "toString(repo_id) IN {repository_ids:Array(String)}" in sql:
             rows = [
                 row for row in rows if row["repository_id"] in params["repository_ids"]
+            ]
+        if "SELECT toString(id) FROM repos FINAL" in sql:
+            authorized = REPOS_CATALOG.get(params["org_id"], set())
+            sentinel_admitted = (
+                "toString(repo_id) = '00000000-0000-0000-0000-000000000000'" in sql
+            )
+            rows = [
+                row
+                for row in rows
+                if row["repository_id"] in authorized
+                or (
+                    sentinel_admitted
+                    and row["repository_id"] == LINEAR_NO_REPOSITORY_ID
+                )
             ]
         entity_id = params["entity_id"]
         arms = []
@@ -224,6 +269,16 @@ def _install_catalog_client(monkeypatch: pytest.MonkeyPatch) -> None:
                     "repository_id": None,
                 }
             ]
+        if "FROM teams FINAL" in sql:
+            # Only reached by the team-filtered case below; teams likewise
+            # carry no repository dimension of their own.
+            return [
+                {
+                    "canonical_id": TEAM_ID,
+                    "label": "Team A",
+                    "repository_id": None,
+                }
+            ]
         return []
 
     monkeypatch.setattr(scope_catalog, "query_dicts", fake_query)
@@ -235,17 +290,24 @@ def _install_status_client(monkeypatch: pytest.MonkeyPatch) -> _FakeWorkItems:
     return fake
 
 
-async def _committed_project_scope() -> Any:
+async def _committed_project_scope(*, team_filter: str | None = None) -> Any:
     """The committed scope, from the real producer -- never hand-built."""
 
     service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(object()))
     resolution = await service.resolve_contract(
         ORG_ID,
         "permission-fingerprint",
-        ScopeResolveRequest(explicit_refs=(ScopeRef(EntityKind.PROJECT, PROJECT_ID),)),
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.PROJECT, PROJECT_ID),),
+            team_filter_refs=(
+                () if team_filter is None else (ScopeRef(EntityKind.TEAM, team_filter),)
+            ),
+        ),
         resolved_at=NOW,
     )
-    assert resolution.outcome.value == "exact"
+    # A team filter makes the resolver's own outcome "filtered" rather than
+    # "exact"; both are committed outcomes carrying a resolved scope.
+    assert resolution.outcome.value == ("filtered" if team_filter else "exact")
     scope = resolution.resolved_scope
     assert scope is not None
     assert scope.direct_scope is DirectScope.PROJECT
@@ -263,6 +325,56 @@ def test_catalog_project_rows_carry_no_repository() -> None:
 
     sql = ClickHouseAuthorizedEntityCatalog._query_for(EntityKind.PROJECT, exact=True)
     assert "NULL AS repository_id" in sql
+
+
+def test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do() -> None:
+    """The derivation can never be wider than the facts it bounds.
+
+    The repository set exists only to bound ``_WORK_ITEMS_SQL`` and the
+    delivery arms. If its project-matching predicate ever drifts from theirs,
+    it could admit a repository those queries would not themselves draw from
+    -- so the two are pinned as the same text, not merely as "both correct".
+    """
+
+    project_predicate = (
+        "project_id = {entity_id:String} OR project_key = {entity_id:String}"
+    )
+    assert project_predicate in native_status_change._PROJECT_REPOSITORIES_SQL
+    assert project_predicate in native_status_change._WORK_ITEMS_SQL
+
+
+def test_derivation_sql_structure_is_pinned() -> None:
+    """Structure the predicate-evaluating fake provably cannot see.
+
+    Codex adversarial review (MEDIUM, 2026-08-03): a substring fake keeps
+    matching after ``OR`` becomes ``AND`` or a ``LIMIT`` is appended, both of
+    which change real ClickHouse results. Assert them on the SQL text itself.
+    """
+
+    sql = native_status_change._PROJECT_REPOSITORIES_SQL
+
+    # The project arms are one parenthesised disjunction, not a conjunction:
+    # a Jira row matches by key and a Linear row by id, never both at once, so
+    # AND would return the empty set for every provider.
+    assert (
+        "  AND (project_id = {entity_id:String} OR project_key = {entity_id:String})\n"
+        in sql
+    )
+    # No bound of its own: this resolves an authorization set, and a truncated
+    # authorization set is a silently narrowed read, not a smaller page.
+    assert "LIMIT" not in sql.upper()
+    # Both authorization arms survive, and the tenant/as_of bounds with them.
+    assert "toString(repo_id) = '00000000-0000-0000-0000-000000000000'" in sql
+    assert "SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}" in sql
+    # Anchored to ``work_items`` specifically: a bare
+    # ``"WHERE org_id = {org_id:String}" in sql`` is satisfied by the ``repos``
+    # sub-select alone, so it stays green with the fact table's own tenant
+    # bound deleted. Because a repository id is org-unique, the ``repos`` arm
+    # masks that deletion for every real repository -- leaving the
+    # repository-less sentinel bucket, which is shared by every tenant, as the
+    # one place the fact table's own bound is the only tenant boundary left.
+    assert "FROM work_items FINAL\nWHERE org_id = {org_id:String}\n" in sql
+    assert "AND updated_at <= {as_of:DateTime64(3, 'UTC')}" in sql
 
 
 @pytest.mark.asyncio
@@ -301,6 +413,69 @@ async def test_committed_project_scope_status_snapshot_reads_its_work_items(
     # the returned facts alone would pass for a snapshot that never queried.
     fake.work_item_read_params()
     assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_project_scope_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A team filter must never be answered with the whole project.
+
+    Codex adversarial review (HIGH, 2026-08-03). ``DevScope`` permits
+    ``team_ids`` alongside ``direct_scope=PROJECT`` and the resolver populates
+    it from ``team_filter_refs``, but no project SQL arm applies a team
+    filter. Deriving the project's full repository set for such a request
+    would answer "project P, team A only" with team B's work from the same
+    project -- so it keeps the fail-closed behavior it had before the
+    derivation existed, exactly like the team-filtered ORGANIZATION case.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope(team_filter=TEAM_ID)
+    assert scope.team_ids == [TEAM_ID]
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+    # And it must not have leaked the derivation query either.
+    assert fake.sql == []
+
+
+@pytest.mark.asyncio
+async def test_repository_revoked_from_the_catalog_is_never_admitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Work-item rows outlive authorization; the derived bound must not.
+
+    Codex adversarial review (HIGH, 2026-08-03). ClickHouse enforces no
+    foreign key, so a repository removed from ``repos`` keeps its
+    ``work_items`` rows. The ORGANIZATION branch enumerates ``repos`` and
+    would never admit it; project scope must not either, purely because it
+    reads a different table.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    bound = fake.work_item_read_params()["repository_ids"]
+    assert REVOKED_REPOSITORY_ID not in bound
+    assert "linear:REVOKED-1" not in {child.entity_id for child in snapshot.children}
+    # ...while the repository-less sentinel, which has no ``repos`` row and
+    # never will, is still admitted -- otherwise the catalog check would have
+    # re-broken every Linear project.
+    assert LINEAR_NO_REPOSITORY_ID in bound
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.dev.native_status_change import (
     _DEPLOYMENTS_SQL,
     _INCIDENT_CHANGES_SQL,
     _INCIDENTS_SQL,
+    _PROJECT_REPOSITORIES_SQL,
     _PULL_REQUEST_CHANGES_SQL,
     _PULL_REQUESTS_SQL,
     _RELATIONSHIPS_SQL,
@@ -99,6 +100,38 @@ def test_status_change_query_parses_against_production_schema(
     except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
         pytest.fail(f"{name} EXPLAIN failed: {exc}\nparams={params!r}\n{sql}")
     assert plan.result_rows, f"{name} returned an empty query plan"
+
+
+def test_project_repository_derivation_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_PROJECT_REPOSITORIES_SQL``.
+
+    Codex adversarial review (MEDIUM, 2026-08-03): the unit fake for this
+    query is a predicate evaluator, not a SQL engine, so nothing else proves
+    the text is valid ClickHouse -- in particular the ``repos`` sub-select and
+    the repository-less sentinel comparison. Kept out of the parametrized
+    inventory above only because that inventory asserts a ``{limit:UInt32}``
+    bound: this query resolves an *authorization* set, where a truncated
+    result is a silently narrowed read rather than a smaller page, so it
+    deliberately has none.
+    """
+
+    sql = _PROJECT_REPOSITORIES_SQL
+    assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
+    assert "LIMIT" not in sql.upper(), "an authorization set must not be truncated"
+    params: dict[str, object] = {
+        "org_id": ORG_ID,
+        "entity_id": "project-target",
+        "as_of": NOW,
+    }
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"project_repositories EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
+        )
+    assert plan.result_rows, "project_repositories returned an empty query plan"
 
 
 def test_direct_work_item_precedes_children_before_limit() -> None:


### PR DESCRIPTION
## Symptom

Ask Dev, live, all merged code: *"What is the status of the Ask Dev project, and what are looking like the current blockers?"* The wave-3.1 pipeline resolved the subject correctly — `dev_runs` row `5425c82c-…` has `preflight_outcome=proceeded_committed_subject` against Linear project `13e65c04-…` "Ask Dev" — and then answered with a vague partial instead of the PRD §10 verdict/completion/blockers.

The `status_snapshot` source observation came back `data_semantics=no_data`, `observed_state=available_unknown`, every content list empty — while ClickHouse `work_items` holds **69 rows** for that project, all updated inside the run's window.

## Root cause

`native_status_change.py` — `_authorized_repository_ids` fell through to `return self._repository_ids(scope)` for a PROJECT scope, and that always returns the empty set, because **a committed project subject carries no repository dimension anywhere on the wire**:

- `scope_catalog.py:213` — the PROJECT catalog query selects `NULL AS repository_id`, so `AuthorizedEntity.repository_id` is `None` for every project (a project spans repositories; it has no repository of its own).
- `scope_service.py:777` (`committed_scope_for`) and `scope_service.py:1169` (`_resolved_scope`) populate `DevScope.repositories` only when the entity is a REPOSITORY.

Both inputs to `_repository_ids` are therefore empty, so `status_snapshot` hit its fail-closed guard (`native_status_change.py:974-981`) and returned `declared=None` with a single `authorized_repositories` UNAVAILABLE ref **before issuing a single project query**. `change_summary` shares the helper and did the same.

This is the same structural problem ORGANIZATION (CHAOS-3255) and TEAM (CHAOS-3303) already have dedicated branches for. PROJECT never got one.

`work_graph_expansion` being skipped in the same run is **not** this bug and is correct as designed: `builtin_steps.py:904-916` `_work_graph_applicable` admits only issue/pull_request refs, and the live observation is `not_applicable` / `not_measured` / `limitation=step_not_applicable`, requirement_level *conditional*. The unavailable **required** source was the mandatory `status_change` one.

## Fix

A PROJECT arm in `_authorized_repository_ids` that re-derives the repository set from canonical work-item project attribution (`_PROJECT_REPOSITORIES_SQL`), bounded by:

- the same `org_id` tenant boundary `_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL` enforces;
- the same `updated_at <= as_of` bound `_WORK_ITEMS_SQL` applies;
- the **byte-identical** `project_id`/`project_key` disjunction every project SQL arm uses, so the derived set can never admit a repository the fact queries it bounds would not themselves have drawn from (pinned by a test);
- the org-scoped `repos` catalog, **plus** an explicit arm for the zero UUID — not a repository but the sentinel the sink writes for repository-less records (`row.repo_id or uuid.UUID(int=0)`), which is every Linear work item.

A **team-filtered** project scope is deliberately excluded from the derivation and keeps failing closed, exactly as the team-filtered organization case does: no project SQL arm applies a team filter, so deriving the project's full repository set would answer "project P, team A only" with team B's work.

## Verification

**RED → GREEN.** New `tests/api/dev/test_project_scope_status_snapshot_repositories.py` builds the scope with the **real producer** (`ScopeResolutionService` over the real `ClickHouseAuthorizedEntityCatalog`), not hand-built. Every pre-existing project-scope test hand-builds a scope carrying `repository_id="repo-a"` — a shape production cannot emit — which is why they were all green while production failed closed. With the source reverted: 2 failed / 3 passed. With the fix: 11/11.

**Mutation: 14/14 killed** — drop the PROJECT branch; drop the `project_id` arm; drop the `project_key` arm; `OR` → `AND`; drop the `as_of` bound; drop the tenant bound on `work_items`; drop it from the `repos` sub-select; drop the `repos` authorization arm; drop the zero-UUID sentinel arm; drop the team-filter guard; inject a `LIMIT`; except-arm fabricates a set; drop the empty-id guard; pass the wrong id in.

**Live dev ClickHouse, read-only.** The corrected SQL `EXPLAIN`s cleanly against the production schema and returns `['00000000-0000-0000-0000-000000000000']`; feeding that into the real `_WORK_ITEMS_SQL` returns all **69 rows** (38 done / 20 backlog / 6 unknown / 4 in_progress / 1 canceled), with the blocker watermark resolving and **155** native `blocks` edges landing on the project's items. 0 linked PRs — Linear-only project, so the answer is completion + blockers, no delivery evidence.

**Suites.** `tests/api/dev` + `tests/api/graphql` + `tests/acceptance`: 2311 passed, 2 failed — both (`test_resolver_sql_explain.py::…[operating_review]`, `[analytics]`) reproduce identically on a clean `origin/main` and are untouched here. ruff + mypy clean.

## Adversarial review

Codex returned `needs-attention` with 4 HIGH + 1 MEDIUM. Two were real defects in this change and are fixed in the second commit (team-filtered widening; bypassing the `repos` authorization catalog). Three are verified pre-existing and **deliberately not fixed here** — reported rather than half-fixed:

1. **Jira project subjects still fail closed.** `team_autoimport_jira.py:106` mints the catalog id as `f"{org_id}:jira:{project_key}"`, while `providers/jira/normalize.py:517-518` writes the raw Jira id/key onto `work_items`. Neither `project_id = {entity_id}` nor `project_key = {entity_id}` matches. **`_WORK_ITEMS_SQL`, `_BLOCKERS_SQL` and `_PULL_REQUESTS_SQL` already use that identical predicate**, so Jira project subjects are broken end-to-end before and after this change — making only the derivation Jira-aware would derive repositories and then have every fact query return nothing. Needs a coordinated change across all project arms.
2. **Mandatory project data-health widens to the whole organization.** `data_health_service.py:381-388` uses `AND (empty({repository_ids}) OR …)`, so an empty list disables repository filtering, and `:195` then falls back to the full org repo set as the denominator. A committed project scope still reaches it with no repositories, so unrelated healthy repositories can make a project's evidence coverage read complete. Separate service, separate semantics (widening, not fail-closed).
3. **The unit fake is a predicate evaluator, not a SQL engine.** Acknowledged in its own docstring rather than papered over. The two properties it provably cannot see — boolean precedence and `LIMIT` — are pinned structurally instead, and `_PROJECT_REPOSITORIES_SQL` now has a real-engine `EXPLAIN` entry in the live inventory. Fully seeded multi-provider live coverage is follow-up work.

Pre-existing and unrelated, flagged in passing: `tests/api/dev/test_status_change_clickhouse_live.py` fails 10/13 on `main` because its shared fixture omits the `member_issue_ids` substitution.

## Out of scope, answered

`dev_run_resolutions` is empty for all runs, and that is **expected design, not a persistence gap**: `subject_preflight.py:239-247` documents `terminating_resolution_entry` as `None` for every termination reason other than an ambiguous mention and for every non-terminal result; `orchestrator.py:1209-1211` is the only production caller of `append_resolution` and sits inside the TERMINATE branch gated on that field; `persistence/service.py:1059` reads the table filtered to `outcome == "ambiguous_candidates"`. A `proceeded_committed_subject` run correctly writes nothing. (Same shape for `dev_run_subject_sets`: `subject_preflight.py:727-735` only mints an audit set when `len(mentions) > 1`.)
