### PR TITLE
docs: add Context Fabric product page

### DIFF
--- a/docs-data/ia/home.tsv
+++ b/docs-data/ia/home.tsv
@@ -1,2 +1,3 @@
 id	parent_id	url	label	kind	nav	public_state	lifecycle	provisional	summary
 home		/	Documentation home	landing	true	public	planned	false	Route readers to a stable task domain.
+context-fabric	home	/context-fabric/	Context Fabric	marketing	true	public	active	false	Understand how Context Fabric connects engineering evidence for people and agents.

--- a/docs/context-fabric/index.md
+++ b/docs/context-fabric/index.md
@@ -1,0 +1,198 @@
+---
+page_id: context-fabric
+summary: See how Context Fabric connects engineering evidence so people and agents can understand the real state of projects, teams, and organizations.
+content_type: marketing
+owner: product
+source_of_truth:
+  - current Ask Dev window and /dev workspace
+  - current Context Fabric Validation surface
+  - Ask Dev Interaction Surface Amendment — Context Fabric relationship, chat window, and full-page workspace
+  - PRD v2.1: Dev Health Agent Context Runtime — Go service and MCP sidecar
+  - full-chaos/dev-health-acr README.md
+applicability: current
+lifecycle: active
+hide:
+  - navigation
+  - toc
+---
+
+<section class="fc-cf-hero" aria-labelledby="fc-cf-title" markdown>
+<div class="fc-cf-hero__copy" markdown>
+
+Context Fabric
+{: .fc-cf-kicker }
+
+# Know what’s actually happening—not just what the tracker says. { #fc-cf-title }
+
+Context Fabric connects the work, code, delivery, reliability, and source-health evidence already flowing through Dev Health. It gives people and agents a shared, evidence-backed view of the real state of a project, team, or organization.
+{: .fc-cf-lede }
+
+<div class="fc-cf-actions" markdown>
+
+[Explore Ask Dev](../use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation){ .md-button .md-button--primary }
+[Use Context Fabric with an agent](https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md){ .md-button }
+
+</div>
+</div>
+
+<aside class="fc-cf-hero__visual" aria-label="Context Fabric connects engineering signals to Ask Dev and compatible agents">
+  <div class="fc-cf-sources" aria-label="Connected engineering evidence">
+    <span>Planning</span>
+    <span>Code and review</span>
+    <span>CI and delivery</span>
+    <span>Incidents and reliability</span>
+  </div>
+  <div class="fc-cf-core">
+    <strong>Context Fabric</strong>
+    <span>State → Pressure → Cause → Evidence → Action</span>
+  </div>
+  <div class="fc-cf-destinations">
+    <div><strong>Ask Dev</strong><span>For people</span></div>
+    <div><strong>MCP</strong><span>For developers and agents</span></div>
+  </div>
+</aside>
+</section>
+
+<section class="fc-cf-section fc-cf-section--intro" markdown>
+
+## Project status is a relationship, not a field
+
+A tracking system records what someone declared. The rest of the engineering ecosystem records what actually happened.
+
+A pull request may be merged while the ticket still says **In Progress**. A feature may be deployed behind a flag, active for users, and followed by an incident or additional rollout work. Each system contains part of the story, but no single status field contains the whole thing.
+
+Context Fabric connects those signals so teams do not have to treat one tracker—or one teammate’s memory—as the only source of truth.
+
+</section>
+
+<section class="fc-cf-example" aria-labelledby="fc-cf-example-title" markdown>
+<div class="fc-cf-example__heading" markdown>
+
+Real-world example
+{: .fc-cf-kicker }
+
+## The ticket says “In Progress.” What is the actual state? { #fc-cf-example-title }
+
+</div>
+
+<div class="fc-cf-example__grid">
+  <div class="fc-cf-example__declared">
+    <span class="fc-cf-example__label">Tracking system</span>
+    <strong>In Progress</strong>
+    <span>Last updated four days ago</span>
+  </div>
+
+  <div class="fc-cf-evidence" aria-label="Observed evidence">
+    <span class="fc-cf-evidence__item is-complete">Pull request merged</span>
+    <span class="fc-cf-evidence__item is-complete">CI passed</span>
+    <span class="fc-cf-evidence__item is-complete">Deployment succeeded</span>
+    <span class="fc-cf-evidence__item is-complete">Feature flag enabled</span>
+    <span class="fc-cf-evidence__item is-current">Available to users</span>
+  </div>
+
+  <div class="fc-cf-example__answer">
+    <span class="fc-cf-example__label">Context Fabric</span>
+    <strong>Implemented, deployed, and available</strong>
+    <p>The delivery evidence shows the feature is live. The tracking record is stale, and any remaining follow-up is reported separately.</p>
+  </div>
+</div>
+</section>
+
+<section class="fc-cf-section" markdown>
+
+## Come to the conversation prepared
+
+Context Fabric is not meant to replace talking with your teammates. It helps you ask better questions and arrive with the relevant evidence already connected—like the A+ student who actually did the reading.
+
+That gives engineering teams, leadership, developers, and agents a common starting point for discussing status, blockers, health, decisions, and next actions.
+
+</section>
+
+<section class="fc-cf-use-cases" aria-labelledby="fc-cf-use-cases-title" markdown>
+
+## Two ways to use Context Fabric { #fc-cf-use-cases-title }
+
+<div class="fc-cf-use-grid" markdown>
+
+<article class="fc-cf-use-card fc-cf-use-card--ask" markdown>
+
+For teams and leaders
+{: .fc-cf-card-kicker }
+
+### Ask Dev
+
+Dev is embedded in the Dev Health application and can answer questions about project, team, and organizational health across the connected ecosystem.
+
+<div class="fc-cf-question-list" markdown>
+
+- Is this project actually done?
+- What is blocking delivery?
+- Which teams need attention?
+- What do this team’s DORA metrics look like over the last 90 days?
+
+</div>
+
+[See how Ask Dev works →](../use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation){ .fc-cf-card-link }
+
+</article>
+
+<article class="fc-cf-use-card fc-cf-use-card--mcp" markdown>
+
+For developers and agents
+{: .fc-cf-card-kicker }
+
+### MCP for agents
+
+Compatible coding, review, documentation, and automation agents can receive scoped context and supporting evidence before they begin work instead of starting cold.
+
+<div class="fc-cf-question-list" markdown>
+
+- What decisions already govern this work?
+- Which related changes or failures matter?
+- What evidence should be verified before editing?
+- What risks and required checks are already known?
+
+</div>
+
+[Configure the ACR MCP sidecar →](https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md){ .fc-cf-card-link }
+
+</article>
+
+</div>
+</section>
+
+<section class="fc-cf-trust" aria-labelledby="fc-cf-trust-title" markdown>
+<div class="fc-cf-trust__copy" markdown>
+
+Evidence before confidence
+{: .fc-cf-kicker }
+
+## An answer should show its work. { #fc-cf-trust-title }
+
+Context Fabric does not quietly turn incomplete data into certainty. It keeps the scope, as-of time, freshness, coverage, conflicts, unavailable sources, and supporting evidence visible.
+
+</div>
+
+<div class="fc-cf-trust__points" markdown>
+
+- Observed facts stay separate from inferences and recommendations.
+- Missing, stale, or unavailable sources are disclosed—not represented as zero.
+- Evidence is authorized again when it is opened.
+- Conflicting systems remain visible instead of being silently overwritten.
+
+</div>
+</section>
+
+<section class="fc-cf-final" aria-labelledby="fc-cf-final-title" markdown>
+
+## See the whole picture before deciding what happens next. { #fc-cf-final-title }
+
+Use Ask Dev when a person needs an evidence-backed answer. Use the ACR MCP path when an agent needs context before it works.
+
+<div class="fc-cf-actions" markdown>
+
+[Start with Ask Dev](../use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation){ .md-button .md-button--primary }
+[Read the technical architecture](../contribute/architecture/platform.md#ask-dev-and-context-fabric-runtime){ .md-button }
+
+</div>
+</section>

--- a/docs/context-fabric/index.md
+++ b/docs/context-fabric/index.md
@@ -1,12 +1,13 @@
 ---
 page_id: context-fabric
-summary: See how Context Fabric connects engineering evidence so people and agents can understand the real state of projects, teams, and organizations.
+summary: See how Context Fabric gives people and agents evidence-backed context about the work, systems, relationships, decisions, and conditions across an engineering organization.
 content_type: marketing
 owner: product
 source_of_truth:
   - current Ask Dev window and /dev workspace
   - current Context Fabric Validation surface
   - Ask Dev Interaction Surface Amendment — Context Fabric relationship, chat window, and full-page workspace
+  - Ask Dev Wave 3.1 — Evidence-backed engineering intelligence
   - "PRD v2.1: Dev Health Agent Context Runtime — Go service and MCP sidecar"
   - full-chaos/dev-health-acr README.md
 applicability: current
@@ -22,25 +23,25 @@ hide:
 Context Fabric
 {: .fc-cf-kicker }
 
-# Know what’s actually happening—not just what the tracker says. { #fc-cf-title }
+# Give people and agents the context behind the work. { #fc-cf-title }
 
-Context Fabric connects the work, code, delivery, reliability, and source-health evidence already flowing through Dev Health. It gives people and agents a shared, evidence-backed view of the real state of a project, team, or organization.
+Context Fabric turns the engineering evidence already flowing through Dev Health into shared operating context: who owns and is affected by the work, what is actually happening, why it matters, how the systems and decisions relate, and what evidence should guide the next action.
 {: .fc-cf-lede }
 
 <div class="fc-cf-actions" markdown>
 
 [Explore Ask Dev](../use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation){ .md-button .md-button--primary }
-[Use Context Fabric with an agent](https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md){ .md-button }
+[Connect an agent](https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md){ .md-button }
 
 </div>
 </div>
 
-<aside class="fc-cf-hero__visual" aria-label="Context Fabric connects engineering signals to Ask Dev and compatible agents">
+<aside class="fc-cf-hero__visual" aria-label="Context Fabric connects the engineering ecosystem to Ask Dev and ACR MCP consumers">
   <div class="fc-cf-sources" aria-label="Connected engineering evidence">
-    <span>Planning</span>
-    <span>Code and review</span>
-    <span>CI and delivery</span>
-    <span>Incidents and reliability</span>
+    <span>Work and priorities</span>
+    <span>Code and delivery</span>
+    <span>Teams and ownership</span>
+    <span>Reliability and operations</span>
   </div>
   <div class="fc-cf-core">
     <strong>Context Fabric</strong>
@@ -48,30 +49,83 @@ Context Fabric connects the work, code, delivery, reliability, and source-health
   </div>
   <div class="fc-cf-destinations">
     <div><strong>Ask Dev</strong><span>For people</span></div>
-    <div><strong>MCP</strong><span>For developers and agents</span></div>
+    <div><strong>ACR / MCP</strong><span>For developers and agents</span></div>
   </div>
 </aside>
 </section>
 
 <section class="fc-cf-section fc-cf-section--intro" markdown>
 
-## Project status is a relationship, not a field
+## Understand the engineering ecosystem around the work
 
-A tracking system records what someone declared. The rest of the engineering ecosystem records what actually happened.
+Planning systems, repositories, reviews, delivery pipelines, incidents, architecture, ownership, investment, dependencies, and source health each describe a different part of engineering reality. On their own, they leave people and agents to reconstruct the surrounding context every time they need to decide or act.
 
-A pull request may be merged while the ticket still says **In Progress**. A feature may be deployed behind a flag, active for users, and followed by an incident or additional rollout work. Each system contains part of the story, but no single status field contains the whole thing.
+Context Fabric connects those authorized signals without flattening them into one status field or opaque score. It creates a bounded, evidence-backed view of the relationships, conditions, history, and constraints that explain what is happening across a project, team, portfolio, or organization.
 
-Context Fabric connects those signals so teams do not have to treat one tracker—or one teammate’s memory—as the only source of truth.
+</section>
 
+<section class="fc-cf-use-cases" aria-labelledby="fc-cf-context-title" markdown>
+
+## Context that answers who, what, why, and how { #fc-cf-context-title }
+
+<div class="fc-cf-use-grid" markdown>
+
+<article class="fc-cf-use-card fc-cf-use-card--ask" markdown>
+
+Connected scope
+{: .fc-cf-card-kicker }
+
+### Who
+
+The teams, owners, reviewers, repositories, services, projects, and stakeholders that are authorized, related, responsible, or affected.
+
+</article>
+
+<article class="fc-cf-use-card fc-cf-use-card--mcp" markdown>
+
+Observed state
+{: .fc-cf-card-kicker }
+
+### What
+
+The work, changes, delivery state, incidents, metrics, investment mix, source coverage, and other evidence that describe current reality.
+
+</article>
+
+<article class="fc-cf-use-card fc-cf-use-card--mcp" markdown>
+
+Relationships and causes
+{: .fc-cf-card-kicker }
+
+### Why
+
+The decisions, dependencies, prior attempts, failures, constraints, and sustained pressures that explain why the current state exists.
+
+</article>
+
+<article class="fc-cf-use-card fc-cf-use-card--ask" markdown>
+
+Ways of working
+{: .fc-cf-card-kicker }
+
+### How
+
+The architecture, workflows, required checks, evidence paths, operating boundaries, and next actions that should shape what happens next.
+
+</article>
+
+</div>
 </section>
 
 <section class="fc-cf-example" aria-labelledby="fc-cf-example-title" markdown>
 <div class="fc-cf-example__heading" markdown>
 
-Real-world example
+One day-to-day use case
 {: .fc-cf-kicker }
 
 ## The ticket says “In Progress.” What is the actual state? { #fc-cf-example-title }
+
+Project status is one familiar place where connected context matters. A tracking system records what someone declared; the rest of the engineering ecosystem records what actually happened.
 
 </div>
 
@@ -100,17 +154,17 @@ Real-world example
 
 <section class="fc-cf-section" markdown>
 
-## Come to the conversation prepared
+## Project status is an example—not the boundary
 
-Context Fabric is not meant to replace talking with your teammates. It helps you ask better questions and arrive with the relevant evidence already connected—like the A+ student who actually did the reading.
+The same fabric supports broader operating questions: project and portfolio health, team conditions and workload pressure, investment balance, operational deficiencies, ownership and dependency risk, changes in delivery or reliability, prior decisions that govern new work, and the quality or freshness of the available evidence.
 
-That gives engineering teams, leadership, developers, and agents a common starting point for discussing status, blockers, health, decisions, and next actions.
+It gives a leader a connected view before deciding where to intervene, a team a better starting point for a conversation, and an agent the relevant history and constraints before it edits code, reviews a change, updates documentation, investigates a failure, or runs automation.
 
 </section>
 
 <section class="fc-cf-use-cases" aria-labelledby="fc-cf-use-cases-title" markdown>
 
-## Two ways to use Context Fabric { #fc-cf-use-cases-title }
+## One fabric, built for people and agents { #fc-cf-use-cases-title }
 
 <div class="fc-cf-use-grid" markdown>
 
@@ -121,14 +175,14 @@ For teams and leaders
 
 ### Ask Dev
 
-Dev is embedded in the Dev Health application and can answer questions about project, team, and organizational health across the connected ecosystem.
+Ask Dev is the people-facing conversational layer in Dev Health. It brings project, team, portfolio, delivery, reliability, investment, operational, and data-trust evidence into one investigation instead of making someone navigate and reconcile every surface manually.
 
 <div class="fc-cf-question-list" markdown>
 
-- Is this project actually done?
-- What is blocking delivery?
-- Which teams need attention?
-- What do this team’s DORA metrics look like over the last 90 days?
+- What needs attention across this portfolio?
+- Which teams show sustained pressure, and why?
+- Where is engineering investment going?
+- What operational deficiencies or source gaps matter first?
 
 </div>
 
@@ -141,16 +195,16 @@ Dev is embedded in the Dev Health application and can answer questions about pro
 For developers and agents
 {: .fc-cf-card-kicker }
 
-### MCP for agents
+### ACR and MCP
 
-Compatible coding, review, documentation, and automation agents can receive scoped context and supporting evidence before they begin work instead of starting cold.
+Compatible coding, review, documentation, CI, research, and automation agents can receive scoped context and supporting evidence before they begin work instead of starting cold or rediscovering the ecosystem from scratch.
 
 <div class="fc-cf-question-list" markdown>
 
-- What decisions already govern this work?
-- Which related changes or failures matter?
-- What evidence should be verified before editing?
-- What risks and required checks are already known?
+- Who owns or is affected by this change?
+- What decisions and dependencies already govern it?
+- Which related code, reviews, incidents, or failures matter?
+- What constraints, risks, evidence, and checks should shape the plan?
 
 </div>
 
@@ -167,11 +221,11 @@ Compatible coding, review, documentation, and automation agents can receive scop
 Evidence before confidence
 {: .fc-cf-kicker }
 
-## An answer should show its work. { #fc-cf-trust-title }
+## Understanding should remain inspectable. { #fc-cf-trust-title }
 
-Context Fabric does not quietly turn incomplete data into certainty. It keeps the scope, as-of time, freshness, coverage, conflicts, unavailable sources, and supporting evidence visible.
+Context Fabric does not quietly turn incomplete data into certainty. It keeps the committed scope, as-of time, freshness, coverage, conflicts, unavailable sources, relationships, and supporting evidence visible.
 
-What it can answer depends on the sources, permissions, freshness, and capabilities available to the organization.
+What it can explain depends on the sources, permissions, freshness, relationships, and capabilities available to the organization.
 
 </div>
 
@@ -187,9 +241,9 @@ What it can answer depends on the sources, permissions, freshness, and capabilit
 
 <section class="fc-cf-final" aria-labelledby="fc-cf-final-title" markdown>
 
-## See the whole picture before deciding what happens next. { #fc-cf-final-title }
+## Give every decision—and every agent—the context behind the work. { #fc-cf-final-title }
 
-Use Ask Dev when a person needs an evidence-backed answer. Use the ACR MCP path when an agent needs context before it works.
+Use Ask Dev when people need shared, evidence-backed understanding. Use ACR and MCP when agents need the relevant scope, relationships, history, constraints, and evidence before they act.
 
 <div class="fc-cf-actions" markdown>
 

--- a/docs/context-fabric/index.md
+++ b/docs/context-fabric/index.md
@@ -7,7 +7,7 @@ source_of_truth:
   - current Ask Dev window and /dev workspace
   - current Context Fabric Validation surface
   - Ask Dev Interaction Surface Amendment — Context Fabric relationship, chat window, and full-page workspace
-  - PRD v2.1: Dev Health Agent Context Runtime — Go service and MCP sidecar
+  - "PRD v2.1: Dev Health Agent Context Runtime — Go service and MCP sidecar"
   - full-chaos/dev-health-acr README.md
 applicability: current
 lifecycle: active
@@ -170,6 +170,8 @@ Evidence before confidence
 ## An answer should show its work. { #fc-cf-trust-title }
 
 Context Fabric does not quietly turn incomplete data into certainty. It keeps the scope, as-of time, freshness, coverage, conflicts, unavailable sources, and supporting evidence visible.
+
+What it can answer depends on the sources, permissions, freshness, and capabilities available to the organization.
 
 </div>
 

--- a/docs/contribute/documentation/content-model.md
+++ b/docs/contribute/documentation/content-model.md
@@ -13,19 +13,21 @@ This is the authoring contract for published documentation. It defines the suppo
 
 ## Principles
 
-1. A page exists to help a reader complete one task, understand one concept, diagnose one failure, or look up one class of exact facts.
+1. A page exists to help a reader complete one task, understand one concept, diagnose one failure, look up one class of exact facts, or understand one product capability.
 2. Content type, audience, product area, and lifecycle are separate dimensions.
 3. A public page has one canonical URL and navigation location.
 4. Task pages link to canonical concepts and reference; they do not copy large definitions or tables.
-5. Internal plans, PRDs, QA specifications, evidence artifacts, and implementation notes use a separate internal schema and never become public by omission.
-6. Metadata is present only when it drives navigation, search, ownership, lifecycle, or factual validation.
-7. `/get-started/` content is authored from blank reader-task briefs. Existing onboarding titles, sequences, and prose are not templates.
+5. Marketing pages explain product value and supported use cases, then link to task guidance and technical sources instead of reproducing them.
+6. Internal plans, PRDs, QA specifications, evidence artifacts, and implementation notes use a separate internal schema and never become public by omission.
+7. Metadata is present only when it drives navigation, search, ownership, lifecycle, or factual validation.
+8. `/get-started/` content is authored from blank reader-task briefs. Existing onboarding titles, sequences, and prose are not templates.
 
 ## Public page types
 
 | Type | Reader intent | Required structure | Not this |
 | --- | --- | --- | --- |
 | `landing` | Choose a task within a domain | Scope, child task groups, one-sentence exclusions, troubleshooting entry | Marketing home, prose essay, complete sitemap |
+| `marketing` | Understand a product capability and decide whether to explore it | Audience problem, value proposition, supported use cases, representative example, trust boundaries, calls to task and technical guidance | User manual, implementation architecture, launch article, unsupported promise |
 | `tutorial` | Reach a first successful outcome while learning | Outcome, prerequisites, ordered path, checkpoints, result, next task | General reference, feature tour |
 | `task-guide` | Complete a specific action | Outcome, prerequisites, steps, expected result, failure path, related exact reference | Concept essay |
 | `workflow-guide` | Use and interpret a product workflow or view | Reader question, context, current UI path, interpretation sequence, evidence path, limitations, next actions, failure states | Screenshot gallery, feature specification |
@@ -99,7 +101,7 @@ Do not repeat these in front matter when the IA manifest already supplies them:
 | --- | --- | --- |
 | Critical | Credentials, destructive operations, upgrades, rollback, security incidents, data loss | Source owner, operations/security, content, and accessibility |
 | High | Permissions, provider setup, API contracts, calculations, AI/analytics interpretation | Source owner, content, IA, accessibility |
-| Medium | Ordinary feature workflows and concepts | Product/source owner and content |
+| Medium | Ordinary feature workflows, product marketing, and concepts | Product/source owner and content |
 | Low | Glossary, navigation index, non-behavioral explanation | Content/IA owner |
 
 Age alone does not make a page incorrect. Review is triggered by source changes, product changes, support findings, or the risk-based interval.
@@ -108,7 +110,8 @@ Age alone does not make a page incorrect. Review is triggered by source changes,
 
 * Literal keys, enums, defaults, schemas, and taxonomies should be generated or checked from code.
 * Procedures are verified against the supported UI, CLI, API, or deployment artifact.
-* Narrative interpretation is human-authored and reviewed.
+* Narrative interpretation and product positioning are human-authored and reviewed.
+* Marketing claims must map to supported product behavior and link to the canonical user or technical guidance that constrains them.
 * A page may cite several sources, but it has one accountable owner.
 * A source link is not a substitute for explaining the supported reader task.
 
@@ -116,7 +119,7 @@ Age alone does not make a page incorrect. Review is triggered by source changes,
 
 Before creating a page, answer:
 
-1. What exact reader task, concept, symptom, or lookup does it serve?
+1. What exact reader task, concept, symptom, lookup, or product capability does it serve?
 2. Which locked domain owns that outcome?
 3. Does a canonical page already answer it?
 4. Which content type fits?

--- a/docs/contribute/documentation/ia-diagrams.md
+++ b/docs/contribute/documentation/ia-diagrams.md
@@ -18,6 +18,7 @@ These diagrams are explanatory views of the IA manifest. The TSV manifest is aut
 ```mermaid
 flowchart TD
   HOME["/ — Documentation home"]
+  CF["/context-fabric/ — product overview"]
   GS["/get-started/ — provisional"]
   USE["/use/"]
   ADMIN["/admin/"]
@@ -26,6 +27,7 @@ flowchart TD
   REF["/reference/"]
   CONTRIB["/contribute/"]
 
+  HOME --> CF
   HOME --> GS
   HOME --> USE
   HOME --> ADMIN
@@ -92,6 +94,7 @@ flowchart TD
 
 ```mermaid
 flowchart LR
+  PROSPECT["Prospective team or stakeholder"] --> CF["Context Fabric product overview"]
   USER["Product user"] --> USE
   LEADER["Engineering leader"] --> USE
   ADMINR["Workspace administrator"] --> ADMIN
@@ -104,6 +107,7 @@ flowchart LR
   SEC --> OPERATE
   SEC --> REF
   NEW["New reader"] --> GS["Get started (provisional)"]
+  CF -. supported workflow .-> USE
   GS -. next real task .-> USE
   GS -. next real task .-> ADMIN
   GS -. next real task .-> OPERATE
@@ -132,13 +136,15 @@ flowchart TD
   START["New or changed material"] --> PUBLIC{"Supported public reader need?"}
   PUBLIC -- No --> INTERNAL["Internal plan, PRD, QA, evidence, or implementation record"]
   PUBLIC -- Yes --> INTENT{"Primary intent?"}
+  INTENT -- Understand product capability --> MARKETING["Canonical marketing page"]
   INTENT -- Complete a task --> DOMAIN{"Which task domain owns the outcome?"}
   DOMAIN --> TASK["Task or workflow page in that domain"]
   INTENT -- Diagnose failure --> TROUBLE["Troubleshooting beside the task/domain"]
   INTENT -- Understand concept --> CONCEPT["One canonical concept page"]
   INTENT -- Look up exact fact --> REFERENCE["Reference"]
   INTENT -- Change the product --> CONTRIBUTOR["Contribute"]
-  TASK --> EXISTS{"Canonical page already exists?"}
+  MARKETING --> EXISTS{"Canonical page already exists?"}
+  TASK --> EXISTS
   CONCEPT --> EXISTS
   REFERENCE --> EXISTS
   EXISTS -- Yes --> MERGE["Extend or merge; add contextual links"]
@@ -212,6 +218,8 @@ flowchart LR
   APP["Application help links"] --> CANON["docs.fullchaos.dev"]
   README["Repository READMEs"] --> CANON
   SEARCH["Search engines"] --> CANON
+  SOCIAL["Marketing and social posts"] --> CF["/context-fabric/"]
+  CF --> CANON
   OLD_WORKER["Non-canonical preview"] --> POLICY{"Preview disposition"}
   OLD_GHP["Legacy GitHub Pages"] --> REDIRECTS["Redirect manifest"]
   OLD_PATH["Moved or merged paths"] --> REDIRECTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Understand what each Dev Health view shows, what data it needs, how to interpret
 <div class="fc-home-actions" markdown>
 
 [Use Dev Health](use/index.md){ .md-button .md-button--primary }
+[Explore Context Fabric](context-fabric/index.md){ .md-button }
 [Browse reference](reference/index.md){ .md-button }
 
 </div>
@@ -28,6 +29,7 @@ Understand what each Dev Health view shows, what data it needs, how to interpret
 **Start with a common task**
 {: .fc-home-routes__label }
 
+- [Understand Context Fabric](context-fabric/index.md)
 - [Investigate where effort appears to be going](use/investment/investigate-effort.md)
 - [Diagnose no or incomplete data](use/troubleshooting/no-or-incomplete-data.md)
 - [Look up weighting and aggregation](reference/metrics/weighting-and-aggregation.md)
@@ -167,6 +169,7 @@ Set up the repository, understand the runtime and data boundaries, run the corre
 
 ## Popular tasks
 
+- [Understand Context Fabric](context-fabric/index.md)
 - [Investigate where effort appears to be going](use/investment/investigate-effort.md)
 - [Diagnose no or incomplete data](use/troubleshooting/no-or-incomplete-data.md)
 - [Set scope and time](use/navigate/scope-and-time.md)

--- a/docs/stylesheets/context-fabric.css
+++ b/docs/stylesheets/context-fabric.css
@@ -1,0 +1,655 @@
+/* Context Fabric product page. Technical diagrams remain in contributor architecture. */
+
+.md-content__inner:has(> .fc-cf-hero) {
+  max-width: 78rem;
+  padding-top: 1.15rem;
+}
+
+.md-content__inner:has(> .fc-cf-hero) > .md-content__button,
+.fc-cf-hero h1 .headerlink,
+.fc-cf-section h2 .headerlink,
+.fc-cf-example h2 .headerlink,
+.fc-cf-use-cases h2 .headerlink,
+.fc-cf-trust h2 .headerlink,
+.fc-cf-final h2 .headerlink {
+  display: none;
+}
+
+.fc-cf-hero {
+  background:
+    radial-gradient(circle at 82% 18%, color-mix(in srgb, var(--fc-aqua), transparent 78%), transparent 30%),
+    radial-gradient(circle at 8% 90%, color-mix(in srgb, var(--fc-flame), transparent 82%), transparent 34%),
+    var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.85rem;
+  color: var(--fc-silver);
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr);
+  margin: 0 0 1rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.fc-cf-hero::before,
+.fc-cf-hero::after {
+  content: "";
+  height: 0.22rem;
+  position: absolute;
+  top: 0;
+  width: 50%;
+}
+
+.fc-cf-hero::before {
+  background: linear-gradient(90deg, var(--fc-red), var(--fc-flame));
+  left: 0;
+}
+
+.fc-cf-hero::after {
+  background: linear-gradient(90deg, var(--fc-aqua), var(--fc-glacier));
+  right: 0;
+}
+
+.fc-cf-hero__copy {
+  align-self: center;
+  padding: clamp(1.7rem, 4.5vw, 3.7rem);
+}
+
+.fc-cf-kicker,
+.fc-cf-card-kicker {
+  color: var(--fc-glacier);
+  font-size: 0.64rem;
+  font-weight: 820;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.65rem !important;
+  text-transform: uppercase;
+}
+
+.fc-cf-hero .fc-cf-hero__copy h1 {
+  color: var(--fc-white);
+  font-size: clamp(2.45rem, 5.3vw, 4.25rem);
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+  margin: 0;
+  max-width: 13ch;
+}
+
+.fc-cf-lede {
+  color: var(--fc-mist);
+  font-size: clamp(0.94rem, 1.7vw, 1.08rem);
+  line-height: 1.55;
+  margin: 1.2rem 0 1.55rem !important;
+  max-width: 59ch !important;
+}
+
+.fc-cf-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.fc-cf-actions .md-button {
+  border-color: var(--fc-mist);
+  color: var(--fc-white);
+  margin: 0;
+  text-decoration: none;
+}
+
+.fc-cf-actions .md-button:hover,
+.fc-cf-actions .md-button:focus-visible {
+  background: var(--fc-carbon);
+  border-color: var(--fc-white);
+  color: var(--fc-white);
+}
+
+.fc-cf-actions .md-button--primary {
+  background: var(--fc-flame);
+  border-color: var(--fc-flame);
+  color: var(--fc-void);
+}
+
+.fc-cf-actions .md-button--primary:hover,
+.fc-cf-actions .md-button--primary:focus-visible {
+  background: var(--fc-amber);
+  border-color: var(--fc-amber);
+  color: var(--fc-void);
+}
+
+.fc-cf-hero__visual {
+  align-content: center;
+  background: color-mix(in srgb, var(--fc-void), transparent 24%);
+  border-left: 1px solid var(--fc-surface);
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  position: relative;
+}
+
+.fc-cf-hero__visual::before {
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--fc-surface), transparent 35%) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--fc-surface), transparent 35%) 1px, transparent 1px);
+  background-size: 1.4rem 1.4rem;
+  content: "";
+  inset: 0;
+  opacity: 0.28;
+  pointer-events: none;
+  position: absolute;
+}
+
+.fc-cf-sources,
+.fc-cf-core,
+.fc-cf-destinations {
+  position: relative;
+  z-index: 1;
+}
+
+.fc-cf-sources {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.fc-cf-sources span {
+  background: var(--fc-carbon);
+  border: 1px solid var(--fc-surface);
+  border-radius: 999px;
+  color: var(--fc-silver);
+  font-size: 0.65rem;
+  font-weight: 680;
+  padding: 0.45rem 0.65rem;
+  text-align: center;
+}
+
+.fc-cf-core {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--fc-flame), transparent 82%), color-mix(in srgb, var(--fc-aqua), transparent 84%)),
+    var(--fc-graphite);
+  border: 1px solid color-mix(in srgb, var(--fc-glacier), var(--fc-surface) 62%);
+  border-radius: 0.78rem;
+  box-shadow: 0 1.2rem 3rem color-mix(in srgb, var(--fc-void), transparent 35%);
+  display: grid;
+  gap: 0.45rem;
+  padding: 1.5rem 1.25rem;
+  text-align: center;
+}
+
+.fc-cf-core::before,
+.fc-cf-core::after {
+  background: linear-gradient(var(--fc-surface), var(--fc-glacier));
+  content: "";
+  height: 0.8rem;
+  left: 50%;
+  position: absolute;
+  width: 1px;
+}
+
+.fc-cf-core::before {
+  top: -0.8rem;
+}
+
+.fc-cf-core::after {
+  background: linear-gradient(var(--fc-flame), var(--fc-surface));
+  bottom: -0.8rem;
+}
+
+.fc-cf-core strong {
+  color: var(--fc-white);
+  font-size: clamp(1.2rem, 2.5vw, 1.65rem);
+  letter-spacing: -0.025em;
+}
+
+.fc-cf-core span {
+  color: var(--fc-mist);
+  font-size: 0.61rem;
+  letter-spacing: 0.035em;
+}
+
+.fc-cf-destinations {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.fc-cf-destinations div {
+  background: var(--fc-carbon);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.55rem;
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.75rem;
+  text-align: center;
+}
+
+.fc-cf-destinations div:first-child {
+  border-top: 0.16rem solid var(--fc-flame);
+}
+
+.fc-cf-destinations div:last-child {
+  border-top: 0.16rem solid var(--fc-aqua);
+}
+
+.fc-cf-destinations strong {
+  color: var(--fc-white);
+  font-size: 0.77rem;
+}
+
+.fc-cf-destinations span {
+  color: var(--fc-mist);
+  font-size: 0.58rem;
+}
+
+.fc-cf-section {
+  margin: 0 auto;
+  max-width: 57rem;
+  padding: clamp(2.1rem, 5vw, 4rem) 1rem;
+  text-align: center;
+}
+
+.fc-cf-section h2,
+.fc-cf-use-cases > h2,
+.fc-cf-trust h2,
+.fc-cf-final h2,
+.fc-cf-example h2 {
+  border: 0;
+  font-size: clamp(1.65rem, 3.4vw, 2.45rem);
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  margin: 0 0 0.85rem;
+  padding: 0;
+}
+
+.fc-cf-section p {
+  color: var(--fc-doc-text-muted);
+  font-size: clamp(0.83rem, 1.4vw, 0.95rem);
+  line-height: 1.7;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 68ch;
+}
+
+.fc-cf-section--intro {
+  padding-bottom: 3rem;
+}
+
+.fc-cf-example {
+  background: var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.8rem;
+  color: var(--fc-silver);
+  margin: 0 0 1rem;
+  overflow: hidden;
+  padding: clamp(1.5rem, 4vw, 2.8rem);
+}
+
+.fc-cf-example__heading {
+  margin: 0 auto 1.5rem;
+  max-width: 58rem;
+  text-align: center;
+}
+
+.fc-cf-example h2 {
+  color: var(--fc-white);
+}
+
+.fc-cf-example__grid {
+  align-items: stretch;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(10rem, 0.68fr) minmax(16rem, 1fr) minmax(14rem, 1fr);
+}
+
+.fc-cf-example__declared,
+.fc-cf-example__answer,
+.fc-cf-evidence {
+  border-radius: 0.62rem;
+  min-width: 0;
+  padding: 1rem;
+}
+
+.fc-cf-example__declared {
+  align-content: center;
+  background: var(--fc-carbon);
+  border: 1px solid var(--fc-surface);
+  display: grid;
+  gap: 0.3rem;
+  text-align: center;
+}
+
+.fc-cf-example__declared strong {
+  color: var(--fc-gold);
+  font-size: 1.25rem;
+}
+
+.fc-cf-example__declared > span:last-child {
+  color: var(--fc-mist);
+  font-size: 0.62rem;
+}
+
+.fc-cf-example__label {
+  color: var(--fc-glacier);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.fc-cf-evidence {
+  background: var(--fc-graphite);
+  border: 1px solid var(--fc-surface);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.fc-cf-evidence__item {
+  align-items: center;
+  background: var(--fc-carbon);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.38rem;
+  color: var(--fc-silver);
+  display: flex;
+  font-size: 0.67rem;
+  gap: 0.5rem;
+  padding: 0.46rem 0.55rem;
+}
+
+.fc-cf-evidence__item::before {
+  border-radius: 50%;
+  content: "";
+  flex: 0 0 0.45rem;
+  height: 0.45rem;
+}
+
+.fc-cf-evidence__item.is-complete::before {
+  background: var(--fc-aqua);
+  box-shadow: 0 0 0 0.17rem color-mix(in srgb, var(--fc-aqua), transparent 82%);
+}
+
+.fc-cf-evidence__item.is-current::before {
+  background: var(--fc-flame);
+  box-shadow: 0 0 0 0.17rem color-mix(in srgb, var(--fc-flame), transparent 82%);
+}
+
+.fc-cf-example__answer {
+  align-content: center;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--fc-aqua), transparent 87%), color-mix(in srgb, var(--fc-flame), transparent 91%)),
+    var(--fc-carbon);
+  border: 1px solid color-mix(in srgb, var(--fc-glacier), var(--fc-surface) 60%);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.fc-cf-example__answer strong {
+  color: var(--fc-white);
+  font-size: 1rem;
+  line-height: 1.28;
+}
+
+.fc-cf-example__answer p {
+  color: var(--fc-mist);
+  font-size: 0.65rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.fc-cf-use-cases {
+  padding: clamp(2rem, 5vw, 4rem) 0;
+  text-align: center;
+}
+
+.fc-cf-use-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 1.25rem;
+  text-align: left;
+}
+
+.fc-cf-use-card {
+  background: var(--fc-doc-surface);
+  border: 1px solid var(--fc-doc-border);
+  border-radius: 0.72rem;
+  box-shadow: 0 0.3rem 1rem color-mix(in srgb, var(--fc-doc-text), transparent 92%);
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: clamp(1.2rem, 3vw, 1.7rem);
+  position: relative;
+}
+
+.fc-cf-use-card::before {
+  content: "";
+  height: 0.2rem;
+  inset: 0 0 auto;
+  position: absolute;
+}
+
+.fc-cf-use-card--ask::before {
+  background: linear-gradient(90deg, var(--fc-red), var(--fc-flame));
+}
+
+.fc-cf-use-card--mcp::before {
+  background: linear-gradient(90deg, var(--fc-aqua), var(--fc-glacier));
+}
+
+.fc-cf-use-card h3 {
+  font-size: 1.35rem;
+  margin: 0 0 0.55rem;
+}
+
+.fc-cf-use-card > p:not(.fc-cf-card-kicker) {
+  color: var(--fc-doc-text-muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.fc-cf-use-card--ask .fc-cf-card-kicker {
+  color: var(--fc-crimson);
+}
+
+[data-md-color-scheme="slate"] .fc-cf-use-card--ask .fc-cf-card-kicker {
+  color: var(--fc-flame);
+}
+
+.fc-cf-use-card--mcp .fc-cf-card-kicker {
+  color: var(--fc-ocean);
+}
+
+[data-md-color-scheme="slate"] .fc-cf-use-card--mcp .fc-cf-card-kicker {
+  color: var(--fc-glacier);
+}
+
+.fc-cf-question-list {
+  border-top: 1px solid var(--fc-doc-border);
+  margin: 0.75rem 0 1rem;
+  padding-top: 0.65rem;
+}
+
+.fc-cf-question-list ul {
+  list-style: none;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.fc-cf-question-list li {
+  color: var(--fc-doc-text-muted);
+  font-size: 0.7rem;
+  list-style: none;
+  margin: 0 !important;
+  padding: 0.35rem 0 0.35rem 1rem;
+  position: relative;
+}
+
+.fc-cf-question-list li::before {
+  color: var(--fc-doc-active);
+  content: "→";
+  font-weight: 800;
+  left: 0;
+  position: absolute;
+}
+
+.fc-cf-question-list li::marker {
+  content: "";
+}
+
+.fc-cf-card-link {
+  color: var(--fc-doc-link);
+  font-size: 0.72rem;
+  font-weight: 780;
+  margin-top: auto;
+  text-decoration: none;
+}
+
+.fc-cf-card-link:hover,
+.fc-cf-card-link:focus-visible {
+  color: var(--fc-doc-link-hover);
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+}
+
+.fc-cf-trust {
+  align-items: start;
+  background:
+    linear-gradient(120deg, color-mix(in srgb, var(--fc-aqua), transparent 90%), transparent 55%),
+    var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-left: 0.26rem solid var(--fc-aqua);
+  border-radius: 0.72rem;
+  color: var(--fc-silver);
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+  margin: clamp(1.5rem, 4vw, 3rem) 0;
+  padding: clamp(1.4rem, 4vw, 2.4rem);
+}
+
+.fc-cf-trust h2 {
+  color: var(--fc-white);
+}
+
+.fc-cf-trust__copy > p:not(.fc-cf-kicker) {
+  color: var(--fc-mist);
+  font-size: 0.75rem;
+  line-height: 1.65;
+}
+
+.fc-cf-trust__points ul {
+  list-style: none;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.fc-cf-trust__points li {
+  border-top: 1px solid var(--fc-surface);
+  color: var(--fc-silver);
+  font-size: 0.72rem;
+  list-style: none;
+  margin: 0 !important;
+  padding: 0.65rem 0 0.65rem 1.15rem;
+  position: relative;
+}
+
+.fc-cf-trust__points li:first-child {
+  border-top: 0;
+}
+
+.fc-cf-trust__points li::before {
+  color: var(--fc-flame);
+  content: "✓";
+  font-weight: 850;
+  left: 0;
+  position: absolute;
+}
+
+.fc-cf-trust__points li::marker {
+  content: "";
+}
+
+.fc-cf-final {
+  background:
+    radial-gradient(circle at 10% 30%, color-mix(in srgb, var(--fc-flame), transparent 83%), transparent 35%),
+    radial-gradient(circle at 92% 75%, color-mix(in srgb, var(--fc-aqua), transparent 82%), transparent 38%),
+    var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.8rem;
+  color: var(--fc-silver);
+  margin: 0 0 2rem;
+  padding: clamp(1.6rem, 5vw, 3.2rem);
+  text-align: center;
+}
+
+.fc-cf-final h2 {
+  color: var(--fc-white);
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 20ch;
+}
+
+.fc-cf-final > p {
+  color: var(--fc-mist);
+  font-size: 0.82rem;
+  margin: 0.8rem auto 1.35rem;
+  max-width: 61ch;
+}
+
+.fc-cf-final .fc-cf-actions {
+  justify-content: center;
+}
+
+@media screen and (max-width: 68rem) {
+  .fc-cf-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .fc-cf-hero__visual {
+    border-left: 0;
+    border-top: 1px solid var(--fc-surface);
+  }
+
+  .fc-cf-example__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .fc-cf-example__answer {
+    grid-column: 1 / -1;
+  }
+}
+
+@media screen and (max-width: 46rem) {
+  .md-content__inner:has(> .fc-cf-hero) {
+    padding-top: 0.75rem;
+  }
+
+  .fc-cf-hero__copy,
+  .fc-cf-hero__visual {
+    padding: 1.25rem;
+  }
+
+  .fc-cf-sources,
+  .fc-cf-destinations,
+  .fc-cf-use-grid,
+  .fc-cf-trust,
+  .fc-cf-example__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fc-cf-example__answer {
+    grid-column: auto;
+  }
+
+  .fc-cf-section {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-cf-use-card,
+  .fc-cf-card-link,
+  .fc-cf-actions .md-button {
+    scroll-behavior: auto;
+    transition: none;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ theme:
 
 nav:
   - Documentation home: index.md
+  - Context Fabric: context-fabric/index.md
   - Get started:
       - get-started/index.md
       - Choose a task: get-started/choose-a-task.md
@@ -272,6 +273,7 @@ extra_css:
   - stylesheets/extra.css
   - stylesheets/home.css
   - stylesheets/home-sections.css
+  - stylesheets/context-fabric.css
   - stylesheets/review-fixes.css
 
 extra:

--- a/scripts/validate_docs_ia_v2.py
+++ b/scripts/validate_docs_ia_v2.py
@@ -11,6 +11,7 @@ from typing import Any
 
 URL_RE = re.compile(r"^/(?:[a-z0-9]+(?:-[a-z0-9]+)*/)*$")
 EXPECTED_TOP_LEVEL = {
+    "/context-fabric/",
     "/get-started/",
     "/use/",
     "/admin/",
@@ -33,6 +34,7 @@ ALLOWED_PUBLIC_STATES = {"public", "internal", "reserved"}
 ALLOWED_LIFECYCLES = {"planned", "active", "deprecated", "archived"}
 ALLOWED_KINDS = {
     "landing",
+    "marketing",
     "section",
     "tutorial",
     "task-guide",
@@ -102,7 +104,18 @@ def validate_nodes(nodes: list[dict[str, Any]]) -> list[str]:
         if "first-10-minutes" in lowered or "first-ten-minutes" in lowered:
             errors.append(f"{node_id}: current onboarding title may not be preserved")
         if "context-fabric" in lowered:
-            errors.append(f"{node_id}: Context Fabric is reserved, not a live IA node")
+            canonical_context_fabric = (
+                node_id == "context-fabric"
+                and url == "/context-fabric/"
+                and parent_id == "home"
+                and kind == "marketing"
+                and public_state == "public"
+            )
+            if not canonical_context_fabric:
+                errors.append(
+                    f"{node_id}: Context Fabric URLs are limited to the canonical "
+                    "top-level marketing page"
+                )
         segments = [segment for segment in url.strip("/").split("/") if segment]
         if len(segments) > 4:
             errors.append(f"{node_id}: URL exceeds the default four-segment budget")

--- a/tests/docs/test_audience_navigation.py
+++ b/tests/docs/test_audience_navigation.py
@@ -3,7 +3,8 @@
 Navigation is organized by durable reader task, not by the superseded
 six-audience buckets. The root ``/`` is the task router and its first
 viewport surfaces the accepted primary tasks directly, so they are
-reachable without search.
+reachable without search. One explicitly governed top-level product overview
+may appear between the home router and the task domains.
 """
 
 from pathlib import Path
@@ -15,8 +16,14 @@ MKDOCS_PATH = ROOT / "mkdocs.yml"
 DOCS_DIR = ROOT / "docs"
 INDEX_PATH = DOCS_DIR / "index.md"
 
+# The single accepted top-level product overview. This is not an audience
+# bucket or a replacement for the task-oriented documentation domains.
+PRODUCT_OVERVIEW_SECTIONS = ("Context Fabric",)
+PRODUCT_OVERVIEW_PATHS = {"Context Fabric": "context-fabric/index.md"}
+
 # The accepted top-level task domains, in navigation order, after the home
-# router entry. These mirror the canonical IA task domains.
+# router and governed product overview. These mirror the canonical IA task
+# domains.
 TASK_DOMAIN_SECTIONS = (
     "Get started",
     "Use Dev Health",
@@ -84,8 +91,16 @@ def test_navigation_is_task_oriented_not_audience_bucketed() -> None:
     assert labels[0] == "Documentation home"
     assert nav[0]["Documentation home"] == "index.md"
 
+    # The only non-task top-level entry is the explicitly governed product
+    # overview, with one exact canonical page.
+    product_start = 1
+    product_end = product_start + len(PRODUCT_OVERVIEW_SECTIONS)
+    assert tuple(labels[product_start:product_end]) == PRODUCT_OVERVIEW_SECTIONS
+    for index, label in enumerate(PRODUCT_OVERVIEW_SECTIONS, start=product_start):
+        assert nav[index][label] == PRODUCT_OVERVIEW_PATHS[label]
+
     # The remaining top level is exactly the accepted task domains, in order.
-    assert tuple(labels[1:]) == TASK_DOMAIN_SECTIONS
+    assert tuple(labels[product_end:]) == TASK_DOMAIN_SECTIONS
 
     # None of the superseded six-audience buckets survive.
     for legacy_section in LEGACY_AUDIENCE_SECTIONS:

--- a/tests/docs/test_design_tokens.py
+++ b/tests/docs/test_design_tokens.py
@@ -9,6 +9,7 @@ STYLESHEETS = ROOT / "docs" / "stylesheets"
 PALETTE_PATH = STYLESHEETS / "logo-palette.css"
 EXTRA_CSS_PATH = STYLESHEETS / "extra.css"
 HOME_CSS_PATH = STYLESHEETS / "home.css"
+CONTEXT_FABRIC_CSS_PATH = STYLESHEETS / "context-fabric.css"
 # Review-only primitive/showcase and design-QA material must never be publicly
 # navigated or built. These paths must NOT exist in the canonical public tree.
 PUBLIC_DESIGN_DIRECTIONS_PATH = ROOT / "docs" / "design-directions.md"
@@ -67,15 +68,23 @@ def test_canonical_uses_the_supplied_full_chaos_palette() -> None:
 def test_canonical_css_imports_palette_and_protects_accessibility_states() -> None:
     assert EXTRA_CSS_PATH.is_file(), f"missing canonical CSS: {EXTRA_CSS_PATH}"
     assert HOME_CSS_PATH.is_file(), f"missing canonical home CSS: {HOME_CSS_PATH}"
+    assert CONTEXT_FABRIC_CSS_PATH.is_file(), (
+        f"missing Context Fabric CSS: {CONTEXT_FABRIC_CSS_PATH}"
+    )
 
     extra_css = EXTRA_CSS_PATH.read_text(encoding="utf-8")
     home_css = HOME_CSS_PATH.read_text(encoding="utf-8")
+    context_fabric_css = CONTEXT_FABRIC_CSS_PATH.read_text(encoding="utf-8")
 
     assert '@import url("logo-palette.css");' in extra_css
     assert ":focus-visible" in extra_css
     assert "prefers-reduced-motion" in extra_css
     assert "fc-home-hero" in home_css
     assert "fc-home-card" in home_css
+    assert "fc-cf-hero" in context_fabric_css
+    assert "fc-cf-use-card" in context_fabric_css
+    assert "prefers-reduced-motion" in context_fabric_css
+    _assert_no_undeclared_raw_css_value(CONTEXT_FABRIC_CSS_PATH)
 
 
 def test_review_only_design_pages_are_not_publicly_built() -> None:

--- a/tests/docs/test_docs_ia_v2.py
+++ b/tests/docs/test_docs_ia_v2.py
@@ -44,7 +44,7 @@ def test_validator_rejects_duplicate_url_and_reused_onboarding_title() -> None:
                 "label": prefix,
                 "url": prefix,
                 "parent_id": "home",
-                "kind": "landing",
+                "kind": "marketing" if prefix == "/context-fabric/" else "landing",
                 "nav": "true",
                 "public_state": "public",
                 "lifecycle": "planned",
@@ -78,3 +78,30 @@ def test_validator_rejects_duplicate_url_and_reused_onboarding_title() -> None:
     errors = module.validate_nodes(nodes)
     assert any("current onboarding title" in error for error in errors)
     assert any("duplicate canonical URL" in error for error in errors)
+
+
+def test_context_fabric_url_is_limited_to_the_canonical_marketing_page() -> None:
+    module: Any = _load_validator()
+    root = Path(__file__).parents[2]
+    nodes = module.load_nodes(root / "docs-data/ia")
+    nodes.append(
+        {
+            "id": "use-context-fabric-copy",
+            "label": "Context Fabric copy",
+            "url": "/use/context-fabric/",
+            "parent_id": "use",
+            "kind": "marketing",
+            "nav": "true",
+            "public_state": "public",
+            "lifecycle": "active",
+            "provisional": "false",
+        }
+    )
+
+    errors = module.validate_nodes(nodes)
+
+    assert any(
+        "Context Fabric URLs are limited to the canonical top-level marketing page"
+        in error
+        for error in errors
+    )


### PR DESCRIPTION
## Summary

Adds a first-class marketing page for Context Fabric at `/context-fabric/` so short social posts can link to a durable product explanation instead of becoming articles themselves.

## Product narrative

- positions Context Fabric as shared, evidence-backed operating context for the engineering ecosystem—not as a project-status feature;
- explains how it helps people and agents understand **who, what, why, and how** across work, code, delivery, reliability, ownership, investment, dependencies, and source health;
- keeps the canonical diagnosis loop: **State → Pressure → Cause → Evidence → Action**;
- retains project status as one concrete day-to-day use case rather than the product boundary;
- presents the two supported experiences: **Ask Dev** for people and **ACR/MCP** for developers and agents;
- makes scope, freshness, coverage, conflicts, unavailable sources, relationships, and evidence part of the product promise.

## Audience separation

- `/context-fabric/`: product marketing and representative use cases;
- `/use/ai-workflows/`: task-oriented Ask Dev guidance;
- `/contribute/architecture/`: exact runtime and contract diagrams;
- social posts: short introduction and link to the product page.

## Design

- adds a responsive, CSS-native product visual using the Full Chaos palette;
- avoids raw Mermaid, database nodes, service boxes, and contract terminology on the marketing page;
- includes an accessible text equivalent, focus states, dark/light support, and reduced-motion handling;
- links to the canonical Ask Dev guide, ACR MCP setup, and technical architecture.

## Documentation system

- activates the previously reserved canonical `/context-fabric/` route;
- introduces the explicit `marketing` page type in the documentation content model and IA validator;
- keeps all other `context-fabric` URL placements prohibited to prevent duplicate product pages;
- governs Context Fabric as the one explicit top-level product overview while preserving the seven task-oriented documentation domains;
- updates the IA diagrams, documentation home, navigation, and design-token tests.

## Validation

PR CI validates:

- strict MkDocs publication and broken-link checks;
- IA manifest and canonical URL rules;
- documentation design-token checks;
- Python lint, typecheck, and tests.
