### PR TITLE
fix/go worker feature validation baseline

### DIFF
--- a/scripts/acceptance/wave31_manifest.py
+++ b/scripts/acceptance/wave31_manifest.py
@@ -1951,7 +1951,35 @@ PROVEN_E2E_CLAIM_LIMITS = (
 #:
 #: Whether a stale row is ACCEPTABLE is a wave-close decision, not a CI
 #: one. CI's only job here is that nobody can be surprised by one.
-DECLARED_STALE_ARTIFACTS: Mapping[str, Mapping[str, str]] = {}
+# The feature-only Go worker migration added the disabled-by-default
+# WORKER_GITLAB_INCIDENTS_ENABLED Compose wiring after these 14 live scenarios
+# were recorded.  That changes the governed runtime surface without changing
+# what any scenario exercised, so acknowledge this exact compose.yml content
+# hash until the scenarios are re-minted.  The hash binding makes the next
+# Compose edit fail loudly again instead of turning this into a permanent
+# exemption.
+_GO_WORKER_FEATURE_COMPOSE_SHA256 = (
+    "0f7ea9fc8466fd413c6b6a13e6112c60afa1663dccf82845fd549a7e1f6ae765"
+)
+DECLARED_STALE_ARTIFACTS: Mapping[str, Mapping[str, str]] = {
+    item_id: {"compose.yml": _GO_WORKER_FEATURE_COMPOSE_SHA256}
+    for item_id in (
+        "defect.ask-dev-not-found.e2e-live-validated",
+        "defect.ask-dev-exact-commit.e2e-live-validated",
+        "positive-control.real-project-status",
+        "attack.unrelated-evidence.e2e-live-validated",
+        "attack.team-attribution.e2e-blocked-by-live-defect",
+        "matrix.exact-project-complete",
+        "matrix.registered-metric-catalog",
+        "matrix.multi-metric-comparison-organization-wide",
+        "matrix.remaining-work-exact-project",
+        "matrix.data-trust-organization-wide",
+        "matrix.team-health.e2e-live-validated",
+        "matrix.team-workload-balance.e2e-live-validated",
+        "matrix.operational-deficiency.e2e-live-validated",
+        "gate.plan-registry-gap-is-loud.e2e-live-validated",
+    )
+}
 
 #: A sha256 hex digest, the only shape a recorded dependency hash may take.
 _SHA256_HEX = re.compile(r"\A[0-9a-f]{64}\Z")
@@ -2471,7 +2499,7 @@ def validate_blocked_execution_artifact(root: Path, item: ManifestItem) -> list[
 
 
 def validate_manifest(
-    root: Path, items: tuple[ManifestItem, ...] = MANIFEST
+    root: Path, items: tuple[ManifestItem, ...] | None = None
 ) -> list[str]:
     """Return integrity errors. An empty list means every claim is honest.
 
@@ -2489,6 +2517,12 @@ def validate_manifest(
     artifact whose recorded content digests no longer match this tree, or citing a script whose
     bytes have changed since.
 
+    Omitting ``items`` validates the complete landed manifest and therefore
+    also rejects stale declarations whose row no longer exists. Passing an
+    explicit subset validates only declarations owned by that subset; this
+    keeps focused integrity checks composable without treating the complete
+    manifest's declarations as orphans.
+
     This function is deliberately fast and offline -- it does NOT run any
     live scenario itself, only checks artifacts scenarios already wrote and
     runs cheap local ``git`` queries. That keeps every commit's normal test
@@ -2496,17 +2530,23 @@ def validate_manifest(
     needing Docker/Compose.
     """
 
+    validate_declaration_ownership = items is None
+    items = MANIFEST if items is None else items
     errors: list[str] = []
     known_ids = {item.id for item in items}
     for declared_id, declared_paths in DECLARED_STALE_ARTIFACTS.items():
         # The declaration table is itself checked, or a typo becomes a
-        # silent no-op that reads like an acknowledged risk.
+        # silent no-op that reads like an acknowledged risk. Explicit subset
+        # validation ignores declarations for rows outside that subset; only
+        # the complete landed-manifest check owns orphan detection.
         if declared_id not in known_ids:
-            errors.append(
-                f"{declared_id}: declared stale but no manifest item has "
-                "that id -- a stale declaration for a row that does not "
-                "exist acknowledges nothing"
-            )
+            if validate_declaration_ownership:
+                errors.append(
+                    f"{declared_id}: declared stale but no manifest item has "
+                    "that id -- a stale declaration for a row that does not "
+                    "exist acknowledges nothing"
+                )
+            continue
         uncovered = sorted(set(declared_paths) - set(RUNTIME_DEPENDENCY_PATHS))
         if uncovered:
             errors.append(
@@ -2728,7 +2768,7 @@ def stale_rows(
 
 
 def build_report(
-    root: Path, items: tuple[ManifestItem, ...] = MANIFEST
+    root: Path, items: tuple[ManifestItem, ...] | None = None
 ) -> ManifestReportJSON:
     """Build the CHAOS-3300 deliverable #1 JSON report.
 
@@ -2738,7 +2778,13 @@ def build_report(
     failure mode this manifest exists to prevent.
     """
 
-    errors = validate_manifest(root, items)
+    validate_complete_manifest = items is None
+    items = MANIFEST if items is None else items
+    errors = (
+        validate_manifest(root)
+        if validate_complete_manifest
+        else validate_manifest(root, items)
+    )
     if errors:
         raise ManifestIntegrityError(
             "manifest integrity check failed:\n" + "\n".join(f"- {e}" for e in errors)

--- a/tests/acceptance/test_wave31_manifest.py
+++ b/tests/acceptance/test_wave31_manifest.py
@@ -1819,6 +1819,30 @@ def test_a_declaration_for_an_unknown_row_or_path_is_rejected(monkeypatch) -> No
     assert any("not covered dependencies" in e for e in validate_manifest(_ROOT))
 
 
+def test_full_manifest_rejects_orphan_among_valid_stale_declarations(
+    monkeypatch,
+) -> None:
+    """Subset validation may ignore declarations it does not own, but the
+    landed full-manifest gate must still catch a declaration whose row was
+    removed while leaving the other declarations valid.
+    """
+
+    declarations = dict(wave31_manifest.DECLARED_STALE_ARTIFACTS)
+    declarations["no.such.row"] = {"compose.yml": _current_hash(_ROOT, "compose.yml")}
+    monkeypatch.setattr(
+        wave31_manifest,
+        "DECLARED_STALE_ARTIFACTS",
+        declarations,
+    )
+
+    errors = validate_manifest(_ROOT)
+
+    assert any(
+        "no.such.row: declared stale but no manifest item has that id" in error
+        for error in errors
+    )
+
+
 def test_the_report_states_what_proven_e2e_does_not_assert() -> None:
     """codex finding (HIGH, 2026-08-03): nine row descriptions say a live
     run is "proven", while a hand-written artifact with correct hashes

--- a/tests/acceptance/wave31-manifest-report.v1.json
+++ b/tests/acceptance/wave31-manifest-report.v1.json
@@ -16,8 +16,51 @@
     "real_project_positive_control": 1
   },
   "proven_e2e_claim_limits": "A proven_e2e row means: a live scenario was run by an operator, its per-assertion results were recorded by the scenario itself, and the script and shared fixture surface it ran against still match this tree. It does NOT mean the validator has established that the run happened. Execution artifacts are unsigned JSON and the validator recomputes exactly the values a forger would compute, so a fabricated artifact validates clean; occurrence rests on operator-recorded evidence and on re-running scenarios, not on this check. commit_sha is metadata only -- shape-checked, never resolved, so a well-formed id naming no commit is accepted. Product code under src/ is outside the digested surface, so for product changes these rows are historical records of a past run rather than statements about the current tree.",
-  "stale_row_count": 0,
-  "stale_rows": {},
+  "stale_row_count": 14,
+  "stale_rows": {
+    "attack.team-attribution.e2e-blocked-by-live-defect": [
+      "compose.yml"
+    ],
+    "attack.unrelated-evidence.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "defect.ask-dev-exact-commit.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "defect.ask-dev-not-found.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "gate.plan-registry-gap-is-loud.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "matrix.data-trust-organization-wide": [
+      "compose.yml"
+    ],
+    "matrix.exact-project-complete": [
+      "compose.yml"
+    ],
+    "matrix.multi-metric-comparison-organization-wide": [
+      "compose.yml"
+    ],
+    "matrix.operational-deficiency.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "matrix.registered-metric-catalog": [
+      "compose.yml"
+    ],
+    "matrix.remaining-work-exact-project": [
+      "compose.yml"
+    ],
+    "matrix.team-health.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "matrix.team-workload-balance.e2e-live-validated": [
+      "compose.yml"
+    ],
+    "positive-control.real-project-status": [
+      "compose.yml"
+    ]
+  },
   "items": [
     {
       "id": "attack.missing-data",
@@ -90,7 +133,9 @@
         "metrics_empty_for_team_scope",
         "limitation_names_unavailable_metric_source"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "attack.unrelated-evidence.availability",
@@ -129,7 +174,9 @@
         "named_repository_committed",
         "unrelated_repo_excluded_from_named_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "attack.unrelated-evidence.exclusion",
@@ -200,7 +247,9 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.exact-project-complete",
@@ -220,7 +269,9 @@
         "evidence_is_linked_to_the_committed_subject",
         "answer_status_not_error"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.legitimate-org-wide-status",
@@ -288,7 +339,9 @@
         "answer_status_not_error",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.multi-metric-comparison-stale-source",
@@ -377,7 +430,9 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.organization-portfolio-status",
@@ -561,7 +616,9 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.remaining-work-exact-project",
@@ -581,7 +638,9 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.struggling-teams-insufficient-sample",
@@ -673,7 +732,9 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.team-workload-balance.e2e-live-validated",
@@ -697,7 +758,9 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "matrix.unwired-intent-safe-fallback",
@@ -798,7 +861,9 @@
         "stream_terminated_as_answer",
         "warnings_present_but_not_a_plan_registry_gap_signal"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "gate.repeated-certified-provider",
@@ -1063,7 +1128,9 @@
         "answer_status_not_error",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "defect.ask-dev-not-found",
@@ -1103,7 +1170,9 @@
         "no_answer_produced",
         "safe_message_does_not_name_subject"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     },
     {
       "id": "defect.no-org-fallback-or-blank",
@@ -1143,7 +1212,9 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml"
+      ]
     }
   ]
 }

--- a/tests/test_0066_celery_river_cutover_guard.py
+++ b/tests/test_0066_celery_river_cutover_guard.py
@@ -89,7 +89,10 @@ def test_github_unit_job_enables_real_postgres_migration_tests() -> None:
     assert coverage_step["env"][_POSTGRES_TEST_URI_ENV] == (
         "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
     )
-    assert coverage_step["env"]["PYTEST_ADDOPTS"] == unit_step["env"]["PYTEST_ADDOPTS"]
+    assert "PYTEST_ADDOPTS" not in coverage_step["env"]
+    assert coverage_step["env"]["DEV_HEALTH_TEST_POSTGRES_ADMIN_URI"] == (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
+    )
     assert "./ci/run_tests.sh ci" in coverage_step["run"]
 
     for job_name in ("test-matrix", "coverage"):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -2550,13 +2550,13 @@ def test_dispatch_sync_run_routes_only_enabled_launchdarkly_unit_to_river(
         sync_run_id=run.id,
         integration_id=launchdarkly.integration_id,
         source_id=launchdarkly.source_id,
-        provider="github",
-        dataset_key="prs",
+        provider="synthetic",
+        dataset_key="matrix-incomplete",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_prs": True},
+        processor_flags={},
     )
     run.total_units = 2
     db_session.add(celery_unit)
@@ -3083,13 +3083,13 @@ def test_dispatch_sync_run_concurrency_cap_defers_regardless_of_transport(
         sync_run_id=run.id,
         integration_id=river_unit.integration_id,
         source_id=river_unit.source_id,
-        provider="github",
-        dataset_key="prs",
+        provider="synthetic",
+        dataset_key="matrix-incomplete",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_prs": True},
+        processor_flags={},
     )
     run.total_units = 2
     db_session.add(celery_unit)
@@ -3155,13 +3155,13 @@ def test_dispatch_sync_run_reclaims_stale_units_of_both_transports_and_redecides
         sync_run_id=run.id,
         integration_id=river_unit.integration_id,
         source_id=river_unit.source_id,
-        provider="github",
-        dataset_key="prs",
+        provider="synthetic",
+        dataset_key="matrix-incomplete",
         cost_class="medium",
         mode=SyncRunMode.INCREMENTAL.value,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_prs": True},
+        processor_flags={},
     )
     stale = datetime.now(timezone.utc) - timedelta(minutes=30)
     river_unit.status = SyncRunUnitStatus.DISPATCHING.value


### PR DESCRIPTION
## Summary

- acknowledge the exact 14 Wave 31 artifacts made stale by the feature-only `WORKER_GITLAB_INCIDENTS_ENABLED` Compose change, bound to the current `compose.yml` digest
- keep full-manifest stale-declaration ownership loud while allowing intentional subset validation to remain composable
- replace real provider routes that recently became native-ready with the checked-in synthetic incomplete control in sync routing tests
- align the 0066 workflow guard with the current inline PostgreSQL migration coverage contract

## Scope

This PR targets `feat/go-worker-runtime-migration` only. It does not enable a provider route, activate migration 0066, or target `main`.

## Validation

- `bash ci/local_validate.sh`
- 11,574 Python tests passed; 98 skipped; 1 expected xfail
- Go format, vet, unit, integration-tag coverage, and live Python oracles passed
- River compatibility passed
- isolated scratch ClickHouse migration and live argMax execution passed
- mutation harness clean; ruff and mypy passed

The Wave 31 declarations are digest-bound. Any later `compose.yml` change fails loudly again until the affected evidence is re-minted.
