### PR TITLE
feat(providersync): unify GitHub PR social aliases

### DIFF
--- a/internal/providersync/github_pr_reviews.go
+++ b/internal/providersync/github_pr_reviews.go
@@ -10,7 +10,10 @@ import (
 // pullRequestReviewRow mirrors the complete row written by
 // ClickHouseStore.insert_git_pull_request_reviews. It is deliberately kept
 // separate from pullRequestRow: D16 preserves Python's three-way unit boundary
-// even though the rows share a repository and pull-request identity.
+// even though the rows share a repository and pull-request identity. The raw
+// review effect belongs to the enclosing PR-social claim, so validate accepts
+// all three aliases even though normalization itself runs under the derived
+// internal pr-reviews claim.
 type pullRequestReviewRow struct {
 	RepoID      string    `json:"repo_id"`
 	Number      int       `json:"number"`
@@ -61,7 +64,7 @@ func normalizeGitHubPullRequestReview(
 }
 
 func (row pullRequestReviewRow) validate(claim Claim) error {
-	if claim.Provider != "github" || claim.Dataset != "pr-reviews" ||
+	if claim.Provider != "github" || !isGitHubPRSocialDataset(claim.Dataset) ||
 		row.OrgID == "" || row.OrgID != claim.OrgID || len(row.RepoID) != 36 ||
 		row.Number < 1 || row.ReviewID == "" || row.Reviewer == "" ||
 		row.State == "" || row.SubmittedAt.IsZero() || row.LastSynced.IsZero() ||

--- a/internal/providersync/github_pr_reviews_effects_clickhouse.go
+++ b/internal/providersync/github_pr_reviews_effects_clickhouse.go
@@ -7,26 +7,28 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// GitHubPullRequestReviewClickHouseEffects persists the two effects emitted by
-// the composed github/pr-reviews unit. Both write and FINAL readback are
+// GitHubPullRequestSocialClickHouseEffects persists the two effects emitted by
+// the composed github PR-social unit. The outer claim may be prs,
+// pr-reviews, or pr-comments; it is preserved for the effect ledger while the
+// two durable effects remain byte-identical. Both write and FINAL readback are
 // guarded by the authoritative unit lease; wiring this sink does not activate
 // a route.
-type GitHubPullRequestReviewClickHouseEffects struct {
+type GitHubPullRequestSocialClickHouseEffects struct {
 	Conn  driver.Conn
 	Lease providerfoundation.LeaseGuard
 }
 
-func (sink GitHubPullRequestReviewClickHouseEffects) WriteEffect(
+func (sink GitHubPullRequestSocialClickHouseEffects) WriteEffect(
 	ctx context.Context, claim Claim, effect EffectBatch,
 ) error {
 	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "pr-reviews" {
+		claim.Provider != "github" || !isGitHubPRSocialDataset(claim.Dataset) {
 		return ErrInvalidConfiguration
 	}
 	if effect.Destination == "git_pull_requests" {
 		return (GitHubPullRequestClickHouseEffects{
 			Conn: sink.Conn, Lease: sink.Lease,
-		}).writePullRequestEffect(ctx, claim, effect, "pr-reviews")
+		}).writePullRequestEffect(ctx, claim, effect, claim.Dataset)
 	}
 	if effect.Destination != "git_pull_request_reviews" {
 		return ErrInvalidConfiguration
@@ -72,18 +74,18 @@ INSERT INTO git_pull_request_reviews (
 	return batch.Send()
 }
 
-func (sink GitHubPullRequestReviewClickHouseEffects) InspectEffect(
+func (sink GitHubPullRequestSocialClickHouseEffects) InspectEffect(
 	ctx context.Context, claim Claim, effect EffectBatch,
 ) (EffectInspection, error) {
 	if ctx == nil || sink.Lease == nil || sink.Conn == nil ||
 		claim.Validate() != nil || claim.Provider != "github" ||
-		claim.Dataset != "pr-reviews" {
+		!isGitHubPRSocialDataset(claim.Dataset) {
 		return EffectConflict, ErrInvalidConfiguration
 	}
 	if effect.Destination == "git_pull_requests" {
 		return (GitHubPullRequestClickHouseEffects{
 			Conn: sink.Conn, Lease: sink.Lease,
-		}).inspectPullRequestEffect(ctx, claim, effect, "pr-reviews")
+		}).inspectPullRequestEffect(ctx, claim, effect, claim.Dataset)
 	}
 	if effect.Destination != "git_pull_request_reviews" {
 		return EffectConflict, ErrInvalidConfiguration
@@ -125,7 +127,7 @@ func (sink GitHubPullRequestReviewClickHouseEffects) InspectEffect(
 	return EffectConflict, nil
 }
 
-func (sink GitHubPullRequestReviewClickHouseEffects) inspectReview(
+func (sink GitHubPullRequestSocialClickHouseEffects) inspectReview(
 	ctx context.Context, expected pullRequestReviewRow,
 ) (EffectInspection, error) {
 	var actual pullRequestReviewRow
@@ -170,5 +172,10 @@ WHERE org_id = ? AND repo_id = ? AND number = ? AND review_id = ?`,
 	return EffectExact, nil
 }
 
-var _ EffectSink = GitHubPullRequestReviewClickHouseEffects{}
-var _ EffectReadback = GitHubPullRequestReviewClickHouseEffects{}
+// GitHubPullRequestReviewClickHouseEffects remains a source-compatible name
+// for the earlier review-only foundation. It now accepts all three PR-social
+// outer claim identities through GitHubPullRequestSocialClickHouseEffects.
+type GitHubPullRequestReviewClickHouseEffects = GitHubPullRequestSocialClickHouseEffects
+
+var _ EffectSink = GitHubPullRequestSocialClickHouseEffects{}
+var _ EffectReadback = GitHubPullRequestSocialClickHouseEffects{}

--- a/internal/providersync/github_pr_reviews_route.go
+++ b/internal/providersync/github_pr_reviews_route.go
@@ -7,25 +7,26 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// GitHubPullRequestReviewRouteHandler is the production-constructible,
-// deliberately-unregistered complete route for github/pr-reviews. Python runs
-// PR collection, GraphQL review enrichment, and both writes in one
-// _sync_github_prs_to_store_async execution. The Go unit keeps the
-// pr-reviews claim for its own ledger/audit identity, but invokes the existing
-// prs collector as an implementation detail and emits the one enriched,
-// complete git_pull_requests row alongside git_pull_request_reviews.
+// GitHubPullRequestSocialRouteHandler is the production-constructible,
+// deliberately-unregistered complete route for the github PR-social aliases:
+// prs, pr-reviews, and pr-comments. Python runs PR collection, GraphQL review
+// enrichment, and both writes in one _sync_github_prs_to_store_async
+// execution, regardless of which of those dataset names caused the unit to be
+// scheduled. The Go unit preserves that outer claim for its ledger/audit and
+// watermark identity, while invoking the existing collectors under derived
+// internal prs and pr-reviews claims.
 //
 // This is the only safe ownership boundary for a ReplacingMergeTree complete
 // row: a separately scheduled review writer cannot patch just three columns,
 // and a base PR writer cannot safely write their defaults after enrichment.
-// The route remains unregistered until pr-comments joins this same unit and
-// the matrix can switch the complete three-way Python boundary atomically.
-type GitHubPullRequestReviewRouteHandler struct {
+// The route remains unregistered until the registry/matrix layer can switch
+// the complete three-way Python boundary atomically.
+type GitHubPullRequestSocialRouteHandler struct {
 	PullRequests GitHubPullRequestRouteHandler
 	Reviews      GitHubPullRequestReviewFetcher
 }
 
-func (handler GitHubPullRequestReviewRouteHandler) Collect(
+func (handler GitHubPullRequestSocialRouteHandler) Collect(
 	ctx context.Context,
 	claim Claim,
 	credential providerfoundation.Credential,
@@ -33,7 +34,7 @@ func (handler GitHubPullRequestReviewRouteHandler) Collect(
 	normalizedAt time.Time,
 ) (CompleteRouteBatch, error) {
 	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
-		claim.Dataset != "pr-reviews" || normalizedAt.IsZero() {
+		!isGitHubPRSocialDataset(claim.Dataset) || normalizedAt.IsZero() {
 		return CompleteRouteBatch{}, ErrInvalidConfiguration
 	}
 
@@ -69,8 +70,13 @@ func (handler GitHubPullRequestReviewRouteHandler) Collect(
 	if len(rows) > 0 {
 		repoID = rows[0].RepoID
 	}
+	// The GraphQL fetcher's concrete contract is github/pr-reviews. Its claim
+	// is derived internally, never substituted for the outer unit claim: the
+	// caller's dataset remains what EffectCommitter later writes to the ledger.
+	reviewClaim := claim
+	reviewClaim.Dataset = "pr-reviews"
 	reviews, err := handler.Reviews.Fetch(
-		ctx, claim, client, repoID, targets, normalizedAt,
+		ctx, reviewClaim, client, repoID, targets, normalizedAt,
 	)
 	if err != nil {
 		return CompleteRouteBatch{}, err
@@ -116,6 +122,19 @@ func (handler GitHubPullRequestReviewRouteHandler) Collect(
 	}, nil
 }
 
+// isGitHubPRSocialDataset mirrors the three aliases that Python maps onto
+// _sync_github_prs_to_store_async. It is intentionally local to this
+// unregistered native unit: descriptor/matrix collapse is a later, atomic
+// routing change and must not be implied by this constructible handler.
+func isGitHubPRSocialDataset(dataset string) bool {
+	switch dataset {
+	case "prs", "pr-reviews", "pr-comments":
+		return true
+	default:
+		return false
+	}
+}
+
 // enrichPullRequestsWithReviews is the in-place equivalent of Python's
 // _enrich_prs_with_reviews_batch. It only changes a PR when at least one
 // review exists, preserving the base collector's zero values for a genuine
@@ -158,4 +177,9 @@ func enrichPullRequestsWithReviews(
 	return nil
 }
 
-var _ CompleteRouteHandler = GitHubPullRequestReviewRouteHandler{}
+// GitHubPullRequestReviewRouteHandler remains a source-compatible name for
+// the earlier foundation. It is now the complete PR-social handler, not an
+// independently owned review-only writer.
+type GitHubPullRequestReviewRouteHandler = GitHubPullRequestSocialRouteHandler
+
+var _ CompleteRouteHandler = GitHubPullRequestSocialRouteHandler{}

--- a/internal/providersync/github_pr_reviews_route_test.go
+++ b/internal/providersync/github_pr_reviews_route_test.go
@@ -84,6 +84,94 @@ func TestGitHubPullRequestReviewRouteComposesOneCompletePRRow(t *testing.T) {
 	}
 }
 
+// TestGitHubPullRequestSocialRoutePreservesAliasIdentityAndParity pins the
+// Python execution boundary: prs, pr-reviews, and pr-comments all invoke
+// _sync_github_prs_to_store_async, so they must produce the same two durable
+// effects while retaining their own claim/ledger/watermark identity. In
+// particular, pr-comments is not a third raw-table fetch: comments_count is
+// already supplied by the PR detail response.
+func TestGitHubPullRequestSocialRoutePreservesAliasIdentityAndParity(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 123456000, time.UTC)
+	graphql := `{"data":{"repository":{"pr0":{"number":42,"reviews":{"nodes":[{"id":"review-1","state":"APPROVED","submittedAt":"2026-07-11T10:30:00Z","author":{"login":"octocat"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+	var baseline CompleteRouteBatch
+	for _, dataset := range []string{"prs", "pr-reviews", "pr-comments"} {
+		t.Run(dataset, func(t *testing.T) {
+			doer := &gitHubPullRequestReviewRouteDoer{
+				t: t, restBodies: defaultGitHubPullRequestFixtures(), graphQLReply: graphql,
+			}
+			claim := nativeTestClaim("github", dataset)
+			batch, err := (GitHubPullRequestSocialRouteHandler{}).Collect(
+				context.Background(), claim, providerfoundation.Credential{},
+				gitHubPullRequestClient(t, doer, "https://api.github.com"), now,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if batch.Evidence.Dataset != dataset || batch.Watermark == nil ||
+				!batch.Watermark.Equal(*claim.BeforeAt) {
+				t.Fatalf("claim=%+v batch=%+v", claim, batch)
+			}
+			ledger, err := NewEffectLedgerState(claim, batch.Effects, now)
+			if err != nil || ledger.Dataset != dataset || ledger.Generation != claim.GenerationKey() {
+				t.Fatalf("claim=%+v ledger=%+v error=%v", claim, ledger, err)
+			}
+			if baseline.Effects == nil {
+				baseline = batch
+				return
+			}
+			for index := range batch.Effects {
+				if batch.Effects[index].Destination != baseline.Effects[index].Destination ||
+					batch.Effects[index].ContentDigest != baseline.Effects[index].ContentDigest {
+					t.Fatalf("effect[%d]=%+v baseline=%+v", index, batch.Effects[index], baseline.Effects[index])
+				}
+			}
+		})
+	}
+}
+
+func TestGitHubPullRequestSocialEffectsAcceptEveryAliasClaim(t *testing.T) {
+	t.Parallel()
+	sink := GitHubPullRequestSocialClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	pullEffect, err := effectBatchFromValues("git_pull_requests", EffectReadbackRequired, []pullRequestRow(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewEffect, err := effectBatchFromValues("git_pull_request_reviews", EffectReadbackRequired, []pullRequestReviewRow(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := pullRequestReadbackFixture(time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	nonEmptyReviewEffect, err := effectBatchFromValues(
+		"git_pull_request_reviews", EffectReadbackRequired, []pullRequestReviewRow{{
+			OrgID: "org-acme", RepoID: row.RepoID, Number: row.Number,
+			ReviewID: "review-1", Reviewer: "octocat", State: "APPROVED",
+			SubmittedAt: row.CreatedAt, LastSynced: row.LastSynced,
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dataset := range []string{"prs", "pr-reviews", "pr-comments"} {
+		t.Run(dataset, func(t *testing.T) {
+			claim := nativeTestClaim("github", dataset)
+			if err := sink.WriteEffect(context.Background(), claim, pullEffect); err != nil {
+				t.Fatalf("pull effect: %v", err)
+			}
+			if err := sink.WriteEffect(context.Background(), claim, reviewEffect); err != nil {
+				t.Fatalf("review effect: %v", err)
+			}
+			// A nil Conn is the final expected failure: reaching it proves the
+			// non-empty review row passed alias-aware scope validation first.
+			if err := sink.WriteEffect(context.Background(), claim, nonEmptyReviewEffect); err != ErrInvalidConfiguration {
+				t.Fatalf("non-empty review effect error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
 func TestGitHubPullRequestReviewRoutePreservesBaseRowOnOptionalReviewFailure(t *testing.T) {
 	t.Parallel()
 	doer := &gitHubPullRequestReviewRouteDoer{
@@ -136,10 +224,12 @@ func TestEnrichPullRequestsWithReviewsLeavesNoReviewRowsUntouched(t *testing.T) 
 	}
 }
 
-func TestGitHubPullRequestReviewRouteIsNotRegisteredUntilTheThreeWayUnitLands(t *testing.T) {
+func TestGitHubPullRequestSocialRouteIsNotRegisteredUntilTheRegistryLayerLands(t *testing.T) {
 	t.Parallel()
-	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "pr-reviews")
-	if !ok || descriptor.RouteReady || len(descriptor.Destinations) != 0 {
-		t.Fatalf("descriptor=%+v ok=%v", descriptor, ok)
+	for _, dataset := range []string{"prs", "pr-reviews", "pr-comments"} {
+		descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", dataset)
+		if !ok || descriptor.RouteReady {
+			t.Fatalf("dataset=%s descriptor=%+v ok=%v", dataset, descriptor, ok)
+		}
 	}
 }

--- a/internal/providersync/testdata/mutation-plans/github_pr_social_aliases.json
+++ b/internal/providersync/testdata/mutation-plans/github_pr_social_aliases.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "name": "github PR-social alias ownership boundary",
+  "build": ["go", "build", "./..."],
+  "$limitation": "The prior github_pr_reviews_compose plan continues to cover the complete-row enrichment and tenant/repository fence. This plan covers only the new alias-preserving claim boundary and its derived internal collector claims.",
+  "mutations": [
+    {
+      "id": "D16-pr-comments-is-a-social-alias",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "case \"prs\", \"pr-reviews\", \"pr-comments\":",
+      "replace": "case \"prs\", \"pr-reviews\":",
+      "rationale": "pr-comments is an alias of Python's one PR-social execution and must construct the same two effects instead of being rejected or acquiring its own raw-table route.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestSocialRoutePreservesAliasIdentityAndParity/pr-comments$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-derived-review-claim",
+      "file": "internal/providersync/github_pr_reviews_route.go",
+      "find": "reviewClaim.Dataset = \"pr-reviews\"",
+      "replace": "reviewClaim.Dataset = claim.Dataset",
+      "rationale": "The GraphQL fetch contract remains pr-reviews internally even when the outer unit is prs or pr-comments; replacing it with the outer alias causes the fetch boundary to reject a valid social unit.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestSocialRoutePreservesAliasIdentityAndParity/pr-comments$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-social-sink-accepts-comments-ledger-claim",
+      "file": "internal/providersync/github_pr_reviews_effects_clickhouse.go",
+      "find": "func (sink GitHubPullRequestSocialClickHouseEffects) WriteEffect(\n\tctx context.Context, claim Claim, effect EffectBatch,\n) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil ||\n\t\tclaim.Provider != \"github\" || !isGitHubPRSocialDataset(claim.Dataset)",
+      "replace": "func (sink GitHubPullRequestSocialClickHouseEffects) WriteEffect(\n\tctx context.Context, claim Claim, effect EffectBatch,\n) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil ||\n\t\tclaim.Provider != \"github\" || claim.Dataset != \"pr-reviews\"",
+      "rationale": "The composite sink must accept the original pr-comments claim for both effects so EffectCommitter records the caller's ledger identity rather than requiring callers to substitute pr-reviews.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestSocialEffectsAcceptEveryAliasClaim/pr-comments$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-review-row-validation-uses-social-claim",
+      "file": "internal/providersync/github_pr_reviews.go",
+      "find": "claim.Provider != \"github\" || !isGitHubPRSocialDataset(claim.Dataset) ||",
+      "replace": "claim.Provider != \"github\" || claim.Dataset != \"pr-reviews\" ||",
+      "rationale": "Raw review rows are written under the enclosing social unit claim, so row validation must not reject a pr-comments ledger recovery after the row was already durably written.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubPullRequestSocialEffectsAcceptEveryAliasClaim/pr-comments$", "./internal/providersync/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Generalizes the composed PR route and effect sink across `prs`, `pr-reviews`, and `pr-comments`.
- Preserves each outer dataset's claim generation, evidence, ledger, and watermark identity while deriving the internal PR/review collector claims.
- Proves the three aliases emit byte-identical durable effects; `pr-comments` uses the REST PR-detail `comments_count` because Python has no distinct raw PR-comments table in this execution.

## Stack

- Depends on: #1461
- Next/final registration: #1463
- Linear: CHAOS-3123

## Test Evidence

- `go test -count=1 ./internal/providersync ./cmd/dev-health-worker`
- `go test -tags=integration -run 'TestGitHubPullRequestReviewEffectsAreNonEmptyTenantFencedAndLeaseGuarded|TestGitHubPullRequestReviewCompositeCrashRecoveryIsExact' ./internal/providersync`
- `bash ci/check_go.sh fmt`
- `bash ci/check_go.sh vet`
- `bash ci/check_go.sh live-python-oracles`
- `python3 scripts/mutation_harness.py run --plan internal/providersync/testdata/mutation-plans/github_pr_social_aliases.json --assert-all-killed` — 4/4 killed

## Risk Notes

- This layer is still unregistered and cannot route live work on its own.
- It deliberately mirrors Python's one PR-social execution boundary rather than inventing a PR-comments persistence surface.
- No schema migration or deployment-profile change.

SCREENSHOT-WAIVER: backend-only worker migration; no rendered UI changes.
