### PR TITLE
fix(providersync): isolate live oracle imports

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -14,6 +14,7 @@ httpx==0.28.1
 idna==3.15
 pydantic==2.13.4
 pydantic-core==2.46.4
+PyYAML==6.0.3
 smmap==5.0.3
 SQLAlchemy==2.0.49
 typing-extensions==4.15.0

--- a/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
@@ -2,9 +2,52 @@
 
 from __future__ import annotations
 
+import pathlib
+import sys
+import types
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
+
+
+def install_minimal_oracle_imports() -> None:
+    """Load the normalizer without unrelated API/client runtime dependencies.
+
+    The Go quality image intentionally contains only the Python standard
+    library plus the few dependencies used directly by provider code.  The
+    aggregate ``dev_health_ops.models`` initializer imports API licensing,
+    which in turn imports FastAPI even though these row oracles only need the
+    standalone work-item and AI-attribution dataclasses.  The normalizer also
+    imports five client Protocols for annotations; importing their concrete
+    module would pull transport/auth dependencies into a row-only oracle.
+
+    Installing a normal namespace package for the model directory and a typed
+    annotation-only client module preserves the real production model and
+    normalizer modules/functions.  Nothing involved in producing row values is
+    replaced.
+    """
+    if "dev_health_ops.models" in sys.modules:
+        return
+    models_dir = (
+        pathlib.Path(__file__).resolve().parents[4] / "src/dev_health_ops/models"
+    )
+    package = types.ModuleType("dev_health_ops.models")
+    package.__path__ = [str(models_dir)]
+    package.__package__ = "dev_health_ops.models"
+    sys.modules[package.__name__] = package
+
+    client_name = "dev_health_ops.providers.github.client"
+    if client_name not in sys.modules:
+        client = types.ModuleType(client_name)
+        for name in (
+            "_GitHubCommentLike",
+            "_GitHubEventLike",
+            "_GitHubIssueLike",
+            "_GitHubMilestoneLike",
+            "_GitHubPullRequestLike",
+        ):
+            setattr(client, name, type(name, (), {}))
+        sys.modules[client_name] = client
 
 
 def object_from_case(value: Any) -> Any:

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_ai-attribution.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_ai-attribution.py
@@ -12,8 +12,11 @@ from uuid import UUID
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_dependency.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_dependency.py
@@ -11,8 +11,11 @@ from typing import Any
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_interaction.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_interaction.py
@@ -11,8 +11,11 @@ from typing import Any
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_issue.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_issue.py
@@ -13,6 +13,11 @@ from uuid import UUID
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr.py
@@ -12,8 +12,11 @@ from uuid import UUID
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_reopen.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_reopen.py
@@ -11,8 +11,11 @@ from typing import Any
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_sprint.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_sprint.py
@@ -12,6 +12,11 @@ from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_status-transition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_status-transition.py
@@ -12,8 +12,11 @@ from uuid import UUID
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
     object_from_case,
 )
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),


### PR DESCRIPTION
## Summary

- fix the hosted Go-quality failure introduced by the GitHub work-item live oracles
- load the real production work-item and AI-attribution model modules without executing the unrelated aggregate API/licensing initializer
- replace only annotation-only GitHub client protocol imports so row oracles do not require the full provider transport/auth runtime
- pin PyYAML in the intentionally minimal live-oracle dependency closure

## Reproduction

PR #1470 failed `go-quality` because importing `dev_health_ops.models` pulled FastAPI into the minimal oracle environment. The exact GitHub Actions dependency closure reproduced the failure locally before this change.

The oracles still execute the real production model modules and GitHub normalization functions; no row-producing logic is stubbed.

## Validation

- exact locked GitHub Actions Python dependency environment: `bash ci/check_go.sh all` passed
  - normal Go tests, race tests, fresh live Python oracles, builds, contracts, and integration coverage passed
- `bash ci/local_validate.sh` passed
  - 11,574 Python tests passed; 98 skipped; 1 expected xfail
  - Ruff, mypy, Go, River, scratch ClickHouse migration, and live argMax passed
- signed commit verified locally

## Landing

Feature-only stack. Base must remain `feat/go-worker-runtime-migration`; do not retarget or merge to `main`.
