### PR TITLE
fix(ask-dev): Jira project subjects resolve via provider-scoped catalog identity (CHAOS-3374)

### DIFF
--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -191,11 +191,38 @@ LIMIT {{limit:UInt32}}
 #: and uses ``INNER JOIN``: an unresolvable identity there means the derivation has
 #: nothing to derive, which IS the correct fail-closed answer (an empty repository
 #: set), not a silent bypass of the join.
+#:
+#: Codex adversarial review (MEDIUM, 2026-08-04), two findings against the first
+#: cut of this CTE, both fixed here rather than accepted as residual risk:
+#:
+#: 1. ``projects``' ReplacingMergeTree key is ``(org_id, provider, id)``, NOT
+#:    ``(org_id, id)`` -- ``id`` alone is only unique WITHIN one provider, not
+#:    across providers in the same org. A same-org, same-id row minted by two
+#:    different providers (today only a coincidence; nothing enforces cross-
+#:    provider id uniqueness) survives ``FINAL`` as TWO rows, since they differ
+#:    on the provider component of the key. The original ``LIMIT 1`` (no
+#:    ``ORDER BY``) would then pick one of them *nondeterministically*, and the
+#:    provider guard would faithfully protect the WRONG provider's identity.
+#:    Fixed by aggregating with no ``GROUP BY`` (the whole filtered set is one
+#:    implicit group) and admitting a result only when ``count() = 1`` --
+#:    exactly one row for this ``(org_id, id)``, at any provider. Two or more
+#:    (or zero) both correctly yield an empty CTE, which every call site above
+#:    already treats as an unresolvable identity (fail closed).
+#: 2. The authorized-entity catalog's own committing query
+#:    (``scope_catalog.ClickHouseAuthorizedEntityCatalog._query_for``,
+#:    ``EntityKind.PROJECT``) filters ``is_active = 1`` -- a project retired
+#:    AFTER a scope was committed against it (a newer ReplacingMergeTree row
+#:    with ``is_active = 0``) must not keep answering here just because this
+#:    CTE re-reads the same table without that filter. Added explicitly rather
+#:    than assumed from ``FINAL`` alone, since retirement is a data state
+#:    (``is_active``), not a version-ordering property ``FINAL`` enforces on
+#:    its own.
 _PROJECT_IDENTITY_CTE = """project AS (
-  SELECT provider AS catalog_provider, ifNull(project_key, '') AS catalog_project_key
+  SELECT any(provider) AS catalog_provider,
+         any(ifNull(project_key, '')) AS catalog_project_key
   FROM projects FINAL
-  WHERE org_id = {org_id:String} AND id = {entity_id:String}
-  LIMIT 1
+  WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
+  HAVING count() = 1
 )"""
 
 

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -155,24 +155,128 @@ ORDER BY m.node_type, m.node_id
 LIMIT {{limit:UInt32}}
 """
 
-_WORK_ITEMS_SQL = """
+#: CHAOS-3374: every project-scoped fact arm below (plus ``PROJECT_REPOSITORIES_SQL``)
+#: joins through the catalog's OWN ``projects`` row for ``{entity_id:String}`` instead
+#: of comparing ``work_items.project_id``/``project_key`` against the catalog id
+#: directly. The two are NOT the same value space for every provider:
+#: ``team_autoimport_jira._project_id`` mints a Jira project's catalog id as
+#: ``f"{org_id}:jira:{project_key}"`` (workers/team_autoimport_jira.py:106-107)
+#: while ``providers/jira/normalize.py:517-518`` writes the RAW Jira id/key onto
+#: ``work_items`` -- so ``project_id = {entity_id:String} OR project_key =
+#: {entity_id:String}`` can never match a Jira row: neither side of the OR is ever
+#: the prefixed catalog id. Linear's catalog id IS the raw ``work_items.project_id``
+#: (see ``team_autoimport_linear._linear_project_records``'s own docstring), which
+#: is why Linear worked and Jira didn't with the identical predicate.
+#:
+#: The fix resolves the catalog row's ``provider`` and (nullable) ``project_key``
+#: through this shared CTE and requires BOTH ``work_items.provider = catalog_provider``
+#: and (``work_items.project_id = {entity_id:String}`` OR the two raw
+#: ``project_key`` values match) -- so a Jira project matches by its own raw key, a
+#: Linear project keeps matching by the raw id it always used, and neither can ever
+#: match the other's rows even if a raw key/id value collided (``provider`` is a
+#: real ``work_items`` column -- CHAOS-3374 requires this explicitly: GitLab's own
+#: ``work_items.project_id`` is a bare repo full path, e.g. "group/project", which
+#: could otherwise coincidentally equal another provider's project id/key string in
+#: the same org). GitLab does not populate ``projects`` today -- no ``write_projects``
+#: call anywhere in ``workers/team_autoimport_gitlab.py`` (audited separately,
+#: CHAOS-3374) -- so a GitLab project subject remains unresolvable at scope-commit
+#: time and never reaches these queries at all; the provider guard here is defense
+#: in depth for whenever that lands, not a fix for an observed GitLab collision.
+#:
+#: ``LEFT JOIN`` (every arm that also serves 'issue'/'work_unit'/'team'/
+#: 'organization'/'repository' scope types): a project-identity lookup miss must
+#: never blank out those OTHER scope types' rows -- only the project arm's own
+#: predicate is gated (``ifNull(catalog_provider, '') != ''`` in
+#: ``_project_identity_match``). ``PROJECT_REPOSITORIES_SQL`` is project-scope-only
+#: and uses ``INNER JOIN``: an unresolvable identity there means the derivation has
+#: nothing to derive, which IS the correct fail-closed answer (an empty repository
+#: set), not a silent bypass of the join.
+_PROJECT_IDENTITY_CTE = """project AS (
+  SELECT provider AS catalog_provider, ifNull(project_key, '') AS catalog_project_key
+  FROM projects FINAL
+  WHERE org_id = {org_id:String} AND id = {entity_id:String}
+  LIMIT 1
+)"""
+
+
+def _project_identity_match(alias: str = "") -> str:
+    """Provider + native-key aware match against a work_items-shaped row.
+
+    ``alias`` is the table prefix (e.g. ``"item."``, ``"blocked."``) for a joined
+    reference; ``""`` for a bare, unaliased ``work_items`` FROM. Every
+    project-scoped arm splices this EXACT text (never a hand-copied variant),
+    joined against ``_PROJECT_IDENTITY_CTE`` as ``project``, so the derivation
+    (``PROJECT_REPOSITORIES_SQL``) can never admit a repository the fact queries
+    it bounds would not themselves draw from -- pinned by
+    ``test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do``.
+    """
+    return (
+        "ifNull(catalog_provider, '') != ''"
+        f" AND {alias}provider = catalog_provider"
+        f" AND ({alias}project_id = {{entity_id:String}}"
+        f" OR (catalog_project_key != '' AND {alias}project_key = catalog_project_key))"
+    )
+
+
+def _project_scope_arm(alias: str = "") -> str:
+    """The full ``scope_type = 'project'`` disjunction arm, identity-scoped."""
+    return (
+        "({scope_type:String} = 'project'\n"
+        f"      AND {_project_identity_match(alias)})"
+    )
+
+
+_PROJECT_LINKED_WORK_ITEMS_CTE = (
+    _PROJECT_IDENTITY_CTE
+    + """, linked AS (
+  SELECT toString(link.repo_id) AS repository_id, link.pr_number
+  FROM work_graph_issue_pr AS link FINAL
+  INNER JOIN work_items AS item FINAL
+    ON item.org_id = link.org_id
+   AND item.repo_id = link.repo_id
+   AND item.work_item_id = link.work_item_id
+  LEFT JOIN project ON 1 = 1
+  WHERE link.org_id = {org_id:String}
+    AND item.org_id = {org_id:String}
+    AND toString(link.repo_id) IN {repository_ids:Array(String)}
+    AND (
+      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
+      OR """
+    + _project_scope_arm("item.")
+    + """
+      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
+    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    + """
+      ))
+    )
+)"""
+)
+
+
+_WORK_ITEMS_SQL = (
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """
 SELECT toString(repo_id) AS repository_id, work_item_id, title, status,
        parent_id, project_id, project_key, updated_at, last_synced
 FROM work_items FINAL
+LEFT JOIN project ON 1 = 1
 WHERE org_id = {org_id:String}
   AND toString(repo_id) IN {repository_ids:Array(String)}
   AND updated_at <= {as_of:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'issue'
       AND (work_item_id = {entity_id:String} OR parent_id = {entity_id:String}))
-    OR ({scope_type:String} = 'project'
-      AND (project_id = {entity_id:String} OR project_key = {entity_id:String}))
+    OR """
+    + _project_scope_arm()
+    + """
     OR ({scope_type:String} = 'work_unit'
       AND work_item_id IN {member_issue_ids:Array(String)})
   )
 ORDER BY (work_item_id = {entity_id:String}) DESC, updated_at DESC, work_item_id
 LIMIT {limit:UInt32}
 """
+)
 
 _BLOCKER_WATERMARK_SQL = """
 SELECT if(
@@ -195,7 +299,10 @@ HAVING countIf(scope_repo_id IS NULL) > 0
        = length({repository_ids:Array(String)})
 """
 
-_BLOCKERS_SQL = """
+_BLOCKERS_SQL = (
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """
 SELECT blocker.work_item_id AS entity_id,
        blocker.title AS display_label,
        blocker.status,
@@ -206,6 +313,7 @@ INNER JOIN work_items AS blocker FINAL
   ON blocker.org_id = edge.org_id AND blocker.work_item_id = edge.source_id
 INNER JOIN work_items AS blocked FINAL
   ON blocked.org_id = edge.org_id AND blocked.work_item_id = edge.target_id
+LEFT JOIN project ON 1 = 1
 WHERE edge.org_id = {org_id:String}
   AND edge.source_type = 'issue'
   AND edge.target_type = 'issue'
@@ -218,29 +326,34 @@ WHERE edge.org_id = {org_id:String}
   AND blocked.updated_at <= {as_of:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'issue' AND edge.target_id = {entity_id:String})
-    OR ({scope_type:String} = 'project'
-      AND (blocked.project_id = {entity_id:String} OR blocked.project_key = {entity_id:String}))
+    OR """
+    + _project_scope_arm("blocked.")
+    + """
     OR ({scope_type:String} = 'work_unit'
       AND edge.target_id IN {member_issue_ids:Array(String)})
   )
 ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """
+)
 
 _PULL_REQUESTS_SQL = (
-    """
-WITH linked AS (
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """, linked AS (
   SELECT toString(link.repo_id) AS repository_id, link.pr_number
   FROM work_graph_issue_pr AS link FINAL
   LEFT JOIN work_items AS item FINAL
     ON item.repo_id = link.repo_id AND item.work_item_id = link.work_item_id
+  LEFT JOIN project ON 1 = 1
   WHERE link.org_id = {org_id:String}
     AND item.org_id = {org_id:String}
     AND toString(link.repo_id) IN {repository_ids:Array(String)}
     AND (
       ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+      OR """
+    + _project_scope_arm("item.")
+    + """
       OR ({scope_type:String} = 'work_unit'
         AND link.work_item_id IN {member_issue_ids:Array(String)})
       OR ({scope_type:String} = 'team'
@@ -500,20 +613,22 @@ WHERE g.repo_id IS NOT NULL
 #: read bound for project scope alone. Every *real* repository id must therefore
 #: still resolve through the same org-scoped ``repos`` catalog.
 #:
-#: Provider scope, deliberate (Codex adversarial review HIGH, 2026-08-03;
-#: ruling: keep the arm provider-scoped rather than grow it). Sharing the fact
-#: queries' predicate exactly is also what stops this arm from *helping* a
-#: provider whose committed id those queries cannot match. Jira is that case:
-#: ``team_autoimport_jira._project_id`` mints the catalog id as
-#: ``f"{org_id}:jira:{project_key}"`` while ``providers/jira/normalize`` writes
-#: the raw Jira id/key onto ``work_items``, so neither arm matches. Deriving
-#: repositories for it anyway would be strictly *worse* than not: the fact
-#: queries would still match nothing and the run would report a confident empty
-#: answer for a project that has data, in place of the disclosed fail-closed
-#: one it reports today. Jira project subjects therefore keep exactly their
-#: current behavior here; making them answerable needs a coordinated
-#: provider-aware change across every project arm at once. Asserted by
-#: ``test_jira_shaped_project_keeps_todays_fail_closed_behaviour``.
+#: Provider-identity scoped (CHAOS-3374, superseding the prior "provider scope,
+#: deliberate" ruling below it superseded a "clean and small" derivation-only
+#: fix that would have made Jira *worse* -- a confident empty answer instead of
+#: a disclosed fail-closed one -- for exactly the reason described in
+#: ``_PROJECT_IDENTITY_CTE``'s own comment: ``team_autoimport_jira._project_id``
+#: mints the catalog id as ``f"{org_id}:jira:{project_key}"`` while
+#: ``providers/jira/normalize`` writes the raw Jira id/key onto ``work_items``.
+#: Rather than leaving the mismatch in place, this arm now joins through the
+#: catalog's own ``provider``/``project_key`` columns (``_project_identity_match``)
+#: so a Jira project matches its own raw key, a Linear project keeps matching
+#: the raw id it always used, and neither can match the other's (or a future
+#: GitLab catalog row's) rows even on a coincidental key/id collision. Asserted
+#: end to end by ``test_jira_shaped_project_resolves_via_provider_scoped_identity``
+#: and the cross-provider collision coverage beside it; the derivation and
+#: ``_WORK_ITEMS_SQL`` share ``_project_identity_match``'s exact text, pinned by
+#: ``test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do``.
 #:
 #: The zero UUID is admitted explicitly rather than by omitting that check.
 #: It is not a repository at all: it is the sentinel
@@ -524,12 +639,18 @@ WHERE g.repo_id IS NOT NULL
 #: existence join would re-empty the set for the exact provider this fix exists
 #: for -- while a blanket "skip the catalog" would have de-authorized nothing
 #: and admitted everything. Naming the sentinel keeps both properties.
-PROJECT_REPOSITORIES_SQL = """
+PROJECT_REPOSITORIES_SQL = (
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """
 SELECT DISTINCT toString(repo_id) AS repository_id
 FROM work_items FINAL
+INNER JOIN project ON 1 = 1
 WHERE org_id = {org_id:String}
   AND updated_at <= {as_of:DateTime64(3, 'UTC')}
-  AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
+  AND """
+    + _project_identity_match()
+    + """
   AND (
     toString(repo_id) = '00000000-0000-0000-0000-000000000000'
     OR toString(repo_id) IN (
@@ -537,9 +658,12 @@ WHERE org_id = {org_id:String}
     )
   )
 """
+)
 
 _TRANSITIONS_SQL = (
-    """
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """
 SELECT transition.work_item_id AS entity_id, item.title AS display_label,
        transition.from_status, transition.to_status,
        transition.occurred_at AS observed_at, transition.last_synced
@@ -548,6 +672,7 @@ INNER JOIN work_items AS item FINAL
   ON item.org_id = transition.org_id
  AND item.repo_id = transition.repo_id
  AND item.work_item_id = transition.work_item_id
+LEFT JOIN project ON 1 = 1
 WHERE transition.org_id = {org_id:String}
   AND item.org_id = {org_id:String}
   AND toString(item.repo_id) IN {repository_ids:Array(String)}
@@ -555,8 +680,9 @@ WHERE transition.org_id = {org_id:String}
   AND transition.occurred_at < {end:DateTime64(3, 'UTC')}
   AND (
     ({scope_type:String} = 'issue' AND transition.work_item_id = {entity_id:String})
-    OR ({scope_type:String} = 'project'
-      AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
+    OR """
+    + _project_scope_arm("item.")
+    + """
     OR ({scope_type:String} = 'team' AND transition.work_item_id IN ("""
     + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
     + """
@@ -569,7 +695,9 @@ LIMIT {limit:UInt32}
 )
 
 _RELATIONSHIPS_SQL = (
-    """
+    "WITH "
+    + _PROJECT_IDENTITY_CTE
+    + """
 SELECT edge_id AS change_id, source_type, source_id, edge_type,
        target_type, target_id, provenance, confidence,
        discovered_at AS observed_at, last_synced
@@ -584,15 +712,21 @@ WHERE org_id = {org_id:String}
     OR ({scope_type:String} = 'project' AND (
       source_id IN (
         SELECT work_item_id FROM work_items FINAL
+        INNER JOIN project ON 1 = 1
         WHERE org_id = {org_id:String}
           AND toString(repo_id) IN {repository_ids:Array(String)}
-          AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
+          AND """
+    + _project_identity_match()
+    + """
       )
       OR target_id IN (
         SELECT work_item_id FROM work_items FINAL
+        INNER JOIN project ON 1 = 1
         WHERE org_id = {org_id:String}
           AND toString(repo_id) IN {repository_ids:Array(String)}
-          AND (project_id = {entity_id:String} OR project_key = {entity_id:String})
+          AND """
+    + _project_identity_match()
+    + """
       )
     ))
     OR ({scope_type:String} = 'team' AND (
@@ -613,27 +747,9 @@ LIMIT {limit:UInt32}
 )
 
 _PULL_REQUEST_CHANGES_SQL = (
-    """
-WITH linked AS (
-  SELECT toString(link.repo_id) AS repository_id, link.pr_number
-  FROM work_graph_issue_pr AS link FINAL
-  INNER JOIN work_items AS item FINAL
-    ON item.org_id = link.org_id
-   AND item.repo_id = link.repo_id
-   AND item.work_item_id = link.work_item_id
-  WHERE link.org_id = {org_id:String}
-    AND item.org_id = {org_id:String}
-    AND toString(link.repo_id) IN {repository_ids:Array(String)}
-    AND (
-      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
-    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    "WITH "
+    + _PROJECT_LINKED_WORK_ITEMS_CTE
     + """
-      ))
-    )
-)
 SELECT concat(toString(pr.repo_id), '#pr', toString(pr.number), '#state#',
               if(isNotNull(pr.merged_at), 'merged',
                  if(isNotNull(pr.closed_at), 'closed', ifNull(pr.state, 'open')))) AS change_id,
@@ -663,27 +779,9 @@ LIMIT {limit:UInt32}
 )
 
 _REVIEW_CHANGES_SQL = (
-    """
-WITH linked AS (
-  SELECT toString(link.repo_id) AS repository_id, link.pr_number
-  FROM work_graph_issue_pr AS link FINAL
-  INNER JOIN work_items AS item FINAL
-    ON item.org_id = link.org_id
-   AND item.repo_id = link.repo_id
-   AND item.work_item_id = link.work_item_id
-  WHERE link.org_id = {org_id:String}
-    AND item.org_id = {org_id:String}
-    AND toString(link.repo_id) IN {repository_ids:Array(String)}
-    AND (
-      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
-    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    "WITH "
+    + _PROJECT_LINKED_WORK_ITEMS_CTE
     + """
-      ))
-    )
-)
 SELECT concat(toString(review.repo_id), '#pr', toString(review.number),
               '#review#', review.review_id) AS change_id,
        change_id AS entity_id,
@@ -710,27 +808,9 @@ LIMIT {limit:UInt32}
 )
 
 _CI_CHANGES_SQL = (
-    """
-WITH linked AS (
-  SELECT toString(link.repo_id) AS repository_id, link.pr_number
-  FROM work_graph_issue_pr AS link FINAL
-  INNER JOIN work_items AS item FINAL
-    ON item.org_id = link.org_id
-   AND item.repo_id = link.repo_id
-   AND item.work_item_id = link.work_item_id
-  WHERE link.org_id = {org_id:String}
-    AND item.org_id = {org_id:String}
-    AND toString(link.repo_id) IN {repository_ids:Array(String)}
-    AND (
-      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
-    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    "WITH "
+    + _PROJECT_LINKED_WORK_ITEMS_CTE
     + """
-      ))
-    )
-)
 SELECT concat(toString(run.repo_id), '#ci#', run.run_id) AS change_id,
        change_id AS entity_id,
        ifNull(run.pipeline_name, concat('CI run ', run.run_id)) AS display_label,
@@ -756,27 +836,9 @@ LIMIT {limit:UInt32}
 )
 
 _DEPLOYMENT_CHANGES_SQL = (
-    """
-WITH linked AS (
-  SELECT toString(link.repo_id) AS repository_id, link.pr_number
-  FROM work_graph_issue_pr AS link FINAL
-  INNER JOIN work_items AS item FINAL
-    ON item.org_id = link.org_id
-   AND item.repo_id = link.repo_id
-   AND item.work_item_id = link.work_item_id
-  WHERE link.org_id = {org_id:String}
-    AND item.org_id = {org_id:String}
-    AND toString(link.repo_id) IN {repository_ids:Array(String)}
-    AND (
-      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
-    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    "WITH "
+    + _PROJECT_LINKED_WORK_ITEMS_CTE
     + """
-      ))
-    )
-)
 SELECT concat(toString(deployment.repo_id), '#deployment#',
               deployment.deployment_id) AS change_id,
        change_id AS entity_id,
@@ -805,27 +867,9 @@ LIMIT {limit:UInt32}
 )
 
 _INCIDENT_CHANGES_SQL = (
-    """
-WITH linked AS (
-  SELECT toString(link.repo_id) AS repository_id, link.pr_number
-  FROM work_graph_issue_pr AS link FINAL
-  INNER JOIN work_items AS item FINAL
-    ON item.org_id = link.org_id
-   AND item.repo_id = link.repo_id
-   AND item.work_item_id = link.work_item_id
-  WHERE link.org_id = {org_id:String}
-    AND item.org_id = {org_id:String}
-    AND toString(link.repo_id) IN {repository_ids:Array(String)}
-    AND (
-      ({scope_type:String} = 'issue' AND link.work_item_id = {entity_id:String})
-      OR ({scope_type:String} = 'project'
-        AND (item.project_id = {entity_id:String} OR item.project_key = {entity_id:String}))
-      OR ({scope_type:String} = 'team' AND link.work_item_id IN ("""
-    + _TEAM_OWNED_WORK_ITEM_IDS_SUBQUERY
+    "WITH "
+    + _PROJECT_LINKED_WORK_ITEMS_CTE
     + """
-      ))
-    )
-)
 SELECT concat(incident.id, '#state#',
               ifNull(incident.normalized_status, 'unknown')) AS change_id,
        incident.id AS entity_id,

--- a/tests/api/dev/test_project_scope_clickhouse_live.py
+++ b/tests/api/dev/test_project_scope_clickhouse_live.py
@@ -282,6 +282,13 @@ class _Seeded:
         #: A DIFFERENT provider's repository, holding a row that shares the
         #: Jira project's raw key -- must never be admitted by either scope.
         self.collision_repo = uuid.uuid4()
+        # CHAOS-3374 round 2 (Codex MEDIUM): projects' ReplacingMergeTree key
+        # is (org_id, provider, id), NOT (org_id, id) -- two providers can
+        # legitimately mint the SAME id in the SAME org and both survive
+        # FINAL. A bare LIMIT 1 (no ORDER BY) would pick one nondeterministically.
+        self.colliding_project_id = str(uuid.uuid4())
+        self.colliding_project_key = f"COLLIDE{uuid.uuid4().hex[:6].upper()}"
+        self.colliding_repo = uuid.uuid4()
 
     @property
     def expected(self) -> list[str]:
@@ -328,6 +335,12 @@ def seeded(sink: Any, raw_client: Any) -> Any:
             repo_id=str(data.collision_repo),
             name="org/collision",
         )
+        _insert_repo(
+            raw_client,
+            org_id=data.org_id,
+            repo_id=str(data.colliding_repo),
+            name="org/colliding",
+        )
 
         sink.org_id = data.org_id
         sink.write_projects(
@@ -367,6 +380,29 @@ def seeded(sink: Any, raw_client: Any) -> Any:
                     org_id=data.org_id,
                     provider="linear",
                     name=PROJECT_NAME + " (other tenant's reference)",
+                    is_active=1,
+                    updated_at=NOW,
+                    last_synced=NOW,
+                ),
+                # CHAOS-3374 round 2: two DIFFERENT providers minting the SAME
+                # catalog id in the SAME org. projects' ReplacingMergeTree key
+                # is (org_id, provider, id), so BOTH survive FINAL -- proving
+                # this is a real, not merely theoretical, engine shape.
+                ProjectRecord(
+                    id=data.colliding_project_id,
+                    org_id=data.org_id,
+                    provider="jira",
+                    project_key=data.colliding_project_key,
+                    name=PROJECT_NAME + " (colliding, jira)",
+                    is_active=1,
+                    updated_at=NOW,
+                    last_synced=NOW,
+                ),
+                ProjectRecord(
+                    id=data.colliding_project_id,
+                    org_id=data.org_id,
+                    provider="linear",
+                    name=PROJECT_NAME + " (colliding, linear)",
                     is_active=1,
                     updated_at=NOW,
                     last_synced=NOW,
@@ -430,6 +466,17 @@ def seeded(sink: Any, raw_client: Any) -> Any:
                     project_id="",
                     project_key=data.jira_project_key,
                     repo_id=data.collision_repo,
+                ),
+                # CHAOS-3374 round 2: the would-be member of the AMBIGUOUS
+                # (two-provider) colliding project. Must never be admitted --
+                # present so a regression back to a bare LIMIT 1 has something
+                # real to (nondeterministically) admit, rather than the test
+                # passing vacuously because nothing matches either way.
+                _jira_work_item(
+                    "COLLIDE-9",
+                    org_id=data.org_id,
+                    project_key=data.colliding_project_key,
+                    repo_id=data.colliding_repo,
                 ),
             ]
         )
@@ -527,6 +574,114 @@ async def test_jira_shaped_project_derivation_resolves_live(
     assert own == seeded.jira_expected
     # The cross-provider collision row must not leak in via the key arm.
     assert str(seeded.collision_repo) not in own
+
+
+@pytest.mark.asyncio
+async def test_cross_provider_id_collision_derivation_stays_fail_closed_live(
+    sink: Any, seeded: Any
+) -> None:
+    """Codex adversarial review (MEDIUM, 2026-08-04), round 2 -- real engine.
+
+    ``projects``' ReplacingMergeTree key is ``(org_id, provider, id)``, not
+    ``(org_id, id)``. Two rows sharing ``colliding_project_id`` under
+    different providers were both written above and BOTH survive ``FINAL``
+    (proven by the raw-row assertion below) -- a real, not merely
+    theoretical, collision. The original ``project AS (... LIMIT 1)`` CTE (no
+    ``ORDER BY``) would pick one of the two nondeterministically and answer
+    with ITS provider's repositories; the fix (``HAVING count() = 1``) must
+    instead derive nothing.
+    """
+
+    rows = await query_dicts(
+        sink,
+        "SELECT provider FROM projects FINAL WHERE org_id = {org_id:String} "
+        "AND id = {id:String} ORDER BY provider",
+        {"org_id": seeded.org_id, "id": seeded.colliding_project_id},
+    )
+    assert sorted(str(row["provider"]) for row in rows) == ["jira", "linear"], (
+        "both colliding rows must survive FINAL for this to be a real test "
+        f"of the collision guard, got {rows}"
+    )
+
+    own = await _derive(
+        sink, PROJECT_REPOSITORIES_SQL, seeded, project_id=seeded.colliding_project_id
+    )
+    assert own == [], (
+        f"an ambiguous (multi-provider) catalog id must derive nothing, got {own}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_provider_id_collision_snapshot_stays_fail_closed_live(
+    sink: Any, seeded: Any
+) -> None:
+    """The whole path, for the collision scenario: real catalog, real resolver,
+    real SQL, real engine -- must refuse rather than guess a provider."""
+
+    service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+    resolution = await service.resolve_contract(
+        seeded.org_id,
+        "permission-live",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.PROJECT, seeded.colliding_project_id),)
+        ),
+    )
+    scope = resolution.resolved_scope
+    assert scope is not None
+
+    snapshot = await StatusChangeService(
+        ClickHouseStatusChangeSource(sink)
+    ).status_snapshot(seeded.org_id, "permission-live", StatusSnapshotRequest(scope))
+
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+
+
+@pytest.mark.asyncio
+async def test_retired_project_derivation_stays_fail_closed_live(
+    sink: Any, seeded: Any
+) -> None:
+    """Codex adversarial review (MEDIUM, 2026-08-04), round 2 -- real engine.
+
+    The Jira project resolves live (see
+    ``test_jira_shaped_project_derivation_resolves_live``). This writes a
+    NEWER row for the exact same ``(org_id, provider, id)`` with
+    ``is_active = 0`` -- the real ReplacingMergeTree retirement mechanism,
+    not a physically absent row -- and re-derives: it must now return
+    nothing, even though the SAME entity answered a moment ago.
+
+    Written through the SAME ``sink.write_projects`` path as the original row
+    (rather than a raw ``now64(3)`` INSERT): ``ClickHouseMetricsSink``'s own
+    datetime serialization is not wall-clock-comparable to the server's
+    ``now64(3)`` (a fixed offset apart), so only a version strictly LATER by
+    that same serialization path is guaranteed to win under ``FINAL`` --
+    exactly what real retirement writes (also through this sink) look like.
+    """
+
+    before = await _derive(
+        sink, PROJECT_REPOSITORIES_SQL, seeded, project_id=seeded.jira_project_id
+    )
+    assert before == seeded.jira_expected
+
+    sink.write_projects(
+        [
+            ProjectRecord(
+                id=seeded.jira_project_id,
+                org_id=seeded.org_id,
+                provider="jira",
+                project_key=seeded.jira_project_key,
+                name=PROJECT_NAME + " (Jira, retired)",
+                is_active=0,
+                updated_at=NOW + timedelta(seconds=1),
+                last_synced=NOW + timedelta(seconds=1),
+            )
+        ]
+    )
+
+    after = await _derive(
+        sink, PROJECT_REPOSITORIES_SQL, seeded, project_id=seeded.jira_project_id
+    )
+    assert after == [], f"a retired project must derive nothing, got {after}"
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_project_scope_clickhouse_live.py
+++ b/tests/api/dev/test_project_scope_clickhouse_live.py
@@ -15,10 +15,25 @@ runs, not that the assertion could ever have failed.
 Seeded shapes, one per rule the derivation has to get right:
 
 * Linear (repository-less, zero-UUID ``repo_id``) — must be admitted;
-* attribution by ``project_key`` rather than ``project_id`` — must be admitted;
+* Linear, a nonzero AUTHORIZED repository — must be admitted;
 * a nonzero repository absent from ``repos`` — must be excluded;
 * a second tenant's rows for the same project id — must be excluded;
 * a row updated after ``as_of`` — must be excluded.
+
+CHAOS-3374 adds a second project, Jira-shaped exactly like production
+(``team_autoimport_jira._project_id`` mints the catalog id as
+``f"{org_id}:jira:{project_key}"``; ``providers/jira/normalize`` writes the
+RAW key onto ``work_items.project_key`` via the real
+``canonical_jira_issue_to_work_item`` producer), plus a cross-provider
+collision row that shares the Jira project's raw key under a DIFFERENT
+provider:
+
+* Jira, attributed by the raw ``project_key`` (not ``project_id``) — must be
+  admitted only under the Jira scope, proving the provider-scoped identity
+  join added by CHAOS-3374 against a real engine, not a predicate fake;
+* a Linear-provider row carrying that SAME raw key — must be excluded from
+  the Jira scope (and was never admissible to the Linear scope either, since
+  a real Linear catalog row's own ``project_key`` is always empty).
 
 Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
 ``-m "not benchmark and not clickhouse"``): ``pytest -m clickhouse`` with
@@ -35,6 +50,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from atlassian import JiraIssue
 
 from dev_health_ops.api.dev.native_status_change import (
     PROJECT_REPOSITORIES_SQL,
@@ -54,6 +70,7 @@ from dev_health_ops.api.dev.status_change_service import (
 from dev_health_ops.api.queries.client import query_dicts
 from dev_health_ops.metrics.schemas import ProjectRecord
 from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.jira.normalize import canonical_jira_issue_to_work_item
 from dev_health_ops.providers.linear.normalize import linear_issue_to_work_item
 from dev_health_ops.providers.status_mapping import StatusMapping
 
@@ -188,6 +205,51 @@ def _work_item(
     )
 
 
+def _jira_work_item(
+    key: str,
+    *,
+    org_id: str,
+    project_key: str,
+    repo_id: uuid.UUID | None,
+    updated_at: datetime | None = None,
+) -> Any:
+    """One work item through the production Jira canonical normalizer.
+
+    ``canonical_jira_issue_to_work_item`` is the real producer that sets
+    ``project_id=None`` and ``project_key=issue.project_key`` (see
+    ``providers/jira/normalize.py``) -- the exact identity mismatch
+    CHAOS-3374 fixes: the catalog id is ``f"{org_id}:jira:{project_key}"``
+    (provider-prefixed) but ``work_items.project_key`` carries the RAW key.
+    """
+
+    identity = MagicMock(spec=IdentityResolver)
+    identity.resolve.side_effect = lambda **kwargs: "user:dev@example.com"
+    status_mapping = MagicMock(spec=StatusMapping)
+    status_mapping.normalize_status.return_value = "in_progress"
+    status_mapping.normalize_type.return_value = "task"
+
+    issue = JiraIssue(
+        cloud_id="cloud-live",
+        key=key,
+        project_key=project_key,
+        issue_type="Task",
+        status="In Progress",
+        created_at=(NOW - timedelta(days=10)).isoformat(),
+        updated_at=(NOW - timedelta(days=1)).isoformat(),
+    )
+    item = canonical_jira_issue_to_work_item(
+        issue=issue,
+        status_mapping=status_mapping,
+        identity=identity,
+        repo_id=repo_id,
+    )
+    return replace(
+        item,
+        org_id=org_id,
+        updated_at=updated_at or (NOW - timedelta(days=1)),
+    )
+
+
 def _insert_repo(client: Any, *, org_id: str, repo_id: str, name: str) -> None:
     client.command(
         "INSERT INTO repos (id, repo, created_at, last_synced, org_id) VALUES "
@@ -201,18 +263,33 @@ class _Seeded:
         self.org_id = f"proj-scope-{uuid.uuid4().hex[:16]}"
         self.other_org_id = f"proj-scope-other-{uuid.uuid4().hex[:16]}"
         self.project_id = str(uuid.uuid4())
-        #: Referenced only by the *other* tenant. This org must derive nothing
-        #: for it -- the probe that makes ``work_items.org_id`` observable at
-        #: all (see test_every_derivation_clause_changes_the_real_result).
+        #: Referenced only by the *other* tenant, but WITH its own catalog row
+        #: under that tenant -- so a mutant that drops the ``work_items``-level
+        #: ``org_id`` bound (rather than merely the identity CTE's own) is what
+        #: this org's probe against it exercises (see
+        #: test_every_derivation_clause_changes_the_real_result's docstring).
         self.other_only_project_id = str(uuid.uuid4())
         self.authorized_repo = uuid.uuid4()
         self.stale_window_repo = uuid.uuid4()
         self.revoked_repo = uuid.uuid4()
         self.foreign_repo = uuid.uuid4()
+        # CHAOS-3374: a Jira-shaped project. The catalog id is
+        # provider-prefixed exactly like production; the raw key is what
+        # actually lands on work_items.project_key.
+        self.jira_project_key = f"ASK{uuid.uuid4().hex[:6].upper()}"
+        self.jira_project_id = f"{self.org_id}:jira:{self.jira_project_key}"
+        self.jira_repo = uuid.uuid4()
+        #: A DIFFERENT provider's repository, holding a row that shares the
+        #: Jira project's raw key -- must never be admitted by either scope.
+        self.collision_repo = uuid.uuid4()
 
     @property
     def expected(self) -> list[str]:
         return sorted({ZERO_REPOSITORY_ID, str(self.authorized_repo)})
+
+    @property
+    def jira_expected(self) -> list[str]:
+        return sorted({str(self.jira_repo)})
 
 
 @pytest.fixture
@@ -239,6 +316,18 @@ def seeded(sink: Any, raw_client: Any) -> Any:
             repo_id=str(data.foreign_repo),
             name="other/repo",
         )
+        _insert_repo(
+            raw_client,
+            org_id=data.org_id,
+            repo_id=str(data.jira_repo),
+            name="org/jira-project",
+        )
+        _insert_repo(
+            raw_client,
+            org_id=data.org_id,
+            repo_id=str(data.collision_repo),
+            name="org/collision",
+        )
 
         sink.org_id = data.org_id
         sink.write_projects(
@@ -251,7 +340,37 @@ def seeded(sink: Any, raw_client: Any) -> Any:
                     is_active=1,
                     updated_at=NOW,
                     last_synced=NOW,
-                )
+                ),
+                ProjectRecord(
+                    id=data.jira_project_id,
+                    org_id=data.org_id,
+                    provider="jira",
+                    project_key=data.jira_project_key,
+                    name=PROJECT_NAME + " (Jira)",
+                    is_active=1,
+                    updated_at=NOW,
+                    last_synced=NOW,
+                ),
+                # CHAOS-3374: deliberately scoped to THIS org's catalog even
+                # though the only matching work_items row (LIVE-7, below) is
+                # written under other_org_id -- isolates the work_items-level
+                # org_id bound as the ONLY thing standing between "excluded"
+                # and "leaked" for the repository-less sentinel bucket, which
+                # the ``repos`` authorization arm cannot gate (see
+                # test_every_derivation_clause_changes_the_real_result's own
+                # "org_id tenant bound" mutant). Scoping this row under
+                # other_org_id instead would let the identity join's OWN
+                # (unmutated) org_id check mask the work_items-level mutant
+                # entirely, making it undetectable by either probe.
+                ProjectRecord(
+                    id=data.other_only_project_id,
+                    org_id=data.org_id,
+                    provider="linear",
+                    name=PROJECT_NAME + " (other tenant's reference)",
+                    is_active=1,
+                    updated_at=NOW,
+                    last_synced=NOW,
+                ),
             ]
         )
         sink.write_work_items(
@@ -269,12 +388,12 @@ def seeded(sink: Any, raw_client: Any) -> Any:
                     project_id=data.project_id,
                     repo_id=None,
                 ),
-                # Attributed by project_key, on an authorized repository.
+                # A nonzero, AUTHORIZED repository -- proves the derivation
+                # isn't reachable only through the zero-UUID sentinel.
                 _work_item(
                     "LIVE-3",
                     org_id=data.org_id,
-                    project_id="",
-                    project_key=data.project_id,
+                    project_id=data.project_id,
                     repo_id=data.authorized_repo,
                 ),
                 # Authorized repository, but outside the as_of bound.
@@ -291,6 +410,26 @@ def seeded(sink: Any, raw_client: Any) -> Any:
                     org_id=data.org_id,
                     project_id=data.project_id,
                     repo_id=data.revoked_repo,
+                ),
+                # CHAOS-3374: the Jira project's own work item, attributed
+                # ONLY via the raw project_key arm (project_id is None, from
+                # the real canonical_jira_issue_to_work_item producer).
+                _jira_work_item(
+                    "ASK-9",
+                    org_id=data.org_id,
+                    project_key=data.jira_project_key,
+                    repo_id=data.jira_repo,
+                ),
+                # CHAOS-3374 cross-provider collision: a Linear-provider row
+                # (adversarially) carrying the Jira project's raw key. Without
+                # the provider guard on the identity join this would leak
+                # into the Jira scope via the project_key arm.
+                _work_item(
+                    "COLLIDE-1",
+                    org_id=data.org_id,
+                    project_id="",
+                    project_key=data.jira_project_key,
+                    repo_id=data.collision_repo,
                 ),
             ]
         )
@@ -369,6 +508,28 @@ async def test_derivation_returns_exactly_the_authorized_project_repositories(
 
 
 @pytest.mark.asyncio
+async def test_jira_shaped_project_derivation_resolves_live(
+    sink: Any, seeded: Any
+) -> None:
+    """CHAOS-3374: the provider-scoped identity join, against a real engine.
+
+    Before the fix, ``PROJECT_REPOSITORIES_SQL`` compared
+    ``work_items.project_id``/``project_key`` against the catalog's
+    (provider-prefixed) id directly -- ``project_id = {entity_id:String} OR
+    project_key = {entity_id:String}`` -- which a raw Jira key never matches.
+    This probe is the RED/GREEN pair for that: it would have returned ``[]``
+    on main.
+    """
+
+    own = await _derive(
+        sink, PROJECT_REPOSITORIES_SQL, seeded, project_id=seeded.jira_project_id
+    )
+    assert own == seeded.jira_expected
+    # The cross-provider collision row must not leak in via the key arm.
+    assert str(seeded.collision_repo) not in own
+
+
+@pytest.mark.asyncio
 async def test_every_derivation_clause_changes_the_real_result(
     sink: Any, seeded: Any
 ) -> None:
@@ -377,28 +538,29 @@ async def test_every_derivation_clause_changes_the_real_result(
     Each mutant is executed on the same seeded data. A mutant that returns the
     correct set is a clause the assertion above could never have caught -- so
     the failure message names the clause rather than just reporting inequality.
+
+    Scoped to the clauses shared by every provider (tenant/time bounds, the
+    ``project_id`` arm, and the ``repos`` authorization arms), probed against
+    the LINEAR-shaped project -- a real Linear catalog row's own
+    ``project_key`` is always empty, so the native-key arm and the provider
+    guard are dead code for this project and belong in
+    ``test_every_jira_identity_clause_changes_the_real_result`` instead, where
+    they are load-bearing.
     """
 
     mutants = {
         "org_id tenant bound on work_items": (
-            "FROM work_items FINAL\nWHERE org_id = {org_id:String}\n",
-            "FROM work_items FINAL\nWHERE 1 = 1\n",
+            "FROM work_items FINAL\nINNER JOIN project ON 1 = 1\nWHERE org_id = {org_id:String}\n",
+            "FROM work_items FINAL\nINNER JOIN project ON 1 = 1\nWHERE 1 = 1\n",
         ),
         "as_of bound": (
             "  AND updated_at <= {as_of:DateTime64(3, 'UTC')}\n",
             "",
         ),
-        "project_key arm": (
-            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
-            "(project_id = {entity_id:String})",
-        ),
         "project_id arm": (
-            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
-            "(project_key = {entity_id:String})",
-        ),
-        "project disjunction (OR -> AND)": (
-            "(project_id = {entity_id:String} OR project_key = {entity_id:String})",
-            "(project_id = {entity_id:String} AND project_key = {entity_id:String})",
+            "(project_id = {entity_id:String}"
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
+            "(catalog_project_key != '' AND project_key = catalog_project_key)",
         ),
         "repos authorization arm": (
             "    toString(repo_id) = '00000000-0000-0000-0000-000000000000'\n"
@@ -423,6 +585,64 @@ async def test_every_derivation_clause_changes_the_real_result(
     assert not survived, (
         "these clauses do not affect the real result, so the assertion above "
         f"cannot be catching them: {sorted(survived)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_jira_identity_clause_changes_the_real_result(
+    sink: Any, seeded: Any
+) -> None:
+    """CHAOS-3374: mutation-check the identity-join clauses, against a real engine.
+
+    Probed against the Jira-shaped project, where the native-key arm and the
+    provider guard are the ONLY thing standing between "resolves correctly"
+    and "leaks the cross-provider collision row" (``COLLIDE-1``, seeded with
+    the identical raw key under ``provider="linear"``).
+    """
+
+    async def probe(sql: str) -> list[str]:
+        return await _derive(sink, sql, seeded, project_id=seeded.jira_project_id)
+
+    mutants = {
+        "provider identity guard": (
+            "ifNull(catalog_provider, '') != '' AND provider = catalog_provider AND ",
+            "",
+        ),
+        "native project_key arm": (
+            "(project_id = {entity_id:String}"
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
+            "(project_id = {entity_id:String})",
+        ),
+        "project disjunction (OR -> AND)": (
+            "(project_id = {entity_id:String}"
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
+            "(project_id = {entity_id:String}"
+            " AND (catalog_project_key != '' AND project_key = catalog_project_key))",
+        ),
+    }
+
+    correct = seeded.jira_expected
+    survived: list[str] = []
+    for label, (original, mutated) in mutants.items():
+        assert original in PROJECT_REPOSITORIES_SQL, f"stale mutant anchor: {label}"
+        sql = PROJECT_REPOSITORIES_SQL.replace(original, mutated, 1)
+        if await probe(sql) == correct:
+            survived.append(label)
+    assert not survived, (
+        "these identity-join clauses do not affect the Jira-shaped result, so "
+        f"the collision guard cannot be catching them: {sorted(survived)}"
+    )
+    # And the specific claim the "provider identity guard" mutant proves:
+    # without it, the collision row's repository leaks in.
+    unguarded = PROJECT_REPOSITORIES_SQL.replace(
+        "ifNull(catalog_provider, '') != '' AND provider = catalog_provider AND ",
+        "",
+        1,
+    )
+    leaked = await probe(unguarded)
+    assert str(seeded.collision_repo) in leaked, (
+        "expected the provider-unguarded mutant to admit the colliding "
+        f"cross-provider repository, got {leaked}"
     )
 
 
@@ -462,6 +682,61 @@ async def test_committed_project_scope_snapshot_reads_its_work_items_live(
         "another tenant's work item reached the read",
         seen,
     )
+    # CHAOS-3374: the Jira project's own item, and the cross-provider
+    # collision row, must never surface under the LINEAR scope either.
+    assert not any(child.endswith("ASK-9") for child in seen), (
+        "the Jira-shaped project's own item leaked into the Linear scope",
+        seen,
+    )
+    assert not any(child.endswith("COLLIDE-1") for child in seen), (
+        "the cross-provider collision row leaked into the Linear scope",
+        seen,
+    )
+
+
+@pytest.mark.asyncio
+async def test_jira_shaped_project_snapshot_reads_its_work_items_live(
+    sink: Any, seeded: Any
+) -> None:
+    """CHAOS-3374 end to end: real catalog, real resolver, real SQL, real engine.
+
+    RED before the fix: this scenario (a Jira project resolved through the
+    real ``ScopeResolutionService``, then read through the real
+    ``ClickHouseStatusChangeSource``) returned ``NO_REPOSITORY_SET_WARNING``
+    and an empty ``snapshot.children`` on main -- the disclosed fail-closed
+    refusal ``test_jira_shaped_project_keeps_todays_fail_closed_behaviour``
+    (unit suite) pinned. GREEN after the fix: the project resolves its own
+    work item, and the cross-provider collision row stays excluded.
+    """
+
+    service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+    resolution = await service.resolve_contract(
+        seeded.org_id,
+        "permission-live",
+        ScopeResolveRequest(
+            explicit_refs=(ScopeRef(EntityKind.PROJECT, seeded.jira_project_id),)
+        ),
+    )
+    assert resolution.outcome.value == "exact"
+    scope = resolution.resolved_scope
+    assert scope is not None
+    assert scope.repositories == []
+
+    snapshot = await StatusChangeService(
+        ClickHouseStatusChangeSource(sink)
+    ).status_snapshot(seeded.org_id, "permission-live", StatusSnapshotRequest(scope))
+
+    assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    seen = {child.entity_id for child in snapshot.children}
+    assert any(child.endswith("ASK-9") for child in seen), seen
+    assert not any(child.endswith("COLLIDE-1") for child in seen), (
+        "a Linear-provider row sharing Jira's raw project key leaked into "
+        "the Jira scope",
+        seen,
+    )
+    assert not any(
+        child.endswith("LIVE-1") or child.endswith("LIVE-3") for child in seen
+    ), ("the Linear project's own items leaked into the Jira scope", seen)
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -79,6 +79,15 @@ JIRA_RAW_PROJECT_ID_ON_WORK_ITEMS = "10001"
 #: all -- simulates the identity read observing a scope the catalog read
 #: resolved a moment earlier (replication lag, a deleted project, etc.).
 GHOST_PROJECT_ID = f"{ORG_ID}:ghost:VANISHED"
+#: CHAOS-3374 round 2 (Codex MEDIUM): the catalog's real ReplacingMergeTree key
+#: is ``(org_id, provider, id)``, not ``(org_id, id)`` -- so the SAME id can
+#: legitimately survive ``FINAL`` twice, once per provider. Two catalog rows
+#: share this id under different providers.
+COLLIDING_PROJECT_ID = f"{ORG_ID}:collide:MULTI"
+#: CHAOS-3374 round 2 (Codex MEDIUM): a project committed while active, then
+#: retired (a newer ``is_active = 0`` row) before the identity read runs.
+RETIRED_PROJECT_ID = f"{ORG_ID}:jira:RETIRED"
+RETIRED_RAW_PROJECT_KEY = "RETIRED"
 
 #: Linear work items carry no repository: the sync lands them under the zero
 #: UUID, which has no ``repos`` row at all (verified against the live dev
@@ -101,23 +110,50 @@ REVOKED_REPOSITORY_ID = "dddddddd-0000-0000-0000-000000000004"
 #: leak is caught by the identity guard, not incidentally masked by repo
 #: authorization).
 COLLISION_REPOSITORY_ID = "ffffffff-0000-0000-0000-000000000006"
+#: Round 2: where ``COLLIDING_PROJECT_ID``'s own (would-be, if the collision
+#: guard failed) work item lives.
+MULTI_PROVIDER_REPOSITORY_ID = "11111111-0000-0000-0000-000000000007"
+#: Round 2: where ``RETIRED_PROJECT_ID``'s own (would-be, if the ``is_active``
+#: guard failed) work item lives.
+RETIRED_PROJECT_REPOSITORY_ID = "22222222-0000-0000-0000-000000000008"
 
 #: The org-scoped ``repos`` catalog. The zero UUID is deliberately absent: it
 #: is the repository-*less* sentinel, not a repository.
 REPOS_CATALOG = {
-    ORG_ID: {KEYED_REPOSITORY_ID, FUTURE_REPOSITORY_ID, COLLISION_REPOSITORY_ID},
+    ORG_ID: {
+        KEYED_REPOSITORY_ID,
+        FUTURE_REPOSITORY_ID,
+        COLLISION_REPOSITORY_ID,
+        MULTI_PROVIDER_REPOSITORY_ID,
+        RETIRED_PROJECT_REPOSITORY_ID,
+    },
     OTHER_ORG_ID: {FOREIGN_REPOSITORY_ID},
 }
 
 #: Simulates the ``projects`` ClickHouse table as read by the
-#: ``native_status_change`` identity CTE -- keyed exactly like the real table's
-#: ReplacingMergeTree ORDER BY prefix, ``(org_id, id)``.
-PROJECTS_CATALOG: dict[tuple[str, str], dict[str, str | None]] = {
-    (ORG_ID, PROJECT_ID): {"provider": "linear", "project_key": None},
-    (ORG_ID, JIRA_PROJECT_ID): {
-        "provider": "jira",
-        "project_key": JIRA_RAW_PROJECT_KEY,
-    },
+#: ``native_status_change`` identity CTE. Keyed by ``(org_id, id)`` for lookup
+#: convenience, but the VALUE is a list of candidate rows -- exactly because
+#: the real table's ReplacingMergeTree key is ``(org_id, provider, id)``, so
+#: more than one row can legitimately survive ``FINAL`` for one ``(org_id,
+#: id)`` pair (see ``COLLIDING_PROJECT_ID``). Each candidate carries its own
+#: ``is_active`` (default ``1``) so retirement (``RETIRED_PROJECT_ID``) can be
+#: modeled without a second dict shape.
+PROJECTS_CATALOG: dict[tuple[str, str], list[dict[str, Any]]] = {
+    (ORG_ID, PROJECT_ID): [{"provider": "linear", "project_key": None}],
+    (ORG_ID, JIRA_PROJECT_ID): [
+        {"provider": "jira", "project_key": JIRA_RAW_PROJECT_KEY}
+    ],
+    (ORG_ID, COLLIDING_PROJECT_ID): [
+        {"provider": "jira", "project_key": "MULTI"},
+        {"provider": "linear", "project_key": None},
+    ],
+    (ORG_ID, RETIRED_PROJECT_ID): [
+        {
+            "provider": "jira",
+            "project_key": RETIRED_RAW_PROJECT_KEY,
+            "is_active": 0,
+        }
+    ],
     # GHOST_PROJECT_ID deliberately absent.
 }
 
@@ -248,6 +284,31 @@ WORK_ITEM_STORE = [
         project_id=JIRA_PROJECT_ID,
         project_key="",
     ),
+    # Round 2: would-be members of COLLIDING_PROJECT_ID / RETIRED_PROJECT_ID.
+    # Neither may ever be admitted -- the first because its catalog id is
+    # ambiguous (two providers), the second because its only catalog row is
+    # retired. Present so a regression back to "pick arbitrarily" or "ignore
+    # is_active" has something real to wrongly admit, rather than the test
+    # passing vacuously because no work item exists to admit in the first
+    # place.
+    _row(
+        work_item_id="jira:MULTI-1",
+        title="Would-be member of the colliding project",
+        status="in_progress",
+        repository_id=MULTI_PROVIDER_REPOSITORY_ID,
+        provider="jira",
+        project_id="99999",
+        project_key="MULTI",
+    ),
+    _row(
+        work_item_id="jira:RETIRED-1",
+        title="Would-be member of the retired project",
+        status="in_progress",
+        repository_id=RETIRED_PROJECT_REPOSITORY_ID,
+        provider="jira",
+        project_id="88888",
+        project_key=RETIRED_RAW_PROJECT_KEY,
+    ),
 ]
 
 IN_SCOPE_WORK_ITEM_IDS = {
@@ -289,8 +350,11 @@ class _FakeWorkItems:
 
     CHAOS-3374: the identity join (``provider = catalog_provider`` / ``project_key
     = catalog_project_key``) is resolved against ``PROJECTS_CATALOG`` exactly
-    like the real ``project AS (SELECT provider, project_key FROM projects
-    FINAL WHERE ...)`` CTE -- keyed by ``(org_id, id)``, absent means no row.
+    like the real ``project AS (... HAVING count() = 1)`` CTE -- filtered to
+    ``is_active`` candidates for this ``(org_id, id)``, and an identity is only
+    admitted when EXACTLY ONE candidate survives that filter (zero -> no row;
+    two or more, e.g. a same-id cross-provider collision -> ambiguous, both
+    fail closed, mirroring ``HAVING count() = 1`` exactly).
     """
 
     def __init__(self) -> None:
@@ -323,13 +387,34 @@ class _FakeWorkItems:
             ]
 
         entity_id = params["entity_id"]
-        catalog = PROJECTS_CATALOG.get((params["org_id"], entity_id))
+        all_candidates = PROJECTS_CATALOG.get((params["org_id"], entity_id), [])
+        # Read which identity predicates the SQL under test actually contains,
+        # exactly like the rest of this fake -- so dropping ``is_active = 1``
+        # or ``HAVING count() = 1`` from the real CTE changes what this fake
+        # admits too, instead of the fake enforcing the fix independently of
+        # whether the SQL text still has it (CHAOS-3374 round 2).
+        if "is_active = 1" in sql:
+            candidates = [row for row in all_candidates if row.get("is_active", 1) == 1]
+        else:
+            candidates = list(all_candidates)
+        if "HAVING count() = 1" in sql:
+            catalog = candidates[0] if len(candidates) == 1 else None
+        else:
+            # Mirrors the old, unguarded ``LIMIT 1`` (no ``ORDER BY``): picks
+            # ARBITRARILY among candidates rather than failing closed on a
+            # collision -- modeled here as "the first one", which is exactly
+            # the nondeterministic-in-production, deterministic-in-this-fake
+            # bug the round-2 fix closes.
+            catalog = candidates[0] if candidates else None
         catalog_provider = catalog["provider"] if catalog else None
         catalog_project_key = (catalog.get("project_key") or "") if catalog else ""
         provider_gated = "provider = catalog_provider" in sql
         if provider_gated and catalog is None:
-            # Mirrors the real ``project`` CTE resolving zero rows: the
-            # provider-gated arm can never match anything.
+            # Mirrors the real ``project`` CTE resolving zero rows: zero
+            # active candidates (never existed, or retired), or more than one
+            # (a same-id, different-provider collision -- ``HAVING count() =
+            # 1`` fails), both leave the provider-gated arm unable to match
+            # anything.
             return []
 
         arms = []
@@ -523,13 +608,13 @@ def test_derivation_sql_structure_is_pinned() -> None:
         " OR (catalog_project_key != '' AND project_key = catalog_project_key))\n"
         in sql
     )
-    # No bound on the REPOSITORY read itself: a truncated authorization set
-    # would be a silently narrowed read, not a smaller page. The identity
-    # CTE's own ``LIMIT 1`` bounds a single unique catalog-row lookup by its
-    # ReplacingMergeTree key, not the derived repository set -- so it is the
-    # ONLY "LIMIT" in the whole query, never the parameterised page size.
-    assert "LIMIT {limit:UInt32}" not in sql
-    assert sql.count("LIMIT") == 1
+    # No bound anywhere in this query: a truncated authorization set would be
+    # a silently narrowed read, not a smaller page. The identity CTE bounds
+    # itself to at most one row via ``HAVING count() = 1`` (CHAOS-3374 round
+    # 2 -- a bare ``LIMIT 1`` would pick nondeterministically between two
+    # same-``(org_id, id)``, different-provider rows, since the catalog's own
+    # ReplacingMergeTree key is ``(org_id, provider, id)``), never a ``LIMIT``.
+    assert "LIMIT" not in sql.upper()
     # Both authorization arms survive, and the tenant/as_of bounds with them.
     assert "toString(repo_id) = '00000000-0000-0000-0000-000000000000'" in sql
     assert "SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}" in sql
@@ -771,6 +856,76 @@ async def test_unresolvable_project_identity_at_read_time_stays_fail_closed(
     _install_catalog_client(monkeypatch, project_id=GHOST_PROJECT_ID)
     scope = await _committed_project_scope(project_id=GHOST_PROJECT_ID)
     assert GHOST_PROJECT_ID not in {key[1] for key in PROJECTS_CATALOG}
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+    assert not any("parent_id" in sql for sql in fake.sql), (
+        "no fact query may run on a repository set that was never resolved"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_provider_id_collision_at_read_time_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex adversarial review (MEDIUM, 2026-08-04), round 2.
+
+    ``projects``' ReplacingMergeTree key is ``(org_id, provider, id)``, not
+    ``(org_id, id)`` -- ``id`` alone is only unique WITHIN one provider. Two
+    different providers minting the SAME id in the SAME org (nothing in the
+    schema forbids it) both survive ``FINAL`` as distinct rows. The original
+    ``project AS (... LIMIT 1)`` CTE (no ``ORDER BY``) would then pick one of
+    them *nondeterministically*, and the provider guard would faithfully
+    protect the WRONG provider's identity -- silently answering with a
+    different project's repositories/facts depending on ClickHouse's whim.
+    The fix (``HAVING count() = 1``) must instead treat this as unresolvable.
+    """
+
+    _install_catalog_client(monkeypatch, project_id=COLLIDING_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=COLLIDING_PROJECT_ID)
+    assert len(PROJECTS_CATALOG[(ORG_ID, COLLIDING_PROJECT_ID)]) == 2
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
+    assert snapshot.children == ()
+    assert not any("parent_id" in sql for sql in fake.sql), (
+        "no fact query may run on a repository set that was never resolved"
+    )
+
+
+@pytest.mark.asyncio
+async def test_retired_project_identity_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex adversarial review (MEDIUM, 2026-08-04), round 2.
+
+    The authorized-entity catalog's own committing query
+    (``ClickHouseAuthorizedEntityCatalog._query_for(EntityKind.PROJECT)``)
+    filters ``is_active = 1``, so a project retired AFTER a scope was
+    committed against it (a newer ReplacingMergeTree row with
+    ``is_active = 0``) must not keep answering here just because the identity
+    CTE re-reads the same table without that filter. The scope-resolution
+    catalog fake below still resolves ``RETIRED_PROJECT_ID`` (modeling a
+    scope committed while the project was active); only the
+    native_status_change-side catalog reflects the later retirement.
+    """
+
+    _install_catalog_client(monkeypatch, project_id=RETIRED_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=RETIRED_PROJECT_ID)
+    assert PROJECTS_CATALOG[(ORG_ID, RETIRED_PROJECT_ID)][0]["is_active"] == 0
 
     fake = _install_status_client(monkeypatch)
     service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -18,10 +18,22 @@ invent are pinned:
 
 * ``test_catalog_project_rows_carry_no_repository`` pins the catalog's own
   ``NULL AS repository_id``, so the committed-scope shape cannot drift; and
-* ``_FakeWorkItems`` **evaluates** the derivation SQL's ``org_id``, ``as_of``
-  and ``project_id``/``project_key`` predicates against a row store rather than
-  returning a canned answer -- dropping any one of them changes the derived
-  repository set and fails a test (mutation-checked).
+* ``_FakeWorkItems`` **evaluates** the derivation SQL's ``org_id``, ``as_of``,
+  ``provider``/``project_key`` identity join, and ``project_id``/``project_key``
+  predicates against a row store rather than returning a canned answer --
+  dropping any one of them changes the derived repository set and fails a test
+  (mutation-checked).
+
+CHAOS-3374: Jira project subjects were fail-closed end to end because
+``team_autoimport_jira._project_id`` mints a Jira project's catalog id as
+``f"{org_id}:jira:{project_key}"`` while ``providers/jira/normalize`` writes
+the RAW Jira id/key onto ``work_items`` -- so neither
+``project_id = {entity_id}`` nor the old ``project_key = {entity_id}`` ever
+matched. The fix joins every project-scoped arm through the catalog's own
+``provider``/``project_key`` columns (see ``native_status_change.
+_project_identity_match``). ``_FakeWorkItems`` models that join with its own
+``PROJECTS_CATALOG`` lookup so these tests exercise the real predicate shape,
+not a stand-in for it.
 """
 
 from __future__ import annotations
@@ -54,12 +66,27 @@ PROJECT_ID = "13e65c04-40ec-4a95-8216-f7c2ce233244"
 PROJECT_NAME = "Ask Dev"
 TEAM_ID = "5b0d3f61-3e5f-4a2f-9a1e-1d2c3b4a5f60"
 
+#: CHAOS-3374: the Jira catalog id is provider-prefixed (mirrors production's
+#: ``team_autoimport_jira._project_id``), while the raw Jira project key below
+#: is what actually lands on ``work_items.project_key``.
+JIRA_PROJECT_ID = f"{ORG_ID}:jira:ASK"
+JIRA_RAW_PROJECT_KEY = "ASK"
+#: Jira's raw numeric project id -- never equal to the catalog id or key, so a
+#: work item attributed only by this column would never resolve (it isn't
+#: used by any test row; the Jira row below is reached via its raw key only).
+JIRA_RAW_PROJECT_ID_ON_WORK_ITEMS = "10001"
+#: A catalog id with no ``projects`` row on the native_status_change side at
+#: all -- simulates the identity read observing a scope the catalog read
+#: resolved a moment earlier (replication lag, a deleted project, etc.).
+GHOST_PROJECT_ID = f"{ORG_ID}:ghost:VANISHED"
+
 #: Linear work items carry no repository: the sync lands them under the zero
 #: UUID, which has no ``repos`` row at all (verified against the live dev
 #: ClickHouse). The fix must derive the project's repository set from
 #: ``work_items`` itself, never from an existence check against ``repos``.
 LINEAR_NO_REPOSITORY_ID = "00000000-0000-0000-0000-000000000000"
-#: Reached only through the SQL's ``project_key`` arm.
+#: Reached only through the SQL's ``project_key`` arm -- now Jira's, since a
+#: real Linear catalog row's own ``project_key`` is always empty (CHAOS-3374).
 KEYED_REPOSITORY_ID = "aaaaaaaa-0000-0000-0000-000000000001"
 #: Same project, another tenant -- must never enter this org's derived set.
 FOREIGN_REPOSITORY_ID = "bbbbbbbb-0000-0000-0000-000000000002"
@@ -70,15 +97,32 @@ FUTURE_REPOSITORY_ID = "cccccccc-0000-0000-0000-000000000003"
 #: authorization. The ORGANIZATION branch enumerates ``repos`` and would never
 #: admit it; neither may the project branch.
 REVOKED_REPOSITORY_ID = "dddddddd-0000-0000-0000-000000000004"
+#: Where a cross-provider collision row lives -- authorized in ``repos`` (so a
+#: leak is caught by the identity guard, not incidentally masked by repo
+#: authorization).
+COLLISION_REPOSITORY_ID = "ffffffff-0000-0000-0000-000000000006"
 
 #: The org-scoped ``repos`` catalog. The zero UUID is deliberately absent: it
 #: is the repository-*less* sentinel, not a repository.
 REPOS_CATALOG = {
-    ORG_ID: {KEYED_REPOSITORY_ID, FUTURE_REPOSITORY_ID},
+    ORG_ID: {KEYED_REPOSITORY_ID, FUTURE_REPOSITORY_ID, COLLISION_REPOSITORY_ID},
     OTHER_ORG_ID: {FOREIGN_REPOSITORY_ID},
 }
 
-EXPECTED_DERIVED_REPOSITORY_IDS = sorted({LINEAR_NO_REPOSITORY_ID, KEYED_REPOSITORY_ID})
+#: Simulates the ``projects`` ClickHouse table as read by the
+#: ``native_status_change`` identity CTE -- keyed exactly like the real table's
+#: ReplacingMergeTree ORDER BY prefix, ``(org_id, id)``.
+PROJECTS_CATALOG: dict[tuple[str, str], dict[str, str | None]] = {
+    (ORG_ID, PROJECT_ID): {"provider": "linear", "project_key": None},
+    (ORG_ID, JIRA_PROJECT_ID): {
+        "provider": "jira",
+        "project_key": JIRA_RAW_PROJECT_KEY,
+    },
+    # GHOST_PROJECT_ID deliberately absent.
+}
+
+EXPECTED_DERIVED_REPOSITORY_IDS = sorted({LINEAR_NO_REPOSITORY_ID})
+JIRA_EXPECTED_REPOSITORY_IDS = sorted({KEYED_REPOSITORY_ID})
 
 NO_REPOSITORY_SET_WARNING = (
     "Status reads require the complete authorized repository set; "
@@ -93,6 +137,7 @@ def _row(
     title: str,
     status: str,
     repository_id: str,
+    provider: str,
     org_id: str = ORG_ID,
     project_id: str = PROJECT_ID,
     project_key: str = "",
@@ -105,6 +150,7 @@ def _row(
         "title": title,
         "status": status,
         "parent_id": "",
+        "provider": provider,
         "project_id": project_id,
         "project_key": project_key,
         "updated_at": updated_at or (NOW - timedelta(days=4)),
@@ -120,21 +166,26 @@ WORK_ITEM_STORE = [
         title="Outcome copy contract",
         status="done",
         repository_id=LINEAR_NO_REPOSITORY_ID,
+        provider="linear",
     ),
     _row(
         work_item_id="linear:CHAOS-3368",
         title="Project status snapshot",
         status="in_progress",
         repository_id=LINEAR_NO_REPOSITORY_ID,
+        provider="linear",
     ),
-    # Attributed by project_key rather than project_id.
+    # The Jira project's own work item -- reached ONLY via the raw project_key
+    # arm (its project_id is the unrelated raw Jira numeric id), and ONLY
+    # because the catalog resolves JIRA_PROJECT_ID to provider="jira".
     _row(
         work_item_id="jira:ASK-9",
         title="Keyed attribution",
         status="in_progress",
         repository_id=KEYED_REPOSITORY_ID,
-        project_id="",
-        project_key=PROJECT_ID,
+        provider="jira",
+        project_id=JIRA_RAW_PROJECT_ID_ON_WORK_ITEMS,
+        project_key=JIRA_RAW_PROJECT_KEY,
     ),
     # Another tenant's item for the same project id.
     _row(
@@ -142,6 +193,7 @@ WORK_ITEM_STORE = [
         title="Other tenant",
         status="done",
         repository_id=FOREIGN_REPOSITORY_ID,
+        provider="linear",
         org_id=OTHER_ORG_ID,
     ),
     # This tenant, this project, but not yet visible at as_of.
@@ -150,6 +202,7 @@ WORK_ITEM_STORE = [
         title="Not yet at as_of",
         status="todo",
         repository_id=FUTURE_REPOSITORY_ID,
+        provider="linear",
         updated_at=NOW + timedelta(days=1),
     ),
     # This tenant, this project, in window -- but its repository is gone from
@@ -159,20 +212,65 @@ WORK_ITEM_STORE = [
         title="Repository no longer authorized",
         status="in_progress",
         repository_id=REVOKED_REPOSITORY_ID,
+        provider="linear",
+    ),
+    # CHAOS-3374 cross-provider collision matrix: three DIFFERENT providers'
+    # rows all carry the SAME raw key/id Jira's project uses. Without the
+    # provider guard on the identity join, any one of these would leak into
+    # the Jira-scoped snapshot (via the project_key arm) or vice versa (via
+    # the project_id arm, since GitLab's own id equals Jira's PREFIXED
+    # catalog id here -- an intentionally adversarial, not realistic,
+    # collision to prove the guard, not just the common case).
+    _row(
+        work_item_id="gitlab:collide-by-key",
+        title="GitLab project sharing Jira's raw key",
+        status="in_progress",
+        repository_id=COLLISION_REPOSITORY_ID,
+        provider="gitlab",
+        project_id="some-group/some-project",
+        project_key=JIRA_RAW_PROJECT_KEY,
+    ),
+    _row(
+        work_item_id="linear:collide-by-key",
+        title="Linear project sharing Jira's raw key",
+        status="in_progress",
+        repository_id=COLLISION_REPOSITORY_ID,
+        provider="linear",
+        project_id="11111111-2222-3333-4444-555555555555",
+        project_key=JIRA_RAW_PROJECT_KEY,
+    ),
+    _row(
+        work_item_id="gitlab:collide-by-id",
+        title="GitLab project sharing Jira's prefixed catalog id",
+        status="in_progress",
+        repository_id=COLLISION_REPOSITORY_ID,
+        provider="gitlab",
+        project_id=JIRA_PROJECT_ID,
+        project_key="",
     ),
 ]
 
 IN_SCOPE_WORK_ITEM_IDS = {
     "linear:CHAOS-3367",
     "linear:CHAOS-3368",
+}
+
+JIRA_IN_SCOPE_WORK_ITEM_IDS = {
     "jira:ASK-9",
+}
+
+#: The collision rows above must never surface for EITHER scope.
+COLLISION_WORK_ITEM_IDS = {
+    "gitlab:collide-by-key",
+    "linear:collide-by-key",
+    "gitlab:collide-by-id",
 }
 
 
 class _FakeWorkItems:
     """Evaluate the production SQL's predicates, don't fake past them.
 
-    A canned-answer fake makes the ``org_id`` / ``as_of`` / ``project_key`` /
+    A canned-answer fake makes the ``org_id`` / ``as_of`` / identity-join /
     ``repos`` predicates unfalsifiable -- deleting any of them from
     ``PROJECT_REPOSITORIES_SQL`` would still return the same rows. This reads
     which predicates the SQL under test actually contains and applies exactly
@@ -188,6 +286,11 @@ class _FakeWorkItems:
     structurally by ``test_derivation_sql_structure_is_pinned``, and the SQL's
     real-engine validity by the ``project_repositories`` entry in
     ``tests/api/dev/test_status_change_clickhouse_live.py``.
+
+    CHAOS-3374: the identity join (``provider = catalog_provider`` / ``project_key
+    = catalog_project_key``) is resolved against ``PROJECTS_CATALOG`` exactly
+    like the real ``project AS (SELECT provider, project_key FROM projects
+    FINAL WHERE ...)`` CTE -- keyed by ``(org_id, id)``, absent means no row.
     """
 
     def __init__(self) -> None:
@@ -218,13 +321,38 @@ class _FakeWorkItems:
                     and row["repository_id"] == LINEAR_NO_REPOSITORY_ID
                 )
             ]
+
         entity_id = params["entity_id"]
+        catalog = PROJECTS_CATALOG.get((params["org_id"], entity_id))
+        catalog_provider = catalog["provider"] if catalog else None
+        catalog_project_key = (catalog.get("project_key") or "") if catalog else ""
+        provider_gated = "provider = catalog_provider" in sql
+        if provider_gated and catalog is None:
+            # Mirrors the real ``project`` CTE resolving zero rows: the
+            # provider-gated arm can never match anything.
+            return []
+
         arms = []
         if "project_id = {entity_id:String}" in sql:
             arms.append(lambda row: row["project_id"] == entity_id)
+        if "project_key = catalog_project_key" in sql:
+            arms.append(
+                lambda row: (
+                    bool(catalog_project_key)
+                    and row["project_key"] == catalog_project_key
+                )
+            )
+        # Legacy substring, kept so a regression back to comparing project_key
+        # against the raw entity_id (pre-CHAOS-3374) is also caught here.
         if "project_key = {entity_id:String}" in sql:
             arms.append(lambda row: row["project_key"] == entity_id)
-        return [row for row in rows if any(arm(row) for arm in arms)]
+
+        def matches(row: dict[str, Any]) -> bool:
+            if provider_gated and row["provider"] != catalog_provider:
+                return False
+            return any(arm(row) for arm in arms)
+
+        return [row for row in rows if matches(row)]
 
     async def __call__(
         self, _client: object, sql: str, params: dict[str, Any]
@@ -338,13 +466,42 @@ def test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do() -> No
     delivery arms. If its project-matching predicate ever drifts from theirs,
     it could admit a repository those queries would not themselves draw from
     -- so the two are pinned as the same text, not merely as "both correct".
+
+    CHAOS-3374: the predicate widened from the plain
+    ``project_id = {entity_id:String} OR project_key = {entity_id:String}``
+    (which never matched a Jira row -- see the module docstring) to a
+    provider-and-native-key-aware join through the catalog's own ``projects``
+    row. Old assertion (pre-CHAOS-3374):
+
+        project_predicate = (
+            "project_id = {entity_id:String} OR project_key = {entity_id:String}"
+        )
+
+    New assertion, below: the shared text now requires the catalog identity to
+    resolve (``ifNull(catalog_provider, '') != ''``), the row's OWN provider to
+    match the catalog row's provider, and either the raw id or the raw native
+    key to match -- never the catalog's (possibly provider-prefixed) id
+    against a raw column on the other side of an OR.
     """
 
     project_predicate = (
-        "project_id = {entity_id:String} OR project_key = {entity_id:String}"
+        "ifNull(catalog_provider, '') != '' AND provider = catalog_provider"
+        " AND (project_id = {entity_id:String}"
+        " OR (catalog_project_key != '' AND project_key = catalog_project_key))"
     )
     assert project_predicate in native_status_change.PROJECT_REPOSITORIES_SQL
     assert project_predicate in native_status_change._WORK_ITEMS_SQL
+    # And both share the identical identity CTE that resolves catalog_provider
+    # / catalog_project_key in the first place -- not two independently
+    # drifting joins that merely happen to use the same column names.
+    assert (
+        native_status_change._PROJECT_IDENTITY_CTE
+        in native_status_change.PROJECT_REPOSITORIES_SQL
+    )
+    assert (
+        native_status_change._PROJECT_IDENTITY_CTE
+        in native_status_change._WORK_ITEMS_SQL
+    )
 
 
 def test_derivation_sql_structure_is_pinned() -> None:
@@ -361,12 +518,18 @@ def test_derivation_sql_structure_is_pinned() -> None:
     # a Jira row matches by key and a Linear row by id, never both at once, so
     # AND would return the empty set for every provider.
     assert (
-        "  AND (project_id = {entity_id:String} OR project_key = {entity_id:String})\n"
+        "  AND ifNull(catalog_provider, '') != '' AND provider = catalog_provider"
+        " AND (project_id = {entity_id:String}"
+        " OR (catalog_project_key != '' AND project_key = catalog_project_key))\n"
         in sql
     )
-    # No bound of its own: this resolves an authorization set, and a truncated
-    # authorization set is a silently narrowed read, not a smaller page.
-    assert "LIMIT" not in sql.upper()
+    # No bound on the REPOSITORY read itself: a truncated authorization set
+    # would be a silently narrowed read, not a smaller page. The identity
+    # CTE's own ``LIMIT 1`` bounds a single unique catalog-row lookup by its
+    # ReplacingMergeTree key, not the derived repository set -- so it is the
+    # ONLY "LIMIT" in the whole query, never the parameterised page size.
+    assert "LIMIT {limit:UInt32}" not in sql
+    assert sql.count("LIMIT") == 1
     # Both authorization arms survive, and the tenant/as_of bounds with them.
     assert "toString(repo_id) = '00000000-0000-0000-0000-000000000000'" in sql
     assert "SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}" in sql
@@ -377,7 +540,13 @@ def test_derivation_sql_structure_is_pinned() -> None:
     # masks that deletion for every real repository -- leaving the
     # repository-less sentinel bucket, which is shared by every tenant, as the
     # one place the fact table's own bound is the only tenant boundary left.
-    assert "FROM work_items FINAL\nWHERE org_id = {org_id:String}\n" in sql
+    # ``INNER JOIN project ON 1 = 1`` sits between the FROM and the WHERE
+    # (CHAOS-3374's identity join) -- anchored here too, so a future edit
+    # can't quietly drop it while leaving this assertion green.
+    assert (
+        "FROM work_items FINAL\nINNER JOIN project ON 1 = 1\nWHERE org_id = {org_id:String}\n"
+        in sql
+    )
     assert "AND updated_at <= {as_of:DateTime64(3, 'UTC')}" in sql
 
 
@@ -417,6 +586,11 @@ async def test_committed_project_scope_status_snapshot_reads_its_work_items(
     # the returned facts alone would pass for a snapshot that never queried.
     fake.work_item_read_params()
     assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
+    # Cross-provider collision rows sharing Linear's raw id space or a Jira
+    # key by coincidence must never leak into a Linear-scoped snapshot either.
+    assert not COLLISION_WORK_ITEM_IDS & {
+        child.entity_id for child in snapshot.children
+    }
 
 
 @pytest.mark.asyncio
@@ -509,32 +683,26 @@ async def test_repository_less_sentinel_is_admitted_without_a_repos_row(
 
 
 @pytest.mark.asyncio
-async def test_jira_shaped_project_keeps_todays_fail_closed_behaviour(
+async def test_jira_shaped_project_resolves_via_provider_scoped_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The new arm is provider-scoped by construction, and discloses it.
+    """GREEN after CHAOS-3374: the identity join makes Jira answerable.
 
-    ``team_autoimport_jira._project_id`` mints a Jira project's catalog id as
-    ``f"{org_id}:jira:{project_key}"``, while ``providers/jira/normalize``
-    writes the *raw* Jira id and key onto ``work_items``. Neither
-    ``project_id = {entity_id}`` nor ``project_key = {entity_id}`` matches --
-    and ``_WORK_ITEMS_SQL``/``_BLOCKERS_SQL``/``_PULL_REQUESTS_SQL`` already
-    share that identical predicate, so Jira project subjects were, and remain,
-    unanswerable end to end.
-
-    Making *only* the derivation provider-aware would be strictly worse than
-    leaving it: it would derive repositories, the fact queries would still
-    match nothing, and the run would report a confident empty answer for a
-    project that has data instead of the disclosed fail-closed one. So the
-    derivation shares the fact queries' predicate exactly, which keeps Jira on
-    today's honest refusal. Asserted here so that stays a decision rather than
-    an accident.
+    Before the fix (see ``test_derivation_matches_projects_exactly_as_the_
+    queries_it_bounds_do``'s old-assertion comment), this exact scenario hit
+    ``test_jira_shaped_project_keeps_todays_fail_closed_behaviour`` and
+    asserted the OPPOSITE: ``NO_REPOSITORY_SET_WARNING in snapshot.warnings``
+    and ``snapshot.children == ()``. That was a deliberate, documented
+    decision -- a derivation-only fix would have turned a disclosed
+    fail-closed refusal into a confident empty answer, which is worse. The
+    coordinated fix implemented here (repository derivation AND every fact
+    arm join through the catalog's own provider/project_key) makes the
+    disclosed refusal unnecessary: the project now resolves for real.
     """
 
-    jira_project_id = f"{ORG_ID}:jira:ASK"
-    _install_catalog_client(monkeypatch, project_id=jira_project_id)
-    scope = await _committed_project_scope(project_id=jira_project_id)
-    assert scope.entity_refs[0].entity_id == jira_project_id
+    _install_catalog_client(monkeypatch, project_id=JIRA_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=JIRA_PROJECT_ID)
+    assert scope.entity_refs[0].entity_id == JIRA_PROJECT_ID
 
     fake = _install_status_client(monkeypatch)
     service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
@@ -543,7 +711,74 @@ async def test_jira_shaped_project_keeps_todays_fail_closed_behaviour(
         ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
     )
 
-    # Disclosed refusal, not a confident empty: the warning is the whole point.
+    assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    bound = fake.work_item_read_params()["repository_ids"]
+    assert sorted(bound) == JIRA_EXPECTED_REPOSITORY_IDS
+    assert {
+        child.entity_id for child in snapshot.children
+    } == JIRA_IN_SCOPE_WORK_ITEM_IDS
+    # None of the cross-provider collision rows sharing Jira's raw key (or,
+    # adversarially, its prefixed catalog id) may leak in.
+    assert not COLLISION_WORK_ITEM_IDS & {
+        child.entity_id for child in snapshot.children
+    }
+
+
+@pytest.mark.asyncio
+async def test_jira_shaped_project_change_summary_is_not_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``change_summary`` shares the same repository-bounding helper as Jira."""
+
+    _install_catalog_client(monkeypatch, project_id=JIRA_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=JIRA_PROJECT_ID)
+    assert scope.comparison_range is not None
+
+    _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    change = await service.change_summary(
+        ORG_ID,
+        "permission-fingerprint",
+        ChangeSummaryRequest(
+            scope=scope,
+            current_start=scope.time_range.start,
+            current_end=scope.time_range.end,
+            comparison_start=scope.comparison_range.start,
+            comparison_end=scope.comparison_range.end,
+        ),
+    )
+
+    assert NO_CHANGE_SET_WARNING not in change.warnings
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_project_identity_at_read_time_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control: a committed scope whose id has no live catalog row.
+
+    The scope-resolution catalog (``scope_catalog``, backing
+    ``ScopeResolutionService``) and the identity join inside
+    ``PROJECT_REPOSITORIES_SQL``/``_WORK_ITEMS_SQL`` read the SAME
+    ``projects`` table in production but are two separate reads. If the row
+    the first read saw is gone by the second (replication lag, concurrent
+    delete), the identity CTE resolves zero rows and the project arm must
+    fail closed -- never fall through to matching on a null/empty provider,
+    which would turn "unknown identity" into "no provider filter at all".
+    """
+
+    _install_catalog_client(monkeypatch, project_id=GHOST_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=GHOST_PROJECT_ID)
+    assert GHOST_PROJECT_ID not in {key[1] for key in PROJECTS_CATALOG}
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
     assert NO_REPOSITORY_SET_WARNING in snapshot.warnings
     assert snapshot.children == ()
     assert not any("parent_id" in sql for sql in fake.sql), (
@@ -560,7 +795,7 @@ async def test_derived_repository_set_is_exactly_the_projects_own_work(
     Asserted on the ``repository_ids`` the real ``_WORK_ITEMS_SQL`` read was
     actually bound by -- the one observable that distinguishes a correct
     derivation from one that dropped the tenant bound, the ``as_of`` bound, or
-    the ``project_key`` arm.
+    the identity join.
     """
 
     _install_catalog_client(monkeypatch)
@@ -576,6 +811,10 @@ async def test_derived_repository_set_is_exactly_the_projects_own_work(
     assert sorted(bound) == EXPECTED_DERIVED_REPOSITORY_IDS
     assert FOREIGN_REPOSITORY_ID not in bound
     assert FUTURE_REPOSITORY_ID not in bound
+    # The Jira-only repository must not leak into the Linear project's set --
+    # the provider guard applies to the derivation, not just the fact reads.
+    assert KEYED_REPOSITORY_ID not in bound
+    assert COLLISION_REPOSITORY_ID not in bound
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -119,17 +119,12 @@ def test_project_repository_derivation_parses_against_production_schema(
 
     sql = PROJECT_REPOSITORIES_SQL
     assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
-    # CHAOS-3374: the identity CTE's own ``LIMIT 1`` bounds a single unique
-    # catalog-row lookup by its ReplacingMergeTree key, not the derived
-    # repository set -- so a parameterised page bound must still never appear,
-    # but that one literal ``LIMIT 1`` is expected and is the ONLY "LIMIT" in
-    # the query.
-    assert "LIMIT {limit:UInt32}" not in sql, (
-        "an authorization set must not be truncated"
-    )
-    assert sql.upper().count("LIMIT") == 1, (
-        "expected exactly the identity CTE's own LIMIT 1, found a different count"
-    )
+    # CHAOS-3374 round 2: the identity CTE bounds itself to at most one row via
+    # ``HAVING count() = 1`` (a bare ``LIMIT 1`` with no ``ORDER BY`` would
+    # pick nondeterministically between two same-``(org_id, id)``,
+    # different-provider rows -- the catalog's own ReplacingMergeTree key is
+    # ``(org_id, provider, id)``), so no ``LIMIT`` of any kind belongs here.
+    assert "LIMIT" not in sql.upper(), "an authorization set must not be truncated"
     params: dict[str, object] = {
         "org_id": ORG_ID,
         "entity_id": "project-target",

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -119,7 +119,17 @@ def test_project_repository_derivation_parses_against_production_schema(
 
     sql = PROJECT_REPOSITORIES_SQL
     assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
-    assert "LIMIT" not in sql.upper(), "an authorization set must not be truncated"
+    # CHAOS-3374: the identity CTE's own ``LIMIT 1`` bounds a single unique
+    # catalog-row lookup by its ReplacingMergeTree key, not the derived
+    # repository set -- so a parameterised page bound must still never appear,
+    # but that one literal ``LIMIT 1`` is expected and is the ONLY "LIMIT" in
+    # the query.
+    assert "LIMIT {limit:UInt32}" not in sql, (
+        "an authorization set must not be truncated"
+    )
+    assert sql.upper().count("LIMIT") == 1, (
+        "expected exactly the identity CTE's own LIMIT 1, found a different count"
+    )
     params: dict[str, object] = {
         "org_id": ORG_ID,
         "entity_id": "project-target",


### PR DESCRIPTION
## Summary

Fixes CHAOS-3374: Jira project subjects failed closed end-to-end because the catalog mints project ids as `{org}:jira:{key}` while `providers/jira/normalize.py` writes the raw Jira id/key onto `work_items` — no project SQL arm ever matched.

- Adds a shared `_PROJECT_IDENTITY_CTE` that reads `provider` + raw `project_key` from the project's own catalog row (`is_active = 1`, `HAVING count() = 1` so zero or multiple active matches fail closed) and joins it into all 11 project SQL arms in `native_status_change.py`, including `PROJECT_REPOSITORIES_SQL` (INNER JOIN, fail-closed by construction; data-health picks the fix up automatically via `_project_repositories`).
- Every project predicate is now provider-scoped: `provider = catalog_provider AND (project_id = id OR (catalog_project_key != '' AND project_key = catalog_project_key))` — closes the general cross-provider collision class, not just Jira-vs-Linear.
- Adversarial-review round: identity lookup now fails closed on same-org cross-provider id collisions (RMT key is `(org_id, provider, id)`, so FINAL retains one row per provider) and on retired projects (`is_active = 1`, matching the authorized catalog contract).
- Deliberately replaces the #1453 pinning test: `test_jira_shaped_project_keeps_todays_fail_closed_behaviour` → `test_jira_shaped_project_resolves_via_provider_scoped_identity` (Jira projects now resolve; team-filtered and unresolvable scopes still fail closed).

Known adjacent gap (separate ticket, CHAOS-3380): GitLab has no project catalog sync at all, so GitLab project subjects remain unresolvable regardless of this join.

## Testing

- Unit `tests/api/dev/` (non-clickhouse): 1846 passed, 19 skipped, 1 xfailed, 0 failed.
- Live ClickHouse (scratch db, real migrations, real sink writes): `test_project_scope_clickhouse_live.py` 10/10, including fail→pass-verified collision and retirement cases; `test_ask_dev_linear_project_subject_live.py` 17/17.
- Pre-existing red untouched: `test_status_change_clickhouse_live.py` 10/14 failing on main (CHAOS-3376), `test_resolver_sql_explain.py` [operating_review]/[analytics].
- ruff + mypy clean (full-repo mypy via pre-commit).
