### PR TITLE
fix(ask-dev): bound blocker facts at the wire limit instead of failing the status tool (CHAOS-3377)

### DIFF
--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -66,6 +66,7 @@ from .status_completion_copy import (
 )
 
 __all__ = [
+    "DISPLAY_TRUNCATED_DISCLOSURE",
     "build_deterministic_status_claims",
     "deterministic_answer_status",
     "open_blockers",
@@ -149,6 +150,22 @@ def open_blockers(actual: DevActualCompletion) -> list[DevRequiredChildFact]:
     return [blocker for blocker in actual.blockers if is_blocker_open(blocker.status)]
 
 
+#: CHAOS-3377 hotfix: disclosed whenever ``actual.display_truncated`` is
+#: True -- ``status_change_service.status_snapshot`` bounds both
+#: ``required_children`` and ``blockers`` to ``request.max_items`` (100) for
+#: display, independent of ``required_child_total``/``required_child_complete``
+#: (which always reflect the true, UNBOUNDED assessment -- see that
+#: module). A real project can have more than 100 outstanding items (the
+#: live acceptance probe found 155 blockers on one project); when that
+#: happens, some of them are silently absent from ``open_required_children``/
+#: ``open_blockers`` below, and that must never be silent -- "never a silent
+#: cap", the same rule every other bounded list in this codebase follows.
+DISPLAY_TRUNCATED_DISCLOSURE = (
+    "some required items or blockers were not displayed because there were "
+    "more than this answer's display limit"
+)
+
+
 def render_verdict_summary(
     actual: DevActualCompletion, *, denominator_withheld: bool = False
 ) -> str:
@@ -166,6 +183,11 @@ def render_verdict_summary(
     model-authored -- must carry that exact sentence, so a server-rendered
     verdict is not exempt from the same honesty requirement a model-authored
     one is held to.
+
+    ``actual.display_truncated`` drives the same kind of positive
+    disclosure for a DIFFERENT truncation: not a withheld denominator, but a
+    real denominator whose full required-item/blocker LIST does not fit in
+    one display page (CHAOS-3377 hotfix).
     """
 
     parts = [translate_completion_state(actual.state)]
@@ -188,6 +210,8 @@ def render_verdict_summary(
         parts.append("Open items: " + "; ".join(reasons) + ".")
     if denominator_withheld:
         parts.append(INCOMPLETE_DENOMINATOR_DISCLOSURE.capitalize() + ".")
+    if actual.display_truncated:
+        parts.append(DISPLAY_TRUNCATED_DISCLOSURE.capitalize() + ".")
     return " ".join(parts)
 
 

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -569,14 +569,37 @@ class StatusChangeService:
         )
         actual = replace(
             actual,
-            # Read from the still-unbounded ``actual.required_children``
-            # (set by ``_assess``) before it is overwritten below with the
-            # bounded display list -- both keyword arguments are evaluated
-            # against the pre-replace object.
-            display_truncated=len(actual.required_children) > request.max_items,
+            # Read from the still-unbounded ``actual.required_children``/
+            # ``actual.blockers`` (set by ``_assess``) before they are
+            # overwritten below with their bounded display lists -- every
+            # keyword argument here is evaluated against the pre-``replace``
+            # object.
+            #
+            # CHAOS-3377 hotfix (live acceptance probe): ``actual.blockers``
+            # was added alongside ``required_children`` but never went
+            # through this same bounding step -- the wire type
+            # (``DevActualCompletion.blockers``) caps at
+            # ``max_length=100`` (``contracts.py``) exactly like
+            # ``required_children`` does, but nothing enforced that cap on
+            # the ``ActualCompletion`` domain object before
+            # ``production_runtime.py`` handed it straight to the wire
+            # constructor. A real project with >100 blocker facts (155,
+            # confirmed against the live org) raised a pydantic
+            # ``too_long`` ``ValidationError`` there, which surfaced as the
+            # status tool erroring and the whole §10 deterministic render
+            # never running -- unit fixtures never exercised more than 100
+            # blockers, so nothing caught it before now. ``display_truncated``
+            # covers BOTH lists (one flag, not two) -- it already means "the
+            # display doesn't reflect everything assessed", and blockers
+            # being cut is exactly that same claim.
+            display_truncated=(
+                len(actual.required_children) > request.max_items
+                or len(actual.blockers) > request.max_items
+            ),
             required_children=self._bounded(
                 actual.required_children, request.max_items
             ),
+            blockers=self._bounded(actual.blockers, request.max_items),
         )
         assessment_source_ids = set(actual.source_ref_ids)
         freshness = {

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -35,6 +35,10 @@ from dev_health_ops.api.dev.contracts import (
 from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
 from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
+from dev_health_ops.api.dev.status_answer_render import (
+    build_deterministic_status_claims,
+    render_verdict_summary,
+)
 from dev_health_ops.api.dev.status_change_service import (
     ChangeCategory,
     ChangeWindow,
@@ -1084,6 +1088,135 @@ async def test_status_snapshot_bounds_evidence_instead_of_failing_validation(
     for conflict in result.actual_completion.conflicts:
         assert conflict.evidence_ref_ids
         assert not (set(conflict.evidence_ref_ids) & pr_evidence_ids)
+
+    await runtime.aclose()
+
+
+class _FakeManyBlockersStatusChangeSource:
+    """CHAOS-3377 hotfix: a project with more blocker facts than the wire
+    cap (155, matching the live acceptance probe's real count on a real
+    org) must not crash ``DevActualCompletion`` construction --
+    ``contracts.py`` caps ``DevActualCompletion.blockers`` at
+    ``max_length=100``, exactly like ``required_children`` above it, and
+    ``status_change_service._assess`` built ``ActualCompletion.blockers``
+    from the raw, UNBOUNDED source list with nothing capping it before
+    ``production_runtime.py`` handed it straight to the wire constructor.
+    Unit fixtures never exceeded 100 blockers, so nothing caught it until
+    the live probe. Mirrors ``_FakeDenseStatusChangeSource`` above, which
+    proves the sibling evidence-count defect the same way.
+    """
+
+    def __init__(self) -> None:
+        self.declared = StatusFact(
+            entity_type="issue",
+            entity_id="issue_parent",
+            display_label="Parent issue",
+            status="in_progress",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+        )
+        self.blockers = tuple(
+            StatusFact(
+                entity_type="issue",
+                entity_id=f"issue_blocker_{index:04d}",
+                display_label=f"Blocker {index}",
+                status="open",
+                observed_at=FRESH_OBSERVED,
+                source_ref_id="ref:work_items",
+                evidence_ref_ids=(),
+                required=True,
+            )
+            for index in range(155)
+        )
+        self.source_refs = (
+            SourceReference(
+                ref_id="ref:work_items",
+                source_system="work_items",
+                source_version="work-items.v1",
+                freshness=production_runtime.FreshnessState.FRESH,
+                watermark=FRESH_OBSERVED,
+                evidence_ref_ids=(),
+            ),
+        )
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        del org_id, scope, as_of, limit
+        return RawStatusSnapshot(
+            declared=self.declared,
+            blockers=self.blockers,
+            source_refs=self.source_refs,
+        )
+
+    async def change_summary(
+        self,
+        *,
+        org_id: str,
+        scope: DevScope,
+        current: ChangeWindow,
+        comparison: ChangeWindow,
+        limit: int,
+    ) -> RawChangeSummary:
+        del org_id, scope, current, comparison, limit
+        return RawChangeSummary(changes=(), source_refs=self.source_refs)
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_bounds_blockers_instead_of_failing_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3377 hotfix, fail->pass against pre-fix main: a real project
+    with 155 blocker facts raised a pydantic ``too_long`` ``ValidationError``
+    constructing ``DevActualCompletion.blockers`` -- the status tool errored,
+    and the whole §10 deterministic renderer (``status_answer_render.py``)
+    never ran for that answer at all. Asserts, through the REAL production
+    tool-registry construction path (not a hand-built ``DevActualCompletion``):
+    (a) no ``ValidationError`` -- the tool call below would have raised, not
+    returned, on unfixed code; (b) the deterministic §10 renderer still
+    fires on the bounded result; (c) the truncation is disclosed, never
+    silent.
+    """
+
+    runtime = await _build_runtime(
+        monkeypatch, status_source=_FakeManyBlockersStatusChangeSource()
+    )
+    scope = _scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert result.status == "success"
+    assert result.actual_completion is not None
+
+    # (a) no ValidationError: the 155-blocker source above would have
+    # raised constructing this very object on unfixed code.
+    assert len(result.actual_completion.blockers) <= 100
+    # (c) truncation is disclosed, never silent.
+    assert result.actual_completion.display_truncated is True
+
+    # (b) the deterministic §10 renderer still fires on the bounded result.
+    claims = build_deterministic_status_claims(
+        actual=result.actual_completion,
+        status_result=result,
+        validity_scope=scope,
+        canonical_evidence_ids=frozenset(
+            item.evidence_ref_id for item in result.evidence
+        ),
+    )
+    assert claims  # at least the verdict claim
+    summary = render_verdict_summary(result.actual_completion)
+    assert "not ready" in summary.casefold()
+    assert "some required items or blockers were not displayed" in summary.casefold()
 
     await runtime.aclose()
 


### PR DESCRIPTION
## Summary

Live-probe hotfix for the merged CHAOS-3377 renderer: `DevActualCompletion.blockers` caps at 100 items on the wire, but `status_snapshot` constructed it from the unbounded assessor list — the real Ask Dev project produces 155 blocker facts, so the status tool died with a pydantic `too_long` ValidationError and the §10 answer degraded to "source Unavailable".

- `status_snapshot()` now bounds `blockers` through the same `_bounded` + priority-ordering step `required_children` already gets (no new mechanism); the existing `display_truncated` wire flag covers both lists.
- `render_verdict_summary` discloses the truncation with closed-vocabulary copy — never silent.
- `required_children` audited for the same latent overflow: already bounded and pinned by a pre-existing 101-child test; no change needed.

## Testing

- New regression mirrors the file's existing dense-evidence precedent: 155-blocker fixture through the real production tool registry — reproduces the exact live ValidationError pre-fix, passes post-fix, and asserts the deterministic render still fires with disclosure.
- Full `tests/api/dev/`: 1921 passed, 19 skipped, 1 xfailed, 0 failed. ruff + mypy clean.
