### PR TITLE
feat(providersync): add GitHub Projects v2 foundation

### DIFF
--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -1,0 +1,618 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const gitHubProjectsV2IntegrationConfigKey = "github_projects_v2"
+
+// GitHubProjectV2Target is durable, non-secret integration configuration.
+//
+// ACTIVATION DECISION PENDING (CHAOS-3123): the active Python producer reads
+// these targets from process-global GITHUB_PROJECTS_V2 and creates a second
+// token client. The Go foundation deliberately chooses claim-owned
+// IntegrationConfig plus the already claim-resolved Credential/HTTPClient,
+// but remains unregistered until that ownership and fanout decision is
+// approved in Linear. It must not be used as route-readiness evidence.
+type GitHubProjectV2Target struct {
+	OrgLogin      string `json:"org_login"`
+	ProjectNumber int    `json:"project_number"`
+}
+
+// GitHubProjectV2Usage is the credential-free actual request accounting for
+// Projects v2. Python classifies unprefixed GraphQL work-item traffic under
+// work_item_prs/graphql_cost; keeping that vocabulary lets the eventual D16
+// composer join actuals to the provider budget without exposing query or
+// target details.
+type GitHubProjectV2Usage struct {
+	Transport    string
+	RouteFamily  string
+	Dimension    string
+	RequestCount int
+}
+
+// GitHubProjectV2FetchResult is a semantic, unregistered fetch result. It is
+// intentionally not CompleteRouteBatch and owns no effects or watermark.
+type GitHubProjectV2FetchResult struct {
+	Rows     githubWorkItemRows
+	Evidence FetchEvidence
+	Usage    GitHubProjectV2Usage
+	Targets  int
+}
+
+// GitHubProjectV2Fetcher temporarily preserves Python's per-source fanout:
+// callers may invoke it once for each existing work-items claim, and each
+// invocation fetches the claim's complete durable target list. Registration
+// is blocked on the unresolved activation/de-amplification decision above.
+type GitHubProjectV2Fetcher struct{}
+
+func githubProjectV2Targets(claim Claim) ([]GitHubProjectV2Target, error) {
+	value, configured := claim.IntegrationConfig[gitHubProjectsV2IntegrationConfigKey]
+	if !configured || value == nil {
+		return []GitHubProjectV2Target{}, nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, ErrInvalidConfiguration
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	var targets []GitHubProjectV2Target
+	if err := decoder.Decode(&targets); err != nil || targets == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	for index := range targets {
+		targets[index].OrgLogin = strings.TrimSpace(targets[index].OrgLogin)
+		if targets[index].OrgLogin == "" || targets[index].ProjectNumber < 1 {
+			return nil, ErrInvalidConfiguration
+		}
+	}
+	return targets, nil
+}
+
+func (GitHubProjectV2Fetcher) Fetch(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+	resolveIdentity githubIdentityResolver,
+) (GitHubProjectV2FetchResult, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		!isWorkItemFamilyDataset(claim.Dataset) || credential.Provider != "github" ||
+		credential.ID == "" || credential.ID != claim.CredentialID || client == nil ||
+		client.Provider != "github" || client.BaseURL == nil || client.Lease == nil ||
+		normalizedAt.IsZero() {
+		return GitHubProjectV2FetchResult{}, ErrInvalidConfiguration
+	}
+	targets, err := githubProjectV2Targets(claim)
+	if err != nil {
+		return GitHubProjectV2FetchResult{}, err
+	}
+	result := GitHubProjectV2FetchResult{
+		Rows: githubWorkItemRows{
+			WorkItems: []githubWorkItemRow{}, StatusTransitions: []githubWorkItemTransitionRow{},
+			Dependencies: []githubWorkItemDependencyRow{}, ReopenEvents: []githubWorkItemReopenRow{},
+			Interactions: []githubWorkItemInteractionRow{}, Sprints: []githubSprintRow{},
+			AIAttributions: []githubAIAttributionRow{},
+		},
+		Evidence: FetchEvidence{Provider: "github", Dataset: "projects-v2"},
+		Usage: GitHubProjectV2Usage{
+			Transport: "graphql", RouteFamily: "work_item_prs", Dimension: BudgetGraphQLCost,
+		},
+		Targets: len(targets),
+	}
+	if len(targets) == 0 {
+		return result, nil
+	}
+	counted := *client
+	counted.Doer = gitHubProjectV2CountingDoer{
+		delegate: client.Doer, requests: &result.Evidence.Requests,
+		graphqlRequests: &result.Usage.RequestCount, graphqlPath: gitHubGraphQLPath(client),
+	}
+	// Python's dict preserves first insertion position while later values win.
+	// Preserve that exact behavior across targets, including duplicate targets.
+	workItemIndex := map[string]int{}
+	for _, target := range targets {
+		items, err := fetchGitHubProjectV2Target(ctx, &counted, target, &result.Evidence)
+		if err != nil {
+			return finishGitHubProjectV2Fetch(result), err
+		}
+		projectScopeID := fmt.Sprintf("ghprojv2:%s#%d", target.OrgLogin, target.ProjectNumber)
+		for _, item := range items {
+			row, transitions, emitted, err := normalizeGitHubProjectV2Item(
+				claim, item, projectScopeID, resolveIdentity, normalizedAt,
+			)
+			if err != nil {
+				return finishGitHubProjectV2Fetch(result), err
+			}
+			if !emitted {
+				continue
+			}
+			if index, exists := workItemIndex[row.WorkItemID]; exists {
+				result.Rows.WorkItems[index] = row
+			} else {
+				workItemIndex[row.WorkItemID] = len(result.Rows.WorkItems)
+				result.Rows.WorkItems = append(result.Rows.WorkItems, row)
+			}
+			result.Rows.StatusTransitions = append(result.Rows.StatusTransitions, transitions...)
+		}
+	}
+	return finishGitHubProjectV2Fetch(result), nil
+}
+
+func finishGitHubProjectV2Fetch(result GitHubProjectV2FetchResult) GitHubProjectV2FetchResult {
+	result.Evidence.Records = len(result.Rows.WorkItems) + len(result.Rows.StatusTransitions)
+	return result
+}
+
+type gitHubProjectV2CountingDoer struct {
+	delegate        providerfoundation.HTTPDoer
+	requests        *int
+	graphqlRequests *int
+	graphqlPath     string
+}
+
+func (doer gitHubProjectV2CountingDoer) Do(request *http.Request) (*http.Response, error) {
+	*doer.requests++
+	if request.URL.EscapedPath() == doer.graphqlPath {
+		*doer.graphqlRequests++
+	}
+	return doer.delegate.Do(request)
+}
+
+func fetchGitHubProjectV2Target(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	target GitHubProjectV2Target,
+	evidence *FetchEvidence,
+) ([]gitHubProjectV2ItemPayload, error) {
+	items := []gitHubProjectV2ItemPayload{}
+	outerCursor := ""
+	seenOuter := map[string]struct{}{}
+	for {
+		variables := map[string]any{
+			"login": target.OrgLogin, "number": target.ProjectNumber,
+			"first": 50, "after": nil,
+		}
+		if outerCursor != "" {
+			variables["after"] = outerCursor
+		}
+		var envelope gitHubProjectV2ItemsEnvelope
+		if err := fetchGitHubProjectV2GraphQL(ctx, client, gitHubProjectsV2ItemsQuery, variables, &envelope, evidence); err != nil {
+			return nil, err
+		}
+		if envelope.Data.Organization == nil || envelope.Data.Organization.ProjectV2 == nil {
+			return items, nil
+		}
+		connection := envelope.Data.Organization.ProjectV2.Items
+		for index := range connection.Nodes {
+			item := connection.Nodes[index]
+			if item.Changes.PageInfo.HasNextPage {
+				cursor := strings.TrimSpace(item.Changes.PageInfo.EndCursor)
+				if cursor == "" || strings.TrimSpace(item.ID) == "" {
+					return nil, providerfoundation.ErrPaginationInvalid
+				}
+				seenChanges := map[string]struct{}{}
+				for {
+					if _, repeated := seenChanges[cursor]; repeated {
+						return nil, providerfoundation.ErrPaginationInvalid
+					}
+					seenChanges[cursor] = struct{}{}
+					var continuation gitHubProjectV2ChangesEnvelope
+					if err := fetchGitHubProjectV2GraphQL(ctx, client, gitHubProjectsV2ChangesQuery,
+						map[string]any{"itemId": item.ID, "after": cursor}, &continuation, evidence); err != nil {
+						return nil, err
+					}
+					if continuation.Data.Node == nil {
+						return nil, providerfoundation.ErrPaginationInvalid
+					}
+					more := continuation.Data.Node.Changes
+					item.Changes.Nodes = append(item.Changes.Nodes, more.Nodes...)
+					if !more.PageInfo.HasNextPage {
+						break
+					}
+					next := strings.TrimSpace(more.PageInfo.EndCursor)
+					if next == "" || next == cursor {
+						return nil, providerfoundation.ErrPaginationInvalid
+					}
+					cursor = next
+				}
+			}
+			items = append(items, item)
+		}
+		if !connection.PageInfo.HasNextPage {
+			return items, nil
+		}
+		next := strings.TrimSpace(connection.PageInfo.EndCursor)
+		if next == "" || next == outerCursor {
+			return nil, providerfoundation.ErrPaginationInvalid
+		}
+		if _, repeated := seenOuter[next]; repeated {
+			return nil, providerfoundation.ErrPaginationInvalid
+		}
+		seenOuter[next] = struct{}{}
+		outerCursor = next
+	}
+}
+
+func fetchGitHubProjectV2GraphQL(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	query string,
+	variables map[string]any,
+	destination any,
+	evidence *FetchEvidence,
+) error {
+	body, err := json.Marshal(map[string]any{"query": query, "variables": variables})
+	if err != nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	response, err := client.Do(ctx, http.MethodPost, gitHubGraphQLPath(client), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	evidence.Pages++
+	defer response.Body.Close()
+	decoder := json.NewDecoder(response.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(destination); err != nil {
+		return providerfoundation.ErrPaginationInvalid
+	}
+	var errorsHolder interface{ graphQLErrors() []json.RawMessage }
+	if typed, ok := destination.(interface{ graphQLErrors() []json.RawMessage }); ok {
+		errorsHolder = typed
+	}
+	if errorsHolder != nil && len(errorsHolder.graphQLErrors()) > 0 {
+		return providerfoundation.ErrGraphQLResponse
+	}
+	return nil
+}
+
+type gitHubProjectV2PageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type gitHubProjectV2Connection[T any] struct {
+	Nodes    []T                     `json:"nodes"`
+	PageInfo gitHubProjectV2PageInfo `json:"pageInfo"`
+}
+
+type gitHubProjectV2ItemsEnvelope struct {
+	Data struct {
+		Organization *struct {
+			ProjectV2 *struct {
+				Items gitHubProjectV2Connection[gitHubProjectV2ItemPayload] `json:"items"`
+			} `json:"projectV2"`
+		} `json:"organization"`
+	} `json:"data"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+func (envelope *gitHubProjectV2ItemsEnvelope) graphQLErrors() []json.RawMessage {
+	return envelope.Errors
+}
+
+type gitHubProjectV2ChangesEnvelope struct {
+	Data struct {
+		Node *struct {
+			Changes gitHubProjectV2Connection[gitHubProjectV2ChangePayload] `json:"changes"`
+		} `json:"node"`
+	} `json:"data"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+func (envelope *gitHubProjectV2ChangesEnvelope) graphQLErrors() []json.RawMessage {
+	return envelope.Errors
+}
+
+type gitHubProjectV2ItemPayload struct {
+	ID          string                                                      `json:"id"`
+	CreatedAt   *string                                                     `json:"createdAt"`
+	UpdatedAt   *string                                                     `json:"updatedAt"`
+	Content     gitHubProjectV2ContentPayload                               `json:"content"`
+	FieldValues gitHubProjectV2Connection[gitHubProjectV2FieldValuePayload] `json:"fieldValues"`
+	Changes     gitHubProjectV2Connection[gitHubProjectV2ChangePayload]     `json:"changes"`
+}
+
+type gitHubProjectV2ContentPayload struct {
+	Typename   string  `json:"__typename"`
+	ID         string  `json:"id"`
+	Number     int     `json:"number"`
+	Title      string  `json:"title"`
+	Body       *string `json:"body"`
+	URL        *string `json:"url"`
+	State      *string `json:"state"`
+	CreatedAt  *string `json:"createdAt"`
+	UpdatedAt  *string `json:"updatedAt"`
+	ClosedAt   *string `json:"closedAt"`
+	Repository struct {
+		NameWithOwner string `json:"nameWithOwner"`
+	} `json:"repository"`
+	Labels    gitHubProjectV2Connection[githubWorkItemLabelPayload] `json:"labels"`
+	Assignees gitHubProjectV2Connection[githubWorkItemUserPayload]  `json:"assignees"`
+	Author    *githubWorkItemUserPayload                            `json:"author"`
+}
+
+type gitHubProjectV2FieldValuePayload struct {
+	Typename string      `json:"__typename"`
+	Name     *string     `json:"name"`
+	Title    *string     `json:"title"`
+	ID       *string     `json:"id"`
+	Number   json.Number `json:"number"`
+	Field    struct {
+		Name string `json:"name"`
+	} `json:"field"`
+}
+
+type gitHubProjectV2ChangePayload struct {
+	Field struct {
+		Name string `json:"name"`
+	} `json:"field"`
+	PreviousValue *struct {
+		Name *string `json:"name"`
+	} `json:"previousValue"`
+	NewValue *struct {
+		Name *string `json:"name"`
+	} `json:"newValue"`
+	CreatedAt *string `json:"createdAt"`
+	Actor     *struct {
+		Login *string `json:"login"`
+	} `json:"actor"`
+}
+
+func normalizeGitHubProjectV2Item(
+	claim Claim,
+	item gitHubProjectV2ItemPayload,
+	projectScopeID string,
+	resolveIdentity githubIdentityResolver,
+	normalizedAt time.Time,
+) (githubWorkItemRow, []githubWorkItemTransitionRow, bool, error) {
+	if claim.Validate() != nil || claim.Provider != "github" || !isWorkItemFamilyDataset(claim.Dataset) ||
+		strings.TrimSpace(projectScopeID) == "" || normalizedAt.IsZero() {
+		return githubWorkItemRow{}, nil, false, ErrInvalidConfiguration
+	}
+	if item.Content.Typename == "PullRequest" || (item.Content.Typename != "Issue" && item.Content.Typename != "DraftIssue") {
+		return githubWorkItemRow{}, []githubWorkItemTransitionRow{}, false, nil
+	}
+	statusRaw, sprintName, sprintID := "", "", ""
+	var storyPoints *float64
+	for _, value := range item.FieldValues.Nodes {
+		fieldName := normalizeWorkItemLabel(value.Field.Name)
+		switch value.Typename {
+		case "ProjectV2ItemFieldSingleSelectValue":
+			if fieldName == "status" && value.Name != nil {
+				statusRaw = *value.Name
+			}
+		case "ProjectV2ItemFieldIterationValue":
+			if strings.Contains(fieldName, "iteration") || strings.Contains(fieldName, "sprint") {
+				if value.Title != nil {
+					sprintName = *value.Title
+				}
+				if value.ID != nil {
+					sprintID = *value.ID
+				}
+			}
+		case "ProjectV2ItemFieldNumberValue":
+			if fieldName == "estimate" || fieldName == "points" || fieldName == "story points" || fieldName == "size" {
+				if parsed, err := strconv.ParseFloat(string(value.Number), 64); err == nil {
+					storyPoints = &parsed
+				}
+			}
+		}
+	}
+	content := item.Content
+	workItemID := "ghproj:" + item.ID
+	if content.Typename == "Issue" && strings.TrimSpace(content.Repository.NameWithOwner) != "" && content.Number > 0 {
+		workItemID = "gh:" + content.Repository.NameWithOwner + "#" + strconv.Itoa(content.Number)
+	}
+	transitions := make([]githubWorkItemTransitionRow, 0, len(item.Changes.Nodes))
+	for _, change := range item.Changes.Nodes {
+		fieldName := normalizeWorkItemLabel(change.Field.Name)
+		if fieldName != "status" && fieldName != "phase" {
+			continue
+		}
+		occurredAt := parseGitHubWorkItemTime(change.CreatedAt)
+		if occurredAt == nil || change.NewValue == nil || change.NewValue.Name == nil || strings.TrimSpace(*change.NewValue.Name) == "" {
+			continue
+		}
+		fromRaw, toRaw := "", strings.TrimSpace(*change.NewValue.Name)
+		if change.PreviousValue != nil && change.PreviousValue.Name != nil {
+			fromRaw = strings.TrimSpace(*change.PreviousValue.Name)
+		}
+		var actor *string
+		if change.Actor != nil && change.Actor.Login != nil {
+			identity := resolveGitHubWorkItemIdentity(githubWorkItemUserPayload{Login: change.Actor.Login}, resolveIdentity)
+			if identity != "" && identity != "unknown" {
+				actor = &identity
+			}
+		}
+		transition := githubWorkItemTransitionRow{
+			WorkItemID: workItemID, Provider: "github", OccurredAt: occurredAt.UTC(),
+			FromStatusRaw: nullableString(fromRaw), ToStatusRaw: nullableString(toRaw),
+			FromStatus: githubProjectV2Status(fromRaw, nil, ""),
+			ToStatus:   githubProjectV2Status(toRaw, nil, ""), Actor: actor, OrgID: claim.OrgID,
+		}
+		if err := transition.validate(claim); err != nil {
+			return githubWorkItemRow{}, nil, false, err
+		}
+		transitions = append(transitions, transition)
+	}
+	createdAt := parseGitHubWorkItemTime(content.CreatedAt)
+	if createdAt == nil {
+		createdAt = parseGitHubWorkItemTime(item.CreatedAt)
+	}
+	if createdAt == nil {
+		fallback := normalizedAt.UTC()
+		createdAt = &fallback
+	}
+	updatedAt := parseGitHubWorkItemTime(content.UpdatedAt)
+	if updatedAt == nil {
+		updatedAt = parseGitHubWorkItemTime(item.UpdatedAt)
+	}
+	if updatedAt == nil {
+		copy := *createdAt
+		updatedAt = &copy
+	}
+	closedAt := parseGitHubWorkItemTime(content.ClosedAt)
+	labels := make([]string, 0, len(content.Labels.Nodes))
+	for _, label := range content.Labels.Nodes {
+		if label.Name != "" {
+			labels = append(labels, label.Name)
+		}
+	}
+	assignees := make([]string, 0, len(content.Assignees.Nodes))
+	for _, user := range content.Assignees.Nodes {
+		identity := resolveGitHubWorkItemIdentity(user, resolveIdentity)
+		if identity != "" && identity != "unknown" {
+			assignees = append(assignees, identity)
+		}
+	}
+	var reporter *string
+	if content.Author != nil {
+		identity := resolveGitHubWorkItemIdentity(*content.Author, resolveIdentity)
+		if identity != "" && identity != "unknown" {
+			reporter = &identity
+		}
+	}
+	state := ""
+	if content.State != nil {
+		state = *content.State
+	}
+	status := githubProjectV2Status(statusRaw, labels, state)
+	row := githubWorkItemRow{
+		WorkItemID: workItemID, Provider: "github", Title: content.Title, Type: "issue",
+		Status: status, StatusRaw: nullableString(statusRaw), Description: content.Body,
+		RepoID: nil, ProjectID: stringPointer(projectScopeID), Assignees: assignees,
+		Reporter: reporter, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC(),
+		ClosedAt: closedAt, Labels: labels, StoryPoints: storyPoints, URL: content.URL,
+		OrgID: claim.OrgID,
+	}
+	if statusRaw == "" {
+		row.StatusRaw = nullableString(state)
+	}
+	if sprintID != "" {
+		row.SprintID = &sprintID
+	}
+	if sprintName != "" {
+		row.SprintName = &sprintName
+	}
+	if closedAt != nil {
+		completed := closedAt.UTC()
+		row.CompletedAt = &completed
+	}
+	if content.Typename == "Issue" {
+		row.Type = githubIssueType(labels)
+	}
+	if row.Description != nil && *row.Description == "" {
+		row.Description = nil
+	}
+	if err := validateGitHubProjectV2Row(claim, row); err != nil {
+		return githubWorkItemRow{}, nil, false, err
+	}
+	return row, transitions, true, nil
+}
+
+func githubProjectV2Status(statusRaw string, labels []string, state string) string {
+	if statusRaw != "" {
+		switch normalizeWorkItemLabel(statusRaw) {
+		case "backlog", "icebox", "triage":
+			return "backlog"
+		case "todo", "to do", "ready", "ready for dev":
+			return "todo"
+		case "in progress", "doing", "wip":
+			return "in_progress"
+		case "in review", "review", "code review", "qa":
+			return "in_review"
+		case "blocked", "on hold":
+			return "blocked"
+		case "done", "closed", "resolved":
+			return "done"
+		case "canceled", "cancelled", "won't do":
+			return "canceled"
+		}
+	}
+	return githubIssueStatus(state, labels)
+}
+
+func validateGitHubProjectV2Row(claim Claim, row githubWorkItemRow) error {
+	if row.Provider != "github" || row.OrgID == "" || row.OrgID != claim.OrgID ||
+		row.WorkItemID == "" || row.RepoID != nil || row.ProjectID == nil ||
+		!strings.HasPrefix(*row.ProjectID, "ghprojv2:") || row.Type == "" || row.Status == "" ||
+		row.CreatedAt.IsZero() || row.UpdatedAt.IsZero() || row.Assignees == nil || row.Labels == nil {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func mergeGitHubProjectV2Rows(repository, projects githubWorkItemRows) githubWorkItemRows {
+	merged := repository
+	merged.WorkItems = append([]githubWorkItemRow{}, repository.WorkItems...)
+	index := make(map[string]int, len(merged.WorkItems)+len(projects.WorkItems))
+	for position, row := range merged.WorkItems {
+		index[row.WorkItemID] = position
+	}
+	for _, row := range projects.WorkItems {
+		if position, exists := index[row.WorkItemID]; exists {
+			merged.WorkItems[position] = row
+		} else {
+			index[row.WorkItemID] = len(merged.WorkItems)
+			merged.WorkItems = append(merged.WorkItems, row)
+		}
+	}
+	merged.StatusTransitions = append(append([]githubWorkItemTransitionRow{}, repository.StatusTransitions...), projects.StatusTransitions...)
+	return merged
+}
+
+// These literals intentionally preserve Python's documented leaf
+// truncations (labels 50, assignees 10, fieldValues 20). The outer items and
+// nested changes connections are fully paginated by the fetcher.
+const gitHubProjectsV2ItemsQuery = `
+query($login: String!, $number: Int!, $after: String, $first: Int!) {
+  organization(login: $login) {
+    projectV2(number: $number) {
+      items(first: $first, after: $after) {
+        nodes {
+          id createdAt updatedAt
+          content {
+            __typename
+            ... on Issue { id number title url state createdAt updatedAt closedAt repository { nameWithOwner } labels(first: 50) { nodes { name } } assignees(first: 10) { nodes { login email name } } author { login email name } }
+            ... on PullRequest { id number title url state createdAt updatedAt closedAt mergedAt repository { nameWithOwner } labels(first: 50) { nodes { name } } assignees(first: 10) { nodes { login email name } } author { login email name } }
+            ... on DraftIssue { id title createdAt updatedAt }
+          }
+          fieldValues(first: 20) { nodes {
+            __typename
+            ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2SingleSelectField { name } } }
+            ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }
+            ... on ProjectV2ItemFieldIterationValue { title id field { ... on ProjectV2FieldCommon { name } } }
+            ... on ProjectV2ItemFieldNumberValue { number field { ... on ProjectV2FieldCommon { name } } }
+          } }
+          changes(first: 100, orderBy: {field: CREATED_AT, direction: ASC}) { nodes { field { ... on ProjectV2FieldCommon { name } } previousValue { ... on ProjectV2ItemFieldSingleSelectValue { name } } newValue { ... on ProjectV2ItemFieldSingleSelectValue { name } } createdAt actor { login } } pageInfo { hasNextPage endCursor } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`
+
+const gitHubProjectsV2ChangesQuery = `
+query($itemId: ID!, $after: String) {
+  node(id: $itemId) {
+    ... on ProjectV2Item {
+      changes(first: 100, after: $after, orderBy: {field: CREATED_AT, direction: ASC}) {
+        nodes { field { ... on ProjectV2FieldCommon { name } } previousValue { ... on ProjectV2ItemFieldSingleSelectValue { name } } newValue { ... on ProjectV2ItemFieldSingleSelectValue { name } } createdAt actor { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`

--- a/internal/providersync/github_work_items_projects_v2_oracle_test.go
+++ b/internal/providersync/github_work_items_projects_v2_oracle_test.go
@@ -1,0 +1,271 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type gitHubProjectV2DecisionOracleRow struct {
+	Emitted         bool `json:"emitted"`
+	TransitionCount int  `json:"transition_count"`
+}
+
+type gitHubProjectV2TargetsOracleRow struct {
+	Targets []string `json:"targets"`
+}
+
+type gitHubProjectV2CompositionOracleRow struct {
+	ItemIDs     []string `json:"item_ids"`
+	Titles      []string `json:"titles"`
+	Transitions []string `json:"transitions"`
+}
+
+type gitHubProjectV2PaginationOracleRow struct {
+	ItemIDs      []string `json:"item_ids"`
+	ChangeCounts []int    `json:"change_counts"`
+	OuterAfter   []string `json:"outer_after"`
+	ChangeAfter  []string `json:"change_after"`
+}
+
+func TestGitHubProjectV2WorkItemMatchesLivePythonProductionRow(t *testing.T) {
+	input := gitHubProjectV2OracleInput()
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/row",
+		[]oracleCase{{ID: "issue_with_project_dimensions", Input: input}},
+		func(t *testing.T, input map[string]any) githubWorkItemRow {
+			row, _, emitted := buildGitHubProjectV2OracleRows(t, input)
+			if !emitted {
+				t.Fatal("Go normalizer skipped issue")
+			}
+			return row
+		}, nil,
+	)
+}
+
+func TestGitHubProjectV2DraftIssueMatchesLivePythonProductionRow(t *testing.T) {
+	input := gitHubProjectV2DraftOracleInput()
+	row, _, emitted := buildGitHubProjectV2OracleRows(t, input)
+	if !emitted || row.WorkItemID != "ghproj:PVTI_DRAFT_1" {
+		t.Fatalf("Go draft issue emitted=%t work_item_id=%q", emitted, row.WorkItemID)
+	}
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/row",
+		[]oracleCase{{ID: "draft_issue_with_project_dimensions", Input: input}},
+		func(t *testing.T, input map[string]any) githubWorkItemRow {
+			row, _, emitted := buildGitHubProjectV2OracleRows(t, input)
+			if !emitted {
+				t.Fatal("Go normalizer skipped draft issue")
+			}
+			return row
+		}, nil,
+	)
+}
+
+func TestGitHubProjectV2TransitionMatchesLivePythonProductionRow(t *testing.T) {
+	input := gitHubProjectV2OracleInput()
+	input["transition_index"] = 1
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/transition",
+		[]oracleCase{{ID: "complete_status_history", Input: input}},
+		func(t *testing.T, input map[string]any) githubWorkItemTransitionRow {
+			_, transitions, emitted := buildGitHubProjectV2OracleRows(t, input)
+			if !emitted || len(transitions) < 2 {
+				t.Fatalf("emitted=%t transitions=%+v", emitted, transitions)
+			}
+			return transitions[input["transition_index"].(int)]
+		}, nil,
+	)
+}
+
+func TestGitHubProjectV2PullRequestSkipMatchesLivePythonProductionDecision(t *testing.T) {
+	input := map[string]any{
+		"project_scope_id": "ghprojv2:acme#3",
+		"item_node": map[string]any{
+			"id": "PVTI_PR", "content": map[string]any{"__typename": "PullRequest", "number": 9, "title": "PR"},
+			"fieldValues": map[string]any{"nodes": []any{}}, "changes": map[string]any{"nodes": []any{}},
+		},
+	}
+	_, transitions, emitted := buildGitHubProjectV2OracleRowsWithDefaults(t, input)
+	if emitted || len(transitions) != 0 {
+		t.Fatalf("Go Projects v2 PR decision emitted=%t transitions=%d", emitted, len(transitions))
+	}
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/pr-skip", []oracleCase{{ID: "pull_request", Input: input}},
+		func(t *testing.T, input map[string]any) gitHubProjectV2DecisionOracleRow {
+			_, transitions, emitted := buildGitHubProjectV2OracleRowsWithDefaults(t, input)
+			return gitHubProjectV2DecisionOracleRow{Emitted: emitted, TransitionCount: len(transitions)}
+		}, nil,
+	)
+}
+
+func TestGitHubProjectV2TargetParserMatchesLivePythonValidTargetSemantics(t *testing.T) {
+	input := map[string]any{"raw": " acme:3, labs:12, acme:3 "}
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/target-parser", []oracleCase{{ID: "ordered_duplicates", Input: input}},
+		func(t *testing.T, _ map[string]any) gitHubProjectV2TargetsOracleRow {
+			claim := githubWorkItemOracleClaim()
+			claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+				map[string]any{"org_login": "acme", "project_number": 3},
+				map[string]any{"org_login": "labs", "project_number": 12},
+				map[string]any{"org_login": "acme", "project_number": 3},
+			}}
+			targets, err := githubProjectV2Targets(claim)
+			if err != nil {
+				t.Fatal(err)
+			}
+			row := gitHubProjectV2TargetsOracleRow{Targets: make([]string, 0, len(targets))}
+			for _, target := range targets {
+				row.Targets = append(row.Targets, target.OrgLogin+":"+strconv.Itoa(target.ProjectNumber))
+			}
+			return row
+		}, nil,
+	)
+}
+
+func TestMergeGitHubProjectV2RowsMatchesLivePythonComposition(t *testing.T) {
+	input := map[string]any{
+		"repository_items":       []any{map[string]any{"work_item_id": "same", "title": "repository"}, map[string]any{"work_item_id": "repo-only", "title": "repo"}},
+		"project_items":          []any{map[string]any{"work_item_id": "same", "title": "project"}, map[string]any{"work_item_id": "project-only", "title": "project"}},
+		"repository_transitions": []any{"repo-transition"}, "project_transitions": []any{"project-transition"},
+	}
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/composition", []oracleCase{{ID: "last_wins_append", Input: input}},
+		func(t *testing.T, _ map[string]any) gitHubProjectV2CompositionOracleRow {
+			got := mergeGitHubProjectV2Rows(
+				githubWorkItemRows{WorkItems: []githubWorkItemRow{{WorkItemID: "same", Title: "repository"}, {WorkItemID: "repo-only", Title: "repo"}}, StatusTransitions: []githubWorkItemTransitionRow{{WorkItemID: "repo-transition"}}},
+				githubWorkItemRows{WorkItems: []githubWorkItemRow{{WorkItemID: "same", Title: "project"}, {WorkItemID: "project-only", Title: "project"}}, StatusTransitions: []githubWorkItemTransitionRow{{WorkItemID: "project-transition"}}},
+			)
+			row := gitHubProjectV2CompositionOracleRow{}
+			for _, item := range got.WorkItems {
+				row.ItemIDs = append(row.ItemIDs, item.WorkItemID)
+				row.Titles = append(row.Titles, item.Title)
+			}
+			for _, transition := range got.StatusTransitions {
+				row.Transitions = append(row.Transitions, transition.WorkItemID)
+			}
+			return row
+		}, nil,
+	)
+}
+
+func TestGitHubProjectV2PaginationMatchesLivePythonProducer(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items-project-v2/pagination", []oracleCase{{ID: "outer_and_nested", Input: map[string]any{}}},
+		func(t *testing.T, _ map[string]any) gitHubProjectV2PaginationOracleRow {
+			doer := &gitHubProjectV2Doer{t: t, replies: []string{
+				`{"data":{"organization":{"projectV2":{"items":{"nodes":[{"id":"PVTI_1","content":{"__typename":"DraftIssue","title":"one"},"fieldValues":{"nodes":[]},"changes":{"nodes":[{"createdAt":"2026-08-01T08:00:00Z"}],"pageInfo":{"hasNextPage":true,"endCursor":"change-1"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"item-1"}}}}}}`,
+				`{"data":{"node":{"changes":{"nodes":[{"createdAt":"2026-08-02T08:00:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+				`{"data":{"organization":{"projectV2":{"items":{"nodes":[{"id":"PVTI_2","content":{"__typename":"DraftIssue","title":"two"},"fieldValues":{"nodes":[]},"changes":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+			}}
+			evidence := FetchEvidence{}
+			items, err := fetchGitHubProjectV2Target(context.Background(), githubProjectV2TestClient(t, doer), GitHubProjectV2Target{OrgLogin: "acme", ProjectNumber: 3}, &evidence)
+			if err != nil {
+				t.Fatal(err)
+			}
+			row := gitHubProjectV2PaginationOracleRow{}
+			for _, item := range items {
+				row.ItemIDs = append(row.ItemIDs, item.ID)
+				row.ChangeCounts = append(row.ChangeCounts, len(item.Changes.Nodes))
+			}
+			for _, body := range doer.bodies {
+				variables := body["variables"].(map[string]any)
+				if itemID, nested := variables["itemId"]; nested {
+					row.ChangeAfter = append(row.ChangeAfter, itemID.(string)+":"+variables["after"].(string))
+					continue
+				}
+				after := "<none>"
+				if variables["after"] != nil {
+					after = variables["after"].(string)
+				}
+				row.OuterAfter = append(row.OuterAfter, after)
+			}
+			return row
+		}, nil,
+	)
+}
+
+func gitHubProjectV2OracleInput() map[string]any {
+	return map[string]any{
+		"org_id": "org-acme", "project_scope_id": "ghprojv2:acme#3",
+		"item_node": map[string]any{
+			"id": "PVTI_1",
+			"content": map[string]any{
+				"__typename": "Issue", "number": 7, "title": "Repair delivery path",
+				"url": "https://github.com/acme/api/issues/7", "state": "OPEN",
+				"createdAt":  "2026-08-01T08:00:00.123456Z",
+				"updatedAt":  "2026-08-03T09:30:00.654321Z",
+				"repository": map[string]any{"nameWithOwner": "acme/api"},
+				"labels":     map[string]any{"nodes": []any{map[string]any{"name": "bug"}}},
+				"assignees":  map[string]any{"nodes": []any{map[string]any{"login": "reviewer"}}},
+				"author":     map[string]any{"login": "author"},
+			},
+			"fieldValues": map[string]any{"nodes": []any{
+				map[string]any{"__typename": "ProjectV2ItemFieldSingleSelectValue", "name": "Doing", "field": map[string]any{"name": "Status"}},
+				map[string]any{"__typename": "ProjectV2ItemFieldIterationValue", "title": "Sprint 8", "id": "ITER_8", "field": map[string]any{"name": "Iteration"}},
+				map[string]any{"__typename": "ProjectV2ItemFieldNumberValue", "number": 5.0, "field": map[string]any{"name": "Story Points"}},
+			}},
+			"changes": map[string]any{"nodes": []any{
+				map[string]any{"field": map[string]any{"name": "Status"}, "previousValue": map[string]any{"name": "Todo"}, "newValue": map[string]any{"name": "Doing"}, "createdAt": "2026-08-02T08:00:00Z", "actor": map[string]any{"login": "maintainer"}},
+				map[string]any{"field": map[string]any{"name": "Phase"}, "previousValue": map[string]any{"name": "Doing"}, "newValue": map[string]any{"name": "Done"}, "createdAt": "2026-08-03T08:00:00Z", "actor": map[string]any{"login": "maintainer"}},
+			}},
+		},
+	}
+}
+
+func gitHubProjectV2DraftOracleInput() map[string]any {
+	return map[string]any{
+		"org_id": "org-acme", "project_scope_id": "ghprojv2:acme#3",
+		"item_node": map[string]any{
+			"id": "PVTI_DRAFT_1",
+			"content": map[string]any{
+				"__typename": "DraftIssue", "title": "Shape the migration",
+				"createdAt": "2026-08-01T08:00:00.123456Z",
+				"updatedAt": "2026-08-03T09:30:00.654321Z",
+			},
+			"fieldValues": map[string]any{"nodes": []any{
+				map[string]any{"__typename": "ProjectV2ItemFieldSingleSelectValue", "name": "Ready", "field": map[string]any{"name": "Status"}},
+				map[string]any{"__typename": "ProjectV2ItemFieldIterationValue", "title": "Sprint 9", "id": "ITER_9", "field": map[string]any{"name": "Sprint"}},
+				map[string]any{"__typename": "ProjectV2ItemFieldNumberValue", "number": 8.5, "field": map[string]any{"name": "Estimate"}},
+			}},
+			"changes": map[string]any{"nodes": []any{}},
+		},
+	}
+}
+
+func buildGitHubProjectV2OracleRows(t *testing.T, input map[string]any) (githubWorkItemRow, []githubWorkItemTransitionRow, bool) {
+	t.Helper()
+	raw, err := json.Marshal(input["item_node"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var item gitHubProjectV2ItemPayload
+	if err := decoder.Decode(&item); err != nil {
+		t.Fatal(err)
+	}
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["org_id"].(string)
+	row, transitions, emitted, err := normalizeGitHubProjectV2Item(
+		claim, item, input["project_scope_id"].(string), nil,
+		time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row, transitions, emitted
+}
+
+func buildGitHubProjectV2OracleRowsWithDefaults(t *testing.T, input map[string]any) (githubWorkItemRow, []githubWorkItemTransitionRow, bool) {
+	t.Helper()
+	copy := make(map[string]any, len(input)+1)
+	for key, value := range input {
+		copy[key] = value
+	}
+	copy["org_id"] = "org-acme"
+	return buildGitHubProjectV2OracleRows(t, copy)
+}

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -1,0 +1,314 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestGitHubProjectV2TargetsComeOnlyFromClaimIntegrationConfig(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": " acme ", "project_number": 3},
+		map[string]any{"org_login": "labs", "project_number": json.Number("12")},
+	}}
+	t.Setenv("GITHUB_PROJECTS_V2", "ignored:99")
+	targets, err := githubProjectV2Targets(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []GitHubProjectV2Target{{OrgLogin: "acme", ProjectNumber: 3}, {OrgLogin: "labs", ProjectNumber: 12}}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("targets=%+v want=%+v", targets, want)
+	}
+}
+
+func TestGitHubProjectV2ActivationDecisionRemainsPending(t *testing.T) {
+	if got := ProviderExecutor("github", "work-items"); got != ExecutorNone {
+		t.Fatalf("Projects v2 foundation was registered before the Linear activation decision: %s", got)
+	}
+	descriptor, known := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	if !known {
+		t.Fatal("github/work-items capability disappeared")
+	}
+	if descriptor.RouteReady || descriptor.RouteEnabled || len(descriptor.Destinations) != 0 {
+		t.Fatalf("unapproved Projects v2 route became active: %+v", descriptor)
+	}
+}
+
+func TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig(t *testing.T) {
+	for _, value := range []any{
+		[]any{map[string]any{"org_login": "", "project_number": 1}},
+		[]any{map[string]any{"org_login": "acme", "project_number": 0}},
+		[]any{map[string]any{"org_login": "acme", "project_number": 1, "token": "forbidden"}},
+		"acme:1",
+	} {
+		claim := githubWorkItemOracleClaim()
+		claim.IntegrationConfig = map[string]any{"github_projects_v2": value}
+		if _, err := githubProjectV2Targets(claim); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("value=%#v error=%v", value, err)
+		}
+	}
+}
+
+type gitHubProjectV2Doer struct {
+	t        *testing.T
+	replies  []string
+	statuses []int
+	bodies   []map[string]any
+}
+
+func (doer *gitHubProjectV2Doer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	if request.URL.Path != "/graphql" {
+		doer.t.Fatalf("unexpected path %s", request.URL.Path)
+	}
+	var body map[string]any
+	decoder := json.NewDecoder(request.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&body); err != nil {
+		doer.t.Fatal(err)
+	}
+	doer.bodies = append(doer.bodies, body)
+	if len(doer.bodies) > len(doer.replies) {
+		doer.t.Fatalf("unexpected request %d", len(doer.bodies))
+	}
+	index := len(doer.bodies) - 1
+	status := http.StatusOK
+	if index < len(doer.statuses) && doer.statuses[index] != 0 {
+		status = doer.statuses[index]
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(doer.replies[index])),
+		Request:    request,
+	}, nil
+}
+
+func TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination(t *testing.T) {
+	doer := &gitHubProjectV2Doer{t: t, replies: []string{
+		`{"data":{"organization":{"projectV2":{"items":{"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","number":7,"title":"Ship it","state":"OPEN","createdAt":"2026-08-01T08:00:00Z","updatedAt":"2026-08-02T08:00:00Z","repository":{"nameWithOwner":"acme/api"},"labels":{"nodes":[]},"assignees":{"nodes":[]}},"fieldValues":{"nodes":[]},"changes":{"nodes":[{"field":{"name":"Status"},"previousValue":{"name":"Todo"},"newValue":{"name":"Doing"},"createdAt":"2026-08-01T09:00:00Z","actor":{"login":"octocat"}}],"pageInfo":{"hasNextPage":true,"endCursor":"change-1"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"item-1"}}}}}}`,
+		`{"data":{"node":{"changes":{"nodes":[{"field":{"name":"Status"},"previousValue":{"name":"Doing"},"newValue":{"name":"Done"},"createdAt":"2026-08-02T09:00:00Z","actor":{"login":"octocat"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+		`{"data":{"organization":{"projectV2":{"items":{"nodes":[{"id":"PVTI_2","content":{"__typename":"PullRequest","number":8,"title":"not a work item"},"fieldValues":{"nodes":[]},"changes":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+	}}
+	client := githubProjectV2TestClient(t, doer)
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{map[string]any{"org_login": "acme", "project_number": 3}}}
+	credential := providerfoundation.Credential{Provider: "github", ID: claim.CredentialID}
+	result, err := (GitHubProjectV2Fetcher{}).Fetch(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC), nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Rows.WorkItems) != 1 || len(result.Rows.StatusTransitions) != 2 {
+		t.Fatalf("rows=%+v", result.Rows)
+	}
+	if result.Evidence.Pages != 3 || result.Evidence.Requests != 3 || result.Evidence.Records != 3 {
+		t.Fatalf("evidence=%+v", result.Evidence)
+	}
+	if got := result.Rows.WorkItems[0]; got.WorkItemID != "gh:acme/api#7" || got.RepoID != nil || got.ProjectID == nil || *got.ProjectID != "ghprojv2:acme#3" {
+		t.Fatalf("work item=%+v", got)
+	}
+	if len(doer.bodies) != 3 || doer.bodies[1]["query"] == doer.bodies[0]["query"] {
+		t.Fatalf("requests=%+v", doer.bodies)
+	}
+	outerQuery := doer.bodies[0]["query"].(string)
+	for _, leaf := range []string{"items(first: $first", "labels(first: 50)", "assignees(first: 10)", "fieldValues(first: 20)", "changes(first: 100"} {
+		if !strings.Contains(outerQuery, leaf) {
+			t.Errorf("query missing documented leaf bound %q", leaf)
+		}
+	}
+}
+
+func TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors(t *testing.T) {
+	for _, replies := range [][]string{
+		{
+			`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":null}}}}}}`,
+			`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+		},
+		{
+			`{"data":{"organization":{"projectV2":{"items":{"nodes":[{"id":"PVTI_1","content":{"__typename":"DraftIssue","title":"Draft","createdAt":"2026-08-01T08:00:00Z","updatedAt":"2026-08-01T08:00:00Z"},"fieldValues":{"nodes":[]},"changes":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+			`{"data":{"node":{"changes":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+		},
+	} {
+		doer := &gitHubProjectV2Doer{t: t, replies: replies}
+		claim := githubWorkItemOracleClaim()
+		claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{map[string]any{"org_login": "acme", "project_number": 3}}}
+		_, err := (GitHubProjectV2Fetcher{}).Fetch(context.Background(), claim,
+			providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+			githubProjectV2TestClient(t, doer), time.Now().UTC(), nil)
+		if !errors.Is(err, providerfoundation.ErrPaginationInvalid) {
+			t.Fatalf("replies=%v error=%v", replies, err)
+		}
+	}
+}
+
+func TestGitHubProjectV2FetcherRequiresClaimResolvedCredentialAndClient(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{map[string]any{"org_login": "acme", "project_number": 3}}}
+	client := githubProjectV2TestClient(t, &gitHubProjectV2Doer{t: t, replies: []string{
+		`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+	}})
+	for _, credential := range []providerfoundation.Credential{
+		{Provider: "github", ID: "77777777-7777-4777-8777-777777777777"},
+		{Provider: "gitlab", ID: claim.CredentialID},
+	} {
+		if _, err := (GitHubProjectV2Fetcher{}).Fetch(context.Background(), claim, credential, client, time.Now().UTC(), nil); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("credential=%+v error=%v", credential.SafeAttributes(), err)
+		}
+	}
+}
+
+func TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce(t *testing.T) {
+	doer := &gitHubProjectV2Doer{
+		t: t, statuses: []int{http.StatusServiceUnavailable, http.StatusOK},
+		replies: []string{
+			`{"message":"unavailable"}`,
+			`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+		},
+	}
+	client := githubProjectV2TestClient(t, doer)
+	client.Retry.MaxAttempts = 2
+	budget := &gitHubProjectV2Budget{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{
+		Provider: "github", OrgID: "org-acme", Host: "api.github.com",
+		CostClass: "medium", Limit: 1, TTL: time.Minute,
+	}
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": "acme", "project_number": 3},
+	}}
+	result, err := (GitHubProjectV2Fetcher{}).Fetch(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		client, time.Now().UTC(), nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Evidence.Requests != 2 || result.Evidence.Pages != 1 ||
+		result.Usage != (GitHubProjectV2Usage{
+			Transport: "graphql", RouteFamily: "work_item_prs",
+			Dimension: BudgetGraphQLCost, RequestCount: 2,
+		}) || budget.acquires != 1 || budget.releases != 1 {
+		t.Fatalf("result=%+v budget=%+v", result, budget)
+	}
+}
+
+func TestGitHubProjectV2FetcherRetainsPhysicalUsageOnTerminalError(t *testing.T) {
+	doer := &gitHubProjectV2Doer{
+		t: t, statuses: []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable},
+		replies: []string{`{"message":"unavailable"}`, `{"message":"still unavailable"}`},
+	}
+	client := githubProjectV2TestClient(t, doer)
+	client.Retry.MaxAttempts = 2
+	budget := &gitHubProjectV2Budget{}
+	client.Budget = budget
+	client.BudgetKey = providerfoundation.BudgetKey{
+		Provider: "github", OrgID: "org-acme", Host: "api.github.com",
+		CostClass: "medium", Limit: 1, TTL: time.Minute,
+	}
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": "acme", "project_number": 3},
+	}}
+	result, err := (GitHubProjectV2Fetcher{}).Fetch(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		client, time.Now().UTC(), nil,
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorTransient {
+		t.Fatalf("error=%v", err)
+	}
+	if result.Targets != 1 || result.Evidence.Requests != 2 || result.Evidence.Pages != 0 ||
+		result.Usage.RequestCount != 2 || budget.acquires != 1 || budget.releases != 1 {
+		t.Fatalf("result=%+v budget=%+v", result, budget)
+	}
+}
+
+func TestGitHubProjectV2FetcherPreservesTemporaryPerClaimFanout(t *testing.T) {
+	doer := &gitHubProjectV2Doer{t: t, replies: []string{
+		`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+		`{"data":{"organization":{"projectV2":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`,
+	}}
+	client := githubProjectV2TestClient(t, doer)
+	for _, source := range []string{"acme/api", "acme/web"} {
+		claim := githubWorkItemOracleClaim()
+		claim.SourceExternalID = source
+		claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+			map[string]any{"org_login": "acme", "project_number": 3},
+		}}
+		result, err := (GitHubProjectV2Fetcher{}).Fetch(
+			context.Background(), claim,
+			providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+			client, time.Now().UTC(), nil,
+		)
+		if err != nil || result.Targets != 1 {
+			t.Fatalf("source=%s result=%+v error=%v", source, result, err)
+		}
+	}
+	if len(doer.bodies) != 2 {
+		t.Fatalf("requests=%d want one target traversal per source claim", len(doer.bodies))
+	}
+}
+
+func TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend(t *testing.T) {
+	repository := githubWorkItemRows{
+		WorkItems:         []githubWorkItemRow{{WorkItemID: "same", Title: "repository"}, {WorkItemID: "repo-only", Title: "repo"}},
+		StatusTransitions: []githubWorkItemTransitionRow{{WorkItemID: "same", ToStatus: "todo"}},
+		Dependencies:      []githubWorkItemDependencyRow{{SourceWorkItemID: "same"}},
+	}
+	project := githubWorkItemRows{
+		WorkItems:         []githubWorkItemRow{{WorkItemID: "same", Title: "project"}, {WorkItemID: "project-only", Title: "project"}},
+		StatusTransitions: []githubWorkItemTransitionRow{{WorkItemID: "same", ToStatus: "done"}},
+	}
+	got := mergeGitHubProjectV2Rows(repository, project)
+	if titles := []string{got.WorkItems[0].Title, got.WorkItems[1].Title, got.WorkItems[2].Title}; !reflect.DeepEqual(titles, []string{"project", "repo", "project"}) {
+		t.Fatalf("titles=%v", titles)
+	}
+	if len(got.StatusTransitions) != 2 || !reflect.DeepEqual(got.Dependencies, repository.Dependencies) {
+		t.Fatalf("rows=%+v", got)
+	}
+}
+
+func githubProjectV2TestClient(t *testing.T, doer providerfoundation.HTTPDoer) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"github", "https://api.github.com", doer, func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+type gitHubProjectV2Budget struct{ acquires, releases int }
+
+func (budget *gitHubProjectV2Budget) Acquire(
+	context.Context, providerfoundation.BudgetKey,
+) (providerfoundation.Reservation, error) {
+	budget.acquires++
+	return gitHubProjectV2Reservation{budget: budget}, nil
+}
+
+type gitHubProjectV2Reservation struct{ budget *gitHubProjectV2Budget }
+
+func (reservation gitHubProjectV2Reservation) Release(context.Context) error {
+	reservation.budget.releases++
+	return nil
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "name": "unregistered github projects v2 semantic foundation",
+  "build": ["go", "build", "./internal/providersync/"],
+  "$limitation": "This plan covers the unregistered Projects v2 fetch, normalization, and composition foundation. Route registration, effects, watermarking, readiness, and the unresolved fanout ownership decision are intentionally absent.",
+  "mutations": [
+    {
+      "id": "P1-credential-matches-claimed-credential",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "credential.ID == \"\" || credential.ID != claim.CredentialID || client == nil ||",
+      "replace": "credential.ID == \"\" || credential.ID == claim.CredentialID || client == nil ||",
+      "rationale": "Projects v2 must use the credential resolved for this claim, never a global or unrelated descriptor",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherRequiresClaimResolvedCredentialAndClient$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P2-nested-missing-cursor-fails-closed",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if cursor == \"\" || strings.TrimSpace(item.ID) == \"\" {",
+      "replace": "if cursor == \"impossible-cursor\" || strings.TrimSpace(item.ID) == \"\" {",
+      "rationale": "hasNextPage without an endCursor cannot establish complete nested history and must not become a partial success",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P3-outer-missing-cursor-fails-closed",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if next == \"\" || next == outerCursor {",
+      "replace": "if false && (next == \"\" || next == outerCursor) {",
+      "rationale": "hasNextPage without an endCursor cannot establish a complete project inventory",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P4-pull-requests-remain-skipped",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if item.Content.Typename == \"PullRequest\" || (item.Content.Typename != \"Issue\" && item.Content.Typename != \"DraftIssue\") {",
+      "replace": "if item.Content.Typename != \"PullRequest\" && (item.Content.Typename != \"Issue\" && item.Content.Typename != \"DraftIssue\") {",
+      "rationale": "The active Python Projects v2 normalizer explicitly emits no WorkItem or transitions for PullRequest content",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2PullRequestSkipMatchesLivePythonProductionDecision$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P5-project-row-is-last-wins",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "merged.WorkItems[position] = row",
+      "replace": "merged.WorkItems[position] = merged.WorkItems[position]",
+      "rationale": "Python overwrites a repository row with the Projects v2 row at the original insertion position",
+      "proof": [["go", "test", "-count=1", "-run", "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P6-project-transitions-append",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "merged.StatusTransitions = append(append([]githubWorkItemTransitionRow{}, repository.StatusTransitions...), projects.StatusTransitions...)",
+      "replace": "merged.StatusTransitions = append([]githubWorkItemTransitionRow{}, repository.StatusTransitions...)",
+      "rationale": "Python appends all Projects v2 transitions after repository transitions instead of deduplicating or replacing them",
+      "proof": [["go", "test", "-count=1", "-run", "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P7-nested-pages-are-composed",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "item.Changes.Nodes = append(item.Changes.Nodes, more.Nodes...)",
+      "replace": "item.Changes.Nodes = append([]gitHubProjectV2ChangePayload{}, more.Nodes...)",
+      "rationale": "Every nested changes page participates in transition history; replacing the first page silently truncates history",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P8-documented-label-leaf-bound-is-preserved",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "expect_occurrences": 2,
+      "find": "labels(first: 50)",
+      "replace": "labels(first: 49)",
+      "rationale": "The port intentionally preserves the active producer's documented unpaginated labels(first: 50) leaf truncation",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P9-physical-attempts-are-counted",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "func (doer gitHubProjectV2CountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.requests++",
+      "replace": "func (doer gitHubProjectV2CountingDoer) Do(request *http.Request) (*http.Response, error) {\n\tif false { *doer.requests++ }",
+      "rationale": "Fetch evidence counts every physical HTTP attempt, including retries inside one logical budget reservation",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P10-graphql-usage-counts-physical-attempts",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if request.URL.EscapedPath() == doer.graphqlPath {\n\t\t*doer.graphqlRequests++",
+      "replace": "if false && request.URL.EscapedPath() == doer.graphqlPath {\n\t\t*doer.graphqlRequests++",
+      "rationale": "The work_item_prs GraphQL actual records every physical wire attempt rather than only successful logical pages",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P11-error-results-retain-request-evidence",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "expect_occurrences": 2,
+      "find": "return finishGitHubProjectV2Fetch(result), err",
+      "replace": "return GitHubProjectV2FetchResult{}, err",
+      "rationale": "Terminal fetch and normalization failures retain already-observed safe usage instead of returning an indistinguishable zero result",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherRetainsPhysicalUsageOnTerminalError$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P12-projects-v2-uses-python-budget-vocabulary",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "Transport: \"graphql\", RouteFamily: \"work_item_prs\", Dimension: BudgetGraphQLCost,",
+      "replace": "Transport: \"graphql\", RouteFamily: \"projects_v2\", Dimension: BudgetGraphQLCost,",
+      "rationale": "Projects v2 actual usage must use Python's work_item_prs/graphql_cost vocabulary so planned and actual usage remain joinable",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P13-draft-issues-are-emitted",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "workItemID := \"ghproj:\" + item.ID",
+      "replace": "workItemID := \"ghproj-draft:\" + item.ID",
+      "rationale": "The live Python Projects v2 producer emits DraftIssue rows with the project-native ghproj item identity",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2DraftIssueMatchesLivePythonProductionRow$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_composition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_composition.py
@@ -1,0 +1,61 @@
+"""Live Python Projects v2 composition oracle."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.metrics.job_work_items import _merge_github_project_v2_rows
+    from dev_health_ops.models.work_items import WorkItem
+
+_THIS_FILE = pathlib.Path(__file__)
+
+
+def _work_item(payload: dict[str, Any]) -> WorkItem:
+    return WorkItem(
+        work_item_id=str(payload["work_item_id"]),
+        provider="github",
+        title=str(payload["title"]),
+        type="issue",
+        status="todo",
+        status_raw="todo",
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    repository = [_work_item(item) for item in case["repository_items"]]
+    projects = [_work_item(item) for item in case["project_items"]]
+    items, transitions = _merge_github_project_v2_rows(
+        repository,
+        list(case["repository_transitions"]),
+        projects,
+        list(case["project_transitions"]),
+    )
+    return {
+        "item_ids": [item.work_item_id for item in items],
+        "titles": [item.title for item in items],
+        "transitions": transitions,
+    }
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/composition",
+        build_row=_build_row,
+        reflected_fields=lambda: dict_literal_keys(
+            _THIS_FILE.read_text(), "_build_row", (RETURN_LITERAL,)
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pagination.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pagination.py
@@ -1,0 +1,156 @@
+"""Live Python Projects v2 outer/nested pagination oracle."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+    from dev_health_ops.providers.github.client import (
+        GitHubWorkClient,
+        ProjectItemChanges,
+    )
+
+_THIS_FILE = pathlib.Path(__file__)
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self.outer_after: list[str] = []
+        self.change_after: list[str] = []
+        self.outer_pages = [
+            {
+                "organization": {
+                    "projectV2": {
+                        "items": {
+                            "nodes": [
+                                {
+                                    "id": "PVTI_1",
+                                    "content": {
+                                        "__typename": "DraftIssue",
+                                        "title": "one",
+                                    },
+                                    "fieldValues": {"nodes": []},
+                                    "changes": {
+                                        "nodes": [
+                                            {"createdAt": "2026-08-01T08:00:00Z"}
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": True,
+                                            "endCursor": "change-1",
+                                        },
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "item-1"},
+                        }
+                    }
+                }
+            },
+            {
+                "organization": {
+                    "projectV2": {
+                        "items": {
+                            "nodes": [
+                                {
+                                    "id": "PVTI_2",
+                                    "content": {
+                                        "__typename": "DraftIssue",
+                                        "title": "two",
+                                    },
+                                    "fieldValues": {"nodes": []},
+                                    "changes": {
+                                        "nodes": [],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            },
+        ]
+
+    def query(
+        self, _operation: str, _query: str, variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        after = variables.get("after")
+        self.outer_after.append(after if isinstance(after, str) else "<none>")
+        return self.outer_pages.pop(0)
+
+    def changes(self, *, item_id: str, after: str | None = None) -> ProjectItemChanges:
+        self.change_after.append(f"{item_id}:{after or '<none>'}")
+        return {
+            "nodes": [{"createdAt": "2026-08-02T08:00:00Z"}],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+
+
+class _OracleGitHubWorkClient(GitHubWorkClient):
+    """Typed adapter that executes the production pagination loop."""
+
+    def __init__(self, harness: _Harness) -> None:
+        # The oracle exercises only iter_project_v2_items, whose concrete
+        # dependencies are the gate and the two query methods below. Avoid
+        # constructing live PyGithub/GraphQL transports while retaining the
+        # production class and method dispatch mypy verifies.
+        self.gate = RateLimitGate()
+        self._harness = harness
+
+    def _query_graphql(
+        self,
+        operation: str,
+        query: str,
+        *,
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return self._harness.query(operation, query, variables or {})
+
+    def _fetch_item_changes(
+        self,
+        *,
+        item_id: str,
+        after: str | None = None,
+    ) -> ProjectItemChanges | None:
+        return self._harness.changes(item_id=item_id, after=after)
+
+
+def _build_row(_case: dict[str, Any]) -> dict[str, Any]:
+    harness = _Harness()
+    client = _OracleGitHubWorkClient(harness)
+    items = list(client.iter_project_v2_items(org_login="acme", project_number=3))
+    return {
+        "item_ids": [item["id"] for item in items],
+        "change_counts": [
+            len((item.get("changes") or {}).get("nodes") or []) for item in items
+        ],
+        "outer_after": harness.outer_after,
+        "change_after": harness.change_after,
+    }
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/pagination",
+        build_row=_build_row,
+        reflected_fields=lambda: dict_literal_keys(
+            _THIS_FILE.read_text(), "_build_row", (RETURN_LITERAL,)
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pr-skip.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pr-skip.py
@@ -1,0 +1,47 @@
+"""Live Projects v2 PullRequest inclusion-decision oracle."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        github_project_v2_item_to_work_item,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+
+_THIS_FILE = pathlib.Path(__file__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    row, transitions = github_project_v2_item_to_work_item(
+        item_node=case["item_node"],
+        project_scope_id=case["project_scope_id"],
+        status_mapping=load_status_mapping(),
+        identity=load_identity_resolver(),
+    )
+    return {"emitted": row is not None, "transition_count": len(transitions)}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/pr-skip",
+        build_row=_build_row,
+        reflected_fields=lambda: dict_literal_keys(
+            _THIS_FILE.read_text(), "_build_row", (RETURN_LITERAL,)
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_row.py
@@ -1,0 +1,48 @@
+"""Live Python oracle for GitHub Projects v2 item normalization."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        github_project_v2_item_to_work_item,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    row, _ = github_project_v2_item_to_work_item(
+        item_node=case["item_node"],
+        project_scope_id=case["project_scope_id"],
+        status_mapping=load_status_mapping(),
+        identity=load_identity_resolver(),
+    )
+    if row is None:
+        raise ValueError("case did not emit a WorkItem")
+    return dataclasses.asdict(dataclasses.replace(row, org_id=case["org_id"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/row",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItem"
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_target-parser.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_target-parser.py
@@ -1,0 +1,41 @@
+"""Live legacy target-parser decision oracle for the durable Go parser."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import pathlib
+from typing import Any
+from unittest.mock import patch
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.metrics.work_items import parse_github_projects_v2_env
+
+_THIS_FILE = pathlib.Path(__file__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    with patch.dict(os.environ, {"GITHUB_PROJECTS_V2": case["raw"]}, clear=False):
+        targets = parse_github_projects_v2_env()
+    return {"targets": [f"{org}:{number}" for org, number in targets]}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/target-parser",
+        build_row=_build_row,
+        reflected_fields=lambda: dict_literal_keys(
+            _THIS_FILE.read_text(), "_build_row", (RETURN_LITERAL,)
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_transition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_transition.py
@@ -1,0 +1,47 @@
+"""Live Python oracle for GitHub Projects v2 status transitions."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.github.normalize import (
+        github_project_v2_item_to_work_item,
+    )
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _, transitions = github_project_v2_item_to_work_item(
+        item_node=case["item_node"],
+        project_scope_id=case["project_scope_id"],
+        status_mapping=load_status_mapping(),
+        identity=load_identity_resolver(),
+    )
+    row = transitions[int(case["transition_index"])]
+    return dataclasses.asdict(dataclasses.replace(row, org_id=case["org_id"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items-project-v2/transition",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItemStatusTransition"
+        ),
+    )
+)

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -374,6 +374,22 @@ def read_work_item_partial_observations(
     return read_partial_observations(exc)
 
 
+def _merge_github_project_v2_rows(
+    repository_items: list[WorkItem],
+    repository_transitions: list[Any],
+    project_items: list[WorkItem],
+    project_transitions: list[Any] | None,
+) -> tuple[list[WorkItem], list[Any]]:
+    """Preserve the active producer's ordered last-wins/append composition."""
+    by_id = {item.work_item_id: item for item in repository_items}
+    for item in project_items:
+        by_id[item.work_item_id] = item
+    return list(by_id.values()), [
+        *repository_transitions,
+        *(project_transitions or []),
+    ]
+
+
 def run_work_items_sync_job(
     *,
     db_url: str,
@@ -920,11 +936,9 @@ def run_work_items_sync_job(
                     status_mapping=status_mapping,
                     identity=identity,
                 )
-                by_id = {w.work_item_id: w for w in work_items}
-                for w in proj_items:
-                    by_id[w.work_item_id] = w
-                work_items = list(by_id.values())
-                transitions.extend(list(proj_tr or []))
+                work_items, transitions = _merge_github_project_v2_rows(
+                    work_items, transitions, proj_items, proj_tr
+                )
 
         if "gitlab" in provider_set:
             # gl_token/gl_url were already resolved above (before the


### PR DESCRIPTION
## Summary

- add an unregistered GitHub Projects v2 GraphQL foundation with complete outer and nested pagination
- normalize Issue and DraftIssue project rows, skip pull requests, preserve transitions, and retain temporary per-source last-wins composition parity
- use claim-resolved GitHub credentials and client paths for public GitHub and GHES without environment token/target fallbacks
- account for physical GraphQL attempts and budget usage, including retained evidence on terminal errors
- prove row, transition, pagination, target parsing, composition, and PR-skip parity through live Python producer oracles

This foundation is intentionally unreachable. It does not register executors, destinations, effects, watermarks, readiness, or aliases. Activation remains blocked on the explicit Projects v2 ownership/configuration decision recorded on CHAOS-3123 and on the later composite GitHub work-item activation layer.

## Checklist

- [x] Added/updated tests and governance evidence.
- [x] Ran the authoritative local validation gate after rebasing onto the current feature head.
- [x] Documented risk and rollback considerations.
- [x] Breaking changes, migrations, and config impacts: none; durable target configuration is added but not activated.

## Test Evidence

- `bash ci/local_validate.sh`
  - 11,574 passed, 98 skipped, 1 xfailed
  - Ruff and mypy passed across 2,113 sources
  - Go format, vet, tests, race checks, live Python oracles, and build passed
  - River compatibility, ClickHouse scratch migration, and argMax live proof passed
- Projects v2 mutation plan: 13/13 killed with restore verification
- signed rebased commit verified locally

## Risk Notes

- Blast radius is limited by explicit non-registration tests and the absence of routing/readiness/effect changes.
- The current per-source fanout and last-wins composition are parity foundations, not an implicit approval of the final Projects v2 ownership model.
- Rollback is the squash commit on the feature branch; this PR must not merge to `main`.

## Optional Context

- Linear: CHAOS-3123
- Stack base: `feat/go-worker-runtime-migration`
