### PR TITLE
feat(providersync): port GitHub work-item semantics

### DIFF
--- a/internal/providersync/github_work_items_rows.go
+++ b/internal/providersync/github_work_items_rows.go
@@ -3,9 +3,13 @@ package providersync
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	"github.com/google/uuid"
@@ -135,9 +139,11 @@ type githubWorkItemRows struct {
 }
 
 type githubWorkItemUserPayload struct {
-	Email *string `json:"email"`
-	Login *string `json:"login"`
-	Name  *string `json:"name"`
+	Email   *string `json:"email"`
+	Login   *string `json:"login"`
+	Name    *string `json:"name"`
+	Type    *string `json:"type"`
+	AppSlug *string `json:"app_slug"`
 }
 
 type githubWorkItemLabelPayload struct {
@@ -157,6 +163,30 @@ type githubIssueWorkItemPayload struct {
 	User      *githubWorkItemUserPayload   `json:"user"`
 	HTMLURL   *string                      `json:"html_url"`
 	URL       *string                      `json:"url"`
+}
+
+type githubPullRequestWorkItemPayload struct {
+	githubIssueWorkItemPayload
+	Merged   bool    `json:"merged"`
+	Draft    bool    `json:"draft"`
+	MergedAt *string `json:"merged_at"`
+	Head     struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+}
+
+type githubWorkItemEventPayload struct {
+	Event     string                      `json:"event"`
+	CreatedAt *string                     `json:"created_at"`
+	Actor     *githubWorkItemUserPayload  `json:"actor"`
+	Label     *githubWorkItemLabelPayload `json:"label"`
+}
+
+type githubWorkItemCommentPayload struct {
+	ID        any                        `json:"id"`
+	Body      string                     `json:"body"`
+	CreatedAt *string                    `json:"created_at"`
+	User      *githubWorkItemUserPayload `json:"user"`
 }
 
 type githubMilestonePayload struct {
@@ -305,6 +335,755 @@ func normalizeGitHubSprint(
 	return row, nil
 }
 
+func normalizeGitHubIssueBundle(
+	claim Claim,
+	repoFullName string,
+	repoID uuid.UUID,
+	raw json.RawMessage,
+	events []json.RawMessage,
+	comments []json.RawMessage,
+	resolveIdentity githubIdentityResolver,
+	normalizedAt time.Time,
+) (githubWorkItemRows, error) {
+	item, err := normalizeGitHubIssueWorkItem(
+		claim, repoFullName, repoID, raw, resolveIdentity, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	// The base row models the no-events fallback. The active Python producer
+	// prefers the first terminal transition and uses closed_at only when no
+	// such transition exists, so recompute the two derived timestamps here.
+	item.StartedAt = nil
+	item.CompletedAt = nil
+	transitions, reopens, err := normalizeGitHubWorkItemEvents(
+		claim, item.WorkItemID, false, events, item.CreatedAt,
+		resolveIdentity, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	for _, transition := range transitions {
+		if item.StartedAt == nil && transition.ToStatus == "in_progress" {
+			started := transition.OccurredAt
+			item.StartedAt = &started
+		}
+		if item.CompletedAt == nil &&
+			(transition.ToStatus == "done" || transition.ToStatus == "canceled") {
+			completed := transition.OccurredAt
+			item.CompletedAt = &completed
+			break
+		}
+	}
+	if item.CompletedAt == nil && item.ClosedAt != nil {
+		completed := item.ClosedAt.UTC()
+		item.CompletedAt = &completed
+	}
+	interactions, err := normalizeGitHubWorkItemComments(
+		claim, item.WorkItemID, comments, resolveIdentity, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	var issue githubIssueWorkItemPayload
+	if json.Unmarshal(raw, &issue) != nil {
+		return githubWorkItemRows{}, providerfoundation.ErrNormalizationInvalid
+	}
+	body := ""
+	if issue.Body != nil {
+		body = *issue.Body
+	}
+	dependencies, err := extractGitHubWorkItemDependencies(
+		claim, item.WorkItemID, repoFullName, body, "", comments, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	return githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{item}, StatusTransitions: transitions,
+		Dependencies: dependencies, ReopenEvents: reopens, Interactions: interactions,
+		Sprints: []githubSprintRow{}, AIAttributions: []githubAIAttributionRow{},
+	}, nil
+}
+
+func normalizeGitHubPullRequestBundle(
+	claim Claim,
+	repoFullName string,
+	repoID uuid.UUID,
+	raw json.RawMessage,
+	events []json.RawMessage,
+	comments []json.RawMessage,
+	resolveIdentity githubIdentityResolver,
+	normalizedAt time.Time,
+) (githubWorkItemRows, error) {
+	if claim.Validate() != nil || claim.Provider != "github" ||
+		!isWorkItemFamilyDataset(claim.Dataset) || strings.TrimSpace(repoFullName) == "" ||
+		repoID == uuid.Nil || normalizedAt.IsZero() {
+		return githubWorkItemRows{}, ErrInvalidConfiguration
+	}
+	var pull githubPullRequestWorkItemPayload
+	if json.Unmarshal(raw, &pull) != nil || pull.Number < 1 || strings.TrimSpace(pull.Title) == "" {
+		return githubWorkItemRows{}, providerfoundation.ErrNormalizationInvalid
+	}
+	createdAt := parseGitHubWorkItemTime(pull.CreatedAt)
+	if createdAt == nil {
+		fallback := normalizedAt.UTC()
+		createdAt = &fallback
+	}
+	updatedAt := parseGitHubWorkItemTime(pull.UpdatedAt)
+	if updatedAt == nil {
+		copy := *createdAt
+		updatedAt = &copy
+	}
+	closedAt := parseGitHubWorkItemTime(pull.ClosedAt)
+	mergedAt := parseGitHubWorkItemTime(pull.MergedAt)
+	labels := make([]string, 0, len(pull.Labels))
+	for _, label := range pull.Labels {
+		if label.Name != "" {
+			labels = append(labels, label.Name)
+		}
+	}
+	state := ""
+	if pull.State != nil {
+		state = *pull.State
+	}
+	statusRaw := state
+	status := githubIssueStatus(state, labels)
+	switch {
+	case pull.Merged || mergedAt != nil:
+		statusRaw, status = "merged", "done"
+	case state == "closed":
+		statusRaw, status = "closed", "canceled"
+	case state == "open" && pull.Draft:
+		statusRaw, status = "open", "todo"
+	case state == "open":
+		statusRaw, status = "open", "in_progress"
+	}
+	assignees := make([]string, 0, len(pull.Assignees))
+	for _, assignee := range pull.Assignees {
+		identity := resolveGitHubWorkItemIdentity(assignee, resolveIdentity)
+		if identity != "" && identity != "unknown" {
+			assignees = append(assignees, identity)
+		}
+	}
+	var reporter *string
+	if pull.User != nil {
+		identity := resolveGitHubWorkItemIdentity(*pull.User, resolveIdentity)
+		if identity != "" && identity != "unknown" {
+			reporter = &identity
+		}
+	}
+	description := pull.Body
+	if description != nil && *description == "" {
+		description = nil
+	}
+	urlValue := pull.HTMLURL
+	if urlValue == nil || *urlValue == "" {
+		urlValue = pull.URL
+	}
+	projectID := repoFullName
+	priority, serviceClass := githubPriorityFromLabels(labels)
+	startedAt := createdAt.UTC()
+	item := githubWorkItemRow{
+		WorkItemID: "ghpr:" + repoFullName + "#" + strconv.Itoa(pull.Number),
+		Provider:   "github", Title: pull.Title, Type: "pr", Status: status,
+		StatusRaw: nullableString(statusRaw), Description: description, RepoID: &repoID,
+		ProjectID: &projectID, Assignees: assignees, Reporter: reporter,
+		CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC(), StartedAt: &startedAt,
+		ClosedAt: closedAt, Labels: labels, URL: urlValue,
+		PriorityRaw: priority, ServiceClass: serviceClass, OrgID: claim.OrgID,
+	}
+	if mergedAt != nil {
+		completed := mergedAt.UTC()
+		item.CompletedAt = &completed
+	} else if closedAt != nil && (status == "done" || status == "canceled") {
+		completed := closedAt.UTC()
+		item.CompletedAt = &completed
+	}
+	if err := item.validate(claim); err != nil {
+		return githubWorkItemRows{}, err
+	}
+	transitions, reopens, err := normalizeGitHubWorkItemEvents(
+		claim, item.WorkItemID, true, events, item.CreatedAt,
+		resolveIdentity, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	interactions, err := normalizeGitHubWorkItemComments(
+		claim, item.WorkItemID, comments, resolveIdentity, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	body := ""
+	if pull.Body != nil {
+		body = *pull.Body
+	}
+	dependencies, err := extractGitHubWorkItemDependencies(
+		claim, item.WorkItemID, repoFullName, body, pull.Head.Ref, comments, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	attributions, err := detectGitHubPullRequestAttributions(
+		claim, repoID, pull, normalizedAt,
+	)
+	if err != nil {
+		return githubWorkItemRows{}, err
+	}
+	return githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{item}, StatusTransitions: transitions,
+		Dependencies: dependencies, ReopenEvents: reopens, Interactions: interactions,
+		Sprints: []githubSprintRow{}, AIAttributions: attributions,
+	}, nil
+}
+
+func normalizeGitHubWorkItemEvents(
+	claim Claim,
+	workItemID string,
+	pullRequest bool,
+	rawEvents []json.RawMessage,
+	createdAt time.Time,
+	resolveIdentity githubIdentityResolver,
+	normalizedAt time.Time,
+) ([]githubWorkItemTransitionRow, []githubWorkItemReopenRow, error) {
+	type eventWithIndex struct {
+		payload githubWorkItemEventPayload
+		index   int
+	}
+	events := make([]eventWithIndex, 0, len(rawEvents))
+	for index, raw := range rawEvents {
+		var event githubWorkItemEventPayload
+		if json.Unmarshal(raw, &event) != nil {
+			return nil, nil, providerfoundation.ErrNormalizationInvalid
+		}
+		events = append(events, eventWithIndex{payload: event, index: index})
+	}
+	sort.SliceStable(events, func(left, right int) bool {
+		leftAt := parseGitHubWorkItemTime(events[left].payload.CreatedAt)
+		rightAt := parseGitHubWorkItemTime(events[right].payload.CreatedAt)
+		switch {
+		case leftAt == nil && rightAt == nil:
+			return events[left].index < events[right].index
+		case leftAt == nil:
+			return true
+		case rightAt == nil:
+			return false
+		default:
+			return leftAt.Before(*rightAt)
+		}
+	})
+	previous := "unknown"
+	if pullRequest {
+		previous = "in_progress"
+	}
+	mergedInHistory := false
+	transitions := make([]githubWorkItemTransitionRow, 0, len(events))
+	reopens := make([]githubWorkItemReopenRow, 0)
+	for _, wrapped := range events {
+		event := wrapped.payload
+		eventType := strings.ToLower(strings.TrimSpace(event.Event))
+		occurredAt := parseGitHubWorkItemTime(event.CreatedAt)
+		transitionAt := createdAt.UTC()
+		if occurredAt != nil {
+			transitionAt = occurredAt.UTC()
+		}
+		toStatus, toRaw := "", ""
+		if pullRequest {
+			switch eventType {
+			case "merged":
+				mergedInHistory, toStatus, toRaw = true, "done", "merged"
+			case "closed":
+				toStatus, toRaw = "canceled", "closed"
+				if mergedInHistory {
+					toStatus = "done"
+				}
+			case "reopened":
+				toStatus, toRaw = "in_progress", "reopened"
+			}
+		} else {
+			switch eventType {
+			case "closed":
+				toStatus, toRaw = "done", "closed"
+			case "reopened":
+				toStatus, toRaw = "todo", "reopened"
+			case "labeled":
+				if event.Label != nil {
+					mapped := githubIssueStatus("", []string{event.Label.Name})
+					if mapped != "unknown" {
+						toStatus, toRaw = mapped, event.Label.Name
+					}
+				}
+			}
+		}
+		if toStatus != "" {
+			transition := githubWorkItemTransitionRow{
+				WorkItemID: workItemID, Provider: "github", OccurredAt: transitionAt,
+				ToStatusRaw: nullableString(toRaw), FromStatus: previous,
+				ToStatus: toStatus, OrgID: claim.OrgID,
+			}
+			if err := transition.validate(claim); err != nil {
+				return nil, nil, err
+			}
+			transitions = append(transitions, transition)
+			previous = toStatus
+		}
+		if eventType != "reopened" || occurredAt == nil {
+			continue
+		}
+		var actor *string
+		if event.Actor != nil {
+			identity := resolveGitHubWorkItemIdentity(*event.Actor, resolveIdentity)
+			if identity != "" && identity != "unknown" {
+				actor = &identity
+			}
+		}
+		reopen := githubWorkItemReopenRow{
+			WorkItemID: workItemID, OccurredAt: occurredAt.UTC(), FromStatus: "done",
+			ToStatus: "todo", FromStatusRaw: stringPointer("closed"),
+			ToStatusRaw: stringPointer("reopened"), Actor: actor,
+			LastSynced: normalizedAt.UTC(), OrgID: claim.OrgID,
+		}
+		if err := reopen.validate(claim); err != nil {
+			return nil, nil, err
+		}
+		reopens = append(reopens, reopen)
+	}
+	return transitions, reopens, nil
+}
+
+func normalizeGitHubWorkItemComments(
+	claim Claim,
+	workItemID string,
+	rawComments []json.RawMessage,
+	resolveIdentity githubIdentityResolver,
+	normalizedAt time.Time,
+) ([]githubWorkItemInteractionRow, error) {
+	rows := make([]githubWorkItemInteractionRow, 0, len(rawComments))
+	for _, raw := range rawComments {
+		var comment githubWorkItemCommentPayload
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		if decoder.Decode(&comment) != nil {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		id := stringValue(comment.ID)
+		occurredAt := parseGitHubWorkItemTime(comment.CreatedAt)
+		if id == "" || id == "0" || occurredAt == nil {
+			continue
+		}
+		var actor *string
+		if comment.User != nil {
+			identity := resolveGitHubWorkItemIdentity(*comment.User, resolveIdentity)
+			if identity != "" && identity != "unknown" {
+				actor = &identity
+			}
+		}
+		row := githubWorkItemInteractionRow{
+			WorkItemID: workItemID, Provider: "github", InteractionType: "comment",
+			OccurredAt: occurredAt.UTC(), Actor: actor,
+			BodyLength: utf8.RuneCountInString(comment.Body),
+			LastSynced: normalizedAt.UTC(), OrgID: claim.OrgID,
+		}
+		if err := row.validate(claim); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+var (
+	githubIssueReferencePattern = regexp.MustCompile(
+		`(?im)(?:^|[\t ])(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves)\s*:?\s*(?:#([0-9]+)|(?:(?:https?://)?github\.com/)?([a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+)#([0-9]+))`,
+	)
+	githubExternalBodyPattern = regexp.MustCompile(
+		`(?i)(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|part\s+of|see)\s*:?\s*([A-Za-z]{2,}-[0-9]+)\b`,
+	)
+	githubExternalBranchPattern = regexp.MustCompile(`(?i)([A-Za-z]{2,}-[0-9]+)`)
+	githubLinearCommentPattern  = regexp.MustCompile(
+		`(?i)linear\.app/[^/\s]+/issue/([A-Za-z][A-Za-z0-9]+-[0-9]+)`,
+	)
+)
+
+func extractGitHubWorkItemDependencies(
+	claim Claim,
+	workItemID string,
+	repoFullName string,
+	body string,
+	branch string,
+	rawComments []json.RawMessage,
+	normalizedAt time.Time,
+) ([]githubWorkItemDependencyRow, error) {
+	rows := make([]githubWorkItemDependencyRow, 0)
+	appendRow := func(source, target, relationship, raw string) error {
+		row := githubWorkItemDependencyRow{
+			SourceWorkItemID: source, TargetWorkItemID: target,
+			RelationshipType: relationship, RelationshipTypeRaw: raw,
+			RelationshipSemanticsVersion: "canonical-blocks.v2",
+			LastSynced:                   normalizedAt.UTC(), OrgID: claim.OrgID,
+		}
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+		rows = append(rows, row)
+		return nil
+	}
+	for _, match := range githubIssueReferencePattern.FindAllStringSubmatch(body, -1) {
+		keyword := strings.ToLower(strings.TrimSpace(match[1]))
+		targetID := ""
+		if match[2] != "" {
+			targetID = "gh:" + repoFullName + "#" + match[2]
+		} else if match[3] != "" && match[4] != "" {
+			targetID = "gh:" + match[3] + "#" + match[4]
+		}
+		if targetID == "" {
+			continue
+		}
+		relationship, reverse := "relates_to", false
+		switch keyword {
+		case "depends on", "blocked by":
+			relationship, reverse = "blocks", true
+		case "blocks":
+			relationship = "blocks"
+		}
+		source, target := workItemID, targetID
+		if reverse {
+			source, target = targetID, workItemID
+		}
+		if err := appendRow(source, target, relationship, strings.ToLower(strings.TrimSpace(match[0]))); err != nil {
+			return nil, err
+		}
+	}
+	seenExternal := map[string]struct{}{}
+	appendExternal := func(key, relationship, raw string) error {
+		key = strings.ToUpper(strings.TrimSpace(key))
+		if key == "" {
+			return nil
+		}
+		if _, exists := seenExternal[key]; exists {
+			return nil
+		}
+		seenExternal[key] = struct{}{}
+		return appendRow(workItemID, "extkey:"+key, relationship, raw)
+	}
+	for _, match := range githubExternalBodyPattern.FindAllStringSubmatch(body, -1) {
+		if err := appendExternal(match[2], githubExternalRelationship(match[1]), "external_issue_key"); err != nil {
+			return nil, err
+		}
+	}
+	for _, match := range githubExternalBranchPattern.FindAllStringSubmatch(branch, -1) {
+		if err := appendExternal(match[1], "external_issue_key", "external_issue_key"); err != nil {
+			return nil, err
+		}
+	}
+	trustedBots := githubLinearLinkbackBots()
+	type commentRelationship struct{ relationship, raw string }
+	best := map[string]commentRelationship{}
+	rank := map[string]int{"blocked_by": 3, "blocks": 2, "relates_to": 1}
+	for _, raw := range rawComments {
+		var comment githubWorkItemCommentPayload
+		if json.Unmarshal(raw, &comment) != nil {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		login := ""
+		if comment.User != nil && comment.User.Login != nil {
+			login = strings.ToLower(strings.TrimSpace(*comment.User.Login))
+		}
+		if comment.Body == "" {
+			continue
+		}
+		if _, trusted := trustedBots[login]; !trusted {
+			continue
+		}
+		for _, indexes := range githubLinearCommentPattern.FindAllStringSubmatchIndex(comment.Body, -1) {
+			key := strings.ToUpper(comment.Body[indexes[2]:indexes[3]])
+			start := indexes[0] - 40
+			if start < 0 {
+				start = 0
+			}
+			preceding := strings.ToLower(comment.Body[start:indexes[0]])
+			relationship := "relates_to"
+			if strings.Contains(preceding, "blocked by") || strings.Contains(preceding, "depends on") {
+				relationship = "blocked_by"
+			} else if strings.Contains(preceding, "blocks") {
+				relationship = "blocks"
+			}
+			current, exists := best[key]
+			if !exists || rank[relationship] > rank[current.relationship] {
+				best[key] = commentRelationship{relationship: relationship, raw: "github_comment_linear_url"}
+			}
+		}
+	}
+	commentKeys := make([]string, 0, len(best))
+	for key := range best {
+		commentKeys = append(commentKeys, key)
+	}
+	// Python preserves insertion order. Sorting is the deterministic equivalent
+	// for provider payloads whose comment ordering can otherwise vary by page.
+	sort.Strings(commentKeys)
+	for _, key := range commentKeys {
+		value := best[key]
+		if err := appendExternal(key, value.relationship, value.raw); err != nil {
+			return nil, err
+		}
+	}
+	return rows, nil
+}
+
+func githubExternalRelationship(keyword string) string {
+	switch strings.ToLower(strings.TrimSpace(keyword)) {
+	case "blocks":
+		return "blocks"
+	case "blocked by", "depends on":
+		return "blocked_by"
+	default:
+		return "relates_to"
+	}
+}
+
+func githubLinearLinkbackBots() map[string]struct{} {
+	configured := os.Getenv("GITHUB_LINEAR_LINKBACK_BOTS")
+	if configured == "" {
+		configured = "linear[bot]"
+	}
+	result := map[string]struct{}{}
+	for _, value := range strings.Split(configured, ",") {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			result[value] = struct{}{}
+		}
+	}
+	return result
+}
+
+type githubAIAttributionSignal struct {
+	Kind       string
+	Source     string
+	Confidence float64
+	Actor      *string
+	Evidence   map[string]any
+}
+
+type githubAIPattern struct {
+	pattern *regexp.Regexp
+	raw     string
+	kind    string
+	actor   string
+}
+
+var githubAIBranchPatterns = []githubAIPattern{
+	newGitHubAIPattern(`(?:^|[-/])copilot(?:[-/]|$)`, "ai_assisted", "copilot"),
+	newGitHubAIPattern(`(?:^|[-/])claude(?:[-/]|$)`, "ai_assisted", "claude"),
+	newGitHubAIPattern(`(?:^|[-/])cursor(?:[-/]|$)`, "ai_assisted", "cursor"),
+	newGitHubAIPattern(`(?:^|[-/])codex(?:[-/]|$)`, "ai_assisted", "codex"),
+	newGitHubAIPattern(`(?:^|[-/])windsurf(?:[-/]|$)`, "ai_assisted", "windsurf"),
+	newGitHubAIPattern(`(?:^|[-/])devin(?:[-/]|$)`, "agent_created", "devin"),
+	newGitHubAIPattern(`(?:^|[-/])agent(?:[-/]|$)`, "agent_created", "agent"),
+	newGitHubAIPattern(`(?:^|[-/])ai(?:[-/]|$)`, "ai_assisted", "ai"),
+}
+
+var githubAIBodyPatterns = []githubAIPattern{
+	newGitHubAIPattern(`\b(?:generated|created|authored|written)\s+(?:by|with|using)\s+(?:copilot|claude|codex|cursor|windsurf|ai|an\s+ai)\b`, "ai_assisted", ""),
+	newGitHubAIPattern(`\bai[\s-]assisted\b`, "ai_assisted", ""),
+	newGitHubAIPattern(`\bagent[\s-]created\b`, "agent_created", ""),
+	newGitHubAIPattern(`\bcopilot\b`, "ai_assisted", "copilot"),
+	newGitHubAIPattern(`\bclaude\b`, "ai_assisted", "claude"),
+	newGitHubAIPattern(`\bcodex\b`, "ai_assisted", "codex"),
+	newGitHubAIPattern(`\bcursor\b`, "ai_assisted", "cursor"),
+}
+
+func newGitHubAIPattern(pattern, kind, actor string) githubAIPattern {
+	return githubAIPattern{pattern: regexp.MustCompile(`(?i)` + pattern), raw: pattern, kind: kind, actor: actor}
+}
+
+func detectGitHubPullRequestAttributions(
+	claim Claim,
+	repoID uuid.UUID,
+	pull githubPullRequestWorkItemPayload,
+	normalizedAt time.Time,
+) ([]githubAIAttributionRow, error) {
+	signals := make([]githubAIAttributionSignal, 0)
+	labelKinds := map[string]string{
+		"ai-assisted": "ai_assisted", "agent-created": "agent_created",
+		"ai-review": "ai_review", "copilot": "ai_assisted",
+		"claude-code": "ai_assisted", "codex": "ai_assisted",
+		"cursor": "ai_assisted", "windsurf": "ai_assisted",
+	}
+	for _, label := range pull.Labels {
+		normalized := strings.ToLower(strings.TrimSpace(label.Name))
+		if kind, ok := labelKinds[normalized]; ok {
+			signals = append(signals, githubAIAttributionSignal{
+				Kind: kind, Source: "pr_label", Confidence: 0.95,
+				Evidence: map[string]any{"label": label.Name},
+			})
+		}
+	}
+	if pull.User != nil {
+		login, userType, appSlug := "", "", ""
+		if pull.User.Login != nil {
+			login = *pull.User.Login
+		}
+		if pull.User.Type != nil {
+			userType = *pull.User.Type
+		}
+		if pull.User.AppSlug != nil {
+			appSlug = *pull.User.AppSlug
+		}
+		if signal := detectGitHubAIAuthor(login, userType, appSlug); signal != nil {
+			signals = append(signals, *signal)
+		}
+	}
+	body := ""
+	if pull.Body != nil {
+		body = *pull.Body
+	}
+	trailerFired := false
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		colon := strings.Index(line, ":")
+		if colon <= 0 {
+			continue
+		}
+		key, value := strings.ToLower(strings.TrimSpace(line[:colon])), strings.TrimSpace(line[colon+1:])
+		if key == "ai-assisted-by" || key == "generated-by" || key == "x-ai-generated" {
+			actor := nullableString(value)
+			signals = append(signals, githubAIAttributionSignal{
+				Kind: "ai_assisted", Source: "commit_trailer", Confidence: 0.85,
+				Actor: actor, Evidence: map[string]any{
+					"trailer_key": strings.TrimSpace(line[:colon]), "trailer_value": value,
+				},
+			})
+			trailerFired = true
+			continue
+		}
+		if key == "co-authored-by" && githubAICoauthorPattern.MatchString(value) {
+			actor := nullableString(value)
+			signals = append(signals, githubAIAttributionSignal{
+				Kind: "ai_assisted", Source: "commit_trailer", Confidence: 0.80,
+				Actor: actor, Evidence: map[string]any{
+					"trailer_key": "Co-authored-by", "trailer_value": value,
+				},
+			})
+			trailerFired = true
+		}
+	}
+	if signal := detectGitHubAITextPattern(pull.Head.Ref, githubAIBranchPatterns, "branch_name", 0.35, "branch"); signal != nil {
+		signals = append(signals, *signal)
+	}
+	if !trailerFired {
+		if signal := detectGitHubAITextPattern(body, githubAIBodyPatterns, "pr_body", 0.25, "matched_text"); signal != nil {
+			signals = append(signals, *signal)
+		}
+	}
+	if len(signals) == 0 {
+		return []githubAIAttributionRow{}, nil
+	}
+	orgID, err := uuid.Parse(claim.OrgID)
+	if err != nil {
+		return nil, providerfoundation.ErrInvalidScope
+	}
+	observedAt := parseGitHubWorkItemTime(pull.CreatedAt)
+	if observedAt == nil {
+		fallback := normalizedAt.UTC()
+		observedAt = &fallback
+	}
+	rows := make([]githubAIAttributionRow, 0, len(signals))
+	for index, signal := range signals {
+		evidence, marshalErr := json.Marshal(signal.Evidence)
+		if marshalErr != nil {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		subjectID := strconv.Itoa(pull.Number)
+		identity := strings.Join([]string{
+			claim.OrgID, repoID.String(), subjectID, signal.Source,
+			strconv.Itoa(index), string(evidence),
+		}, "|")
+		row := githubAIAttributionRow{
+			RecordID: uuid.NewSHA1(uuid.NameSpaceURL, []byte(identity)),
+			OrgID:    orgID, Provider: "github", SubjectType: "pull_request",
+			SubjectID: subjectID, RepoID: &repoID, Kind: signal.Kind,
+			Source: signal.Source, Confidence: signal.Confidence, Actor: signal.Actor,
+			Evidence: signal.Evidence, ObservedAt: observedAt.UTC(),
+			IngestedAt: normalizedAt.UTC(),
+		}
+		if err := row.validate(claim); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+var githubAICoauthorPattern = regexp.MustCompile(
+	`(?i)(copilot@github\.com|noreply\+copilot@github\.com|claude.*@anthropic\.com|<[\w.+-]*copilot[\w.+-]*@|<[\w.+-]*claude[\w.+-]*@|cursor-agent|chatgpt-codex|sweep-ai|devin@)`,
+)
+
+func detectGitHubAIAuthor(login, userType, appSlug string) *githubAIAttributionSignal {
+	lower := strings.ToLower(strings.TrimSpace(login))
+	ciBots := map[string]bool{
+		"github-actions[bot]": true, "dependabot[bot]": true, "renovate[bot]": true,
+	}
+	if ciBots[lower] {
+		return nil
+	}
+	known := map[string]bool{
+		"copilot[bot]": true, "claude-code[bot]": true, "cursor-agent[bot]": true,
+		"chatgpt-codex[bot]": true, "sweep-ai[bot]": true,
+		"coderabbit[bot]": true, "devin[bot]": true,
+	}
+	confidence := 0.0
+	knownBot := false
+	if known[lower] {
+		confidence, knownBot = 0.90, true
+	} else if strings.EqualFold(userType, "bot") && strings.HasSuffix(lower, "[bot]") {
+		confidence = 0.55
+	}
+	if confidence == 0 {
+		return nil
+	}
+	actor := login
+	return &githubAIAttributionSignal{
+		Kind: "agent_created", Source: "bot_author", Confidence: confidence,
+		Actor: &actor, Evidence: map[string]any{
+			"login": login, "user_type": nullableString(userType),
+			"app_slug": nullableString(appSlug), "known_ai_bot": knownBot,
+		},
+	}
+}
+
+func detectGitHubAITextPattern(
+	value string,
+	patterns []githubAIPattern,
+	source string,
+	confidence float64,
+	textKey string,
+) *githubAIAttributionSignal {
+	for _, candidate := range patterns {
+		indexes := candidate.pattern.FindStringIndex(value)
+		if indexes == nil {
+			continue
+		}
+		var actor *string
+		if candidate.actor != "" {
+			actorValue := candidate.actor
+			actor = &actorValue
+		}
+		evidence := map[string]any{"matched_pattern": candidate.raw}
+		if source == "branch_name" {
+			evidence["branch"] = value
+		} else {
+			evidence[textKey] = value[indexes[0]:indexes[1]]
+		}
+		return &githubAIAttributionSignal{
+			Kind: candidate.kind, Source: source, Confidence: confidence,
+			Actor: actor, Evidence: evidence,
+		}
+	}
+	return nil
+}
+
 func isWorkItemFamilyDataset(dataset string) bool {
 	switch dataset {
 	case "work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments":
@@ -437,6 +1216,54 @@ func (row githubSprintRow) validate(claim Claim) error {
 	if row.Provider != "github" || row.OrgID == "" || row.OrgID != claim.OrgID ||
 		row.SprintID == "" || row.Name == nil || row.State == nil ||
 		row.StartedAt == nil || row.StartedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func (row githubWorkItemTransitionRow) validate(claim Claim) error {
+	if row.WorkItemID == "" || row.Provider != "github" || row.OccurredAt.IsZero() ||
+		row.FromStatus == "" || row.ToStatus == "" || row.OrgID == "" || row.OrgID != claim.OrgID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func (row githubWorkItemDependencyRow) validate(claim Claim) error {
+	if row.SourceWorkItemID == "" || row.TargetWorkItemID == "" ||
+		row.RelationshipType == "" || row.RelationshipTypeRaw == "" ||
+		row.RelationshipSemanticsVersion != "canonical-blocks.v2" ||
+		row.LastSynced.IsZero() || row.OrgID == "" || row.OrgID != claim.OrgID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func (row githubWorkItemReopenRow) validate(claim Claim) error {
+	if row.WorkItemID == "" || row.OccurredAt.IsZero() || row.FromStatus == "" ||
+		row.ToStatus == "" || row.LastSynced.IsZero() ||
+		row.OrgID == "" || row.OrgID != claim.OrgID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func (row githubWorkItemInteractionRow) validate(claim Claim) error {
+	if row.WorkItemID == "" || row.Provider != "github" ||
+		row.InteractionType != "comment" || row.OccurredAt.IsZero() ||
+		row.BodyLength < 0 || row.LastSynced.IsZero() ||
+		row.OrgID == "" || row.OrgID != claim.OrgID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func (row githubAIAttributionRow) validate(claim Claim) error {
+	if row.RecordID == uuid.Nil || row.OrgID == uuid.Nil || row.OrgID.String() != claim.OrgID ||
+		row.Provider != "github" || row.SubjectType != "pull_request" || row.SubjectID == "" ||
+		row.RepoID == nil || *row.RepoID == uuid.Nil || row.Kind == "" || row.Source == "" ||
+		row.Confidence < 0 || row.Confidence > 1 || row.Evidence == nil ||
+		row.ObservedAt.IsZero() || row.IngestedAt.IsZero() {
 		return providerfoundation.ErrInvalidScope
 	}
 	return nil

--- a/internal/providersync/github_work_items_semantic_oracle_test.go
+++ b/internal/providersync/github_work_items_semantic_oracle_test.go
@@ -1,0 +1,337 @@
+package providersync
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestGitHubPullRequestWorkItemMatchesLivePythonProductionRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/pr",
+		[]oracleCase{{
+			ID: "merged_priority_pr",
+			Input: githubPullRequestSemanticOracleInput(map[string]any{
+				"number": 17, "title": "Repair delivery path",
+				"body": "Routine repair", "state": "closed", "merged": true,
+				"created_at": "2026-08-01T08:00:00.123456Z",
+				"updated_at": "2026-08-03T09:30:00.654321Z",
+				"closed_at":  "2026-08-03T09:30:00Z",
+				"merged_at":  "2026-08-03T09:29:00Z",
+				"labels":     []any{map[string]any{"name": "p1"}},
+				"assignees":  []any{map[string]any{"login": "reviewer"}},
+				"user":       map[string]any{"login": "author"},
+				"head":       map[string]any{"ref": "feature/repair"},
+				"html_url":   "https://github.com/acme/api/pull/17",
+			}, []any{}),
+		}},
+		buildGitHubPullRequestWorkItemOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemStatusTransitionMatchesLivePythonProductionRow(t *testing.T) {
+	events := []any{
+		map[string]any{"event": "reopened", "created_at": "2026-08-02T09:00:00Z"},
+		map[string]any{"event": "merged", "created_at": "2026-08-03T09:29:00Z"},
+	}
+	input := githubPullRequestSemanticOracleInput(map[string]any{
+		"number": 17, "title": "Repair delivery path", "body": "Routine repair",
+		"state": "closed", "merged": true,
+		"created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z",
+		"closed_at":  "2026-08-03T09:30:00Z",
+		"merged_at":  "2026-08-03T09:29:00Z",
+		"labels":     []any{}, "assignees": []any{},
+		"user": map[string]any{"login": "author"},
+		"head": map[string]any{"ref": "feature/repair"},
+	}, events)
+	input["transition_index"] = 1
+	issueInput := githubIssueSemanticOracleInput(map[string]any{
+		"number": 42, "title": "Repair delivery path", "state": "open",
+		"created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z",
+		"labels":     []any{}, "assignees": []any{},
+	}, []any{map[string]any{
+		"event": "labeled", "created_at": "2026-08-02T09:00:00Z",
+		"label": map[string]any{"name": "doing"},
+	}}, nil)
+	issueInput["transition_index"] = 0
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/status-transition",
+		[]oracleCase{
+			{ID: "merged_after_reopen", Input: input},
+			{ID: "issue_labeled_in_progress", Input: issueInput},
+		},
+		buildGitHubStatusTransitionOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemReopenMatchesLivePythonProductionRow(t *testing.T) {
+	input := githubIssueSemanticOracleInput(
+		map[string]any{
+			"number": 42, "title": "Repair delivery path", "state": "open",
+			"created_at": "2026-08-01T08:00:00Z",
+			"updated_at": "2026-08-03T09:30:00Z",
+			"labels":     []any{}, "assignees": []any{},
+		},
+		[]any{map[string]any{
+			"event": "reopened", "created_at": "2026-08-03T08:00:00Z",
+			"actor": map[string]any{"login": "maintainer"},
+		}}, nil,
+	)
+	input["work_item_id"] = "gh:acme/api#42"
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/reopen",
+		[]oracleCase{{ID: "reopened_by_maintainer", Input: input}},
+		buildGitHubReopenOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemInteractionMatchesLivePythonProductionRow(t *testing.T) {
+	comment := map[string]any{
+		"id": 99, "body": "Looks good 👋",
+		"created_at": "2026-08-03T08:30:00Z",
+		"user":       map[string]any{"login": "reviewer"},
+	}
+	input := githubIssueSemanticOracleInput(
+		map[string]any{
+			"number": 42, "title": "Repair delivery path", "state": "open",
+			"created_at": "2026-08-01T08:00:00Z",
+			"updated_at": "2026-08-03T09:30:00Z",
+			"labels":     []any{}, "assignees": []any{},
+		}, nil, []any{comment},
+	)
+	input["work_item_id"] = "gh:acme/api#42"
+	input["raw_comment"] = comment
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/interaction",
+		[]oracleCase{{ID: "unicode_comment", Input: input}},
+		buildGitHubInteractionOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemDependencyMatchesLivePythonProductionRows(t *testing.T) {
+	bodyInput := githubIssueSemanticOracleInput(
+		map[string]any{
+			"number": 42, "title": "Repair delivery path",
+			"body": "Blocked by #7", "state": "open",
+			"created_at": "2026-08-01T08:00:00Z",
+			"updated_at": "2026-08-03T09:30:00Z",
+			"labels":     []any{}, "assignees": []any{},
+		}, nil, nil,
+	)
+	bodyInput["producer"] = "body"
+	bodyInput["work_item_id"] = "gh:acme/api#42"
+	comment := map[string]any{
+		"id":         101,
+		"body":       "Blocked by https://linear.app/fullchaos/issue/CHAOS-99/task",
+		"created_at": "2026-08-03T08:00:00Z",
+		"user":       map[string]any{"login": "linear[bot]"},
+	}
+	commentInput := githubPullRequestSemanticOracleInput(map[string]any{
+		"number": 17, "title": "Repair delivery path", "body": "Routine repair",
+		"state": "open", "created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z",
+		"labels":     []any{}, "assignees": []any{},
+		"user": map[string]any{"login": "author"},
+		"head": map[string]any{"ref": "feature/repair"},
+	}, nil)
+	commentInput["producer"] = "comment"
+	commentInput["work_item_id"] = "ghpr:acme/api#17"
+	commentInput["raw_comments"] = []any{comment}
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/dependency",
+		[]oracleCase{
+			{ID: "body_reverse_blocker", Input: bodyInput},
+			{ID: "trusted_linear_comment", Input: commentInput},
+		},
+		buildGitHubDependencyOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubAIAttributionMatchesLivePythonProductionRows(t *testing.T) {
+	base := map[string]any{
+		"number": 17, "title": "Repair delivery path", "body": "Routine repair",
+		"state": "open", "created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z", "assignees": []any{},
+		"head": map[string]any{"ref": "feature/repair"},
+	}
+	labelPR := cloneSemanticOracleMap(base)
+	labelPR["labels"] = []any{map[string]any{"name": "codex"}}
+	labelPR["user"] = map[string]any{"login": "author", "type": "User"}
+	labelInput := githubPullRequestSemanticOracleInput(labelPR, nil)
+	labelInput["signal_source"] = "pr_label"
+	botPR := cloneSemanticOracleMap(base)
+	botPR["labels"] = []any{}
+	botPR["user"] = map[string]any{"login": "chatgpt-codex[bot]", "type": "Bot"}
+	botInput := githubPullRequestSemanticOracleInput(botPR, nil)
+	botInput["signal_source"] = "bot_author"
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/ai-attribution",
+		[]oracleCase{
+			{ID: "codex_label", Input: labelInput},
+			{ID: "known_bot_author", Input: botInput},
+		},
+		buildGitHubAIAttributionOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubSemanticRowsAreStableAcrossCompleteUnitRetry(t *testing.T) {
+	comment := map[string]any{
+		"id": 101, "body": "Looks good",
+		"created_at": "2026-08-03T08:00:00Z",
+		"user":       map[string]any{"login": "reviewer"},
+	}
+	input := githubPullRequestSemanticOracleInput(map[string]any{
+		"number": 17, "title": "Repair delivery path",
+		"body": "Blocked by #7", "state": "open",
+		"created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z",
+		"labels":     []any{map[string]any{"name": "codex"}},
+		"assignees":  []any{}, "user": map[string]any{"login": "author"},
+		"head": map[string]any{"ref": "feature/repair"},
+	}, []any{map[string]any{
+		"event": "reopened", "created_at": "2026-08-02T09:00:00Z",
+		"actor": map[string]any{"login": "maintainer"},
+	}})
+	input["raw_comments"] = []any{comment}
+
+	first := buildGitHubPullRequestSemanticOracleRows(t, input)
+	second := buildGitHubPullRequestSemanticOracleRows(t, input)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("complete semantic rows changed across retry:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+}
+
+func githubPullRequestSemanticOracleInput(rawPR map[string]any, events []any) map[string]any {
+	return map[string]any{
+		"repo_full_name": "acme/api",
+		"repo_id":        "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		"org_id":         "77777777-7777-4777-8777-777777777777",
+		"raw_pr":         rawPR, "raw_events": events,
+	}
+}
+
+func githubIssueSemanticOracleInput(rawIssue map[string]any, events, comments []any) map[string]any {
+	return map[string]any{
+		"repo_full_name": "acme/api",
+		"repo_id":        "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		"org_id":         "77777777-7777-4777-8777-777777777777",
+		"raw_issue":      rawIssue, "raw_events": events, "raw_comments": comments,
+	}
+}
+
+func buildGitHubPullRequestWorkItemOracleRow(t *testing.T, input map[string]any) githubWorkItemRow {
+	return buildGitHubPullRequestSemanticOracleRows(t, input).WorkItems[0]
+}
+
+func buildGitHubStatusTransitionOracleRow(t *testing.T, input map[string]any) githubWorkItemTransitionRow {
+	if _, isPullRequest := input["raw_pr"]; isPullRequest {
+		return buildGitHubPullRequestSemanticOracleRows(t, input).StatusTransitions[int(input["transition_index"].(int))]
+	}
+	return buildGitHubIssueSemanticOracleRows(t, input).StatusTransitions[int(input["transition_index"].(int))]
+}
+
+func buildGitHubReopenOracleRow(t *testing.T, input map[string]any) githubWorkItemReopenRow {
+	return buildGitHubIssueSemanticOracleRows(t, input).ReopenEvents[0]
+}
+
+func buildGitHubInteractionOracleRow(t *testing.T, input map[string]any) githubWorkItemInteractionRow {
+	return buildGitHubIssueSemanticOracleRows(t, input).Interactions[0]
+}
+
+func buildGitHubDependencyOracleRow(t *testing.T, input map[string]any) githubWorkItemDependencyRow {
+	if input["producer"] == "body" {
+		return buildGitHubIssueSemanticOracleRows(t, input).Dependencies[0]
+	}
+	return buildGitHubPullRequestSemanticOracleRows(t, input).Dependencies[0]
+}
+
+func buildGitHubAIAttributionOracleRow(t *testing.T, input map[string]any) githubAIAttributionRow {
+	rows := buildGitHubPullRequestSemanticOracleRows(t, input).AIAttributions
+	for _, row := range rows {
+		if row.Source == input["signal_source"] {
+			return row
+		}
+	}
+	t.Fatalf("missing Go attribution source %q", input["signal_source"])
+	return githubAIAttributionRow{}
+}
+
+func buildGitHubPullRequestSemanticOracleRows(t *testing.T, input map[string]any) githubWorkItemRows {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["org_id"].(string)
+	rows, err := normalizeGitHubPullRequestBundle(
+		claim, input["repo_full_name"].(string), uuid.MustParse(input["repo_id"].(string)),
+		marshalSemanticOracleValue(t, input["raw_pr"]),
+		marshalSemanticOracleValues(t, input["raw_events"]),
+		marshalSemanticOracleValues(t, input["raw_comments"]),
+		nil, githubWorkItemOracleNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func buildGitHubIssueSemanticOracleRows(t *testing.T, input map[string]any) githubWorkItemRows {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["org_id"].(string)
+	rows, err := normalizeGitHubIssueBundle(
+		claim, input["repo_full_name"].(string), uuid.MustParse(input["repo_id"].(string)),
+		marshalSemanticOracleValue(t, input["raw_issue"]),
+		marshalSemanticOracleValues(t, input["raw_events"]),
+		marshalSemanticOracleValues(t, input["raw_comments"]),
+		nil, githubWorkItemOracleNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func marshalSemanticOracleValues(t *testing.T, value any) []json.RawMessage {
+	t.Helper()
+	if value == nil {
+		return nil
+	}
+	items := value.([]any)
+	rows := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		rows = append(rows, marshalSemanticOracleValue(t, item))
+	}
+	return rows
+}
+
+func marshalSemanticOracleValue(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func cloneSemanticOracleMap(source map[string]any) map[string]any {
+	result := make(map[string]any, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/internal/providersync/github_work_items_semantics_test.go
+++ b/internal/providersync/github_work_items_semantics_test.go
@@ -1,0 +1,211 @@
+package providersync
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestNormalizeGitHubIssueBundleMatchesPythonEventsCommentsAndDependencies(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	normalizedAt := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	issue := json.RawMessage(`{
+	  "number":42,"title":"Repair delivery path",
+	  "body":"Blocked by #7\nCloses other/repo#9\nSee CHAOS-42",
+	  "state":"closed","created_at":"2026-08-01T08:00:00Z",
+	  "updated_at":"2026-08-03T09:30:00Z","closed_at":"2026-08-03T09:30:00Z",
+	  "labels":[{"name":"doing"}],"assignees":[],"user":{"login":"reporter"}
+	}`)
+	events := []json.RawMessage{
+		json.RawMessage(`{"event":"reopened","created_at":"2026-08-03T08:00:00Z","actor":{"login":"maintainer"}}`),
+		json.RawMessage(`{"event":"closed","created_at":"2026-08-02T08:00:00Z"}`),
+		json.RawMessage(`{"event":"labeled","created_at":"2026-08-01T10:00:00Z","label":{"name":"doing"}}`),
+	}
+	comments := []json.RawMessage{
+		json.RawMessage(`{"id":99,"body":"Looks good 👋","created_at":"2026-08-03T08:30:00Z","user":{"login":"reviewer"}}`),
+		json.RawMessage(`{"id":0,"body":"missing id","created_at":"2026-08-03T08:31:00Z"}`),
+	}
+
+	rows, err := normalizeGitHubIssueBundle(
+		claim, "acme/api", repoID, issue, events, comments, nil, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows.WorkItems) != 1 || len(rows.StatusTransitions) != 3 ||
+		len(rows.ReopenEvents) != 1 || len(rows.Interactions) != 1 ||
+		len(rows.Dependencies) != 3 {
+		t.Fatalf("rows=%+v", rows)
+	}
+	item := rows.WorkItems[0]
+	if item.StartedAt == nil || !item.StartedAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) ||
+		item.CompletedAt == nil || !item.CompletedAt.Equal(time.Date(2026, 8, 2, 8, 0, 0, 0, time.UTC)) {
+		t.Fatalf("item transition timestamps=%+v", item)
+	}
+	gotTransitions := make([]string, 0, len(rows.StatusTransitions))
+	for _, transition := range rows.StatusTransitions {
+		gotTransitions = append(gotTransitions, transition.FromStatus+"->"+transition.ToStatus)
+		if transition.OrgID != claim.OrgID {
+			t.Fatalf("transition tenant=%+v", transition)
+		}
+	}
+	if want := []string{"unknown->in_progress", "in_progress->done", "done->todo"}; !reflect.DeepEqual(gotTransitions, want) {
+		t.Fatalf("transitions=%v want=%v", gotTransitions, want)
+	}
+	if rows.ReopenEvents[0].Actor == nil || *rows.ReopenEvents[0].Actor != "github:maintainer" ||
+		!rows.ReopenEvents[0].LastSynced.Equal(normalizedAt) || rows.ReopenEvents[0].OrgID != claim.OrgID {
+		t.Fatalf("reopen=%+v", rows.ReopenEvents[0])
+	}
+	if rows.Interactions[0].BodyLength != 12 || rows.Interactions[0].Actor == nil ||
+		*rows.Interactions[0].Actor != "github:reviewer" || rows.Interactions[0].OrgID != claim.OrgID {
+		t.Fatalf("interaction=%+v", rows.Interactions[0])
+	}
+	gotDependencies := make([]string, 0, len(rows.Dependencies))
+	for _, dependency := range rows.Dependencies {
+		gotDependencies = append(gotDependencies,
+			dependency.SourceWorkItemID+"|"+dependency.TargetWorkItemID+"|"+dependency.RelationshipType,
+		)
+		if dependency.OrgID != claim.OrgID || !dependency.LastSynced.Equal(normalizedAt) ||
+			dependency.RelationshipSemanticsVersion != "canonical-blocks.v2" {
+			t.Fatalf("dependency=%+v", dependency)
+		}
+	}
+	wantDependencies := []string{
+		"gh:acme/api#7|gh:acme/api#42|blocks",
+		"gh:acme/api#42|gh:other/repo#9|relates_to",
+		"gh:acme/api#42|extkey:CHAOS-42|relates_to",
+	}
+	if !reflect.DeepEqual(gotDependencies, wantDependencies) {
+		t.Fatalf("dependencies=%v want=%v", gotDependencies, wantDependencies)
+	}
+}
+
+func TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	normalizedAt := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	pr := json.RawMessage(`{
+	  "number":17,"title":"Codex generated repair","body":"AI-Assisted-By: Codex\nCloses CHAOS-17",
+	  "state":"closed","merged":true,"draft":false,
+	  "created_at":"2026-08-01T08:00:00Z","updated_at":"2026-08-03T09:30:00Z",
+	  "closed_at":"2026-08-03T09:30:00Z","merged_at":"2026-08-03T09:29:00Z",
+	  "labels":[{"name":"codex"},{"name":"p1"}],"assignees":[],
+	  "user":{"login":"chatgpt-codex[bot]","type":"Bot"},
+	  "head":{"ref":"codex/chaos-17-repair"},"html_url":"https://github.com/acme/api/pull/17"
+	}`)
+	events := []json.RawMessage{
+		json.RawMessage(`{"event":"closed","created_at":"2026-08-03T09:30:00Z"}`),
+		json.RawMessage(`{"event":"merged","created_at":"2026-08-03T09:29:00Z"}`),
+		json.RawMessage(`{"event":"reopened","created_at":"2026-08-02T09:00:00Z","actor":{"login":"maintainer"}}`),
+	}
+	comments := []json.RawMessage{
+		json.RawMessage(`{"id":101,"body":"Linked: https://linear.app/fullchaos/issue/CHAOS-99/task","created_at":"2026-08-03T08:00:00Z","user":{"login":"linear[bot]"}}`),
+		json.RawMessage(`{"id":102,"body":"https://linear.app/fullchaos/issue/CHAOS-100/task","created_at":"2026-08-03T08:01:00Z","user":{"login":"other[bot]"}}`),
+	}
+
+	rows, err := normalizeGitHubPullRequestBundle(
+		claim, "acme/api", repoID, pr, events, comments, nil, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows.WorkItems) != 1 || len(rows.StatusTransitions) != 3 ||
+		len(rows.ReopenEvents) != 1 || len(rows.Interactions) != 2 ||
+		len(rows.Dependencies) != 2 || len(rows.AIAttributions) != 4 {
+		t.Fatalf("rows=%+v", rows)
+	}
+	item := rows.WorkItems[0]
+	if item.WorkItemID != "ghpr:acme/api#17" || item.Type != "pr" || item.Status != "done" ||
+		item.StatusRaw == nil || *item.StatusRaw != "merged" || item.StartedAt == nil ||
+		!item.StartedAt.Equal(item.CreatedAt) || item.CompletedAt == nil ||
+		!item.CompletedAt.Equal(time.Date(2026, 8, 3, 9, 29, 0, 0, time.UTC)) {
+		t.Fatalf("item=%+v", item)
+	}
+	gotTransitions := make([]string, 0, len(rows.StatusTransitions))
+	for _, transition := range rows.StatusTransitions {
+		gotTransitions = append(gotTransitions, transition.FromStatus+"->"+transition.ToStatus)
+	}
+	if want := []string{"in_progress->in_progress", "in_progress->done", "done->done"}; !reflect.DeepEqual(gotTransitions, want) {
+		t.Fatalf("transitions=%v want=%v", gotTransitions, want)
+	}
+	gotTargets := make(map[string]string, len(rows.Dependencies))
+	for _, dependency := range rows.Dependencies {
+		gotTargets[dependency.TargetWorkItemID] = dependency.RelationshipType
+	}
+	if gotTargets["extkey:CHAOS-17"] != "relates_to" ||
+		gotTargets["extkey:CHAOS-99"] != "relates_to" || len(gotTargets) != 2 {
+		t.Fatalf("dependency targets=%v", gotTargets)
+	}
+	wantSources := []string{"pr_label", "bot_author", "commit_trailer", "branch_name"}
+	gotSources := make([]string, 0, len(rows.AIAttributions))
+	for _, attribution := range rows.AIAttributions {
+		gotSources = append(gotSources, attribution.Source)
+		if attribution.SubjectID != "17" || attribution.RepoID == nil || *attribution.RepoID != repoID ||
+			attribution.OrgID != uuid.MustParse(claim.OrgID) || attribution.RecordID == uuid.Nil ||
+			!attribution.IngestedAt.Equal(normalizedAt) {
+			t.Fatalf("attribution=%+v", attribution)
+		}
+	}
+	if !reflect.DeepEqual(gotSources, wantSources) {
+		t.Fatalf("sources=%v want=%v", gotSources, wantSources)
+	}
+	second, err := normalizeGitHubPullRequestBundle(
+		claim, "acme/api", repoID, pr, events, comments, nil, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range rows.AIAttributions {
+		if rows.AIAttributions[index].RecordID != second.AIAttributions[index].RecordID {
+			t.Fatalf("record id changed across retry: %s != %s", rows.AIAttributions[index].RecordID, second.AIAttributions[index].RecordID)
+		}
+	}
+}
+
+func TestNormalizeGitHubPullRequestStatusPartitionsMatchPython(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	normalizedAt := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	tests := []struct {
+		name          string
+		extra         string
+		wantStatus    string
+		wantRaw       string
+		wantCompleted bool
+	}{
+		{name: "merged boolean without timestamp", extra: `"state":"closed","merged":true`, wantStatus: "done", wantRaw: "merged"},
+		{name: "merged timestamp without boolean", extra: `"state":"closed","merged":false,"merged_at":"2026-08-03T09:29:00Z"`, wantStatus: "done", wantRaw: "merged", wantCompleted: true},
+		{name: "closed unmerged", extra: `"state":"closed","merged":false,"closed_at":"2026-08-03T09:30:00Z"`, wantStatus: "canceled", wantRaw: "closed", wantCompleted: true},
+		{name: "open draft", extra: `"state":"open","draft":true`, wantStatus: "todo", wantRaw: "open"},
+		{name: "open ready", extra: `"state":"open","draft":false`, wantStatus: "in_progress", wantRaw: "open"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			raw := json.RawMessage(`{"number":17,"title":"Partition","created_at":"2026-08-01T08:00:00Z",` + test.extra + `}`)
+			rows, err := normalizeGitHubPullRequestBundle(
+				claim, "acme/api", repoID, raw, nil, nil, nil, normalizedAt,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			item := rows.WorkItems[0]
+			if item.Status != test.wantStatus || item.StatusRaw == nil || *item.StatusRaw != test.wantRaw {
+				t.Fatalf("status=%q raw=%v want status=%q raw=%q", item.Status, item.StatusRaw, test.wantStatus, test.wantRaw)
+			}
+			if (item.CompletedAt != nil) != test.wantCompleted {
+				t.Fatalf("completed_at=%v want_present=%v", item.CompletedAt, test.wantCompleted)
+			}
+		})
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_semantics.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_semantics.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "name": "github work-item semantic provider batch",
+  "build": ["go", "build", "./internal/providersync/"],
+  "$limitation": "This layer pins the seven semantic lists produced by the active Python GitHub provider. Source pagination, direct ClickHouse effects, derived metrics, and route activation remain later stack layers; all five work-item aliases remain disabled here.",
+  "mutations": [
+    {
+      "id": "S1-issue-events-are-processed-oldest-first",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\t\treturn leftAt.Before(*rightAt)",
+      "replace": "\t\t\treturn rightAt.Before(*leftAt)",
+      "rationale": "GitHub events arrive newest-first but Python sorts them chronologically before deriving transitions and first started/completed timestamps",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubIssueBundleMatchesPythonEventsCommentsAndDependencies$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2-merged-boolean-and-timestamp-are-independent-signals",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\tcase pull.Merged || mergedAt != nil:",
+      "replace": "\tcase pull.Merged && mergedAt != nil:",
+      "rationale": "PyGithub treats either the merged boolean or a merged timestamp as authoritative; requiring both misclassifies valid merged PR payloads",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestStatusPartitionsMatchPython$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S3-closed-after-merged-history-stays-done",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\t\t\tif mergedInHistory {\n\t\t\t\t\ttoStatus = \"done\"\n\t\t\t\t}",
+      "replace": "\t\t\t\tif mergedInHistory && false {\n\t\t\t\t\ttoStatus = \"done\"\n\t\t\t\t}",
+      "rationale": "a close event following a merge records completion, not cancellation, and the transition history must retain that distinction",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S4-comment-length-counts-unicode-codepoints",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\t\tBodyLength: utf8.RuneCountInString(comment.Body),",
+      "replace": "\t\t\tBodyLength: len(comment.Body) + 0*utf8.RuneCountInString(comment.Body),",
+      "rationale": "Python len counts Unicode codepoints while Go len counts UTF-8 bytes, which inflates non-ASCII interaction lengths",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubIssueBundleMatchesPythonEventsCommentsAndDependencies$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S5-comment-linkbacks-require-the-exact-trusted-bot",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\tif _, trusted := trustedBots[login]; !trusted {",
+      "replace": "\t\tif _, trusted := trustedBots[login]; trusted {",
+      "rationale": "accepting ordinary or unrelated bot comments would let third parties forge Linear attachment edges and team inheritance",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S6-blocked-by-reverses-the-github-edge",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\tcase \"depends on\", \"blocked by\":\n\t\t\trelationship, reverse = \"blocks\", true",
+      "replace": "\t\tcase \"depends on\", \"blocked by\":\n\t\t\trelationship, reverse = \"blocks\", false",
+      "rationale": "the referenced issue blocks the current issue, so source and target must be reversed exactly as the Python producer emits them",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubIssueBundleMatchesPythonEventsCommentsAndDependencies$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S7-ai-attribution-subject-is-the-bare-pr-number",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\tsubjectID := strconv.Itoa(pull.Number)",
+      "replace": "\t\tsubjectID := \"ghpr:\" + strconv.Itoa(pull.Number)",
+      "rationale": "the AI attribution sink joins GitHub pull requests by the provider's bare PR number plus repo_id, not the WorkItem identifier",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S8-ai-attribution-effect-identity-is-retry-stable",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\t\tidentity := strings.Join([]string{",
+      "replace": "\t\tidentity := strconv.FormatInt(time.Now().UnixNano(), 10) + strings.Join([]string{",
+      "rationale": "ordinary River retries must rebuild byte-identical effect rows instead of generating new record IDs and conflicting with the prepared manifest",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S9-pr-body-trailers-suppress-the-duplicate-body-signal",
+      "file": "internal/providersync/github_work_items_rows.go",
+      "find": "\tif !trailerFired {",
+      "replace": "\tif !trailerFired || trailerFired {",
+      "rationale": "Python suppresses weak PR-body detection when the same body already produced a stronger commit-trailer signal",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNormalizeGitHubPullRequestBundlePreservesPythonPRSemantics$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
@@ -1,0 +1,25 @@
+"""Shared case decoding for live GitHub work-item row oracle pairs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+
+def object_from_case(value: Any) -> Any:
+    """Build the PyGithub-shaped object consumed by production normalizers."""
+    if isinstance(value, dict):
+        return SimpleNamespace(
+            **{
+                key: (
+                    datetime.fromisoformat(item.replace("Z", "+00:00"))
+                    if key.endswith("_at") and isinstance(item, str)
+                    else object_from_case(item)
+                )
+                for key, item in value.items()
+            }
+        )
+    if isinstance(value, list):
+        return [object_from_case(item) for item in value]
+    return value

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_ai-attribution.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_ai-attribution.py
@@ -1,0 +1,73 @@
+"""Live Python oracle for GitHub PR AI attribution records."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.models.ai_attribution import AIAttributionRecord
+    from dev_health_ops.providers.github.normalize import (
+        _to_utc,
+        detect_pr_attributions,
+    )
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/ai_attribution.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    pr = object_from_case(case["raw_pr"])
+    signals = detect_pr_attributions(pr=pr)
+    source = case["signal_source"]
+    signal = next(
+        candidate for candidate in signals if candidate.source.value == source
+    )
+    observed_at = _to_utc(pr.created_at)
+    if observed_at is None:
+        raise ValueError("production PR AI attribution case requires created_at")
+    row = AIAttributionRecord.from_signal(
+        signal,
+        org_id=UUID(case["org_id"]),
+        provider="github",
+        subject_type="pull_request",
+        subject_id=str(int(case["raw_pr"]["number"])),
+        repo_id=UUID(case["repo_id"]),
+        observed_at=observed_at,
+    )
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/ai-attribution",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "AIAttributionRecord"
+        ),
+        excluded_fields={
+            "ingested_at": (
+                "the production constructor stamps wall-clock now and has no clock "
+                "parameter; Go stamps the complete unit normalizedAt and its retry "
+                "stability is asserted separately"
+            ),
+            "record_id": (
+                "the Python producer assigns uuid4 while Go derives a stable retry "
+                "identifier; non-zero and retry-stable Go IDs are asserted separately"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_dependency.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_dependency.py
@@ -1,0 +1,72 @@
+"""Live Python oracle for GitHub body and trusted-comment dependency rows."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        extract_github_comment_dependencies,
+        extract_github_dependencies,
+    )
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    if case["producer"] == "body":
+        raw_item = case["raw_pr"] if "raw_pr" in case else case["raw_issue"]
+        rows = extract_github_dependencies(
+            work_item_id=case["work_item_id"],
+            issue_or_pr=object_from_case(raw_item),
+            repo_full_name=case["repo_full_name"],
+        )
+    elif case["producer"] == "comment":
+        rows = extract_github_comment_dependencies(
+            work_item_id=case["work_item_id"],
+            comments=[
+                (
+                    comment.get("body"),
+                    (comment.get("user") or {}).get("login"),
+                )
+                for comment in case["raw_comments"]
+            ],
+        )
+    else:
+        raise ValueError(f"unknown dependency producer {case['producer']!r}")
+    row = dataclasses.replace(
+        rows[int(case.get("row_index", 0))], org_id=case["org_id"]
+    )
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/dependency",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItemDependency"
+        ),
+        excluded_fields={
+            "last_synced": (
+                "the production constructor stamps wall-clock now and has no clock "
+                "parameter; Go stamps the complete unit normalizedAt and its retry "
+                "stability is asserted separately"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_interaction.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_interaction.py
@@ -1,0 +1,57 @@
+"""Live Python oracle for GitHub comment interaction rows."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        github_comment_to_interaction_event,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    row = github_comment_to_interaction_event(
+        comment=object_from_case(case["raw_comment"]),
+        work_item_id=case["work_item_id"],
+        identity=load_identity_resolver(),
+    )
+    if row is None:
+        raise ValueError("production comment normalizer rejected oracle case")
+    row = dataclasses.replace(row, org_id=case["org_id"])
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/interaction",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItemInteractionEvent"
+        ),
+        excluded_fields={
+            "last_synced": (
+                "the production constructor stamps wall-clock now and has no clock "
+                "parameter; Go stamps the complete unit normalizedAt and its retry "
+                "stability is asserted separately"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr.py
@@ -1,0 +1,57 @@
+"""Live Python oracle for GitHub pull request -> WorkItem normalization."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        enrich_work_item_with_priority,
+        github_pr_to_work_item,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    pr = object_from_case(case["raw_pr"])
+    events = object_from_case(case.get("raw_events", []))
+    row, _ = github_pr_to_work_item(
+        pr=pr,
+        repo_full_name=case["repo_full_name"],
+        repo_id=UUID(case["repo_id"]),
+        status_mapping=load_status_mapping(),
+        identity=load_identity_resolver(),
+        events=events,
+    )
+    row = enrich_work_item_with_priority(row, row.labels)
+    row = dataclasses.replace(row, org_id=case["org_id"])
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/pr",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItem"
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_reopen.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_reopen.py
@@ -1,0 +1,55 @@
+"""Live Python oracle for GitHub reopen event rows."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import detect_github_reopen_events
+    from dev_health_ops.providers.identity import load_identity_resolver
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    rows = detect_github_reopen_events(
+        work_item_id=case["work_item_id"],
+        events=object_from_case(case["raw_events"]),
+        identity=load_identity_resolver(),
+    )
+    row = dataclasses.replace(
+        rows[int(case.get("row_index", 0))], org_id=case["org_id"]
+    )
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/reopen",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItemReopenEvent"
+        ),
+        excluded_fields={
+            "last_synced": (
+                "the production constructor stamps wall-clock now and has no clock "
+                "parameter; Go stamps the complete unit normalizedAt and its retry "
+                "stability is asserted separately"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_status-transition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_status-transition.py
@@ -1,0 +1,63 @@
+"""Live Python oracle for GitHub work-item status transition rows."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    object_from_case,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        github_issue_to_work_item,
+        github_pr_to_work_item,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    common = {
+        "repo_full_name": case["repo_full_name"],
+        "repo_id": UUID(case["repo_id"]),
+        "status_mapping": load_status_mapping(),
+        "identity": load_identity_resolver(),
+        "events": object_from_case(case["raw_events"]),
+    }
+    if "raw_pr" in case:
+        _, transitions = github_pr_to_work_item(
+            pr=object_from_case(case["raw_pr"]), **common
+        )
+    else:
+        _, transitions = github_issue_to_work_item(
+            issue=object_from_case(case["raw_issue"]), **common
+        )
+    row = dataclasses.replace(
+        transitions[int(case["transition_index"])], org_id=case["org_id"]
+    )
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/status-transition",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItemStatusTransition"
+        ),
+    )
+)


### PR DESCRIPTION
## Summary

- port GitHub issue and pull-request work-item semantic normalization to Go
- emit the Python-equivalent work item, transition, reopen, interaction, dependency, sprint, and AI-attribution row families
- add live Python-to-Go differential oracles built from the real Python producers
- keep all five GitHub work-item route aliases disabled until the complete D16 composite is ready

## Scope

This is an unregistered semantic layer only. It does not fetch provider data, emit effects, advance watermarks, change route readiness, or activate deployment aliases. The PR targets only `feat/go-worker-runtime-migration`.

GitHub Projects v2, REST collection, PR-social GraphQL collection, effects, orchestration, and final composite acceptance remain later stack layers.

## Validation

- `bash ci/local_validate.sh` — passed
  - 11,574 Python tests passed; 98 skipped; 1 expected xfail
  - Ruff format/lint, mypy, Go format/vet/test, River compatibility, scratch ClickHouse migration, and live argMax proof passed
- live Python producer oracles passed for work items, transitions, reopens, interactions, dependencies, and AI attribution
- 9 semantic mutation proofs completed green -> red -> green

## Landing

Feature-only stack. Do not retarget or merge to `main`.
