### PR TITLE
fix(ask-dev): server-render the §10 status verdict deterministically at every terminal (CHAOS-3377)

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
+        "sha256": "91dc5d89676096a86ee4489da6f7ed7fd50aa44d9e7ef735a9d52a09b7cc9188"
       },
       "schema_version": "dev_tool_result.v1"
     },

--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -425,5 +425,12 @@
       "case": "invalid_out_of_order",
       "path": "examples/streams/invalid_out_of_order.json"
     }
+  ],
+  "vocabulary": [
+    {
+      "case": "internal_prose_denylist",
+      "path": "vocabulary/internal_prose_denylist.v1.json",
+      "sha256": "621ed38192bb17f3c9e9f826a3b3572c29cc8cd58865c77e9ea4ad9296990e7a"
+    }
   ]
 }

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -23,6 +23,14 @@
       "additionalProperties": false,
       "description": "Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.",
       "properties": {
+        "blockers": {
+          "items": {
+            "$ref": "#/$defs/DevRequiredChildFact"
+          },
+          "maxItems": 100,
+          "title": "Blockers",
+          "type": "array"
+        },
         "conflicts": {
           "items": {
             "$ref": "#/$defs/DevStatusConflict"

--- a/contracts/ask-dev/v1/vocabulary/internal_prose_denylist.v1.json
+++ b/contracts/ask-dev/v1/vocabulary/internal_prose_denylist.v1.json
@@ -1,0 +1,28 @@
+{
+  "completion_states": [
+    "not_ready"
+  ],
+  "evidence_handle_pattern": "^ev1_[0-9a-f]{40}$",
+  "extra_tokens": [
+    "actual_completion"
+  ],
+  "reason_codes": [
+    "active_blocking_incident",
+    "assessment_source_limit_reached",
+    "child_requirement_unknown",
+    "ci_requirement_unknown",
+    "declared_status_missing",
+    "open_blocker",
+    "required_child_incomplete",
+    "required_ci_not_passing",
+    "required_ci_skip_state_unknown",
+    "required_ci_work_skipped",
+    "required_deployment_not_succeeded",
+    "required_pull_request_unmerged",
+    "required_release_evidence_missing",
+    "required_review_unresolved",
+    "required_source_not_fresh",
+    "review_changes_requested"
+  ],
+  "schema_version": "ask_dev_internal_prose_denylist.v1"
+}

--- a/src/dev_health_ops/api/dev/answer_text_sanitizer.py
+++ b/src/dev_health_ops/api/dev/answer_text_sanitizer.py
@@ -1,0 +1,54 @@
+"""CHAOS-3377 defect 3: structural JSON-tail sanitization for model prose.
+
+A live run showed a model-authored ``direct_summary`` ending in a stray
+``}}}{`` -- leftover structural JSON characters, not prose. The narrative
+provider boundary (``answer_frames/narrative_fallback.py``) already validates
+its own output strictly, but the legacy v1 path (``dict(decision.value)`` in
+``orchestrator.py``) takes the model's free-text fields as-is.
+
+This is fixed structurally, not by replacing the literal string ``'}}}{'``:
+that would fix the one reported string and nothing else shaped like it. The
+rule instead is general -- strip a TRAILING run of bare JSON-structural
+characters (``{ } [ ] " ,``) once real prose has ended, since ordinary English
+text does not end in a bare run of those characters with no surrounding word
+content. It is applied to every model-authored free-text field
+(``direct_summary``, each claim's ``text``, each warning) at the seam where
+the model's raw decision is turned into an answer candidate, before that
+candidate is validated or persisted.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["sanitize_model_text"]
+
+#: A trailing run of two or more bare JSON-structural characters, optionally
+#: preceded/interleaved with whitespace -- e.g. ``'}}}{'``, ``' }] '``,
+#: ``'"}'``. Two or more, not one: a single trailing brace/bracket is not by
+#: itself distinguishable from legitimate prose that happens to end a
+#: sentence inside a quotation of code or JSON ("the response was `{}`."),
+#: and one is a much weaker signal of a parser-boundary leak than a bare run
+#: of two or more with nothing else around them.
+_TRAILING_JSON_ARTIFACT = re.compile(r'[\s{}\[\]",:]{2,}\Z')
+
+
+def sanitize_model_text(text: str) -> str:
+    """Strip a trailing JSON-structural artifact from model-authored prose.
+
+    Repeats until stable (a single pass can uncover a second artifact
+    directly behind the first, e.g. ``'... done.} }'``), then trims
+    surrounding whitespace. Text with no such tail is returned unchanged.
+    Never touches the interior of the string -- a legitimate brace pair
+    inside a sentence ("the payload is `{}`  by default") is left alone,
+    since the pattern only ever matches anchored at the very end.
+    """
+
+    if not text:
+        return text
+    previous = None
+    cleaned = text
+    while previous != cleaned:
+        previous = cleaned
+        cleaned = _TRAILING_JSON_ARTIFACT.sub("", cleaned)
+    return cleaned.rstrip()

--- a/src/dev_health_ops/api/dev/answer_text_sanitizer.py
+++ b/src/dev_health_ops/api/dev/answer_text_sanitizer.py
@@ -1,20 +1,35 @@
 """CHAOS-3377 defect 3: structural JSON-tail sanitization for model prose.
 
 A live run showed a model-authored ``direct_summary`` ending in a stray
-``}}}{`` -- leftover structural JSON characters, not prose. The narrative
-provider boundary (``answer_frames/narrative_fallback.py``) already validates
-its own output strictly, but the legacy v1 path (``dict(decision.value)`` in
-``orchestrator.py``) takes the model's free-text fields as-is.
+``}}}{`` -- leftover structural JSON characters, not prose.
 
-This is fixed structurally, not by replacing the literal string ``'}}}{'``:
-that would fix the one reported string and nothing else shaped like it. The
-rule instead is general -- strip a TRAILING run of bare JSON-structural
-characters (``{ } [ ] " ,``) once real prose has ended, since ordinary English
-text does not end in a bare run of those characters with no surrounding word
-content. It is applied to every model-authored free-text field
-(``direct_summary``, each claim's ``text``, each warning) at the seam where
-the model's raw decision is turned into an answer candidate, before that
-candidate is validated or persisted.
+Where the leak can and cannot originate (verified, not assumed): the raw
+provider completion is parsed with a single strict ``json.loads`` call
+(``dev_health_ops/llm/agent/openai_compatible.py``, ``_normalize_response``,
+``payload = json.loads(str(message.content or ""))``). That call either
+succeeds -- producing a syntactically valid JSON object, whose ``value``
+dict becomes ``AgentFinalAnswer.value`` unchanged -- or raises
+``json.JSONDecodeError``, which is handled well above this module (a
+provider/schema-repair error, never silently reaching ``decision.value``).
+There is no lenient fallback parse (no fenced-JSON extraction, no
+best-effort regex) anywhere on that path. So a reported trailing artifact on
+``direct_summary`` cannot be an ENVELOPE malformation -- the envelope, by
+construction, parsed as valid JSON -- it can only be literal content the
+model put INSIDE an otherwise well-formed string value. There is no separate
+"envelope" boundary to validate; the anomaly is embedded in the prose itself,
+which is exactly why this module operates on the text, not the parse layer.
+
+That constrains the fix to a PRECISE text-level rule, not a blanket one.
+Codex adversarial review (round 2) reproduced three cases where the first
+revision's blanket "trailing run of >=2 JSON-structural characters" regex
+corrupted legitimate content: ``"Expected payload: {}"``, ``"Valid
+alternatives are []"``, ``"Use an empty object: { }"`` -- each ends in a
+syntactically VALID, balanced, well-nested bracket literal that is plausible
+real prose (an inline example), not leaked debris. The fix distinguishes the
+two with a real bracket-matching pass over the trailing run: a candidate tail
+is stripped only when it is NOT a validly balanced/nested bracket sequence
+(the reported ``'}}}{'`` opens nothing and closes from empty -- structurally
+invalid by construction), never merely because it is JSON-shaped.
 """
 
 from __future__ import annotations
@@ -23,32 +38,57 @@ import re
 
 __all__ = ["sanitize_model_text"]
 
-#: A trailing run of two or more bare JSON-structural characters, optionally
-#: preceded/interleaved with whitespace -- e.g. ``'}}}{'``, ``' }] '``,
-#: ``'"}'``. Two or more, not one: a single trailing brace/bracket is not by
-#: itself distinguishable from legitimate prose that happens to end a
-#: sentence inside a quotation of code or JSON ("the response was `{}`."),
-#: and one is a much weaker signal of a parser-boundary leak than a bare run
-#: of two or more with nothing else around them.
-_TRAILING_JSON_ARTIFACT = re.compile(r'[\s{}\[\]",:]{2,}\Z')
+#: The maximal trailing run of bare JSON-structural characters (braces,
+#: brackets, quotes, commas, colons, whitespace) -- the CANDIDATE tail to
+#: validate. Extracted once; validity (not shape) decides whether it is
+#: stripped. See ``_is_structurally_invalid``.
+_TRAILING_CANDIDATE = re.compile(r'[\s{}\[\]",:]+\Z')
+
+_OPENERS = {"{": "}", "[": "]"}
+_CLOSERS = {"}": "{", "]": "["}
+
+
+def _is_structurally_invalid(candidate: str) -> bool:
+    """Whether ``candidate`` (a run of only ``{ } [ ] " , :`` and whitespace)
+    is NOT a validly nested, fully-closed bracket sequence.
+
+    A real stack-based bracket match, not a character-count balance check:
+    counting opens vs. closes alone would call ``']['`` valid (one of each),
+    when a close before any matching open is exactly the "leftover fragment"
+    shape a leaked JSON tail has. Quotes/commas/colons are ignored for
+    nesting purposes -- they carry no structural relationship here -- but
+    still count as part of the candidate (so ``'": }'`` is still scanned).
+    """
+
+    stack: list[str] = []
+    for char in candidate:
+        if char in _OPENERS:
+            stack.append(char)
+        elif char in _CLOSERS:
+            if not stack or stack[-1] != _CLOSERS[char]:
+                return True
+            stack.pop()
+    return bool(stack)
 
 
 def sanitize_model_text(text: str) -> str:
-    """Strip a trailing JSON-structural artifact from model-authored prose.
+    """Strip a trailing JSON-structural artifact from model-authored prose,
+    but only when the trailing run is not itself validly bracketed.
 
-    Repeats until stable (a single pass can uncover a second artifact
-    directly behind the first, e.g. ``'... done.} }'``), then trims
-    surrounding whitespace. Text with no such tail is returned unchanged.
-    Never touches the interior of the string -- a legitimate brace pair
-    inside a sentence ("the payload is `{}`  by default") is left alone,
-    since the pattern only ever matches anchored at the very end.
+    ``"...done.}}}{"`` -> ``"...done."`` (the tail opens nothing and closes
+    from empty -- invalid, stripped). ``"Expected payload: {}"`` is returned
+    UNCHANGED (the tail is a balanced, well-nested, plausible inline
+    example). Text with no trailing structural run at all is returned
+    unchanged. Never touches the interior of the string -- the candidate
+    pattern is anchored at the very end.
     """
 
     if not text:
         return text
-    previous = None
-    cleaned = text
-    while previous != cleaned:
-        previous = cleaned
-        cleaned = _TRAILING_JSON_ARTIFACT.sub("", cleaned)
-    return cleaned.rstrip()
+    match = _TRAILING_CANDIDATE.search(text)
+    if match is None:
+        return text
+    candidate = match.group(0)
+    if not _is_structurally_invalid(candidate):
+        return text
+    return text[: match.start()].rstrip()

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 
 from .contracts import (
     AnswerStatus,
-    DevActualCompletion,
     DevAnswer,
     DevClaim,
     DevContractVersions,
@@ -21,6 +20,17 @@ from .contracts import (
     DevModelMetadata,
     DevScopeResolution,
     DevToolResult,
+)
+from .status_completion_copy import (
+    INCOMPLETE_DENOMINATOR_DISCLOSURE,
+    any_tool_result_withheld_its_completion_denominator,
+    translate_reason_codes,
+)
+from .status_completion_copy import (
+    has_incomplete_denominator_disclosure as _has_incomplete_denominator_disclosure,
+)
+from .status_completion_copy import (
+    is_completion_assessment_untrustworthy as _completion_assessment_is_untrustworthy,
 )
 
 _NUMBER = re.compile(r"(?<![A-Za-z_])[-+]?\d+(?:[.,]\d+)*(?:%|\b)")
@@ -64,14 +74,15 @@ _NUMBER = re.compile(r"(?<![A-Za-z_])[-+]?\d+(?:[.,]\d+)*(?:%|\b)")
 # reader always sees the caveat verbatim alongside whatever else the
 # text says, which is a materially different risk than the caveat being
 # silently absent.
-INCOMPLETE_DENOMINATOR_DISCLOSURE = (
-    "the required-work completion total could not be fully verified"
-)
-
-
-def _has_incomplete_denominator_disclosure(text: str) -> bool:
-    return INCOMPLETE_DENOMINATOR_DISCLOSURE.casefold() in text.casefold()
-
+#
+# CHAOS-3377: this constant and the two predicates below (``_completion_
+# assessment_is_untrustworthy``/``any_tool_result_withheld_its_completion_
+# denominator``) now live in ``status_completion_copy.py`` -- imported above
+# -- so ``status_answer_render.py``'s deterministic §10 renderer can use the
+# identical disclosure obligation without importing this module (which now
+# also imports THAT module's reason-code translation table below, for
+# ``completion_truncation_detail``; the shared module exists specifically to
+# break that cycle).
 
 _NON_REPAIRABLE_VALIDATION_MARKERS = (
     "unknown evidence",
@@ -170,31 +181,9 @@ def _claim_has_grounding_reference(claim: DevClaim) -> bool:
 # denominator makes the count itself unknown; the general reason code
 # makes the REST of the evidence (blockers/PRs/CI/deployments/incidents)
 # behind that "complete" claim unknown, which is exactly as untrustworthy.
-_ASSESSMENT_SOURCE_LIMIT_REACHED = "assessment_source_limit_reached"
-
-
-def _completion_assessment_is_untrustworthy(actual: DevActualCompletion) -> bool:
-    return (
-        actual.required_child_total is None
-        or _ASSESSMENT_SOURCE_LIMIT_REACHED in actual.reason_codes
-    )
-
-
-def _any_tool_result_withheld_its_completion_denominator(
-    tool_results: tuple[DevToolResult, ...],
-) -> bool:
-    """Whether any executed tool in this run reported a completion
-    assessment that cannot be trusted to ground a completion claim
-    (CHAOS-3297 s2): either the denominator itself is withheld
-    (required_child_total is None, whenever the required-child source
-    was truncated), or assessment_source_limit_reached fired for any
-    other reason (round 9) -- see the module-level comment above.
-    """
-    return any(
-        result.actual_completion is not None
-        and _completion_assessment_is_untrustworthy(result.actual_completion)
-        for result in tool_results
-    )
+# See ``status_completion_copy.py`` for ``_completion_assessment_is_
+# untrustworthy``/``any_tool_result_withheld_its_completion_denominator``,
+# imported above.
 
 
 def completion_truncation_detail(tool_results: tuple[DevToolResult, ...]) -> str:
@@ -207,11 +196,20 @@ def completion_truncation_detail(tool_results: tuple[DevToolResult, ...]) -> str
     count -- never raw evidence/child content, so it stays safe to show
     verbatim in a terminal error message. Selection matches the trigger
     predicate above (round 9): either signal, not just a null total.
+
+    CHAOS-3377 defect 2: the reason codes are translated through the same
+    closed-vocabulary table ``status_answer_render.py`` uses, not rendered
+    raw -- this message is a ``DevError.safe_message``, which
+    ``no_match_terminal.user_visible_strings`` scans exactly like answer
+    prose, and the widened internal-token denylist (CHAOS-3377) would
+    otherwise fail this terminal closed on its own error message.
     """
     for result in tool_results:
         actual = result.actual_completion
         if actual is not None and _completion_assessment_is_untrustworthy(actual):
-            reasons = ", ".join(actual.reason_codes) or "unknown reason"
+            reasons = "; ".join(translate_reason_codes(actual.reason_codes)) or (
+                "an unknown reason"
+            )
             displayed = len(actual.required_children)
             return (
                 f"The required-work assessment could not verify a "
@@ -475,7 +473,7 @@ def validate_answer_candidate(
             repairable=False,
         )
     completion_denominator_withheld = (
-        _any_tool_result_withheld_its_completion_denominator(context.tool_results)
+        any_tool_result_withheld_its_completion_denominator(context.tool_results)
     )
     for claim in answer.claims:
         if resolved_scope is not None and claim.validity_scope != resolved_scope:
@@ -533,6 +531,30 @@ def validate_answer_candidate(
             repairable=True,
         )
 
+    # CHAOS-3377 defect 1 (refusal ceiling): the mirror image of the
+    # CHAOS-3290 floor below. A model can self-declare
+    # ``AnswerStatus.REFUSED`` in the same free-form JSON it authors
+    # ``direct_summary``/``claims`` in, and nothing previously stopped it
+    # from doing so alongside real claim/metric/evidence grounding -- the
+    # live defect this ticket reports (a "Refused" chip over a fully
+    # substantive body). PRD §12's "a result with content is not a refusal"
+    # applies here exactly as it does to CHAOS-3367's no-match path: a
+    # refusal that carries material grounding is not an honest refusal, it
+    # is a mislabeled answer. ``repairable=True`` (not one of
+    # ``_NON_REPAIRABLE_VALIDATION_MARKERS``): this is a one-field labeling
+    # mistake the model can correct in the same bounded repair pass
+    # CHAOS-3257 already gives a status/coverage mismatch, by reissuing the
+    # same grounded content under an accurate status.
+    if answer.status is AnswerStatus.REFUSED and _answer_has_material_grounding(answer):
+        raise AnswerValidationError(
+            "a refused answer cannot carry claim, metric, or evidence "
+            "grounding -- reissue with an accurate status (complete, "
+            "partial, degraded, or insufficient_evidence) for the evidence "
+            "already retrieved",
+            code="refused_with_material_grounding",
+            repairable=True,
+        )
+
     # CHAOS-3290 grounding floor -- see the constants above for the full
     # reasoning. Only reachable once every other invariant already passed,
     # so this never overrides a real rejection; it only catches the shape
@@ -586,6 +608,7 @@ __all__ = [
     "INCOMPLETE_DENOMINATOR_DISCLOSURE",
     "AnswerValidationContext",
     "AnswerValidationError",
+    "any_tool_result_withheld_its_completion_denominator",
     "completion_truncation_detail",
     "validate_answer_candidate",
 ]

--- a/src/dev_health_ops/api/dev/answer_validator.py
+++ b/src/dev_health_ops/api/dev/answer_validator.py
@@ -220,7 +220,7 @@ def completion_truncation_detail(tool_results: tuple[DevToolResult, ...]) -> str
     return "The required-work assessment could not verify a complete total."
 
 
-def _answer_has_material_grounding(answer: DevAnswer) -> bool:
+def answer_has_material_grounding(answer: DevAnswer) -> bool:
     """Whether the answer carries anything an evidence-linked reader could
     actually check: a metric, an evidence entry, or a claim that references
     at least one of either. A claim with no reference at all (an
@@ -545,7 +545,7 @@ def validate_answer_candidate(
     # mistake the model can correct in the same bounded repair pass
     # CHAOS-3257 already gives a status/coverage mismatch, by reissuing the
     # same grounded content under an accurate status.
-    if answer.status is AnswerStatus.REFUSED and _answer_has_material_grounding(answer):
+    if answer.status is AnswerStatus.REFUSED and answer_has_material_grounding(answer):
         raise AnswerValidationError(
             "a refused answer cannot carry claim, metric, or evidence "
             "grounding -- reissue with an accurate status (complete, "
@@ -560,7 +560,7 @@ def validate_answer_candidate(
     # so this never overrides a real rejection; it only catches the shape
     # those checks vacuously allow through: nothing to check because there
     # is nothing there.
-    if not _answer_has_material_grounding(answer):
+    if not answer_has_material_grounding(answer):
         summary = answer.direct_summary.strip()
         if answer.status is AnswerStatus.COMPLETE:
             if _tool_results_offer_groundable_material(context.tool_results):
@@ -608,6 +608,7 @@ __all__ = [
     "INCOMPLETE_DENOMINATOR_DISCLOSURE",
     "AnswerValidationContext",
     "AnswerValidationError",
+    "answer_has_material_grounding",
     "any_tool_result_withheld_its_completion_denominator",
     "completion_truncation_detail",
     "validate_answer_candidate",

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -953,6 +953,15 @@ class DevActualCompletion(ContractModel):
     display_truncated: bool = False
     conflicts: list[DevStatusConflict] = Field(default_factory=list, max_length=20)
     evidence_ref_ids: list[OpaqueID] = Field(default_factory=list, max_length=25)
+    # CHAOS-3377 HIGH 3: blockers (``open_blocker``) previously had no typed
+    # wire representation distinct from ``required_children`` -- a NOT_READY
+    # verdict caused solely by an open blocker rendered no blocker detail at
+    # all. Reuses ``DevRequiredChildFact``'s shape (structurally identical:
+    # fact_id/text/status/evidence_ref_ids); mirrors ``required_children``
+    # by carrying ALL blockers, not a pre-filtered "open" subset, so a
+    # consumer applies its own openness predicate rather than trusting one
+    # it cannot verify.
+    blockers: list[DevRequiredChildFact] = Field(default_factory=list, max_length=100)
 
     @model_validator(mode="after")
     def validate_required_child_counts(self) -> Self:
@@ -1078,6 +1087,8 @@ class DevToolResult(ContractModel):
             referenced.update(self.actual_completion.evidence_ref_ids)
             for child in self.actual_completion.required_children:
                 referenced.update(child.evidence_ref_ids)
+            for blocker in self.actual_completion.blockers:
+                referenced.update(blocker.evidence_ref_ids)
             for conflict in self.actual_completion.conflicts:
                 referenced.update(conflict.evidence_ref_ids)
         if not referenced <= known:

--- a/src/dev_health_ops/api/dev/export_contracts.py
+++ b/src/dev_health_ops/api/dev/export_contracts.py
@@ -17,6 +17,7 @@ from .contract_fixtures import (
     stream_fixtures,
 )
 from .contracts import CONTRACT_MODELS, DevStreamEvent, validate_stream
+from .status_change_service import STATUS_REASON_CODES
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 ARTIFACT_ROOT = REPOSITORY_ROOT / "contracts" / "ask-dev" / "v1"
@@ -149,6 +150,28 @@ def expected_artifacts() -> dict[str, str]:
     for label, stream_payloads in stream_fixtures().items():
         path = f"examples/streams/{label}.json"
         artifacts[path] = _json(stream_payloads)
+    # CHAOS-3377 (web adversarial review, MEDIUM: no drift guard on the
+    # client's internal-token denylist). The §10 completion-assessment
+    # internal vocabulary a client must never render raw -- the same set
+    # ``no_match_terminal.INTERNAL_TOKEN_DENYLIST`` derives on the ops side
+    # -- published as a checked-in artifact so a web-side sync (mirroring
+    # ``ask-dev-contracts.mjs``'s existing pinned-commit pattern for the
+    # JSON-schema artifacts above) can generate/verify its own denylist
+    # against this file instead of a hand-maintained, driftable copy.
+    # ``evidence_handle_pattern`` is a regex, not a literal token: an
+    # evidence handle carries a random 40-hex-char suffix, so the client
+    # must match it by SHAPE, not by a fixed string (see
+    # ``contracts_v2/base.py``'s own ``ev1_[0-9a-f]{40}`` pattern).
+    denylist_contents = _json(
+        {
+            "schema_version": "ask_dev_internal_prose_denylist.v1",
+            "reason_codes": sorted(STATUS_REASON_CODES),
+            "completion_states": ["not_ready"],
+            "extra_tokens": ["actual_completion"],
+            "evidence_handle_pattern": "^ev1_[0-9a-f]{40}$",
+        }
+    )
+    artifacts["vocabulary/internal_prose_denylist.v1.json"] = denylist_contents
     manifest = {
         "schema_version": "ask_dev_contract_manifest.v1",
         "compatibility": "additive-within-v1",
@@ -156,6 +179,13 @@ def expected_artifacts() -> dict[str, str]:
         "stream_sequences": [
             {"case": label, "path": f"examples/streams/{label}.json"}
             for label in stream_fixtures()
+        ],
+        "vocabulary": [
+            {
+                "case": "internal_prose_denylist",
+                "path": "vocabulary/internal_prose_denylist.v1.json",
+                "sha256": _sha256(denylist_contents),
+            }
         ],
     }
     artifacts["manifest.json"] = _json(manifest)

--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -50,6 +50,7 @@ from typing import get_args
 
 from .contracts import (
     AnswerStatus,
+    DevActualCompletion,
     DevAnswer,
     DevContractVersions,
     DevCoverage,
@@ -60,6 +61,7 @@ from .contracts import (
 )
 from .contracts_v2 import PublicOutcome, ResolutionOutcome
 from .orchestrator_states import RunState
+from .status_change_service import STATUS_REASON_CODES
 
 __all__ = [
     "INTERNAL_TOKEN_DENYLIST",
@@ -81,6 +83,25 @@ def _underscore_members(values: Iterable[str]) -> frozenset[str]:
     return frozenset(value for value in values if "_" in value)
 
 
+#: CHAOS-3377 defect 2: the CHAOS-3367 denylist covered only scope-resolution
+#: and run/outcome vocabulary -- a live run showed the §10 completion
+#: assessment's own internal tokens (``not_ready``, ``open_blocker``,
+#: ``required_child_incomplete``, ...) and evidence-handle ids (``ev1_...``)
+#: leaking into user-visible prose instead. Widened here rather than only in
+#: ``status_answer_render.py``'s translation tables, because those tables
+#: only cover the module's OWN server-rendered copy; this denylist is the
+#: fail-closed backstop ``orchestrator.finish()`` runs over EVERY terminal
+#: (including any model-authored prose that still reaches a field this
+#: module scans), so a leak survives here even if a future producer forgets
+#: to route through the deterministic renderer at all.
+#:
+#: ``STATUS_REASON_CODES`` is ``status_change_service``'s own derived,
+#: pinned-total set (see that module), so this cannot silently fall behind a
+#: reason code added there. ``DevActualCompletion.state`` is a 3-member
+#: ``Literal`` on the wire, so its members are pulled the same way
+#: ``DevError.code`` already is below.
+_EXTRA_INTERNAL_TOKENS: frozenset[str] = frozenset({"actual_completion", "ev1_"})
+
 #: Every internal vocabulary token that must never reach a user-visible
 #: string, derived from the live enums. See the module docstring for why only
 #: underscore-bearing members are kept.
@@ -91,6 +112,11 @@ INTERNAL_TOKEN_DENYLIST: frozenset[str] = (
     | _underscore_members(member.value for member in PublicOutcome)
     | _underscore_members(member.value for member in ResolutionOutcome)
     | _underscore_members(get_args(DevError.model_fields["code"].annotation))
+    | _underscore_members(STATUS_REASON_CODES)
+    | _underscore_members(
+        get_args(DevActualCompletion.model_fields["state"].annotation)
+    )
+    | _EXTRA_INTERNAL_TOKENS
 )
 
 # NOT included, deliberately: ``ToolID``. A round-2 review argued that a

--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -48,6 +48,7 @@ from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import get_args
 
+from .answer_validator import answer_has_material_grounding
 from .contracts import (
     AnswerStatus,
     DevActualCompletion,
@@ -66,6 +67,7 @@ from .status_change_service import STATUS_REASON_CODES
 __all__ = [
     "INTERNAL_TOKEN_DENYLIST",
     "NEVER_ATTESTABLE_TOKENS",
+    "REFUSED_WITH_GROUNDING_SUMMARY",
     "WITHHELD_COPY",
     "attested_strings",
     "internal_token_leak",
@@ -480,6 +482,70 @@ def named_subject_not_found_answer(
 #: not read as a claim the server made.
 WITHHELD_COPY = "This part of the answer could not be shown."
 
+#: CHAOS-3377 HIGH (codex adversarial web review, round 2): the read-time
+#: counterpart of ``answer_validator``'s "a refused answer cannot carry
+#: material grounding" write-time check. A row persisted before that check
+#: existed can still have ``status=refused`` alongside real claim/metric/
+#: evidence content. The web client's own defense-in-depth backstop
+#: (``AskDevAnswer.refusedDespiteMaterialGrounding``) was found relabeling
+#: that contradiction "Answered" while STILL rendering the model's original
+#: (rejected-shaped) prose underneath -- exactly the leak this server-side
+#: normalization now closes upstream, so the client never receives it in
+#: the first place. A neutral statement, not a redaction of the model's
+#: words: the original claim/direct_summary text is discarded entirely,
+#: never partially edited into something that could still read as a claim
+#: the server verified.
+REFUSED_WITH_GROUNDING_SUMMARY = (
+    "This answer's recorded status could not be reconciled with its own "
+    "content. The original narrative has been withheld; the structured "
+    "metrics and evidence below are unaffected."
+)
+
+
+def _normalize_refused_with_grounding(answer: DevAnswer) -> DevAnswer:
+    """The read-time mirror of ``answer_validator``'s "refused answer cannot
+    carry material grounding" check (CHAOS-3377 HIGH, web adversarial
+    review round 2).
+
+    A NEW run can no longer persist this contradiction (the write-time
+    check rejects it, repairable, and demotes through
+    ``Orchestrator._server_grounded_answer`` if the model still won't
+    self-correct -- see ``orchestrator.py``). A row written before that
+    check existed can still have it. This is the single read-time seam
+    both ``router.py`` call sites that hand a persisted answer back to a
+    client already go through (``redact_persisted_answer``, below) --
+    exactly one place, mirroring the write path's single seam
+    (``Orchestrator._deterministic_status_render``) rather than requiring
+    every future replay call site to remember to check.
+
+    The model's own ``claims``/``direct_summary`` are discarded outright --
+    the same "narrative loses when it disagrees with the frame" rule the
+    write-time demotion already applies -- while ``metrics``/``evidence``
+    (server-issued, unaffected by the contradiction) are kept.
+    ``status`` is recomputed from the answer's own persisted ``coverage``
+    (the same fully-covered test ``deterministic_answer_status`` uses),
+    never left as the self-contradicted ``REFUSED``.
+    """
+
+    if answer.status is not AnswerStatus.REFUSED or not answer_has_material_grounding(
+        answer
+    ):
+        return answer
+    coverage = answer.coverage
+    fully_covered = (
+        coverage.available_source_count == coverage.required_source_count
+        and not coverage.unavailable_required_sources
+        and not coverage.stale_required_sources
+        and not coverage.degraded_required_sources
+    )
+    return answer.model_copy(
+        update={
+            "status": AnswerStatus.COMPLETE if fully_covered else AnswerStatus.PARTIAL,
+            "direct_summary": REFUSED_WITH_GROUNDING_SUMMARY,
+            "claims": [],
+        }
+    )
+
 
 def redact_persisted_answer(
     answer: DevAnswer, *, question: str | None = None
@@ -503,8 +569,16 @@ def redact_persisted_answer(
     This redacts; it does not repair the stored row. Backfilling or
     quarantining already-persisted violating rows is a separate operational
     task, deliberately not done implicitly on a read path.
+
+    CHAOS-3377 HIGH (round 2): the refused-with-grounding normalization
+    (``_normalize_refused_with_grounding``) runs FIRST, unconditionally --
+    it is not an internal-token leak, so it is not gated behind the
+    ``internal_token_leak`` check below, which would otherwise skip it
+    entirely for a contradictory row whose prose happens not to contain a
+    denylisted token.
     """
 
+    answer = _normalize_refused_with_grounding(answer)
     attested = attested_strings(answer, question)
     if (
         internal_token_leak(user_visible_strings(answer=answer), attested=attested)

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -14,7 +14,7 @@ import logging
 import re
 import time
 from collections import Counter
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal, Protocol
@@ -61,6 +61,7 @@ from .answer_validator import (
 from .contracts import (
     AnswerStatus,
     DevAnswer,
+    DevClaim,
     DevContractVersions,
     DevCoverage,
     DevError,
@@ -1950,49 +1951,33 @@ class DevOrchestrator:
                             for warning in candidate["warnings"]
                         ]
                     # CHAOS-3377 defects 1/2/5 -- the §10 deterministic
-                    # renderer. When this run executed status_snapshot.v1,
-                    # the server already computed a real completion verdict
-                    # (`actual_completion`); the direct verdict/completion/
-                    # blockers are rendered from THAT here, overwriting
-                    # whatever the model proposed for status/direct_summary/
-                    # claims -- exactly the same "server-derived fields
-                    # overwrite the model's" pattern `metrics`/`evidence`/
-                    # `coverage` already follow above. The model cannot
-                    # mislabel a substantive answer as refused, narrate a raw
-                    # internal token, or contradict the frame's own blocker
-                    # list, because none of its own text for this content
-                    # reaches the candidate at all.
-                    status_result = status_snapshot_result(tuple(tool_results))
-                    if (
-                        status_result is not None
-                        and status_result.actual_completion is not None
-                        and resolution.resolved_scope is not None
-                    ):
-                        actual = status_result.actual_completion
-                        canonical_evidence_ids = frozenset(
-                            item.evidence_ref_id for item in canonical_evidence
-                        )
-                        deterministic_claims = build_deterministic_status_claims(
-                            actual=actual,
-                            validity_scope=resolution.resolved_scope,
-                            canonical_evidence_ids=canonical_evidence_ids,
-                            tool_results=tuple(tool_results),
-                        )
-                        candidate["status"] = deterministic_answer_status(
-                            coverage=server_coverage,
-                            tool_results=tuple(tool_results),
-                        ).value
-                        candidate["direct_summary"] = render_verdict_summary(
-                            actual,
-                            denominator_withheld=(
-                                any_tool_result_withheld_its_completion_denominator(
-                                    tuple(tool_results)
-                                )
-                            ),
-                        )
+                    # renderer. When this run executed status_snapshot.v1
+                    # for the CURRENT resolved scope, the server already
+                    # computed a real completion verdict (`actual_completion`
+                    # bound to that scope -- see `_deterministic_status_
+                    # render`/`status_snapshot_result`); the direct verdict/
+                    # completion/blockers are rendered from THAT here,
+                    # overwriting whatever the model proposed for status/
+                    # direct_summary/claims -- exactly the same
+                    # "server-derived fields overwrite the model's" pattern
+                    # `metrics`/`evidence`/`coverage` already follow above.
+                    # The model cannot mislabel a substantive answer as
+                    # refused, narrate a raw internal token, or contradict
+                    # the frame's own blocker list, because none of its own
+                    # text for this content reaches the candidate at all.
+                    rendered_status = self._deterministic_status_render(
+                        resolution=resolution,
+                        tool_requests=tuple(tool_requests),
+                        tool_results=tuple(tool_results),
+                        server_coverage=server_coverage,
+                        canonical_evidence=canonical_evidence,
+                    )
+                    if rendered_status is not None:
+                        det_status, det_direct_summary, det_claims = rendered_status
+                        candidate["status"] = det_status.value
+                        candidate["direct_summary"] = det_direct_summary
                         candidate["claims"] = [
-                            claim.model_dump(mode="json")
-                            for claim in deterministic_claims
+                            claim.model_dump(mode="json") for claim in det_claims
                         ]
                     try:
                         answer = validate_answer_candidate(
@@ -2277,6 +2262,31 @@ class DevOrchestrator:
                         ),
                     )
                 if isinstance(decision, AgentRefusal):
+                    # CHAOS-3377 HIGH 2 (codex adversarial review): a
+                    # refusal reached AFTER a real status_snapshot.v1 result
+                    # already exists for the run's current resolved scope is
+                    # the same defect class the §10 deterministic renderer
+                    # exists to close -- the model declined to answer over
+                    # material the server already retrieved and can report
+                    # honestly. Checked before the unconditional REFUSED
+                    # terminal below, never after.
+                    deterministic_refusal_answer = self._deterministic_status_answer(
+                        answer_id=answer_id,
+                        conversation_id=conversation_id,
+                        resolution=resolution,
+                        tool_requests=tuple(tool_requests),
+                        tool_results=tuple(tool_results),
+                        now=datetime.now(UTC),
+                        model=DevModelMetadata(
+                            provider_source=self._provider_source,
+                            provider_family=self._provider_family,
+                            model_fingerprint=decision_result.model_fingerprint,
+                        ),
+                    )
+                    if deterministic_refusal_answer is not None:
+                        return await finish(
+                            RunState.COMPLETED, answer=deterministic_refusal_answer
+                        )
                     return await finish(
                         RunState.REFUSED,
                         error=error(
@@ -2313,6 +2323,7 @@ class DevOrchestrator:
                     answer_id=answer_id,
                     conversation_id=conversation_id,
                     resolution=resolution,
+                    tool_requests=tuple(tool_requests),
                     tool_results=tuple(tool_results),
                     model_fingerprint=model_fingerprint,
                 )
@@ -2516,16 +2527,151 @@ class DevOrchestrator:
             "required": sorted(properties),
         }
 
+    @staticmethod
+    def _deterministic_status_render(
+        *,
+        resolution: DevScopeResolution,
+        tool_requests: tuple[DevToolRequest, ...],
+        tool_results: tuple[DevToolResult, ...],
+        server_coverage: DevCoverage,
+        canonical_evidence: Sequence[DevEvidenceRef],
+    ) -> tuple[AnswerStatus, str, list[DevClaim]] | None:
+        """The §10 deterministic (status, direct_summary, claims), or
+        ``None`` if this run has no ``status_snapshot.v1`` result bound to
+        the CURRENT resolved scope.
+
+        The one seam every terminal that can carry an answer -- a validated
+        ``AgentFinalAnswer``, an ``AgentRefusal``, or a budget-exhaustion
+        partial -- renders §10 content through (CHAOS-3377 HIGH 2, codex
+        adversarial review: a prior revision only applied the override
+        inside the ``AgentFinalAnswer`` branch, so a provider that emitted
+        ``AgentRefusal`` -- or a run that hit ``BudgetExceeded`` -- AFTER a
+        real ``status_snapshot.v1`` result already existed could still
+        terminate REFUSED, or with generic budget boilerplate, without ever
+        inspecting the retrieved material. The reported defect class stayed
+        reachable from those two paths).
+        """
+
+        if resolution.resolved_scope is None:
+            return None
+        status_result = status_snapshot_result(
+            tool_requests, tool_results, authorized_scope=resolution.resolved_scope
+        )
+        if status_result is None or status_result.actual_completion is None:
+            return None
+        actual = status_result.actual_completion
+        canonical_evidence_ids = frozenset(
+            item.evidence_ref_id for item in canonical_evidence
+        )
+        claims = build_deterministic_status_claims(
+            actual=actual,
+            status_result=status_result,
+            validity_scope=resolution.resolved_scope,
+            canonical_evidence_ids=canonical_evidence_ids,
+            tool_results=tool_results,
+        )
+        status = deterministic_answer_status(
+            coverage=server_coverage, tool_results=tool_results
+        )
+        direct_summary = render_verdict_summary(
+            actual,
+            denominator_withheld=any_tool_result_withheld_its_completion_denominator(
+                tool_results
+            ),
+        )
+        return status, direct_summary, claims
+
+    def _deterministic_status_answer(
+        self,
+        *,
+        answer_id: str,
+        conversation_id: str,
+        resolution: DevScopeResolution,
+        tool_requests: tuple[DevToolRequest, ...],
+        tool_results: tuple[DevToolResult, ...],
+        now: datetime,
+        model: DevModelMetadata,
+    ) -> DevAnswer | None:
+        """A full, server-rendered §10 ``DevAnswer`` for this run, or
+        ``None`` if there is nothing to render (no bound status_snapshot
+        result, or no canonical grounding to attach it to). Used by the
+        ``AgentRefusal`` and ``BudgetExceeded`` terminals -- see
+        ``_deterministic_status_render`` for why those need this too, not
+        only the ``AgentFinalAnswer`` branch (which merges the same render
+        into an existing candidate instead of building a fresh answer).
+        """
+
+        canonical_data = self._canonical_answer_data(tool_results)
+        if canonical_data is None:
+            return None
+        canonical_metrics, canonical_evidence = canonical_data
+        server_coverage = self._coverage_with_plan_sources(
+            self._coverage_from_tool_results(tool_requests, tool_results, now),
+            None,
+        )
+        rendered = self._deterministic_status_render(
+            resolution=resolution,
+            tool_requests=tool_requests,
+            tool_results=tool_results,
+            server_coverage=server_coverage,
+            canonical_evidence=canonical_evidence,
+        )
+        if rendered is None:
+            return None
+        status, direct_summary, claims = rendered
+        return DevAnswer(
+            schema_version="dev_answer.v1",
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            generated_at=now,
+            resolved_scope=resolution,
+            as_of=now,
+            status=status,
+            direct_summary=direct_summary,
+            claims=claims,
+            metrics=canonical_metrics,
+            evidence=canonical_evidence,
+            conflicts=[],
+            coverage=server_coverage,
+            warnings=[],
+            suggested_follow_up_questions=[],
+            versions=self._versions,
+            model=model,
+        )
+
     def _budget_answer(
         self,
         *,
         answer_id: str,
         conversation_id: str,
         resolution: DevScopeResolution,
+        tool_requests: tuple[DevToolRequest, ...],
         tool_results: tuple[DevToolResult, ...],
         model_fingerprint: str,
     ) -> DevAnswer | None:
-        """Return only canonical retrieved data when a later model call is blocked."""
+        """Return canonical retrieved data when a later model call is
+        blocked -- the §10 deterministic render if this run has a
+        status_snapshot.v1 result bound to the current resolved scope
+        (CHAOS-3377 HIGH 2: budget exhaustion after a real completion
+        assessment must not discard it for generic boilerplate), otherwise
+        the prior generic "budget reached" summary.
+        """
+
+        deterministic = self._deterministic_status_answer(
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            resolution=resolution,
+            tool_requests=tool_requests,
+            tool_results=tool_results,
+            now=datetime.now(UTC),
+            model=DevModelMetadata(
+                provider_source=self._provider_source,
+                provider_family=self._provider_family,
+                model_fingerprint=model_fingerprint,
+            ),
+        )
+        if deterministic is not None:
+            return deterministic
 
         canonical_data = self._canonical_answer_data(tool_results)
         if canonical_data is None:

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -50,9 +50,11 @@ from dev_health_ops.metrics.prometheus import (
 
 from . import terminal_frames
 from .answer_frames import narrative_fallback
+from .answer_text_sanitizer import sanitize_model_text
 from .answer_validator import (
     AnswerValidationContext,
     AnswerValidationError,
+    any_tool_result_withheld_its_completion_denominator,
     completion_truncation_detail,
     validate_answer_candidate,
 )
@@ -107,6 +109,12 @@ from .preflight_outcomes import (
     project_preflight_error,
 )
 from .prompts import PromptComposer, PromptConversationTurn
+from .status_answer_render import (
+    build_deterministic_status_claims,
+    deterministic_answer_status,
+    render_verdict_summary,
+    status_snapshot_result,
+)
 from .subject_preflight import (
     SUBJECT_BEARING_TOOLS,
     PreflightDecision,
@@ -233,6 +241,11 @@ SERVER_GROUNDED_WARNING = (
 #: says what the verdict was.
 GUARD_DEMOTED_NAMED_ENTITY_STATUS = "advisory_named_entity"
 GUARD_DEMOTED_GROUNDING_FLOOR_STATUS = "advisory_grounding_floor"
+#: CHAOS-3377 defect 1: a model that still self-declared ``status=refused``
+#: over material grounding after its one repair attempt is demoted the same
+#: way a grounding-floor violation is -- never a hard FAILED, which would
+#: throw away real evidence the run already retrieved.
+GUARD_DEMOTED_REFUSAL_STATUS = "advisory_refused_with_grounding"
 
 _LEGACY_GUARD_TERMINALS: dict[str, tuple[str, str]] = {
     "resolve_scope_ambiguous": (
@@ -1912,6 +1925,75 @@ class DevOrchestrator:
                             "model": model.model_dump(mode="json"),
                         }
                     )
+                    # CHAOS-3377 defect 3: strip a trailing JSON-structural
+                    # artifact from every model-authored free-text field at
+                    # this seam -- before anything else reads or validates
+                    # them -- rather than special-casing the one reported
+                    # string later.
+                    if isinstance(candidate.get("direct_summary"), str):
+                        candidate["direct_summary"] = sanitize_model_text(
+                            candidate["direct_summary"]
+                        )
+                    if isinstance(candidate.get("claims"), list):
+                        candidate["claims"] = [
+                            {**claim, "text": sanitize_model_text(claim["text"])}
+                            if isinstance(claim, dict)
+                            and isinstance(claim.get("text"), str)
+                            else claim
+                            for claim in candidate["claims"]
+                        ]
+                    if isinstance(candidate.get("warnings"), list):
+                        candidate["warnings"] = [
+                            sanitize_model_text(warning)
+                            if isinstance(warning, str)
+                            else warning
+                            for warning in candidate["warnings"]
+                        ]
+                    # CHAOS-3377 defects 1/2/5 -- the §10 deterministic
+                    # renderer. When this run executed status_snapshot.v1,
+                    # the server already computed a real completion verdict
+                    # (`actual_completion`); the direct verdict/completion/
+                    # blockers are rendered from THAT here, overwriting
+                    # whatever the model proposed for status/direct_summary/
+                    # claims -- exactly the same "server-derived fields
+                    # overwrite the model's" pattern `metrics`/`evidence`/
+                    # `coverage` already follow above. The model cannot
+                    # mislabel a substantive answer as refused, narrate a raw
+                    # internal token, or contradict the frame's own blocker
+                    # list, because none of its own text for this content
+                    # reaches the candidate at all.
+                    status_result = status_snapshot_result(tuple(tool_results))
+                    if (
+                        status_result is not None
+                        and status_result.actual_completion is not None
+                        and resolution.resolved_scope is not None
+                    ):
+                        actual = status_result.actual_completion
+                        canonical_evidence_ids = frozenset(
+                            item.evidence_ref_id for item in canonical_evidence
+                        )
+                        deterministic_claims = build_deterministic_status_claims(
+                            actual=actual,
+                            validity_scope=resolution.resolved_scope,
+                            canonical_evidence_ids=canonical_evidence_ids,
+                            tool_results=tuple(tool_results),
+                        )
+                        candidate["status"] = deterministic_answer_status(
+                            coverage=server_coverage,
+                            tool_results=tuple(tool_results),
+                        ).value
+                        candidate["direct_summary"] = render_verdict_summary(
+                            actual,
+                            denominator_withheld=(
+                                any_tool_result_withheld_its_completion_denominator(
+                                    tuple(tool_results)
+                                )
+                            ),
+                        )
+                        candidate["claims"] = [
+                            claim.model_dump(mode="json")
+                            for claim in deterministic_claims
+                        ]
                     try:
                         answer = validate_answer_candidate(
                             candidate, validation_context
@@ -2017,6 +2099,47 @@ class DevOrchestrator:
                                     answer=demoted,
                                     grounding_validation_status=(
                                         GUARD_DEMOTED_GROUNDING_FLOOR_STATUS
+                                    ),
+                                )
+                            return await finish(
+                                RunState.INSUFFICIENT_EVIDENCE,
+                                error=error(
+                                    "insufficient_evidence",
+                                    "The answer did not include enough "
+                                    "grounded detail to present as a "
+                                    "result.",
+                                ),
+                            )
+                        if exc.code == "refused_with_material_grounding":
+                            # CHAOS-3377 defect 1: the model kept self-
+                            # declaring REFUSED over real grounding even
+                            # after the bounded repair pass. Same demotion
+                            # seam as the grounding floor above -- the run
+                            # has genuine server-verified material
+                            # (`_server_grounded_answer`'s own third guard
+                            # refuses to build on nothing), so it terminates
+                            # COMPLETED with that material rather than a
+                            # hard FAILED that would discard evidence the
+                            # run already retrieved.
+                            demoted = self._server_grounded_answer(
+                                answer_id=answer_id,
+                                conversation_id=conversation_id,
+                                resolution=resolution,
+                                coverage=server_coverage,
+                                tool_results=tuple(tool_results),
+                                investigation_result=investigation_result,
+                                model=model,
+                                now=now,
+                                cutover_active=self._frame_cutover_active(
+                                    preflight_result
+                                ),
+                            )
+                            if demoted is not None:
+                                return await finish(
+                                    RunState.COMPLETED,
+                                    answer=demoted,
+                                    grounding_validation_status=(
+                                        GUARD_DEMOTED_REFUSAL_STATUS
                                     ),
                                 )
                             return await finish(

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1810,6 +1810,11 @@ async def _assemble_production_runtime(
         required_children = [
             wire_required_child(fact) for fact in result.actual.required_children
         ]
+        # CHAOS-3377 HIGH 3: blockers get the exact same evidence-minting and
+        # truncation treatment as required_children below, so the §10
+        # deterministic renderer can build a grounded claim from a blocker
+        # exactly as it does from a required child.
+        blockers = [wire_required_child(fact) for fact in result.actual.blockers]
 
         # DevToolResult.evidence caps at 25 entries; a dense scope can mint
         # far more across six independently-bounded categories. Bound the
@@ -1839,6 +1844,11 @@ async def _assemble_production_runtime(
             *(
                 evidence_id
                 for fact in required_children
+                for evidence_id in fact.evidence_ref_ids
+            ),
+            *(
+                evidence_id
+                for fact in blockers
                 for evidence_id in fact.evidence_ref_ids
             ),
             *(
@@ -1887,6 +1897,10 @@ async def _assemble_production_runtime(
         required_children = [
             fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
             for fact in required_children
+        ]
+        blockers = [
+            fact.model_copy(update={"evidence_ref_ids": _kept(fact.evidence_ref_ids)})
+            for fact in blockers
         ]
 
         category_facts: Mapping[str, Sequence[Any]] = {
@@ -1940,6 +1954,7 @@ async def _assemble_production_runtime(
             display_truncated=result.actual.display_truncated,
             conflicts=conflicts,
             evidence_ref_ids=aggregate_evidence_ids,
+            blockers=blockers,
         )
         source_health = [
             DevSourceHealth(

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -13,30 +13,51 @@ tool result's raw internal tokens (``not_ready``, ``open_blocker``,
 ``ev1_...`` evidence ids) verbatim, and it can misclassify a completed
 required item as a "current blocker".
 
-This module is the fix: build the verdict sentence and the blocker list
-directly from ``DevActualCompletion``, using closed, fail-closed translation
-tables, so a STATUS-class answer's §10 content is server-rendered rather than
-model-narrated. ``orchestrator.py`` calls this to OVERWRITE the model's
-``status``/``direct_summary``/``claims`` for a run whose tool results include
-an ``actual_completion`` assessment -- the model's own prose for that content
-never reaches the wire; the deterministic sections cannot be authored,
-contradicted, or polluted by it.
+This module is the fix: build the verdict sentence and the outstanding-work
+list directly from ``DevActualCompletion`` (plus the sibling fact lists on
+``DevToolResult`` -- pull requests, CI, deployments, incidents), using closed,
+fail-closed translation tables and the SAME openness predicates
+``status_change_service`` uses, so a STATUS-class answer's §10 content is
+server-rendered rather than model-narrated. ``orchestrator.py`` calls this to
+OVERWRITE the model's ``status``/``direct_summary``/``claims`` for a run whose
+tool results include an ``actual_completion`` assessment bound to the run's
+current resolved scope -- the model's own prose for that content never
+reaches the wire; the deterministic sections cannot be authored, contradicted,
+or polluted by it.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
 from .contracts import (
     AnswerStatus,
     ClaimKind,
     DevActualCompletion,
+    DevCIFact,
     DevClaim,
     DevClaimFlags,
     DevCoverage,
+    DevDeploymentFact,
+    DevIncidentFact,
+    DevPullRequestFact,
     DevRequiredChildFact,
     DevScope,
+    DevToolRequest,
     DevToolResult,
+    ToolID,
+)
+from .status_change_service import (
+    is_blocker_open,
+    is_ci_not_passing,
+    is_ci_work_skipped,
+    is_deployment_not_succeeded,
+    is_incident_active_and_blocking,
+    is_pull_request_changes_requested,
+    is_pull_request_review_unresolved,
+    is_pull_request_unmerged,
+    is_required_child_open,
 )
 from .status_completion_copy import (
     INCOMPLETE_DENOMINATOR_DISCLOSURE,
@@ -47,8 +68,9 @@ from .status_completion_copy import (
 __all__ = [
     "build_deterministic_status_claims",
     "deterministic_answer_status",
-    "is_open_child_status",
+    "open_blockers",
     "open_required_children",
+    "outstanding_facts",
     "render_verdict_summary",
     "status_snapshot_result",
     "translate_completion_state",
@@ -57,8 +79,8 @@ __all__ = [
 
 #: Closed, total vocabulary for ``DevActualCompletion.state`` (the wire type
 #: is itself a 3-member ``Literal``, so this dict is exhaustive by
-#: construction -- ``test_status_answer_render.py`` pins totality against
-#: that ``Literal``'s own ``get_args``).
+#: construction -- ``test_chaos_3377_status_answer_render.py`` pins totality
+#: against that ``Literal``'s own ``get_args``).
 _COMPLETION_STATE_COPY: Mapping[str, str] = {
     "ready": "Ready: every required item is complete.",
     "not_ready": "Not ready: required work is still open.",
@@ -72,28 +94,6 @@ _DEFAULT_STATE_COPY = "The completion state could not be determined."
 #: shared with ``answer_validator.completion_truncation_detail`` so the two
 #: user-visible surfaces cannot render the reason codes two different ways
 #: (or one raw and one translated).
-
-#: A required child (or blocker -- both are wired onto ``required_children``
-#: as ``DevRequiredChildFact`` by ``production_runtime.status_snapshot``'s
-#: ``actual_completion`` construction) is CLOSED when its own ``status``
-#: reads as done. Mirrors the predicate ``status_change_service._assess``
-#: already uses to decide ``required_child_incomplete``/``open_blocker``
-#: (that function's own two closed-vocabulary sets, unioned): a status this
-#: module would call "open" can never be one ``_assess`` itself called
-#: "complete" for the *same* reason-code decision, and vice versa -- the two
-#: cannot disagree about which items are still outstanding.
-_CLOSED_CHILD_STATUS_TOKENS: frozenset[str] = frozenset(
-    {
-        "complete",
-        "completed",
-        "done",
-        "closed",
-        "canceled",
-        "cancelled",
-        "resolved",
-        "merged",
-    }
-)
 
 
 def translate_completion_state(state: str) -> str:
@@ -109,33 +109,44 @@ def translate_completion_state(state: str) -> str:
     return _COMPLETION_STATE_COPY.get(state, _DEFAULT_STATE_COPY)
 
 
-def is_open_child_status(status: str) -> bool:
-    """Whether a required-child/blocker's own ``status`` reads as outstanding."""
-
-    return status.strip().casefold() not in _CLOSED_CHILD_STATUS_TOKENS
-
-
 def open_required_children(
     actual: DevActualCompletion,
 ) -> list[DevRequiredChildFact]:
-    """The frame's own prioritized blocker list (CHAOS-3377 defect 5).
+    """Required children whose own ``status`` reads as outstanding.
 
-    Every ``DevRequiredChildFact`` on ``actual.required_children`` whose own
-    ``status`` field is NOT one of the closed-vocabulary "done" tokens.
-    Built entirely from the server-computed ``status`` field on each fact --
-    never from narrative -- so an item the frame itself marked
-    complete/done/closed/etc can never appear here, closing the exact
-    self-contradiction (a "completed" item listed under "Current blockers")
-    the ticket reported. Order is preserved from ``required_children``,
-    which ``status_change_service._ordered_status`` already produces in a
-    stable, deterministic priority order.
+    Uses ``status_change_service.is_required_child_open`` -- the SAME
+    predicate ``_assess`` itself calls to decide ``required_child_incomplete``
+    -- rather than a locally re-derived copy (CHAOS-3377 HIGH 3, codex
+    adversarial review: a prior revision's own "safe superset" of closed
+    tokens disagreed with the assessor, treating ``resolved``/``merged`` as
+    closed when ``_assess`` still counted them as the reason a verdict was
+    NOT_READY). Importing the one predicate both call makes that class of
+    disagreement structurally impossible, not just less likely.
     """
 
     return [
         child
         for child in actual.required_children
-        if is_open_child_status(child.status)
+        if is_required_child_open(child.status)
     ]
+
+
+def open_blockers(actual: DevActualCompletion) -> list[DevRequiredChildFact]:
+    """Blockers (``open_blocker``) whose own ``status`` reads as outstanding.
+
+    CHAOS-3377 HIGH 3: blockers previously had no typed wire representation
+    at all distinct from ``required_children`` -- a NOT_READY verdict caused
+    solely by an open blocker (no incomplete required child) rendered an
+    EMPTY outstanding-work list, silently omitting the exact work making it
+    not ready. ``DevActualCompletion.blockers`` (added alongside this fix)
+    closes that gap; this mirrors ``open_required_children`` but against the
+    blocker-specific closed-vocabulary predicate (``is_blocker_open``, which
+    treats ``resolved`` as closed and ``required_child``'s predicate does
+    not -- see ``status_change_service``'s own comment on why the two
+    vocabularies are intentionally different).
+    """
+
+    return [blocker for blocker in actual.blockers if is_blocker_open(blocker.status)]
 
 
 def render_verdict_summary(
@@ -147,7 +158,7 @@ def render_verdict_summary(
     dynamic piece is either a plain integer (the completion fraction) or
     routed through the closed-vocabulary translation tables above.
 
-    ``denominator_withheld`` mirrors ``answer_validator``'s own
+    ``denominator_withheld`` mirrors ``status_completion_copy``'s own
     ``any_tool_result_withheld_its_completion_denominator`` /
     ``INCOMPLETE_DENOMINATOR_DISCLOSURE`` positive-disclosure obligation
     (CHAOS-3297 s2 round 8): when the required-child source was truncated,
@@ -181,21 +192,50 @@ def render_verdict_summary(
 
 
 def status_snapshot_result(
+    tool_requests: Sequence[DevToolRequest],
     tool_results: Sequence[DevToolResult],
+    *,
+    authorized_scope: DevScope,
 ) -> DevToolResult | None:
-    """The first executed tool result carrying a completion assessment, if any.
+    """The most recent ``status_snapshot.v1`` result bound to the run's
+    CURRENT resolved scope, or ``None``.
 
-    A run may call more than one tool; this is the seam
-    ``orchestrator.py`` uses to decide whether THIS run has server-owned §10
-    material to render deterministically at all -- a non-STATUS question
-    (whose tool results never set ``actual_completion``) is untouched by this
-    module.
+    CHAOS-3377 HIGH 1 (codex adversarial review): a prior revision returned
+    the FIRST tool result carrying ``actual_completion``, with no check that
+    it was even a ``status_snapshot.v1`` call, let alone that its own request
+    scope matched the answer being rendered. A run's authorized scope can
+    change mid-run (a ``resolve_scope.v1`` commit narrows/widens it -- see
+    ``Orchestrator.run``'s ``resolution``/``authorized_scope`` reassignment),
+    and a model may call ``status_snapshot.v1`` more than once; an earlier
+    snapshot for a DIFFERENT subject would silently overwrite the final
+    answer's verdict/blockers with someone else's data -- confidently wrong
+    scope, not just stale content.
+
+    ``tool_requests``/``tool_results`` are the orchestrator's own
+    index-aligned lists (appended together at the same call sites), so they
+    are paired by position; ``tool_call_id`` is also cross-checked as a
+    cheap integrity assertion. Filtered to ``STATUS_SNAPSHOT`` calls whose
+    request scope equals ``authorized_scope`` -- the run's FINAL resolved
+    scope, passed by the caller -- and the LAST such match wins (a repeated
+    call for the same scope supersedes an earlier one). Ambiguity is never
+    guessed at: a call whose scope does not match is simply excluded, never
+    substituted.
     """
 
-    for result in tool_results:
-        if result.actual_completion is not None:
-            return result
-    return None
+    if len(tool_requests) != len(tool_results):
+        return None
+    latest: DevToolResult | None = None
+    for request, result in zip(tool_requests, tool_results, strict=True):
+        if request.tool_id is not ToolID.STATUS_SNAPSHOT:
+            continue
+        if result.actual_completion is None:
+            continue
+        if request.tool_call_id != result.tool_call_id:
+            continue
+        if request.scope != authorized_scope:
+            continue
+        latest = result
+    return latest
 
 
 def deterministic_answer_status(
@@ -225,25 +265,193 @@ def deterministic_answer_status(
     return AnswerStatus.COMPLETE if fully_covered else AnswerStatus.PARTIAL
 
 
+@dataclass(frozen=True, slots=True)
+class _OutstandingFact:
+    """One typed piece of "why not ready" content, from any blocker-producing
+    category, before it becomes a ``DevClaim``. See ``outstanding_facts``.
+    """
+
+    claim_id_suffix: str
+    text: str
+    evidence_ref_ids: tuple[str, ...]
+
+
+def _pull_request_facts(
+    pull_requests: Sequence[DevPullRequestFact],
+) -> list[_OutstandingFact]:
+    facts: list[_OutstandingFact] = []
+    for pr in pull_requests:
+        if is_pull_request_unmerged(required=pr.required, merged=pr.merged):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"pr-unmerged:{pr.entity_id}",
+                    text=f"Blocked: pull request {pr.display_label} has not merged.",
+                    evidence_ref_ids=tuple(pr.evidence_ref_ids),
+                )
+            )
+        if is_pull_request_changes_requested(
+            required=pr.required, changes_requested=pr.changes_requested
+        ):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"pr-changes-requested:{pr.entity_id}",
+                    text=(
+                        f"Blocked: pull request {pr.display_label} has "
+                        "requested changes outstanding."
+                    ),
+                    evidence_ref_ids=tuple(pr.evidence_ref_ids),
+                )
+            )
+        elif is_pull_request_review_unresolved(
+            required=pr.required, review_state=pr.review_state
+        ):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"pr-review-unresolved:{pr.entity_id}",
+                    text=f"Blocked: pull request {pr.display_label} awaits review.",
+                    evidence_ref_ids=tuple(pr.evidence_ref_ids),
+                )
+            )
+    return facts
+
+
+def _ci_facts(ci_checks: Sequence[DevCIFact]) -> list[_OutstandingFact]:
+    facts: list[_OutstandingFact] = []
+    for ci in ci_checks:
+        if is_ci_work_skipped(
+            required=ci.required, skipped_required_work=ci.skipped_required_work
+        ):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"ci-skipped:{ci.entity_id}",
+                    text=f"Blocked: required CI work was skipped for {ci.display_label}.",
+                    evidence_ref_ids=tuple(ci.evidence_ref_ids),
+                )
+            )
+        elif is_ci_not_passing(required=ci.required, conclusion=ci.conclusion):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"ci-not-passing:{ci.entity_id}",
+                    text=f"Blocked: CI check {ci.display_label} is not passing.",
+                    evidence_ref_ids=tuple(ci.evidence_ref_ids),
+                )
+            )
+    return facts
+
+
+def _deployment_facts(
+    deployments: Sequence[DevDeploymentFact],
+) -> list[_OutstandingFact]:
+    facts: list[_OutstandingFact] = []
+    for deployment in deployments:
+        if is_deployment_not_succeeded(
+            required=deployment.required, status=deployment.status
+        ):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"deployment-not-succeeded:{deployment.entity_id}",
+                    text=f"Blocked: deployment {deployment.display_label} has not succeeded.",
+                    evidence_ref_ids=tuple(deployment.evidence_ref_ids),
+                )
+            )
+    return facts
+
+
+def _incident_facts(incidents: Sequence[DevIncidentFact]) -> list[_OutstandingFact]:
+    facts: list[_OutstandingFact] = []
+    for incident in incidents:
+        if is_incident_active_and_blocking(
+            active=incident.active, blocking=incident.blocking
+        ):
+            facts.append(
+                _OutstandingFact(
+                    claim_id_suffix=f"incident:{incident.entity_id}",
+                    text=(
+                        f"Blocked: active incident {incident.display_label} "
+                        "is blocking this work."
+                    ),
+                    evidence_ref_ids=tuple(incident.evidence_ref_ids),
+                )
+            )
+    return facts
+
+
+def outstanding_facts(
+    actual: DevActualCompletion, status_result: DevToolResult
+) -> list[_OutstandingFact]:
+    """Every typed "why not ready" fact across ALL blocker-producing
+    categories (CHAOS-3377 HIGH 3), never only required children.
+
+    A NOT_READY verdict can be caused by an open blocker, an unmerged/
+    unreviewed/changes-requested pull request, failing/skipped required CI,
+    an undeployed release, or an active blocking incident -- ``_assess``
+    (``status_change_service.py``) computes a reason code for every one of
+    these independently. A blocker list built from ``required_children``
+    alone can be completely empty while the verdict itself is NOT_READY,
+    silently omitting the exact work making it so. This reads the same
+    typed fact lists ``_assess`` reads (``DevToolResult.pull_requests``/
+    ``.ci_checks``/``.deployments``/``.incidents``, plus
+    ``actual.required_children``/``.blockers``) and applies the exact same
+    predicates (imported from ``status_change_service``, never re-derived)
+    to each.
+
+    Never interpolates a fact's own raw ``status``/``conclusion``/etc.
+    string into claim text (CHAOS-3377 MEDIUM 4, codex adversarial review: a
+    provider-supplied status string is unconstrained and can coincidentally
+    equal an internal denylisted token -- e.g. a literal ``not_ready`` --
+    which would make ``orchestrator.finish()``'s fail-closed token scan
+    convert an otherwise-valid answer into ``internal_error``). Every phrase
+    here is a fixed, closed-vocabulary sentence naming only the fact's
+    ``display_label`` (an identifying name, already rendered as safe content
+    elsewhere in this contract, e.g. ``DevEvidenceRef.display_label``) --
+    never its raw status field.
+    """
+
+    facts: list[_OutstandingFact] = []
+    for child in open_required_children(actual):
+        facts.append(
+            _OutstandingFact(
+                claim_id_suffix=f"child:{child.fact_id}",
+                text=f"Blocked: {child.text}.",
+                evidence_ref_ids=tuple(child.evidence_ref_ids),
+            )
+        )
+    for blocker in open_blockers(actual):
+        facts.append(
+            _OutstandingFact(
+                claim_id_suffix=f"blocker:{blocker.fact_id}",
+                text=f"Blocked: {blocker.text}.",
+                evidence_ref_ids=tuple(blocker.evidence_ref_ids),
+            )
+        )
+    facts.extend(_pull_request_facts(status_result.pull_requests))
+    facts.extend(_ci_facts(status_result.ci_checks))
+    facts.extend(_deployment_facts(status_result.deployments))
+    facts.extend(_incident_facts(status_result.incidents))
+    return facts
+
+
 def build_deterministic_status_claims(
     *,
     actual: DevActualCompletion,
+    status_result: DevToolResult,
     validity_scope: DevScope,
     canonical_evidence_ids: frozenset[str],
     tool_results: Sequence[DevToolResult] = (),
 ) -> list[DevClaim]:
-    """Server-rendered §10 claims: one verdict claim, then one per open
-    required item/blocker -- never from model narrative.
+    """Server-rendered §10 claims: one verdict claim, then one per
+    outstanding fact across every blocker-producing category -- never from
+    model narrative.
 
     Every claim cites only evidence IDs already present in this run's
     canonical evidence set (``canonical_evidence_ids``, the same tuple
     ``Orchestrator._canonical_answer_data`` computed for this candidate), so
     the result satisfies ``DevAnswer``'s own "claim references unknown
-    evidence" invariant by construction. A blocker whose own evidence was
-    truncated out of the tool result is skipped rather than emitted
-    ungrounded -- an ``OBSERVED`` claim requires at least one reference
-    (``DevClaim.validate_grounding``), and fabricating one would be worse
-    than omitting the item.
+    evidence" invariant by construction. An outstanding fact whose own
+    evidence was truncated out of the tool result is skipped rather than
+    emitted ungrounded -- an ``OBSERVED`` claim requires at least one
+    reference (``DevClaim.validate_grounding``), and fabricating one would be
+    worse than omitting the item.
 
     ``tool_results`` (defaulting to empty, i.e. "denominator not withheld")
     drives the same positive-disclosure obligation ``render_verdict_summary``
@@ -278,18 +486,18 @@ def build_deterministic_status_claims(
             flags=DevClaimFlags(),
         )
     )
-    for child in open_required_children(actual):
+    for fact in outstanding_facts(actual, status_result):
         evidence_ids = [
-            ref for ref in child.evidence_ref_ids if ref in canonical_evidence_ids
+            ref for ref in fact.evidence_ref_ids if ref in canonical_evidence_ids
         ][:25]
         if not evidence_ids:
             continue
         claims.append(
             DevClaim(
                 schema_version="dev_claim.v1",
-                claim_id=f"status-blocker:{child.fact_id}",
+                claim_id=f"status-blocker:{fact.claim_id_suffix}",
                 kind=ClaimKind.OBSERVED,
-                text=f"Blocked: {child.text} ({child.status}){disclosure_suffix}",
+                text=f"{fact.text}{disclosure_suffix}",
                 confidence=1.0,
                 evidence_ref_ids=evidence_ids,
                 metric_ref_ids=[],
@@ -297,7 +505,9 @@ def build_deterministic_status_claims(
                 flags=DevClaimFlags(),
             )
         )
-    # DevAnswer.claims caps at 100 (contracts.py); required_children itself
-    # is already capped at 100 and the verdict adds one more, so this bound
-    # is defensive rather than expected to trim anything in practice.
+    # DevAnswer.claims caps at 100 (contracts.py); each contributing list is
+    # independently capped upstream (required_children/blockers at 100,
+    # pull_requests/ci_checks/deployments/incidents at 100 each on
+    # DevToolResult), so this bound is defensive rather than expected to
+    # trim anything in practice.
     return claims[:100]

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -1,0 +1,303 @@
+"""CHAOS-3377: the §10 deterministic status-answer renderer.
+
+The live defect this closes: a project-status question's ``status_snapshot.v1``
+tool call already computes a real, server-owned ``ActualCompletion`` verdict
+(``DevToolResult.actual_completion``) -- state, the completion fraction, a
+reason-code explanation, and a per-child status list -- but the FINAL
+``dev_answer.v1`` the client renders never carried any of that structured
+data. It only has free-text ``direct_summary``/``claims[].text``, which the
+model authors by reading the same tool result and narrating it in prose. That
+narration is where CHAOS-3377's five defects came from: the model can
+self-declare ``status=refused`` over a fully assessed answer, it can quote the
+tool result's raw internal tokens (``not_ready``, ``open_blocker``,
+``ev1_...`` evidence ids) verbatim, and it can misclassify a completed
+required item as a "current blocker".
+
+This module is the fix: build the verdict sentence and the blocker list
+directly from ``DevActualCompletion``, using closed, fail-closed translation
+tables, so a STATUS-class answer's §10 content is server-rendered rather than
+model-narrated. ``orchestrator.py`` calls this to OVERWRITE the model's
+``status``/``direct_summary``/``claims`` for a run whose tool results include
+an ``actual_completion`` assessment -- the model's own prose for that content
+never reaches the wire; the deterministic sections cannot be authored,
+contradicted, or polluted by it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from .contracts import (
+    AnswerStatus,
+    ClaimKind,
+    DevActualCompletion,
+    DevClaim,
+    DevClaimFlags,
+    DevCoverage,
+    DevRequiredChildFact,
+    DevScope,
+    DevToolResult,
+)
+from .status_completion_copy import (
+    INCOMPLETE_DENOMINATOR_DISCLOSURE,
+    any_tool_result_withheld_its_completion_denominator,
+    translate_reason_code,
+)
+
+__all__ = [
+    "build_deterministic_status_claims",
+    "deterministic_answer_status",
+    "is_open_child_status",
+    "open_required_children",
+    "render_verdict_summary",
+    "status_snapshot_result",
+    "translate_completion_state",
+    "translate_reason_code",
+]
+
+#: Closed, total vocabulary for ``DevActualCompletion.state`` (the wire type
+#: is itself a 3-member ``Literal``, so this dict is exhaustive by
+#: construction -- ``test_status_answer_render.py`` pins totality against
+#: that ``Literal``'s own ``get_args``).
+_COMPLETION_STATE_COPY: Mapping[str, str] = {
+    "ready": "Ready: every required item is complete.",
+    "not_ready": "Not ready: required work is still open.",
+    "indeterminate": "Indeterminate: completion could not be determined from the available evidence.",
+}
+_DEFAULT_STATE_COPY = "The completion state could not be determined."
+
+#: Reason-code translation (``translate_reason_code``) is imported from
+#: ``status_completion_copy.py`` above -- that module owns the closed-
+#: vocabulary table and its totality check against ``STATUS_REASON_CODES``,
+#: shared with ``answer_validator.completion_truncation_detail`` so the two
+#: user-visible surfaces cannot render the reason codes two different ways
+#: (or one raw and one translated).
+
+#: A required child (or blocker -- both are wired onto ``required_children``
+#: as ``DevRequiredChildFact`` by ``production_runtime.status_snapshot``'s
+#: ``actual_completion`` construction) is CLOSED when its own ``status``
+#: reads as done. Mirrors the predicate ``status_change_service._assess``
+#: already uses to decide ``required_child_incomplete``/``open_blocker``
+#: (that function's own two closed-vocabulary sets, unioned): a status this
+#: module would call "open" can never be one ``_assess`` itself called
+#: "complete" for the *same* reason-code decision, and vice versa -- the two
+#: cannot disagree about which items are still outstanding.
+_CLOSED_CHILD_STATUS_TOKENS: frozenset[str] = frozenset(
+    {
+        "complete",
+        "completed",
+        "done",
+        "closed",
+        "canceled",
+        "cancelled",
+        "resolved",
+        "merged",
+    }
+)
+
+
+def translate_completion_state(state: str) -> str:
+    """The safe, closed-vocabulary sentence for a raw ``ActualCompletion.state``.
+
+    Fail-closed: an unrecognized state (never possible for a validated
+    ``DevActualCompletion`` today, since the wire field is itself a 3-member
+    ``Literal``, but kept total rather than partial so a future wire
+    relaxation cannot reintroduce a raw-token leak here) renders as the
+    generic ``_DEFAULT_STATE_COPY``, never the input string.
+    """
+
+    return _COMPLETION_STATE_COPY.get(state, _DEFAULT_STATE_COPY)
+
+
+def is_open_child_status(status: str) -> bool:
+    """Whether a required-child/blocker's own ``status`` reads as outstanding."""
+
+    return status.strip().casefold() not in _CLOSED_CHILD_STATUS_TOKENS
+
+
+def open_required_children(
+    actual: DevActualCompletion,
+) -> list[DevRequiredChildFact]:
+    """The frame's own prioritized blocker list (CHAOS-3377 defect 5).
+
+    Every ``DevRequiredChildFact`` on ``actual.required_children`` whose own
+    ``status`` field is NOT one of the closed-vocabulary "done" tokens.
+    Built entirely from the server-computed ``status`` field on each fact --
+    never from narrative -- so an item the frame itself marked
+    complete/done/closed/etc can never appear here, closing the exact
+    self-contradiction (a "completed" item listed under "Current blockers")
+    the ticket reported. Order is preserved from ``required_children``,
+    which ``status_change_service._ordered_status`` already produces in a
+    stable, deterministic priority order.
+    """
+
+    return [
+        child
+        for child in actual.required_children
+        if is_open_child_status(child.status)
+    ]
+
+
+def render_verdict_summary(
+    actual: DevActualCompletion, *, denominator_withheld: bool = False
+) -> str:
+    """One deterministic sentence describing the completion verdict.
+
+    Never the raw ``state``/``reason_codes`` tokens (PRD §12) -- every
+    dynamic piece is either a plain integer (the completion fraction) or
+    routed through the closed-vocabulary translation tables above.
+
+    ``denominator_withheld`` mirrors ``answer_validator``'s own
+    ``any_tool_result_withheld_its_completion_denominator`` /
+    ``INCOMPLETE_DENOMINATOR_DISCLOSURE`` positive-disclosure obligation
+    (CHAOS-3297 s2 round 8): when the required-child source was truncated,
+    every user-visible piece of completion language -- deterministic or
+    model-authored -- must carry that exact sentence, so a server-rendered
+    verdict is not exempt from the same honesty requirement a model-authored
+    one is held to.
+    """
+
+    parts = [translate_completion_state(actual.state)]
+    if (
+        actual.required_child_total is not None
+        and actual.required_child_complete is not None
+    ):
+        parts.append(
+            f"{actual.required_child_complete} of {actual.required_child_total} "
+            "required items are complete."
+        )
+    seen: set[str] = set()
+    reasons: list[str] = []
+    for code in actual.reason_codes:
+        translated = translate_reason_code(code)
+        if translated not in seen:
+            seen.add(translated)
+            reasons.append(translated)
+    if reasons:
+        parts.append("Open items: " + "; ".join(reasons) + ".")
+    if denominator_withheld:
+        parts.append(INCOMPLETE_DENOMINATOR_DISCLOSURE.capitalize() + ".")
+    return " ".join(parts)
+
+
+def status_snapshot_result(
+    tool_results: Sequence[DevToolResult],
+) -> DevToolResult | None:
+    """The first executed tool result carrying a completion assessment, if any.
+
+    A run may call more than one tool; this is the seam
+    ``orchestrator.py`` uses to decide whether THIS run has server-owned §10
+    material to render deterministically at all -- a non-STATUS question
+    (whose tool results never set ``actual_completion``) is untouched by this
+    module.
+    """
+
+    for result in tool_results:
+        if result.actual_completion is not None:
+            return result
+    return None
+
+
+def deterministic_answer_status(
+    *, coverage: DevCoverage, tool_results: Sequence[DevToolResult]
+) -> AnswerStatus:
+    """The answer status for a server-rendered §10 answer -- never REFUSED.
+
+    Mirrors ``Orchestrator._server_grounded_answer``'s own coverage-driven
+    status choice: DEGRADED if any executed tool came back unavailable/error,
+    COMPLETE only when the server's own coverage accounting shows every
+    required source fresh and available (the same invariant
+    ``DevAnswer.validate_answer_invariants`` enforces), PARTIAL otherwise.
+    A deterministic, evidence-grounded verdict is by construction not a
+    refusal -- Ask Dev looked, and reports what it found -- so REFUSED is not
+    a reachable output of this function.
+    """
+
+    degraded = any(result.status in {"unavailable", "error"} for result in tool_results)
+    if degraded:
+        return AnswerStatus.DEGRADED
+    fully_covered = (
+        coverage.available_source_count == coverage.required_source_count
+        and not coverage.unavailable_required_sources
+        and not coverage.stale_required_sources
+        and not coverage.degraded_required_sources
+    )
+    return AnswerStatus.COMPLETE if fully_covered else AnswerStatus.PARTIAL
+
+
+def build_deterministic_status_claims(
+    *,
+    actual: DevActualCompletion,
+    validity_scope: DevScope,
+    canonical_evidence_ids: frozenset[str],
+    tool_results: Sequence[DevToolResult] = (),
+) -> list[DevClaim]:
+    """Server-rendered §10 claims: one verdict claim, then one per open
+    required item/blocker -- never from model narrative.
+
+    Every claim cites only evidence IDs already present in this run's
+    canonical evidence set (``canonical_evidence_ids``, the same tuple
+    ``Orchestrator._canonical_answer_data`` computed for this candidate), so
+    the result satisfies ``DevAnswer``'s own "claim references unknown
+    evidence" invariant by construction. A blocker whose own evidence was
+    truncated out of the tool result is skipped rather than emitted
+    ungrounded -- an ``OBSERVED`` claim requires at least one reference
+    (``DevClaim.validate_grounding``), and fabricating one would be worse
+    than omitting the item.
+
+    ``tool_results`` (defaulting to empty, i.e. "denominator not withheld")
+    drives the same positive-disclosure obligation ``render_verdict_summary``
+    documents -- applied to every claim here, not only the verdict one, since
+    ``answer_validator`` checks each claim independently.
+    """
+
+    denominator_withheld = any_tool_result_withheld_its_completion_denominator(
+        tuple(tool_results)
+    )
+    disclosure_suffix = (
+        f" {INCOMPLETE_DENOMINATOR_DISCLOSURE.capitalize()}."
+        if denominator_withheld
+        else ""
+    )
+    claims: list[DevClaim] = []
+    verdict_evidence = [
+        ref for ref in actual.evidence_ref_ids if ref in canonical_evidence_ids
+    ][:25]
+    claims.append(
+        DevClaim(
+            schema_version="dev_claim.v1",
+            claim_id=f"status-verdict:{actual.rule_id}:{actual.rule_version}",
+            kind=ClaimKind.OBSERVED if verdict_evidence else ClaimKind.INFERRED,
+            text=render_verdict_summary(
+                actual, denominator_withheld=denominator_withheld
+            ),
+            confidence=1.0 if verdict_evidence else 0.999999,
+            evidence_ref_ids=verdict_evidence,
+            metric_ref_ids=[],
+            validity_scope=validity_scope,
+            flags=DevClaimFlags(),
+        )
+    )
+    for child in open_required_children(actual):
+        evidence_ids = [
+            ref for ref in child.evidence_ref_ids if ref in canonical_evidence_ids
+        ][:25]
+        if not evidence_ids:
+            continue
+        claims.append(
+            DevClaim(
+                schema_version="dev_claim.v1",
+                claim_id=f"status-blocker:{child.fact_id}",
+                kind=ClaimKind.OBSERVED,
+                text=f"Blocked: {child.text} ({child.status}){disclosure_suffix}",
+                confidence=1.0,
+                evidence_ref_ids=evidence_ids,
+                metric_ref_ids=[],
+                validity_scope=validity_scope,
+                flags=DevClaimFlags(),
+            )
+        )
+    # DevAnswer.claims caps at 100 (contracts.py); required_children itself
+    # is already capped at 100 and the verdict adds one more, so this bound
+    # is defensive rather than expected to trim anything in practice.
+    return claims[:100]

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -34,6 +34,37 @@ MAX_STATUS_ITEMS = 100
 MAX_CHANGE_ITEMS = 100
 MAX_STATUS_ASSESSMENT_ITEMS = 1_000
 
+#: CHAOS-3377: the closed vocabulary of ``ActualCompletion.reason_codes`` this
+#: module's ``_assess`` can emit, listed once here rather than only as the
+#: scattered ``reasons.add(...)`` literals below, so a consumer that must
+#: never let a raw reason code reach user-visible prose (the internal-token
+#: denylist in ``no_match_terminal.py``, and the closed-vocabulary
+#: translation table in ``status_answer_render.py``) has one place to derive
+#: its "every code this rule can produce" set from instead of hand-copying
+#: the list a second time. ``test_status_change_service.py`` pins this
+#: against the literal ``reasons.add(...)`` calls in ``_assess`` so the two
+#: cannot silently drift apart.
+STATUS_REASON_CODES: frozenset[str] = frozenset(
+    {
+        "child_requirement_unknown",
+        "declared_status_missing",
+        "required_source_not_fresh",
+        "assessment_source_limit_reached",
+        "required_release_evidence_missing",
+        "required_child_incomplete",
+        "open_blocker",
+        "required_pull_request_unmerged",
+        "required_review_unresolved",
+        "review_changes_requested",
+        "ci_requirement_unknown",
+        "required_ci_skip_state_unknown",
+        "required_ci_work_skipped",
+        "required_ci_not_passing",
+        "required_deployment_not_succeeded",
+        "active_blocking_incident",
+    }
+)
+
 
 class StatusResultState(StrEnum):
     COMPLETE = "complete"

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -65,6 +65,87 @@ STATUS_REASON_CODES: frozenset[str] = frozenset(
     }
 )
 
+# --- CHAOS-3377 HIGH 3 (codex adversarial review): the assessor's own
+# "is this outstanding" predicates, extracted into named, importable
+# functions rather than left as inline literals inside ``_assess`` below.
+# ``status_answer_render.py`` (the §10 deterministic renderer) imports and
+# calls these directly instead of re-deriving its own copy -- a prior
+# revision hand-copied a "safe superset" of the required-child predicate
+# that silently disagreed with this one (treated ``resolved``/``merged`` as
+# closed when this predicate does not), which could render an item as a
+# closed required-child while `_assess` itself still counted it as the
+# reason a verdict was NOT_READY. ``_assess`` below now calls these same
+# functions, so the two can never diverge again -- there is exactly one
+# place each predicate is written.
+#
+# Required children and blockers use two SLIGHTLY DIFFERENT closed-status
+# vocabularies (blockers additionally treat ``resolved`` as closed; neither
+# treats ``merged`` as closed for either category) -- this is not an
+# oversight to unify, it is `_assess`'s own pre-existing, tested behavior,
+# preserved exactly rather than "cleaned up" into one shared set.
+REQUIRED_CHILD_CLOSED_STATUS_TOKENS: frozenset[str] = frozenset(
+    {"complete", "completed", "done", "closed", "canceled", "cancelled"}
+)
+BLOCKER_CLOSED_STATUS_TOKENS: frozenset[str] = frozenset(
+    {"complete", "completed", "done", "closed", "resolved", "canceled", "cancelled"}
+)
+_CI_PASSING_TOKENS: frozenset[str] = frozenset({"success", "passed", "green"})
+_DEPLOYMENT_SUCCESS_TOKENS: frozenset[str] = frozenset(
+    {"success", "succeeded", "deployed", "complete", "completed"}
+)
+
+
+def is_required_child_open(status: str) -> bool:
+    """Whether a required child's own ``status`` reads as still outstanding."""
+
+    return status.casefold() not in REQUIRED_CHILD_CLOSED_STATUS_TOKENS
+
+
+def is_blocker_open(status: str) -> bool:
+    """Whether a blocker's own ``status`` reads as still outstanding."""
+
+    return status.casefold() not in BLOCKER_CLOSED_STATUS_TOKENS
+
+
+def is_pull_request_unmerged(*, required: bool, merged: bool) -> bool:
+    return required and not merged
+
+
+def is_pull_request_review_unresolved(
+    *, required: bool, review_state: str | None
+) -> bool:
+    return required and not review_state
+
+
+def is_pull_request_changes_requested(
+    *, required: bool, changes_requested: int
+) -> bool:
+    return required and changes_requested > 0
+
+
+def is_ci_skip_state_unknown(
+    *, required: bool | None, skipped_required_work: bool | None
+) -> bool:
+    return bool(required) and skipped_required_work is None
+
+
+def is_ci_work_skipped(
+    *, required: bool | None, skipped_required_work: bool | None
+) -> bool:
+    return bool(required) and skipped_required_work is True
+
+
+def is_ci_not_passing(*, required: bool | None, conclusion: str) -> bool:
+    return bool(required) and conclusion.casefold() not in _CI_PASSING_TOKENS
+
+
+def is_deployment_not_succeeded(*, required: bool, status: str) -> bool:
+    return required and status.casefold() not in _DEPLOYMENT_SUCCESS_TOKENS
+
+
+def is_incident_active_and_blocking(*, active: bool, blocking: bool) -> bool:
+    return blocking and active
+
 
 class StatusResultState(StrEnum):
     COMPLETE = "complete"
@@ -204,6 +285,19 @@ class ActualCompletion:
     conflicts: tuple[StatusConflict, ...]
     source_ref_ids: tuple[str, ...]
     evidence_ref_ids: tuple[str, ...]
+    # CHAOS-3377 HIGH 3 (codex adversarial review): the §10 deterministic
+    # renderer's blocker list previously came ONLY from ``required_children``
+    # -- ``raw.blockers`` never had a typed home on ``ActualCompletion`` at
+    # all, so a NOT_READY verdict caused entirely by ``open_blocker`` (no
+    # incomplete required child) rendered an empty blocker list, silently
+    # omitting the exact work making it not ready. Mirrors
+    # ``required_children``: ALL blockers (not pre-filtered to open ones),
+    # ordered the same way, so a consumer applies its own closed-vocabulary
+    # openness predicate (``is_blocker_open`` below) rather than trusting a
+    # pre-filtered list it cannot independently verify. Defaulted to ``()``
+    # so the ~10 existing direct-construction call sites across the test
+    # suite (predating this field) do not have to be touched.
+    blockers: tuple[StatusFact, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -743,55 +837,69 @@ class StatusChangeService:
         if release_evidence_required and not raw.deployments:
             reasons.add("required_release_evidence_missing")
         incomplete_children = [
-            child
-            for child in required_children
-            if child.status.casefold()
-            not in {"complete", "completed", "done", "closed", "canceled", "cancelled"}
+            child for child in required_children if is_required_child_open(child.status)
         ]
         if incomplete_children:
             reasons.add("required_child_incomplete")
+        blockers = self._ordered_status(raw.blockers)
         open_blockers = [
-            blocker
-            for blocker in raw.blockers
-            if blocker.status.casefold()
-            not in {
-                "complete",
-                "completed",
-                "done",
-                "closed",
-                "resolved",
-                "canceled",
-                "cancelled",
-            }
+            blocker for blocker in blockers if is_blocker_open(blocker.status)
         ]
         if open_blockers:
             reasons.add("open_blocker")
-        if any(pr.required and not pr.merged for pr in raw.pull_requests):
+        if any(
+            is_pull_request_unmerged(required=pr.required, merged=pr.merged)
+            for pr in raw.pull_requests
+        ):
             reasons.add("required_pull_request_unmerged")
-        if any(pr.required and not pr.review_state for pr in raw.pull_requests):
+        if any(
+            is_pull_request_review_unresolved(
+                required=pr.required, review_state=pr.review_state
+            )
+            for pr in raw.pull_requests
+        ):
             reasons.add("required_review_unresolved")
-        if any(pr.required and pr.changes_requested > 0 for pr in raw.pull_requests):
+        if any(
+            is_pull_request_changes_requested(
+                required=pr.required, changes_requested=pr.changes_requested
+            )
+            for pr in raw.pull_requests
+        ):
             reasons.add("review_changes_requested")
         if any(ci.required is None for ci in raw.ci):
             reasons.add("ci_requirement_unknown")
-        if any(ci.required and ci.skipped_required_work is None for ci in raw.ci):
+        if any(
+            is_ci_skip_state_unknown(
+                required=ci.required, skipped_required_work=ci.skipped_required_work
+            )
+            for ci in raw.ci
+        ):
             reasons.add("required_ci_skip_state_unknown")
-        if any(ci.required and ci.skipped_required_work is True for ci in raw.ci):
+        if any(
+            is_ci_work_skipped(
+                required=ci.required, skipped_required_work=ci.skipped_required_work
+            )
+            for ci in raw.ci
+        ):
             reasons.add("required_ci_work_skipped")
         if any(
-            ci.required
-            and ci.conclusion.casefold() not in {"success", "passed", "green"}
+            is_ci_not_passing(required=ci.required, conclusion=ci.conclusion)
             for ci in raw.ci
         ):
             reasons.add("required_ci_not_passing")
         if any(
-            deployment.required
-            and deployment.status.casefold()
-            not in {"success", "succeeded", "deployed", "complete", "completed"}
+            is_deployment_not_succeeded(
+                required=deployment.required, status=deployment.status
+            )
             for deployment in raw.deployments
         ):
             reasons.add("required_deployment_not_succeeded")
-        if any(incident.blocking and incident.active for incident in raw.incidents):
+        if any(
+            is_incident_active_and_blocking(
+                active=incident.active, blocking=incident.blocking
+            )
+            for incident in raw.incidents
+        ):
             reasons.add("active_blocking_incident")
 
         declared_complete = declared_optional or (
@@ -859,6 +967,7 @@ class StatusChangeService:
             conflicts=tuple(conflicts),
             source_ref_ids=used_source_ids,
             evidence_ref_ids=self._fact_evidence(raw),
+            blockers=blockers,
         )
 
     @staticmethod

--- a/src/dev_health_ops/api/dev/status_completion_copy.py
+++ b/src/dev_health_ops/api/dev/status_completion_copy.py
@@ -1,0 +1,138 @@
+"""Shared completion-assessment copy: the CHAOS-3297 s2 disclosure obligation
+and the CHAOS-3377 reason-code translation table.
+
+Split out of ``answer_validator.py`` (which originated the disclosure
+obligation) and ``status_answer_render.py`` (which originated the
+translation table) into their own dependency-free module. Both of those
+modules need pieces the OTHER one owns -- the validator's
+``completion_truncation_detail`` must stop rendering ``ActualCompletion``'s
+raw reason codes into a user-visible ``DevError.safe_message`` (CHAOS-3377
+defect 2: those codes are exactly what the widened internal-token denylist in
+``no_match_terminal.py`` now forbids everywhere), and the deterministic
+renderer needs the validator's disclosure constant and withheld-denominator
+predicate. Neither module may import the other without a cycle, so both
+import this one instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from .contracts import DevActualCompletion, DevToolResult
+from .status_change_service import STATUS_REASON_CODES
+
+__all__ = [
+    "INCOMPLETE_DENOMINATOR_DISCLOSURE",
+    "any_tool_result_withheld_its_completion_denominator",
+    "has_incomplete_denominator_disclosure",
+    "is_completion_assessment_untrustworthy",
+    "translate_reason_code",
+]
+
+# CHAOS-3297 s2 round 8 (closure, ratified on the ticket): a positive
+# disclosure obligation, not a vocabulary sweep against fabricated completion
+# language -- see answer_validator.py's original module-level comment
+# (rounds 5-8) for the full history of why an absence-of-bad-phrasing check
+# cannot work here. A string either contains this sentence, verbatim and
+# case-insensitive, or it does not.
+INCOMPLETE_DENOMINATOR_DISCLOSURE = (
+    "the required-work completion total could not be fully verified"
+)
+
+
+def has_incomplete_denominator_disclosure(text: str) -> bool:
+    return INCOMPLETE_DENOMINATOR_DISCLOSURE.casefold() in text.casefold()
+
+
+# CHAOS-3297 s2 round 9 (codex CONFIRMED): status_change_service._assess
+# nulls required_child_total/required_child_complete ONLY when the
+# required-child source itself was truncated; every OTHER assessment
+# category sets this general reason code while leaving the denominator
+# non-None. The disclosure obligation must fire on EITHER signal.
+_ASSESSMENT_SOURCE_LIMIT_REACHED = "assessment_source_limit_reached"
+
+
+def is_completion_assessment_untrustworthy(actual: DevActualCompletion) -> bool:
+    return (
+        actual.required_child_total is None
+        or _ASSESSMENT_SOURCE_LIMIT_REACHED in actual.reason_codes
+    )
+
+
+def any_tool_result_withheld_its_completion_denominator(
+    tool_results: tuple[DevToolResult, ...],
+) -> bool:
+    """Whether any executed tool in this run reported a completion
+    assessment that cannot be trusted to ground a completion claim.
+    """
+
+    return any(
+        result.actual_completion is not None
+        and is_completion_assessment_untrustworthy(result.actual_completion)
+        for result in tool_results
+    )
+
+
+# --- CHAOS-3377 defect 2: closed-vocabulary reason-code translation --------
+
+#: Closed-vocabulary translation for every reason code
+#: ``status_change_service._assess`` can emit (``STATUS_REASON_CODES``).
+#: Fail-closed: a code this table has never seen renders as
+#: ``_DEFAULT_REASON_COPY``, never the raw token.
+_REASON_CODE_COPY: Mapping[str, str] = {
+    "child_requirement_unknown": "it is unknown whether some sub-items are required",
+    "declared_status_missing": "no declared status was recorded",
+    "required_source_not_fresh": "a required data source is stale or unavailable",
+    "assessment_source_limit_reached": (
+        "the assessment hit a display limit, so this total may be incomplete"
+    ),
+    "required_release_evidence_missing": "required release evidence is missing",
+    "required_child_incomplete": "one or more required sub-items are not complete",
+    "open_blocker": "one or more blocking items are still open",
+    "required_pull_request_unmerged": "a required pull request has not merged",
+    "required_review_unresolved": "a required review has not been completed",
+    "review_changes_requested": "a reviewer has requested changes",
+    "ci_requirement_unknown": "it is unknown whether some CI checks are required",
+    "required_ci_skip_state_unknown": (
+        "it is unknown whether a required CI check was skipped"
+    ),
+    "required_ci_work_skipped": "required CI work was skipped",
+    "required_ci_not_passing": "a required CI check is not passing",
+    "required_deployment_not_succeeded": "a required deployment has not succeeded",
+    "active_blocking_incident": "an active incident is blocking this work",
+}
+_DEFAULT_REASON_COPY = "an unresolved requirement"
+
+# Import-time totality: every code this module can translate must be one
+# _assess can actually emit, and vice versa.
+_missing_from_copy_table = STATUS_REASON_CODES - set(_REASON_CODE_COPY)
+_missing_from_reason_codes = set(_REASON_CODE_COPY) - STATUS_REASON_CODES
+if _missing_from_copy_table or _missing_from_reason_codes:  # pragma: no cover
+    raise RuntimeError(
+        "status_completion_copy._REASON_CODE_COPY has diverged from "
+        "status_change_service.STATUS_REASON_CODES: "
+        f"missing translation(s)={sorted(_missing_from_copy_table)}, "
+        f"stale translation(s)={sorted(_missing_from_reason_codes)}"
+    )
+
+
+def translate_reason_code(code: str) -> str:
+    """The safe, closed-vocabulary clause for one raw ``ActualCompletion``
+    reason code. Fail-closed: an unrecognized code renders as
+    ``_DEFAULT_REASON_COPY``, never the raw token.
+    """
+
+    return _REASON_CODE_COPY.get(code, _DEFAULT_REASON_COPY)
+
+
+def translate_reason_codes(codes: Sequence[str]) -> list[str]:
+    """``translate_reason_code`` over a sequence, de-duplicated in order."""
+
+    seen: set[str] = set()
+    translated: list[str] = []
+    for code in codes:
+        text = translate_reason_code(code)
+        if text not in seen:
+            seen.add(text)
+            translated.append(text)
+    return translated

--- a/tests/api/dev/test_answer_validator.py
+++ b/tests/api/dev/test_answer_validator.py
@@ -741,3 +741,33 @@ def test_unsupported_inferred_claim_does_not_disable_the_grounding_floor() -> No
     with pytest.raises(AnswerValidationError) as raised:
         validate_answer_candidate(payload, _context_without_groundable_material())
     assert raised.value.code == "answer_grounding_floor_not_met"
+
+
+# CHAOS-3377 defect 1: PRD §12's "a result with content is not a refusal"
+# applied to a model that self-declares ``status=refused`` alongside real
+# claim/metric/evidence grounding -- the live defect reported as a "Refused"
+# chip over a fully substantive answer. This is the mirror image of the
+# CHAOS-3290 floor above (a substantive-looking answer with no grounding);
+# here a substantively-grounded answer is dishonestly labeled as having no
+# content at all.
+def test_refused_status_with_material_grounding_is_rejected_and_repairable() -> None:
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload["status"] = "refused"
+    with pytest.raises(AnswerValidationError) as raised:
+        validate_answer_candidate(payload, _context())
+    assert raised.value.code == "refused_with_material_grounding"
+    # Repairable: this is a one-field labeling mistake, not a trust breach --
+    # the model can reissue the same grounded content under an honest status
+    # in the same bounded repair pass CHAOS-3257 already gives a
+    # status/coverage mismatch.
+    assert raised.value.repairable is True
+
+
+def test_refused_status_with_no_grounding_is_still_a_valid_refusal() -> None:
+    """Negative control: a genuine refusal (nothing retrieved, nothing
+    claimed) must not be caught by the new check -- only a refusal that
+    contradicts itself by also carrying real content is rejected.
+    """
+    payload = _empty_payload(status="refused", direct_summary="I can't help with that.")
+    answer = validate_answer_candidate(payload, _context_without_groundable_material())
+    assert answer.status.value == "refused"

--- a/tests/api/dev/test_chaos_3297_s5_guard_cutover.py
+++ b/tests/api/dev/test_chaos_3297_s5_guard_cutover.py
@@ -641,7 +641,7 @@ def test_c4b_the_grounding_floor_can_never_reach_the_demotion_seam() -> None:
 
     from dev_health_ops.api.dev import answer_validator
 
-    source = inspect.getsource(answer_validator._answer_has_material_grounding)
+    source = inspect.getsource(answer_validator.answer_has_material_grounding)
     assert "answer.metrics" in source and "answer.evidence" in source, (
         "the floor no longer keys on answer.metrics/answer.evidence; the "
         "orchestrator's 'this branch cannot fire' reasoning must be re-derived"

--- a/tests/api/dev/test_chaos_3377_answer_text_sanitizer.py
+++ b/tests/api/dev/test_chaos_3377_answer_text_sanitizer.py
@@ -1,9 +1,13 @@
 """CHAOS-3377 defect 3: structural JSON-tail sanitization.
 
-Fixed structurally (a trailing-artifact regex applied to any model-authored
-text), not by replacing the one literal reported string -- these tests prove
-that: the exact reported tail is covered, but so are shapes that are not a
-literal match for it.
+Fixed structurally (a real bracket-validity check over the trailing run of
+JSON-structural characters), not by replacing the one literal reported
+string, and NOT by a blanket "any trailing JSON-shaped punctuation" regex
+either -- codex adversarial review (round 2) reproduced three cases where
+that blanket rule corrupted legitimate content. These tests prove both
+halves: the exact reported tail (and other genuinely INVALID shapes) are
+still stripped, and the reviewer's three repro strings (and other genuinely
+VALID bracket literals) are left untouched.
 """
 
 from __future__ import annotations
@@ -25,38 +29,62 @@ def test_the_reported_live_tail_is_stripped() -> None:
     [
         ("Done for now.} }", "Done for now."),
         ("Verdict reached.]}", "Verdict reached."),
-        ("All set.{}{}", "All set."),
         ("No artifact at all.", "No artifact at all."),
         (
             "Ends in a real closing paren (see above)",
             "Ends in a real closing paren (see above)",
         ),
         ("Trailing brackets][", "Trailing brackets"),
+        # A single dangling closing brace with nothing to match is exactly
+        # as structurally invalid as a longer run -- the bracket-validity
+        # check does not need a length threshold to catch it.
+        ("The response is done}", "The response is done"),
     ],
 )
-def test_generic_trailing_artifact_shapes_are_stripped_not_just_the_literal_one(
-    raw: str, expected: str
-) -> None:
-    """The rule is structural (a trailing run of >=2 JSON-structural
-    characters), so it generalizes past the one literal '}}}{' the ticket
-    reported -- proving this is not a one-off string replace.
+def test_invalid_trailing_bracket_shapes_are_stripped(raw: str, expected: str) -> None:
+    """The rule is structural (bracket-matching validity), so it generalizes
+    past the one literal '}}}{' the ticket reported -- proving this is not a
+    one-off string replace.
     """
 
     assert sanitize_model_text(raw) == expected
 
 
-def test_does_not_touch_interior_braces_that_are_part_of_real_prose() -> None:
-    text = "The payload is `{}` by default in every environment."
+# --- codex adversarial review round 2: must-NOT-strip negative controls ---
+# (the exact three repro strings that defeated the first revision's blanket
+# "any trailing run of >=2 JSON-structural characters" rule)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Expected payload: {}",
+        "Valid alternatives are []",
+        "Use an empty object: { }",
+    ],
+)
+def test_valid_balanced_bracket_examples_are_never_stripped(text: str) -> None:
+    """Reviewer repros: each of these ends in a syntactically VALID,
+    balanced, well-nested bracket literal that reads as a plausible inline
+    example, not leaked debris. A blanket "trailing JSON-shaped punctuation"
+    rule corrupted all three; the bracket-validity check must not.
+    """
+
     assert sanitize_model_text(text) == text
 
 
-def test_single_trailing_brace_is_left_alone() -> None:
-    """A single trailing structural character is not, by itself, a strong
-    enough signal of a parser-boundary leak (the run threshold is >=2) --
-    this is the deliberate false-positive boundary, not a gap.
+def test_all_set_with_two_empty_object_literals_is_not_stripped() -> None:
+    """Two back-to-back empty object literals are still validly bracketed
+    (each opens and closes in turn) -- not the unbalanced, opens-nothing
+    shape a leaked tail has.
     """
 
-    text = "The response is done}"
+    text = "All set.{}{}"
+    assert sanitize_model_text(text) == text
+
+
+def test_does_not_touch_interior_braces_that_are_part_of_real_prose() -> None:
+    text = "The payload is `{}` by default in every environment."
     assert sanitize_model_text(text) == text
 
 
@@ -69,3 +97,8 @@ def test_repeated_application_is_idempotent() -> None:
     once = sanitize_model_text(text)
     twice = sanitize_model_text(once)
     assert once == twice
+
+
+def test_no_trailing_structural_run_is_a_no_op() -> None:
+    text = "A perfectly ordinary sentence with no trailing punctuation issue"
+    assert sanitize_model_text(text) == text

--- a/tests/api/dev/test_chaos_3377_answer_text_sanitizer.py
+++ b/tests/api/dev/test_chaos_3377_answer_text_sanitizer.py
@@ -1,0 +1,71 @@
+"""CHAOS-3377 defect 3: structural JSON-tail sanitization.
+
+Fixed structurally (a trailing-artifact regex applied to any model-authored
+text), not by replacing the one literal reported string -- these tests prove
+that: the exact reported tail is covered, but so are shapes that are not a
+literal match for it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.answer_text_sanitizer import sanitize_model_text
+
+
+def test_the_reported_live_tail_is_stripped() -> None:
+    text = "The project is 39 of 69 required items complete.}}}{"
+    assert (
+        sanitize_model_text(text) == "The project is 39 of 69 required items complete."
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Done for now.} }", "Done for now."),
+        ("Verdict reached.]}", "Verdict reached."),
+        ("All set.{}{}", "All set."),
+        ("No artifact at all.", "No artifact at all."),
+        (
+            "Ends in a real closing paren (see above)",
+            "Ends in a real closing paren (see above)",
+        ),
+        ("Trailing brackets][", "Trailing brackets"),
+    ],
+)
+def test_generic_trailing_artifact_shapes_are_stripped_not_just_the_literal_one(
+    raw: str, expected: str
+) -> None:
+    """The rule is structural (a trailing run of >=2 JSON-structural
+    characters), so it generalizes past the one literal '}}}{' the ticket
+    reported -- proving this is not a one-off string replace.
+    """
+
+    assert sanitize_model_text(raw) == expected
+
+
+def test_does_not_touch_interior_braces_that_are_part_of_real_prose() -> None:
+    text = "The payload is `{}` by default in every environment."
+    assert sanitize_model_text(text) == text
+
+
+def test_single_trailing_brace_is_left_alone() -> None:
+    """A single trailing structural character is not, by itself, a strong
+    enough signal of a parser-boundary leak (the run threshold is >=2) --
+    this is the deliberate false-positive boundary, not a gap.
+    """
+
+    text = "The response is done}"
+    assert sanitize_model_text(text) == text
+
+
+def test_empty_and_none_like_inputs_are_returned_unchanged() -> None:
+    assert sanitize_model_text("") == ""
+
+
+def test_repeated_application_is_idempotent() -> None:
+    text = "Verdict reached.}}}{"
+    once = sanitize_model_text(text)
+    twice = sanitize_model_text(once)
+    assert once == twice

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -1,10 +1,12 @@
 """CHAOS-3377: the §10 deterministic status-answer renderer.
 
 Per-defect fail->pass coverage for the ticket's five presentation defects,
-scoped to the pure rendering functions in ``status_answer_render.py``. The
-orchestrator-level wiring (candidate override, status never REFUSED for a
-run with a status_snapshot result) is covered separately in
-``test_chaos_3377_orchestrator_status_answer.py``.
+plus the codex adversarial review's HIGH/MEDIUM findings against the first
+revision (scope binding, per-category outstanding facts, no raw-status
+interpolation), scoped to the pure rendering functions in
+``status_answer_render.py``. The orchestrator-level wiring (candidate
+override applied to AgentFinalAnswer/AgentRefusal/BudgetExceeded alike, scope
+binding end to end) is covered separately in ``test_orchestrator.py``.
 """
 
 from __future__ import annotations
@@ -17,24 +19,37 @@ from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import (
     AnswerStatus,
     DevActualCompletion,
+    DevCIFact,
     DevCoverage,
+    DevDeploymentFact,
+    DevIncidentFact,
+    DevPullRequestFact,
     DevRequiredChildFact,
     DevScope,
+    DevToolRequest,
     DevToolResult,
 )
 from dev_health_ops.api.dev.status_answer_render import (
     build_deterministic_status_claims,
     deterministic_answer_status,
-    is_open_child_status,
+    open_blockers,
     open_required_children,
+    outstanding_facts,
     render_verdict_summary,
     status_snapshot_result,
     translate_completion_state,
     translate_reason_code,
 )
-from dev_health_ops.api.dev.status_change_service import STATUS_REASON_CODES
+from dev_health_ops.api.dev.status_change_service import (
+    STATUS_REASON_CODES,
+    is_required_child_open,
+)
 
 SCOPE = DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
+OTHER_SCOPE = DevScope.model_validate(
+    {**positive_fixtures()["dev_scope.v1"], "organization_id": "org_other"}
+)
+OBSERVED_AT = positive_fixtures()["dev_answer.v1"]["as_of"]
 
 
 def _actual(
@@ -42,6 +57,7 @@ def _actual(
     state: str = "not_ready",
     reason_codes: tuple[str, ...] = ("open_blocker",),
     required_children: tuple[DevRequiredChildFact, ...] = (),
+    blockers: tuple[DevRequiredChildFact, ...] = (),
     required_child_total: int | None = 69,
     required_child_complete: int | None = 39,
     evidence_ref_ids: tuple[str, ...] = ("ev_01",),
@@ -52,6 +68,7 @@ def _actual(
         rule_version="actual-completion.v4",
         reason_codes=list(reason_codes),
         required_children=list(required_children),
+        blockers=list(blockers),
         required_child_total=required_child_total,
         required_child_complete=required_child_complete,
         display_truncated=False,
@@ -69,14 +86,141 @@ def _child(fact_id: str, text: str, status: str, evidence_ref_ids=("ev_01",)):
     )
 
 
-def _tool_result(
-    *, actual_completion: DevActualCompletion | None, status: str = "success"
+def _pull_request(
+    entity_id: str,
+    *,
+    required: bool = True,
+    merged: bool = True,
+    review_state: str | None = "approved",
+    changes_requested: int = 0,
+    evidence_ref_ids=("ev_01",),
+) -> DevPullRequestFact:
+    return DevPullRequestFact(
+        entity_id=entity_id,
+        display_label=f"PR {entity_id}",
+        state="open",
+        review_state=review_state,
+        changes_requested=changes_requested,
+        merged=merged,
+        required=required,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _ci(
+    entity_id: str,
+    *,
+    required: bool | None = True,
+    skipped_required_work: bool | None = False,
+    conclusion: str = "success",
+    evidence_ref_ids=("ev_01",),
+) -> DevCIFact:
+    return DevCIFact(
+        entity_id=entity_id,
+        display_label=f"CI {entity_id}",
+        conclusion=conclusion,
+        required=required,
+        skipped_required_work=skipped_required_work,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _deployment(
+    entity_id: str,
+    *,
+    required: bool = True,
+    status: str = "succeeded",
+    evidence_ref_ids=("ev_01",),
+) -> DevDeploymentFact:
+    return DevDeploymentFact(
+        entity_id=entity_id,
+        display_label=f"Deployment {entity_id}",
+        status=status,
+        required=required,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _incident(
+    entity_id: str,
+    *,
+    active: bool = False,
+    blocking: bool = False,
+    evidence_ref_ids=("ev_01",),
+) -> DevIncidentFact:
+    return DevIncidentFact(
+        entity_id=entity_id,
+        display_label=f"Incident {entity_id}",
+        status="open",
+        active=active,
+        blocking=blocking,
+        observed_at=OBSERVED_AT,
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _tool_request(
+    *,
+    scope: DevScope = SCOPE,
+    tool_id: str = "status_snapshot.v1",
+    tool_call_id: str = "tool_call_01",
 ):
+    payload = dict(positive_fixtures()["dev_tool_request.v1"])
+    payload.update(
+        {
+            "tool_id": tool_id,
+            "scope": scope.model_dump(mode="json"),
+            "tool_call_id": tool_call_id,
+        }
+    )
+    return DevToolRequest.model_validate(payload)
+
+
+def _evidence_stub(ref_id: str) -> dict:
+    base = dict(positive_fixtures()["dev_tool_result.v1"]["evidence"][0])
+    base["evidence_ref_id"] = ref_id
+    return base
+
+
+def _tool_result(
+    *,
+    actual_completion: DevActualCompletion | None,
+    status: str = "success",
+    tool_call_id: str = "tool_call_01",
+    pull_requests: tuple[DevPullRequestFact, ...] = (),
+    ci_checks: tuple[DevCIFact, ...] = (),
+    deployments: tuple[DevDeploymentFact, ...] = (),
+    incidents: tuple[DevIncidentFact, ...] = (),
+) -> DevToolResult:
     payload = dict(positive_fixtures()["dev_tool_result.v1"])
+    payload["tool_call_id"] = tool_call_id
     payload["actual_completion"] = (
         actual_completion.model_dump(mode="json") if actual_completion else None
     )
     payload["status"] = status
+    payload["pull_requests"] = [item.model_dump(mode="json") for item in pull_requests]
+    payload["ci_checks"] = [item.model_dump(mode="json") for item in ci_checks]
+    payload["deployments"] = [item.model_dump(mode="json") for item in deployments]
+    payload["incidents"] = [item.model_dump(mode="json") for item in incidents]
+    # DevToolResult.validate_evidence_closure requires every evidence ID any
+    # fact references to be present in `evidence` -- mint a stub for
+    # whatever `actual_completion`/the category facts above reference so
+    # tests can freely choose evidence ids without hand-maintaining a
+    # matching `evidence` array.
+    referenced: set[str] = set()
+    if actual_completion is not None:
+        referenced.update(actual_completion.evidence_ref_ids)
+        for child in actual_completion.required_children:
+            referenced.update(child.evidence_ref_ids)
+        for blocker in actual_completion.blockers:
+            referenced.update(blocker.evidence_ref_ids)
+    for group in (pull_requests, ci_checks, deployments, incidents):
+        for item in group:
+            referenced.update(item.evidence_ref_ids)
+    payload["evidence"] = [_evidence_stub(ref_id) for ref_id in sorted(referenced)]
     return DevToolResult.model_validate(payload)
 
 
@@ -127,15 +271,48 @@ def test_verdict_summary_never_contains_raw_state_or_reason_tokens() -> None:
 
 def test_verdict_claim_never_leaks_an_evidence_handle() -> None:
     actual = _actual(evidence_ref_ids=("ev1_" + "a" * 40,))
+    status_result = _tool_result(actual_completion=actual)
     claims = build_deterministic_status_claims(
         actual=actual,
+        status_result=status_result,
         validity_scope=SCOPE,
         canonical_evidence_ids=frozenset({"ev1_" + "a" * 40}),
     )
     assert "ev1_" not in claims[0].text
 
 
-# --- defect 5: blocker list must never contradict itself ---
+# --- MEDIUM 4 (codex adversarial review): raw provider status strings must
+# never be interpolated into claim text -- a provider-supplied status can
+# coincidentally equal a denylisted internal token.
+
+
+def test_blocker_claim_text_never_interpolates_the_raw_child_status() -> None:
+    """Reviewer repro: a required child whose own status happens to equal a
+    denylisted token ('not_ready') must not turn its claim text into a
+    leak -- the fix is structural (never render raw status), not a denylist
+    dodge.
+    """
+
+    actual = _actual(
+        required_children=(
+            _child("issue:OPEN-1", "release gate", "not_ready", ("ev_01",)),
+        )
+    )
+    status_result = _tool_result(actual_completion=actual)
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=status_result,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    blocker_claims = [c for c in claims if c.claim_id.startswith("status-blocker:")]
+    assert blocker_claims
+    for claim in blocker_claims:
+        assert "not_ready" not in claim.text
+
+
+# --- defect 5 / HIGH 3: outstanding work must never contradict itself, and
+# must be complete across every blocker-producing category ---
 
 
 def test_open_required_children_excludes_completed_and_done_items() -> None:
@@ -161,48 +338,58 @@ def test_open_required_children_excludes_completed_and_done_items() -> None:
     assert "issue:CLOSED-1" not in open_ids
 
 
+def test_open_required_children_uses_the_assessors_exact_predicate() -> None:
+    """HIGH 3 fail->pass: a prior revision's own "safe superset" treated
+    'resolved'/'merged' as closed for required children. The assessor
+    (``status_change_service._assess``) does NOT -- it counts a required
+    child with either status as INCOMPLETE. The renderer must agree, or a
+    NOT_READY verdict can render a supposedly-closed item that the assessor
+    itself still counted as the reason it is not ready.
+    """
+
+    actual = _actual(
+        required_children=(
+            _child("issue:RESOLVED-1", "Marked resolved", "resolved"),
+            _child("issue:MERGED-1", "Marked merged", "merged"),
+        )
+    )
+    open_ids = {child.fact_id for child in open_required_children(actual)}
+    assert open_ids == {"issue:RESOLVED-1", "issue:MERGED-1"}
+    # And the renderer's predicate is LITERALLY the assessor's, not a
+    # separately-maintained copy that happens to agree today.
+    assert is_required_child_open("resolved") is True
+    assert is_required_child_open("merged") is True
+
+
+def test_open_blockers_treats_resolved_as_closed_but_not_merged() -> None:
+    """The blocker vocabulary is intentionally different from the required-
+    child one (``status_change_service`` treats a blocker's own 'resolved'
+    as closed, but not 'merged' -- pre-existing, tested behavior preserved
+    by importing the exact predicate rather than re-deriving it).
+    """
+
+    actual = _actual(
+        blockers=(
+            _child("issue:BLOCKER-RESOLVED", "Blocker resolved", "resolved"),
+            _child("issue:BLOCKER-MERGED", "Blocker merged", "merged"),
+            _child("issue:BLOCKER-OPEN", "Blocker open", "open"),
+        )
+    )
+    open_ids = {blocker.fact_id for blocker in open_blockers(actual)}
+    assert open_ids == {"issue:BLOCKER-MERGED", "issue:BLOCKER-OPEN"}
+
+
 @pytest.mark.parametrize(
     "status",
-    [
-        "complete",
-        "completed",
-        "DONE",
-        "closed",
-        "canceled",
-        "cancelled",
-        "resolved",
-        "merged",
-    ],
+    ["complete", "completed", "DONE", "closed", "canceled", "cancelled"],
 )
-def test_is_open_child_status_closed_vocabulary(status: str) -> None:
-    assert is_open_child_status(status) is False
+def test_is_required_child_open_closed_vocabulary(status: str) -> None:
+    assert is_required_child_open(status) is False
 
 
 @pytest.mark.parametrize("status", ["in_progress", "Open", "Blocked", "in_review"])
-def test_is_open_child_status_open_vocabulary(status: str) -> None:
-    assert is_open_child_status(status) is True
-
-
-def test_blocker_claims_never_include_a_closed_item() -> None:
-    actual = _actual(
-        required_children=(
-            _child("issue:OPEN-1", "Open work item", "in_progress", ("ev_01",)),
-            _child("issue:DONE-1", "Finished work item", "completed", ("ev_01",)),
-        )
-    )
-    claims = build_deterministic_status_claims(
-        actual=actual,
-        validity_scope=SCOPE,
-        canonical_evidence_ids=frozenset({"ev_01"}),
-    )
-    blocker_claim_ids = {
-        claim.claim_id
-        for claim in claims
-        if claim.claim_id.startswith("status-blocker:")
-    }
-    assert blocker_claim_ids == {"status-blocker:issue:OPEN-1"}
-    for claim in claims:
-        assert "issue:DONE-1" not in claim.claim_id
+def test_is_required_child_open_open_vocabulary(status: str) -> None:
+    assert is_required_child_open(status) is True
 
 
 def test_blocker_claim_skipped_rather_than_fabricated_when_evidence_is_truncated() -> (
@@ -218,12 +405,171 @@ def test_blocker_claim_skipped_rather_than_fabricated_when_evidence_is_truncated
             _child("issue:OPEN-1", "Open item", "Open", ("ev_missing",)),
         )
     )
+    status_result = _tool_result(actual_completion=actual)
     claims = build_deterministic_status_claims(
         actual=actual,
+        status_result=status_result,
         validity_scope=SCOPE,
         canonical_evidence_ids=frozenset({"ev_01"}),
     )
-    assert all(claim.claim_id != "status-blocker:issue:OPEN-1" for claim in claims)
+    assert all(
+        claim.claim_id != "status-blocker:child:issue:OPEN-1" for claim in claims
+    )
+
+
+# --- HIGH 3 (codex adversarial review): every blocker-producing category
+# must be able to independently explain a NOT_READY verdict -- one test per
+# category as the SOLE cause, per the reviewer's request.
+
+
+def test_open_blocker_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(
+        reason_codes=("open_blocker",),
+        blockers=(_child("b1", "Open blocker item", "open"),),
+    )
+    status_result = _tool_result(actual_completion=actual)
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "blocker:b1" for f in facts)
+
+
+def test_unmerged_pull_request_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("required_pull_request_unmerged",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        pull_requests=(_pull_request("pr-1", required=True, merged=False),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    matching = [f for f in facts if f.claim_id_suffix == "pr-unmerged:pr-1"]
+    assert len(matching) == 1
+    assert "has not merged" in matching[0].text
+
+
+def test_review_unresolved_pull_request_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("required_review_unresolved",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        pull_requests=(
+            _pull_request("pr-2", required=True, merged=True, review_state=None),
+        ),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "pr-review-unresolved:pr-2" for f in facts)
+
+
+def test_changes_requested_pull_request_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("review_changes_requested",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        pull_requests=(
+            _pull_request("pr-3", required=True, merged=True, changes_requested=2),
+        ),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "pr-changes-requested:pr-3" for f in facts)
+
+
+def test_ci_not_passing_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("required_ci_not_passing",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        ci_checks=(_ci("ci-1", required=True, conclusion="failure"),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "ci-not-passing:ci-1" for f in facts)
+
+
+def test_ci_work_skipped_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("required_ci_work_skipped",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        ci_checks=(_ci("ci-2", required=True, skipped_required_work=True),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "ci-skipped:ci-2" for f in facts)
+
+
+def test_deployment_not_succeeded_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("required_deployment_not_succeeded",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        deployments=(_deployment("dep-1", required=True, status="failed"),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "deployment-not-succeeded:dep-1" for f in facts)
+
+
+def test_active_blocking_incident_is_the_sole_cause_and_is_rendered() -> None:
+    actual = _actual(reason_codes=("active_blocking_incident",))
+    status_result = _tool_result(
+        actual_completion=actual,
+        incidents=(_incident("inc-1", active=True, blocking=True),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    assert any(f.claim_id_suffix == "incident:inc-1" for f in facts)
+
+
+def test_outstanding_facts_never_interpolates_raw_status_fields() -> None:
+    """None of the per-category phrases embed the fact's own raw
+    status/conclusion string -- only its display_label and a fixed,
+    translated phrase (MEDIUM 4).
+    """
+
+    actual = _actual(
+        reason_codes=(
+            "required_pull_request_unmerged",
+            "required_ci_not_passing",
+            "required_deployment_not_succeeded",
+        )
+    )
+    status_result = _tool_result(
+        actual_completion=actual,
+        pull_requests=(_pull_request("pr-9", required=True, merged=False),),
+        ci_checks=(_ci("ci-9", required=True, conclusion="not_ready"),),
+        deployments=(_deployment("dep-9", required=True, status="not_ready"),),
+    )
+    facts = outstanding_facts(actual, status_result)
+    for fact in facts:
+        assert "not_ready" not in fact.text
+
+
+def test_claims_built_across_multiple_categories_at_once() -> None:
+    """A verdict caused by several categories at once gets a claim for
+    EACH, not just the first one found.
+    """
+
+    actual = _actual(
+        reason_codes=(
+            "open_blocker",
+            "required_pull_request_unmerged",
+            "active_blocking_incident",
+        ),
+        blockers=(_child("b1", "Blocking item", "open", ("ev_01",)),),
+    )
+    status_result = _tool_result(
+        actual_completion=actual,
+        pull_requests=(
+            _pull_request(
+                "pr-1", required=True, merged=False, evidence_ref_ids=("ev_01",)
+            ),
+        ),
+        incidents=(
+            _incident("inc-1", active=True, blocking=True, evidence_ref_ids=("ev_01",)),
+        ),
+    )
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=status_result,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    blocker_claim_ids = {
+        c.claim_id for c in claims if c.claim_id.startswith("status-blocker:")
+    }
+    assert blocker_claim_ids == {
+        "status-blocker:blocker:b1",
+        "status-blocker:pr-unmerged:pr-1",
+        "status-blocker:incident:inc-1",
+    }
 
 
 # --- defect 1: a deterministic verdict is never a refusal ---
@@ -263,14 +609,85 @@ def test_deterministic_status_downgrades_on_degraded_tool_result() -> None:
     assert status is AnswerStatus.DEGRADED
 
 
-# --- seam: which runs get the deterministic renderer at all ---
+# --- HIGH 1 (codex adversarial review): the renderer must bind to the
+# CURRENT resolved scope, never the first status_snapshot result seen ---
 
 
-def test_status_snapshot_result_finds_the_actual_completion_bearing_result() -> None:
-    plain = _tool_result(actual_completion=None)
-    status_bearing = _tool_result(actual_completion=_actual())
-    assert status_snapshot_result((plain,)) is None
-    assert status_snapshot_result((plain, status_bearing)) is status_bearing
+def test_status_snapshot_result_requires_a_status_snapshot_tool_id() -> None:
+    other_tool_request = _tool_request(tool_id="query_metric.v1")
+    result_with_actual = _tool_result(actual_completion=_actual())
+    assert (
+        status_snapshot_result(
+            (other_tool_request,), (result_with_actual,), authorized_scope=SCOPE
+        )
+        is None
+    )
+
+
+def test_status_snapshot_result_requires_scope_to_match_the_final_authorized_scope() -> (
+    None
+):
+    """Fail->pass for HIGH 1: a status_snapshot.v1 result called against a
+    DIFFERENT scope than the run's final resolved scope must never be
+    selected -- an earlier subject's snapshot must not silently overwrite a
+    later, differently-scoped answer.
+    """
+
+    stale_request = _tool_request(scope=OTHER_SCOPE)
+    stale_result = _tool_result(
+        actual_completion=_actual(), tool_call_id="tool_call_01"
+    )
+    assert (
+        status_snapshot_result(
+            (stale_request,), (stale_result,), authorized_scope=SCOPE
+        )
+        is None
+    )
+
+
+def test_status_snapshot_result_selects_the_latest_match_for_the_current_scope() -> (
+    None
+):
+    stale_request = _tool_request(
+        scope=OTHER_SCOPE, tool_id="status_snapshot.v1", tool_call_id="tool_call_01"
+    )
+    stale_result = _tool_result(
+        actual_completion=_actual(state="ready"), tool_call_id="tool_call_01"
+    )
+    current_request = _tool_request(
+        scope=SCOPE, tool_id="status_snapshot.v1", tool_call_id="tool_call_02"
+    )
+    current_result = _tool_result(
+        actual_completion=_actual(state="not_ready"), tool_call_id="tool_call_02"
+    )
+    selected = status_snapshot_result(
+        (stale_request, current_request),
+        (stale_result, current_result),
+        authorized_scope=SCOPE,
+    )
+    assert selected is current_result
+    assert selected is not None and selected.actual_completion is not None
+    assert selected.actual_completion.state == "not_ready"
+
+
+def test_status_snapshot_result_picks_the_last_of_two_matches_for_the_same_scope() -> (
+    None
+):
+    first_request = _tool_request(scope=SCOPE, tool_call_id="tool_call_01")
+    first_result = _tool_result(
+        actual_completion=_actual(state="not_ready"), tool_call_id="tool_call_01"
+    )
+    second_request = _tool_request(scope=SCOPE, tool_call_id="tool_call_02")
+    second_result = _tool_result(
+        actual_completion=_actual(state="ready", reason_codes=()),
+        tool_call_id="tool_call_02",
+    )
+    selected = status_snapshot_result(
+        (first_request, second_request),
+        (first_result, second_result),
+        authorized_scope=SCOPE,
+    )
+    assert selected is second_result
 
 
 # --- CHAOS-3297 s2 round 8 disclosure obligation still applies ---

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -1,0 +1,285 @@
+"""CHAOS-3377: the §10 deterministic status-answer renderer.
+
+Per-defect fail->pass coverage for the ticket's five presentation defects,
+scoped to the pure rendering functions in ``status_answer_render.py``. The
+orchestrator-level wiring (candidate override, status never REFUSED for a
+run with a status_snapshot result) is covered separately in
+``test_chaos_3377_orchestrator_status_answer.py``.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    AnswerStatus,
+    DevActualCompletion,
+    DevCoverage,
+    DevRequiredChildFact,
+    DevScope,
+    DevToolResult,
+)
+from dev_health_ops.api.dev.status_answer_render import (
+    build_deterministic_status_claims,
+    deterministic_answer_status,
+    is_open_child_status,
+    open_required_children,
+    render_verdict_summary,
+    status_snapshot_result,
+    translate_completion_state,
+    translate_reason_code,
+)
+from dev_health_ops.api.dev.status_change_service import STATUS_REASON_CODES
+
+SCOPE = DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
+
+
+def _actual(
+    *,
+    state: str = "not_ready",
+    reason_codes: tuple[str, ...] = ("open_blocker",),
+    required_children: tuple[DevRequiredChildFact, ...] = (),
+    required_child_total: int | None = 69,
+    required_child_complete: int | None = 39,
+    evidence_ref_ids: tuple[str, ...] = ("ev_01",),
+) -> DevActualCompletion:
+    return DevActualCompletion(
+        state=state,
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=list(reason_codes),
+        required_children=list(required_children),
+        required_child_total=required_child_total,
+        required_child_complete=required_child_complete,
+        display_truncated=False,
+        conflicts=[],
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _child(fact_id: str, text: str, status: str, evidence_ref_ids=("ev_01",)):
+    return DevRequiredChildFact(
+        fact_id=fact_id,
+        text=text,
+        status=status,
+        evidence_ref_ids=list(evidence_ref_ids),
+    )
+
+
+def _tool_result(
+    *, actual_completion: DevActualCompletion | None, status: str = "success"
+):
+    payload = dict(positive_fixtures()["dev_tool_result.v1"])
+    payload["actual_completion"] = (
+        actual_completion.model_dump(mode="json") if actual_completion else None
+    )
+    payload["status"] = status
+    return DevToolResult.model_validate(payload)
+
+
+# --- defect 2: raw internal vocabulary must never reach translated copy ---
+
+
+def test_translation_tables_are_total_and_closed() -> None:
+    """Every ``STATUS_REASON_CODES`` member translates to safe copy, and the
+    completion ``state`` Literal is fully covered -- the totality assertion
+    the module raises at import time if this ever drifts.
+    """
+
+    for code in STATUS_REASON_CODES:
+        translated = translate_reason_code(code)
+        assert code not in translated
+
+    for state in get_args(DevActualCompletion.model_fields["state"].annotation):
+        translated = translate_completion_state(state)
+        assert state not in translated
+
+
+def test_unknown_reason_code_fails_closed_to_generic_copy() -> None:
+    """A code the table has never seen must never reach the raw token --
+    this is what makes the table fail-closed rather than a best-effort map.
+    """
+
+    translated = translate_reason_code("some_future_reason_code_v7")
+    assert translated == "an unresolved requirement"
+    assert "some_future_reason_code_v7" not in translated
+
+
+def test_verdict_summary_never_contains_raw_state_or_reason_tokens() -> None:
+    actual = _actual(
+        state="not_ready",
+        reason_codes=("open_blocker", "required_child_incomplete"),
+    )
+    summary = render_verdict_summary(actual)
+    for forbidden in (
+        "not_ready",
+        "open_blocker",
+        "required_child_incomplete",
+        "actual_completion",
+    ):
+        assert forbidden not in summary
+    # The numeric completion fraction is still real, checkable content.
+    assert "39" in summary and "69" in summary
+
+
+def test_verdict_claim_never_leaks_an_evidence_handle() -> None:
+    actual = _actual(evidence_ref_ids=("ev1_" + "a" * 40,))
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev1_" + "a" * 40}),
+    )
+    assert "ev1_" not in claims[0].text
+
+
+# --- defect 5: blocker list must never contradict itself ---
+
+
+def test_open_required_children_excludes_completed_and_done_items() -> None:
+    """CHAOS-3377 defect 5 fail->pass: the live bug listed an item labeled
+    'completed'/'done' under 'Current blockers'. A blocker section built
+    from ``open_required_children`` cannot reproduce that -- it filters on
+    the frame's OWN ``status`` field, not narrative.
+    """
+
+    actual = _actual(
+        required_children=(
+            _child("issue:OPEN-1", "Open work item", "in_progress"),
+            _child("issue:DONE-1", "Finished work item", "completed"),
+            _child("issue:DONE-2", "Also finished", "done"),
+            _child("issue:CLOSED-1", "Closed out", "Closed"),
+        )
+    )
+    open_children = open_required_children(actual)
+    open_ids = {child.fact_id for child in open_children}
+    assert open_ids == {"issue:OPEN-1"}
+    assert "issue:DONE-1" not in open_ids
+    assert "issue:DONE-2" not in open_ids
+    assert "issue:CLOSED-1" not in open_ids
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "complete",
+        "completed",
+        "DONE",
+        "closed",
+        "canceled",
+        "cancelled",
+        "resolved",
+        "merged",
+    ],
+)
+def test_is_open_child_status_closed_vocabulary(status: str) -> None:
+    assert is_open_child_status(status) is False
+
+
+@pytest.mark.parametrize("status", ["in_progress", "Open", "Blocked", "in_review"])
+def test_is_open_child_status_open_vocabulary(status: str) -> None:
+    assert is_open_child_status(status) is True
+
+
+def test_blocker_claims_never_include_a_closed_item() -> None:
+    actual = _actual(
+        required_children=(
+            _child("issue:OPEN-1", "Open work item", "in_progress", ("ev_01",)),
+            _child("issue:DONE-1", "Finished work item", "completed", ("ev_01",)),
+        )
+    )
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    blocker_claim_ids = {
+        claim.claim_id
+        for claim in claims
+        if claim.claim_id.startswith("status-blocker:")
+    }
+    assert blocker_claim_ids == {"status-blocker:issue:OPEN-1"}
+    for claim in claims:
+        assert "issue:DONE-1" not in claim.claim_id
+
+
+def test_blocker_claim_skipped_rather_than_fabricated_when_evidence_is_truncated() -> (
+    None
+):
+    """An open child whose evidence didn't survive result truncation is
+    omitted, not emitted with an invented reference -- an OBSERVED claim
+    must cite real, canonical evidence.
+    """
+
+    actual = _actual(
+        required_children=(
+            _child("issue:OPEN-1", "Open item", "Open", ("ev_missing",)),
+        )
+    )
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    assert all(claim.claim_id != "status-blocker:issue:OPEN-1" for claim in claims)
+
+
+# --- defect 1: a deterministic verdict is never a refusal ---
+
+
+def test_deterministic_status_is_never_refused() -> None:
+    coverage = DevCoverage.model_validate(
+        {
+            "required_source_count": 1,
+            "available_source_count": 1,
+            "unavailable_required_sources": [],
+            "stale_required_sources": [],
+            "as_of": positive_fixtures()["dev_answer.v1"]["as_of"],
+        }
+    )
+    status = deterministic_answer_status(
+        coverage=coverage, tool_results=(_tool_result(actual_completion=_actual()),)
+    )
+    assert status is not AnswerStatus.REFUSED
+    assert status is AnswerStatus.COMPLETE
+
+
+def test_deterministic_status_downgrades_on_degraded_tool_result() -> None:
+    coverage = DevCoverage.model_validate(
+        {
+            "required_source_count": 1,
+            "available_source_count": 1,
+            "unavailable_required_sources": [],
+            "stale_required_sources": [],
+            "as_of": positive_fixtures()["dev_answer.v1"]["as_of"],
+        }
+    )
+    status = deterministic_answer_status(
+        coverage=coverage,
+        tool_results=(_tool_result(actual_completion=_actual(), status="unavailable"),),
+    )
+    assert status is AnswerStatus.DEGRADED
+
+
+# --- seam: which runs get the deterministic renderer at all ---
+
+
+def test_status_snapshot_result_finds_the_actual_completion_bearing_result() -> None:
+    plain = _tool_result(actual_completion=None)
+    status_bearing = _tool_result(actual_completion=_actual())
+    assert status_snapshot_result((plain,)) is None
+    assert status_snapshot_result((plain, status_bearing)) is status_bearing
+
+
+# --- CHAOS-3297 s2 round 8 disclosure obligation still applies ---
+
+
+def test_verdict_carries_the_disclosure_when_denominator_withheld() -> None:
+    actual = _actual(required_child_total=None, required_child_complete=None)
+    summary = render_verdict_summary(actual, denominator_withheld=True)
+    assert (
+        "the required-work completion total could not be fully verified"
+        in summary.casefold()
+    )

--- a/tests/api/dev/test_no_match_terminal.py
+++ b/tests/api/dev/test_no_match_terminal.py
@@ -504,6 +504,82 @@ def test_a_clean_persisted_answer_is_returned_untouched() -> None:
     assert redact_persisted_answer(stored) is stored
 
 
+# --- CHAOS-3377 HIGH (codex adversarial web review, round 2): a persisted
+# refused-with-grounding row must be normalized on read, not handed back
+# verbatim for the client to relabel around.
+
+
+def _refused_with_grounding_answer():
+    from dev_health_ops.api.dev.contracts import DevAnswer
+
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload["status"] = "refused"
+    payload["direct_summary"] = "I can't help with that request."
+    return DevAnswer.model_validate(payload)
+
+
+def test_a_persisted_refused_with_grounding_row_is_normalized_on_read() -> None:
+    """Fail->pass: a row written before ``answer_validator``'s write-time
+    check existed can still say status=refused while carrying real
+    claim/metric/evidence content. The read boundary must not hand this
+    back verbatim -- the client backstop that used to relabel it 'Answered'
+    while still rendering the rejected-shaped prose underneath is exactly
+    the leak this closes upstream.
+    """
+
+    stored = _refused_with_grounding_answer()
+    assert stored.claims  # the fixture answer has real, grounded claims
+
+    normalized = redact_persisted_answer(stored)
+
+    assert normalized.status.value != "refused"
+    assert normalized.direct_summary != "I can't help with that request."
+    assert normalized.claims == []
+    # Structured, server-issued content survives -- only the model's own
+    # prose (the part that disagreed with its own status) is discarded.
+    assert normalized.metrics == stored.metrics
+    assert normalized.evidence == stored.evidence
+
+
+def test_normalization_runs_even_when_the_prose_has_no_denylisted_token() -> None:
+    """The refused-with-grounding contradiction is not itself an
+    internal-token leak (its direct_summary here is ordinary English) -- it
+    must not be gated behind the ``internal_token_leak`` check, which would
+    silently skip a clean-looking but self-contradictory row.
+    """
+
+    stored = _refused_with_grounding_answer()
+    assert internal_token_leak(user_visible_strings(answer=stored)) is None
+
+    normalized = redact_persisted_answer(stored)
+    assert normalized.status.value != "refused"
+    assert normalized.claims == []
+
+
+def test_a_genuine_refusal_with_no_grounding_is_not_normalized() -> None:
+    """Negative control: a row that is REFUSED with no material grounding at
+    all is a genuine refusal, not a contradiction -- normalization must
+    leave it untouched.
+    """
+
+    payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+    payload.update(
+        {
+            "status": "refused",
+            "direct_summary": "I can't help with that request.",
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+        }
+    )
+    from dev_health_ops.api.dev.contracts import DevAnswer
+
+    stored = DevAnswer.model_validate(payload)
+    normalized = redact_persisted_answer(stored)
+    assert normalized.status.value == "refused"
+    assert normalized.direct_summary == "I can't help with that request."
+
+
 # --- round 3: the codex web-review findings that apply to the server --------
 
 

--- a/tests/api/dev/test_no_match_terminal.py
+++ b/tests/api/dev/test_no_match_terminal.py
@@ -125,17 +125,27 @@ def test_denylist_derives_every_token_the_prd_names(token: str) -> None:
     assert token in INTERNAL_TOKEN_DENYLIST
 
 
-def test_denylist_is_disjoint_from_the_completion_reason_vocabulary() -> None:
-    """``completion_truncation_detail`` renders ``ActualCompletion``'s reason
-    codes verbatim into a user-visible ``DevError.safe_message``, by design
-    (CHAOS-3297 s2: rejecting a fabricated total without saying why leaves the
-    user with nothing). Those codes are snake_case too, so a collision with an
-    internal enum member would make ``orchestrator.finish()``'s fail-closed
-    check destroy a legitimate terminal.
+def test_denylist_now_includes_the_completion_reason_vocabulary() -> None:
+    """CHAOS-3377 defect 2 REVERSES this file's prior invariant, so the
+    reversal is pinned explicitly rather than just deleting the old test.
 
-    Pinned here so a future reason code that collides is a build failure, not
-    a production incident. If this fails, rename the reason code -- do not
-    widen the denylist's exclusions.
+    Before CHAOS-3377, ``completion_truncation_detail`` rendered
+    ``ActualCompletion``'s reason codes VERBATIM into a user-visible
+    ``DevError.safe_message`` by design, so the denylist deliberately
+    excluded them (a collision would have made ``orchestrator.finish()``'s
+    fail-closed check destroy that legitimate terminal). A live run then
+    showed those same raw codes (``not_ready``, ``open_blocker``,
+    ``required_child_incomplete``, ...) leaking into ordinary answer prose --
+    a path this file's denylist was never watching, because the exclusion
+    covered the whole vocabulary rather than just the one sanctioned surface.
+
+    The fix (CHAOS-3377) is symmetric: ``completion_truncation_detail`` (see
+    ``status_completion_copy.translate_reason_codes``) now renders translated
+    copy instead of the raw codes, so nothing legitimate needs the exclusion
+    any more, and the denylist can cover the whole reason-code vocabulary
+    like every other internal enum it already derives from.
+    ``status_change_service.STATUS_REASON_CODES`` is the single source of
+    truth both this denylist and the translation table derive from.
     """
 
     completion_reason_codes = frozenset(
@@ -158,7 +168,37 @@ def test_denylist_is_disjoint_from_the_completion_reason_vocabulary() -> None:
             "active_blocking_incident",
         }
     )
-    assert not (completion_reason_codes & INTERNAL_TOKEN_DENYLIST)
+    assert completion_reason_codes <= INTERNAL_TOKEN_DENYLIST
+
+
+def test_completion_truncation_detail_never_renders_a_raw_reason_code() -> None:
+    """The other half of the reversal above: with the codes now denylisted,
+    ``completion_truncation_detail`` (the one sanctioned pre-CHAOS-3377
+    renderer of this vocabulary) MUST NOT emit them raw any more, or its own
+    output would fail ``orchestrator.finish()``'s fail-closed scan.
+    """
+
+    from dev_health_ops.api.dev.answer_validator import completion_truncation_detail
+    from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+    from dev_health_ops.api.dev.contracts import DevToolResult
+
+    payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+    payload["actual_completion"] = {
+        "state": "not_ready",
+        "rule_id": "actual-completion",
+        "rule_version": "actual-completion.v4",
+        "reason_codes": ["open_blocker", "required_child_incomplete"],
+        "required_children": [],
+        "required_child_total": None,
+        "required_child_complete": None,
+        "display_truncated": False,
+        "conflicts": [],
+        "evidence_ref_ids": [],
+    }
+    detail = completion_truncation_detail((DevToolResult.model_validate(payload),))
+    assert internal_token_leak([detail]) is None
+    for raw_token in ("open_blocker", "required_child_incomplete"):
+        assert raw_token not in detail
 
 
 def test_internal_token_leak_finds_a_token_inside_a_sentence() -> None:

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -1364,6 +1364,263 @@ async def test_resolved_project_scope_is_committed_for_the_status_tool() -> None
     assert committed_scope.direct_scope.value == "project"
 
 
+def _scope_shaped_status_completion(*, direct_scope: str) -> dict:
+    """A distinct, recognizable ``actual_completion`` payload per scope kind
+    -- 'ready' for organization scope, 'not_ready' for anything else -- so a
+    test can prove WHICH of several status_snapshot.v1 results the
+    deterministic renderer actually used."""
+
+    if direct_scope == "organization":
+        return {
+            "state": "ready",
+            "rule_id": "actual-completion",
+            "rule_version": "actual-completion.v4",
+            "reason_codes": [],
+            "required_children": [],
+            "blockers": [],
+            "required_child_total": 1,
+            "required_child_complete": 1,
+            "display_truncated": False,
+            "conflicts": [],
+            # Non-empty: the verdict claim's text states the completion
+            # fraction (a number), and DevAnswer's numeric-claim check
+            # requires a metric or evidence reference on any claim
+            # containing one.
+            "evidence_ref_ids": ["ev_01"],
+        }
+    return {
+        "state": "not_ready",
+        "rule_id": "actual-completion",
+        "rule_version": "actual-completion.v4",
+        "reason_codes": ["open_blocker"],
+        "required_children": [],
+        "blockers": [
+            {
+                "fact_id": "issue:B1",
+                "text": "Open blocker for the resolved subject",
+                "status": "open",
+                "evidence_ref_ids": ["ev_01"],
+            }
+        ],
+        "required_child_total": 3,
+        "required_child_complete": 1,
+        "display_truncated": False,
+        "conflicts": [],
+        "evidence_ref_ids": ["ev_01"],
+    }
+
+
+def _multi_scope_status_registry(
+    *, resolve_scope_result: DevScopeResolution
+) -> AskDevToolRegistry:
+    """resolve_scope.v1 commits ``resolve_scope_result``; every
+    status_snapshot.v1 call gets an ``actual_completion`` shaped by ITS OWN
+    request scope, so a test can distinguish a stale (pre-commit) snapshot
+    from the current (post-commit) one purely by content.
+    """
+
+    async def execute(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        if request.tool_id is ToolID.RESOLVE_SCOPE:
+            payload["scope_resolution"] = resolve_scope_result.model_dump(mode="json")
+        elif request.tool_id is ToolID.STATUS_SNAPSHOT:
+            payload["actual_completion"] = _scope_shaped_status_completion(
+                direct_scope=request.scope.direct_scope.value
+            )
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+
+@pytest.mark.asyncio
+async def test_earlier_differently_scoped_status_snapshot_is_never_used_for_the_final_answer() -> (
+    None
+):
+    """CHAOS-3377 HIGH 1 fail->pass, full orchestrator run (codex adversarial
+    review): the model calls status_snapshot.v1 under organization scope
+    FIRST (a 'ready' verdict), then resolves to a more specific project
+    scope, then calls status_snapshot.v1 AGAIN under the newly-committed
+    scope (a 'not_ready' verdict with a real blocker). The deterministic
+    renderer must reflect ONLY the project-scoped (current) result -- the
+    stale organization-scoped 'ready' verdict must never leak into, or
+    overwrite, the final differently-scoped answer.
+    """
+
+    script_id = "multi-scope-status-snapshot"
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev project", "limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_03",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_multi_scope_status_registry(
+                resolve_scope_result=_project_resolution()
+            ),
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status.value != "refused"
+    summary = result.answer.direct_summary.casefold()
+    # Reflects the SECOND (project-scoped, not_ready) snapshot...
+    assert "not ready" in summary
+    # ...never the first (organization-scoped, ready) one.
+    assert summary.strip() != "ready: every required item is complete."
+    assert any(
+        "Open blocker for the resolved subject" in claim.text
+        for claim in result.answer.claims
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_refusal_after_status_snapshot_is_never_refused() -> None:
+    """CHAOS-3377 HIGH 2 fail->pass: a provider that emits AgentRefusal
+    AFTER a real status_snapshot.v1 result already exists for the run's
+    current resolved scope must not terminate REFUSED -- the deterministic
+    §10 verdict is rendered instead, the same as it would be for a
+    validated AgentFinalAnswer.
+    """
+
+    script_id = "status-snapshot-then-refusal"
+
+    async def status_snapshot(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "actual_completion": _scope_shaped_status_completion(
+                    direct_scope=request.scope.direct_scope.value
+                ),
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(decision=AgentRefusal(code="unsupported", message="no")),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status.value != "refused"
+    assert "not ready" in result.answer.direct_summary.casefold()
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_after_status_snapshot_renders_the_deterministic_verdict() -> (
+    None
+):
+    """CHAOS-3377 HIGH 2 fail->pass: budget exhaustion AFTER a real
+    status_snapshot.v1 result already exists for the run's current resolved
+    scope must not discard it for the generic "budget reached" boilerplate
+    ``_budget_answer`` otherwise falls back to.
+    """
+
+    script_id = "status-snapshot-then-budget"
+
+    async def status_snapshot(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "actual_completion": _scope_shaped_status_completion(
+                    direct_scope=request.scope.direct_scope.value
+                ),
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    usage=AgentUsage(estimated_cost_microusd=600_000),
+                )
+            ],
+            script_id=script_id,
+            registry=registry,
+            limits=DevRunLimits(
+                max_estimated_cost_microusd=1_500_000,
+                estimated_cost_per_call_microusd=1_000_000,
+            ),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status.value != "refused"
+    assert "not ready" in result.answer.direct_summary.casefold()
+    assert result.answer.direct_summary != (
+        "The provider budget was reached. This answer contains only the "
+        "validated data retrieved before the limit."
+    )
+    assert any(
+        "Open blocker for the resolved subject" in claim.text
+        for claim in result.answer.claims
+    )
+
+
 @pytest.mark.asyncio
 async def test_unresolved_named_entity_never_falls_back_to_organization_scope() -> None:
     """An explicit reference that resolves to nothing must never leave the

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -2503,13 +2503,22 @@ async def test_second_false_complete_claim_still_fails_closed() -> None:
 async def test_repair_exhausted_completion_ratio_claim_surfaces_truncation_detail() -> (
     None
 ):
-    """CHAOS-3297 s2 round 5 (codex MEDIUM): rejecting a fabricated
-    completion ratio must not leave the user with only a generic
-    "validation failed" if the one bounded repair pass also fails -- the
-    FAILED terminal's DevError.safe_message must still surface the reason
-    codes and how many required items were actually displayed, end to
-    end through the real orchestrator run loop (not just the validator
-    function in isolation).
+    """CHAOS-3297 s2 round 5 (codex MEDIUM) established: rejecting a
+    fabricated completion ratio must not leave the user with only a generic
+    "validation failed" if the one bounded repair pass also fails.
+
+    CHAOS-3377 supersedes the ORIGINAL outcome this test pinned (a FAILED
+    terminal whose DevError.safe_message surfaced the raw reason codes),
+    for exactly the reason that ticket exists: a run whose tool results
+    include a real ``actual_completion`` assessment now gets the §10
+    deterministic renderer, which overwrites the model's fabricated
+    status/direct_summary/claims with a server-rendered, honest verdict
+    BEFORE validation ever runs -- so the fabricated "100% complete" claim
+    here never reaches the validator at all, and the run completes with
+    truthful content instead of failing. The two things this test always
+    cared about -- (1) the user is never left with nothing, and (2) the
+    reason codes never reach them raw -- both still hold, just via the
+    better mechanism: end to end through the real orchestrator run loop.
     """
     script_id = "repair-exhausted-completion-ratio"
 
@@ -2580,15 +2589,255 @@ async def test_repair_exhausted_completion_ratio_claim_surfaces_truncation_detai
         )
     )
 
-    assert result.state is RunState.FAILED
-    assert result.error is not None
-    # DevError.code is a closed wire vocabulary (dev_error.v1); the
-    # specific "completion_denominator_withheld" classification is
-    # internal-only (AnswerValidationError.code), used to select this
-    # enriched message, not to widen the wire contract.
-    assert result.error.code == "answer_validation_failed"
-    assert "assessment_source_limit_reached" in result.error.safe_message
-    assert "1 required item" in result.error.safe_message
+    assert result.state is RunState.COMPLETED
+    assert result.error is None
+    assert result.answer is not None
+    assert result.answer.status is not AnswerStatus.REFUSED
+    # The fabricated model claim never reached the wire -- the deterministic
+    # verdict replaced it entirely.
+    assert "100% complete" not in result.answer.direct_summary
+    for claim in result.answer.claims:
+        assert "100% complete" not in claim.text
+    # The withheld-denominator disclosure obligation (CHAOS-3297 s2 round 8)
+    # still applies to the deterministic verdict, exactly as it did to a
+    # model-authored one.
+    all_text = " ".join(
+        [result.answer.direct_summary, *(claim.text for claim in result.answer.claims)]
+    )
+    assert (
+        "the required-work completion total could not be fully verified"
+        in all_text.casefold()
+    )
+    # And the raw reason code that used to leak into DevError.safe_message
+    # (pre-CHAOS-3377) must not leak into the answer either.
+    assert "assessment_source_limit_reached" not in all_text
+
+
+# --- CHAOS-3377 acceptance: the live defect, end to end ------------------
+
+
+# The PRD's literal prohibited strings for a substantive project-status
+# answer -- bound as literals here, never derived from the code under test
+# (a control that imports its own expected value from the module it is
+# checking cannot fail when that module is wrong). Mirrors
+# test_no_match_terminal.py's PRD_PROHIBITED_TOKENS convention.
+CHAOS_3377_PROHIBITED_STRINGS = (
+    "actual_completion",
+    "not_ready",
+    "open_blocker",
+    "required_child_incomplete",
+    "required_release_evidence_missing",
+    "ev1_",
+    "}}}{",
+)
+
+
+@pytest.mark.asyncio
+async def test_substantive_status_answer_is_never_refused_and_never_leaks_internal_vocabulary() -> (
+    None
+):
+    """CHAOS-3377 acceptance test, all five defects at once, end to end
+    through the real orchestrator run loop -- not the render functions in
+    isolation.
+
+    The model's own (fabricated) final answer below is deliberately built
+    to hit every one of the five reported defects at once: it self-declares
+    ``status=refused`` over a real ``actual_completion`` assessment (defect
+    1), narrates the raw internal tokens verbatim plus a couple more the
+    live defect didn't show but the same class covers (defect 2), leaks a
+    trailing JSON artifact (defect 3), and lists a 'done' required item
+    under its own fabricated 'blockers' claim while omitting the genuinely
+    open one (defect 5) -- and its ``resolved_scope`` is a PROJECT scope, so
+    a client rendering it would hit defect 4's repository-count line if it
+    doesn't special-case a non-repository scope (asserted at the DevScope
+    level here; the chip/count rendering itself is a web-side fix, tested
+    in AskDevAnswer.test.tsx).
+
+    None of that model text may reach the wire: the §10 deterministic
+    renderer overwrites status/direct_summary/claims entirely once a
+    status_snapshot result carries ``actual_completion``.
+    """
+
+    script_id = "chaos-3377-acceptance-substantive"
+
+    project_scope = deepcopy(positive_fixtures()["dev_scope_resolution.v1"])
+    project_scope["requested_scope"]["direct_scope"] = "project"
+    project_scope["requested_scope"]["repositories"] = []
+    project_scope["requested_scope"]["entity_refs"] = [
+        {
+            "entity_type": "project",
+            "entity_id": "project_falcon_nine",
+            "display_label": "Falcon Nine",
+            "repository_id": None,
+        }
+    ]
+    # The shared fixture's surface_context is repository-shaped; DevScope
+    # cross-validates it against direct_scope, so it must move with it.
+    project_scope["requested_scope"]["surface_context"] = None
+    project_scope["resolved_scope"] = deepcopy(project_scope["requested_scope"])
+    project_scope["authorized_repository_ids"] = []
+    project_scope["authorized_entity_ids"] = ["project_falcon_nine"]
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return DevScopeResolution.model_validate(project_scope)
+
+    open_evidence_id = "ev1_" + hashlib.sha256(b"open-child").hexdigest()[:40]
+    done_evidence_id = "ev1_" + hashlib.sha256(b"done-child").hexdigest()[:40]
+    verdict_evidence_id = "ev1_" + hashlib.sha256(b"verdict").hexdigest()[:40]
+
+    async def status_snapshot(_context: Any, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "scope_resolution": project_scope,
+                "metrics": [],
+                "evidence": [
+                    {
+                        **positive_fixtures()["dev_tool_result.v1"]["evidence"][0],
+                        "evidence_ref_id": eid,
+                    }
+                    for eid in (open_evidence_id, done_evidence_id, verdict_evidence_id)
+                ],
+                "actual_completion": {
+                    "state": "not_ready",
+                    "rule_id": "actual-completion",
+                    "rule_version": "actual-completion.v4",
+                    "reason_codes": ["open_blocker", "required_child_incomplete"],
+                    "required_children": [
+                        {
+                            "fact_id": "issue:OPEN-1",
+                            "text": "Wire the presentation seam",
+                            "status": "in_progress",
+                            "evidence_ref_ids": [open_evidence_id],
+                        },
+                        {
+                            "fact_id": "issue:DONE-1",
+                            "text": "Land the frame contract",
+                            "status": "completed",
+                            "evidence_ref_ids": [done_evidence_id],
+                        },
+                    ],
+                    "required_child_total": 69,
+                    "required_child_complete": 39,
+                    "display_truncated": False,
+                    "conflicts": [],
+                    "evidence_ref_ids": [verdict_evidence_id],
+                },
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+
+    fabricated_answer = _answer(script_id=script_id)
+    fabricated_answer.update(
+        {
+            "resolved_scope": project_scope,
+            "status": "refused",
+            "direct_summary": (
+                "actual_completion state is not_ready with open_blocker and "
+                "required_child_incomplete; required_release_evidence_missing "
+                "also fired. See ev1_deadbeef for detail.}}}{"
+            ),
+            "claims": [
+                {
+                    **fabricated_answer["claims"][0],
+                    "text": "Current blockers: Land the frame contract (done).",
+                    "evidence_ref_ids": [],
+                    "metric_ref_ids": [],
+                    "kind": "inferred",
+                    "confidence": 0.5,
+                    "validity_scope": project_scope["resolved_scope"],
+                }
+            ],
+            "metrics": [],
+            "evidence": [],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(fabricated_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    answer = result.answer
+
+    # Defect 1: never a "Refused" label over a substantive, assessed answer.
+    assert answer.status is not AnswerStatus.REFUSED
+
+    # Defects 2/3/5: none of the PRD-prohibited strings anywhere the client
+    # renders prose, and the model's fabricated, self-contradicting blocker
+    # claim is gone.
+    all_text = " ".join(user_visible_strings(answer=answer))
+    for forbidden in CHAOS_3377_PROHIBITED_STRINGS:
+        assert forbidden not in all_text, f"{forbidden!r} leaked into: {all_text!r}"
+    assert "done" not in " ".join(claim.text for claim in answer.claims).casefold() or (
+        "Land the frame contract" not in " ".join(claim.text for claim in answer.claims)
+    )
+    # The genuinely open item is present in some form; the completed one
+    # naming "Land the frame contract" as a blocker is not.
+    blocker_texts = " ".join(claim.text for claim in answer.claims)
+    assert "Land the frame contract" not in blocker_texts
+    assert "39" in answer.direct_summary and "69" in answer.direct_summary
+
+    # Defect 4 (scope-level half): the resolved scope is a PROJECT scope,
+    # not a repository count -- a client has the subject to render.
+    assert answer.resolved_scope.resolved_scope is not None
+    assert answer.resolved_scope.resolved_scope.direct_scope.value == "project"
+    assert answer.resolved_scope.resolved_scope.entity_refs[0].display_label == (
+        "Falcon Nine"
+    )
+
+
+@pytest.mark.asyncio
+async def test_genuine_refusal_with_no_grounding_still_completes_as_refused() -> None:
+    """Negative control (do not regress CHAOS-3367/#1449 or the CHAOS-3377
+    validator check): a run whose tool results carry NO ``actual_completion``
+    and whose model answer carries no grounding either is a genuine refusal,
+    and must still render as one end to end.
+    """
+
+    script_id = "chaos-3377-negative-control-genuine-refusal"
+    refusal_answer = _answer(script_id=script_id)
+    refusal_answer.update(
+        {
+            "status": "refused",
+            "direct_summary": "I can't help with that request.",
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [ScriptedStep(decision=AgentFinalAnswer(refusal_answer))],
+            script_id=script_id,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status is AnswerStatus.REFUSED
+    assert result.answer.direct_summary == "I can't help with that request."
 
 
 # --- CHAOS-3262: an invalid model tool request degrades, it does not kill the run ---


### PR DESCRIPTION
## Summary

Fixes CHAOS-3377 (ops half): the §10 project-status answer is server-rendered deterministically from the run's own status snapshot; model narration can no longer contradict, pollute, or erase it.

- **Deterministic §10 renderer** (`status_answer_render.py`): when the run's tool results carry a `status_snapshot.v1` with `actual_completion`, verdict/completion/blockers are rendered server-side and overwrite the model candidate's `status`/`direct_summary`/`claims` before validation. Snapshot selection is bound to the run's final authorized scope via `tool_call_id` pairing (latest authoritative match; ambiguity → no override), and the render applies at **every** terminal — final answer, `AgentRefusal`, and budget exhaustion.
- **Blockers come from the assessor, not narration**: `_assess`'s literal completion predicates are extracted into named shared functions; outstanding-work claims cover all six blocker-producing categories (required children, blockers, PRs, CI, deployments, incidents), each pinned by a sole-cause NOT_READY test. New typed `blockers` field on `DevActualCompletion` (contract artifacts regenerated).
- **Closed presentation vocabulary**: reason codes translate through a fail-closed table (`status_completion_copy.py`); the §12 denylist widens to the full status-reason vocabulary; `completion_truncation_detail` renders translated copy instead of verbatim reason codes; no claim text ever interpolates raw provider status strings.
- **JSON-tail sanitizer** (`answer_text_sanitizer.py`): stack-based bracket-validity check — strips only structurally invalid trailing runs (`}}}{`), never balanced examples ("Expected payload: {}" et al., pinned by negative controls).
- **Refusal-with-grounding is repaired, not relabeled**: a repairable validator check demotes refused-but-grounded candidates through the server-grounded seam on the write path, and `redact_persisted_answer` normalizes replayed legacy rows at read time (claims/summary discarded, metrics/evidence kept, status recomputed from coverage).
- Publishes `internal_prose_denylist.v1.json` vocabulary artifact for client-side mirroring.

Closes the last open defect set under CHAOS-3293 (Wave 3.1 corrective). Companion web PR: full-chaos/dev-health-web (renders subject for project scopes, withholds inconsistent rows, boundary-aware token guard).

## Testing

- Full `tests/api/dev/`: 1920 passed, 19 skipped, 1 xfailed, 0 failed (pre-existing red excluded: CHAOS-3376 live fixture, `test_resolver_sql_explain.py` two params).
- Two codex adversarial review rounds; every finding fail→pass verified against pre-fix code, including scope-binding, all-terminal, sole-cause-per-category, and sanitizer negative controls.
- ruff + mypy clean; contract-artifact drift test green after regeneration.
