### PR TITLE
feat(providersync): compose GitHub PR review effects

### DIFF
--- a/internal/providersync/github_pr_reviews_effects_clickhouse.go
+++ b/internal/providersync/github_pr_reviews_effects_clickhouse.go
@@ -7,9 +7,10 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// GitHubPullRequestReviewClickHouseEffects is the non-routed persistence
-// foundation for github/pr-reviews. Both write and FINAL readback are guarded
-// by the authoritative unit lease; wiring this sink does not activate a route.
+// GitHubPullRequestReviewClickHouseEffects persists the two effects emitted by
+// the composed github/pr-reviews unit. Both write and FINAL readback are
+// guarded by the authoritative unit lease; wiring this sink does not activate
+// a route.
 type GitHubPullRequestReviewClickHouseEffects struct {
 	Conn  driver.Conn
 	Lease providerfoundation.LeaseGuard
@@ -19,8 +20,15 @@ func (sink GitHubPullRequestReviewClickHouseEffects) WriteEffect(
 	ctx context.Context, claim Claim, effect EffectBatch,
 ) error {
 	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "pr-reviews" ||
-		effect.Destination != "git_pull_request_reviews" {
+		claim.Provider != "github" || claim.Dataset != "pr-reviews" {
+		return ErrInvalidConfiguration
+	}
+	if effect.Destination == "git_pull_requests" {
+		return (GitHubPullRequestClickHouseEffects{
+			Conn: sink.Conn, Lease: sink.Lease,
+		}).writePullRequestEffect(ctx, claim, effect, "pr-reviews")
+	}
+	if effect.Destination != "git_pull_request_reviews" {
 		return ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {
@@ -69,7 +77,15 @@ func (sink GitHubPullRequestReviewClickHouseEffects) InspectEffect(
 ) (EffectInspection, error) {
 	if ctx == nil || sink.Lease == nil || sink.Conn == nil ||
 		claim.Validate() != nil || claim.Provider != "github" ||
-		claim.Dataset != "pr-reviews" || effect.Destination != "git_pull_request_reviews" {
+		claim.Dataset != "pr-reviews" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if effect.Destination == "git_pull_requests" {
+		return (GitHubPullRequestClickHouseEffects{
+			Conn: sink.Conn, Lease: sink.Lease,
+		}).inspectPullRequestEffect(ctx, claim, effect, "pr-reviews")
+	}
+	if effect.Destination != "git_pull_request_reviews" {
 		return EffectConflict, ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {

--- a/internal/providersync/github_pr_reviews_effects_integration_test.go
+++ b/internal/providersync/github_pr_reviews_effects_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const gitPullRequestReviewsDDL = `CREATE TABLE git_pull_request_reviews (org_id String, repo_id UUID, number UInt32, review_id String, reviewer String, state String, submitted_at DateTime64(3, 'UTC'), last_synced DateTime64(3, 'UTC'), source_id Nullable(UUID)) ENGINE = ReplacingMergeTree(last_synced) ORDER BY (org_id, repo_id, number, review_id)`
@@ -91,5 +93,183 @@ func TestGitHubPullRequestReviewEffectsAreNonEmptyTenantFencedAndLeaseGuarded(t 
 	}
 	if inspection, err := safe.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
 		t.Fatalf("foreign newer row crossed tenant fence: inspection=%s err=%v", inspection, err)
+	}
+}
+
+// TestGitHubPullRequestReviewCompositeCrashRecoveryIsExact proves the D16
+// boundary against the real engines. A crash after the enriched complete PR
+// write must recover by FINAL readback, never blind replay into a second
+// ReplacingMergeTree version.
+func TestGitHubPullRequestReviewCompositeCrashRecoveryIsExact(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReviewCompositeHarness(t, ctx)
+	claim, now := harness.claim, harness.now
+	normalizedAt := now.Add(123456 * time.Microsecond)
+	graphql := `{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[{"id":"review-1","state":"CHANGES_REQUESTED","submittedAt":"2026-07-11T10:30:00Z","author":{"login":"octocat"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+	collect := func(current Claim, stamp time.Time) CompleteRouteBatch {
+		doer := &gitHubPullRequestReviewRouteDoer{
+			t: t, restBodies: defaultGitHubPullRequestFixtures(), graphQLReply: graphql,
+		}
+		batch, err := (GitHubPullRequestReviewRouteHandler{}).Collect(
+			ctx, current, providerfoundation.Credential{},
+			gitHubPullRequestClient(t, doer, "https://api.github.com"), stamp,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return batch
+	}
+	first := collect(claim, normalizedAt)
+	sink := GitHubPullRequestReviewClickHouseEffects{
+		Conn: harness.conn, Lease: leaseGuardAt(harness.repository, claim, now),
+	}
+	crash := errors.New("simulated crash after enriched pull-request write")
+	_, err := (EffectCommitter{
+		Ledger: harness.repository,
+		Sink: crashAfterGitHubPullRequestReviewWrite{
+			sink: sink, destination: "git_pull_requests", failure: crash,
+		},
+		Now: func() time.Time { return now.Add(10 * time.Second) },
+	}).Commit(ctx, claim, first.Effects, normalizedAt)
+	if !errors.Is(err, crash) {
+		t.Fatalf("first commit error=%v", err)
+	}
+	persisted, err := harness.repository.LoadEffects(ctx, claim, now.Add(11*time.Second))
+	if err != nil || len(persisted.Effects) != 2 {
+		t.Fatalf("persisted=%+v error=%v", persisted, err)
+	}
+
+	recoveryNow := now.Add(61 * time.Second)
+	freshRepository, err := NewPostgresRepository(harness.repository.Pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := freshRepository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: recoveryNow, LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err = freshRepository.LoadEffects(ctx, recovered, recoveryNow)
+	if err != nil || !persisted.CreatedAt.UTC().Equal(normalizedAt.UTC()) {
+		t.Fatalf("reloaded ledger=%+v error=%v", persisted, err)
+	}
+	rebuilt := collect(recovered, persisted.CreatedAt)
+	for index := range first.Effects {
+		if rebuilt.Effects[index].Destination != first.Effects[index].Destination ||
+			rebuilt.Effects[index].ContentDigest != first.Effects[index].ContentDigest {
+			t.Fatalf("rebuilt effect[%d]=%+v want=%+v", index, rebuilt.Effects[index], first.Effects[index])
+		}
+	}
+	freshSink := GitHubPullRequestReviewClickHouseEffects{
+		Conn: harness.conn, Lease: leaseGuardAt(freshRepository, recovered, recoveryNow),
+	}
+	result, err := (EffectCommitter{
+		Ledger: freshRepository, Sink: freshSink, Readback: freshSink,
+		Now: func() time.Time { return recoveryNow },
+	}).Commit(ctx, recovered, rebuilt.Effects, persisted.CreatedAt)
+	if err != nil || result != (EffectCommitResult{Skipped: 1, MarkedCommitted: 1}) {
+		t.Fatalf("recovery result=%+v error=%v", result, err)
+	}
+	assertPullRequestVersionCount(t, ctx, harness, "c7198fbc-1945-3717-05d8-eb78866b4e79", 42, 1)
+	var reviewRows uint64
+	if err := harness.conn.QueryRow(ctx, `SELECT count() FROM git_pull_request_reviews WHERE org_id = ?`, claim.OrgID).Scan(&reviewRows); err != nil {
+		t.Fatal(err)
+	}
+	if reviewRows != 1 {
+		t.Fatalf("physical git_pull_request_reviews versions=%d want 1", reviewRows)
+	}
+}
+
+type crashAfterGitHubPullRequestReviewWrite struct {
+	sink        GitHubPullRequestReviewClickHouseEffects
+	destination string
+	failure     error
+}
+
+func (writer crashAfterGitHubPullRequestReviewWrite) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := writer.sink.WriteEffect(ctx, claim, effect); err != nil {
+		return err
+	}
+	if effect.Destination == writer.destination {
+		return writer.failure
+	}
+	return nil
+}
+
+func startPullRequestReviewCompositeHarness(
+	t *testing.T,
+	ctx context.Context,
+) *pullRequestReadbackHarness {
+	t.Helper()
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := postgres.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET provider = 'github', dataset_key = 'pr-reviews',
+    cost_class = 'medium', processor_flags = '{"sync_prs": true}',
+    since_at = '2026-07-01T00:00:00Z', before_at = '2026-07-31T23:59:59Z'
+WHERE id = $1`, firstUnitID); err != nil {
+		t.Fatal(err)
+	}
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitPullRequestsDDL); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Exec(ctx, gitPullRequestReviewsDDL); err != nil {
+		t.Fatal(err)
+	}
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &pullRequestReadbackHarness{
+		conn: conn, repository: repository, claim: claim, now: now,
+		sink: GitHubPullRequestClickHouseEffects{
+			Conn: conn, Lease: leaseGuardAt(repository, claim, now),
+		},
 	}
 }

--- a/internal/providersync/github_pr_reviews_route.go
+++ b/internal/providersync/github_pr_reviews_route.go
@@ -1,0 +1,161 @@
+package providersync
+
+import (
+	"context"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubPullRequestReviewRouteHandler is the production-constructible,
+// deliberately-unregistered complete route for github/pr-reviews. Python runs
+// PR collection, GraphQL review enrichment, and both writes in one
+// _sync_github_prs_to_store_async execution. The Go unit keeps the
+// pr-reviews claim for its own ledger/audit identity, but invokes the existing
+// prs collector as an implementation detail and emits the one enriched,
+// complete git_pull_requests row alongside git_pull_request_reviews.
+//
+// This is the only safe ownership boundary for a ReplacingMergeTree complete
+// row: a separately scheduled review writer cannot patch just three columns,
+// and a base PR writer cannot safely write their defaults after enrichment.
+// The route remains unregistered until pr-comments joins this same unit and
+// the matrix can switch the complete three-way Python boundary atomically.
+type GitHubPullRequestReviewRouteHandler struct {
+	PullRequests GitHubPullRequestRouteHandler
+	Reviews      GitHubPullRequestReviewFetcher
+}
+
+func (handler GitHubPullRequestReviewRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "pr-reviews" || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+
+	// The REST collector is intentionally reused rather than re-listing PRs:
+	// selecting a second independently-watermarked set would let review rows
+	// describe PRs that the enclosing complete row effect does not contain.
+	baseClaim := claim
+	baseClaim.Dataset = "prs"
+	base, err := handler.PullRequests.Collect(
+		ctx, baseClaim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(base.Effects) != 1 || base.Effects[0].Destination != "git_pull_requests" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	rows, err := decodeEffectRows[pullRequestRow](base.Effects[0])
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	targets := make([]GitHubPullRequestReviewTarget, 0, len(rows))
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		targets = append(targets, GitHubPullRequestReviewTarget{
+			Number: row.Number, CreatedAt: row.CreatedAt,
+		})
+	}
+
+	repoID := ""
+	if len(rows) > 0 {
+		repoID = rows[0].RepoID
+	}
+	reviews, err := handler.Reviews.Fetch(
+		ctx, claim, client, repoID, targets, normalizedAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	// Non-rate review failures intentionally degrade to the original PR rows,
+	// exactly as Python does. The typed marker makes an absent enrichment
+	// observable without misreporting it as an empty review collection.
+	if reviews.Complete() {
+		if err := enrichPullRequestsWithReviews(rows, reviews.Rows); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+	}
+	prEffect, err := effectBatchFromValues(
+		"git_pull_requests", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	reviewEffect, err := effectBatchFromValues(
+		"git_pull_request_reviews", EffectReadbackRequired, reviews.Rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	result := map[string]any{
+		"prs_synced":        len(rows),
+		"pr_reviews_synced": len(reviews.Rows),
+		"repo":              base.Result["repo"],
+	}
+	if reviews.Incomplete != nil {
+		result["pr_reviews_incomplete"] = reviews.Incomplete.Cause
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{prEffect, reviewEffect}, Result: result,
+		Watermark: base.Watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests:   base.Evidence.Requests + reviews.Evidence.Requests,
+			Pages:      base.Evidence.Pages + reviews.Evidence.Pages,
+			Records:    len(rows) + len(reviews.Rows),
+			CapReached: base.Evidence.CapReached,
+		},
+	}, nil
+}
+
+// enrichPullRequestsWithReviews is the in-place equivalent of Python's
+// _enrich_prs_with_reviews_batch. It only changes a PR when at least one
+// review exists, preserving the base collector's zero values for a genuine
+// no-review result and for the documented optional-enrichment degradation.
+func enrichPullRequestsWithReviews(
+	rows []pullRequestRow,
+	reviews []pullRequestReviewRow,
+) error {
+	byNumber := make(map[int][]pullRequestReviewRow, len(rows))
+	for _, review := range reviews {
+		if review.Number < 1 || review.RepoID == "" || review.SubmittedAt.IsZero() {
+			return providerfoundation.ErrNormalizationInvalid
+		}
+		byNumber[review.Number] = append(byNumber[review.Number], review)
+	}
+	for index := range rows {
+		row := &rows[index]
+		prReviews := byNumber[row.Number]
+		if len(prReviews) == 0 {
+			continue
+		}
+		var firstReviewAt *time.Time
+		changesRequestedCount := 0
+		for _, review := range prReviews {
+			if review.RepoID != row.RepoID || review.OrgID != row.OrgID {
+				return providerfoundation.ErrInvalidScope
+			}
+			at := review.SubmittedAt.UTC()
+			if firstReviewAt == nil || at.Before(*firstReviewAt) {
+				firstReviewAt = &at
+			}
+			if review.State == "CHANGES_REQUESTED" {
+				changesRequestedCount++
+			}
+		}
+		row.FirstReviewAt = firstReviewAt
+		row.ReviewsCount = len(prReviews)
+		row.ChangesRequestedCount = changesRequestedCount
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubPullRequestReviewRouteHandler{}

--- a/internal/providersync/github_pr_reviews_route_test.go
+++ b/internal/providersync/github_pr_reviews_route_test.go
@@ -1,0 +1,145 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitHubPullRequestReviewRouteDoer struct {
+	t             *testing.T
+	restBodies    map[string]string
+	graphQLStatus int
+	graphQLReply  string
+	paths         []string
+}
+
+func (doer *gitHubPullRequestReviewRouteDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.paths = append(doer.paths, request.URL.Path)
+	if request.URL.Path == "/graphql" {
+		_, _ = io.ReadAll(request.Body)
+		status := doer.graphQLStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+		return gitHubPullRequestReviewResponse(request, status, doer.graphQLReply), nil
+	}
+	if body, ok := doer.restBodies[request.URL.Path]; ok {
+		return gitHubPullRequestReviewResponse(request, http.StatusOK, body), nil
+	}
+	return gitHubPullRequestReviewResponse(request, http.StatusNotFound, `{}`), nil
+}
+
+func TestGitHubPullRequestReviewRouteComposesOneCompletePRRow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 123456000, time.UTC)
+	doer := &gitHubPullRequestReviewRouteDoer{
+		t: t, restBodies: defaultGitHubPullRequestFixtures(),
+		graphQLReply: `{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[` +
+			`{"databaseId":9007199254740993,"state":"APPROVED","submittedAt":"2026-07-11T10:30:00Z","author":{"login":"octocat"}},` +
+			`{"id":"R_changes","state":"CHANGES_REQUESTED","submittedAt":"2026-07-10T11:00:00Z","author":{"login":"hubot"}}` +
+			`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`,
+	}
+	claim := nativeTestClaim("github", "pr-reviews")
+	batch, err := (GitHubPullRequestReviewRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) ||
+		batch.Evidence.Provider != "github" || batch.Evidence.Dataset != "pr-reviews" ||
+		batch.Evidence.Requests != 4 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 {
+		t.Fatalf("batch evidence=%+v watermark=%v", batch.Evidence, batch.Watermark)
+	}
+	if len(batch.Effects) != 2 || batch.Effects[0].Destination != "git_pull_requests" ||
+		batch.Effects[1].Destination != "git_pull_request_reviews" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || batch.Effects[1].Recovery != EffectReadbackRequired {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var pull pullRequestRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &pull); err != nil {
+		t.Fatal(err)
+	}
+	first := time.Date(2026, 7, 10, 11, 0, 0, 0, time.UTC)
+	if pull.FirstReviewAt == nil || !pull.FirstReviewAt.Equal(first) ||
+		pull.ReviewsCount != 2 || pull.ChangesRequestedCount != 1 ||
+		pull.CommentsCount != 3 || pull.FirstCommentAt != nil {
+		t.Fatalf("enriched pull=%+v", pull)
+	}
+	reviews, err := decodeEffectRows[pullRequestReviewRow](batch.Effects[1])
+	if err != nil || len(reviews) != 2 {
+		t.Fatalf("reviews=%+v err=%v", reviews, err)
+	}
+	if batch.Result["prs_synced"] != 1 || batch.Result["pr_reviews_synced"] != 2 ||
+		batch.Result["pr_reviews_incomplete"] != nil {
+		t.Fatalf("result=%+v", batch.Result)
+	}
+}
+
+func TestGitHubPullRequestReviewRoutePreservesBaseRowOnOptionalReviewFailure(t *testing.T) {
+	t.Parallel()
+	doer := &gitHubPullRequestReviewRouteDoer{
+		t: t, restBodies: defaultGitHubPullRequestFixtures(), graphQLStatus: http.StatusServiceUnavailable,
+		graphQLReply: `{"message":"temporarily unavailable"}`,
+	}
+	claim := nativeTestClaim("github", "pr-reviews")
+	batch, err := (GitHubPullRequestReviewRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pull pullRequestRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &pull); err != nil {
+		t.Fatal(err)
+	}
+	if pull.FirstReviewAt != nil || pull.ReviewsCount != 0 || pull.ChangesRequestedCount != 0 ||
+		len(batch.Effects[1].Rows) != 0 || batch.Result["pr_reviews_incomplete"] != "transient" {
+		t.Fatalf("batch=%+v pull=%+v", batch, pull)
+	}
+}
+
+func TestEnrichPullRequestsWithReviewsRejectsForeignReview(t *testing.T) {
+	t.Parallel()
+	row := pullRequestReadbackFixture(time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	row.OrgID = "org-acme"
+	err := enrichPullRequestsWithReviews([]pullRequestRow{row}, []pullRequestReviewRow{{
+		OrgID: "other-org", RepoID: row.RepoID, Number: row.Number,
+		ReviewID: "review-1", Reviewer: "octocat", State: "APPROVED",
+		SubmittedAt: row.CreatedAt, LastSynced: row.LastSynced,
+	}})
+	if err != providerfoundation.ErrInvalidScope {
+		t.Fatalf("error=%v want ErrInvalidScope", err)
+	}
+}
+
+func TestEnrichPullRequestsWithReviewsLeavesNoReviewRowsUntouched(t *testing.T) {
+	t.Parallel()
+	row := pullRequestReadbackFixture(time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	row.FirstReviewAt = nil
+	row.ReviewsCount, row.ChangesRequestedCount = 0, 0
+	rows := []pullRequestRow{row}
+	if err := enrichPullRequestsWithReviews(rows, nil); err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].FirstReviewAt != nil || rows[0].ReviewsCount != 0 || rows[0].ChangesRequestedCount != 0 {
+		t.Fatalf("row=%+v", rows[0])
+	}
+}
+
+func TestGitHubPullRequestReviewRouteIsNotRegisteredUntilTheThreeWayUnitLands(t *testing.T) {
+	t.Parallel()
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "pr-reviews")
+	if !ok || descriptor.RouteReady || len(descriptor.Destinations) != 0 {
+		t.Fatalf("descriptor=%+v ok=%v", descriptor, ok)
+	}
+}

--- a/internal/providersync/github_prs_effects_clickhouse.go
+++ b/internal/providersync/github_prs_effects_clickhouse.go
@@ -24,8 +24,23 @@ func (sink GitHubPullRequestClickHouseEffects) WriteEffect(
 	claim Claim,
 	effect EffectBatch,
 ) error {
+	return sink.writePullRequestEffect(ctx, claim, effect, "prs")
+}
+
+// writePullRequestEffect owns the complete git_pull_requests row write. The
+// public prs sink deliberately restricts it to github/prs; the composed
+// github/pr-reviews route calls this same whole-row writer under its own unit
+// claim after it has enriched the three review-derived columns. Keeping the
+// SQL and validation here prevents two subtly different complete-row writers
+// from racing on a ReplacingMergeTree table, which has no partial-column merge.
+func (sink GitHubPullRequestClickHouseEffects) writePullRequestEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+	dataset string,
+) error {
 	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "prs" ||
+		claim.Provider != "github" || claim.Dataset != dataset ||
 		effect.Destination != "git_pull_requests" {
 		return ErrInvalidConfiguration
 	}
@@ -89,8 +104,21 @@ func (sink GitHubPullRequestClickHouseEffects) InspectEffect(
 	claim Claim,
 	effect EffectBatch,
 ) (EffectInspection, error) {
+	return sink.inspectPullRequestEffect(ctx, claim, effect, "prs")
+}
+
+// inspectPullRequestEffect is the companion to writePullRequestEffect. It
+// uses the exact same FINAL whole-row readback for github/prs and the composed
+// github/pr-reviews unit, so crash recovery cannot bless a row whose review
+// columns came from a different physical version.
+func (sink GitHubPullRequestClickHouseEffects) inspectPullRequestEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+	dataset string,
+) (EffectInspection, error) {
 	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "prs" ||
+		claim.Provider != "github" || claim.Dataset != dataset ||
 		effect.Destination != "git_pull_requests" {
 		return EffectConflict, ErrInvalidConfiguration
 	}

--- a/internal/providersync/testdata/mutation-plans/github_pr_reviews_compose.json
+++ b/internal/providersync/testdata/mutation-plans/github_pr_reviews_compose.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "name": "github/pr-reviews composed complete-row route",
+  "build": ["go", "build", "./..."],
+  "$limitation": "The plan targets the new composition boundary rather than re-testing the independently mutation-tested REST PR collector and GraphQL review fetch foundations. The Docker-backed crash proof is intentionally kept as an integration gate rather than a mutation proof because each mutation below has a deterministic focused unit proof.",
+  "mutations": [
+    {
+      "id": "D16-reuse-the-prs-selection-unit",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "baseClaim.Dataset = \"prs\"",
+      "replace": "baseClaim.Dataset = \"pr-reviews\"",
+      "rationale": "Review enrichment must reuse the REST collector's selected PR set rather than create an independently watermarked list; the base handler only accepts the internal prs view.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewRouteComposesOneCompletePRRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-apply-complete-review-enrichment",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "if reviews.Complete() {",
+      "replace": "if false {",
+      "rationale": "A complete GraphQL review response must enrich the same git_pull_requests row before the effect digest is built; otherwise review metrics are persisted as fabricated defaults.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewRouteComposesOneCompletePRRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-changes-requested-count",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "if review.State == \"CHANGES_REQUESTED\" {",
+      "replace": "if false {",
+      "rationale": "Only CHANGES_REQUESTED reviews contribute to the complete PR row's changes_requested_count, a separate product metric from total reviews_count.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestReviewRouteComposesOneCompletePRRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-review-row-tenant-and-repository-fence",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "if review.RepoID != row.RepoID || review.OrgID != row.OrgID {",
+      "replace": "if false {",
+      "rationale": "A review row from another repository or tenant must never enrich this PR's complete row, even if the pull number collides.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEnrichPullRequestsWithReviewsRejectsForeignReview$", "./internal/providersync/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Composes GitHub REST pull-request collection with the production GraphQL review batch.
- Enriches the complete `git_pull_requests` row and emits `git_pull_request_reviews` in one crash-recoverable effect manifest.
- Adds tenant-fenced exact readback and real PostgreSQL/ClickHouse crash recovery coverage.

## Stack

- Base: `feat/go-worker-runtime-migration`
- Next: #1462
- Final registration: #1463
- Linear: CHAOS-3123

## Test Evidence

- `go test -count=1 ./internal/providersync ./cmd/dev-health-worker`
- `go test -tags=integration -run 'TestGitHubPullRequestReviewEffectsAreNonEmptyTenantFencedAndLeaseGuarded|TestGitHubPullRequestReviewCompositeCrashRecoveryIsExact' ./internal/providersync`
- `bash ci/check_go.sh fmt`
- `bash ci/check_go.sh vet`
- `bash ci/check_go.sh live-python-oracles`
- `python3 scripts/mutation_harness.py run --plan internal/providersync/testdata/mutation-plans/github_pr_reviews_compose.json --assert-all-killed` — 4/4 killed

## Risk Notes

- Switches remain default-off; this layer does not register or activate a route.
- No schema migration or deployment-profile change.
- Rollback is this stack layer before the alias and registration layers land.

SCREENSHOT-WAIVER: backend-only worker migration; no rendered UI changes.
