### PR TITLE
fix(ci): install locked httpx oracle dependencies

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -2,10 +2,16 @@
 # Keep direct imports and their transitives explicit: CI installs this file
 # with --no-deps so an undeclared dependency fails instead of drifting latest.
 annotated-types==0.7.0
+anyio==4.13.0
+certifi==2026.4.22
 defusedxml==0.7.1
 gitdb==4.0.12
 GitPython==3.1.54
 greenlet==3.5.0
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.15
 pydantic==2.13.4
 pydantic-core==2.46.4
 smmap==5.0.3

--- a/tests/test_go_live_oracle_ci.py
+++ b/tests/test_go_live_oracle_ci.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import tomllib
+import yaml
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "go.yml"
+REQUIREMENTS = ROOT / "ci" / "requirements-live-python-oracles.txt"
+LOCKFILE = ROOT / "uv.lock"
+
+
+def _canonical_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _locked_packages() -> dict[str, dict[str, Any]]:
+    lock = tomllib.loads(LOCKFILE.read_text(encoding="utf-8"))
+    return {
+        _canonical_name(str(package["name"])): package for package in lock["package"]
+    }
+
+
+def _locked_closure(root: str) -> dict[str, str]:
+    packages = _locked_packages()
+    pending = [_canonical_name(root)]
+    closure: dict[str, str] = {}
+    while pending:
+        name = pending.pop()
+        if name in closure:
+            continue
+        package = packages[name]
+        closure[name] = str(package["version"])
+        pending.extend(
+            _canonical_name(str(dependency["name"]))
+            for dependency in package.get("dependencies", [])
+        )
+    return closure
+
+
+def _pinned_requirements() -> dict[str, str]:
+    pins: dict[str, str] = {}
+    for raw_line in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, separator, version = line.partition("==")
+        assert separator, f"live-oracle requirement must be exactly pinned: {line}"
+        canonical_name = _canonical_name(name)
+        assert canonical_name not in pins, (
+            f"duplicate live-oracle requirement: {canonical_name}"
+        )
+        pins[canonical_name] = version
+    return pins
+
+
+def test_go_quality_bootstraps_locked_live_oracle_dependencies() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["go-quality"]["steps"]
+    commands = [str(step.get("run", "")).strip() for step in steps]
+
+    install = (
+        "python -m pip install --no-deps -r ci/requirements-live-python-oracles.txt"
+    )
+    quality_gate = "bash ci/check_go.sh all"
+    assert install in commands
+    assert commands.index(install) < commands.index(quality_gate)
+
+    pins = _pinned_requirements()
+    locked = _locked_packages()
+    for package, version in pins.items():
+        assert str(locked[package]["version"]) == version, (
+            f"live-oracle pin for {package} must match uv.lock"
+        )
+    for package, version in _locked_closure("httpx").items():
+        assert pins.get(package) == version, (
+            f"live Python oracles require locked {package}=={version}"
+        )


### PR DESCRIPTION
## Summary

- install the exact `uv.lock`-pinned `httpx` dependency closure for live Python oracles
- enforce workflow bootstrap ordering and dependency parity with a CI contract test
- restore the hosted `go-quality` path that failed on GitLab incidents PR #1447

## Root cause

The Go workflow installs the live-oracle requirements with `--no-deps`, but that requirements file omitted `httpx` and its transitive closure. The live production provider import therefore failed at `src/dev_health_ops/providers/_http.py` before the Python/Go oracle could run.

Linear: [CHAOS-3378](https://linear.app/fullchaos/issue/CHAOS-3378/go-quality-live-python-oracles-lack-httpx-in-workflow-environment)

## Validation

- regression test failed on the untouched baseline because `httpx` was missing
- isolated Python 3.13.14 `--no-deps` bootstrap succeeded
- `bash ci/check_go.sh live-python-oracles`
  - `internal/providersync`: passed
  - `internal/scheduler/sync`: passed
- focused pytest, Ruff, mypy, Go format/vet, and repository hooks passed
- rebased commit is signed

## Scope

This stack targets `feat/go-worker-runtime-migration` through its synchronization layer only. It does not change provider routing, deployment ownership, River cutover, scheduler ownership, or migration `0066`.
