### PR TITLE
feat(providersync): add GitHub PR review fetch foundation

### DIFF
--- a/internal/providersync/github_pr_reviews_fetch.go
+++ b/internal/providersync/github_pr_reviews_fetch.go
@@ -1,0 +1,347 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	gitHubPullRequestReviewBatchSize = 50
+	gitHubPullRequestReviewPageSize  = 100
+	gitHubPullRequestReviewMaxPages  = 100
+)
+
+// GitHubPullRequestReviewTarget is a PR already selected by the PR collector.
+// Reviews deliberately do not list PRs themselves: Python enriches the same
+// selected PR set after its REST PR traversal, and this foundation must not
+// become a second, independently watermarked git_pull_requests producer.
+type GitHubPullRequestReviewTarget struct {
+	Number    int
+	CreatedAt time.Time
+}
+
+// GitHubPullRequestReviewUsage is the safe, bounded accounting emitted by the
+// review fetch. It mirrors Python's pr_social GraphQL attribution without
+// retaining a query, response body, repository name, or credential detail.
+type GitHubPullRequestReviewUsage struct {
+	Transport    string
+	RouteFamily  string
+	Dimension    string
+	RequestCount int
+}
+
+// GitHubPullRequestReviewFetchIncomplete says the optional review enrichment
+// degraded before it established a complete result. Consumers must inspect
+// Incomplete rather than treating an empty Rows slice as a complete empty
+// review collection. Cause is intentionally the stable provider class (or a
+// fixed local reason), never the provider response/error text.
+type GitHubPullRequestReviewFetchIncomplete struct {
+	Cause string
+}
+
+// GitHubPullRequestReviewFetchResult is intentionally not CompleteRouteBatch:
+// this is a non-routed fetch foundation and cannot write effects, advance a
+// watermark, or assert route readiness. Rate limits, cancellation, and lease
+// loss return errors; other fetch failures return Incomplete to preserve the
+// Python optional-enrichment behavior without fabricating completeness.
+type GitHubPullRequestReviewFetchResult struct {
+	Rows       []pullRequestReviewRow
+	Evidence   FetchEvidence
+	Usage      GitHubPullRequestReviewUsage
+	Incomplete *GitHubPullRequestReviewFetchIncomplete
+}
+
+func (result GitHubPullRequestReviewFetchResult) Complete() bool {
+	return result.Incomplete == nil
+}
+
+// GitHubPullRequestReviewFetcher fetches the nested GraphQL reviews
+// connection for caller-selected PRs. MaxPages is a total GraphQL request
+// budget (initial alias batches plus per-PR continuation requests); zero uses
+// the bounded production default. repoID is derived by the caller's existing
+// repositoryIdentity path alongside PR selection, exactly as Python passes
+// repo_id into _enrich_prs_with_reviews_batch; this fetch never refetches repo
+// metadata or creates a competing repository-identity request.
+type GitHubPullRequestReviewFetcher struct {
+	MaxPages int
+}
+
+func (fetcher GitHubPullRequestReviewFetcher) Fetch(
+	ctx context.Context,
+	claim Claim,
+	client *providerfoundation.HTTPClient,
+	repoID string,
+	targets []GitHubPullRequestReviewTarget,
+	normalizedAt time.Time,
+) (GitHubPullRequestReviewFetchResult, error) {
+	result := GitHubPullRequestReviewFetchResult{
+		Evidence: FetchEvidence{Provider: "github", Dataset: "pr-reviews"},
+		Usage: GitHubPullRequestReviewUsage{
+			Transport: "graphql", RouteFamily: "pr_social", Dimension: BudgetGraphQLCost,
+		},
+	}
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "pr-reviews" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || client.Lease == nil || normalizedAt.IsZero() {
+		return GitHubPullRequestReviewFetchResult{}, ErrInvalidConfiguration
+	}
+	if len(targets) == 0 {
+		return result, nil
+	}
+	if len(repoID) != 36 {
+		return GitHubPullRequestReviewFetchResult{}, providerfoundation.ErrNormalizationInvalid
+	}
+	maxPages := fetcher.MaxPages
+	if maxPages == 0 {
+		maxPages = gitHubPullRequestReviewMaxPages
+	}
+	if maxPages < 1 || maxPages > gitHubPullRequestReviewMaxPages {
+		return GitHubPullRequestReviewFetchResult{}, ErrInvalidConfiguration
+	}
+	targetByNumber := make(map[int]GitHubPullRequestReviewTarget, len(targets))
+	for _, target := range targets {
+		if target.Number < 1 || target.CreatedAt.IsZero() {
+			return GitHubPullRequestReviewFetchResult{}, providerfoundation.ErrNormalizationInvalid
+		}
+		if _, duplicate := targetByNumber[target.Number]; duplicate {
+			return GitHubPullRequestReviewFetchResult{}, providerfoundation.ErrNormalizationInvalid
+		}
+		targetByNumber[target.Number] = target
+	}
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return GitHubPullRequestReviewFetchResult{}, err
+	}
+	counted := *client
+	counted.Doer = gitHubPullRequestReviewCountingDoer{
+		delegate: client.Doer, requests: &result.Evidence.Requests,
+		graphqlRequests: &result.Usage.RequestCount, graphqlPath: gitHubGraphQLPath(client),
+	}
+
+	numbers := make([]int, 0, len(targets))
+	for _, target := range targets {
+		numbers = append(numbers, target.Number)
+	}
+	for start := 0; start < len(numbers); start += gitHubPullRequestReviewBatchSize {
+		end := min(start+gitHubPullRequestReviewBatchSize, len(numbers))
+		connections, err := fetcher.fetchPage(ctx, &counted, owner, repository, numbers[start:end], nil, &result)
+		if err != nil {
+			return fetcher.finishFailure(result, err)
+		}
+		for _, number := range numbers[start:end] {
+			connection, ok := connections[number]
+			if !ok {
+				return fetcher.finishFailure(result, providerfoundation.ErrNormalizationInvalid)
+			}
+			if err := appendGitHubPullRequestReviewRows(&result, claim, repoID, targetByNumber[number], connection.Nodes, normalizedAt); err != nil {
+				return fetcher.finishFailure(result, err)
+			}
+			cursor := connection.PageInfo.EndCursor
+			for connection.PageInfo.HasNextPage {
+				if cursor == "" {
+					return fetcher.finishFailure(result, providerfoundation.ErrPaginationInvalid)
+				}
+				connections, err = fetcher.fetchPage(ctx, &counted, owner, repository, []int{number}, map[int]string{number: cursor}, &result)
+				if err != nil {
+					return fetcher.finishFailure(result, err)
+				}
+				connection, ok = connections[number]
+				if !ok {
+					return fetcher.finishFailure(result, providerfoundation.ErrNormalizationInvalid)
+				}
+				if err := appendGitHubPullRequestReviewRows(&result, claim, repoID, targetByNumber[number], connection.Nodes, normalizedAt); err != nil {
+					return fetcher.finishFailure(result, err)
+				}
+				next := connection.PageInfo.EndCursor
+				if connection.PageInfo.HasNextPage && next == cursor {
+					return fetcher.finishFailure(result, providerfoundation.ErrPaginationInvalid)
+				}
+				cursor = next
+			}
+		}
+	}
+	result.Evidence.Records = len(result.Rows)
+	return result, nil
+}
+
+// gitHubPullRequestReviewCountingDoer observes actual wire attempts, including
+// HTTPClient retries. Budget reservations remain owned by HTTPClient.Do (one
+// per logical call); this wrapper only provides the same actual-usage evidence
+// the Python instrumented GraphQL client drains on success and failure.
+type gitHubPullRequestReviewCountingDoer struct {
+	delegate        providerfoundation.HTTPDoer
+	requests        *int
+	graphqlRequests *int
+	graphqlPath     string
+}
+
+func (doer gitHubPullRequestReviewCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	*doer.requests++
+	if request.URL.EscapedPath() == doer.graphqlPath {
+		*doer.graphqlRequests++
+	}
+	return doer.delegate.Do(request)
+}
+
+func (fetcher GitHubPullRequestReviewFetcher) fetchPage(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	owner, repository string,
+	numbers []int,
+	after map[int]string,
+	result *GitHubPullRequestReviewFetchResult,
+) (map[int]gitHubPullRequestReviewConnection, error) {
+	maxPages := fetcher.MaxPages
+	if maxPages == 0 {
+		maxPages = gitHubPullRequestReviewMaxPages
+	}
+	if result.Evidence.Pages >= maxPages {
+		return nil, errGitHubPullRequestReviewPaginationCap
+	}
+	body, err := json.Marshal(map[string]any{
+		"query":     gitHubPullRequestReviewsQuery(numbers, after),
+		"variables": map[string]string{"owner": owner, "repo": repository},
+	})
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	response, err := client.Do(ctx, http.MethodPost, gitHubGraphQLPath(client), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	result.Evidence.Pages++
+	defer response.Body.Close()
+	decoder := json.NewDecoder(response.Body)
+	decoder.UseNumber()
+	var envelope gitHubPullRequestReviewGraphQLEnvelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, providerfoundation.ErrPaginationInvalid
+	}
+	if len(envelope.Errors) > 0 || envelope.Data.Repository == nil {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	connections := make(map[int]gitHubPullRequestReviewConnection, len(numbers))
+	for index, number := range numbers {
+		pull, ok := envelope.Data.Repository["pr"+strconv.Itoa(index)]
+		if !ok || pull.Number != number {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		connections[number] = pull.Reviews
+	}
+	return connections, nil
+}
+
+func (fetcher GitHubPullRequestReviewFetcher) finishFailure(
+	result GitHubPullRequestReviewFetchResult, err error,
+) (GitHubPullRequestReviewFetchResult, error) {
+	if errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) || isRateLimited(err) {
+		return result, err
+	}
+	result.Rows = nil
+	result.Evidence.Records = 0
+	result.Incomplete = &GitHubPullRequestReviewFetchIncomplete{Cause: gitHubPullRequestReviewFailureCause(err)}
+	return result, nil
+}
+
+func gitHubPullRequestReviewFailureCause(err error) string {
+	if errors.Is(err, errGitHubPullRequestReviewPaginationCap) {
+		return "pagination_cap"
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil {
+		return string(providerErr.Class)
+	}
+	return "invalid_response"
+}
+
+var errGitHubPullRequestReviewPaginationCap = errors.New("github pull request review pagination cap reached")
+
+type gitHubPullRequestReviewGraphQLEnvelope struct {
+	Data struct {
+		Repository map[string]gitHubPullRequestReviewGraphQLPull `json:"repository"`
+	} `json:"data"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+type gitHubPullRequestReviewGraphQLPull struct {
+	Number  int                               `json:"number"`
+	Reviews gitHubPullRequestReviewConnection `json:"reviews"`
+}
+
+type gitHubPullRequestReviewConnection struct {
+	Nodes    []gitHubPullRequestReviewGraphQLNode `json:"nodes"`
+	PageInfo struct {
+		HasNextPage bool   `json:"hasNextPage"`
+		EndCursor   string `json:"endCursor"`
+	} `json:"pageInfo"`
+}
+
+type gitHubPullRequestReviewGraphQLNode struct {
+	ID             any             `json:"id"`
+	DatabaseID     any             `json:"databaseId"`
+	FullDatabaseID any             `json:"fullDatabaseId"`
+	Author         json.RawMessage `json:"author"`
+	State          any             `json:"state"`
+	SubmittedAt    *string         `json:"submittedAt"`
+}
+
+func appendGitHubPullRequestReviewRows(
+	result *GitHubPullRequestReviewFetchResult,
+	claim Claim,
+	repoID string,
+	target GitHubPullRequestReviewTarget,
+	nodes []gitHubPullRequestReviewGraphQLNode,
+	normalizedAt time.Time,
+) error {
+	for _, node := range nodes {
+		payload := gitHubReviewPayload{
+			ID:          gitHubPullRequestReviewID(node),
+			Reviewer:    node.Author,
+			State:       node.State,
+			SubmittedAt: node.SubmittedAt,
+		}
+		row, err := normalizeGitHubPullRequestReview(claim, repoID, target.Number, payload, target.CreatedAt, normalizedAt)
+		if err != nil {
+			return err
+		}
+		result.Rows = append(result.Rows, row)
+	}
+	return nil
+}
+
+func gitHubPullRequestReviewID(node gitHubPullRequestReviewGraphQLNode) any {
+	for _, candidate := range []any{node.DatabaseID, node.FullDatabaseID, node.ID} {
+		if strings.TrimSpace(stringValue(candidate)) != "" {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func gitHubPullRequestReviewsQuery(numbers []int, after map[int]string) string {
+	aliases := make([]string, 0, len(numbers))
+	for index, number := range numbers {
+		cursor := any(nil)
+		if after != nil {
+			if value, ok := after[number]; ok {
+				cursor = value
+			}
+		}
+		encodedCursor, _ := json.Marshal(cursor)
+		aliases = append(aliases, fmt.Sprintf(
+			"pr%d: pullRequest(number: %d) { number reviews(first: %d, after: %s) { nodes { id databaseId fullDatabaseId state submittedAt author { login } } pageInfo { hasNextPage endCursor } } }",
+			index, number, gitHubPullRequestReviewPageSize, encodedCursor,
+		))
+	}
+	return "query($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { " + strings.Join(aliases, " ") + " } }"
+}

--- a/internal/providersync/github_pr_reviews_fetch_test.go
+++ b/internal/providersync/github_pr_reviews_fetch_test.go
@@ -1,0 +1,240 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitHubPullRequestReviewFetchDoer struct {
+	t             *testing.T
+	graphQLBodies []string
+	graphQLReply  []string
+	graphQLStatus []int
+	requests      int
+}
+
+func (doer *gitHubPullRequestReviewFetchDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests++
+	if request.URL.Path == "/repos/acme/api" {
+		return gitHubPullRequestReviewResponse(request, http.StatusOK, gitHubPullRequestRepoFixture), nil
+	}
+	if request.URL.Path != "/graphql" {
+		doer.t.Fatalf("unexpected request %s", request.URL.String())
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		doer.t.Fatal(err)
+	}
+	doer.graphQLBodies = append(doer.graphQLBodies, string(body))
+	index := len(doer.graphQLBodies) - 1
+	status := http.StatusOK
+	if index < len(doer.graphQLStatus) && doer.graphQLStatus[index] != 0 {
+		status = doer.graphQLStatus[index]
+	}
+	reply := `{"data":{"repository":{}}}`
+	if index < len(doer.graphQLReply) {
+		reply = doer.graphQLReply[index]
+	}
+	return gitHubPullRequestReviewResponse(request, status, reply), nil
+}
+
+func gitHubPullRequestReviewResponse(request *http.Request, status int, body string) *http.Response {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if status == http.StatusForbidden {
+		header.Set("X-RateLimit-Remaining", "0")
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader(body)), Request: request}
+}
+
+func gitHubPullRequestReviewFetchTarget() []GitHubPullRequestReviewTarget {
+	return []GitHubPullRequestReviewTarget{{
+		Number: 42, CreatedAt: time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC),
+	}}
+}
+
+const gitHubPullRequestReviewFetchRepoID = "c7198fbc-1945-3717-05d8-eb78866b4e79"
+
+func TestGitHubPullRequestReviewFetcherPaginatesAndReportsBoundedUsage(t *testing.T) {
+	doer := &gitHubPullRequestReviewFetchDoer{t: t, graphQLReply: []string{
+		`{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[{"databaseId":9007199254740993,"state":"APPROVED","submittedAt":"2026-07-11T10:30:00Z","author":{"login":"octocat"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`,
+		`{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[{"id":"R_kwDO","state":"CHANGES_REQUESTED","submittedAt":null,"author":null}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`,
+	}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	budget := &gitHubPullRequestReviewBudget{}
+	gate := &gitHubPullRequestReviewGate{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{Provider: "github", OrgID: "org-native", Host: "api.github.com", CostClass: "medium", Limit: 1, TTL: time.Minute}
+	client.Gate = gate
+
+	now := time.Date(2026, 8, 4, 12, 0, 0, 123456000, time.UTC)
+	result, err := (GitHubPullRequestReviewFetcher{MaxPages: 2}).Fetch(
+		context.Background(), nativeTestClaim("github", "pr-reviews"), client,
+		gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Complete() || result.Incomplete != nil {
+		t.Fatalf("result=%+v", result)
+	}
+	if result.Evidence.Requests != 2 || result.Evidence.Pages != 2 || result.Evidence.Records != 2 {
+		t.Fatalf("evidence=%+v", result.Evidence)
+	}
+	if result.Usage != (GitHubPullRequestReviewUsage{Transport: "graphql", RouteFamily: "pr_social", Dimension: BudgetGraphQLCost, RequestCount: 2}) {
+		t.Fatalf("usage=%+v", result.Usage)
+	}
+	if budget.acquires != 2 || budget.releases != 2 || gate.waits != 2 {
+		t.Fatalf("budget acquires=%d releases=%d gate waits=%d", budget.acquires, budget.releases, gate.waits)
+	}
+	queries := make([]string, 0, len(doer.graphQLBodies))
+	for _, body := range doer.graphQLBodies {
+		var envelope struct {
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		queries = append(queries, envelope.Query)
+	}
+	if len(queries) != 2 || !strings.Contains(queries[0], `reviews(first: 100, after: null)`) ||
+		!strings.Contains(queries[1], `after: "cursor-1"`) {
+		t.Fatalf("graphql bodies=%q", doer.graphQLBodies)
+	}
+	if result.Rows[0].ReviewID != "9007199254740993" || result.Rows[1].Reviewer != "Unknown" ||
+		!result.Rows[1].SubmittedAt.Equal(gitHubPullRequestReviewFetchTarget()[0].CreatedAt) {
+		t.Fatalf("rows=%+v", result.Rows)
+	}
+}
+
+func TestGitHubPullRequestReviewFetcherRateLimitPropagates(t *testing.T) {
+	doer := &gitHubPullRequestReviewFetchDoer{t: t, graphQLStatus: []int{http.StatusForbidden}, graphQLReply: []string{`{"message":"API rate limit exceeded"}`}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	result, err := (GitHubPullRequestReviewFetcher{}).Fetch(
+		context.Background(), nativeTestClaim("github", "pr-reviews"), client,
+		gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), time.Now(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("error=%v", err)
+	}
+	if result.Incomplete != nil || result.Usage.RequestCount != 1 || result.Evidence.Requests != 1 {
+		t.Fatalf("rate limit result lost partial usage=%+v", result)
+	}
+}
+
+func TestGitHubPullRequestReviewFetcherCountsRetriesButReservesOnce(t *testing.T) {
+	doer := &gitHubPullRequestReviewFetchDoer{t: t, graphQLStatus: []int{http.StatusServiceUnavailable}, graphQLReply: []string{
+		`{"message":"unavailable"}`,
+		`{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`,
+	}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	client.Retry.MaxAttempts = 2
+	budget := &gitHubPullRequestReviewBudget{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{Provider: "github", OrgID: "org-native", Host: "api.github.com", CostClass: "medium", Limit: 1, TTL: time.Minute}
+
+	result, err := (GitHubPullRequestReviewFetcher{}).Fetch(
+		context.Background(), nativeTestClaim("github", "pr-reviews"), client,
+		gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), time.Now(),
+	)
+	if err != nil || !result.Complete() {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	// The logical GraphQL POST acquires one budget reservation. HTTPClient
+	// retries that POST within the reservation, while usage records both actual
+	// GraphQL wire attempts.
+	if budget.acquires != 1 || budget.releases != 1 || result.Evidence.Requests != 2 ||
+		result.Usage.RequestCount != 2 || result.Evidence.Pages != 1 {
+		t.Fatalf("budget=%+v evidence=%+v usage=%+v", budget, result.Evidence, result.Usage)
+	}
+}
+
+func TestGitHubPullRequestReviewFetcherMarksNonRateFailuresIncomplete(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+		body   string
+		cause  string
+	}{
+		{name: "transient HTTP", status: http.StatusServiceUnavailable, body: `{"message":"unavailable"}`, cause: "transient"},
+		{name: "graphql errors", body: `{"data":{"repository":{}},"errors":[{"message":"schema changed"}]}`, cause: "invalid_response"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitHubPullRequestReviewFetchDoer{t: t, graphQLStatus: []int{test.status}, graphQLReply: []string{test.body}}
+			result, err := (GitHubPullRequestReviewFetcher{}).Fetch(
+				context.Background(), nativeTestClaim("github", "pr-reviews"),
+				gitHubPullRequestClient(t, doer, "https://api.github.com"),
+				gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), time.Now(),
+			)
+			if err != nil || result.Complete() || result.Incomplete == nil || result.Incomplete.Cause != test.cause ||
+				len(result.Rows) != 0 || result.Evidence.Records != 0 {
+				t.Fatalf("result=%+v error=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestGitHubPullRequestReviewFetcherReturnsTypedPaginationIncomplete(t *testing.T) {
+	doer := &gitHubPullRequestReviewFetchDoer{t: t, graphQLReply: []string{
+		`{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`,
+	}}
+	result, err := (GitHubPullRequestReviewFetcher{MaxPages: 1}).Fetch(
+		context.Background(), nativeTestClaim("github", "pr-reviews"),
+		gitHubPullRequestClient(t, doer, "https://api.github.com"),
+		gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), time.Now(),
+	)
+	if err != nil || result.Incomplete == nil || result.Incomplete.Cause != "pagination_cap" || result.Complete() {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}
+
+func TestGitHubPullRequestReviewFetcherChecksLeaseBeforeRequest(t *testing.T) {
+	doer := &gitHubPullRequestReviewFetchDoer{t: t}
+	client, err := providerfoundation.NewHTTPClient("github", "https://api.github.com", doer,
+		func(*http.Request) error { return nil }, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return providerfoundation.ErrLeaseLost }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := (GitHubPullRequestReviewFetcher{}).Fetch(
+		context.Background(), nativeTestClaim("github", "pr-reviews"), client,
+		gitHubPullRequestReviewFetchRepoID, gitHubPullRequestReviewFetchTarget(), time.Now(),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || doer.requests != 0 || result.Incomplete != nil {
+		t.Fatalf("result=%+v error=%v requests=%d", result, err, doer.requests)
+	}
+}
+
+type gitHubPullRequestReviewBudget struct{ acquires, releases int }
+
+func (budget *gitHubPullRequestReviewBudget) Acquire(_ context.Context, _ providerfoundation.BudgetKey) (providerfoundation.Reservation, error) {
+	budget.acquires++
+	return gitHubPullRequestReviewReservation{budget: budget}, nil
+}
+
+type gitHubPullRequestReviewReservation struct {
+	budget *gitHubPullRequestReviewBudget
+}
+
+func (reservation gitHubPullRequestReviewReservation) Release(context.Context) error {
+	reservation.budget.releases++
+	return nil
+}
+
+type gitHubPullRequestReviewGate struct{ waits int }
+
+func (gate *gitHubPullRequestReviewGate) Wait(context.Context) (time.Duration, error) {
+	gate.waits++
+	return 0, nil
+}
+func (gate *gitHubPullRequestReviewGate) Penalize(context.Context, time.Duration) error { return nil }

--- a/internal/providersync/testdata/mutation-plans/github_pr_reviews_fetch.json
+++ b/internal/providersync/testdata/mutation-plans/github_pr_reviews_fetch.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "name": "github/pr-reviews non-routed fetch foundation",
+  "build": ["go", "build", "./..."],
+  "mutations": [
+    {
+      "id": "pagination-cap-marks-incomplete",
+      "file": "internal/providersync/github_pr_reviews_fetch.go",
+      "find": "if result.Evidence.Pages >= maxPages {",
+      "replace": "if false {",
+      "rationale": "a bounded GraphQL review traversal that has another page must return the typed incomplete marker, never silently accept an unbounded collection",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewFetcherReturnsTypedPaginationIncomplete$", "./internal/providersync/"]]
+    },
+    {
+      "id": "rate-limit-propagates-not-degrades",
+      "file": "internal/providersync/github_pr_reviews_fetch.go",
+      "find": "|| isRateLimited(err) {",
+      "replace": "|| false {",
+      "rationale": "a GitHub rate limit carries retry and deferral semantics, so it must stay an error instead of becoming optional-enrichment incompleteness",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewFetcherRateLimitPropagates$", "./internal/providersync/"]]
+    },
+    {
+      "id": "lease-loss-propagates-not-degrades",
+      "file": "internal/providersync/github_pr_reviews_fetch.go",
+      "find": "if errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, context.Canceled) ||",
+      "replace": "if false || errors.Is(err, context.Canceled) ||",
+      "rationale": "a lost lease is control-plane loss before a provider request, never an optional provider failure that may be returned as an incomplete result",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewFetcherChecksLeaseBeforeRequest$", "./internal/providersync/"]]
+    },
+    {
+      "id": "non-rate-failure-has-explicit-marker",
+      "file": "internal/providersync/github_pr_reviews_fetch.go",
+      "find": "result.Incomplete = &GitHubPullRequestReviewFetchIncomplete{Cause: gitHubPullRequestReviewFailureCause(err)}",
+      "replace": "result.Incomplete = nil",
+      "rationale": "a swallowed non-rate failure must carry an explicit typed marker so an empty review list cannot be treated as complete or route-ready",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewFetcherMarksNonRateFailuresIncomplete$", "./internal/providersync/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- fetch GitHub pull-request reviews for the PR collector's already-selected targets
- batch up to 50 PR aliases per GraphQL request and page each review connection in bounded 100-row pages
- reuse `providerfoundation.HTTPClient` for lease, budget, gate, retry, and rate-limit behavior
- return an explicit typed incomplete result for degraded non-rate failures, preventing an empty result from masquerading as complete coverage
- account for actual GraphQL wire attempts, including retries, under the `pr_social` usage family

Linear: [CHAOS-3123 — Port GitHub sync-unit execution to Go](https://linear.app/fullchaos/issue/CHAOS-3123)

## Parity decisions

- accepts the caller-derived repository ID, exactly like Python `_enrich_prs_with_reviews_batch`; it does not refetch repository metadata
- HTTP rate limits propagate for retry/deferral
- HTTP-200 GraphQL application errors degrade to typed incomplete, matching the live Python `APIException` path
- partial rows are discarded when the fetch is incomplete

## Scope

This remains non-routed foundation code. It does not compose the shared `git_pull_requests` update, write effects, register/activate a provider route, change the matrix, or touch deployment ownership, scheduler ownership, River cutover, or migration `0066`.

## Validation

- focused GitHub review-fetch tests
- `bash ci/check_go.sh fmt`
- `bash ci/check_go.sh vet`
- `bash ci/check_go.sh live-python-oracles`
- shared mutation harness: 4/4 mutations killed and clean restore verified
- pre-push Ruff format/check and mypy
- signed commit
