### PR TITLE
fix(ask-dev): apply the adversarial-review rulings on the project repository derivation

### DIFF
--- a/src/dev_health_ops/api/dev/data_health_service.py
+++ b/src/dev_health_ops/api/dev/data_health_service.py
@@ -25,6 +25,7 @@ from dev_health_ops.models.settings import (
 from .entitlement import AskDevEntitlementAuthorizer
 from .evidence_service import EvidenceScopeAuthorizer
 from .native_evidence import SourceFreshnessPolicy, default_native_freshness_policies
+from .native_status_change import PROJECT_REPOSITORIES_SQL
 from .scope_service import (
     EntityKind,
     ScopeResolution,
@@ -269,12 +270,53 @@ class NativeDataHealthReader:
         configurations = configuration_rows or []
         schedules = await self._schedules(org_id)
         repository_ids = sorted(_repository_ids(scope))
+        # A committed PROJECT subject carries no repository dimension (the
+        # catalog resolves projects with ``NULL AS repository_id``), so
+        # ``_repository_ids`` is empty for one and the ``empty(array) OR ...``
+        # arm in ``_watermark`` below then disables repository filtering
+        # entirely -- measuring the whole organization and reporting it as the
+        # project's coverage. Because source health is a *mandatory* source for
+        # the project status plan, unrelated healthy repositories could make a
+        # project's evidence coverage read complete. Resolve the same
+        # repository set the status/change reader derives, from the same shared
+        # query, or fail closed. Codex adversarial review (HIGH, 2026-08-03).
+        project_scope_unresolved = False
+        if not repository_ids:
+            project_ids = [
+                entity.canonical_id
+                for entity in scope.entities
+                if entity.kind is EntityKind.PROJECT
+            ]
+            if project_ids:
+                if scope.team_filters:
+                    # No data-health query applies a team filter either, so a
+                    # team-filtered project must not be answered with the whole
+                    # project's repository set.
+                    project_scope_unresolved = True
+                else:
+                    repository_ids = await self._project_repositories(
+                        org_id, project_ids[0]
+                    )
+                    project_scope_unresolved = not repository_ids
         observations: list[SourceHealthObservation] = []
         for source in source_systems:
             if source == "acr":
                 observations.append(
                     SourceHealthObservation(
                         source, False, False, warning="acr_optional"
+                    )
+                )
+                continue
+            if project_scope_unresolved:
+                # ``configured=None`` maps to DataHealthState.UNAVAILABLE --
+                # an explicit "this could not be measured for this subject",
+                # never a silent organization-wide substitute.
+                observations.append(
+                    SourceHealthObservation(
+                        source,
+                        None,
+                        False,
+                        warning="project_repository_scope_unavailable",
                     )
                 )
                 continue
@@ -333,6 +375,38 @@ class NativeDataHealthReader:
                 )
             )
         return tuple(observations)
+
+    async def _project_repositories(self, org_id: str, project_id: str) -> list[str]:
+        """The project's repository set, from the one shared derivation.
+
+        Deliberately the same ``PROJECT_REPOSITORIES_SQL`` the status/change
+        reader uses rather than a second query with the same intent: two
+        independently-drifting notions of "which repositories is this project
+        in" is exactly the class of bug this fix exists to close. A failed or
+        empty derivation returns ``[]`` and the caller fails closed -- an
+        unreadable attribution source is never "this project spans no
+        repositories", and never an excuse to widen to the organization.
+        """
+
+        if not project_id:
+            return []
+        try:
+            rows = await query_dicts(
+                self._client,
+                PROJECT_REPOSITORIES_SQL,
+                {
+                    "org_id": org_id,
+                    "entity_id": project_id,
+                    # Data health is a "right now" measurement, unlike a
+                    # snapshot's caller-supplied as_of.
+                    "as_of": datetime.now(UTC),
+                },
+            )
+        except Exception:
+            return []
+        return sorted(
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+        )
 
     async def _repositories(self, org_id: str) -> set[str]:
         rows = await query_dicts(

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -500,6 +500,21 @@ WHERE g.repo_id IS NOT NULL
 #: read bound for project scope alone. Every *real* repository id must therefore
 #: still resolve through the same org-scoped ``repos`` catalog.
 #:
+#: Provider scope, deliberate (Codex adversarial review HIGH, 2026-08-03;
+#: ruling: keep the arm provider-scoped rather than grow it). Sharing the fact
+#: queries' predicate exactly is also what stops this arm from *helping* a
+#: provider whose committed id those queries cannot match. Jira is that case:
+#: ``team_autoimport_jira._project_id`` mints the catalog id as
+#: ``f"{org_id}:jira:{project_key}"`` while ``providers/jira/normalize`` writes
+#: the raw Jira id/key onto ``work_items``, so neither arm matches. Deriving
+#: repositories for it anyway would be strictly *worse* than not: the fact
+#: queries would still match nothing and the run would report a confident empty
+#: answer for a project that has data, in place of the disclosed fail-closed
+#: one it reports today. Jira project subjects therefore keep exactly their
+#: current behavior here; making them answerable needs a coordinated
+#: provider-aware change across every project arm at once. Asserted by
+#: ``test_jira_shaped_project_keeps_todays_fail_closed_behaviour``.
+#:
 #: The zero UUID is admitted explicitly rather than by omitting that check.
 #: It is not a repository at all: it is the sentinel
 #: ``ClickHouseMetricsSink`` writes whenever a record has no repository
@@ -509,7 +524,7 @@ WHERE g.repo_id IS NOT NULL
 #: existence join would re-empty the set for the exact provider this fix exists
 #: for -- while a blanket "skip the catalog" would have de-authorized nothing
 #: and admitted everything. Naming the sentinel keeps both properties.
-_PROJECT_REPOSITORIES_SQL = """
+PROJECT_REPOSITORIES_SQL = """
 SELECT DISTINCT toString(repo_id) AS repository_id
 FROM work_items FINAL
 WHERE org_id = {org_id:String}
@@ -980,7 +995,7 @@ class ClickHouseStatusChangeSource:
             async with asyncio.timeout(QUERY_TIMEOUT_SECONDS):
                 rows = await query_dicts(
                     self._client,
-                    _PROJECT_REPOSITORIES_SQL,
+                    PROJECT_REPOSITORIES_SQL,
                     {
                         "org_id": org_id,
                         "entity_id": entity_id,
@@ -1029,7 +1044,7 @@ class ClickHouseStatusChangeSource:
         ``scope.repositories`` and ``entity_refs[0].repository_id`` are always
         empty for a production project commit -- and is re-derived here from
         canonical work-item project attribution
-        (``_PROJECT_REPOSITORIES_SQL``). Without this branch every project
+        (``PROJECT_REPOSITORIES_SQL``). Without this branch every project
         subject failed closed below while its work items sat in ``work_items``
         matching the very ``project_id`` the scope committed.
 

--- a/tests/api/dev/test_project_scope_clickhouse_live.py
+++ b/tests/api/dev/test_project_scope_clickhouse_live.py
@@ -1,0 +1,505 @@
+"""Live-ClickHouse proof for the committed-project repository derivation.
+
+The unit suite for this fix
+(``test_project_scope_status_snapshot_repositories.py``) replaces the
+ClickHouse round trip with a predicate evaluator. That is honest about what it
+covers and explicit about what it cannot: boolean precedence, the ``repos``
+sub-select, ``LIMIT``, and anything else that is a property of the *engine*
+rather than of the predicate list. This file closes that gap by executing
+``PROJECT_REPOSITORIES_SQL`` against a real migrated ClickHouse over rows
+written by the real producers, and then **mutation-checks the real results**:
+each mutant SQL is executed too, and must return a materially different set.
+Without that second half, a green assertion here would only prove the query
+runs, not that the assertion could ever have failed.
+
+Seeded shapes, one per rule the derivation has to get right:
+
+* Linear (repository-less, zero-UUID ``repo_id``) — must be admitted;
+* attribution by ``project_key`` rather than ``project_id`` — must be admitted;
+* a nonzero repository absent from ``repos`` — must be excluded;
+* a second tenant's rows for the same project id — must be excluded;
+* a row updated after ``as_of`` — must be excluded.
+
+Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
+``-m "not benchmark and not clickhouse"``): ``pytest -m clickhouse`` with
+``CLICKHOUSE_URI`` pointing at a SCRATCH database — never the dev ``default``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.dev.native_status_change import (
+    PROJECT_REPOSITORIES_SQL,
+    ClickHouseStatusChangeSource,
+)
+from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
+from dev_health_ops.api.dev.scope_service import (
+    EntityKind,
+    ScopeRef,
+    ScopeResolutionService,
+    ScopeResolveRequest,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    StatusChangeService,
+    StatusSnapshotRequest,
+)
+from dev_health_ops.api.queries.client import query_dicts
+from dev_health_ops.metrics.schemas import ProjectRecord
+from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.linear.normalize import linear_issue_to_work_item
+from dev_health_ops.providers.status_mapping import StatusMapping
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+NOW = datetime.now(UTC).replace(microsecond=0)
+ZERO_REPOSITORY_ID = "00000000-0000-0000-0000-000000000000"
+PROJECT_NAME = "Ask Dev Project Scope Live"
+
+NO_REPOSITORY_SET_WARNING = (
+    "Status reads require the complete authorized repository set; "
+    "scope was not widened."
+)
+
+#: Database names this file refuses to touch — it writes rows. A warning in a
+#: docstring is not an enforcement boundary; this is.
+_PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _database_of(dsn: str | None) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(dsn or "").path.lstrip("/").strip().lower()
+
+
+def _scratch_database(dsn: str) -> str:
+    """Return the DSN's database, or fail closed if it is a protected one.
+
+    Kept as a hard ``RuntimeError`` even though the skip below normally
+    prevents it from firing: the skip is convenience, this is the boundary.
+    A developer who forces the fixture past the marker must still not seed the
+    dev database.
+    """
+
+    database = _database_of(dsn)
+    if database in _PROTECTED_DATABASES:
+        raise RuntimeError(
+            "refusing to seed ClickHouse database "
+            f"{database or '<unset>'!r}: point CLICKHOUSE_URI at a named "
+            "SCRATCH database (e.g. .../ci_local_validate)."
+        )
+    return database
+
+
+#: A developer's shell commonly exports ``CLICKHOUSE_URI`` pointing at the dev
+#: ``default`` database. Skipping (loudly, with this reason) rather than
+#: erroring keeps that from looking like a broken test -- while still never
+#: reading as a pass: the measurement plainly did not happen.
+_SKIP_REASON = (
+    "Requires a migrated SCRATCH CLICKHOUSE_URI "
+    "(e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate); "
+    f"got database {_database_of(CLICKHOUSE_URI) or '<unset>'!r}, which this "
+    "suite refuses to seed"
+)
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI or _database_of(CLICKHOUSE_URI) in _PROTECTED_DATABASES,
+        reason=_SKIP_REASON,
+    ),
+]
+
+
+@pytest.fixture
+def sink() -> Any:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    _scratch_database(CLICKHOUSE_URI)
+    metrics_sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    try:
+        yield metrics_sink
+    finally:
+        metrics_sink.close()
+
+
+@pytest.fixture
+def raw_client() -> Any:
+    import clickhouse_connect
+
+    assert CLICKHOUSE_URI is not None
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _work_item(
+    identifier: str,
+    *,
+    org_id: str,
+    project_id: str,
+    repo_id: uuid.UUID | None,
+    project_key: str | None = None,
+    updated_at: datetime | None = None,
+) -> Any:
+    """One work item through the production Linear normalizer.
+
+    Hand-built fixtures pass unit tests while the live path fails; the fields
+    this test actually varies (tenant, repository, project attribution, time)
+    are patched onto the normalizer's own output rather than replacing it.
+    """
+
+    identity = MagicMock(spec=IdentityResolver)
+    identity.resolve.side_effect = lambda **kwargs: "user:dev@example.com"
+    status_mapping = MagicMock(spec=StatusMapping)
+    status_mapping.normalize_status.return_value = "in_progress"
+    status_mapping.normalize_type.return_value = "task"
+
+    issue = {
+        "id": f"issue-{identifier}",
+        "identifier": identifier,
+        "title": f"Work item {identifier}",
+        "createdAt": (NOW - timedelta(days=10)).isoformat(),
+        "updatedAt": (NOW - timedelta(days=1)).isoformat(),
+        "state": {"id": "s1", "name": "In Progress", "type": "started"},
+        "team": {"id": "t1", "key": "CHAOS", "name": "Fullchaos"},
+        "project": {"id": project_id, "name": PROJECT_NAME},
+    }
+    item, _ = linear_issue_to_work_item(
+        issue=issue, status_mapping=status_mapping, identity=identity
+    )
+    return replace(
+        item,
+        org_id=org_id,
+        repo_id=repo_id,
+        project_id=project_id,
+        project_key=project_key,
+        updated_at=updated_at or (NOW - timedelta(days=1)),
+    )
+
+
+def _insert_repo(client: Any, *, org_id: str, repo_id: str, name: str) -> None:
+    client.command(
+        "INSERT INTO repos (id, repo, created_at, last_synced, org_id) VALUES "
+        "({repo_id:UUID}, {name:String}, now64(3), now64(3), {org_id:String})",
+        parameters={"repo_id": repo_id, "name": name, "org_id": org_id},
+    )
+
+
+class _Seeded:
+    def __init__(self) -> None:
+        self.org_id = f"proj-scope-{uuid.uuid4().hex[:16]}"
+        self.other_org_id = f"proj-scope-other-{uuid.uuid4().hex[:16]}"
+        self.project_id = str(uuid.uuid4())
+        #: Referenced only by the *other* tenant. This org must derive nothing
+        #: for it -- the probe that makes ``work_items.org_id`` observable at
+        #: all (see test_every_derivation_clause_changes_the_real_result).
+        self.other_only_project_id = str(uuid.uuid4())
+        self.authorized_repo = uuid.uuid4()
+        self.stale_window_repo = uuid.uuid4()
+        self.revoked_repo = uuid.uuid4()
+        self.foreign_repo = uuid.uuid4()
+
+    @property
+    def expected(self) -> list[str]:
+        return sorted({ZERO_REPOSITORY_ID, str(self.authorized_repo)})
+
+
+@pytest.fixture
+def seeded(sink: Any, raw_client: Any) -> Any:
+    data = _Seeded()
+    try:
+        # Authorization catalog: the revoked repository is deliberately absent,
+        # while its work items below are not.
+        _insert_repo(
+            raw_client,
+            org_id=data.org_id,
+            repo_id=str(data.authorized_repo),
+            name="org/authorized",
+        )
+        _insert_repo(
+            raw_client,
+            org_id=data.org_id,
+            repo_id=str(data.stale_window_repo),
+            name="org/stale-window",
+        )
+        _insert_repo(
+            raw_client,
+            org_id=data.other_org_id,
+            repo_id=str(data.foreign_repo),
+            name="other/repo",
+        )
+
+        sink.org_id = data.org_id
+        sink.write_projects(
+            [
+                ProjectRecord(
+                    id=data.project_id,
+                    org_id=data.org_id,
+                    provider="linear",
+                    name=PROJECT_NAME,
+                    is_active=1,
+                    updated_at=NOW,
+                    last_synced=NOW,
+                )
+            ]
+        )
+        sink.write_work_items(
+            [
+                # Linear: repository-less, lands on the zero UUID.
+                _work_item(
+                    "LIVE-1",
+                    org_id=data.org_id,
+                    project_id=data.project_id,
+                    repo_id=None,
+                ),
+                _work_item(
+                    "LIVE-2",
+                    org_id=data.org_id,
+                    project_id=data.project_id,
+                    repo_id=None,
+                ),
+                # Attributed by project_key, on an authorized repository.
+                _work_item(
+                    "LIVE-3",
+                    org_id=data.org_id,
+                    project_id="",
+                    project_key=data.project_id,
+                    repo_id=data.authorized_repo,
+                ),
+                # Authorized repository, but outside the as_of bound.
+                _work_item(
+                    "LIVE-4",
+                    org_id=data.org_id,
+                    project_id=data.project_id,
+                    repo_id=data.stale_window_repo,
+                    updated_at=NOW + timedelta(days=30),
+                ),
+                # Nonzero repository with no current ``repos`` row.
+                _work_item(
+                    "LIVE-5",
+                    org_id=data.org_id,
+                    project_id=data.project_id,
+                    repo_id=data.revoked_repo,
+                ),
+            ]
+        )
+        sink.org_id = data.other_org_id
+        sink.write_work_items(
+            [
+                _work_item(
+                    "LIVE-6",
+                    org_id=data.other_org_id,
+                    project_id=data.project_id,
+                    repo_id=data.foreign_repo,
+                ),
+                # Repository-less, exactly like ours: the sentinel bucket is
+                # the one place the ``repos`` arm cannot separate tenants, so
+                # this is what makes the fact table's own ``org_id`` bound
+                # load-bearing rather than merely redundant.
+                _work_item(
+                    "LIVE-7",
+                    org_id=data.other_org_id,
+                    project_id=data.other_only_project_id,
+                    repo_id=None,
+                ),
+            ]
+        )
+        yield data
+    finally:
+        for table in ("work_items", "projects", "repos"):
+            raw_client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id IN "
+                "({org_id:String}, {other_org_id:String})",
+                parameters={
+                    "org_id": data.org_id,
+                    "other_org_id": data.other_org_id,
+                },
+            )
+
+
+async def _derive(sink: Any, sql: str, seeded: Any, *, project_id: str) -> list[str]:
+    rows = await query_dicts(
+        sink,
+        sql,
+        {
+            "org_id": seeded.org_id,
+            "entity_id": project_id,
+            "as_of": NOW,
+        },
+    )
+    return sorted(
+        {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+    )
+
+
+async def _probes(sink: Any, sql: str, seeded: Any) -> tuple[list[str], list[str]]:
+    """Both observable answers this query has to get right.
+
+    The second probe is not redundant. A project referenced only by another
+    tenant must derive *nothing* for this org; deriving the sentinel bucket
+    for it instead would turn a disclosed fail-closed answer into a confident
+    empty one -- a difference the first probe's repository set cannot show,
+    because the sentinel is already in it legitimately.
+    """
+
+    return (
+        await _derive(sink, sql, seeded, project_id=seeded.project_id),
+        await _derive(sink, sql, seeded, project_id=seeded.other_only_project_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_derivation_returns_exactly_the_authorized_project_repositories(
+    sink: Any, seeded: Any
+) -> None:
+    own, other_tenants = await _probes(sink, PROJECT_REPOSITORIES_SQL, seeded)
+    assert own == seeded.expected
+    assert other_tenants == []
+
+
+@pytest.mark.asyncio
+async def test_every_derivation_clause_changes_the_real_result(
+    sink: Any, seeded: Any
+) -> None:
+    """Mutation-check against the engine, not against a fake.
+
+    Each mutant is executed on the same seeded data. A mutant that returns the
+    correct set is a clause the assertion above could never have caught -- so
+    the failure message names the clause rather than just reporting inequality.
+    """
+
+    mutants = {
+        "org_id tenant bound on work_items": (
+            "FROM work_items FINAL\nWHERE org_id = {org_id:String}\n",
+            "FROM work_items FINAL\nWHERE 1 = 1\n",
+        ),
+        "as_of bound": (
+            "  AND updated_at <= {as_of:DateTime64(3, 'UTC')}\n",
+            "",
+        ),
+        "project_key arm": (
+            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
+            "(project_id = {entity_id:String})",
+        ),
+        "project_id arm": (
+            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
+            "(project_key = {entity_id:String})",
+        ),
+        "project disjunction (OR -> AND)": (
+            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
+            "(project_id = {entity_id:String} AND project_key = {entity_id:String})",
+        ),
+        "repos authorization arm": (
+            "    toString(repo_id) = '00000000-0000-0000-0000-000000000000'\n"
+            "    OR toString(repo_id) IN (\n"
+            "      SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}\n"
+            "    )\n",
+            "    1 = 1\n",
+        ),
+        "repository-less sentinel arm": (
+            "    toString(repo_id) = '00000000-0000-0000-0000-000000000000'\n    OR ",
+            "    ",
+        ),
+    }
+
+    correct: tuple[list[str], list[str]] = (seeded.expected, [])
+    survived: list[str] = []
+    for label, (original, mutated) in mutants.items():
+        assert original in PROJECT_REPOSITORIES_SQL, f"stale mutant anchor: {label}"
+        sql = PROJECT_REPOSITORIES_SQL.replace(original, mutated, 1)
+        if await _probes(sink, sql, seeded) == correct:
+            survived.append(label)
+    assert not survived, (
+        "these clauses do not affect the real result, so the assertion above "
+        f"cannot be catching them: {sorted(survived)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_snapshot_reads_its_work_items_live(
+    sink: Any, seeded: Any
+) -> None:
+    """The whole path: real catalog, real resolver, real SQL, real engine."""
+
+    service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+    resolution = await service.resolve_contract(
+        seeded.org_id,
+        "permission-live",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.PROJECT, seeded.project_id),)
+        ),
+    )
+    assert resolution.outcome.value == "exact"
+    scope = resolution.resolved_scope
+    assert scope is not None
+    assert scope.repositories == []
+    assert scope.entity_refs[0].repository_id is None
+
+    snapshot = await StatusChangeService(
+        ClickHouseStatusChangeSource(sink)
+    ).status_snapshot(seeded.org_id, "permission-live", StatusSnapshotRequest(scope))
+
+    assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    seen = {child.entity_id for child in snapshot.children}
+    assert any(child.endswith("LIVE-1") for child in seen), seen
+    assert any(child.endswith("LIVE-3") for child in seen), seen
+    assert not any(child.endswith("LIVE-5") for child in seen), (
+        "a repository absent from the authorization catalog reached the read",
+        seen,
+    )
+    assert not any(child.endswith("LIVE-6") for child in seen), (
+        "another tenant's work item reached the read",
+        seen,
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_project_scope_is_fail_closed_live(
+    sink: Any, seeded: Any, raw_client: Any
+) -> None:
+    """No project SQL arm applies a team filter, so the request is refused."""
+
+    raw_client.command(
+        "INSERT INTO teams (id, name, provider, is_active, updated_at, "
+        "last_synced, org_id) VALUES ({team_id:String}, 'Team A', 'linear', 1, "
+        "now64(3), now64(3), {org_id:String})",
+        parameters={"team_id": "team-live-a", "org_id": seeded.org_id},
+    )
+    try:
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_contract(
+            seeded.org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, seeded.project_id),),
+                team_filter_refs=(ScopeRef(EntityKind.TEAM, "team-live-a"),),
+            ),
+        )
+        scope = resolution.resolved_scope
+        assert scope is not None
+        assert scope.team_ids == ["team-live-a"]
+
+        snapshot = await StatusChangeService(
+            ClickHouseStatusChangeSource(sink)
+        ).status_snapshot(
+            seeded.org_id, "permission-live", StatusSnapshotRequest(scope)
+        )
+
+        assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+        assert snapshot.children == ()
+    finally:
+        raw_client.command(
+            "ALTER TABLE teams DELETE WHERE org_id = {org_id:String}",
+            parameters={"org_id": seeded.org_id},
+        )

--- a/tests/api/dev/test_project_scope_data_health.py
+++ b/tests/api/dev/test_project_scope_data_health.py
@@ -1,0 +1,257 @@
+"""Project data-health must measure the project, not the organization.
+
+``NativeDataHealthReader._watermark`` filters with
+``AND (empty({repository_ids}) OR toString(repo_id) IN {repository_ids})``, and
+``DataHealthService`` then falls back to ``observation.relevant_repository_ids``
+when the scope contributed none. A committed PROJECT subject carries no
+repository dimension at all, so both behaviors combined measured every
+repository in the organization and reported the result as the project's
+coverage -- and because source health is a *mandatory* source of the project
+status plan, unrelated healthy repositories could make a project's evidence
+coverage read complete.
+
+Codex adversarial review (HIGH, 2026-08-03). The reader now resolves the same
+repository set the status/change reader derives, from the same shared
+``PROJECT_REPOSITORIES_SQL``, or fails closed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev import data_health_service
+from dev_health_ops.api.dev.data_health_service import NativeDataHealthReader
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ResolvedTimeRange,
+    ScopeResolution,
+    ScopeResolutionOutcome,
+)
+
+NOW = datetime(2026, 8, 4, tzinfo=UTC)
+ORG_ID = "org-under-test"
+PROJECT_ID = "13e65c04-40ec-4a95-8216-f7c2ce233244"
+PROJECT_REPOSITORY_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+UNRELATED_REPOSITORY_ID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+
+def _time_range() -> ResolvedTimeRange:
+    return ResolvedTimeRange(
+        "UTC",
+        NOW - timedelta(days=30),
+        NOW,
+        (NOW - timedelta(days=30)).isoformat(),
+        NOW.isoformat(),
+        NOW - timedelta(days=60),
+        NOW - timedelta(days=30),
+        (NOW - timedelta(days=60)).isoformat(),
+        (NOW - timedelta(days=30)).isoformat(),
+    )
+
+
+def _project_resolution(*, team_filter: bool = False) -> ScopeResolution:
+    """A committed project subject, in the shape the resolver produces.
+
+    ``repository_id=None`` is not an arbitrary choice: the catalog's project
+    query selects ``NULL AS repository_id``, so this is the only shape a
+    project commit can have.
+    """
+
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(AuthorizedEntity(EntityKind.PROJECT, PROJECT_ID, "Ask Dev", None),),
+        team_filters=(
+            (AuthorizedEntity(EntityKind.TEAM, "team-a", "Team A", None),)
+            if team_filter
+            else ()
+        ),
+        candidates=(),
+        time_range=_time_range(),
+    )
+
+
+def _repository_resolution() -> ScopeResolution:
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(
+            AuthorizedEntity(
+                EntityKind.REPOSITORY,
+                PROJECT_REPOSITORY_ID,
+                "org/repo",
+                PROJECT_REPOSITORY_ID,
+            ),
+        ),
+        team_filters=(),
+        candidates=(),
+        time_range=_time_range(),
+    )
+
+
+class _FakeClient:
+    """Answers the three query shapes ``NativeDataHealthReader`` issues."""
+
+    def __init__(self, *, derived: list[str] | None, fail: bool = False) -> None:
+        self.derived = derived
+        self.fail = fail
+        self.watermark_params: list[dict[str, Any]] = []
+        self.org_wide_enumerated = False
+
+    async def __call__(
+        self, _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM work_items FINAL" in sql and "SELECT DISTINCT" in sql:
+            if self.fail:
+                raise RuntimeError("clickhouse unavailable")
+            return [{"repository_id": value} for value in (self.derived or [])]
+        if "groupUniqArray(toString(id))" in sql:
+            # The org-wide fallback: reaching it for a project scope is the
+            # bug, so record rather than merely serve it.
+            self.org_wide_enumerated = True
+            return [
+                {
+                    "repository_ids": [
+                        PROJECT_REPOSITORY_ID,
+                        UNRELATED_REPOSITORY_ID,
+                    ]
+                }
+            ]
+        self.watermark_params.append(dict(params))
+        return [
+            {
+                "watermark": NOW - timedelta(hours=1),
+                "covered_repository_ids": list(params.get("repository_ids") or []),
+            }
+        ]
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, client: _FakeClient) -> None:
+    monkeypatch.setattr(data_health_service, "query_dicts", client)
+
+
+@pytest.mark.asyncio
+async def test_project_data_health_is_bound_to_the_projects_repositories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient(derived=[PROJECT_REPOSITORY_ID])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert [params["repository_ids"] for params in client.watermark_params] == [
+        [PROJECT_REPOSITORY_ID]
+    ]
+    assert not client.org_wide_enumerated
+    assert observations[0].relevant_repository_ids == (PROJECT_REPOSITORY_ID,)
+    assert UNRELATED_REPOSITORY_ID not in observations[0].relevant_repository_ids
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_project_repositories_fail_closed_not_org_wide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty derivation is a refusal, never "measure everything instead"."""
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    # ``configured is None`` is what DataHealthService maps to
+    # DataHealthState.UNAVAILABLE -- an explicit "not measured for this
+    # subject", never a silent organization-wide substitute.
+    assert observations[0].configured is None
+    assert observations[0].warning == "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_failed_project_derivation_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient(derived=None, fail=True)
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert not client.org_wide_enumerated
+    assert observations[0].configured is None
+    assert observations[0].warning == "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_project_data_health_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No data-health query applies a team filter either."""
+
+    client = _FakeClient(derived=[PROJECT_REPOSITORY_ID])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(team_filter=True),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert observations[0].configured is None
+    assert observations[0].warning == "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_repository_scope_behaviour_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: only the no-repository PROJECT case changed."""
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_repository_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert [params["repository_ids"] for params in client.watermark_params] == [
+        [PROJECT_REPOSITORY_ID]
+    ]
+    assert observations[0].warning != "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_acr_stays_optional_for_an_unresolvable_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-closed arm must not swallow acr's own optional semantics."""
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["acr", "work_items"],
+    )
+
+    by_source = {item.source_system: item for item in observations}
+    assert by_source["acr"].warning == "acr_optional"
+    assert by_source["acr"].required is False
+    assert by_source["work_items"].warning == "project_repository_scope_unavailable"

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -174,7 +174,7 @@ class _FakeWorkItems:
 
     A canned-answer fake makes the ``org_id`` / ``as_of`` / ``project_key`` /
     ``repos`` predicates unfalsifiable -- deleting any of them from
-    ``_PROJECT_REPOSITORIES_SQL`` would still return the same rows. This reads
+    ``PROJECT_REPOSITORIES_SQL`` would still return the same rows. This reads
     which predicates the SQL under test actually contains and applies exactly
     those, so a dropped predicate changes the derived repository set and a
     test fails.
@@ -251,7 +251,9 @@ class _FakeWorkItems:
         raise AssertionError("the work-item read was never issued")
 
 
-def _install_catalog_client(monkeypatch: pytest.MonkeyPatch) -> None:
+def _install_catalog_client(
+    monkeypatch: pytest.MonkeyPatch, *, project_id: str = PROJECT_ID
+) -> None:
     """Serve the real catalog SQL the shapes production ClickHouse returns."""
 
     async def fake_query(
@@ -262,7 +264,7 @@ def _install_catalog_client(monkeypatch: pytest.MonkeyPatch) -> None:
         if "FROM projects FINAL" in sql:
             return [
                 {
-                    "canonical_id": PROJECT_ID,
+                    "canonical_id": project_id,
                     "label": PROJECT_NAME,
                     # The production SQL selects ``NULL AS repository_id`` --
                     # pinned by test_catalog_project_rows_carry_no_repository.
@@ -290,7 +292,9 @@ def _install_status_client(monkeypatch: pytest.MonkeyPatch) -> _FakeWorkItems:
     return fake
 
 
-async def _committed_project_scope(*, team_filter: str | None = None) -> Any:
+async def _committed_project_scope(
+    *, team_filter: str | None = None, project_id: str = PROJECT_ID
+) -> Any:
     """The committed scope, from the real producer -- never hand-built."""
 
     service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(object()))
@@ -298,7 +302,7 @@ async def _committed_project_scope(*, team_filter: str | None = None) -> Any:
         ORG_ID,
         "permission-fingerprint",
         ScopeResolveRequest(
-            explicit_refs=(ScopeRef(EntityKind.PROJECT, PROJECT_ID),),
+            explicit_refs=(ScopeRef(EntityKind.PROJECT, project_id),),
             team_filter_refs=(
                 () if team_filter is None else (ScopeRef(EntityKind.TEAM, team_filter),)
             ),
@@ -339,7 +343,7 @@ def test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do() -> No
     project_predicate = (
         "project_id = {entity_id:String} OR project_key = {entity_id:String}"
     )
-    assert project_predicate in native_status_change._PROJECT_REPOSITORIES_SQL
+    assert project_predicate in native_status_change.PROJECT_REPOSITORIES_SQL
     assert project_predicate in native_status_change._WORK_ITEMS_SQL
 
 
@@ -351,7 +355,7 @@ def test_derivation_sql_structure_is_pinned() -> None:
     which change real ClickHouse results. Assert them on the SQL text itself.
     """
 
-    sql = native_status_change._PROJECT_REPOSITORIES_SQL
+    sql = native_status_change.PROJECT_REPOSITORIES_SQL
 
     # The project arms are one parenthesised disjunction, not a conjunction:
     # a Jira row matches by key and a Linear row by id, never both at once, so
@@ -472,10 +476,79 @@ async def test_repository_revoked_from_the_catalog_is_never_admitted(
     bound = fake.work_item_read_params()["repository_ids"]
     assert REVOKED_REPOSITORY_ID not in bound
     assert "linear:REVOKED-1" not in {child.entity_id for child in snapshot.children}
-    # ...while the repository-less sentinel, which has no ``repos`` row and
-    # never will, is still admitted -- otherwise the catalog check would have
-    # re-broken every Linear project.
-    assert LINEAR_NO_REPOSITORY_ID in bound
+
+
+@pytest.mark.asyncio
+async def test_repository_less_sentinel_is_admitted_without_a_repos_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The zero UUID's exception, asserted apart from the revocation rule.
+
+    Deliberately a separate test from the revoked-repository one above: they
+    pull in opposite directions on the same predicate, and a single test
+    asserting both would still pass if the two arms were merged into one
+    wrong rule. The sentinel has no ``repos`` row and never will (it is what
+    the sink writes when a record has no repository at all), so a bare
+    existence check would re-break every Linear project.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert LINEAR_NO_REPOSITORY_ID not in REPOS_CATALOG[ORG_ID]
+    assert LINEAR_NO_REPOSITORY_ID in fake.work_item_read_params()["repository_ids"]
+    assert {"linear:CHAOS-3367", "linear:CHAOS-3368"} <= {
+        child.entity_id for child in snapshot.children
+    }
+
+
+@pytest.mark.asyncio
+async def test_jira_shaped_project_keeps_todays_fail_closed_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new arm is provider-scoped by construction, and discloses it.
+
+    ``team_autoimport_jira._project_id`` mints a Jira project's catalog id as
+    ``f"{org_id}:jira:{project_key}"``, while ``providers/jira/normalize``
+    writes the *raw* Jira id and key onto ``work_items``. Neither
+    ``project_id = {entity_id}`` nor ``project_key = {entity_id}`` matches --
+    and ``_WORK_ITEMS_SQL``/``_BLOCKERS_SQL``/``_PULL_REQUESTS_SQL`` already
+    share that identical predicate, so Jira project subjects were, and remain,
+    unanswerable end to end.
+
+    Making *only* the derivation provider-aware would be strictly worse than
+    leaving it: it would derive repositories, the fact queries would still
+    match nothing, and the run would report a confident empty answer for a
+    project that has data instead of the disclosed fail-closed one. So the
+    derivation shares the fact queries' predicate exactly, which keeps Jira on
+    today's honest refusal. Asserted here so that stays a decision rather than
+    an accident.
+    """
+
+    jira_project_id = f"{ORG_ID}:jira:ASK"
+    _install_catalog_client(monkeypatch, project_id=jira_project_id)
+    scope = await _committed_project_scope(project_id=jira_project_id)
+    assert scope.entity_refs[0].entity_id == jira_project_id
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    # Disclosed refusal, not a confident empty: the warning is the whole point.
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+    assert not any("parent_id" in sql for sql in fake.sql), (
+        "no fact query may run on a repository set that was never resolved"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -15,13 +15,13 @@ from dev_health_ops.api.dev.native_status_change import (
     _DEPLOYMENTS_SQL,
     _INCIDENT_CHANGES_SQL,
     _INCIDENTS_SQL,
-    _PROJECT_REPOSITORIES_SQL,
     _PULL_REQUEST_CHANGES_SQL,
     _PULL_REQUESTS_SQL,
     _RELATIONSHIPS_SQL,
     _REVIEW_CHANGES_SQL,
     _TRANSITIONS_SQL,
     _WORK_ITEMS_SQL,
+    PROJECT_REPOSITORIES_SQL,
 )
 
 CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
@@ -105,7 +105,7 @@ def test_status_change_query_parses_against_production_schema(
 def test_project_repository_derivation_parses_against_production_schema(
     ch_client: Any,
 ) -> None:
-    """Real-engine validation for ``_PROJECT_REPOSITORIES_SQL``.
+    """Real-engine validation for ``PROJECT_REPOSITORIES_SQL``.
 
     Codex adversarial review (MEDIUM, 2026-08-03): the unit fake for this
     query is a predicate evaluator, not a SQL engine, so nothing else proves
@@ -117,7 +117,7 @@ def test_project_repository_derivation_parses_against_production_schema(
     deliberately has none.
     """
 
-    sql = _PROJECT_REPOSITORIES_SQL
+    sql = PROJECT_REPOSITORIES_SQL
     assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
     assert "LIMIT" not in sql.upper(), "an authorization set must not be truncated"
     params: dict[str, object] = {


### PR DESCRIPTION
Follow-up to #1452, which was merged while these were in flight — so the reviewer-prescribed fixes below are **not** in it.

Rulings applied, one per finding.

## 1. Team filters — done in #1452

A committed PROJECT scope may carry `team_ids` and no project SQL arm applies a team filter, so it now fails closed rather than answering "project P, team A only" with team B's work. Landed in #1452; noted here for completeness.

**Follow-up scope (not this PR):** canonical team attribution *inside* the project queries, so a team-filtered project can be answered instead of refused.

## 2. Jira identity — went provider-scoped, deliberately

The ruling allowed provider-aware matching only if it stayed clean and small. It is not just bigger — **on its own it is wrong.**

`_WORK_ITEMS_SQL`, `_BLOCKERS_SQL` and `_PULL_REQUESTS_SQL` all use the same `project_id = {entity_id} OR project_key = {entity_id}` predicate the derivation does. `team_autoimport_jira._project_id` mints a Jira project's catalog id as `f"{org_id}:jira:{project_key}"`, while `providers/jira/normalize` writes the *raw* Jira id and key onto `work_items`, so none of them match. Making only the derivation Jira-aware would resolve repositories and then have every fact query return nothing — turning today's **disclosed fail-closed** answer into a **confident empty** one for a project that has data. That is strictly worse than the status quo.

So the derivation shares the fact queries' predicate exactly, which is what keeps Jira on its current honest refusal. The property is documented at the SQL and asserted by `test_jira_shaped_project_keeps_todays_fail_closed_behaviour`, so it stays a decision rather than an accident. **No regression; ready for the Jira ticket** — which needs a coordinated provider-aware change across every project arm at once.

## 3. Unauthorized repository ids — done in #1452, tests now split

Nonzero repository ids require a current org-scoped `repos` match; the zero UUID is an explicit, commented exception (it is not a repository but the sentinel the sink writes for repository-less records — every Linear work item). Per the ruling the two cases are now **separate tests**: they pull in opposite directions on the same predicate, and one combined test would still pass if the arms were merged into a single wrong rule.

## 4. Data-health widening — targeted fix only

`NativeDataHealthReader` now resolves a project's repositories through the same shared `PROJECT_REPOSITORIES_SQL` (made public — one source of truth rather than two that can drift), and fails closed with `project_repository_scope_unavailable` when the derivation is empty, failed, or team-filtered. Previously the empty list hit `AND (empty({repository_ids}) OR …)`, which disables repository filtering entirely, and the service then used the whole organization as the coverage denominator — so unrelated healthy repositories could make a mandatory source read complete for a project.

`acr` keeps its own optional semantics through the new arm (asserted). The shared typed authorization service across all readers remains a refactor ticket.

## 5. Dishonest fake — real-engine oracle

New `tests/api/dev/test_project_scope_clickhouse_live.py` (`clickhouse`-marked) executes the derivation against a **real migrated ClickHouse** over rows written by the **real Linear normalizer and sink**: Linear zero-UUID, `project_key` attribution, a repository revoked from `repos`, a foreign tenant, and an out-of-window row. It then **mutation-checks the real results** — seven mutant queries are executed and each must change the answer, so a green assertion cannot be one that could never have failed.

Verified by running it against a throwaway ClickHouse container. The dev stack was never written to; the suite's scratch-database guard is what stopped it, and it now *skips* with an explicit reason when `CLICKHOUSE_URI` points at a protected database instead of erroring — while the hard `RuntimeError` stays as the boundary.

### The oracle earned its keep immediately

It found that dropping the tenant bound from the derivation **does not change the derived repository set** — the `repos` arm masks it for every real repository, because a repository id is org-unique. The bound is load-bearing only in the repository-less sentinel bucket, which every tenant shares, and there the damage is not a wrong set but a wrong *outcome*: a project referenced only by another tenant would derive the sentinel and report a confident empty answer instead of failing closed. The oracle now probes both cases, and the mutant dies.

The same mutant had also survived earlier in the unit suite for an unrelated reason — a structural assertion that matched the `repos` sub-select's `org_id` rather than the fact table's. Both are fixed.

## Verification

- **Mutation: 19/19** across both modules (14 status/change, 5 data-health), plus **7/7 against the real engine**.
- `tests/api/dev` + `tests/api/graphql` + `tests/acceptance`: 2319 passed, 2 failed — both (`test_resolver_sql_explain.py::…[operating_review]`, `[analytics]`) reproduce identically on a clean `main` and are untouched here.
- Live suite on a scratch ClickHouse: 4 passed.
- ruff + mypy clean on the touched files.

Still open and unfixed, reported rather than half-fixed: Jira project subjects (finding 2 above), and `tests/api/dev/test_status_change_clickhouse_live.py` failing 10/13 on `main` because its shared fixture omits the `member_issue_ids` substitution — that live EXPLAIN guard has been validating nothing. The entry this PR adds to that file passes independently of the break.
