### PR TITLE
feat(providersync): add GitHub PR review effects foundation

### DIFF
--- a/internal/providersync/github_pr_reviews.go
+++ b/internal/providersync/github_pr_reviews.go
@@ -1,0 +1,72 @@
+package providersync
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// pullRequestReviewRow mirrors the complete row written by
+// ClickHouseStore.insert_git_pull_request_reviews. It is deliberately kept
+// separate from pullRequestRow: D16 preserves Python's three-way unit boundary
+// even though the rows share a repository and pull-request identity.
+type pullRequestReviewRow struct {
+	RepoID      string    `json:"repo_id"`
+	Number      int       `json:"number"`
+	ReviewID    string    `json:"review_id"`
+	Reviewer    string    `json:"reviewer"`
+	State       string    `json:"state"`
+	SubmittedAt time.Time `json:"submitted_at"`
+	LastSynced  time.Time `json:"last_synced"`
+	SourceID    *string   `json:"source_id"`
+	OrgID       string    `json:"org_id"`
+}
+
+type gitHubReviewPayload struct {
+	ID          any             `json:"id"`
+	Reviewer    json.RawMessage `json:"author"`
+	State       any             `json:"state"`
+	SubmittedAt *string         `json:"submitted_at"`
+}
+
+func normalizeGitHubPullRequestReview(
+	claim Claim,
+	repoID string,
+	number int,
+	review gitHubReviewPayload,
+	createdAt time.Time,
+	normalizedAt time.Time,
+) (pullRequestReviewRow, error) {
+	reviewID := stringValue(review.ID)
+	reviewer := gitHubPullUserLogin(review.Reviewer)
+	if reviewer == "" {
+		reviewer = "Unknown"
+	}
+	state := stringValue(review.State)
+	submittedAt := parseGitHubPullTime(review.SubmittedAt)
+	if submittedAt == nil {
+		fallback := createdAt.UTC()
+		submittedAt = &fallback
+	}
+	row := pullRequestReviewRow{
+		RepoID: repoID, Number: number, ReviewID: reviewID,
+		Reviewer: reviewer, State: state, SubmittedAt: submittedAt.UTC(),
+		LastSynced: normalizedAt.UTC().Truncate(time.Millisecond), OrgID: claim.OrgID,
+	}
+	if err := row.validate(claim); err != nil {
+		return pullRequestReviewRow{}, err
+	}
+	return row, nil
+}
+
+func (row pullRequestReviewRow) validate(claim Claim) error {
+	if claim.Provider != "github" || claim.Dataset != "pr-reviews" ||
+		row.OrgID == "" || row.OrgID != claim.OrgID || len(row.RepoID) != 36 ||
+		row.Number < 1 || row.ReviewID == "" || row.Reviewer == "" ||
+		row.State == "" || row.SubmittedAt.IsZero() || row.LastSynced.IsZero() ||
+		row.SourceID != nil {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}

--- a/internal/providersync/github_pr_reviews_effects_clickhouse.go
+++ b/internal/providersync/github_pr_reviews_effects_clickhouse.go
@@ -1,0 +1,158 @@
+package providersync
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubPullRequestReviewClickHouseEffects is the non-routed persistence
+// foundation for github/pr-reviews. Both write and FINAL readback are guarded
+// by the authoritative unit lease; wiring this sink does not activate a route.
+type GitHubPullRequestReviewClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubPullRequestReviewClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "pr-reviews" ||
+		effect.Destination != "git_pull_request_reviews" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pullRequestReviewRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_pull_request_reviews (
+  repo_id, number, review_id, reviewer, state, submitted_at,
+  last_synced, source_id, org_id
+)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.RepoID, row.Number, row.ReviewID, row.Reviewer, row.State,
+			row.SubmittedAt, row.LastSynced, row.SourceID, row.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubPullRequestReviewClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || sink.Conn == nil ||
+		claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "pr-reviews" || effect.Destination != "git_pull_request_reviews" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pullRequestReviewRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+		inspection, err := sink.inspectReview(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink GitHubPullRequestReviewClickHouseEffects) inspectReview(
+	ctx context.Context, expected pullRequestReviewRow,
+) (EffectInspection, error) {
+	var actual pullRequestReviewRow
+	rows, err := sink.Conn.Query(ctx, `
+SELECT reviewer, state, submitted_at, last_synced, source_id, org_id
+FROM git_pull_request_reviews FINAL
+WHERE org_id = ? AND repo_id = ? AND number = ? AND review_id = ?`,
+		expected.OrgID, expected.RepoID, expected.Number, expected.ReviewID,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		if found {
+			return EffectConflict, nil
+		}
+		if err := rows.Scan(
+			&actual.Reviewer, &actual.State, &actual.SubmittedAt,
+			&actual.LastSynced, &actual.SourceID, &actual.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	if !found {
+		return EffectAbsent, nil
+	}
+	if actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent, nil
+	}
+	if !actual.LastSynced.UTC().Equal(expected.LastSynced.UTC()) ||
+		actual.Reviewer != expected.Reviewer || actual.State != expected.State ||
+		!actual.SubmittedAt.UTC().Equal(expected.SubmittedAt.UTC()) ||
+		actual.SourceID != nil || actual.OrgID != expected.OrgID {
+		return EffectConflict, nil
+	}
+	return EffectExact, nil
+}
+
+var _ EffectSink = GitHubPullRequestReviewClickHouseEffects{}
+var _ EffectReadback = GitHubPullRequestReviewClickHouseEffects{}

--- a/internal/providersync/github_pr_reviews_effects_integration_test.go
+++ b/internal/providersync/github_pr_reviews_effects_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const gitPullRequestReviewsDDL = `CREATE TABLE git_pull_request_reviews (org_id String, repo_id UUID, number UInt32, review_id String, reviewer String, state String, submitted_at DateTime64(3, 'UTC'), last_synced DateTime64(3, 'UTC'), source_id Nullable(UUID)) ENGINE = ReplacingMergeTree(last_synced) ORDER BY (org_id, repo_id, number, review_id)`
+
+func TestGitHubPullRequestReviewEffectsAreNonEmptyTenantFencedAndLeaseGuarded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close(ctx)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.Exec(ctx, gitPullRequestReviewsDDL); err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("github", "pr-reviews")
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	row := pullRequestReviewRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		Number: 42, ReviewID: "9007199254740993", Reviewer: "octocat",
+		State: "APPROVED", SubmittedAt: now.Add(-time.Hour), LastSynced: now,
+	}
+	effect, err := effectBatchFromValues(
+		"git_pull_request_reviews", EffectReadbackRequired, []pullRequestReviewRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safe := GitHubPullRequestReviewClickHouseEffects{
+		Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if inspection, err := safe.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty inspection=%s err=%v", inspection, err)
+	}
+
+	leaseLost := errors.New("lease lost before send")
+	assertions := 0
+	guarded := GitHubPullRequestReviewClickHouseEffects{
+		Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			assertions++
+			if assertions == 2 {
+				return leaseLost
+			}
+			return nil
+		}),
+	}
+	if err := guarded.WriteEffect(ctx, claim, effect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("write after lost lease err=%v assertions=%d", err, assertions)
+	}
+	if inspection, err := safe.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("lost-lease write became visible: inspection=%s err=%v", inspection, err)
+	}
+	if err := safe.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := safe.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("persisted inspection=%s err=%v", inspection, err)
+	}
+
+	foreign := row
+	foreign.OrgID = "other-org"
+	foreign.LastSynced = now.Add(time.Minute)
+	foreignClaim := claim
+	foreignClaim.OrgID = foreign.OrgID
+	foreignEffect, err := effectBatchFromValues(
+		"git_pull_request_reviews", EffectReadbackRequired, []pullRequestReviewRow{foreign},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := safe.WriteEffect(ctx, foreignClaim, foreignEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := safe.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign newer row crossed tenant fence: inspection=%s err=%v", inspection, err)
+	}
+}

--- a/internal/providersync/github_pr_reviews_generic_oracle_test.go
+++ b/internal/providersync/github_pr_reviews_generic_oracle_test.go
@@ -1,0 +1,82 @@
+package providersync
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+var oracleReviewClaim = Claim{Unit: Unit{
+	OrgID: "org-oracle", Provider: "github", Dataset: "pr-reviews",
+	SourceExternalID: "octo/widgets",
+}}
+
+var oracleReviewNormalizedAt = time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+
+func oracleReviewCases() []oracleCase {
+	return []oracleCase{
+		{ID: "approved", Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "number": 42,
+			"created_at": "2026-07-10T09:00:00Z",
+			"review":     map[string]any{"id": 9007199254740993, "reviewer": "octocat", "state": "APPROVED", "submitted_at": "2026-07-11T10:30:00Z"},
+		}},
+		{ID: "fallback_time_and_reviewer", Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "number": 7,
+			"created_at": "2026-07-12T09:00:00Z",
+			"review":     map[string]any{"id": "R_kwDO", "reviewer": nil, "state": "CHANGES_REQUESTED", "submitted_at": nil},
+		}},
+	}
+}
+
+func buildReviewRowForOracle(t *testing.T, input map[string]any) pullRequestReviewRow {
+	t.Helper()
+	reviewMap := input["review"].(map[string]any)
+	wire := map[string]any{
+		"id": reviewMap["id"], "author": map[string]any{"login": reviewMap["reviewer"]},
+		"state": reviewMap["state"], "submitted_at": reviewMap["submitted_at"],
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(encoded)))
+	decoder.UseNumber()
+	var payload gitHubReviewPayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	created, err := time.Parse(time.RFC3339, input["created_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizeGitHubPullRequestReview(
+		oracleReviewClaim, input["repo_id"].(string), int(input["number"].(int)),
+		payload,
+		created, oracleReviewNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func TestGitHubPullRequestReviewRowMatchesLivePythonProducer(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/prreviews/row", oracleReviewCases(), buildReviewRowForOracle,
+		map[string]string{
+			"last_synced": "stamped from the frozen native normalizedAt",
+			"source_id":   "native provider effects never set external-ingest source_id",
+			"org_id":      "stamped from the authoritative unit claim",
+		},
+	)
+}
+
+func TestNormalizeGitHubPullRequestReviewFailsClosed(t *testing.T) {
+	row, err := normalizeGitHubPullRequestReview(
+		oracleReviewClaim, "", 0, gitHubReviewPayload{}, time.Time{}, time.Time{},
+	)
+	if err == nil || row != (pullRequestReviewRow{}) {
+		t.Fatalf("row=%+v err=%v", row, err)
+	}
+}

--- a/internal/providersync/testdata/oracle_pairs/github_prreviews_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prreviews_row.py
@@ -1,0 +1,72 @@
+"""Live Python producer oracle for GitHub pull-request review rows."""
+
+from __future__ import annotations
+
+import pathlib
+from types import SimpleNamespace
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
+_MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+_FETCH_UTILS_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/fetch_utils.py"
+
+
+class _Row:
+    def __init__(self, **values: Any) -> None:
+        self.__dict__.update(values)
+
+
+class _ReviewClient:
+    def __init__(self, review: SimpleNamespace, number: int) -> None:
+        self._review = review
+        self._number = number
+
+    def iter_pr_reviews_batch(self, **_kwargs: Any):
+        yield self._number, (self._review,)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    github = load_live_module(_PROCESSOR_SOURCE)
+    fetch_utils = load_live_module(_FETCH_UTILS_SOURCE)
+    review = SimpleNamespace(**case["review"])
+    number = int(case["number"])
+    client = _ReviewClient(review, number)
+    github.GitPullRequestReview = _Row
+    github._coerce_datetime = fetch_utils.safe_parse_datetime
+    github._github_work_client_from_connector = lambda *_args, **_kwargs: client
+    github.drain_provider_usage = lambda _client: []
+    pr = SimpleNamespace(number=number, created_at=case["created_at"])
+    rows = github._enrich_prs_with_reviews_batch(
+        connector=object(),
+        owner="octo",
+        repo_name="widgets",
+        repo_id=case["repo_id"],
+        pr_objects=[pr],
+        raw_gh_prs=[pr],
+        ingestion_sink=object(),
+        loop=object(),
+        gate=object(),
+        usage_sink=[],
+    )
+    if len(rows) != 1:
+        raise RuntimeError(f"expected one non-empty review row, got {len(rows)}")
+    return vars(rows[0])
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/prreviews/row",
+        build_row=_build_row,
+        reflected_fields=lambda: class_annotated_field_names(
+            _MODEL_SOURCE.read_text(), "GitPullRequestReview"
+        ),
+        excluded_fields={
+            "last_synced": "SQLAlchemy default is materialized by the sink, not the producer",
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -753,7 +753,16 @@ def _target_feature_policy() -> None:
     _load_source_module("dev_health_ops.licensing.registry", _LICENSE_REGISTRY_SOURCE)
 
 
+def _target_fetch_utils() -> None:
+    _install_module("dev_health_ops.utils", {"BATCH_SIZE": 1000})
+
+
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
+    _FETCH_UTILS_SOURCE: (
+        "dev_health_ops.processors.fetch_utils",
+        _FETCH_UTILS_SOURCE,
+        _target_fetch_utils,
+    ),
     _BASE_GIT_SOURCE: (
         "dev_health_ops.processors.base_git",
         _BASE_GIT_SOURCE,


### PR DESCRIPTION
## Summary

- add the live Python differential oracle and typed Go normalizer for GitHub pull-request review rows
- add tenant-fenced `git_pull_request_reviews` ClickHouse write and `FINAL` readback effects
- prove lost-lease-before-send isolation, exact readback, and cross-tenant fencing against real ClickHouse

Linear: [CHAOS-3123 — Port GitHub sync-unit execution to Go](https://linear.app/fullchaos/issue/CHAOS-3123)

## Scope

This is the non-routed foundation layer for `github/pr-reviews`. It deliberately does not register or activate the route and does not change the provider matrix, deployment ownership, scheduler ownership, River cutover, or migration `0066`.

The remaining route stack is intentionally decomposed into:

1. bounded GraphQL fetch/pagination with provider-foundation retry and rate-budget parity
2. composition of the Python-equivalent shared `git_pull_requests` update plus review rows, including crash/retry proof
3. equivalent `pr-comments` support
4. joint matrix/switch/runtime registration for the PR social family

## Validation

- `go test -count=1 ./internal/providersync`
- `bash ci/check_go.sh live-python-oracles`
- `go vet ./internal/providersync`
- focused Docker-backed ClickHouse integration test
- Ruff format and check
- signed commit

The Python oracle executes the live `_enrich_prs_with_reviews_batch` producer and includes a review ID above JavaScript's exact-integer range plus fallback timestamp/reviewer behavior.
