### PR TITLE
fix(ask-dev): data-health never widens past the authorized subject scope (CHAOS-3375)

### DIFF
--- a/src/dev_health_ops/api/dev/data_health_service.py
+++ b/src/dev_health_ops/api/dev/data_health_service.py
@@ -25,7 +25,11 @@ from dev_health_ops.models.settings import (
 from .entitlement import AskDevEntitlementAuthorizer
 from .evidence_service import EvidenceScopeAuthorizer
 from .native_evidence import SourceFreshnessPolicy, default_native_freshness_policies
-from .native_status_change import _TEAM_REPOSITORIES_SQL, PROJECT_REPOSITORIES_SQL
+from .native_status_change import (
+    _PROJECT_IDENTITY_CTE,
+    _TEAM_REPOSITORIES_SQL,
+    PROJECT_REPOSITORIES_SQL,
+)
 from .scope_service import (
     EntityKind,
     ScopeResolution,
@@ -44,6 +48,23 @@ NATIVE_EVIDENCE_SOURCES = (
     "ci_runs",
     "deployments",
     "incidents",
+)
+
+#: CHAOS-3375 (post-CHAOS-3374 rebase): ``PROJECT_REPOSITORIES_SQL`` now
+#: ``INNER JOIN``s the provider-identity CTE (``_PROJECT_IDENTITY_CTE``,
+#: ``HAVING count() = 1``, ``is_active = 1``), so an unresolvable identity
+#: (retired between scope commit and this read, or a same-id cross-provider
+#: collision) empties the join and returns zero rows -- indistinguishable,
+#: by row count alone, from a project whose identity resolves cleanly but
+#: which genuinely owns zero repositories. The two must not read the same:
+#: the standing fail-closed ruling is that an unresolvable identity is
+#: never a clean "measured empty" answer. This reuses the exact same
+#: canonical CTE (imported, never re-implemented) to answer only "did the
+#: identity resolve" -- ``count()`` over an aggregate CTE with no rows still
+#: returns exactly one row with value 0, so ``resolved = 0`` unambiguously
+#: means "did not resolve".
+_PROJECT_IDENTITY_RESOLVED_SQL = (
+    "WITH " + _PROJECT_IDENTITY_CTE + "\nSELECT count() AS resolved FROM project"
 )
 
 
@@ -472,6 +493,16 @@ class NativeDataHealthReader:
         repositories", and never as an excuse to widen to the organization;
         a genuinely empty, *measured* result is likewise never widened, only
         reported as no data for this subject.
+
+        Post-CHAOS-3374 rebase: ``PROJECT_REPOSITORIES_SQL`` now ``INNER
+        JOIN``s the provider-identity CTE, so a zero-row result is ambiguous
+        between "identity resolved, project genuinely owns zero
+        repositories" and "identity did not resolve" (retired between scope
+        commit and this read, or a same-id cross-provider collision). A
+        second, cheap query against the *same* canonical identity CTE
+        (``_PROJECT_IDENTITY_RESOLVED_SQL``) disambiguates before either
+        answer is reported -- the standing fail-closed ruling is that an
+        unresolvable identity is never a clean "measured empty" answer.
         """
 
         if not project_id:
@@ -490,18 +521,44 @@ class NativeDataHealthReader:
             )
         except Exception:
             return _ScopeRepositoryDerivation(available=False)
-        return _ScopeRepositoryDerivation(
-            available=True,
-            repository_ids=tuple(
-                sorted(
-                    {
-                        str(row["repository_id"])
-                        for row in rows
-                        if row.get("repository_id")
-                    }
-                )
-            ),
+        repository_ids = tuple(
+            sorted(
+                {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+            )
         )
+        if repository_ids:
+            return _ScopeRepositoryDerivation(
+                available=True, repository_ids=repository_ids
+            )
+        if not await self._project_identity_resolved(org_id, project_id):
+            return _ScopeRepositoryDerivation(available=False)
+        return _ScopeRepositoryDerivation(available=True, repository_ids=())
+
+    async def _project_identity_resolved(self, org_id: str, project_id: str) -> bool:
+        """Whether the committed project id still resolves to exactly one
+
+        active catalog row, via the exact same canonical identity CTE
+        ``PROJECT_REPOSITORIES_SQL`` itself joins through. Only called when
+        the derivation above returned zero rows, to tell a genuinely
+        repo-less project apart from an unresolvable one. A query failure
+        here is itself treated as unresolved -- there is no honest "assume
+        resolved" default when the check that would prove it cannot run.
+        """
+
+        try:
+            rows = await query_dicts(
+                self._client,
+                _PROJECT_IDENTITY_RESOLVED_SQL,
+                {"org_id": org_id, "entity_id": project_id},
+            )
+        except Exception:
+            return False
+        if not rows:
+            return False
+        try:
+            return int(rows[0].get("resolved") or 0) >= 1
+        except (TypeError, ValueError):
+            return False
 
     async def _team_repositories(
         self, org_id: str, team_id: str

--- a/src/dev_health_ops/api/dev/data_health_service.py
+++ b/src/dev_health_ops/api/dev/data_health_service.py
@@ -25,7 +25,7 @@ from dev_health_ops.models.settings import (
 from .entitlement import AskDevEntitlementAuthorizer
 from .evidence_service import EvidenceScopeAuthorizer
 from .native_evidence import SourceFreshnessPolicy, default_native_freshness_policies
-from .native_status_change import PROJECT_REPOSITORIES_SQL
+from .native_status_change import _TEAM_REPOSITORIES_SQL, PROJECT_REPOSITORIES_SQL
 from .scope_service import (
     EntityKind,
     ScopeResolution,
@@ -252,6 +252,30 @@ class DataHealthService:
         return DataHealthResult(tuple(results), complete_eligible)
 
 
+@dataclass(frozen=True, slots=True)
+class _ScopeRepositoryDerivation:
+    """Outcome of re-deriving a subject's repositories for a scope kind
+    (PROJECT, TEAM) that carries no repository dimension of its own.
+
+    CHAOS-3375: mirrors ``native_status_change.TeamAttributionResult``'s
+    measured/unmeasured distinction. ``available=False`` means the
+    derivation query itself failed (client/query error) -- the repository
+    set is UNKNOWN, never "this subject spans zero repositories".
+    ``available=True`` with an empty ``repository_ids`` is the genuine
+    zero-repository case: a real, measured answer, not a failure. Collapsing
+    the two into the same ``[]`` return (as a prior version of this reader
+    did) is exactly the bug this type exists to prevent -- a project/team
+    that legitimately has no repositories must read as "no data measured
+    for this subject" (``DataHealthState.NO_DATA``), never silently
+    upgraded to org-wide measurement (the original CHAOS-3375 defect) nor
+    conflated with ``DataHealthState.UNAVAILABLE`` (an unrelated query
+    failure).
+    """
+
+    available: bool
+    repository_ids: tuple[str, ...] = ()
+
+
 class NativeDataHealthReader:
     """Reconcile existing sync configuration with native source watermarks."""
 
@@ -270,34 +294,66 @@ class NativeDataHealthReader:
         configurations = configuration_rows or []
         schedules = await self._schedules(org_id)
         repository_ids = sorted(_repository_ids(scope))
-        # A committed PROJECT subject carries no repository dimension (the
-        # catalog resolves projects with ``NULL AS repository_id``), so
-        # ``_repository_ids`` is empty for one and the ``empty(array) OR ...``
-        # arm in ``_watermark`` below then disables repository filtering
-        # entirely -- measuring the whole organization and reporting it as the
-        # project's coverage. Because source health is a *mandatory* source for
-        # the project status plan, unrelated healthy repositories could make a
-        # project's evidence coverage read complete. Resolve the same
-        # repository set the status/change reader derives, from the same shared
-        # query, or fail closed. Codex adversarial review (HIGH, 2026-08-03).
-        project_scope_unresolved = False
+        # A committed PROJECT or TEAM subject carries no repository dimension
+        # of its own (the catalog resolves projects with ``NULL AS
+        # repository_id``; a team commit's ``AuthorizedEntity.repository_id``
+        # is always ``None`` -- ``ScopeResolutionService._committed_scope_for``
+        # 's own docstring), so ``_repository_ids`` is empty for either and
+        # the ``empty(array) OR ...`` arm in ``_watermark`` below then
+        # disables repository filtering entirely -- measuring the whole
+        # organization and reporting it as the subject's coverage. Because
+        # source health is a *mandatory* source for the project/team status
+        # plan, unrelated healthy repositories could make a subject's
+        # evidence coverage read complete. Resolve the same repository set
+        # the status/change reader derives, from the same shared query, or
+        # fail closed. Codex adversarial review (HIGH, 2026-08-03; CHAOS-3375
+        # widened the PROJECT-only fix to TEAM, which #1453 left unpatched --
+        # a committed TEAM direct scope reaches this exact same ``empty(...)
+        # OR ...`` widening, unguarded, via ``production_runtime._scope_
+        # request``'s ``DirectScope.TEAM`` branch).
+        subject_scope_unresolved = False
+        subject_scope_measured_empty = False
+        subject_scope_warning: str | None = None
         if not repository_ids:
             project_ids = [
                 entity.canonical_id
                 for entity in scope.entities
                 if entity.kind is EntityKind.PROJECT
             ]
+            team_ids = [
+                entity.canonical_id
+                for entity in scope.entities
+                if entity.kind is EntityKind.TEAM
+            ]
             if project_ids:
                 if scope.team_filters:
                     # No data-health query applies a team filter either, so a
                     # team-filtered project must not be answered with the whole
                     # project's repository set.
-                    project_scope_unresolved = True
+                    subject_scope_unresolved = True
+                    subject_scope_warning = "project_repository_scope_unavailable"
                 else:
-                    repository_ids = await self._project_repositories(
+                    derivation = await self._project_repositories(
                         org_id, project_ids[0]
                     )
-                    project_scope_unresolved = not repository_ids
+                    if not derivation.available:
+                        subject_scope_unresolved = True
+                        subject_scope_warning = "project_repository_scope_unavailable"
+                    elif derivation.repository_ids:
+                        repository_ids = list(derivation.repository_ids)
+                    else:
+                        subject_scope_measured_empty = True
+                        subject_scope_warning = "project_repository_scope_empty"
+            elif team_ids:
+                derivation = await self._team_repositories(org_id, team_ids[0])
+                if not derivation.available:
+                    subject_scope_unresolved = True
+                    subject_scope_warning = "team_repository_scope_unavailable"
+                elif derivation.repository_ids:
+                    repository_ids = list(derivation.repository_ids)
+                else:
+                    subject_scope_measured_empty = True
+                    subject_scope_warning = "team_repository_scope_empty"
         observations: list[SourceHealthObservation] = []
         for source in source_systems:
             if source == "acr":
@@ -307,7 +363,7 @@ class NativeDataHealthReader:
                     )
                 )
                 continue
-            if project_scope_unresolved:
+            if subject_scope_unresolved:
                 # ``configured=None`` maps to DataHealthState.UNAVAILABLE --
                 # an explicit "this could not be measured for this subject",
                 # never a silent organization-wide substitute.
@@ -316,7 +372,7 @@ class NativeDataHealthReader:
                         source,
                         None,
                         False,
-                        warning="project_repository_scope_unavailable",
+                        warning=subject_scope_warning,
                     )
                 )
                 continue
@@ -340,8 +396,23 @@ class NativeDataHealthReader:
                 ),
                 default=None,
             )
-            watermark, covered = await self._watermark(source, org_id, repository_ids)
-            relevant = set(repository_ids) or await self._repositories(org_id)
+            if subject_scope_measured_empty:
+                # A genuinely empty, measured repository set (project/team
+                # confirmed to own zero repositories) must never reach
+                # ``_watermark`` with an empty ``repository_ids`` list --
+                # that would re-trigger the exact ``empty(array) OR ...``
+                # org-wide widening this fix exists to close. There is
+                # nothing to look up: report no watermark and no coverage
+                # directly, distinctly warned from the derivation-failed
+                # (``..._unavailable``) branch above.
+                watermark: datetime | None = None
+                covered: set[str] = set()
+                relevant: set[str] = set()
+            else:
+                watermark, covered = await self._watermark(
+                    source, org_id, repository_ids
+                )
+                relevant = set(repository_ids) or await self._repositories(org_id)
             if watermark is not None:
                 configured = True
             intervals = [
@@ -371,25 +442,40 @@ class NativeDataHealthReader:
                     relevant_repository_ids=tuple(sorted(relevant)),
                     maximum_age=maximum_age,
                     freshness_policy_version=freshness_version,
-                    warning="active_sync_failure" if failure else None,
+                    warning=(
+                        "active_sync_failure"
+                        if failure
+                        else (
+                            subject_scope_warning
+                            if subject_scope_measured_empty
+                            else None
+                        )
+                    ),
                 )
             )
         return tuple(observations)
 
-    async def _project_repositories(self, org_id: str, project_id: str) -> list[str]:
+    async def _project_repositories(
+        self, org_id: str, project_id: str
+    ) -> _ScopeRepositoryDerivation:
         """The project's repository set, from the one shared derivation.
 
         Deliberately the same ``PROJECT_REPOSITORIES_SQL`` the status/change
         reader uses rather than a second query with the same intent: two
         independently-drifting notions of "which repositories is this project
-        in" is exactly the class of bug this fix exists to close. A failed or
-        empty derivation returns ``[]`` and the caller fails closed -- an
-        unreadable attribution source is never "this project spans no
-        repositories", and never an excuse to widen to the organization.
+        in" is exactly the class of bug this fix exists to close.
+
+        CHAOS-3375: a query failure and a query that legitimately returns
+        zero rows are no longer collapsed into the same ``[]`` -- see
+        ``_ScopeRepositoryDerivation``. Either way the caller must never
+        treat an unresolved/failed derivation as "this project spans no
+        repositories", and never as an excuse to widen to the organization;
+        a genuinely empty, *measured* result is likewise never widened, only
+        reported as no data for this subject.
         """
 
         if not project_id:
-            return []
+            return _ScopeRepositoryDerivation(available=False)
         try:
             rows = await query_dicts(
                 self._client,
@@ -403,9 +489,69 @@ class NativeDataHealthReader:
                 },
             )
         except Exception:
-            return []
-        return sorted(
-            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+            return _ScopeRepositoryDerivation(available=False)
+        return _ScopeRepositoryDerivation(
+            available=True,
+            repository_ids=tuple(
+                sorted(
+                    {
+                        str(row["repository_id"])
+                        for row in rows
+                        if row.get("repository_id")
+                    }
+                )
+            ),
+        )
+
+    async def _team_repositories(
+        self, org_id: str, team_id: str
+    ) -> _ScopeRepositoryDerivation:
+        """The team's repository set, from the one shared derivation.
+
+        Deliberately the same ``_TEAM_REPOSITORIES_SQL`` (re-derived from
+        ``team_repo_ownership``) that ``native_status_change.
+        ClickHouseStatusChangeSource.team_repository_ids`` uses, for the
+        same reason ``_project_repositories`` above shares
+        ``PROJECT_REPOSITORIES_SQL``: one canonical notion of "which
+        repositories does this team own", never a second query that can
+        independently drift.
+
+        CHAOS-3375: a committed TEAM direct scope carries no repository
+        dimension of its own (``ScopeResolutionService._committed_scope_
+        for``'s own docstring: "authorized_repository_ids ... stay empty
+        for a team commit"), the same structural gap ``_project_repositories``
+        closes for PROJECT -- but #1453 only special-cased PROJECT, leaving
+        a team subject to fall straight through to the ``empty(repository_
+        ids) OR ...`` org-wide widening this whole fix exists to close.
+        """
+
+        if not team_id:
+            return _ScopeRepositoryDerivation(available=False)
+        try:
+            rows = await query_dicts(
+                self._client,
+                _TEAM_REPOSITORIES_SQL,
+                {
+                    "org_id": org_id,
+                    "team_id": team_id,
+                    # Data health is a "right now" measurement, unlike a
+                    # snapshot's caller-supplied as_of.
+                    "as_of": datetime.now(UTC),
+                },
+            )
+        except Exception:
+            return _ScopeRepositoryDerivation(available=False)
+        return _ScopeRepositoryDerivation(
+            available=True,
+            repository_ids=tuple(
+                sorted(
+                    {
+                        str(row["repository_id"])
+                        for row in rows
+                        if row.get("repository_id")
+                    }
+                )
+            ),
         )
 
     async def _repositories(self, org_id: str) -> set[str]:

--- a/src/dev_health_ops/api/dev/data_health_service.py
+++ b/src/dev_health_ops/api/dev/data_health_service.py
@@ -375,6 +375,26 @@ class NativeDataHealthReader:
                 else:
                     subject_scope_measured_empty = True
                     subject_scope_warning = "team_repository_scope_empty"
+            elif scope.team_filters:
+                # Codex adversarial review (HIGH): a team-FILTERED scope with
+                # no repository-carrying entity at all -- the canonical shape
+                # is a team-filtered ORGANIZATION scope (``direct_scope=
+                # ORGANIZATION`` plus ``scope.team_ids``,
+                # ``ScopeResolutionOutcome.FILTERED``) -- fell through this
+                # whole ``if not repository_ids:`` block untouched (neither
+                # the PROJECT nor TEAM branch above matches an ORGANIZATION
+                # entity), leaving ``repository_ids`` empty and reaching the
+                # SAME ``empty(repository_ids) OR ...`` org-wide widening,
+                # unguarded -- the third entry point to the same class of
+                # bug. No data-health query applies a team filter (mirrors
+                # ``native_status_change._authorized_repository_ids``'s own
+                # documented ruling for the identical ORG+team-filter shape:
+                # deriving the full org repository set would silently widen
+                # a team-filtered request to every repository in the
+                # organization -- fail closed instead, never guess at an
+                # intersection).
+                subject_scope_unresolved = True
+                subject_scope_warning = "team_filtered_scope_unavailable"
         observations: list[SourceHealthObservation] = []
         for source in source_systems:
             if source == "acr":
@@ -388,12 +408,56 @@ class NativeDataHealthReader:
                 # ``configured=None`` maps to DataHealthState.UNAVAILABLE --
                 # an explicit "this could not be measured for this subject",
                 # never a silent organization-wide substitute.
+                #
+                # Codex adversarial review (HIGH): ``required`` must stay
+                # ``True`` here. This is still one of the caller's own
+                # mandatory ``NATIVE_EVIDENCE_SOURCES`` -- it merely failed
+                # to resolve -- never an optional source like ``acr`` above.
+                # ``DataHealthService.inspect``'s ``complete_eligible =
+                # all(not item.required or item.state is COMPLETE ...)``
+                # treats ``required=False`` as "this source can never block
+                # completeness", so a prior ``required=False`` here let a
+                # derivation failure on every mandatory source still report
+                # ``complete_eligible=True`` -- and
+                # ``production_runtime.py``'s ``data_health`` tool executor
+                # maps that straight to ``status="success"``, the exact
+                # fail-open outcome the whole CHAOS-3375 fix exists to
+                # prevent, just through ``required`` instead of the
+                # repository widening.
                 observations.append(
                     SourceHealthObservation(
                         source,
                         None,
-                        False,
+                        True,
                         warning=subject_scope_warning,
+                    )
+                )
+                continue
+            if source == "incidents" and repository_ids:
+                # Codex adversarial review (MEDIUM): ``operational_incidents``
+                # carries no ``repo_id`` column of its own
+                # (``_SOURCE_TABLES["incidents"]``'s ``repo_column`` is
+                # ``None``), so ``_watermark``'s ``repo_filter`` is
+                # unconditionally ``""`` for it -- it reads every
+                # organization incident regardless of ``repository_ids``.
+                # Correct for a genuine org-wide request (``repository_ids``
+                # empty, no PROJECT/TEAM/REPOSITORY narrowing); silently
+                # WRONG for any narrower-than-org scope reaching this point
+                # with a non-empty ``repository_ids`` (a REPOSITORY-direct
+                # scope, or a resolved PROJECT/TEAM subject): an unrelated
+                # repository's or team's incident would drive THIS subject's
+                # STALE/NO_DATA classification. Report unavailable rather
+                # than a confidently wrongly-scoped answer -- there is no
+                # repository-bearing incident relationship this reader can
+                # join through today (unlike ``native_evidence.py``'s own
+                # incidents spec, which joins ``work_graph_deployment_
+                # incident_edges`` for exactly this reason).
+                observations.append(
+                    SourceHealthObservation(
+                        source,
+                        None,
+                        True,
+                        warning="incident_repository_scope_unavailable",
                     )
                 )
                 continue

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -589,6 +589,19 @@ LIMIT 1
 #: excluding pattern-matched-but-unresolved ownership rows (``repo_id IS
 #: NULL`` -- a ``match_type='pattern'`` row that has not yet resolved to a
 #: concrete repository contributes no queryable repository id).
+#:
+#: CHAOS-3375 (Codex adversarial review, HIGH): the first cut stopped there
+#: and trusted every ``team_repo_ownership.repo_id`` outright, exactly the
+#: mistake the adjacent ``PROJECT_REPOSITORIES_SQL`` derivation's own review
+#: comment above documents for ``work_items.repo_id``. ClickHouse enforces no
+#: foreign key, so a repository revoked from ``repos`` -- de-authorized, and
+#: correctly invisible to the ORGANIZATION branch, which enumerates ``repos``
+#: itself -- can keep a stale ``team_repo_ownership`` row and would have
+#: become an admitted read bound for team scope alone. Every *real*
+#: repository id must therefore still resolve through the same org-scoped
+#: ``repos`` catalog. Verified against a live migrated ClickHouse: an
+#: orphaned ownership row (repo_id absent from ``repos``) is admitted by the
+#: query without this clause and excluded with it.
 _TEAM_REPOSITORIES_SQL = """
 SELECT toString(g.repo_id) AS repository_id
 FROM (
@@ -606,6 +619,9 @@ FROM (
   GROUP BY org_id, provider, repo_full_name, team_id
 ) AS g
 WHERE g.repo_id IS NOT NULL
+  AND toString(g.repo_id) IN (
+    SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}
+  )
 """
 
 #: Re-derive one project's repository set from canonical work-item attribution.

--- a/tests/api/dev/test_data_health_service.py
+++ b/tests/api/dev/test_data_health_service.py
@@ -270,6 +270,63 @@ async def test_measured_empty_subject_is_no_data_distinct_from_unavailable() -> 
 
 
 @pytest.mark.asyncio
+async def test_unresolved_mandatory_sources_never_report_complete_eligible() -> None:
+    """CHAOS-3375 (Codex adversarial review, HIGH): a derivation failure on
+
+    EVERY mandatory native source used to still report ``complete_eligible
+    =True``, because ``NativeDataHealthReader.read``'s unresolved-scope
+    branch constructed each ``SourceHealthObservation`` with ``required=
+    False`` -- and ``complete_eligible = all(not item.required or
+    item.state is COMPLETE ...)`` treats ``required=False`` as "this source
+    can never block completeness", regardless of its actual state.
+    ``production_runtime.py``'s ``data_health`` tool executor maps
+    ``complete_eligible`` straight to ``status="success" if result.
+    complete_eligible else "partial"`` -- so a fully-unresolved subject
+    (every mandatory source UNAVAILABLE) would have reported tool
+    ``status="success"``, exactly the fail-open outcome CHAOS-3375 exists
+    to close. ``required`` must stay ``True`` for these -- they are still
+    the caller's own mandatory sources, merely unmeasured.
+    """
+
+    observations = [
+        SourceHealthObservation(
+            source,
+            None,
+            True,
+            warning="team_repository_scope_unavailable",
+        )
+        for source in ("work_items", "pull_requests", "commits")
+    ]
+    policies = {
+        source: SourceFreshnessPolicy(source, f"{source}.v1", timedelta(hours=48))
+        for source in ("work_items", "pull_requests", "commits")
+    }
+    result = await DataHealthService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        reader=Reader(observations),
+        policies=policies,
+        now=NOW,
+    ).inspect(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        required_sources=list(policies),
+    )
+
+    assert all(
+        item.state is DataHealthState.UNAVAILABLE and item.required
+        for item in result.sources
+    )
+    assert result.complete_eligible is False
+    # The exact mapping production_runtime.py's data_health tool executor
+    # applies -- asserted here directly so this test fails if that mapping
+    # or this fix ever drifts apart.
+    tool_status = "success" if result.complete_eligible else "partial"
+    assert tool_status == "partial"
+
+
+@pytest.mark.asyncio
 async def test_relevant_missing_repository_is_not_reported_as_complete() -> None:
     organization_scope = ScopeResolution(
         outcome=ScopeResolutionOutcome.EXACT,

--- a/tests/api/dev/test_data_health_service.py
+++ b/tests/api/dev/test_data_health_service.py
@@ -219,6 +219,57 @@ async def test_schedule_derived_source_policy_overrides_fallback_threshold() -> 
 
 
 @pytest.mark.asyncio
+async def test_measured_empty_subject_is_no_data_distinct_from_unavailable() -> None:
+    """CHAOS-3375: a genuinely empty, *measured* PROJECT/TEAM repository
+
+    derivation (``NativeDataHealthReader``'s ``project_repository_scope_
+    empty`` / ``team_repository_scope_empty`` warnings) must read as
+    ``DataHealthState.NO_DATA`` -- "queried, genuinely nothing in scope" --
+    never the same ``DataHealthState.UNAVAILABLE`` a *failed* derivation
+    (``..._unavailable``) reports. Collapsing the two was the residual gap
+    CHAOS-3375 closed on top of #1453's PROJECT-only widening fix.
+    """
+
+    observations = [
+        SourceHealthObservation(
+            "measured_empty",
+            True,
+            True,
+            watermark=None,
+            warning="project_repository_scope_empty",
+        ),
+        SourceHealthObservation(
+            "unavailable",
+            None,
+            False,
+            warning="project_repository_scope_unavailable",
+        ),
+    ]
+    policies = {
+        source: SourceFreshnessPolicy(source, f"{source}.v1", timedelta(hours=48))
+        for source in ("measured_empty", "unavailable")
+    }
+    result = await DataHealthService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        reader=Reader(observations),
+        policies=policies,
+        now=NOW,
+    ).inspect(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        required_sources=list(policies),
+    )
+
+    by_source = {item.source_system: item for item in result.sources}
+    assert by_source["measured_empty"].state is DataHealthState.NO_DATA
+    assert by_source["unavailable"].state is DataHealthState.UNAVAILABLE
+    assert by_source["measured_empty"].state is not by_source["unavailable"].state
+    assert result.complete_eligible is False
+
+
+@pytest.mark.asyncio
 async def test_relevant_missing_repository_is_not_reported_as_complete() -> None:
     organization_scope = ScopeResolution(
         outcome=ScopeResolutionOutcome.EXACT,

--- a/tests/api/dev/test_project_scope_data_health.py
+++ b/tests/api/dev/test_project_scope_data_health.py
@@ -42,13 +42,18 @@ from typing import Any
 import pytest
 
 from dev_health_ops.api.dev import data_health_service
-from dev_health_ops.api.dev.data_health_service import NativeDataHealthReader
+from dev_health_ops.api.dev.data_health_service import (
+    DataHealthService,
+    NativeDataHealthReader,
+)
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
     EntityKind,
     ResolvedTimeRange,
     ScopeResolution,
     ScopeResolutionOutcome,
+    ScopeResolveRequest,
+    TimeRangeRequest,
 )
 
 NOW = datetime(2026, 8, 4, tzinfo=UTC)
@@ -125,6 +130,40 @@ def _repository_resolution() -> ScopeResolution:
             ),
         ),
         team_filters=(),
+        candidates=(),
+        time_range=_time_range(),
+    )
+
+
+def _organization_resolution() -> ScopeResolution:
+    """A plain, un-filtered ORGANIZATION scope: the genuine org-wide case
+
+    the ``empty(repository_ids) OR ...`` arm exists to serve, distinct from
+    the team-FILTERED shape below.
+    """
+
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(AuthorizedEntity(EntityKind.ORGANIZATION, ORG_ID, "Org"),),
+        team_filters=(),
+        candidates=(),
+        time_range=_time_range(),
+    )
+
+
+def _organization_team_filtered_resolution() -> ScopeResolution:
+    """A team-FILTERED organization scope, in the shape the resolver
+
+    produces for ``direct_scope=ORGANIZATION`` plus ``scope.team_ids``
+    (``ScopeResolutionService.resolve``'s ``FILTERED`` outcome): the
+    ORGANIZATION entity carries no repository dimension, and the team lives
+    only in ``team_filters``, never in ``entities``.
+    """
+
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.FILTERED,
+        entities=(AuthorizedEntity(EntityKind.ORGANIZATION, ORG_ID, "Org"),),
+        team_filters=(AuthorizedEntity(EntityKind.TEAM, "team-a", "Team A", None),),
         candidates=(),
         time_range=_time_range(),
     )
@@ -216,6 +255,77 @@ async def test_project_data_health_is_bound_to_the_projects_repositories(
     assert not client.org_wide_enumerated
     assert observations[0].relevant_repository_ids == (PROJECT_REPOSITORY_ID,)
     assert UNRELATED_REPOSITORY_ID not in observations[0].relevant_repository_ids
+
+
+@pytest.mark.asyncio
+async def test_incidents_reports_unavailable_not_org_wide_for_a_resolved_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex adversarial review (MEDIUM): every other
+
+    ``NATIVE_EVIDENCE_SOURCES`` member has a ``repo_id`` column
+    (``_SOURCE_TABLES``) that ``_watermark`` can filter by, but
+    ``operational_incidents`` (source ``"incidents"``) does not -- its
+    ``repo_filter`` is unconditionally ``""``, so even with the project's
+    repositories correctly derived, the incidents watermark query would
+    read every organization incident. Assert it reports unavailable
+    instead, while every repo-bearing source in the same read is correctly
+    scoped -- covering all of ``NATIVE_EVIDENCE_SOURCES``, not only
+    ``work_items``.
+    """
+
+    from dev_health_ops.api.dev.data_health_service import NATIVE_EVIDENCE_SOURCES
+
+    client = _FakeClient(derived=[PROJECT_REPOSITORY_ID])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=list(NATIVE_EVIDENCE_SOURCES),
+    )
+    by_source = {item.source_system: item for item in observations}
+
+    assert not client.org_wide_enumerated
+    assert by_source["incidents"].configured is None
+    assert by_source["incidents"].required is True
+    assert by_source["incidents"].warning == "incident_repository_scope_unavailable"
+    for source in NATIVE_EVIDENCE_SOURCES:
+        if source == "incidents":
+            continue
+        assert by_source[source].warning != "incident_repository_scope_unavailable"
+        assert by_source[source].relevant_repository_ids == (PROJECT_REPOSITORY_ID,)
+    # Every repo-bearing source's watermark call was scoped to the
+    # project's own repositories -- the incidents branch above never
+    # reached ``_watermark`` at all.
+    assert all(
+        params["repository_ids"] == [PROJECT_REPOSITORY_ID]
+        for params in client.watermark_params
+    )
+    assert len(client.watermark_params) == len(NATIVE_EVIDENCE_SOURCES) - 1
+
+
+@pytest.mark.asyncio
+async def test_incidents_stays_org_wide_for_a_genuine_organization_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unavailable branch above must be scope-narrowing-specific: a
+
+    genuine org-wide request (no PROJECT/TEAM/REPOSITORY narrowing, empty
+    ``repository_ids``) legitimately measures every organization incident,
+    and must not regress to unavailable.
+    """
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_organization_resolution(),
+        source_systems=["incidents"],
+    )
+
+    assert observations[0].warning != "incident_repository_scope_unavailable"
 
 
 @pytest.mark.asyncio
@@ -353,6 +463,40 @@ async def test_team_filtered_project_data_health_fails_closed(
     assert client.watermark_params == []
     assert observations[0].configured is None
     assert observations[0].warning == "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_team_filtered_organization_data_health_fails_closed_not_org_wide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3375 (Codex adversarial review, HIGH): a team-FILTERED
+
+    ORGANIZATION scope (``direct_scope=ORGANIZATION`` plus ``scope.
+    team_ids``, ``ScopeResolutionOutcome.FILTERED``) has no repository-
+    carrying entity at all -- the team lives only in ``scope.team_filters``,
+    never in ``scope.entities`` -- so neither the PROJECT nor the TEAM
+    branch above matched it, and it fell through to the SAME org-wide
+    ``empty(repository_ids) OR ...`` widening this whole fix exists to
+    close: a third, previously-unguarded entry point. No data-health query
+    applies a team filter, so this must fail closed exactly like a
+    team-filtered PROJECT scope does above, never derive or guess at an
+    intersection.
+    """
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_organization_team_filtered_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    assert observations[0].configured is None
+    assert observations[0].required is True
+    assert observations[0].warning == "team_filtered_scope_unavailable"
 
 
 @pytest.mark.asyncio
@@ -503,3 +647,61 @@ async def test_acr_stays_optional_for_a_measured_empty_project(
     assert by_source["acr"].warning == "acr_optional"
     assert by_source["acr"].required is False
     assert by_source["work_items"].warning == "project_repository_scope_empty"
+
+
+class _Entitlement:
+    async def require(self, _org_id: str) -> None:
+        return None
+
+
+class _Authorizer:
+    def __init__(self, resolution: ScopeResolution) -> None:
+        self._resolution = resolution
+
+    async def resolve(self, *_args: object) -> ScopeResolution:
+        return self._resolution
+
+
+def _scope_request() -> ScopeResolveRequest:
+    return ScopeResolveRequest(explicit_refs=(), time_range=TimeRangeRequest())
+
+
+@pytest.mark.asyncio
+async def test_derivation_failure_on_every_mandatory_source_fails_the_whole_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3375 (Codex adversarial review, HIGH), end to end through
+
+    ``DataHealthService.inspect`` -- not just ``NativeDataHealthReader.
+    read`` in isolation. The reviewer's own repro: a derivation failure on
+    every mandatory native source used to still report ``complete_eligible
+    =True`` (``NativeDataHealthReader.read``'s unresolved-scope branch
+    built each ``SourceHealthObservation`` with ``required=False``, and
+    ``inspect``'s ``complete_eligible = all(not item.required or item.
+    state is COMPLETE ...)`` treats ``required=False`` as "never blocks
+    completeness" regardless of state). ``production_runtime.py``'s
+    ``data_health`` tool executor maps ``complete_eligible`` straight to
+    ``status="success" if result.complete_eligible else "partial"`` -- the
+    exact fail-open outcome this asserts against.
+    """
+
+    client = _FakeClient(derived=None, fail=True)
+    _install(monkeypatch, client)
+
+    reader = NativeDataHealthReader(object(), None)
+    resolution = _project_resolution()
+    result = await DataHealthService(
+        entitlement=_Entitlement(),
+        authorizer=_Authorizer(resolution),
+        reader=reader,
+    ).inspect(
+        org_id=ORG_ID,
+        permission_fingerprint="permission-v1",
+        scope_request=_scope_request(),
+        required_sources=["work_items", "pull_requests"],
+    )
+
+    assert all(item.required for item in result.sources)
+    assert result.complete_eligible is False
+    tool_status = "success" if result.complete_eligible else "partial"
+    assert tool_status == "partial"

--- a/tests/api/dev/test_project_scope_data_health.py
+++ b/tests/api/dev/test_project_scope_data_health.py
@@ -131,17 +131,37 @@ def _repository_resolution() -> ScopeResolution:
 
 
 class _FakeClient:
-    """Answers the three query shapes ``NativeDataHealthReader`` issues."""
+    """Answers the four query shapes ``NativeDataHealthReader`` issues."""
 
-    def __init__(self, *, derived: list[str] | None, fail: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        derived: list[str] | None,
+        fail: bool = False,
+        identity_resolved: bool = True,
+        identity_check_fails: bool = False,
+    ) -> None:
         self.derived = derived
         self.fail = fail
+        # Only consulted when ``derived`` is empty and the identity-check
+        # query fires (``_project_identity_resolved``): whether the
+        # provider-identity CTE resolves the committed project id to exactly
+        # one active catalog row.
+        self.identity_resolved = identity_resolved
+        self.identity_check_fails = identity_check_fails
         self.watermark_params: list[dict[str, Any]] = []
+        self.identity_check_calls: list[dict[str, Any]] = []
         self.org_wide_enumerated = False
 
     async def __call__(
         self, _client: object, sql: str, params: dict[str, Any]
     ) -> list[dict[str, Any]]:
+        if "SELECT count() AS resolved FROM project" in sql:
+            # _PROJECT_IDENTITY_RESOLVED_SQL
+            self.identity_check_calls.append(dict(params))
+            if self.identity_check_fails:
+                raise RuntimeError("clickhouse unavailable")
+            return [{"resolved": 1 if self.identity_resolved else 0}]
         if "FROM work_items FINAL" in sql and "SELECT DISTINCT" in sql:
             # PROJECT_REPOSITORIES_SQL
             if self.fail:
@@ -212,7 +232,7 @@ async def test_project_with_zero_repositories_is_measured_empty_not_unavailable(
     exists to close).
     """
 
-    client = _FakeClient(derived=[])
+    client = _FakeClient(derived=[], identity_resolved=True)
     _install(monkeypatch, client)
 
     observations = await NativeDataHealthReader(object(), None).read(
@@ -223,9 +243,69 @@ async def test_project_with_zero_repositories_is_measured_empty_not_unavailable(
 
     assert client.watermark_params == []
     assert not client.org_wide_enumerated
+    # The identity-resolution disambiguation query ran and confirmed the
+    # project id still resolves -- that is what licenses "measured empty"
+    # rather than "unavailable" below.
+    assert client.identity_check_calls == [{"org_id": ORG_ID, "entity_id": PROJECT_ID}]
     assert observations[0].warning == "project_repository_scope_empty"
     assert observations[0].watermark is None
     assert observations[0].relevant_repository_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_project_with_unresolvable_identity_is_unavailable_not_measured_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3375 (post-CHAOS-3374 rebase): ``PROJECT_REPOSITORIES_SQL``
+
+    now ``INNER JOIN``s the provider-identity CTE (``HAVING count() = 1``,
+    ``is_active = 1``), so a retired project or a same-id cross-provider
+    collision empties the join and returns zero rows -- indistinguishable
+    from a genuinely repo-less project by row count alone. The standing
+    fail-closed ruling is that an unresolvable identity must never read as
+    a clean, measured-empty answer: this must be
+    ``project_repository_scope_unavailable``, not ``..._empty``.
+    """
+
+    client = _FakeClient(derived=[], identity_resolved=False)
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    assert client.identity_check_calls == [{"org_id": ORG_ID, "entity_id": PROJECT_ID}]
+    assert observations[0].configured is None
+    assert observations[0].warning == "project_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_project_identity_check_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed disambiguation query is itself treated as unresolved --
+
+    there is no honest "assume resolved" default when the check that would
+    prove it cannot run.
+    """
+
+    client = _FakeClient(derived=[], identity_check_fails=True)
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_project_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    assert observations[0].configured is None
+    assert observations[0].warning == "project_repository_scope_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_project_scope_data_health.py
+++ b/tests/api/dev/test_project_scope_data_health.py
@@ -1,18 +1,37 @@
-"""Project data-health must measure the project, not the organization.
+"""PROJECT/TEAM data-health must measure the subject, not the organization.
 
 ``NativeDataHealthReader._watermark`` filters with
 ``AND (empty({repository_ids}) OR toString(repo_id) IN {repository_ids})``, and
 ``DataHealthService`` then falls back to ``observation.relevant_repository_ids``
-when the scope contributed none. A committed PROJECT subject carries no
-repository dimension at all, so both behaviors combined measured every
-repository in the organization and reported the result as the project's
-coverage -- and because source health is a *mandatory* source of the project
-status plan, unrelated healthy repositories could make a project's evidence
-coverage read complete.
+when the scope contributed none. A committed PROJECT or TEAM subject carries
+no repository dimension at all, so both behaviors combined measured every
+repository in the organization and reported the result as the subject's
+coverage -- and because source health is a *mandatory* source of the
+project/team status plan, unrelated healthy repositories could make a
+subject's evidence coverage read complete.
 
-Codex adversarial review (HIGH, 2026-08-03). The reader now resolves the same
-repository set the status/change reader derives, from the same shared
-``PROJECT_REPOSITORIES_SQL``, or fails closed.
+Codex adversarial review (HIGH, 2026-08-03) fixed this for PROJECT (#1453):
+the reader resolves the same repository set the status/change reader
+derives, from the same shared ``PROJECT_REPOSITORIES_SQL``, or fails closed.
+
+CHAOS-3375 found two residual gaps in that fix, both covered below:
+
+1. A committed TEAM direct scope reaches the *exact same* widening bug
+   (``production_runtime._scope_request``'s ``DirectScope.TEAM`` branch
+   commits a TEAM entity with ``repository_id=None``, just like PROJECT) --
+   #1453 only special-cased ``EntityKind.PROJECT``, so a team subject fell
+   straight through to the org-wide ``empty(repository_ids) OR ...`` arm,
+   completely unguarded. Fixed by re-deriving via the same
+   ``_TEAM_REPOSITORIES_SQL`` ``native_status_change.
+   ClickHouseStatusChangeSource.team_repository_ids`` uses.
+2. A failed derivation (query error) and a *successful* derivation that
+   legitimately returns zero rows (the subject genuinely owns no
+   repositories) were collapsed into the same ``[]`` return and reported
+   identically as ``..._unavailable`` / ``DataHealthState.UNAVAILABLE``.
+   The two are now distinct: a measured-empty subject reports
+   ``..._empty`` / ``DataHealthState.NO_DATA`` ("queried, genuinely
+   nothing in scope"), never conflated with "could not be measured at
+   all".
 """
 
 from __future__ import annotations
@@ -36,6 +55,8 @@ NOW = datetime(2026, 8, 4, tzinfo=UTC)
 ORG_ID = "org-under-test"
 PROJECT_ID = "13e65c04-40ec-4a95-8216-f7c2ce233244"
 PROJECT_REPOSITORY_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+TEAM_ID = "team-9f3d0f9e-04ee-4e0a-8f1f-2c5f6a2b7c11"
+TEAM_REPOSITORY_ID = "cccccccc-0000-0000-0000-000000000003"
 UNRELATED_REPOSITORY_ID = "bbbbbbbb-0000-0000-0000-000000000002"
 
 
@@ -74,6 +95,24 @@ def _project_resolution(*, team_filter: bool = False) -> ScopeResolution:
     )
 
 
+def _team_resolution() -> ScopeResolution:
+    """A committed team subject, in the shape ``_scope_request`` produces.
+
+    ``repository_id=None`` is not an arbitrary choice: teams are resolved
+    organization-scoped with no repository dimension
+    (``ScopeResolutionService._committed_scope_for``'s own docstring), so
+    this is the only shape a team commit can have.
+    """
+
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(AuthorizedEntity(EntityKind.TEAM, TEAM_ID, "Team Nine", None),),
+        team_filters=(),
+        candidates=(),
+        time_range=_time_range(),
+    )
+
+
 def _repository_resolution() -> ScopeResolution:
     return ScopeResolution(
         outcome=ScopeResolutionOutcome.EXACT,
@@ -104,6 +143,12 @@ class _FakeClient:
         self, _client: object, sql: str, params: dict[str, Any]
     ) -> list[dict[str, Any]]:
         if "FROM work_items FINAL" in sql and "SELECT DISTINCT" in sql:
+            # PROJECT_REPOSITORIES_SQL
+            if self.fail:
+                raise RuntimeError("clickhouse unavailable")
+            return [{"repository_id": value} for value in (self.derived or [])]
+        if "team_repo_ownership" in sql:
+            # _TEAM_REPOSITORIES_SQL
             if self.fail:
                 raise RuntimeError("clickhouse unavailable")
             return [{"repository_id": value} for value in (self.derived or [])]
@@ -154,10 +199,18 @@ async def test_project_data_health_is_bound_to_the_projects_repositories(
 
 
 @pytest.mark.asyncio
-async def test_unresolvable_project_repositories_fail_closed_not_org_wide(
+async def test_project_with_zero_repositories_is_measured_empty_not_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An empty derivation is a refusal, never "measure everything instead"."""
+    """A *successful* derivation returning zero rows is a real, measured
+
+    answer ("this project genuinely owns no repositories") -- never widened
+    to the organization, and never conflated with a *failed* derivation
+    (below). It must still never enumerate the org-wide repository set, and
+    must never reach ``_watermark`` with an empty ``repository_ids`` list
+    either (that would silently re-trigger the exact widening this fix
+    exists to close).
+    """
 
     client = _FakeClient(derived=[])
     _install(monkeypatch, client)
@@ -170,17 +223,24 @@ async def test_unresolvable_project_repositories_fail_closed_not_org_wide(
 
     assert client.watermark_params == []
     assert not client.org_wide_enumerated
-    # ``configured is None`` is what DataHealthService maps to
-    # DataHealthState.UNAVAILABLE -- an explicit "not measured for this
-    # subject", never a silent organization-wide substitute.
-    assert observations[0].configured is None
-    assert observations[0].warning == "project_repository_scope_unavailable"
+    assert observations[0].warning == "project_repository_scope_empty"
+    assert observations[0].watermark is None
+    assert observations[0].relevant_repository_ids == ()
 
 
 @pytest.mark.asyncio
 async def test_failed_project_derivation_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A *failed* derivation (query error) is unmeasured, distinct from the
+
+    measured-empty case above -- ``configured is None`` is what
+    ``DataHealthService`` maps to ``DataHealthState.UNAVAILABLE``, an
+    explicit "not measured for this subject", never a silent
+    organization-wide substitute and never the "no data" a measured-empty
+    project reports.
+    """
+
     client = _FakeClient(derived=None, fail=True)
     _install(monkeypatch, client)
 
@@ -216,10 +276,115 @@ async def test_team_filtered_project_data_health_fails_closed(
 
 
 @pytest.mark.asyncio
+async def test_team_data_health_is_bound_to_the_teams_repositories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3375: a committed TEAM subject must be bound to its own
+
+    ``team_repo_ownership`` repositories, the same way a PROJECT subject is
+    bound to ``PROJECT_REPOSITORIES_SQL`` above -- #1453 never covered this
+    scope kind at all.
+    """
+
+    client = _FakeClient(derived=[TEAM_REPOSITORY_ID])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_team_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert [params["repository_ids"] for params in client.watermark_params] == [
+        [TEAM_REPOSITORY_ID]
+    ]
+    assert not client.org_wide_enumerated
+    assert observations[0].relevant_repository_ids == (TEAM_REPOSITORY_ID,)
+    assert UNRELATED_REPOSITORY_ID not in observations[0].relevant_repository_ids
+
+
+@pytest.mark.asyncio
+async def test_team_with_zero_owned_repositories_is_measured_empty_not_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A team that genuinely owns zero repositories (a real, measured
+
+    ``team_repo_ownership`` result) must never be widened to the
+    organization, and must be distinct from a failed team derivation below.
+    """
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_team_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    assert observations[0].warning == "team_repository_scope_empty"
+    assert observations[0].watermark is None
+    assert observations[0].relevant_repository_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_failed_team_derivation_fails_closed_not_org_wide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3375: before this fix, a team subject reached this exact
+
+    ``empty(repository_ids) OR ...`` widening completely unguarded -- the
+    fake client's ``org_wide_enumerated`` flag would have flipped ``True``
+    and every mandatory source's watermark query would have run unfiltered
+    across the whole organization.
+    """
+
+    client = _FakeClient(derived=None, fail=True)
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_team_resolution(),
+        source_systems=["work_items"],
+    )
+
+    assert client.watermark_params == []
+    assert not client.org_wide_enumerated
+    assert observations[0].configured is None
+    assert observations[0].warning == "team_repository_scope_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_acr_stays_optional_for_a_measured_empty_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-closed/measured-empty arms must not swallow acr's own
+
+    optional semantics.
+    """
+
+    client = _FakeClient(derived=[])
+    _install(monkeypatch, client)
+
+    observations = await NativeDataHealthReader(object(), None).read(
+        org_id=ORG_ID,
+        scope=_team_resolution(),
+        source_systems=["acr", "work_items"],
+    )
+
+    by_source = {item.source_system: item for item in observations}
+    assert by_source["acr"].warning == "acr_optional"
+    assert by_source["acr"].required is False
+    assert by_source["work_items"].warning == "team_repository_scope_empty"
+
+
+@pytest.mark.asyncio
 async def test_repository_scope_behaviour_is_unchanged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression guard: only the no-repository PROJECT case changed."""
+    """Regression guard: only the no-repository PROJECT/TEAM cases changed."""
 
     client = _FakeClient(derived=[])
     _install(monkeypatch, client)
@@ -237,10 +402,13 @@ async def test_repository_scope_behaviour_is_unchanged(
 
 
 @pytest.mark.asyncio
-async def test_acr_stays_optional_for_an_unresolvable_project(
+async def test_acr_stays_optional_for_a_measured_empty_project(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The fail-closed arm must not swallow acr's own optional semantics."""
+    """The fail-closed/measured-empty arms must not swallow acr's own
+
+    optional semantics.
+    """
 
     client = _FakeClient(derived=[])
     _install(monkeypatch, client)
@@ -254,4 +422,4 @@ async def test_acr_stays_optional_for_an_unresolvable_project(
     by_source = {item.source_system: item for item in observations}
     assert by_source["acr"].warning == "acr_optional"
     assert by_source["acr"].required is False
-    assert by_source["work_items"].warning == "project_repository_scope_unavailable"
+    assert by_source["work_items"].warning == "project_repository_scope_empty"

--- a/tests/api/dev/test_team_scope_clickhouse_live.py
+++ b/tests/api/dev/test_team_scope_clickhouse_live.py
@@ -1,0 +1,332 @@
+"""Live-ClickHouse proof for the committed-team repository derivation.
+
+``ClickHouseStatusChangeSource.team_repository_ids`` re-derives a committed
+TEAM subject's repositories from ``team_repo_ownership`` (CHAOS-3303). The
+unit suites for this area mock ``query_dicts`` entirely and so cannot prove
+anything about the query's own predicates -- this file closes that gap by
+executing ``_TEAM_REPOSITORIES_SQL`` against a real migrated ClickHouse over
+rows written directly to ``team_repo_ownership``/``repos``.
+
+CHAOS-3375 (Codex adversarial review, HIGH): the first cut of this query
+trusted every ``team_repo_ownership.repo_id`` outright. ClickHouse enforces
+no foreign key, so a repository revoked from ``repos`` -- de-authorized --
+can keep a stale ``team_repo_ownership`` row and become an admitted read
+bound for team scope alone (an *unrelated, removed* repository's watermark
+queries would then run). This file seeds exactly that shape and asserts the
+orphaned repository is excluded, while a genuinely authorized one is
+admitted.
+
+Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
+``-m "not benchmark and not clickhouse"``): ``pytest -m clickhouse`` with
+``CLICKHOUSE_URI`` pointing at a SCRATCH database -- never the dev
+``default``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+NOW = datetime.now(UTC).replace(microsecond=0)
+
+#: Database names this file refuses to touch -- it writes rows. A warning in
+#: a docstring is not an enforcement boundary; this is.
+_PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _database_of(dsn: str | None) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(dsn or "").path.lstrip("/").strip().lower()
+
+
+def _scratch_database(dsn: str) -> str:
+    """Return the DSN's database, or fail closed if it is a protected one.
+
+    Kept as a hard ``RuntimeError`` even though the skip below normally
+    prevents it from firing: the skip is convenience, this is the boundary.
+    A developer who forces the fixture past the marker must still not seed
+    the dev database.
+    """
+
+    database = _database_of(dsn)
+    if database in _PROTECTED_DATABASES:
+        raise RuntimeError(
+            "refusing to seed ClickHouse database "
+            f"{database or '<unset>'!r}: point CLICKHOUSE_URI at a named "
+            "SCRATCH database (e.g. .../ci_local_validate)."
+        )
+    return database
+
+
+#: A developer's shell commonly exports ``CLICKHOUSE_URI`` pointing at the
+#: dev ``default`` database. Skipping (loudly, with this reason) rather than
+#: erroring keeps that from looking like a broken test -- while still never
+#: reading as a pass: the measurement plainly did not happen.
+_SKIP_REASON = (
+    "Requires a migrated SCRATCH CLICKHOUSE_URI "
+    "(e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate); "
+    f"got database {_database_of(CLICKHOUSE_URI) or '<unset>'!r}, which this "
+    "suite refuses to seed"
+)
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI or _database_of(CLICKHOUSE_URI) in _PROTECTED_DATABASES,
+        reason=_SKIP_REASON,
+    ),
+]
+
+
+@pytest.fixture
+def sink() -> Any:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    _scratch_database(CLICKHOUSE_URI)
+    metrics_sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    try:
+        yield metrics_sink
+    finally:
+        metrics_sink.close()
+
+
+@pytest.fixture
+def raw_client() -> Any:
+    import clickhouse_connect
+
+    assert CLICKHOUSE_URI is not None
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _insert_repo(client: Any, *, org_id: str, repo_id: str, name: str) -> None:
+    client.command(
+        "INSERT INTO repos (id, repo, created_at, last_synced, org_id) VALUES "
+        "({repo_id:UUID}, {name:String}, now64(3), now64(3), {org_id:String})",
+        parameters={"repo_id": repo_id, "name": name, "org_id": org_id},
+    )
+
+
+def _insert_team_repo_ownership(
+    client: Any,
+    *,
+    org_id: str,
+    team_id: str,
+    repo_id: str,
+    repo_full_name: str,
+    valid_from: datetime,
+    valid_to: datetime | None = None,
+) -> None:
+    client.command(
+        "INSERT INTO team_repo_ownership "
+        "(org_id, provider, team_id, repo_id, repo_full_name, match_type, "
+        "source, is_primary, specificity, priority, valid_from, valid_to, "
+        "updated_at) VALUES "
+        "({org_id:String}, 'github', {team_id:String}, {repo_id:UUID}, "
+        "{repo_full_name:String}, 'exact', 'native', 1, 100, 0, "
+        "{valid_from:DateTime64(3, 'UTC')}, {valid_to:Nullable(DateTime64(3, 'UTC'))}, "
+        "now64(3))",
+        parameters={
+            "org_id": org_id,
+            "team_id": team_id,
+            "repo_id": repo_id,
+            "repo_full_name": repo_full_name,
+            "valid_from": valid_from,
+            "valid_to": valid_to,
+        },
+    )
+
+
+class _Seeded:
+    def __init__(self) -> None:
+        self.org_id = f"team-scope-{uuid.uuid4().hex[:16]}"
+        self.other_org_id = f"team-scope-other-{uuid.uuid4().hex[:16]}"
+        self.team_id = f"team-{uuid.uuid4().hex[:12]}"
+        self.other_team_id = f"team-other-{uuid.uuid4().hex[:12]}"
+        self.authorized_repo = uuid.uuid4()
+        #: Owned by the team in ``team_repo_ownership``, but with NO
+        #: corresponding row in ``repos`` -- a revoked/deleted repository
+        #: whose stale ownership row must never authorize a read.
+        self.orphaned_repo = uuid.uuid4()
+        #: Authorized in ``repos``, but the ownership window has already
+        #: closed (``valid_to`` in the past) -- isolates the ``valid_to``
+        #: clause: it is NOT also orphaned, so only that clause excludes it.
+        self.expired_repo = uuid.uuid4()
+        #: Authorized in ``repos``, but the ownership window has not started
+        #: yet (``valid_from`` in the future) -- isolates the ``valid_from``
+        #: clause the same way.
+        self.future_repo = uuid.uuid4()
+        #: Owned by a DIFFERENT team in the SAME org, authorized in
+        #: ``repos`` -- isolates the ``team_id`` clause.
+        self.other_team_repo = uuid.uuid4()
+        #: Owned by ``team_id`` under a DIFFERENT org, but (deliberately)
+        #: also present in THIS org's ``repos`` catalog -- isolates the
+        #: ``team_repo_ownership``-level ``org_id`` clause specifically: if
+        #: it were removed, only this row (not the repos-catalog check)
+        #: would newly admit it.
+        self.foreign_org_repo = uuid.uuid4()
+
+
+@pytest.fixture
+def seeded(sink: Any, raw_client: Any) -> Any:
+    data = _Seeded()
+    for repo_id, name in (
+        (data.authorized_repo, "org/authorized"),
+        (data.expired_repo, "org/expired"),
+        (data.future_repo, "org/future"),
+        (data.other_team_repo, "org/other-team"),
+        (data.foreign_org_repo, "org/foreign-org"),
+    ):
+        _insert_repo(raw_client, org_id=data.org_id, repo_id=str(repo_id), name=name)
+    # Deliberately no ``repos`` row for ``orphaned_repo`` under ANY org --
+    # ownership rows alone must never be sufficient to authorize a
+    # repository.
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.org_id,
+        team_id=data.team_id,
+        repo_id=str(data.authorized_repo),
+        repo_full_name="org/authorized",
+        valid_from=NOW - timedelta(days=30),
+    )
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.org_id,
+        team_id=data.team_id,
+        repo_id=str(data.orphaned_repo),
+        repo_full_name="org/orphaned",
+        valid_from=NOW - timedelta(days=30),
+    )
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.org_id,
+        team_id=data.team_id,
+        repo_id=str(data.expired_repo),
+        repo_full_name="org/expired",
+        valid_from=NOW - timedelta(days=60),
+        valid_to=NOW - timedelta(days=1),
+    )
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.org_id,
+        team_id=data.team_id,
+        repo_id=str(data.future_repo),
+        repo_full_name="org/future",
+        valid_from=NOW + timedelta(days=1),
+    )
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.org_id,
+        team_id=data.other_team_id,
+        repo_id=str(data.other_team_repo),
+        repo_full_name="org/other-team",
+        valid_from=NOW - timedelta(days=30),
+    )
+    _insert_team_repo_ownership(
+        raw_client,
+        org_id=data.other_org_id,
+        team_id=data.team_id,
+        repo_id=str(data.foreign_org_repo),
+        repo_full_name="org/foreign-org",
+        valid_from=NOW - timedelta(days=30),
+    )
+    return data
+
+
+@pytest.mark.asyncio
+async def test_orphaned_ownership_row_cannot_reach_any_watermark_query(
+    sink: Any, seeded: Any
+) -> None:
+    """CHAOS-3375: a ``team_repo_ownership`` row with no ``repos`` catalog
+
+    row must never be admitted -- proven against a real engine, not a
+    predicate fake. Without the fix's ``repos``-catalog intersection, this
+    assertion fails: the orphaned repository comes back alongside the
+    authorized one.
+    """
+
+    source = ClickHouseStatusChangeSource(sink, now=NOW)
+    result = await source.team_repository_ids(seeded.org_id, seeded.team_id, as_of=NOW)
+
+    assert result.measured is True
+    assert result.repository_ids == (str(seeded.authorized_repo),)
+    assert str(seeded.orphaned_repo) not in result.repository_ids
+    assert str(seeded.expired_repo) not in result.repository_ids
+    assert str(seeded.future_repo) not in result.repository_ids
+    assert str(seeded.other_team_repo) not in result.repository_ids
+    assert str(seeded.foreign_org_repo) not in result.repository_ids
+
+
+@pytest.mark.asyncio
+async def test_every_derivation_clause_changes_the_real_result(
+    sink: Any, seeded: Any
+) -> None:
+    """Mutation-check against the engine, not against a fake.
+
+    Each mutant is executed on the same seeded data. A mutant that returns
+    the correct set is a clause the assertion above could never have
+    caught -- so the failure message names the clause rather than just
+    reporting inequality.
+    """
+
+    from dev_health_ops.api.dev.native_status_change import _TEAM_REPOSITORIES_SQL
+    from dev_health_ops.api.queries.client import query_dicts
+
+    correct = [str(seeded.authorized_repo)]
+    mutants = {
+        "org_id tenant bound on team_repo_ownership": (
+            "FROM team_repo_ownership\n  WHERE org_id = {org_id:String}\n",
+            "FROM team_repo_ownership\n  WHERE 1 = 1\n",
+        ),
+        "team_id bound": (
+            "AND team_id = {team_id:String}\n",
+            "",
+        ),
+        "valid_from bound": (
+            "AND valid_from <= {as_of:DateTime64(3, 'UTC')}\n",
+            "",
+        ),
+        "valid_to bound": (
+            "AND (valid_to IS NULL OR valid_to > {as_of:DateTime64(3, 'UTC')})\n",
+            "",
+        ),
+        "repos authorization arm": (
+            "AND toString(g.repo_id) IN (\n"
+            "    SELECT toString(id) FROM repos FINAL WHERE org_id = {org_id:String}\n"
+            "  )\n",
+            "",
+        ),
+    }
+
+    survived: list[str] = []
+    for label, (original, mutated) in mutants.items():
+        assert original in _TEAM_REPOSITORIES_SQL, f"stale mutant anchor: {label}"
+        sql = _TEAM_REPOSITORIES_SQL.replace(original, mutated, 1)
+        rows = await query_dicts(
+            sink,
+            sql,
+            {"org_id": seeded.org_id, "team_id": seeded.team_id, "as_of": NOW},
+        )
+        observed = sorted(
+            {str(row["repository_id"]) for row in rows if row.get("repository_id")}
+        )
+        if observed == sorted(correct):
+            survived.append(label)
+
+    assert not survived, (
+        "these mutants returned the SAME result as the real query, so the "
+        f"assertion above could never have caught them: {survived}"
+    )


### PR DESCRIPTION
## Summary

Fixes CHAOS-3375: project/team data-health must never widen to org-wide data. The ticket's original PROJECT clauses were already fixed by #1453 (premise-checked clause by clause); this PR closes the rest of the class, found via audit + adversarial review:

- **TEAM scopes** fell through the PROJECT-only special case to `_watermark(source, org_id, [])`, where an empty repository list disables filtering — a team's mandatory evidence coverage measured the whole org. `read()` now derives team repositories via `_TEAM_REPOSITORIES_SQL` or fails closed.
- **Team-filtered ORGANIZATION scopes** (team only in `scope.team_filters`) were a third unguarded entry point — now fail closed (`team_filtered_scope_unavailable`), mirroring the derivation ruling in `native_status_change`.
- **Derivation failure marked mandatory sources optional**: the unresolved-scope path emitted `SourceHealthObservation(required=False)`, so `complete_eligible` read `True` and the DATA_HEALTH tool reported `status=success` on a failure-only run. Now `required=True` (only `acr` stays optional).
- **`_TEAM_REPOSITORIES_SQL` trusted revoked repos**: ownership rows for repositories removed from the org catalog still authorized watermark reads. Now intersected with `repos FINAL` (same pattern as the project derivation), live-verified on migrated ClickHouse with a 5-clause mutation test (orphaned/expired/future/cross-team/cross-org rows).
- **Incidents watermark stayed org-wide** for subject-scoped requests (`repo_column=None` skips repo filtering entirely) — now reports required-unavailable when repositories are in scope; genuine org-wide requests unchanged.
- **Unresolvable project identity misclassified as measured-empty**: a zero-row derivation (retired/collided identity under the #1460 identity CTE) reported `NO_DATA` → `AVAILABLE_CURRENT`. Zero-row results now re-verify that exactly one active canonical identity resolves; otherwise UNAVAILABLE. Measured-empty / unavailable / (no truncation path exists) kept as distinct states.

## Testing

- Full `tests/api/dev/`: 1858 passed, 48 skipped (live-ClickHouse-marked), 1 xfailed, 0 failed.
- New live suite `test_team_scope_clickhouse_live.py` (`@pytest.mark.clickhouse`) run against a real migrated scratch DB via the production sink/query path.
- Every fix verified guard-observed-failing: new tests reproduce the defect against pre-fix code (org-wide watermark firing, `complete_eligible=true` on failure, orphaned repo leaking live) and pass post-fix.
- ruff + mypy clean (full-package mypy via pre-commit).
