### PR TITLE
feat(providersync): fetch GitHub work-item PR social data

### DIFF
--- a/internal/providersync/github_work_items_social_adapter.go
+++ b/internal/providersync/github_work_items_social_adapter.go
@@ -1,0 +1,171 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// githubWorkItemPRSocialUser mirrors GitHubGraphQLUser, the exact object the
+// active Python GitHubWorkClient adapter gives the semantic normalizers.
+type githubWorkItemPRSocialUser struct {
+	Login *string `json:"login"`
+	Email *string `json:"email"`
+	Name  *string `json:"name"`
+}
+
+// githubWorkItemPRSocialComment mirrors GitHubGraphQLComment after Python's
+// _comment_from_graphql conversion. Keeping this typed intermediate makes the
+// camelCase GraphQL-to-semantic boundary independently oracle-testable.
+type githubWorkItemPRSocialComment struct {
+	ID        any                        `json:"id"`
+	CreatedAt *time.Time                 `json:"created_at"`
+	User      githubWorkItemPRSocialUser `json:"user"`
+	Body      string                     `json:"body"`
+}
+
+// githubWorkItemPRSocialEvent mirrors GitHubGraphQLEvent after Python's
+// _event_from_graphql conversion.
+type githubWorkItemPRSocialEvent struct {
+	CreatedAt *time.Time                 `json:"created_at"`
+	Event     string                     `json:"event"`
+	Actor     githubWorkItemPRSocialUser `json:"actor"`
+	Label     any                        `json:"label"`
+}
+
+// githubWorkItemPRSocialSemanticPayload is the explicit composition seam
+// between the raw GraphQL fetch foundation and normalizeGitHubPullRequestBundle.
+type githubWorkItemPRSocialSemanticPayload struct {
+	Comments []json.RawMessage
+	Events   []json.RawMessage
+}
+
+type githubWorkItemPRSocialRawComment struct {
+	ID             any     `json:"id"`
+	DatabaseID     any     `json:"databaseId"`
+	FullDatabaseID any     `json:"fullDatabaseId"`
+	Body           *string `json:"body"`
+	CreatedAt      *string `json:"createdAt"`
+	Author         *struct {
+		Login *string `json:"login"`
+	} `json:"author"`
+}
+
+type githubWorkItemPRSocialRawEvent struct {
+	TypeName  string  `json:"__typename"`
+	CreatedAt *string `json:"createdAt"`
+	Actor     *struct {
+		Login *string `json:"login"`
+	} `json:"actor"`
+}
+
+func adaptGitHubWorkItemPRSocialPayload(
+	payload GitHubWorkItemPRSocialPayload,
+) (githubWorkItemPRSocialSemanticPayload, error) {
+	adapted := githubWorkItemPRSocialSemanticPayload{
+		Comments: make([]json.RawMessage, 0, len(payload.Comments)),
+		Events:   make([]json.RawMessage, 0, len(payload.Events)),
+	}
+	for _, raw := range payload.Comments {
+		comment, err := adaptGitHubWorkItemPRSocialComment(raw)
+		if err != nil {
+			return githubWorkItemPRSocialSemanticPayload{}, err
+		}
+		encoded, err := json.Marshal(comment)
+		if err != nil {
+			return githubWorkItemPRSocialSemanticPayload{}, providerfoundation.ErrNormalizationInvalid
+		}
+		adapted.Comments = append(adapted.Comments, encoded)
+	}
+	for _, raw := range payload.Events {
+		event, err := adaptGitHubWorkItemPRSocialEvent(raw)
+		if err != nil {
+			return githubWorkItemPRSocialSemanticPayload{}, err
+		}
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			return githubWorkItemPRSocialSemanticPayload{}, providerfoundation.ErrNormalizationInvalid
+		}
+		adapted.Events = append(adapted.Events, encoded)
+	}
+	return adapted, nil
+}
+
+func adaptGitHubWorkItemPRSocialComment(
+	raw json.RawMessage,
+) (githubWorkItemPRSocialComment, error) {
+	var node githubWorkItemPRSocialRawComment
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if decoder.Decode(&node) != nil {
+		return githubWorkItemPRSocialComment{}, providerfoundation.ErrNormalizationInvalid
+	}
+	comment := githubWorkItemPRSocialComment{
+		ID:        githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID, node.ID),
+		CreatedAt: parseGitHubWorkItemTime(node.CreatedAt),
+	}
+	if node.Body != nil {
+		comment.Body = *node.Body
+	}
+	if node.Author != nil {
+		comment.User.Login = node.Author.Login
+	}
+	return comment, nil
+}
+
+func adaptGitHubWorkItemPRSocialEvent(
+	raw json.RawMessage,
+) (githubWorkItemPRSocialEvent, error) {
+	var node githubWorkItemPRSocialRawEvent
+	if json.Unmarshal(raw, &node) != nil {
+		return githubWorkItemPRSocialEvent{}, providerfoundation.ErrNormalizationInvalid
+	}
+	event := githubWorkItemPRSocialEvent{
+		CreatedAt: parseGitHubWorkItemTime(node.CreatedAt),
+		Event: map[string]string{
+			"MergedEvent": "merged", "ClosedEvent": "closed", "ReopenedEvent": "reopened",
+		}[node.TypeName],
+	}
+	if node.Actor != nil {
+		event.Actor.Login = node.Actor.Login
+	}
+	return event, nil
+}
+
+// githubWorkItemPRSocialPythonTruthyID mirrors Python's
+// databaseId or fullDatabaseId or id precedence without converting a
+// precision-sensitive integer to float64 or a string.
+func githubWorkItemPRSocialPythonTruthyID(candidates ...any) any {
+	for _, candidate := range candidates {
+		switch value := candidate.(type) {
+		case nil:
+			continue
+		case string:
+			if value != "" {
+				return value
+			}
+		case json.Number:
+			integer := new(big.Int)
+			if _, ok := integer.SetString(value.String(), 10); ok {
+				if integer.Sign() != 0 {
+					return integer
+				}
+				continue
+			}
+			if strings.TrimSpace(value.String()) != "" && value.String() != "0" {
+				return value.String()
+			}
+		case bool:
+			if value {
+				return value
+			}
+		default:
+			return value
+		}
+	}
+	return nil
+}

--- a/internal/providersync/github_work_items_social_adapter_oracle_test.go
+++ b/internal/providersync/github_work_items_social_adapter_oracle_test.go
@@ -1,0 +1,122 @@
+package providersync
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGitHubWorkItemPRSocialCommentAdapterMatchesLivePythonProducer(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/pr-social-comment",
+		[]oracleCase{{
+			ID: "database_id_unicode_body",
+			Input: map[string]any{"raw_node": map[string]any{
+				"id": "IC_kwfallback", "databaseId": 9007199254740993,
+				"body": "Looks good 👋", "createdAt": "2026-08-03T08:30:00.123456Z",
+				"author": map[string]any{"login": "reviewer"},
+			}},
+		}, {
+			ID: "full_database_id_fallback",
+			Input: map[string]any{"raw_node": map[string]any{
+				"id": "IC_kwfallback", "databaseId": 0,
+				"fullDatabaseId": "9223372036854775808",
+				"body":           "Full database ID", "createdAt": "2026-08-03T08:31:00Z",
+				"author": map[string]any{"login": "reviewer"},
+			}},
+		}, {
+			ID: "node_id_fallback",
+			Input: map[string]any{"raw_node": map[string]any{
+				"id": "IC_kwfinal", "databaseId": 0, "fullDatabaseId": "",
+				"body": "Node ID", "createdAt": "2026-08-03T08:32:00Z",
+				"author": map[string]any{"login": "reviewer"},
+			}},
+		}},
+		buildGitHubWorkItemPRSocialCommentOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemPRSocialEventAdapterMatchesLivePythonProducer(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/pr-social-event",
+		[]oracleCase{
+			{ID: "merged", Input: map[string]any{"raw_node": map[string]any{
+				"__typename": "MergedEvent", "createdAt": "2026-08-01T09:00:00Z",
+				"actor": map[string]any{"login": "merger"},
+			}}},
+			{ID: "closed", Input: map[string]any{"raw_node": map[string]any{
+				"__typename": "ClosedEvent", "createdAt": "2026-08-02T08:00:00.654321Z",
+				"actor": map[string]any{"login": "closer"},
+			}}},
+			{ID: "reopened", Input: map[string]any{"raw_node": map[string]any{
+				"__typename": "ReopenedEvent", "createdAt": "2026-08-03T08:00:00Z",
+				"actor": map[string]any{"login": "reopener"},
+			}}},
+		},
+		buildGitHubWorkItemPRSocialEventOracleRow,
+		nil,
+	)
+}
+
+func TestGitHubWorkItemPRSocialCommentIDFallbackMatchesPythonTruthiness(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "full_database_id_fallback",
+			raw:  `{"databaseId":0,"fullDatabaseId":"9223372036854775808","id":"IC_kwfallback"}`,
+			want: "9223372036854775808",
+		},
+		{
+			name: "node_id_fallback",
+			raw:  `{"databaseId":0,"fullDatabaseId":"","id":"IC_kwfinal"}`,
+			want: "IC_kwfinal",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			row, err := adaptGitHubWorkItemPRSocialComment(json.RawMessage(test.raw))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, ok := row.ID.(string)
+			if !ok || got != test.want {
+				t.Fatalf("id=%v (%T), want string %q", row.ID, row.ID, test.want)
+			}
+		})
+	}
+}
+
+func buildGitHubWorkItemPRSocialCommentOracleRow(
+	t *testing.T, input map[string]any,
+) githubWorkItemPRSocialComment {
+	t.Helper()
+	raw, err := json.Marshal(input["raw_node"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := adaptGitHubWorkItemPRSocialComment(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildGitHubWorkItemPRSocialEventOracleRow(
+	t *testing.T, input map[string]any,
+) githubWorkItemPRSocialEvent {
+	t.Helper()
+	raw, err := json.Marshal(input["raw_node"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := adaptGitHubWorkItemPRSocialEvent(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/github_work_items_social_fetch.go
+++ b/internal/providersync/github_work_items_social_fetch.go
@@ -1,0 +1,413 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	gitHubWorkItemPRSocialBatchSize          = 50
+	gitHubWorkItemPRSocialPageSize           = 100
+	gitHubWorkItemPRSocialDefaultMaxRequests = 1000
+	gitHubWorkItemPRSocialMaxRequests        = 1000
+)
+
+// GitHubWorkItemPRSocialPayload preserves the GraphQL node payloads consumed
+// by the work-item normalizers. This fetch foundation deliberately does not
+// normalize rows, emit effects, or own a watermark.
+type GitHubWorkItemPRSocialPayload struct {
+	Comments []json.RawMessage
+	Events   []json.RawMessage
+}
+
+// GitHubWorkItemPRSocialUsage is safe provider-budget evidence. It records
+// actual GraphQL wire attempts (including retries), without retaining query,
+// response, repository, or credential data.
+type GitHubWorkItemPRSocialUsage struct {
+	Transport    string
+	RouteFamily  string
+	Dimension    string
+	RequestCount int
+}
+
+// GitHubWorkItemPRSocialFetchIncomplete distinguishes Python's optional
+// PR-social degradation from a complete empty result. Cause is a stable class
+// or local pagination reason, never provider response text.
+type GitHubWorkItemPRSocialFetchIncomplete struct {
+	Cause string
+}
+
+// GitHubWorkItemPRSocialFetchResult is intentionally not CompleteRouteBatch.
+// The work-item route must compose this raw fetch with every other work-item
+// surface before it can write effects or advance the canonical watermark.
+type GitHubWorkItemPRSocialFetchResult struct {
+	Payloads   map[int]GitHubWorkItemPRSocialPayload
+	Evidence   FetchEvidence
+	Usage      GitHubWorkItemPRSocialUsage
+	Incomplete *GitHubWorkItemPRSocialFetchIncomplete
+}
+
+func (result GitHubWorkItemPRSocialFetchResult) Complete() bool {
+	return result.Incomplete == nil
+}
+
+// GitHubWorkItemPRSocialFetcher fetches issue comments and status-bearing
+// timeline events for PR numbers selected by the caller's REST traversal.
+// Reviews and review comments are intentionally absent from every query. The
+// per-fetch request cap bounds the initial alias batches plus all independent
+// per-PR connection continuations.
+type GitHubWorkItemPRSocialFetcher struct {
+	MaxRequests int
+}
+
+func (fetcher GitHubWorkItemPRSocialFetcher) Fetch(
+	ctx context.Context,
+	claim Claim,
+	client *providerfoundation.HTTPClient,
+	targets []int,
+	commentsLimit int,
+	eventsLimit int,
+) (GitHubWorkItemPRSocialFetchResult, error) {
+	result := GitHubWorkItemPRSocialFetchResult{
+		Payloads: make(map[int]GitHubWorkItemPRSocialPayload, len(targets)),
+		Evidence: FetchEvidence{Provider: "github", Dataset: "work-items-pr-social"},
+		Usage: GitHubWorkItemPRSocialUsage{
+			Transport: "graphql", RouteFamily: "work_item_prs", Dimension: BudgetGraphQLCost,
+		},
+	}
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "work-items" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || client.Lease == nil || commentsLimit < 0 || eventsLimit < 0 {
+		return GitHubWorkItemPRSocialFetchResult{}, ErrInvalidConfiguration
+	}
+	maxRequests := fetcher.MaxRequests
+	if maxRequests == 0 {
+		maxRequests = gitHubWorkItemPRSocialDefaultMaxRequests
+	}
+	if maxRequests < 1 || maxRequests > gitHubWorkItemPRSocialMaxRequests {
+		return GitHubWorkItemPRSocialFetchResult{}, ErrInvalidConfiguration
+	}
+	seen := make(map[int]struct{}, len(targets))
+	for _, number := range targets {
+		if number < 1 {
+			return GitHubWorkItemPRSocialFetchResult{}, providerfoundation.ErrNormalizationInvalid
+		}
+		if _, duplicate := seen[number]; duplicate {
+			return GitHubWorkItemPRSocialFetchResult{}, providerfoundation.ErrNormalizationInvalid
+		}
+		seen[number] = struct{}{}
+		result.Payloads[number] = GitHubWorkItemPRSocialPayload{}
+	}
+	if len(targets) == 0 || commentsLimit == 0 && eventsLimit == 0 {
+		return result, nil
+	}
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return GitHubWorkItemPRSocialFetchResult{}, err
+	}
+	counted := *client
+	counted.Doer = gitHubWorkItemPRSocialCountingDoer{
+		delegate: client.Doer, requests: &result.Evidence.Requests,
+		graphqlRequests: &result.Usage.RequestCount, graphqlPath: gitHubGraphQLPath(client),
+	}
+
+	for start := 0; start < len(targets); start += gitHubWorkItemPRSocialBatchSize {
+		end := min(start+gitHubWorkItemPRSocialBatchSize, len(targets))
+		commentsFirst := min(commentsLimit, gitHubWorkItemPRSocialPageSize)
+		eventsFirst := min(eventsLimit, gitHubWorkItemPRSocialPageSize)
+		pulls, err := fetcher.fetchPage(
+			ctx, &counted, owner, repository, targets[start:end],
+			commentsFirst, nil, eventsFirst, nil, &result,
+		)
+		if err != nil {
+			return fetcher.finishFailure(result, err)
+		}
+		for _, number := range targets[start:end] {
+			pull, ok := pulls[number]
+			if !ok {
+				return fetcher.finishFailure(result, providerfoundation.ErrGraphQLResponse)
+			}
+			payload := result.Payloads[number]
+			if commentsLimit > 0 {
+				if pull.Comments == nil {
+					return fetcher.finishFailure(result, providerfoundation.ErrGraphQLResponse)
+				}
+				appendGitHubWorkItemPRSocialNodes(&payload.Comments, pull.Comments.Nodes, commentsLimit)
+				if err := fetcher.drainComments(
+					ctx, &counted, owner, repository, number, commentsLimit,
+					pull.Comments.PageInfo, &payload, &result,
+				); err != nil {
+					return fetcher.finishFailure(result, err)
+				}
+			}
+			if eventsLimit > 0 {
+				if pull.TimelineItems == nil {
+					return fetcher.finishFailure(result, providerfoundation.ErrGraphQLResponse)
+				}
+				appendGitHubWorkItemPRSocialNodes(&payload.Events, pull.TimelineItems.Nodes, eventsLimit)
+				if err := fetcher.drainEvents(
+					ctx, &counted, owner, repository, number, eventsLimit,
+					pull.TimelineItems.PageInfo, &payload, &result,
+				); err != nil {
+					return fetcher.finishFailure(result, err)
+				}
+			}
+			result.Payloads[number] = payload
+		}
+	}
+	for _, payload := range result.Payloads {
+		result.Evidence.Records += len(payload.Comments) + len(payload.Events)
+	}
+	return result, nil
+}
+
+func (fetcher GitHubWorkItemPRSocialFetcher) drainComments(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	owner, repository string,
+	number, limit int,
+	pageInfo gitHubWorkItemPRSocialPageInfo,
+	payload *GitHubWorkItemPRSocialPayload,
+	result *GitHubWorkItemPRSocialFetchResult,
+) error {
+	cursor := pageInfo.EndCursor
+	for pageInfo.HasNextPage && len(payload.Comments) < limit {
+		if cursor == nil || strings.TrimSpace(*cursor) == "" {
+			return errGitHubWorkItemPRSocialPaginationInvalid
+		}
+		first := min(limit-len(payload.Comments), gitHubWorkItemPRSocialPageSize)
+		pulls, err := fetcher.fetchPage(
+			ctx, client, owner, repository, []int{number}, first, cursor, 0, nil, result,
+		)
+		if err != nil {
+			return err
+		}
+		pull, ok := pulls[number]
+		if !ok || pull.Comments == nil {
+			return providerfoundation.ErrGraphQLResponse
+		}
+		appendGitHubWorkItemPRSocialNodes(&payload.Comments, pull.Comments.Nodes, limit)
+		pageInfo = pull.Comments.PageInfo
+		next := pageInfo.EndCursor
+		if pageInfo.HasNextPage && len(payload.Comments) < limit &&
+			(next == nil || strings.TrimSpace(*next) == "" || *next == *cursor) {
+			return errGitHubWorkItemPRSocialPaginationInvalid
+		}
+		cursor = next
+	}
+	return nil
+}
+
+func (fetcher GitHubWorkItemPRSocialFetcher) drainEvents(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	owner, repository string,
+	number, limit int,
+	pageInfo gitHubWorkItemPRSocialPageInfo,
+	payload *GitHubWorkItemPRSocialPayload,
+	result *GitHubWorkItemPRSocialFetchResult,
+) error {
+	cursor := pageInfo.EndCursor
+	for pageInfo.HasNextPage && len(payload.Events) < limit {
+		if cursor == nil || strings.TrimSpace(*cursor) == "" {
+			return errGitHubWorkItemPRSocialPaginationInvalid
+		}
+		first := min(limit-len(payload.Events), gitHubWorkItemPRSocialPageSize)
+		pulls, err := fetcher.fetchPage(
+			ctx, client, owner, repository, []int{number}, 0, nil, first, cursor, result,
+		)
+		if err != nil {
+			return err
+		}
+		pull, ok := pulls[number]
+		if !ok || pull.TimelineItems == nil {
+			return providerfoundation.ErrGraphQLResponse
+		}
+		appendGitHubWorkItemPRSocialNodes(&payload.Events, pull.TimelineItems.Nodes, limit)
+		pageInfo = pull.TimelineItems.PageInfo
+		next := pageInfo.EndCursor
+		if pageInfo.HasNextPage && len(payload.Events) < limit &&
+			(next == nil || strings.TrimSpace(*next) == "" || *next == *cursor) {
+			return errGitHubWorkItemPRSocialPaginationInvalid
+		}
+		cursor = next
+	}
+	return nil
+}
+
+func appendGitHubWorkItemPRSocialNodes(destination *[]json.RawMessage, nodes []json.RawMessage, limit int) {
+	remaining := limit - len(*destination)
+	if remaining <= 0 {
+		return
+	}
+	if len(nodes) > remaining {
+		nodes = nodes[:remaining]
+	}
+	*destination = append(*destination, nodes...)
+}
+
+func (fetcher GitHubWorkItemPRSocialFetcher) fetchPage(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	owner, repository string,
+	numbers []int,
+	commentsFirst int,
+	commentsAfter *string,
+	eventsFirst int,
+	eventsAfter *string,
+	result *GitHubWorkItemPRSocialFetchResult,
+) (map[int]gitHubWorkItemPRSocialGraphQLPull, error) {
+	maxRequests := fetcher.MaxRequests
+	if maxRequests == 0 {
+		maxRequests = gitHubWorkItemPRSocialDefaultMaxRequests
+	}
+	if result.Evidence.Pages >= maxRequests {
+		result.Evidence.CapReached = true
+		return nil, errGitHubWorkItemPRSocialPaginationCap
+	}
+	body, err := json.Marshal(map[string]any{
+		"query": gitHubWorkItemPRSocialQuery(
+			numbers, commentsFirst, commentsAfter, eventsFirst, eventsAfter,
+		),
+		"variables": map[string]string{"owner": owner, "repo": repository},
+	})
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	response, err := client.Do(ctx, http.MethodPost, gitHubGraphQLPath(client), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	result.Evidence.Pages++
+	defer response.Body.Close()
+	decoder := json.NewDecoder(response.Body)
+	decoder.UseNumber()
+	var envelope gitHubWorkItemPRSocialGraphQLEnvelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	if len(envelope.Errors) > 0 || envelope.Data.Repository == nil {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	pulls := make(map[int]gitHubWorkItemPRSocialGraphQLPull, len(numbers))
+	for index, number := range numbers {
+		pull, ok := (*envelope.Data.Repository)["pr"+strconv.Itoa(index)]
+		if !ok || pull == nil || pull.Number != number {
+			return nil, providerfoundation.ErrGraphQLResponse
+		}
+		pulls[number] = *pull
+	}
+	return pulls, nil
+}
+
+func (fetcher GitHubWorkItemPRSocialFetcher) finishFailure(
+	result GitHubWorkItemPRSocialFetchResult,
+	err error,
+) (GitHubWorkItemPRSocialFetchResult, error) {
+	if errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) || isRateLimited(err) {
+		return result, err
+	}
+	result.Payloads = nil
+	result.Evidence.Records = 0
+	result.Incomplete = &GitHubWorkItemPRSocialFetchIncomplete{
+		Cause: gitHubWorkItemPRSocialFailureCause(err),
+	}
+	return result, nil
+}
+
+func gitHubWorkItemPRSocialFailureCause(err error) string {
+	if errors.Is(err, errGitHubWorkItemPRSocialPaginationCap) {
+		return "pagination_cap"
+	}
+	if errors.Is(err, errGitHubWorkItemPRSocialPaginationInvalid) {
+		return "invalid_pagination"
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil {
+		return string(providerErr.Class)
+	}
+	return "invalid_response"
+}
+
+var (
+	errGitHubWorkItemPRSocialPaginationCap     = errors.New("github work-item PR-social request cap reached")
+	errGitHubWorkItemPRSocialPaginationInvalid = errors.New("github work-item PR-social cursor is missing or stalled")
+)
+
+type gitHubWorkItemPRSocialCountingDoer struct {
+	delegate        providerfoundation.HTTPDoer
+	requests        *int
+	graphqlRequests *int
+	graphqlPath     string
+}
+
+func (doer gitHubWorkItemPRSocialCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	*doer.requests++
+	if request.URL.EscapedPath() == doer.graphqlPath {
+		*doer.graphqlRequests++
+	}
+	return doer.delegate.Do(request)
+}
+
+type gitHubWorkItemPRSocialGraphQLEnvelope struct {
+	Data struct {
+		Repository *map[string]*gitHubWorkItemPRSocialGraphQLPull `json:"repository"`
+	} `json:"data"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+type gitHubWorkItemPRSocialGraphQLPull struct {
+	Number        int                               `json:"number"`
+	Comments      *gitHubWorkItemPRSocialConnection `json:"comments"`
+	TimelineItems *gitHubWorkItemPRSocialConnection `json:"timelineItems"`
+}
+
+type gitHubWorkItemPRSocialConnection struct {
+	Nodes    []json.RawMessage              `json:"nodes"`
+	PageInfo gitHubWorkItemPRSocialPageInfo `json:"pageInfo"`
+}
+
+type gitHubWorkItemPRSocialPageInfo struct {
+	HasNextPage bool    `json:"hasNextPage"`
+	EndCursor   *string `json:"endCursor"`
+}
+
+func gitHubWorkItemPRSocialQuery(
+	numbers []int,
+	commentsFirst int,
+	commentsAfter *string,
+	eventsFirst int,
+	eventsAfter *string,
+) string {
+	commentsCursor, _ := json.Marshal(commentsAfter)
+	eventsCursor, _ := json.Marshal(eventsAfter)
+	aliases := make([]string, 0, len(numbers))
+	for index, number := range numbers {
+		fields := []string{"number"}
+		if commentsFirst > 0 {
+			fields = append(fields, fmt.Sprintf(
+				"comments(first: %d, after: %s, orderBy: {field: UPDATED_AT, direction: ASC}) { nodes { id databaseId fullDatabaseId body createdAt author { login } } pageInfo { hasNextPage endCursor } }",
+				commentsFirst, commentsCursor,
+			))
+		}
+		if eventsFirst > 0 {
+			fields = append(fields, fmt.Sprintf(
+				"timelineItems(itemTypes: [MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: %d, after: %s) { nodes { __typename ... on MergedEvent { createdAt actor { login } } ... on ClosedEvent { createdAt actor { login } } ... on ReopenedEvent { createdAt actor { login } } } pageInfo { hasNextPage endCursor } }",
+				eventsFirst, eventsCursor,
+			))
+		}
+		aliases = append(aliases, fmt.Sprintf(
+			"pr%d: pullRequest(number: %d) { %s }", index, number, strings.Join(fields, " "),
+		))
+	}
+	return "query($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { " + strings.Join(aliases, " ") + " } }"
+}

--- a/internal/providersync/github_work_items_social_fetch_test.go
+++ b/internal/providersync/github_work_items_social_fetch_test.go
@@ -1,0 +1,431 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+type gitHubWorkItemPRSocialFetchDoer struct {
+	t        *testing.T
+	replies  []string
+	status   []int
+	bodies   []string
+	requests int
+}
+
+func (doer *gitHubWorkItemPRSocialFetchDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests++
+	if request.URL.Path != "/graphql" {
+		doer.t.Fatalf("unexpected request %s", request.URL.String())
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		doer.t.Fatal(err)
+	}
+	doer.bodies = append(doer.bodies, string(body))
+	index := len(doer.bodies) - 1
+	status := http.StatusOK
+	if index < len(doer.status) && doer.status[index] != 0 {
+		status = doer.status[index]
+	}
+	reply := `{"data":{"repository":{}}}`
+	if index < len(doer.replies) {
+		reply = doer.replies[index]
+	}
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if status == http.StatusForbidden {
+		header.Set("X-RateLimit-Remaining", "0")
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(reply)),
+		Request:    request,
+	}, nil
+}
+
+func gitHubWorkItemPRSocialClaim() Claim {
+	return nativeTestClaim("github", "work-items")
+}
+
+var githubWorkItemPRSocialRepoID = uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+
+func gitHubWorkItemPRSocialQueryFromBody(t *testing.T, body string) string {
+	t.Helper()
+	var envelope struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	return envelope.Query
+}
+
+func gitHubWorkItemPRSocialConnectionJSON(nodes string, hasNext bool, cursor *string) string {
+	endCursor := "null"
+	if cursor != nil {
+		endCursor = strconv.Quote(*cursor)
+	}
+	return `{"nodes":` + nodes + `,"pageInfo":{"hasNextPage":` + strconv.FormatBool(hasNext) + `,"endCursor":` + endCursor + `}}`
+}
+
+func TestGitHubWorkItemPRSocialFetcherBatchesFiftyAndReportsActualUsage(t *testing.T) {
+	firstAliases := make([]string, 50)
+	for index := range firstAliases {
+		number := index + 1
+		firstAliases[index] = `"pr` + strconv.Itoa(index) + `":{"number":` + strconv.Itoa(number) + `,"comments":` +
+			gitHubWorkItemPRSocialConnectionJSON(`[{"id":"c`+strconv.Itoa(number)+`","body":"comment"}]`, false, nil) +
+			`,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[{"__typename":"ClosedEvent","createdAt":"2026-08-01T00:00:00Z"}]`, false, nil) + `}`
+	}
+	doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: []string{
+		`{"data":{"repository":{` + strings.Join(firstAliases, ",") + `}}}`,
+		`{"data":{"repository":{"pr0":{"number":51,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, false, nil) +
+			`,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, false, nil) + `}}}}`,
+	}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	budget := &gitHubPullRequestReviewBudget{}
+	gate := &gitHubPullRequestReviewGate{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{
+		Provider: "github", OrgID: "org-native", Host: "api.github.com",
+		CostClass: "medium", Limit: 1, TTL: time.Minute,
+	}
+	client.Gate = gate
+	targets := make([]int, 51)
+	for index := range targets {
+		targets[index] = index + 1
+	}
+
+	result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(), client, targets, 500, 1000,
+	)
+	if err != nil || !result.Complete() {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	if len(result.Payloads) != 51 || len(result.Payloads[1].Comments) != 1 || len(result.Payloads[1].Events) != 1 {
+		t.Fatalf("payloads=%+v", result.Payloads)
+	}
+	if result.Evidence != (FetchEvidence{Provider: "github", Dataset: "work-items-pr-social", Requests: 2, Pages: 2, Records: 100}) {
+		t.Fatalf("evidence=%+v", result.Evidence)
+	}
+	if result.Usage != (GitHubWorkItemPRSocialUsage{Transport: "graphql", RouteFamily: "work_item_prs", Dimension: BudgetGraphQLCost, RequestCount: 2}) {
+		t.Fatalf("usage=%+v", result.Usage)
+	}
+	usageWasReserved := false
+	for _, estimate := range ProviderRequestPlan(
+		"github", "work-items", 1, map[string]bool{"sync_prs": true},
+	) {
+		if estimate.RouteFamily == result.Usage.RouteFamily && estimate.Dimension == result.Usage.Dimension {
+			usageWasReserved = true
+			break
+		}
+	}
+	if !usageWasReserved {
+		t.Fatalf("usage=%+v has no matching request-plan reservation", result.Usage)
+	}
+	if budget.acquires != 2 || budget.releases != 2 || gate.waits != 2 || doer.requests != 2 {
+		t.Fatalf("budget=%+v gate=%+v requests=%d", budget, gate, doer.requests)
+	}
+	firstQuery := gitHubWorkItemPRSocialQueryFromBody(t, doer.bodies[0])
+	if strings.Count(firstQuery, "pullRequest(number:") != 50 || strings.Contains(firstQuery, "reviews(") ||
+		!strings.Contains(firstQuery, "comments(first: 100, after: null") ||
+		!strings.Contains(firstQuery, "timelineItems(itemTypes: [MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: 100, after: null") {
+		t.Fatalf("unexpected initial query: %s", firstQuery)
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherDrainsCommentAndEventCursorsIndependently(t *testing.T) {
+	commentsCursor := "comments-1"
+	eventsCursor := "events-1"
+	doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: []string{
+		`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[{"id":"c1"}]`, true, &commentsCursor) +
+			`,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[{"__typename":"ClosedEvent"}]`, true, &eventsCursor) + `}}}}`,
+		`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[{"id":"c2"}]`, false, nil) + `}}}}`,
+		`{"data":{"repository":{"pr0":{"number":42,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[{"__typename":"ReopenedEvent"}]`, false, nil) + `}}}}`,
+	}}
+	result, err := (GitHubWorkItemPRSocialFetcher{MaxRequests: 3}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(),
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 500, 1000,
+	)
+	if err != nil || !result.Complete() {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	if len(result.Payloads[42].Comments) != 2 || len(result.Payloads[42].Events) != 2 ||
+		result.Evidence.Pages != 3 || result.Evidence.Requests != 3 {
+		t.Fatalf("result=%+v", result)
+	}
+	commentQuery := gitHubWorkItemPRSocialQueryFromBody(t, doer.bodies[1])
+	eventQuery := gitHubWorkItemPRSocialQueryFromBody(t, doer.bodies[2])
+	if !strings.Contains(commentQuery, `comments(first: 100, after: "comments-1"`) || strings.Contains(commentQuery, "timelineItems") {
+		t.Fatalf("comment continuation query=%s", commentQuery)
+	}
+	if !strings.Contains(eventQuery, `timelineItems(itemTypes: [MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: 100, after: "events-1"`) || strings.Contains(eventQuery, "comments(") {
+		t.Fatalf("event continuation query=%s", eventQuery)
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherHonorsDeclaredLimitsWithoutOverfetch(t *testing.T) {
+	commentsCursor := "more-comments"
+	eventsCursor := "more-events"
+	doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: []string{
+		`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[{"id":"c1"},{"id":"c2"},{"id":"must-not-escape-limit"}]`, true, &commentsCursor) +
+			`,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[{"__typename":"ClosedEvent"},{"__typename":"MustNotEscapeLimit"}]`, true, &eventsCursor) + `}}}}`,
+	}}
+	result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(),
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 2, 1,
+	)
+	if err != nil || !result.Complete() || doer.requests != 1 ||
+		len(result.Payloads[42].Comments) != 2 || len(result.Payloads[42].Events) != 1 {
+		t.Fatalf("result=%+v error=%v requests=%d", result, err, doer.requests)
+	}
+	query := gitHubWorkItemPRSocialQueryFromBody(t, doer.bodies[0])
+	if !strings.Contains(query, "comments(first: 2") || !strings.Contains(query, "first: 1, after: null") {
+		t.Fatalf("query=%s", query)
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherRejectsMissingAndStalledCursors(t *testing.T) {
+	cursor := "same"
+	for _, test := range []struct {
+		name          string
+		replies       []string
+		commentsLimit int
+		eventsLimit   int
+	}{
+		{
+			name: "missing comment cursor", commentsLimit: 500,
+			replies: []string{`{"data":{"repository":{"pr0":{"number":42,"comments":` +
+				gitHubWorkItemPRSocialConnectionJSON(`[]`, true, nil) + `}}}}`},
+		},
+		{
+			name: "stalled comment cursor", commentsLimit: 500,
+			replies: []string{
+				`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, true, &cursor) + `}}}}`,
+				`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, true, &cursor) + `}}}}`,
+			},
+		},
+		{
+			name: "missing event cursor", eventsLimit: 1000,
+			replies: []string{`{"data":{"repository":{"pr0":{"number":42,"timelineItems":` +
+				gitHubWorkItemPRSocialConnectionJSON(`[]`, true, nil) + `}}}}`},
+		},
+		{
+			name: "stalled event cursor", eventsLimit: 1000,
+			replies: []string{
+				`{"data":{"repository":{"pr0":{"number":42,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, true, &cursor) + `}}}}`,
+				`{"data":{"repository":{"pr0":{"number":42,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, true, &cursor) + `}}}}`,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: test.replies}
+			result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+				context.Background(), gitHubWorkItemPRSocialClaim(),
+				gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, test.commentsLimit, test.eventsLimit,
+			)
+			if err != nil || result.Complete() || result.Incomplete == nil || result.Incomplete.Cause != "invalid_pagination" || result.Payloads != nil {
+				t.Fatalf("result=%+v error=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherReturnsTypedGraphQLAndCapIncomplete(t *testing.T) {
+	cursor := "next"
+	for _, test := range []struct {
+		name      string
+		replies   []string
+		max       int
+		wantCause string
+	}{
+		{
+			name: "graphql errors", max: 10, wantCause: "invalid_response",
+			replies: []string{`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, false, nil) + `}}},"errors":[{"message":"schema changed"}]}`},
+		},
+		{
+			name: "request cap", max: 1, wantCause: "pagination_cap",
+			replies: []string{`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[]`, true, &cursor) + `}}}}`},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: test.replies}
+			result, err := (GitHubWorkItemPRSocialFetcher{MaxRequests: test.max}).Fetch(
+				context.Background(), gitHubWorkItemPRSocialClaim(),
+				gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 500, 0,
+			)
+			if err != nil || result.Complete() || result.Incomplete == nil || result.Incomplete.Cause != test.wantCause || result.Payloads != nil {
+				t.Fatalf("result=%+v error=%v", result, err)
+			}
+			if result.Evidence.Requests != 1 || result.Usage.RequestCount != 1 || doer.requests != 1 {
+				t.Fatalf("usage lost on incomplete: result=%+v requests=%d", result, doer.requests)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherPropagatesRateLimitCancelAndLeaseLoss(t *testing.T) {
+	t.Run("rate limit", func(t *testing.T) {
+		doer := &gitHubWorkItemPRSocialFetchDoer{t: t, status: []int{http.StatusForbidden}, replies: []string{`{"message":"rate limited"}`}}
+		result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+			context.Background(), gitHubWorkItemPRSocialClaim(),
+			gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 500, 1000,
+		)
+		var providerErr *providerfoundation.ProviderError
+		if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited ||
+			result.Incomplete != nil || result.Evidence.Requests != 1 || result.Usage.RequestCount != 1 {
+			t.Fatalf("result=%+v error=%v", result, err)
+		}
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		doer := &gitHubWorkItemPRSocialFetchDoer{t: t}
+		result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+			ctx, gitHubWorkItemPRSocialClaim(),
+			gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 500, 1000,
+		)
+		if !errors.Is(err, context.Canceled) || result.Incomplete != nil || doer.requests != 0 {
+			t.Fatalf("result=%+v error=%v requests=%d", result, err, doer.requests)
+		}
+	})
+
+	t.Run("lease loss", func(t *testing.T) {
+		doer := &gitHubWorkItemPRSocialFetchDoer{t: t}
+		client, err := providerfoundation.NewHTTPClient(
+			"github", "https://api.github.com", doer, func(*http.Request) error { return nil },
+			providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+			providerfoundation.LeaseGuardFunc(func(context.Context) error { return providerfoundation.ErrLeaseLost }),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+			context.Background(), gitHubWorkItemPRSocialClaim(), client, []int{42}, 500, 1000,
+		)
+		if !errors.Is(err, providerfoundation.ErrLeaseLost) || result.Incomplete != nil || doer.requests != 0 {
+			t.Fatalf("result=%+v error=%v requests=%d", result, err, doer.requests)
+		}
+	})
+}
+
+func TestGitHubWorkItemPRSocialFetcherMarksNonRateProviderFailureIncomplete(t *testing.T) {
+	doer := &gitHubWorkItemPRSocialFetchDoer{t: t, status: []int{http.StatusServiceUnavailable}, replies: []string{`{"message":"unavailable"}`}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	client.Retry.MaxAttempts = 1
+	result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(), client, []int{42}, 500, 1000,
+	)
+	if err != nil || result.Complete() || result.Incomplete == nil || result.Incomplete.Cause != "transient" || result.Payloads != nil {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetcherCountsRetryAttemptsButOneLogicalPage(t *testing.T) {
+	doer := &gitHubWorkItemPRSocialFetchDoer{
+		t:      t,
+		status: []int{http.StatusServiceUnavailable, http.StatusOK},
+		replies: []string{
+			`{"message":"unavailable"}`,
+			`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(`[{"id":"9007199254740993","body":"preserved"}]`, false, nil) + `}}}}`,
+		},
+	}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	client.Retry.MaxAttempts = 2
+	budget := &gitHubPullRequestReviewBudget{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{
+		Provider: "github", OrgID: "org-native", Host: "api.github.com",
+		CostClass: "medium", Limit: 1, TTL: time.Minute,
+	}
+
+	result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(), client, []int{42}, 500, 0,
+	)
+	if err != nil || !result.Complete() {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	if result.Evidence.Requests != 2 || result.Usage.RequestCount != 2 || result.Evidence.Pages != 1 ||
+		budget.acquires != 1 || budget.releases != 1 || doer.requests != 2 {
+		t.Fatalf("result=%+v budget=%+v requests=%d", result, budget, doer.requests)
+	}
+	if got := string(result.Payloads[42].Comments[0]); !strings.Contains(got, `"id":"9007199254740993"`) ||
+		!strings.Contains(got, `"body":"preserved"`) {
+		t.Fatalf("raw payload changed: %s", got)
+	}
+}
+
+func TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle(t *testing.T) {
+	doer := &gitHubWorkItemPRSocialFetchDoer{t: t, replies: []string{
+		`{"data":{"repository":{"pr0":{"number":42,"comments":` + gitHubWorkItemPRSocialConnectionJSON(
+			`[{"databaseId":9007199254740993,"body":"Blocked by https://linear.app/fullchaos/issue/CHAOS-501/task","createdAt":"2026-08-03T08:30:00Z","author":{"login":"linear[bot]"}}]`, false, nil,
+		) + `,"timelineItems":` + gitHubWorkItemPRSocialConnectionJSON(
+			`[{"__typename":"ClosedEvent","createdAt":"2026-08-02T08:00:00Z","actor":{"login":"closer"}},{"__typename":"ReopenedEvent","createdAt":"2026-08-03T08:00:00Z","actor":{"login":"reopener"}},{"__typename":"MergedEvent","createdAt":"2026-08-03T09:00:00Z","actor":{"login":"merger"}}]`, false, nil,
+		) + `}}}}`,
+	}}
+	result, err := (GitHubWorkItemPRSocialFetcher{}).Fetch(
+		context.Background(), gitHubWorkItemPRSocialClaim(),
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), []int{42}, 500, 1000,
+	)
+	if err != nil || !result.Complete() {
+		t.Fatalf("fetch result=%+v error=%v", result, err)
+	}
+	adapted, err := adaptGitHubWorkItemPRSocialPayload(result.Payloads[42])
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := gitHubWorkItemPRSocialClaim()
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	rows, err := normalizeGitHubPullRequestBundle(
+		claim, "acme/api", githubWorkItemPRSocialRepoID,
+		json.RawMessage(`{
+		  "number":42,"title":"Keep social facts","body":"Routine repair",
+		  "state":"open","merged":false,"draft":false,
+		  "created_at":"2026-08-01T08:00:00Z","updated_at":"2026-08-03T09:30:00Z",
+		  "labels":[],"assignees":[],"user":{"login":"author"},
+		  "head":{"ref":"feature/repair"}
+		}`),
+		adapted.Events, adapted.Comments, nil,
+		time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows.WorkItems) != 1 || len(rows.StatusTransitions) != 3 ||
+		len(rows.ReopenEvents) != 1 || len(rows.Interactions) != 1 ||
+		len(rows.Dependencies) != 1 {
+		t.Fatalf("fetch->adapter->normalize dropped semantic rows: %+v", rows)
+	}
+	if rows.Interactions[0].Actor == nil || *rows.Interactions[0].Actor != "github:linear[bot]" ||
+		rows.Interactions[0].BodyLength != 60 {
+		// The exact body length is asserted independently by the live semantic
+		// oracle; the fixed independent count ensures the fetched body,
+		// timestamp, and author reached the interaction producer instead of a
+		// zero-value stand-in.
+		actor := "<nil>"
+		if rows.Interactions[0].Actor != nil {
+			actor = *rows.Interactions[0].Actor
+		}
+		t.Fatalf("interaction=%+v actor=%q", rows.Interactions[0], actor)
+	}
+	if dependency := rows.Dependencies[0]; dependency.TargetWorkItemID != "extkey:CHAOS-501" ||
+		dependency.RelationshipType != "blocked_by" {
+		t.Fatalf("dependency=%+v", dependency)
+	}
+	merged := rows.StatusTransitions[2]
+	if merged.ToStatus != "done" || merged.ToStatusRaw == nil || *merged.ToStatusRaw != "merged" {
+		t.Fatalf("merged transition=%+v", merged)
+	}
+}

--- a/internal/providersync/request_plan.go
+++ b/internal/providersync/request_plan.go
@@ -32,7 +32,7 @@ func ProviderRequestPlan(
 	var estimates []RequestEstimate
 	switch provider {
 	case "github":
-		estimates = githubRequestPlan(dataset, spanDays)
+		estimates = githubRequestPlan(dataset, spanDays, flags)
 	case "gitlab":
 		estimates = gitLabRequestPlan(dataset, spanDays)
 	case "linear":
@@ -89,17 +89,41 @@ func gitLabRequestPlan(dataset string, spanDays int) []RequestEstimate {
 	}
 }
 
-func githubRequestPlan(dataset string, spanDays int) []RequestEstimate {
-	if dataset != "cicd" && dataset != "tests" && dataset != "deployments" {
+func githubRequestPlan(dataset string, spanDays int, flags map[string]bool) []RequestEstimate {
+	switch dataset {
+	case "work-items", "work-item-labels", "work-item-projects", "work-item-history", "work-item-comments":
+		floor := 1
+		if dataset == "work-items" {
+			floor = 2
+		}
+		estimates := []RequestEstimate{{
+			Dimension: BudgetRESTCore, Units: max(floor, floor*spanDays),
+			Confidence: "medium", RouteFamily: "work_items",
+		}}
+		if flags["sync_prs"] {
+			estimates = append(estimates,
+				RequestEstimate{
+					Dimension: BudgetGraphQLCost, Units: max(3, 3*spanDays),
+					Confidence: "medium", RouteFamily: "work_item_prs",
+				},
+				RequestEstimate{
+					Dimension: BudgetSecondaryAbuseRisk, Units: 1,
+					Confidence: "low", RouteFamily: "work_item_prs",
+				},
+			)
+		}
+		return estimates
+	case "cicd", "tests", "deployments":
+		routeFamily := dataset
+		if dataset == "cicd" {
+			routeFamily = "tests"
+		}
+		return []RequestEstimate{
+			{BudgetRESTCore, 4 * spanDays, "low", routeFamily},
+			{BudgetContentsBlob, 2 * spanDays, "low", routeFamily},
+		}
+	default:
 		return nil
-	}
-	routeFamily := dataset
-	if dataset == "cicd" {
-		routeFamily = "tests"
-	}
-	return []RequestEstimate{
-		{BudgetRESTCore, 4 * spanDays, "low", routeFamily},
-		{BudgetContentsBlob, 2 * spanDays, "low", routeFamily},
 	}
 }
 

--- a/internal/providersync/request_plan_test.go
+++ b/internal/providersync/request_plan_test.go
@@ -55,8 +55,15 @@ func TestProviderRequestPlansMatchLivePythonBudgetFunctions(t *testing.T) {
 			)
 		}
 		if test.ActualRouteFamily != "" {
-			if len(got) != 1 || got[0].RouteFamily != test.ActualRouteFamily ||
-				got[0].Dimension != test.ActualDimension {
+			matched := false
+			for _, estimate := range got {
+				if estimate.RouteFamily == test.ActualRouteFamily &&
+					estimate.Dimension == test.ActualDimension {
+					matched = true
+					break
+				}
+			}
+			if !matched {
 				t.Fatalf(
 					"%s/%s actual resolver=(%s,%s) request plan=%+v",
 					test.Provider, test.Dataset, test.ActualRouteFamily,
@@ -77,6 +84,47 @@ func TestProviderRequestPlansFailClosedForUnknownRoutes(t *testing.T) {
 	} {
 		if plan := ProviderRequestPlan(test.provider, test.dataset, 1, nil); len(plan) != 0 {
 			t.Fatalf("%s/%s plan=%+v", test.provider, test.dataset, plan)
+		}
+	}
+}
+
+func TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure(t *testing.T) {
+	t.Parallel()
+	for _, dataset := range []string{
+		"work-items", "work-item-labels", "work-item-projects",
+		"work-item-history", "work-item-comments",
+	} {
+		restUnits := 3
+		if dataset == "work-items" {
+			restUnits = 6
+		}
+		withoutPRs := ProviderRequestPlan(
+			"github", dataset, 3, map[string]bool{"sync_prs": false},
+		)
+		if want := []RequestEstimate{{
+			Dimension: BudgetRESTCore, Units: restUnits,
+			Confidence: "medium", RouteFamily: "work_items",
+		}}; !reflect.DeepEqual(withoutPRs, want) {
+			t.Fatalf("%s without PRs=%+v want=%+v", dataset, withoutPRs, want)
+		}
+		withPRs := ProviderRequestPlan(
+			"github", dataset, 3, map[string]bool{"sync_prs": true},
+		)
+		if want := []RequestEstimate{
+			{
+				Dimension: BudgetGraphQLCost, Units: 9,
+				Confidence: "medium", RouteFamily: "work_item_prs",
+			},
+			{
+				Dimension: BudgetSecondaryAbuseRisk, Units: 1,
+				Confidence: "low", RouteFamily: "work_item_prs",
+			},
+			{
+				Dimension: BudgetRESTCore, Units: restUnits,
+				Confidence: "medium", RouteFamily: "work_items",
+			},
+		}; !reflect.DeepEqual(withPRs, want) {
+			t.Fatalf("%s with PRs=%+v want=%+v", dataset, withPRs, want)
 		}
 	}
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_social_fetch.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_social_fetch.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": 1,
+  "name": "github/work-items PR-social non-routed fetch foundation",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "alias-batches-stop-at-fifty",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "gitHubWorkItemPRSocialBatchSize          = 50",
+      "replace": "gitHubWorkItemPRSocialBatchSize          = 51",
+      "rationale": "GitHub PR-social aliases are bounded to fifty caller-selected PRs per initial GraphQL request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherBatchesFiftyAndReportsActualUsage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "comment-continuation-does-not-refetch-events",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "ctx, client, owner, repository, []int{number}, first, cursor, 0, nil, result,",
+      "replace": "ctx, client, owner, repository, []int{number}, first, cursor, 1, nil, result,",
+      "rationale": "comment pagination advances only the comment connection and does not duplicate event traffic or mix cursors",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherDrainsCommentAndEventCursorsIndependently$", "./internal/providersync/"]]
+    },
+    {
+      "id": "event-continuation-does-not-refetch-comments",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "ctx, client, owner, repository, []int{number}, 0, nil, first, cursor, result,",
+      "replace": "ctx, client, owner, repository, []int{number}, 1, nil, first, cursor, result,",
+      "rationale": "event pagination advances only the timeline connection and does not duplicate comment traffic or mix cursors",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherDrainsCommentAndEventCursorsIndependently$", "./internal/providersync/"]]
+    },
+    {
+      "id": "missing-comment-cursor-is-incomplete",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "for pageInfo.HasNextPage && len(payload.Comments) < limit {\n\t\tif cursor == nil || strings.TrimSpace(*cursor) == \"\" {",
+      "replace": "for pageInfo.HasNextPage && len(payload.Comments) < limit {\n\t\tif false || strings.TrimSpace(*cursor) == \"\" {",
+      "rationale": "a comment connection advertising another page must supply a cursor before any continuation request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherRejectsMissingAndStalledCursors$/missing_comment_cursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "stalled-comment-cursor-is-incomplete",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "(next == nil || strings.TrimSpace(*next) == \"\" || *next == *cursor) {\n\t\t\treturn errGitHubWorkItemPRSocialPaginationInvalid\n\t\t}\n\t\tcursor = next\n\t}\n\treturn nil\n}\n\nfunc (fetcher GitHubWorkItemPRSocialFetcher) drainEvents",
+      "replace": "(next == nil || strings.TrimSpace(*next) == \"\" || false) {\n\t\t\treturn errGitHubWorkItemPRSocialPaginationInvalid\n\t\t}\n\t\tcursor = next\n\t}\n\treturn nil\n}\n\nfunc (fetcher GitHubWorkItemPRSocialFetcher) drainEvents",
+      "rationale": "a comment continuation that repeats its cursor cannot be treated as forward progress",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherRejectsMissingAndStalledCursors$/stalled_comment_cursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "missing-event-cursor-is-incomplete",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "for pageInfo.HasNextPage && len(payload.Events) < limit {\n\t\tif cursor == nil || strings.TrimSpace(*cursor) == \"\" {",
+      "replace": "for pageInfo.HasNextPage && len(payload.Events) < limit {\n\t\tif false || strings.TrimSpace(*cursor) == \"\" {",
+      "rationale": "a timeline connection advertising another page must supply a cursor before any continuation request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherRejectsMissingAndStalledCursors$/missing_event_cursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "stalled-event-cursor-is-incomplete",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "(next == nil || strings.TrimSpace(*next) == \"\" || *next == *cursor) {\n\t\t\treturn errGitHubWorkItemPRSocialPaginationInvalid\n\t\t}\n\t\tcursor = next\n\t}\n\treturn nil\n}\n\nfunc appendGitHubWorkItemPRSocialNodes",
+      "replace": "(next == nil || strings.TrimSpace(*next) == \"\" || false) {\n\t\t\treturn errGitHubWorkItemPRSocialPaginationInvalid\n\t\t}\n\t\tcursor = next\n\t}\n\treturn nil\n}\n\nfunc appendGitHubWorkItemPRSocialNodes",
+      "rationale": "a timeline continuation that repeats its cursor cannot be treated as forward progress",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherRejectsMissingAndStalledCursors$/stalled_event_cursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "declared-record-limits-truncate-provider-overreturn",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "if len(nodes) > remaining {",
+      "replace": "if false {",
+      "rationale": "a provider page that returns more nodes than requested cannot escape the caller-declared comment or event cap",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherHonorsDeclaredLimitsWithoutOverfetch$", "./internal/providersync/"]]
+    },
+    {
+      "id": "request-cap-marks-incomplete",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "if result.Evidence.Pages >= maxRequests {",
+      "replace": "if result.Evidence.Pages > maxRequests {",
+      "rationale": "the bounded social traversal must stop before issuing a logical GraphQL request beyond its declared cap",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherReturnsTypedGraphQLAndCapIncomplete$/request_cap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "graphql-errors-never-become-empty-data",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "if len(envelope.Errors) > 0 || envelope.Data.Repository == nil {",
+      "replace": "if false || envelope.Data.Repository == nil {",
+      "rationale": "an HTTP-200 GraphQL errors envelope is a typed degraded fetch, never a complete empty repository payload",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherReturnsTypedGraphQLAndCapIncomplete$/graphql_errors$", "./internal/providersync/"]]
+    },
+    {
+      "id": "actual-wire-attempts-are-counted",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "func (doer gitHubWorkItemPRSocialCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.requests++",
+      "replace": "func (doer gitHubWorkItemPRSocialCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.requests += 0",
+      "rationale": "usage evidence counts physical GraphQL retry attempts while the transport reserves provider budget once per logical call",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherCountsRetryAttemptsButOneLogicalPage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "rate-limit-propagates-not-degrades",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "|| isRateLimited(err) {",
+      "replace": "|| false {",
+      "rationale": "GitHub rate limits retain retry and deferral semantics rather than becoming Python-style optional social degradation",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherPropagatesRateLimitCancelAndLeaseLoss$/rate_limit$", "./internal/providersync/"]]
+    },
+    {
+      "id": "non-rate-failure-has-typed-marker",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "result.Incomplete = &GitHubWorkItemPRSocialFetchIncomplete{\n\t\tCause: gitHubWorkItemPRSocialFailureCause(err),\n\t}",
+      "replace": "result.Incomplete = nil",
+      "rationale": "a swallowed non-rate PR-social failure must remain distinguishable from a complete empty social payload",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherMarksNonRateProviderFailureIncomplete$", "./internal/providersync/"]]
+    },
+    {
+      "id": "usage-family-matches-work-item-budget",
+      "file": "internal/providersync/github_work_items_social_fetch.go",
+      "find": "Transport: \"graphql\", RouteFamily: \"work_item_prs\", Dimension: BudgetGraphQLCost,",
+      "replace": "Transport: \"graphql\", RouteFamily: \"pr_social\", Dimension: BudgetGraphQLCost,",
+      "rationale": "the work-item PR GraphQL actual is keyed to the same work_item_prs family reserved by the Python budget estimator",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetcherBatchesFiftyAndReportsActualUsage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "comment-adapter-preserves-created-at",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "ID:        githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID, node.ID),\n\t\tCreatedAt: parseGitHubWorkItemTime(node.CreatedAt),",
+      "replace": "ID:        githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID, node.ID),\n\t\tCreatedAt: nil,",
+      "rationale": "the GraphQL comment createdAt timestamp must become Python's created_at semantic field instead of being silently dropped",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialCommentAdapterMatchesLivePythonProducer$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "comment-adapter-preserves-author",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "comment.User.Login = node.Author.Login",
+      "replace": "comment.User.Login = nil",
+      "rationale": "the GraphQL author must become Python's user.login so interactions retain identity and trusted-bot dependencies remain admissible",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialCommentAdapterMatchesLivePythonProducer$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "event-adapter-maps-closed-typename",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "\"MergedEvent\": \"merged\", \"ClosedEvent\": \"closed\", \"ReopenedEvent\": \"reopened\",",
+      "replace": "\"MergedEvent\": \"merged\", \"ClosedEvent\": \"\", \"ReopenedEvent\": \"reopened\",",
+      "rationale": "ClosedEvent must become Python's closed event token so the status transition is not silently discarded",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialEventAdapterMatchesLivePythonProducer$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "composition-keeps-adapted-comments",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "adapted.Comments = append(adapted.Comments, encoded)",
+      "replace": "if false { adapted.Comments = append(adapted.Comments, encoded) }",
+      "rationale": "adapted comments must cross the composition seam so interaction and trusted-comment dependency rows cannot both disappear",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "composition-keeps-adapted-events",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "adapted.Events = append(adapted.Events, encoded)",
+      "replace": "if false { adapted.Events = append(adapted.Events, encoded) }",
+      "rationale": "adapted events must cross the composition seam so transitions and reopen rows cannot both disappear",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "work-item-base-rest-plan-is-present",
+      "file": "internal/providersync/request_plan.go",
+      "find": "case \"work-items\", \"work-item-labels\", \"work-item-projects\", \"work-item-history\", \"work-item-comments\":",
+      "replace": "case \"work-items-disabled\", \"work-item-labels\", \"work-item-projects\", \"work-item-history\", \"work-item-comments\":",
+      "rationale": "the canonical GitHub work-items unit must reserve the Python REST work_items estimate instead of presenting an empty admission plan",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestProviderRequestPlansMatchLivePythonBudgetFunctions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "canonical-work-items-rest-floor-is-two",
+      "file": "internal/providersync/request_plan.go",
+      "find": "if dataset == \"work-items\" {\n\t\t\tfloor = 2",
+      "replace": "if false {\n\t\t\tfloor = 2",
+      "rationale": "Python budgets two REST_CORE units per span day for canonical work-items while the four derived aliases reserve one",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestProviderRequestPlansMatchLivePythonBudgetFunctions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "sync-prs-enables-work-item-expansion-plan",
+      "file": "internal/providersync/request_plan.go",
+      "find": "if flags[\"sync_prs\"] {",
+      "replace": "if false {",
+      "rationale": "planner-stamped sync_prs must add both PR GraphQL and secondary-abuse reservations for every work-item family alias",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestProviderRequestPlansMatchLivePythonBudgetFunctions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "work-item-pr-graphql-plan-scales-by-three",
+      "file": "internal/providersync/request_plan.go",
+      "find": "Dimension: BudgetGraphQLCost, Units: max(3, 3*spanDays),",
+      "replace": "Dimension: BudgetGraphQLCost, Units: max(2, 2*spanDays),",
+      "rationale": "work_item_prs GraphQL pressure uses Python's three-unit floor and per-day scaling",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestProviderRequestPlansMatchLivePythonBudgetFunctions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "work-item-pr-secondary-abuse-plan-is-distinct",
+      "file": "internal/providersync/request_plan.go",
+      "find": "Dimension: BudgetSecondaryAbuseRisk, Units: 1,",
+      "replace": "Dimension: BudgetGraphQLCost, Units: 1,",
+      "rationale": "Python reserves a distinct work_item_prs secondary-abuse bucket rather than folding that risk into GraphQL cost",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemRequestPlansCoverEveryAliasAndPRPressure$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestProviderRequestPlansMatchLivePythonBudgetFunctions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "event-adapter-maps-merged-typename",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "\"MergedEvent\": \"merged\", \"ClosedEvent\": \"closed\", \"ReopenedEvent\": \"reopened\",",
+      "replace": "\"MergedEvent\": \"\", \"ClosedEvent\": \"closed\", \"ReopenedEvent\": \"reopened\",",
+      "rationale": "MergedEvent must independently become Python's merged event token so the terminal done transition cannot silently disappear",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialEventAdapterMatchesLivePythonProducer$/merged$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialFetchAdaptsIntoCompletePRSemanticBundle$", "./internal/providersync/"]]
+    },
+    {
+      "id": "comment-id-falls-back-to-full-database-id",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID, node.ID)",
+      "replace": "githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.ID)",
+      "rationale": "a falsey numeric databaseId must preserve Python's next-choice fullDatabaseId before considering the GraphQL node id",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialCommentIDFallbackMatchesPythonTruthiness$/full_database_id_fallback$", "./internal/providersync/"]]
+    },
+    {
+      "id": "comment-id-falls-back-to-node-id",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID, node.ID)",
+      "replace": "githubWorkItemPRSocialPythonTruthyID(node.DatabaseID, node.FullDatabaseID)",
+      "rationale": "when both database ID forms are falsey the adapter must retain Python's final GraphQL node-id fallback",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialCommentIDFallbackMatchesPythonTruthiness$/node_id_fallback$", "./internal/providersync/"]]
+    },
+    {
+      "id": "numeric-zero-id-is-python-falsey",
+      "file": "internal/providersync/github_work_items_social_adapter.go",
+      "find": "if integer.Sign() != 0 {\n\t\t\t\t\treturn integer",
+      "replace": "if true {\n\t\t\t\t\treturn integer",
+      "rationale": "numeric zero is falsey in Python's databaseId-or-fullDatabaseId-or-id chain and must never stop fallback traversal",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemPRSocialCommentIDFallbackMatchesPythonTruthiness$/full_database_id_fallback$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-comment.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-comment.py
@@ -1,0 +1,36 @@
+"""Live Python oracle for the GraphQL PR issue-comment adapter."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.client import GitHubWorkClient
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/client.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return dataclasses.asdict(GitHubWorkClient._comment_from_graphql(case["raw_node"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/pr-social-comment",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _CLIENT_SOURCE.read_text(), "GitHubGraphQLComment"
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-event.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-event.py
@@ -1,0 +1,36 @@
+"""Live Python oracle for the GraphQL PR timeline-event adapter."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.client import GitHubWorkClient
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/client.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return dataclasses.asdict(GitHubWorkClient._event_from_graphql(case["raw_node"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/pr-social-event",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _CLIENT_SOURCE.read_text(), "GitHubGraphQLEvent"
+        ),
+    )
+)

--- a/internal/providersync/testdata/python_provider_budget_oracle.py
+++ b/internal/providersync/testdata/python_provider_budget_oracle.py
@@ -68,26 +68,54 @@ def _linear_cases(linear: Any) -> list[dict[str, object]]:
 
 
 def _github_cases(github: Any) -> list[dict[str, object]]:
-    return [
-        {
-            "provider": "github",
-            "dataset": dataset,
-            "span_days": span_days,
-            "flags": {},
-            "estimates": _render(
-                github._dataset_estimates(
-                    dataset_key=dataset,
-                    flags={},
-                    org_id="org",
-                    host="fixture.example",
-                    credential_fingerprint="fingerprint",
-                    span_days=span_days,
-                )
-            ),
-        }
-        for span_days in (1, 3)
-        for dataset in ("cicd", "tests", "deployments")
-    ]
+    cases: list[dict[str, object]] = []
+    for span_days in (1, 3):
+        for dataset in ("cicd", "tests", "deployments"):
+            cases.append(
+                {
+                    "provider": "github",
+                    "dataset": dataset,
+                    "span_days": span_days,
+                    "flags": {},
+                    "estimates": _render(
+                        github._dataset_estimates(
+                            dataset_key=dataset,
+                            flags={},
+                            org_id="org",
+                            host="fixture.example",
+                            credential_fingerprint="fingerprint",
+                            span_days=span_days,
+                        )
+                    ),
+                }
+            )
+        for dataset in WORK_ITEM_DATASETS:
+            for flags in ({"sync_prs": False}, {"sync_prs": True}):
+                case: dict[str, object] = {
+                    "provider": "github",
+                    "dataset": dataset,
+                    "span_days": span_days,
+                    "flags": flags,
+                    "estimates": _render(
+                        github._dataset_estimates(
+                            dataset_key=dataset,
+                            flags=flags,
+                            org_id="org",
+                            host="fixture.example",
+                            credential_fingerprint="fingerprint",
+                            span_days=span_days,
+                        )
+                    ),
+                }
+                if flags["sync_prs"]:
+                    route_family, dimension = github.GITHUB_USAGE_RESOLVER.resolve(
+                        transport="graphql",
+                        operation="POST /graphql PR social data",
+                    )
+                    case["actual_route_family"] = route_family
+                    case["actual_dimension"] = dimension.value
+                cases.append(case)
+    return cases
 
 
 def _gitlab_cases(gitlab: Any) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary

- add an unregistered GitHub GraphQL fetcher for work-item pull-request comments and merged/closed/reopened timeline events
- adapt GraphQL payloads into the existing Python-compatible semantic inputs, including precision-safe identifier fallbacks
- account for REST and GraphQL request budgets across all five GitHub work-item aliases
- prove fetch-to-semantic parity with live Python producer oracles and clause-level mutation coverage

This is a foundation layer in the Go Worker Migration stack. It deliberately does **not** register routes, publish effects, advance watermarks, change readiness, or activate aliases. It targets only `feat/go-worker-runtime-migration`.

## Checklist

- [x] Added/updated tests and governance evidence.
- [x] Ran the authoritative local validation gate.
- [x] Documented risk and rollback considerations.
- [x] Breaking changes, migrations, and config impacts: none; this layer is unreachable until the composite activation PR.

## Test Evidence

- `bash ci/local_validate.sh`
  - 11,574 passed, 98 skipped, 1 xfailed
  - Go format, vet, tests, race checks, live Python oracles, and build passed
  - River compatibility, ClickHouse scratch migration, and argMax live proof passed
- mutation plan: 28/28 killed with restore verification
- signed commit verified locally

## Risk Notes

- Blast radius is limited because no executor, routing, destination, readiness, effects, or watermark registration changes in this layer.
- The composite activation layer must preserve the all-or-nothing GitHub work-item effect and watermark contract before these fetchers become reachable.
- Rollback is the squash commit on the feature branch; this PR must not merge to `main`.

## Optional Context

- Linear: CHAOS-3123
- Stack base: `feat/go-worker-runtime-migration`
