### PR TITLE
feat(providersync): collect GitHub work-item REST data

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2333",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2402",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2333
+        "line": 2402
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2478",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2547",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2478
+        "line": 2547
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2231",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2300",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2231
+        "line": 2300
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2377",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2446",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2377
+        "line": 2446
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/internal/providerfoundation/pagination.go
+++ b/internal/providerfoundation/pagination.go
@@ -38,6 +38,11 @@ type GitHubPageOptions struct {
 	Query    url.Values
 	DataKey  string
 	MaxPages int
+	// MaxItems stops after appending exactly this many items, even when the
+	// current response advertises rel=next. Zero leaves the item count
+	// unbounded. This models provider APIs whose public iterator contract has
+	// an item limit without spending one speculative request past the limit.
+	MaxItems int
 	// StopAt, when set, is evaluated for each item in page order (codex H1,
 	// CHAOS-3122). The first item it reports true for is excluded from
 	// Items, and pagination stops immediately without requesting a next
@@ -64,7 +69,8 @@ func CollectGitHubLinkPages(
 	options GitHubPageOptions,
 ) (PageCollection, error) {
 	if ctx == nil || client == nil || strings.TrimSpace(options.Path) == "" ||
-		options.MaxPages < 1 || options.MaxPages > maximumProviderPages {
+		options.MaxPages < 1 || options.MaxPages > maximumProviderPages ||
+		options.MaxItems < 0 {
 		return PageCollection{}, ErrPaginationInvalid
 	}
 	next, err := pageURL(options.Path, options.Query)
@@ -79,25 +85,28 @@ func CollectGitHubLinkPages(
 		}
 		response, err := client.Do(ctx, http.MethodGet, next, nil)
 		if err != nil {
-			return PageCollection{}, err
+			return result, err
 		}
 		items, decodeErr := decodePage(response, options.DataKey)
 		if decodeErr != nil {
-			return PageCollection{}, decodeErr
+			return result, decodeErr
 		}
 		result.Pages++
-		if options.StopAt == nil {
+		if options.StopAt == nil && options.MaxItems == 0 {
 			result.Items = append(result.Items, items...)
 			next = githubNextLink(response.Header.Get("Link"))
 			continue
 		}
 		crossedBoundary := false
 		for _, item := range items {
-			if options.StopAt(item) {
+			if options.StopAt != nil && options.StopAt(item) {
 				crossedBoundary = true
 				break
 			}
 			result.Items = append(result.Items, item)
+			if options.MaxItems > 0 && len(result.Items) >= options.MaxItems {
+				return result, nil
+			}
 		}
 		if crossedBoundary {
 			return result, nil

--- a/internal/providerfoundation/pagination_test.go
+++ b/internal/providerfoundation/pagination_test.go
@@ -65,6 +65,49 @@ func TestGitHubLinkPaginationReportsHardCapWithoutExtraCall(t *testing.T) {
 	}
 }
 
+func TestGitHubLinkPaginationStopsAtExplicitItemLimitWithoutExtraPage(t *testing.T) {
+	t.Parallel()
+	doer := &paginationDoer{responses: []paginationResponse{
+		{
+			body:    `[{"id":1},{"id":2}]`,
+			headers: http.Header{"Link": {`<https://api.github.com/items?page=2>; rel="next"`}},
+		},
+		{body: `[{"id":3}]`},
+	}}
+	client := paginationClient(t, "github", "https://api.github.com", doer)
+	result, err := CollectGitHubLinkPages(context.Background(), client, GitHubPageOptions{
+		Path: "/items", MaxPages: 2, MaxItems: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Pages != 1 || result.CapReached || len(result.Items) != 2 || len(doer.requests) != 1 {
+		t.Fatalf("result=%+v calls=%d", result, len(doer.requests))
+	}
+}
+
+func TestGitHubLinkPaginationReturnsSuccessfulPagesBeforeLaterFailure(t *testing.T) {
+	t.Parallel()
+	doer := &paginationDoer{responses: []paginationResponse{
+		{
+			body:    `[{"id":1}]`,
+			headers: http.Header{"Link": {`<https://api.github.com/items?page=2>; rel="next"`}},
+		},
+		{status: http.StatusBadGateway, body: `{"message":"down"}`},
+	}}
+	client := paginationClient(t, "github", "https://api.github.com", doer)
+	result, err := CollectGitHubLinkPages(context.Background(), client, GitHubPageOptions{
+		Path: "/items", MaxPages: 2,
+	})
+	var providerErr *ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != ErrorTransient {
+		t.Fatalf("error=%v", err)
+	}
+	if result.Pages != 1 || result.CapReached || len(result.Items) != 1 || len(doer.requests) != 2 {
+		t.Fatalf("result=%+v calls=%d", result, len(doer.requests))
+	}
+}
+
 func TestGitHubLinkPaginationRejectsSameHostSchemeDowngradeBeforeRequest(t *testing.T) {
 	t.Parallel()
 	doer := &paginationDoer{responses: []paginationResponse{{
@@ -311,6 +354,7 @@ func paginationClient(t *testing.T, provider, base string, doer HTTPDoer) *HTTPC
 type paginationResponse struct {
 	body    string
 	headers http.Header
+	status  int
 }
 
 type paginationDoer struct {
@@ -329,8 +373,12 @@ func (d *paginationDoer) Do(request *http.Request) (*http.Response, error) {
 	}
 	d.requests = append(d.requests, request.Clone(request.Context()))
 	response := d.responses[len(d.requests)-1]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: status,
 		Header:     response.headers.Clone(),
 		Body:       io.NopCloser(strings.NewReader(response.body)),
 		Request:    request,

--- a/internal/providersync/github_work_items_rest_collect.go
+++ b/internal/providersync/github_work_items_rest_collect.go
@@ -1,0 +1,527 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	githubWorkItemEventLimit   = 1000
+	githubWorkItemCommentLimit = 500
+)
+
+// GitHubWorkItemsRESTIncomplete preserves Python's intentionally best-effort
+// milestone and issue-comment behavior without turning a failed optional
+// request into an indistinguishable successful empty collection. Cause is a
+// stable provider error class, never provider response text.
+type GitHubWorkItemsRESTIncomplete struct {
+	Component string
+	SubjectID string
+	Cause     string
+}
+
+// GitHubWorkItemsRESTPullRequest is a REST-selected PR awaiting the composed
+// GraphQL social fetch. The later layer must use Number as its GraphQL target
+// and pass Payload to normalizeGitHubPullRequestBundle with the returned
+// events/comments; this collector deliberately does not fabricate empty PR
+// social data or emit a partially normalized PR row.
+type GitHubWorkItemsRESTPullRequest struct {
+	Number    int
+	CreatedAt time.Time
+	Payload   json.RawMessage
+}
+
+// GitHubWorkItemsRESTResult is a typed, non-routed collection result. It owns
+// no effects, watermark, or capability registration. Rows contains the issue
+// and milestone facts REST can establish completely; PullRequests are handed
+// to the later GraphQL social layer before the composite can become complete.
+type GitHubWorkItemsRESTResult struct {
+	RepoFullName string
+	RepoID       uuid.UUID
+	Rows         githubWorkItemRows
+	PullRequests []GitHubWorkItemsRESTPullRequest
+	Incomplete   []GitHubWorkItemsRESTIncomplete
+	Evidence     FetchEvidence
+}
+
+// NoOptionalDegradation reports only whether this REST layer observed an
+// optional milestone or issue-comment degradation. It is deliberately not a
+// composite-completion signal: every PullRequests entry still awaits the
+// GraphQL social fetch before the GitHub work-item producer can be complete.
+func (result GitHubWorkItemsRESTResult) NoOptionalDegradation() bool {
+	return len(result.Incomplete) == 0
+}
+
+// GitHubWorkItemsRESTCollector builds the REST half of GitHub's composite
+// work-item producer. It remains intentionally unregistered until the PR
+// GraphQL social layer and every direct/derived effect are composed atomically.
+type GitHubWorkItemsRESTCollector struct {
+	MaxPages int
+}
+
+type githubWorkItemsRESTOptions struct {
+	includeIssues       bool
+	includePullRequests bool
+	fetchComments       bool
+	fetchMilestones     bool
+	commentsLimit       int
+}
+
+type githubWorkItemsRESTListIssue struct {
+	Number      int             `json:"number"`
+	UpdatedAt   *string         `json:"updated_at"`
+	PullRequest json.RawMessage `json:"pull_request"`
+}
+
+type githubWorkItemsRESTCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	requests *int
+}
+
+func (doer githubWorkItemsRESTCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	*doer.requests = *doer.requests + 1
+	return doer.delegate.Do(request)
+}
+
+func (collector GitHubWorkItemsRESTCollector) Collect(
+	ctx context.Context,
+	claim Claim,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (GitHubWorkItemsRESTResult, error) {
+	result := GitHubWorkItemsRESTResult{
+		Rows:         emptyGitHubWorkItemRows(),
+		PullRequests: []GitHubWorkItemsRESTPullRequest{},
+		Incomplete:   []GitHubWorkItemsRESTIncomplete{},
+		Evidence: FetchEvidence{
+			Provider: "github", Dataset: "work-items",
+		},
+	}
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "work-items" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || client.Doer == nil || normalizedAt.IsZero() {
+		return result, ErrInvalidConfiguration
+	}
+	options, err := githubWorkItemsRESTOptionsForClaim(claim)
+	if err != nil {
+		return result, err
+	}
+	maxPages := collector.MaxPages
+	if maxPages == 0 {
+		maxPages = nativeMaxPages
+	}
+	if maxPages < 1 || maxPages > nativeMaxPages {
+		return result, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return result, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+	counted := *client
+	counted.Doer = githubWorkItemsRESTCountingDoer{
+		delegate: client.Doer, requests: &result.Evidence.Requests,
+	}
+
+	var repo githubWorkItemsRESTRepositoryPayload
+	if err := fetchObject(ctx, &counted, root, &repo); err != nil {
+		return result, err
+	}
+	result.RepoFullName = strings.TrimSpace(repo.FullName)
+	repoIdentity, identityErr := repositoryIdentity(result.RepoFullName)
+	if identityErr != nil {
+		return result, identityErr
+	}
+	result.RepoID, err = uuid.Parse(repoIdentity)
+	if err != nil {
+		return result, providerfoundation.ErrNormalizationInvalid
+	}
+
+	if options.fetchMilestones {
+		page, pageErr := providerfoundation.CollectGitHubLinkPages(
+			ctx, &counted, providerfoundation.GitHubPageOptions{
+				Path:     root + "/milestones",
+				Query:    url.Values{"state": {"all"}, "per_page": {"100"}},
+				MaxPages: maxPages,
+			},
+		)
+		result.addPageEvidence(page)
+		if pageErr != nil {
+			if fatalErr := githubWorkItemsRESTOptionalFailure(
+				ctx, &counted, pageErr,
+			); fatalErr != nil {
+				return result, fatalErr
+			}
+			result.addIncomplete("milestones", "", pageErr)
+		}
+		if page.CapReached {
+			return result, ErrPaginationCapExceeded
+		}
+		for _, raw := range page.Items {
+			row, normalizeErr := normalizeGitHubSprint(
+				claim, result.RepoFullName, raw, normalizedAt,
+			)
+			if normalizeErr != nil {
+				result.addIncomplete("milestones", "", normalizeErr)
+				break
+			}
+			result.Rows.Sprints = append(result.Rows.Sprints, row)
+		}
+	}
+
+	if options.includeIssues {
+		if err := collector.collectIssues(
+			ctx, claim, &counted, root, options, normalizedAt, &result,
+		); err != nil {
+			return result, err
+		}
+	}
+	if options.includePullRequests {
+		if err := collector.collectPullRequests(
+			ctx, claim, &counted, root, normalizedAt, &result,
+		); err != nil {
+			return result, err
+		}
+	}
+	result.Evidence.Records = len(result.Rows.WorkItems) +
+		len(result.Rows.Sprints) + len(result.PullRequests)
+	return result, nil
+}
+
+type githubWorkItemsRESTRepositoryPayload struct {
+	FullName string `json:"full_name"`
+}
+
+func (collector GitHubWorkItemsRESTCollector) collectIssues(
+	ctx context.Context,
+	claim Claim,
+	client *providerfoundation.HTTPClient,
+	root string,
+	options githubWorkItemsRESTOptions,
+	normalizedAt time.Time,
+	result *GitHubWorkItemsRESTResult,
+) error {
+	query := url.Values{"state": {"all"}, "per_page": {"100"}}
+	if claim.SinceAt != nil {
+		query.Set("since", claim.SinceAt.UTC().Format(time.RFC3339))
+	}
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx, client, providerfoundation.GitHubPageOptions{
+			Path: root + "/issues", Query: query, MaxPages: collector.maxPages(),
+		},
+	)
+	result.addPageEvidence(page)
+	if err != nil {
+		return err
+	}
+	if page.CapReached {
+		return ErrPaginationCapExceeded
+	}
+	for _, raw := range page.Items {
+		var listed githubWorkItemsRESTListIssue
+		if json.Unmarshal(raw, &listed) != nil || listed.Number < 1 {
+			return providerfoundation.ErrNormalizationInvalid
+		}
+		if len(listed.PullRequest) != 0 && string(listed.PullRequest) != "null" {
+			continue
+		}
+		if githubWorkItemsRESTUpdatedAfterBefore(listed.UpdatedAt, claim.BeforeAt) {
+			continue
+		}
+		events, eventPage, err := collectGitHubWorkItemChildPages(
+			ctx, client, root+"/issues/"+strconv.Itoa(listed.Number)+"/events",
+			collector.maxPages(), githubWorkItemEventLimit,
+		)
+		result.addPageEvidence(eventPage)
+		if err != nil {
+			return err
+		}
+		if eventPage.CapReached {
+			return ErrPaginationCapExceeded
+		}
+		comments := []json.RawMessage{}
+		if options.fetchComments && options.commentsLimit > 0 {
+			commentRows, commentPage, commentErr := collectGitHubWorkItemChildPages(
+				ctx, client, root+"/issues/"+strconv.Itoa(listed.Number)+"/comments",
+				collector.maxPages(), options.commentsLimit,
+			)
+			result.addPageEvidence(commentPage)
+			switch {
+			case commentErr != nil:
+				if fatalErr := githubWorkItemsRESTOptionalFailure(
+					ctx, client, commentErr,
+				); fatalErr != nil {
+					return fatalErr
+				}
+				result.addIncomplete("issue_comments", strconv.Itoa(listed.Number), commentErr)
+				comments = commentRows
+			case commentPage.CapReached:
+				return ErrPaginationCapExceeded
+			default:
+				comments = commentRows
+			}
+		}
+		rows, normalizeErr := normalizeGitHubIssueBundle(
+			claim, result.RepoFullName, result.RepoID, raw, events, comments,
+			nil, normalizedAt,
+		)
+		if normalizeErr != nil && len(comments) > 0 {
+			// Comment normalization is inside Python's best-effort comment loop.
+			// Preserve the required issue/event facts and expose the degradation.
+			result.addIncomplete("issue_comments", strconv.Itoa(listed.Number), normalizeErr)
+			rows, normalizeErr = normalizeGitHubIssueBundle(
+				claim, result.RepoFullName, result.RepoID, raw, events, nil,
+				nil, normalizedAt,
+			)
+		}
+		if normalizeErr != nil {
+			return normalizeErr
+		}
+		appendGitHubWorkItemRows(&result.Rows, rows)
+	}
+	return nil
+}
+
+func (collector GitHubWorkItemsRESTCollector) collectPullRequests(
+	ctx context.Context,
+	claim Claim,
+	client *providerfoundation.HTTPClient,
+	root string,
+	normalizedAt time.Time,
+	result *GitHubWorkItemsRESTResult,
+) error {
+	query := url.Values{
+		"state": {"all"}, "sort": {"updated"}, "direction": {"desc"},
+		"per_page": {"100"},
+	}
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx, client, providerfoundation.GitHubPageOptions{
+			Path: root + "/pulls", Query: query, MaxPages: collector.maxPages(),
+			StopAt: func(raw json.RawMessage) bool {
+				return pullCrossedSinceBoundary(raw, claim)
+			},
+		},
+	)
+	result.addPageEvidence(page)
+	if err != nil {
+		return err
+	}
+	if page.CapReached {
+		return ErrPaginationCapExceeded
+	}
+	numbers, err := filterGitHubPullWindow(page.Items, claim)
+	if err != nil {
+		return err
+	}
+	for _, number := range numbers {
+		var raw json.RawMessage
+		if err := fetchObject(
+			ctx, client, root+"/pulls/"+strconv.Itoa(number), &raw,
+		); err != nil {
+			return err
+		}
+		var pull githubPullRequestWorkItemPayload
+		if json.Unmarshal(raw, &pull) != nil || pull.Number != number ||
+			strings.TrimSpace(pull.Title) == "" {
+			return providerfoundation.ErrNormalizationInvalid
+		}
+		createdAt := parseGitHubWorkItemTime(pull.CreatedAt)
+		if createdAt == nil {
+			fallback := normalizedAt.UTC()
+			createdAt = &fallback
+		}
+		result.PullRequests = append(result.PullRequests, GitHubWorkItemsRESTPullRequest{
+			Number: number, CreatedAt: createdAt.UTC(),
+			Payload: append(json.RawMessage(nil), raw...),
+		})
+	}
+	return nil
+}
+
+func (collector GitHubWorkItemsRESTCollector) maxPages() int {
+	if collector.MaxPages == 0 {
+		return nativeMaxPages
+	}
+	return collector.MaxPages
+}
+
+func collectGitHubWorkItemChildPages(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	path string,
+	maxPages int,
+	itemLimit int,
+) ([]json.RawMessage, providerfoundation.PageCollection, error) {
+	// MaxItems stops on the exact provider iterator limit without fetching a
+	// speculative next page. MaxPages remains the fail-closed traversal bound;
+	// reaching it with a rel=next is never relabeled as successful partial data.
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx, client, providerfoundation.GitHubPageOptions{
+			Path: path, Query: url.Values{"per_page": {"100"}},
+			MaxPages: maxPages, MaxItems: itemLimit,
+		},
+	)
+	if err != nil || page.CapReached {
+		return page.Items, page, err
+	}
+	return page.Items, page, nil
+}
+
+func githubWorkItemsRESTOptionsForClaim(claim Claim) (githubWorkItemsRESTOptions, error) {
+	options := githubWorkItemsRESTOptions{
+		includeIssues:       true,
+		includePullRequests: claim.ProcessorFlags["sync_prs"],
+		fetchComments:       true,
+		fetchMilestones:     true,
+		commentsLimit:       githubWorkItemCommentLimit,
+	}
+	for name, target := range map[string]*bool{
+		"include_issues":        &options.includeIssues,
+		"include_pull_requests": &options.includePullRequests,
+		"fetch_comments":        &options.fetchComments,
+		"fetch_milestones":      &options.fetchMilestones,
+	} {
+		value, present := claim.DatasetOptions[name]
+		if !present || value == nil {
+			continue
+		}
+		parsed, ok := value.(bool)
+		if !ok {
+			return githubWorkItemsRESTOptions{}, ErrInvalidConfiguration
+		}
+		*target = parsed
+	}
+	commentsLimit, err := githubWorkItemsRESTNonNegativeIntOption(
+		claim.DatasetOptions, "comments_limit", githubWorkItemCommentLimit,
+	)
+	if err != nil {
+		return githubWorkItemsRESTOptions{}, err
+	}
+	options.commentsLimit = commentsLimit
+	return options, nil
+}
+
+func githubWorkItemsRESTNonNegativeIntOption(
+	options map[string]any,
+	name string,
+	fallback int,
+) (int, error) {
+	value, present := options[name]
+	if !present || value == nil {
+		return fallback, nil
+	}
+	var parsed int64
+	switch typed := value.(type) {
+	case int:
+		parsed = int64(typed)
+	case int64:
+		parsed = typed
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed ||
+			typed < 0 || typed > float64(math.MaxInt) {
+			return 0, ErrInvalidConfiguration
+		}
+		parsed = int64(typed)
+	case json.Number:
+		var err error
+		parsed, err = strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return 0, ErrInvalidConfiguration
+		}
+	default:
+		return 0, ErrInvalidConfiguration
+	}
+	if parsed < 0 || uint64(parsed) > uint64(math.MaxInt) {
+		return 0, ErrInvalidConfiguration
+	}
+	return int(parsed), nil
+}
+
+func githubWorkItemsRESTUpdatedAfterBefore(value *string, before *time.Time) bool {
+	if before == nil {
+		return false
+	}
+	updatedAt := parseGitHubWorkItemTime(value)
+	return updatedAt != nil && updatedAt.After(before.UTC())
+}
+
+func githubWorkItemsRESTOptionalFailure(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, providerfoundation.ErrLeaseLost) ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		isRateLimited(err) || ctx.Err() != nil {
+		return err
+	}
+	if client == nil || client.Lease == nil {
+		return ErrInvalidConfiguration
+	}
+	if leaseErr := client.Lease.Assert(ctx); leaseErr != nil {
+		return leaseErr
+	}
+	return nil
+}
+
+func (result *GitHubWorkItemsRESTResult) addPageEvidence(
+	page providerfoundation.PageCollection,
+) {
+	result.Evidence.Pages += page.Pages
+	result.Evidence.CapReached = result.Evidence.CapReached || page.CapReached
+}
+
+func (result *GitHubWorkItemsRESTResult) addIncomplete(
+	component string,
+	subjectID string,
+	err error,
+) {
+	result.Incomplete = append(result.Incomplete, GitHubWorkItemsRESTIncomplete{
+		Component: component, SubjectID: subjectID,
+		Cause: githubWorkItemsRESTFailureCause(err),
+	})
+}
+
+func githubWorkItemsRESTFailureCause(err error) string {
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil {
+		return string(providerErr.Class)
+	}
+	return "invalid_response"
+}
+
+func emptyGitHubWorkItemRows() githubWorkItemRows {
+	return githubWorkItemRows{
+		WorkItems:         []githubWorkItemRow{},
+		StatusTransitions: []githubWorkItemTransitionRow{},
+		Dependencies:      []githubWorkItemDependencyRow{},
+		ReopenEvents:      []githubWorkItemReopenRow{},
+		Interactions:      []githubWorkItemInteractionRow{},
+		Sprints:           []githubSprintRow{},
+		AIAttributions:    []githubAIAttributionRow{},
+	}
+}
+
+func appendGitHubWorkItemRows(target *githubWorkItemRows, source githubWorkItemRows) {
+	target.WorkItems = append(target.WorkItems, source.WorkItems...)
+	target.StatusTransitions = append(target.StatusTransitions, source.StatusTransitions...)
+	target.Dependencies = append(target.Dependencies, source.Dependencies...)
+	target.ReopenEvents = append(target.ReopenEvents, source.ReopenEvents...)
+	target.Interactions = append(target.Interactions, source.Interactions...)
+	target.Sprints = append(target.Sprints, source.Sprints...)
+	target.AIAttributions = append(target.AIAttributions, source.AIAttributions...)
+}

--- a/internal/providersync/github_work_items_rest_collect_test.go
+++ b/internal/providersync/github_work_items_rest_collect_test.go
@@ -1,0 +1,578 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type githubWorkItemsRESTReply struct {
+	status int
+	body   string
+	link   string
+}
+
+type githubWorkItemsRESTDoer struct {
+	t        *testing.T
+	replies  map[string][]githubWorkItemsRESTReply
+	requests []string
+}
+
+func (doer *githubWorkItemsRESTDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	key := request.URL.Path
+	doer.requests = append(doer.requests, key+"?"+request.URL.RawQuery)
+	replies := doer.replies[key]
+	if len(replies) == 0 {
+		doer.t.Fatalf("unexpected request %s", request.URL.String())
+	}
+	reply := replies[0]
+	if len(replies) > 1 {
+		doer.replies[key] = replies[1:]
+	}
+	status := reply.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if status == http.StatusForbidden {
+		header.Set("X-RateLimit-Remaining", "0")
+	}
+	if reply.link != "" {
+		header.Set("Link", reply.link)
+	}
+	return &http.Response{
+		StatusCode: status, Header: header,
+		Body: io.NopCloser(strings.NewReader(reply.body)), Request: request,
+	}, nil
+}
+
+func githubWorkItemsRESTClaim() Claim {
+	claim := nativeTestClaim("github", "work-items")
+	claim.ProcessorFlags = map[string]bool{
+		"family_dataset_work_items":         true,
+		"family_dataset_work_item_labels":   true,
+		"family_dataset_work_item_projects": true,
+		"family_dataset_work_item_history":  true,
+		"family_dataset_work_item_comments": true,
+		"sync_prs":                          true,
+	}
+	claim.DatasetOptions = map[string]any{
+		"include_issues":        true,
+		"include_pull_requests": true,
+		"fetch_comments":        true,
+		"fetch_milestones":      true,
+		"comments_limit":        500,
+	}
+	return claim
+}
+
+func githubWorkItemsRESTFixtures() map[string][]githubWorkItemsRESTReply {
+	return map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":            {{body: `{"id":4567,"full_name":"Acme/API-Renamed"}`}},
+		"/repos/acme/api/milestones": {{body: `[{"id":77,"number":7,"title":"July","state":"open","created_at":"2026-07-01T00:00:00Z","due_on":"2026-07-31T00:00:00Z"}]`}},
+		"/repos/acme/api/issues": {{body: `[
+			{"number":42,"title":"Issue in window","body":"blocks CHAOS-42","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z","user":{"login":"octocat"}},
+			{"number":43,"title":"PR stub","updated_at":"2026-07-20T00:00:00Z","pull_request":{"url":"https://api.github.com/repos/acme/api/pulls/43"}},
+			{"number":44,"title":"Future issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-08-01T00:00:00Z"}
+		]`}},
+		"/repos/acme/api/issues/42/events":   {{body: `[{"event":"closed","created_at":"2026-07-21T00:00:00Z","actor":{"login":"closer"}}]`}},
+		"/repos/acme/api/issues/42/comments": {{body: `[{"id":9007199254740993,"body":"hello 👋","created_at":"2026-07-20T12:00:00Z","user":{"login":"reviewer"}}]`}},
+		"/repos/acme/api/pulls": {{body: `[
+			{"number":53,"updated_at":"2026-08-01T00:00:00Z"},
+			{"number":52,"updated_at":"2026-07-22T00:00:00Z"},
+			{"number":51,"updated_at":"2026-06-30T00:00:00Z"}
+		]`}},
+		"/repos/acme/api/pulls/52": {{body: `{
+			"number":52,"title":"PR in window","body":"Fixes CHAOS-52","state":"open","draft":false,"merged":false,
+			"created_at":"2026-07-10T00:00:00Z","updated_at":"2026-07-22T00:00:00Z",
+			"head":{"ref":"feature/CHAOS-52"},"user":{"login":"dev"}
+		}`}},
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorBuildsIssueRowsAndPullTargets(t *testing.T) {
+	t.Parallel()
+	doer := &githubWorkItemsRESTDoer{t: t, replies: githubWorkItemsRESTFixtures()}
+	now := time.Date(2026, 8, 4, 12, 0, 0, 123456000, time.UTC)
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), githubWorkItemsRESTClaim(),
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.NoOptionalDegradation() || len(result.Incomplete) != 0 {
+		t.Fatalf("result incomplete=%+v", result.Incomplete)
+	}
+	if result.RepoFullName != "Acme/API-Renamed" || result.RepoID.String() != "616d4a76-b639-d421-808b-3cef6940d4b9" {
+		t.Fatalf("repo=%q id=%s", result.RepoFullName, result.RepoID)
+	}
+	if len(result.Rows.WorkItems) != 1 || result.Rows.WorkItems[0].WorkItemID != "gh:Acme/API-Renamed#42" ||
+		len(result.Rows.StatusTransitions) != 1 || len(result.Rows.Interactions) != 1 ||
+		len(result.Rows.Sprints) != 1 || len(result.PullRequests) != 1 ||
+		result.PullRequests[0].Number != 52 {
+		t.Fatalf("rows=%+v pulls=%+v", result.Rows, result.PullRequests)
+	}
+	if result.Evidence.Requests != 7 || result.Evidence.Pages != 5 ||
+		result.Evidence.Records != 3 || result.Evidence.CapReached {
+		t.Fatalf("evidence=%+v requests=%v", result.Evidence, doer.requests)
+	}
+	wantPaths := []string{
+		"/repos/acme/api?", "/repos/acme/api/milestones?", "/repos/acme/api/issues?",
+		"/repos/acme/api/issues/42/events?", "/repos/acme/api/issues/42/comments?",
+		"/repos/acme/api/pulls?", "/repos/acme/api/pulls/52?",
+	}
+	for index, prefix := range wantPaths {
+		if index >= len(doer.requests) || !strings.HasPrefix(doer.requests[index], prefix) {
+			t.Fatalf("requests=%v want prefix order=%v", doer.requests, wantPaths)
+		}
+	}
+	if strings.Contains(strings.Join(doer.requests, "\n"), "/pulls/51?") ||
+		strings.Contains(strings.Join(doer.requests, "\n"), "/pulls/53?") ||
+		strings.Contains(strings.Join(doer.requests, "\n"), "/issues/43/events?") {
+		t.Fatalf("out-of-window or PR-stub detail fetched: %v", doer.requests)
+	}
+	if !strings.Contains(doer.requests[2], "since=2026-07-01T00%3A00%3A00Z") {
+		t.Fatalf("issues window query=%s", doer.requests[2])
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorHonorsExplicitFalseOptions(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": false, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": false,
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api": {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim, gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if err != nil || !result.NoOptionalDegradation() || len(result.Rows.WorkItems) != 0 ||
+		len(result.Rows.Sprints) != 0 || len(result.PullRequests) != 0 ||
+		result.Evidence.Requests != 1 || result.Evidence.Pages != 0 || result.Evidence.Records != 0 {
+		t.Fatalf("result=%+v error=%v requests=%v", result, err, doer.requests)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorDefaultsMatchActivePythonFlags(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = nil
+	claim.ProcessorFlags["sync_prs"] = false
+	options, err := githubWorkItemsRESTOptionsForClaim(claim)
+	if err != nil || !options.includeIssues || options.includePullRequests ||
+		!options.fetchComments || !options.fetchMilestones || options.commentsLimit != 500 {
+		t.Fatalf("options=%+v error=%v", options, err)
+	}
+	claim.ProcessorFlags["sync_prs"] = true
+	options, err = githubWorkItemsRESTOptionsForClaim(claim)
+	if err != nil || !options.includePullRequests {
+		t.Fatalf("sync_prs options=%+v error=%v", options, err)
+	}
+}
+
+func TestGitHubWorkItemsRESTResultDoesNotClaimCompositeCompletionWithPendingPRSocial(t *testing.T) {
+	t.Parallel()
+	result := GitHubWorkItemsRESTResult{
+		PullRequests: []GitHubWorkItemsRESTPullRequest{{Number: 42}},
+		Incomplete:   []GitHubWorkItemsRESTIncomplete{},
+	}
+	if !result.NoOptionalDegradation() || len(result.PullRequests) != 1 {
+		t.Fatalf("result=%+v", result)
+	}
+	// NoOptionalDegradation reports only the REST optional-enrichment state.
+	// A pending PR target still requires GraphQL social collection before any
+	// composite route may claim complete or advance a watermark.
+}
+
+func TestGitHubWorkItemsRESTCollectorFailsClosedOnAnyPaginationCap(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": true, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": false,
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api": {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/issues": {{
+			body: `[{"number":42,"title":"Issue","state":"open","updated_at":"2026-07-20T00:00:00Z"}]`,
+			link: `<https://api.github.com/repos/acme/api/issues?page=2>; rel="next"`,
+		}},
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{MaxPages: 1}).Collect(
+		context.Background(), claim, gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) || result.Evidence.CapReached == false ||
+		len(result.Rows.WorkItems) != 0 {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorFailsClosedOnOptionalAndRequiredChildCaps(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		path string
+	}{
+		{name: "milestones", path: "/repos/acme/api/milestones"},
+		{name: "issue events", path: "/repos/acme/api/issues/42/events"},
+		{name: "issue comments", path: "/repos/acme/api/issues/42/comments"},
+		{name: "pull list", path: "/repos/acme/api/pulls"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			fixtures := githubWorkItemsRESTFixtures()
+			if test.name == "pull list" {
+				fixtures[test.path][0].body = `[{"number":52,"updated_at":"2026-07-22T00:00:00Z"}]`
+			}
+			fixtures[test.path][0].link = "<https://api.github.com" + test.path + "?page=2>; rel=\"next\""
+			result, err := (GitHubWorkItemsRESTCollector{MaxPages: 1}).Collect(
+				context.Background(), githubWorkItemsRESTClaim(),
+				gitHubPullRequestClient(t, &githubWorkItemsRESTDoer{t: t, replies: fixtures}, "https://api.github.com"),
+				time.Now(),
+			)
+			if !errors.Is(err, ErrPaginationCapExceeded) || !result.Evidence.CapReached {
+				t.Fatalf("component=%s result=%+v error=%v", test.name, result, err)
+			}
+			if test.name == "milestones" && len(result.Incomplete) != 0 {
+				t.Fatalf("pagination cap was degraded as optional: %+v", result.Incomplete)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorMarksOptionalDegradationIncomplete(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions["include_pull_requests"] = false
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":                    {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/milestones":         {{status: http.StatusInternalServerError, body: `{"message":"down"}`}},
+		"/repos/acme/api/issues":             {{body: `[{"number":42,"title":"Issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z"}]`}},
+		"/repos/acme/api/issues/42/events":   {{body: `[]`}},
+		"/repos/acme/api/issues/42/comments": {{status: http.StatusBadGateway, body: `{"message":"down"}`}},
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim, gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if err != nil || result.NoOptionalDegradation() || len(result.Incomplete) != 2 ||
+		result.Incomplete[0].Component != "milestones" ||
+		result.Incomplete[0].Cause != "transient" ||
+		result.Incomplete[1].Component != "issue_comments" ||
+		result.Incomplete[1].SubjectID != "42" || result.Incomplete[1].Cause != "transient" ||
+		len(result.Rows.WorkItems) != 1 ||
+		len(result.Rows.Sprints) != 0 || len(result.Rows.Interactions) != 0 {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	if result.Evidence.Requests != 5 || result.Evidence.Pages != 2 || result.Evidence.Records != 1 {
+		t.Fatalf("evidence=%+v", result.Evidence)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorRetainsOptionalRowsBeforeLaterPageFailure(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions["include_pull_requests"] = false
+	milestonePath := "/repos/acme/api/milestones"
+	commentPath := "/repos/acme/api/issues/42/comments"
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api": {{body: `{"full_name":"Acme/API"}`}},
+		milestonePath: {
+			{body: `[{"id":77,"number":7,"title":"July","state":"open","created_at":"2026-07-01T00:00:00Z"}]`, link: "<https://api.github.com" + milestonePath + "?page=2>; rel=\"next\""},
+			{status: http.StatusBadGateway, body: `{"message":"down"}`},
+		},
+		"/repos/acme/api/issues":           {{body: `[{"number":42,"title":"Issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z"}]`}},
+		"/repos/acme/api/issues/42/events": {{body: `[]`}},
+		commentPath: {
+			{body: `[{"id":9,"body":"kept","created_at":"2026-07-20T12:00:00Z","user":{"login":"reviewer"}}]`, link: "<https://api.github.com" + commentPath + "?page=2>; rel=\"next\""},
+			{status: http.StatusBadGateway, body: `{"message":"down"}`},
+		},
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if err != nil || result.NoOptionalDegradation() || len(result.Incomplete) != 2 ||
+		len(result.Rows.Sprints) != 1 || len(result.Rows.Interactions) != 1 ||
+		result.Evidence.Pages != 4 || result.Evidence.Requests != 7 {
+		t.Fatalf("result=%+v error=%v requests=%v", result, err, doer.requests)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorPropagatesOptionalRateLimits(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": false, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": true,
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":            {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/milestones": {{status: http.StatusForbidden, body: `{"message":"API rate limit exceeded"}`}},
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited ||
+		len(result.Incomplete) != 0 {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}
+
+type githubWorkItemsRESTExpiringLease struct {
+	assertions int
+	failAt     int
+}
+
+func (lease *githubWorkItemsRESTExpiringLease) Assert(context.Context) error {
+	lease.assertions++
+	if lease.assertions >= lease.failAt {
+		return providerfoundation.ErrLeaseLost
+	}
+	return nil
+}
+
+func TestGitHubWorkItemsRESTCollectorRechecksLeaseBeforeOptionalDegradation(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": false, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": true,
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":            {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/milestones": {{status: http.StatusBadGateway, body: `{"message":"down"}`}},
+	}}
+	lease := &githubWorkItemsRESTExpiringLease{failAt: 5}
+	client, err := providerfoundation.NewHTTPClient(
+		"github", "https://api.github.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		},
+		lease,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim, client, time.Now(),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(result.Incomplete) != 0 ||
+		lease.assertions != 5 {
+		t.Fatalf("result=%+v error=%v assertions=%d", result, err, lease.assertions)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorRequiredFailuresReturnErrors(t *testing.T) {
+	t.Parallel()
+	for _, failedPath := range []string{
+		"/repos/acme/api", "/repos/acme/api/issues", "/repos/acme/api/issues/42/events",
+		"/repos/acme/api/pulls", "/repos/acme/api/pulls/52",
+	} {
+		failedPath := failedPath
+		t.Run(strings.TrimPrefix(failedPath, "/"), func(t *testing.T) {
+			fixtures := githubWorkItemsRESTFixtures()
+			fixtures[failedPath] = []githubWorkItemsRESTReply{{status: http.StatusBadGateway, body: `{"message":"down"}`}}
+			claim := githubWorkItemsRESTClaim()
+			claim.DatasetOptions["fetch_milestones"] = false
+			claim.DatasetOptions["fetch_comments"] = false
+			_, err := (GitHubWorkItemsRESTCollector{}).Collect(
+				context.Background(), claim,
+				gitHubPullRequestClient(t, &githubWorkItemsRESTDoer{t: t, replies: fixtures}, "https://api.github.com"),
+				time.Now(),
+			)
+			var providerErr *providerfoundation.ProviderError
+			if !errors.As(err, &providerErr) {
+				t.Fatalf("path=%s error=%v want ProviderError", failedPath, err)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorRowsAreRetryStable(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 123456000, time.UTC)
+	collect := func() GitHubWorkItemsRESTResult {
+		t.Helper()
+		result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+			context.Background(), githubWorkItemsRESTClaim(),
+			gitHubPullRequestClient(t, &githubWorkItemsRESTDoer{t: t, replies: githubWorkItemsRESTFixtures()}, "https://api.github.com"),
+			now,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	first, second := collect(), collect()
+	if !reflect.DeepEqual(first.Rows, second.Rows) || !reflect.DeepEqual(first.PullRequests, second.PullRequests) {
+		t.Fatalf("retry drift:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorCountsPhysicalRetries(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": false, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": true,
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api": {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/milestones": {
+			{status: http.StatusServiceUnavailable, body: `{"message":"retry"}`},
+			{body: `[]`},
+		},
+	}}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	client.Retry.MaxAttempts = 2
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(context.Background(), claim, client, time.Now())
+	if err != nil || !result.NoOptionalDegradation() || result.Evidence.Requests != 3 || result.Evidence.Pages != 1 {
+		t.Fatalf("result=%+v error=%v requests=%v", result, err, doer.requests)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorRejectsInvalidBooleanOption(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions["fetch_comments"] = "false"
+	_, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{}}, "https://api.github.com"),
+		time.Now(),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+	}
+}
+
+func TestGitHubWorkItemsRESTPullPayloadNumberMatchesSelectedTarget(t *testing.T) {
+	t.Parallel()
+	fixtures := githubWorkItemsRESTFixtures()
+	fixtures["/repos/acme/api/pulls/52"] = []githubWorkItemsRESTReply{{body: strings.ReplaceAll(
+		fixtures["/repos/acme/api/pulls/52"][0].body, `"number":52`, `"number":`+strconv.Itoa(99),
+	)}}
+	_, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), githubWorkItemsRESTClaim(),
+		gitHubPullRequestClient(t, &githubWorkItemsRESTDoer{t: t, replies: fixtures}, "https://api.github.com"),
+		time.Now(),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("error=%v want normalization failure", err)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorStopsAtExactlyOneThousandEvents(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": true, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": false,
+		"comments_limit": 17,
+	}
+	eventReplies := githubWorkItemsRESTFullPageReplies(
+		10, 100, "/repos/acme/api/issues/42/events",
+		func(index int) string {
+			return `{"id":` + strconv.Itoa(index+1) +
+				`,"event":"assigned","created_at":"2026-07-20T00:00:00Z"}`
+		},
+	)
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":                  {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/issues":           {{body: `[{"number":42,"title":"Issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z"}]`}},
+		"/repos/acme/api/issues/42/events": eventReplies,
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if err != nil || !result.NoOptionalDegradation() || result.Evidence.Pages != 11 ||
+		result.Evidence.Requests != 12 || len(result.Rows.WorkItems) != 1 {
+		t.Fatalf("result=%+v error=%v requests=%d", result, err, len(doer.requests))
+	}
+	if got := countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/issues/42/events?"); got != 10 {
+		t.Fatalf("event requests=%d want 10; requests=%v", got, doer.requests)
+	}
+}
+
+func TestGitHubWorkItemsRESTCollectorUsesConfiguredFullPageCommentLimit(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions = map[string]any{
+		"include_issues": true, "include_pull_requests": false,
+		"fetch_comments": true, "fetch_milestones": false,
+		"comments_limit": 200,
+	}
+	commentReplies := githubWorkItemsRESTFullPageReplies(
+		2, 100, "/repos/acme/api/issues/42/comments",
+		func(index int) string {
+			return `{"id":` + strconv.Itoa(index+1) +
+				`,"body":"comment","created_at":"2026-07-20T00:00:00Z","user":{"login":"reviewer"}}`
+		},
+	)
+	doer := &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api":                    {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		"/repos/acme/api/issues":             {{body: `[{"number":42,"title":"Issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z"}]`}},
+		"/repos/acme/api/issues/42/events":   {{body: `[]`}},
+		"/repos/acme/api/issues/42/comments": commentReplies,
+	}}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now(),
+	)
+	if err != nil || !result.NoOptionalDegradation() || len(result.Rows.Interactions) != 200 ||
+		result.Evidence.Pages != 4 || result.Evidence.Requests != 5 {
+		t.Fatalf("result=%+v error=%v requests=%d", result, err, len(doer.requests))
+	}
+	if got := countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/issues/42/comments?"); got != 2 {
+		t.Fatalf("comment requests=%d want 2; requests=%v", got, doer.requests)
+	}
+}
+
+func githubWorkItemsRESTFullPageReplies(
+	pages int,
+	itemsPerPage int,
+	path string,
+	item func(int) string,
+) []githubWorkItemsRESTReply {
+	replies := make([]githubWorkItemsRESTReply, 0, pages)
+	for page := 0; page < pages; page++ {
+		items := make([]string, 0, itemsPerPage)
+		for offset := 0; offset < itemsPerPage; offset++ {
+			items = append(items, item(page*itemsPerPage+offset))
+		}
+		replies = append(replies, githubWorkItemsRESTReply{
+			body: "[" + strings.Join(items, ",") + "]",
+			// Even the final full page advertises another page. An exact item
+			// limit must stop before that speculative request.
+			link: "<https://api.github.com" + path + "?page=" +
+				strconv.Itoa(page+2) + ">; rel=\"next\"",
+		})
+	}
+	return replies
+}
+
+func countGitHubWorkItemsRESTRequests(requests []string, prefix string) int {
+	count := 0
+	for _, request := range requests {
+		if strings.HasPrefix(request, prefix) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/providersync/github_work_items_rest_selection_oracle_test.go
+++ b/internal/providersync/github_work_items_rest_selection_oracle_test.go
@@ -1,0 +1,114 @@
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type githubWorkItemsRESTSelectionOracleRow struct {
+	IncludeIssues        bool     `json:"include_issues"`
+	IncludePullRequests  bool     `json:"include_pull_requests"`
+	FetchComments        bool     `json:"fetch_comments"`
+	FetchMilestones      bool     `json:"fetch_milestones"`
+	CommentsLimit        int      `json:"comments_limit"`
+	SelectedWorkItemIDs  []string `json:"selected_work_item_ids"`
+	IssueCalls           int      `json:"issue_calls"`
+	PRCalls              int      `json:"pr_calls"`
+	MilestoneCalls       int      `json:"milestone_calls"`
+	CommentCalls         int      `json:"comment_calls"`
+	EventLimit           int      `json:"event_limit"`
+	CommentLimitObserved int      `json:"comment_limit_observed"`
+}
+
+func TestGitHubWorkItemsRESTSelectionMatchesLivePythonProducer(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "all_optional_controls", Input: map[string]any{
+			"sync_prs": false,
+			"dataset_options": map[string]any{
+				"fetch_comments": true, "fetch_milestones": true, "comments_limit": 37,
+			},
+		}},
+		{ID: "optional_fetches_disabled_prs_enabled", Input: map[string]any{
+			"sync_prs": true,
+			"dataset_options": map[string]any{
+				"fetch_comments": false, "fetch_milestones": false, "comments_limit": 0,
+			},
+		}},
+	}
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items/rest-selection", cases,
+		buildGitHubWorkItemsRESTSelectionOracleRow, nil,
+	)
+}
+
+func buildGitHubWorkItemsRESTSelectionOracleRow(
+	t *testing.T,
+	input map[string]any,
+) githubWorkItemsRESTSelectionOracleRow {
+	t.Helper()
+	datasetOptions, ok := input["dataset_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("dataset_options=%T", input["dataset_options"])
+	}
+	claim := githubWorkItemsRESTClaim()
+	claim.ProcessorFlags["sync_prs"], _ = input["sync_prs"].(bool)
+	claim.DatasetOptions = map[string]any{
+		"include_issues": true, "include_pull_requests": claim.ProcessorFlags["sync_prs"],
+		"fetch_comments":   datasetOptions["fetch_comments"],
+		"fetch_milestones": datasetOptions["fetch_milestones"],
+		"comments_limit":   datasetOptions["comments_limit"],
+	}
+	doer := &githubWorkItemsRESTDoer{t: t, replies: githubWorkItemsRESTSelectionFixtures(claim)}
+	result, err := (GitHubWorkItemsRESTCollector{}).Collect(
+		context.Background(), claim,
+		gitHubPullRequestClient(t, doer, "https://api.github.com"),
+		time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	options, err := githubWorkItemsRESTOptionsForClaim(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := githubWorkItemsRESTSelectionOracleRow{
+		IncludeIssues: options.includeIssues, IncludePullRequests: options.includePullRequests,
+		FetchComments: options.fetchComments, FetchMilestones: options.fetchMilestones,
+		CommentsLimit:  options.commentsLimit,
+		IssueCalls:     countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/issues?"),
+		PRCalls:        countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/pulls?"),
+		MilestoneCalls: countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/milestones?"),
+		CommentCalls:   countGitHubWorkItemsRESTRequests(doer.requests, "/repos/acme/api/issues/1/comments?"),
+		EventLimit:     githubWorkItemEventLimit, CommentLimitObserved: -1,
+	}
+	if row.CommentCalls > 0 {
+		row.CommentLimitObserved = options.commentsLimit
+	}
+	for _, workItem := range result.Rows.WorkItems {
+		row.SelectedWorkItemIDs = append(row.SelectedWorkItemIDs, workItem.WorkItemID)
+	}
+	return row
+}
+
+func githubWorkItemsRESTSelectionFixtures(claim Claim) map[string][]githubWorkItemsRESTReply {
+	replies := map[string][]githubWorkItemsRESTReply{
+		"/repos/acme/api": {{body: `{"full_name":"acme/api"}`}},
+		"/repos/acme/api/issues": {{body: `[
+			{"number":1,"title":"Issue 1","state":"open","body":"","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z","html_url":"https://github.com/acme/api/issues/1","labels":[],"assignees":[],"user":{"login":"reporter","type":"User"}},
+			{"number":2,"title":"Issue 2","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-08-01T00:00:00Z"},
+			{"number":3,"title":"PR stub","updated_at":"2026-07-20T00:00:00Z","pull_request":{"url":"stub"}}
+		]`}},
+		"/repos/acme/api/issues/1/events": {{body: `[]`}},
+	}
+	if claim.DatasetOptions["fetch_milestones"] == true {
+		replies["/repos/acme/api/milestones"] = []githubWorkItemsRESTReply{{body: `[]`}}
+	}
+	if claim.DatasetOptions["fetch_comments"] == true {
+		replies["/repos/acme/api/issues/1/comments"] = []githubWorkItemsRESTReply{{body: `[]`}}
+	}
+	if claim.DatasetOptions["include_pull_requests"] == true {
+		replies["/repos/acme/api/pulls"] = []githubWorkItemsRESTReply{{body: `[]`}}
+	}
+	return replies
+}

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -65,6 +65,16 @@ func TestPostgresLeaseClaimRenewRecoveryAndTerminalFence(t *testing.T) {
 	if err := repository.Assert(ctx, first, now.Add(89*time.Second)); err != nil {
 		t.Fatal(err)
 	}
+	// Dataset options are intentionally joined live when the already-planned
+	// unit is claimed. Admin PATCH can therefore replace a frozen provider
+	// control before first claim or expired-lease recovery without rewriting the
+	// unit row itself.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.integration_datasets
+SET options = '{"include_archived":false,"comments_limit":37}'::jsonb
+WHERE integration_id = $1 AND dataset_key = 'commits'`, firstIntegrationID); err != nil {
+		t.Fatal(err)
+	}
 
 	secondOwner := uuid.NewString()
 	second, err := repository.Claim(ctx, ClaimRequest{
@@ -74,7 +84,8 @@ func TestPostgresLeaseClaimRenewRecoveryAndTerminalFence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !second.Recovered || second.Attempt != 2 || second.GenerationKey() != first.GenerationKey() {
+	if !second.Recovered || second.Attempt != 2 || second.GenerationKey() != first.GenerationKey() ||
+		second.DatasetOptions["comments_limit"] != float64(37) {
 		t.Fatalf("recovered claim=%+v", second)
 	}
 	if err := repository.Assert(ctx, first, now.Add(92*time.Second)); !errors.Is(err, ErrLeaseLost) {

--- a/internal/providersync/testdata/mutation-plans/github_work_items_rest_collector.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_rest_collector.json
@@ -1,0 +1,215 @@
+{
+  "schema_version": 1,
+  "name": "github work-item unregistered REST collector",
+  "build": ["go", "build", "./internal/providersync/"],
+  "$limitation": "This plan covers REST repository identity, selection, bounded traversal, optional-degradation markers, request evidence, and retry-stable semantic rows. PR GraphQL social data, effects, readback/recovery, watermark advancement, alias activation, and route readiness remain later stack layers.",
+  "mutations": [
+    {
+      "id": "R1-repository-identity-uses-api-full-name",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\trepoIdentity, identityErr := repositoryIdentity(result.RepoFullName)",
+      "replace": "\trepoIdentity, identityErr := repositoryIdentity(claim.SourceExternalID)",
+      "rationale": "the work-item rows must follow the API full_name used by the active Python repository model after a rename, not remain keyed to stale planner input",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorBuildsIssueRowsAndPullTargets$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2-issues-endpoint-pr-stubs-are-not-issues",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tif len(listed.PullRequest) != 0 && string(listed.PullRequest) != \"null\" {",
+      "replace": "\t\tif false && len(listed.PullRequest) != 0 && string(listed.PullRequest) != \"null\" {",
+      "rationale": "GitHub's issues endpoint includes PR stubs, which must be excluded so they cannot be fetched and normalized a second time as issues",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorBuildsIssueRowsAndPullTargets$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3-active-until-boundary-excludes-future-issues",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\treturn updatedAt != nil && updatedAt.After(before.UTC())",
+      "replace": "\treturn updatedAt != nil && updatedAt.Before(before.UTC())",
+      "rationale": "GitHub has no issues-list active_until parameter, so the collector's client-side comparison is the only barrier against ingesting future-window issues",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorBuildsIssueRowsAndPullTargets$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-optional-milestone-cap-still-fails-closed",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tif page.CapReached {\n\t\t\treturn result, ErrPaginationCapExceeded\n\t\t}\n\t\tfor _, raw := range page.Items {",
+      "replace": "\t\tif false && page.CapReached {\n\t\t\treturn result, ErrPaginationCapExceeded\n\t\t}\n\t\tfor _, raw := range page.Items {",
+      "rationale": "best-effort provider errors do not authorize accepting a known truncated milestone inventory as complete",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorFailsClosedOnOptionalAndRequiredChildCaps$/milestones$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-optional-failure-emits-a-typed-marker",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\t\tresult.addIncomplete(\"milestones\", \"\", pageErr)",
+      "replace": "\t\t\t_ = pageErr",
+      "rationale": "a swallowed milestone request failure must not become indistinguishable from a successful empty milestone list",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorMarksOptionalDegradationIncomplete$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-required-event-fetch-failure-propagates",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif eventPage.CapReached {",
+      "replace": "\t\tif false && err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif eventPage.CapReached {",
+      "rationale": "issue events drive status and reopen facts, so a failed traversal cannot be normalized as an event-free successful issue",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorRequiredFailuresReturnErrors$/repos/acme/api/issues/42/events$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R7-pr-detail-must-match-selected-number",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tif json.Unmarshal(raw, &pull) != nil || pull.Number != number ||",
+      "replace": "\t\tif json.Unmarshal(raw, &pull) != nil || false ||",
+      "rationale": "a detail response for a different PR number must never be attached to the selected GraphQL target",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTPullPayloadNumberMatchesSelectedTarget$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R8-explicit-false-claim-options-disable-fetches",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tparsed, ok := value.(bool)",
+      "replace": "\t\tparsed, ok := true, true",
+      "rationale": "explicit work-item claim options must override defaults so disabled issues, PRs, comments, and milestones do not issue provider requests",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorHonorsExplicitFalseOptions$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R9-request-evidence-counts-physical-attempts",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "func (doer githubWorkItemsRESTCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.requests = *doer.requests + 1\n\treturn doer.delegate.Do(request)\n}",
+      "replace": "func (doer githubWorkItemsRESTCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\treturn doer.delegate.Do(request)\n}",
+      "rationale": "provider usage evidence must count actual wire attempts, including HTTP retries, rather than only successful logical pages",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorCountsPhysicalRetries$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R10-item-limit-stops-without-speculative-next-page",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "\t\t\tif options.MaxItems > 0 && len(result.Items) >= options.MaxItems {",
+      "replace": "\t\t\tif false && options.MaxItems > 0 && len(result.Items) >= options.MaxItems {",
+      "rationale": "the 500-comment and 1000-event iterator limits must stop on the exact item without spending or depending on one extra provider page",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubLinkPaginationStopsAtExplicitItemLimitWithoutExtraPage$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "R11-rate-limits-never-degrade-as-optional",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tisRateLimited(err) || ctx.Err() != nil {",
+      "replace": "\t\tfalse || ctx.Err() != nil {",
+      "rationale": "GitHub rate limits carry retry scheduling semantics and must propagate instead of becoming best-effort incompleteness",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorPropagatesOptionalRateLimits$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R12-lease-is-rechecked-before-optional-degradation",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\tif leaseErr := client.Lease.Assert(ctx); leaseErr != nil {",
+      "replace": "\tif leaseErr := client.Lease.Assert(ctx); false && leaseErr != nil {",
+      "rationale": "an optional provider failure cannot be swallowed after the collection lease has been lost",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorRechecksLeaseBeforeOptionalDegradation$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R13-events-caller-pins-the-active-thousand-item-limit",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\t\tcollector.maxPages(), githubWorkItemEventLimit,",
+      "replace": "\t\t\tcollector.maxPages(), githubWorkItemEventLimit/2,",
+      "rationale": "the REST caller must preserve the active Python event limit of exactly 1000 per issue rather than merely exercising generic item-limited pagination",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorStopsAtExactlyOneThousandEvents$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R14-comments-caller-uses-the-frozen-configured-limit",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\t\t\tcollector.maxPages(), options.commentsLimit,",
+      "replace": "\t\t\t\tcollector.maxPages(), githubWorkItemCommentLimit,",
+      "rationale": "comments_limit is a per-claim runtime control and must not collapse back to a Go-global default at the child collection call site",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorUsesConfiguredFullPageCommentLimit$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R15-comments-limit-is-read-from-the-frozen-claim",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\toptions.commentsLimit = commentsLimit",
+      "replace": "\toptions.commentsLimit = commentsLimit*0 + githubWorkItemCommentLimit",
+      "rationale": "the typed collector options must retain the planner-frozen comments_limit value instead of accepting it and then silently discarding it",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorUsesConfiguredFullPageCommentLimit$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R16-later-page-errors-retain-earlier-successful-pages",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "\t\tif err != nil {\n\t\t\treturn result, err\n\t\t}",
+      "replace": "\t\tif err != nil {\n\t\t\treturn PageCollection{}, err\n\t\t}",
+      "rationale": "a later GitHub page failure must return earlier decoded pages so optional Python-compatible collectors can retain already observed rows while marking typed degradation",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubLinkPaginationReturnsSuccessfulPagesBeforeLaterFailure$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "R17-milestones-retain-rows-before-optional-page-failure",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\tfor _, raw := range page.Items {",
+      "replace": "\t\tfor _, raw := range []json.RawMessage{} {",
+      "rationale": "successfully decoded milestone pages remain valid observations when a later optional page fails and must be emitted beside the typed incomplete marker",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorRetainsOptionalRowsBeforeLaterPageFailure$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R18-comments-retain-rows-before-optional-page-failure",
+      "file": "internal/providersync/github_work_items_rest_collect.go",
+      "find": "\t\t\t\tresult.addIncomplete(\"issue_comments\", strconv.Itoa(listed.Number), commentErr)\n\t\t\t\tcomments = commentRows\n\t\t\tcase commentPage.CapReached:",
+      "replace": "\t\t\t\tresult.addIncomplete(\"issue_comments\", strconv.Itoa(listed.Number), commentErr)\n\t\t\t\tcomments = nil\n\t\t\tcase commentPage.CapReached:",
+      "rationale": "successfully decoded comment pages must still produce interaction rows when a later best-effort page fails",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRESTCollectorRetainsOptionalRowsBeforeLaterPageFailure$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R19-legacy-and-default-configs-use-canonical-runtime-defaults",
+      "file": "src/dev_health_ops/providers/github/work_item_options.py",
+      "find": "    \"comments_limit\": 500,",
+      "replace": "    \"comments_limit\": 501,",
+      "rationale": "an unrepaired in-flight Python unit must use the same safe fallback as Go without consulting mutable process-local environment at execution time",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/providers/github/work_item_options.py"],
+      "proof": [["pytest", "-q", "tests/test_dataset_adapters.py::test_github_work_items_unrepaired_options_use_safe_defaults_not_live_env"]]
+    },
+    {
+      "id": "R20-planner-durably-backfills-legacy-dataset-options",
+      "file": "src/dev_health_ops/sync/planner.py",
+      "find": "    if repaired_dataset_options != dataset_options:\n        dataset.options = repaired_dataset_options",
+      "replace": "    if repaired_dataset_options != dataset_options:\n        dataset.options = dataset_options",
+      "rationale": "legacy GitHub work-items datasets must be repaired durably before unit planning so later Go claims consume explicit persisted controls",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/sync/planner.py"],
+      "proof": [["pytest", "-q", "tests/test_sync_planner.py::test_planner_durably_snapshots_legacy_github_work_item_env"]]
+    },
+    {
+      "id": "R21-patch-cascades-controls-into-live-claim-options",
+      "file": "src/dev_health_ops/api/admin/routers/sync.py",
+      "find": "        if work_items_dataset is not None:\n            work_items_dataset.options = {\n                **dataset_options,\n                **canonical_runtime_options,\n            }",
+      "replace": "        if work_items_dataset is not None:\n            work_items_dataset.options = dataset_options",
+      "rationale": "PATCH must update the live IntegrationDataset options joined by a stale already-planned Go claim, not only the parent sync_options document",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/api/admin/routers/sync.py"],
+      "proof": [["pytest", "-q", "tests/api/admin/test_sync_configs.py::test_github_work_item_defaults_and_patch_controls_reach_stale_planned_claim"]]
+    },
+    {
+      "id": "R22-durable-boundaries-snapshot-legacy-env-values",
+      "file": "src/dev_health_ops/providers/github/work_item_options.py",
+      "find": "        source[\"comments_limit\"] = env_int(\"GITHUB_COMMENTS_LIMIT\", 500)",
+      "replace": "        source[\"comments_limit\"] = 500",
+      "rationale": "legacy documented environment controls must be snapshotted once into durable config and dataset options before Go can own the claim",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/providers/github/work_item_options.py"],
+      "proof": [["pytest", "-q", "tests/test_sync_planner.py::test_planner_durably_snapshots_legacy_github_work_item_env", "tests/api/admin/test_sync_configs.py::test_github_work_item_defaults_and_patch_controls_reach_stale_planned_claim"]]
+    },
+    {
+      "id": "R23-explicit-config-precedes-legacy-env-snapshot",
+      "file": "src/dev_health_ops/providers/github/work_item_options.py",
+      "find": "    if source.get(\"comments_limit\") is None:",
+      "replace": "    if True:",
+      "rationale": "an explicit persisted comments_limit must win over the legacy environment value at every durable snapshot boundary",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/providers/github/work_item_options.py"],
+      "proof": [["pytest", "-q", "tests/test_github_provider.py::test_github_work_item_runtime_snapshot_preserves_explicit_config"]]
+    },
+    {
+      "id": "R24-patch-seeds-from-the-durable-dataset-snapshot",
+      "file": "src/dev_health_ops/api/admin/routers/sync.py",
+      "find": "        canonical_runtime_options = snapshot_github_work_item_runtime_options(\n            {\n                **current_options,\n                **integration_options,\n                **dataset_options,\n                **sync_options,\n            }\n        )",
+      "replace": "        canonical_runtime_options = snapshot_github_work_item_runtime_options(\n            {\n                **current_options,\n                **integration_options,\n                **sync_options,\n            }\n        )",
+      "rationale": "an unrelated PATCH must seed missing legacy SyncConfiguration controls from the repaired work-items dataset before consulting a changed process environment",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/api/admin/routers/sync.py"],
+      "proof": [["pytest", "-q", "tests/api/admin/test_sync_configs.py::test_github_work_item_defaults_and_patch_controls_reach_stale_planned_claim"]]
+    },
+    {
+      "id": "R25-patch-seeds-from-the-durable-integration-snapshot",
+      "file": "src/dev_health_ops/api/admin/routers/sync.py",
+      "find": "        canonical_runtime_options = snapshot_github_work_item_runtime_options(\n            {\n                **current_options,\n                **integration_options,\n                **dataset_options,\n                **sync_options,\n            }\n        )",
+      "replace": "        canonical_runtime_options = snapshot_github_work_item_runtime_options(\n            {\n                **current_options,\n                **dataset_options,\n                **sync_options,\n            }\n        )",
+      "rationale": "a partial runtime PATCH must seed omitted controls from the repaired integration snapshot before consulting a changed process environment while explicit PATCH fields still win",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/api/admin/routers/sync.py"],
+      "proof": [["pytest", "-q", "tests/api/admin/test_sync_configs.py::test_github_work_item_defaults_and_patch_controls_reach_stale_planned_claim"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_rest-selection.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_rest-selection.py
@@ -1,0 +1,259 @@
+"""Live producer oracle for GitHub work-item controls and issue selection."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, TypeVar
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.processors.dataset_adapters import _github_work_item_options
+    from dev_health_ops.providers.base import (
+        IngestionContext,
+        IngestionWindow,
+        WorkItemIngestionOptions,
+    )
+    from dev_health_ops.providers.github.client import (
+        GitHubWorkClient,
+        _GitHubCommentLike,
+        _GitHubEventLike,
+        _GitHubIssueBaseLike,
+        _GitHubIssueLike,
+        _GitHubMilestoneLike,
+        _GitHubPullRequestLike,
+    )
+    from dev_health_ops.providers.github.provider import GitHubProvider
+    from dev_health_ops.providers.identity import load_identity_resolver
+    from dev_health_ops.providers.status_mapping import load_status_mapping
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_ADAPTER_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/dataset_adapters.py"
+_TItem = TypeVar("_TItem")
+
+
+@dataclass(frozen=True)
+class _OracleUser:
+    login: str
+    email: str | None = None
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class _OracleIssue:
+    number: int
+    title: str
+    state: str
+    body: str
+    created_at: datetime
+    updated_at: datetime
+    closed_at: datetime | None
+    html_url: str
+    url: str
+    pull_request: object | None
+    labels: tuple[object, ...]
+    assignees: tuple[_OracleUser, ...]
+    user: _OracleUser
+
+    def get_comments(self) -> Iterable[_GitHubCommentLike]:
+        return ()
+
+    def get_events(self) -> Iterable[_GitHubEventLike]:
+        return ()
+
+
+def _issue(
+    number: int, updated_at: datetime, *, pull_stub: bool = False
+) -> _OracleIssue:
+    return _OracleIssue(
+        number=number,
+        title=f"Issue {number}",
+        state="open",
+        body="",
+        created_at=datetime(2026, 7, 2, tzinfo=timezone.utc),
+        updated_at=updated_at,
+        closed_at=None,
+        html_url=f"https://github.com/acme/api/issues/{number}",
+        url=f"https://api.github.com/repos/acme/api/issues/{number}",
+        pull_request=object() if pull_stub else None,
+        labels=(),
+        assignees=(),
+        user=_OracleUser(login="reporter"),
+    )
+
+
+class _Repo:
+    def __init__(self, issues: list[_OracleIssue]) -> None:
+        self.issues = issues
+
+    def get_issues(self, *args: object, **kwargs: object) -> Iterable[Any]:
+        return self.issues
+
+
+class _OracleGitHubWorkClient(GitHubWorkClient):
+    """Network-free client that preserves production issue selection."""
+
+    def __init__(self) -> None:
+        self.issue_calls = 0
+        self.pr_calls = 0
+        self.milestone_calls = 0
+        self.comment_calls = 0
+        self.event_limit = -1
+        self.comment_limit = -1
+        self.repo = _Repo(
+            [
+                _issue(1, datetime(2026, 7, 20, tzinfo=timezone.utc)),
+                _issue(2, datetime(2026, 8, 1, tzinfo=timezone.utc)),
+                _issue(
+                    3,
+                    datetime(2026, 7, 20, tzinfo=timezone.utc),
+                    pull_stub=True,
+                ),
+            ]
+        )
+
+    def get_repo(self, **_kwargs: Any) -> _Repo:
+        self.issue_calls += 1
+        return self.repo
+
+    def _call_github(self, operation: str, call: Callable[[], _TItem]) -> _TItem:
+        return call()
+
+    def _iter_github_items(
+        self,
+        source: Iterable[_TItem],
+        *,
+        operation: str,
+        limit: int | None,
+        skip: Callable[[_TItem], bool] | None = None,
+        stop: Callable[[_TItem], bool] | None = None,
+        scan_limit: int | None = None,
+    ) -> Iterable[_TItem]:
+        yield from self._iter_with_limit(
+            source,
+            operation=operation,
+            limit=limit,
+            skip=skip,
+            stop=stop,
+            scan_limit=scan_limit,
+        )
+
+    def iter_repo_milestones(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        state: str = "all",
+        limit: int | None = None,
+    ) -> Iterable[_GitHubMilestoneLike]:
+        self.milestone_calls += 1
+        return ()
+
+    def iter_issue_events(
+        self,
+        issue: _GitHubIssueLike | _GitHubPullRequestLike,
+        *,
+        limit: int | None = None,
+    ) -> Iterable[_GitHubEventLike]:
+        self.event_limit = -1 if limit is None else limit
+        return ()
+
+    def iter_issue_comments(
+        self, issue: _GitHubIssueBaseLike, *, limit: int | None = None
+    ) -> Iterable[_GitHubCommentLike]:
+        self.comment_calls += 1
+        self.comment_limit = -1 if limit is None else limit
+        return ()
+
+    def iter_pull_requests(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        state: str = "all",
+        sort: str = "updated",
+        direction: str = "desc",
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int | None = None,
+        scan_limit: int | None = None,
+    ) -> Iterable[_GitHubPullRequestLike]:
+        self.pr_calls += 1
+        return ()
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    dataset_options = dict(case["dataset_options"])
+    adapter_context = SyncTaskContext(
+        unit_id="oracle-unit",
+        sync_run_id="oracle-run",
+        org_id="oracle-org",
+        integration_id="oracle-integration",
+        source_id="oracle-source",
+        source_external_id="acme/api",
+        provider="github",
+        dataset_key="work-items",
+        cost_class="network",
+        mode="incremental",
+        window_start=None,
+        window_end=None,
+        processor_flags={"sync_prs": bool(case["sync_prs"])},
+        credential_id=None,
+        decrypted_credentials={},
+        db_url="postgresql://oracle.invalid/oracle",
+        dataset_options=dataset_options,
+    )
+    controls = _github_work_item_options(adapter_context)
+    client = _OracleGitHubWorkClient()
+    context = IngestionContext(
+        repo="acme/api",
+        repo_id=UUID("616d4a76-b639-d421-808b-3cef6940d4b9"),
+        window=IngestionWindow(
+            updated_since=datetime(2026, 7, 1, tzinfo=timezone.utc),
+            active_until=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        ),
+        work_item_options=WorkItemIngestionOptions(**controls),
+    )
+    provider = GitHubProvider(
+        status_mapping=load_status_mapping(),
+        identity=load_identity_resolver(),
+        client=client,
+    )
+    batch = provider._ingest_with_client(client=client, ctx=context)
+    return {
+        **controls,
+        "selected_work_item_ids": [item.work_item_id for item in batch.work_items],
+        "issue_calls": client.issue_calls,
+        "pr_calls": client.pr_calls,
+        "milestone_calls": client.milestone_calls,
+        "comment_calls": client.comment_calls,
+        "event_limit": client.event_limit,
+        "comment_limit_observed": client.comment_limit,
+    }
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/rest-selection",
+        build_row=_build_row,
+        reflected_fields=lambda: dict_literal_keys(
+            _ADAPTER_SOURCE.read_text(),
+            "_github_work_item_options",
+            (RETURN_LITERAL,),
+        ),
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -47,6 +47,9 @@ _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/bud
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
 _BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
 _GITHUB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/github/code_client.py")
+_GITHUB_WORK_ITEM_OPTIONS_SOURCE = _source(
+    "dev_health_ops/providers/github/work_item_options.py"
+)
 _GITLAB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/gitlab/code_client.py")
 _GITLAB_COMMITS_SOURCE = _source("dev_health_ops/providers/gitlab/commits.py")
 _GITLAB_COMMIT_STATS_SOURCE = _source("dev_health_ops/providers/gitlab/commit_stats.py")
@@ -95,6 +98,7 @@ _SAFE_SOURCE_MODULES: dict[str, Path] = {
     "dev_health_ops.sync.budget_types": _BUDGET_TYPES_SOURCE,
     "dev_health_ops.sync.datasets": _DATASETS_SOURCE,
     "dev_health_ops.providers.usage": _USAGE_SOURCE,
+    "dev_health_ops.providers.github.work_item_options": _GITHUB_WORK_ITEM_OPTIONS_SOURCE,
 }
 
 
@@ -121,6 +125,14 @@ def _unsupported_dependency(*_args: Any, **_kwargs: Any) -> Any:
 
 def _target_dataset_adapters() -> None:
     _load_safe_source("dev_health_ops.sync.datasets")
+    _install_module(
+        "dev_health_ops.providers.utils",
+        {
+            "env_flag": lambda _name, default: default,
+            "env_int": lambda _name, default: default,
+        },
+    )
+    _load_safe_source("dev_health_ops.providers.github.work_item_options")
     _install_module(
         "dev_health_ops.credentials.resolver",
         {

--- a/internal/providersync/testdata/python_work_item_contract_oracle.py
+++ b/internal/providersync/testdata/python_work_item_contract_oracle.py
@@ -60,8 +60,9 @@ def main() -> int:
                         "sync_prs": sync_prs,
                         "include_issues": kwargs.get("include_issues"),
                         "include_pull_requests": kwargs.get("include_pull_requests"),
-                        "has_fetch_comments": "fetch_comments" in kwargs,
-                        "has_fetch_milestones": "fetch_milestones" in kwargs,
+                        "fetch_comments": kwargs.get("fetch_comments"),
+                        "fetch_milestones": kwargs.get("fetch_milestones"),
+                        "comments_limit": kwargs.get("comments_limit"),
                     }
                 )
             result[provider][dataset] = {"variants": variants}

--- a/internal/providersync/work_item_contract_test.go
+++ b/internal/providersync/work_item_contract_test.go
@@ -16,8 +16,9 @@ type workItemContractVariant struct {
 	SyncPRs             bool  `json:"sync_prs"`
 	IncludeIssues       *bool `json:"include_issues"`
 	IncludePullRequests *bool `json:"include_pull_requests"`
-	HasFetchComments    bool  `json:"has_fetch_comments"`
-	HasFetchMilestones  bool  `json:"has_fetch_milestones"`
+	FetchComments       *bool `json:"fetch_comments"`
+	FetchMilestones     *bool `json:"fetch_milestones"`
+	CommentsLimit       *int  `json:"comments_limit"`
 }
 
 type workItemContractEntry struct {
@@ -53,16 +54,18 @@ func TestWorkItemCompatibilityContractComesFromLivePythonAdapter(t *testing.T) {
 				t.Fatalf("%s/%s entry=%+v", provider, dataset, entry)
 			}
 			for index, variant := range entry.Variants {
-				if variant.HasFetchComments || variant.HasFetchMilestones {
-					t.Fatalf("%s/%s unexpectedly partitions full work-item job: %+v", provider, dataset, variant)
-				}
 				if provider == "github" {
 					if variant.IncludeIssues == nil || !*variant.IncludeIssues ||
 						variant.IncludePullRequests == nil ||
-						*variant.IncludePullRequests != (index == 1) {
+						*variant.IncludePullRequests != (index == 1) ||
+						variant.FetchComments == nil || !*variant.FetchComments ||
+						variant.FetchMilestones == nil || !*variant.FetchMilestones ||
+						variant.CommentsLimit == nil || *variant.CommentsLimit != 500 {
 						t.Fatalf("%s/%s variant=%+v", provider, dataset, variant)
 					}
-				} else if variant.IncludeIssues != nil || variant.IncludePullRequests != nil {
+				} else if variant.IncludeIssues != nil || variant.IncludePullRequests != nil ||
+					variant.FetchComments != nil || variant.FetchMilestones != nil ||
+					variant.CommentsLimit != nil {
 					t.Fatalf("%s/%s GitLab flags drifted: %+v", provider, dataset, variant)
 				}
 			}

--- a/internal/scheduler/sync/testdata/python_planner_oracle.py
+++ b/internal/scheduler/sync/testdata/python_planner_oracle.py
@@ -52,6 +52,8 @@ class _Placeholder:
 _package("dev_health_ops")
 _package("dev_health_ops.backfill")
 _package("dev_health_ops.credentials")
+_package("dev_health_ops.providers")
+_package("dev_health_ops.providers.github")
 _package("dev_health_ops.sync")
 _module(
     "dev_health_ops.backfill.chunker",
@@ -62,6 +64,11 @@ _module(
     AUTH_SOURCE_ENVIRONMENT="environment",
     AUTH_SOURCE_INTEGRATION_CREDENTIAL="integration_credential",
     credential_fingerprint=lambda *_args, **_kwargs: "unused",
+)
+_module(
+    "dev_health_ops.providers.utils",
+    env_flag=lambda _name, default: default,
+    env_int=lambda _name, default: default,
 )
 _module(
     "dev_health_ops.models",
@@ -81,6 +88,10 @@ _module(
     sync_datasets_require_canonical_incident_feature=lambda *_args, **_kwargs: False,
 )
 datasets = _load("dev_health_ops.sync.datasets", SOURCE / "sync/datasets.py")
+_load(
+    "dev_health_ops.providers.github.work_item_options",
+    SOURCE / "providers/github/work_item_options.py",
+)
 _module(
     "dev_health_ops.sync.dispatch_outbox",
     OUTBOX_KIND_DISCOVERY="reference_discovery",

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -59,6 +59,10 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.providers.github.work_item_options import (
+    canonical_github_work_item_runtime_options,
+    snapshot_github_work_item_runtime_options,
+)
 from dev_health_ops.sync.canonical_incident_gate import (
     CanonicalIncidentFeatureDisabledError,
     is_canonical_incident_feature_enabled_async,
@@ -1293,6 +1297,8 @@ def _planner_dataset_options(
         and isinstance(mappings, dict)
     ):
         options["service_repository_mappings"] = mappings
+    if provider == "github" and dataset_key == "work-items":
+        options.update(canonical_github_work_item_runtime_options(parent_options))
     return options
 
 
@@ -1322,6 +1328,11 @@ async def _create_planner_managed_config(
     ``SyncConfiguration`` carries no credential column of its own, so there is
     exactly one place a credential attaches to sync work.
     """
+    if provider.lower() == "github":
+        parent_options = {
+            **parent_options,
+            **snapshot_github_work_item_runtime_options(parent_options),
+        }
     credential_uuid = uuid.UUID(credential_id) if credential_id else None
     integration = Integration(
         org_id=org_id,
@@ -2133,6 +2144,64 @@ async def update_sync_config(
         for key in cleared_keys:
             merged_options.pop(key, None)
         mutable_config.sync_options = merged_options
+    if (
+        str(getattr(config, "provider", "")).lower() == "github"
+        and (integration_id := getattr(config, "integration_id", None)) is not None
+    ):
+        current_options = dict(getattr(config, "sync_options") or {})
+        integration = await session.get(Integration, integration_id)
+        scoped_integration = (
+            integration
+            if integration is not None and str(integration.org_id) == org_id
+            else None
+        )
+        integration_options = (
+            dict(scoped_integration.config or {})
+            if scoped_integration is not None
+            else {}
+        )
+        dataset_result = await session.execute(
+            select(IntegrationDataset).where(
+                IntegrationDataset.org_id == org_id,
+                IntegrationDataset.integration_id == integration_id,
+                IntegrationDataset.dataset_key == "work-items",
+            )
+        )
+        work_items_dataset = dataset_result.scalar_one_or_none()
+        dataset_options = (
+            dict(work_items_dataset.options or {})
+            if work_items_dataset is not None
+            else {}
+        )
+
+        # A planner repair can durably snapshot legacy runtime defaults in the
+        # Integration and work-items dataset before the older
+        # SyncConfiguration row has those keys. Read every durable store before
+        # consulting the environment; explicit PATCH values win last. Dataset
+        # options outrank the integration for the same reason they do in the
+        # planner repair: they are the dataset-specific execution contract.
+        canonical_runtime_options = snapshot_github_work_item_runtime_options(
+            {
+                **current_options,
+                **integration_options,
+                **dataset_options,
+                **sync_options,
+            }
+        )
+        mutable_config.sync_options = {
+            **current_options,
+            **canonical_runtime_options,
+        }
+        if scoped_integration is not None:
+            scoped_integration.config = {
+                **integration_options,
+                **canonical_runtime_options,
+            }
+        if work_items_dataset is not None:
+            work_items_dataset.options = {
+                **dataset_options,
+                **canonical_runtime_options,
+            }
     if (
         str(getattr(config, "provider", "")).lower() == "pagerduty"
         and "service_repository_mappings" in sync_options

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -409,6 +409,7 @@ def run_work_items_sync_job(
     include_pull_requests: bool | None = None,
     fetch_comments: bool | None = None,
     fetch_milestones: bool | None = None,
+    comments_limit: int | None = None,
     require_source: bool = False,
 ) -> dict[str, Any] | None:
     """
@@ -906,6 +907,7 @@ def run_work_items_sync_job(
                         include_pull_requests=include_pull_requests,
                         fetch_comments=fetch_comments,
                         fetch_milestones=fetch_milestones,
+                        comments_limit=comments_limit,
                     ),
                 )
                 for batch in github_provider.iter_ingest(ctx):

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -12,6 +12,9 @@ from dev_health_ops.credentials.resolver import (
     resolve_gitlab_url,
 )
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
+from dev_health_ops.providers.github.work_item_options import (
+    canonical_github_work_item_runtime_options,
+)
 from dev_health_ops.providers.usage import (
     PROVIDER_USAGE_OBSERVATION_KEY,
     attach_partial_observations,
@@ -292,14 +295,40 @@ def _work_item_kwargs(context: SyncTaskContext) -> dict[str, Any]:
             "gitlab_url": gitlab_url,
         }
     if context.provider == "github":
-        flags = _explicit_flags(context)
-        kwargs["include_issues"] = context.dataset_key in _WORK_ITEM_DATASETS
-        # CHAOS-646: only ingest PRs as work items when the PRS dataset is also
-        # enabled for this config. The planner stamps ``sync_prs`` on the github
-        # work-items unit (False when PRs are not selected); None would let the
-        # provider fall back to the GITHUB_INCLUDE_PRS env default (PRs ON).
-        kwargs["include_pull_requests"] = flags["sync_prs"]
+        kwargs.update(
+            {
+                name: value
+                for name, value in _github_work_item_options(context).items()
+                if value is not None
+            }
+        )
     return kwargs
+
+
+def _github_work_item_options(context: SyncTaskContext) -> dict[str, Any]:
+    """Return the runtime controls frozen onto a GitHub work-items claim."""
+    flags = _explicit_flags(context)
+    raw_dataset_options = getattr(context, "dataset_options", None)
+    if raw_dataset_options is None:
+        dataset_options: dict[str, Any] = {}
+    elif isinstance(raw_dataset_options, dict):
+        dataset_options = raw_dataset_options
+    else:
+        raise ValueError("GitHub work-items dataset_options must be a mapping")
+
+    runtime_options = canonical_github_work_item_runtime_options(dataset_options)
+
+    # Keep this literal exhaustive: the live Python-Go oracle reflects these
+    # keys from production rather than maintaining a hand-selected field list.
+    return {
+        "include_issues": context.dataset_key in _WORK_ITEM_DATASETS,
+        # CHAOS-646: only ingest PRs as work items when the PRS dataset is also
+        # enabled for this config. None would re-enable the environment default.
+        "include_pull_requests": flags["sync_prs"],
+        "fetch_comments": runtime_options["fetch_comments"],
+        "fetch_milestones": runtime_options["fetch_milestones"],
+        "comments_limit": runtime_options["comments_limit"],
+    }
 
 
 def _run_github_dataset(

--- a/src/dev_health_ops/providers/base.py
+++ b/src/dev_health_ops/providers/base.py
@@ -72,6 +72,7 @@ class WorkItemIngestionOptions:
     include_pull_requests: bool | None = None
     fetch_comments: bool | None = None
     fetch_milestones: bool | None = None
+    comments_limit: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -151,7 +151,11 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
             else _wi_opts.fetch_milestones
         )
 
-        comments_limit = env_int("GITHUB_COMMENTS_LIMIT", 500)
+        comments_limit = (
+            env_int("GITHUB_COMMENTS_LIMIT", 500)
+            if _wi_opts.comments_limit is None
+            else _wi_opts.comments_limit
+        )
 
         sprint_cache: dict[str, Sprint] = {}
         repo_full_name = f"{owner}/{repo}"

--- a/src/dev_health_ops/providers/github/work_item_options.py
+++ b/src/dev_health_ops/providers/github/work_item_options.py
@@ -1,0 +1,63 @@
+"""Canonical runtime controls for the GitHub work-item producer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from dev_health_ops.providers.utils import env_flag, env_int
+
+GITHUB_WORK_ITEM_RUNTIME_DEFAULTS: dict[str, bool | int] = {
+    "fetch_comments": True,
+    "fetch_milestones": True,
+    "comments_limit": 500,
+}
+
+
+def canonical_github_work_item_runtime_options(
+    options: Mapping[str, Any] | None,
+) -> dict[str, bool | int]:
+    """Return explicit, validated controls without consulting process env.
+
+    Planner-managed units persist this result in ``IntegrationDataset.options``.
+    The same function is also applied at adapter execution for legacy/in-flight
+    units created before the durable planner repair ran.
+    """
+    source = options or {}
+    result = dict(GITHUB_WORK_ITEM_RUNTIME_DEFAULTS)
+    for name in ("fetch_comments", "fetch_milestones"):
+        value = source.get(name)
+        if value is None:
+            continue
+        if not isinstance(value, bool):
+            raise ValueError(f"GitHub work-items {name} must be a boolean")
+        result[name] = value
+    comments_limit = source.get("comments_limit")
+    if comments_limit is not None:
+        if (
+            isinstance(comments_limit, bool)
+            or not isinstance(comments_limit, int)
+            or comments_limit < 0
+        ):
+            raise ValueError("GitHub work-items comments_limit must be non-negative")
+        result["comments_limit"] = comments_limit
+    return result
+
+
+def snapshot_github_work_item_runtime_options(
+    options: Mapping[str, Any] | None,
+) -> dict[str, bool | int]:
+    """Freeze documented legacy env fallbacks at a durable Python boundary.
+
+    Explicit persisted values always win. Environment is consulted only for a
+    missing value; once this result is stored, later repairs and PATCH requests
+    preserve the snapshot rather than re-reading process-local state.
+    """
+    source = dict(options or {})
+    if source.get("fetch_comments") is None:
+        source["fetch_comments"] = env_flag("GITHUB_FETCH_COMMENTS", True)
+    if source.get("fetch_milestones") is None:
+        source["fetch_milestones"] = env_flag("GITHUB_FETCH_MILESTONES", True)
+    if source.get("comments_limit") is None:
+        source["comments_limit"] = env_int("GITHUB_COMMENTS_LIMIT", 500)
+    return canonical_github_work_item_runtime_options(source)

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -57,6 +57,9 @@ from dev_health_ops.models import (
     SyncRunUnit,
     SyncRunUnitStatus,
 )
+from dev_health_ops.providers.github.work_item_options import (
+    snapshot_github_work_item_runtime_options,
+)
 from dev_health_ops.sync.canonical_incident_gate import (
     require_canonical_incident_feature_sync,
     sync_datasets_require_canonical_incident_feature,
@@ -169,6 +172,7 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
 
     integration = _load_integration(session, request.integration_id, request.org_id)
     repair_outcome = repair_pagerduty_operational_integration(session, integration)
+    _repair_github_work_item_runtime_options(session, integration)
     mode = _validate_mode(request.mode)
     if repair_outcome is not None:
         return _terminalize_pagerduty_disabled_plan(
@@ -422,6 +426,39 @@ def _load_enabled_sources(
 
 _CODE_HOST_SECURITY_PROVIDERS = frozenset({"github", "gitlab"})
 _SCHEDULED_SECURITY_TRIGGER = "schedule"
+
+
+def _repair_github_work_item_runtime_options(
+    session: Session, integration: Integration
+) -> None:
+    """Durably default legacy GitHub work-item datasets before unit planning."""
+    if str(integration.provider).lower() != "github":
+        return
+    integration_options = dict(integration.config or {})
+    dataset = (
+        session.query(IntegrationDataset)
+        .filter(
+            IntegrationDataset.org_id == integration.org_id,
+            IntegrationDataset.integration_id == integration.id,
+            IntegrationDataset.dataset_key == DatasetKey.WORK_ITEMS.value,
+        )
+        .one_or_none()
+    )
+    dataset_options = dict(dataset.options or {}) if dataset is not None else {}
+    canonical = snapshot_github_work_item_runtime_options(
+        {**integration_options, **dataset_options}
+    )
+    repaired_integration_options = {**integration_options, **canonical}
+    if repaired_integration_options != integration_options:
+        integration.config = repaired_integration_options
+
+    if dataset is None:
+        session.flush()
+        return
+    repaired_dataset_options = {**dataset_options, **canonical}
+    if repaired_dataset_options != dataset_options:
+        dataset.options = repaired_dataset_options
+    session.flush()
 
 
 def _ensure_security_dataset_for_scheduled_code_host_sync(

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -957,6 +957,206 @@ async def test_update_sync_config_changes_is_active(client):
 
 
 @pytest.mark.asyncio
+async def test_github_work_item_defaults_and_patch_controls_reach_stale_planned_claim(
+    client, session_maker, monkeypatch
+):
+    ac, _ = client
+    monkeypatch.setenv("GITHUB_FETCH_COMMENTS", "false")
+    monkeypatch.setenv("GITHUB_FETCH_MILESTONES", "false")
+    monkeypatch.setenv("GITHUB_COMMENTS_LIMIT", "7")
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "github-work-item-runtime-controls",
+            "provider": "github",
+            "sync_targets": ["work-items"],
+            "sync_options": {"owner": "acme"},
+            "repos": ["api"],
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["parent"]["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        integration = await session.get(Integration, config.integration_id)
+        assert integration is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "work-items",
+                )
+            )
+        ).scalar_one()
+        assert config.sync_options["fetch_comments"] is False
+        assert config.sync_options["fetch_milestones"] is False
+        assert config.sync_options["comments_limit"] == 7
+        assert dataset.options["fetch_comments"] is False
+        assert dataset.options["fetch_milestones"] is False
+        assert dataset.options["comments_limit"] == 7
+
+        # Reproduce a legacy planner-managed config created before runtime
+        # options were durable. The planner repair must snapshot the current
+        # environment into the integration and dataset, while this older
+        # SyncConfiguration row remains sparse until a later PATCH.
+        runtime_keys = {"fetch_comments", "fetch_milestones", "comments_limit"}
+        config.sync_options = {
+            key: value
+            for key, value in config.sync_options.items()
+            if key not in runtime_keys
+        }
+        integration.config = {
+            key: value
+            for key, value in integration.config.items()
+            if key not in runtime_keys
+        }
+        dataset.options = {
+            **{
+                key: value
+                for key, value in dataset.options.items()
+                if key not in runtime_keys
+            },
+            "unrelated": "preserve",
+        }
+        await session.commit()
+
+    dispatch = MagicMock()
+    dispatch.apply_async.return_value = MagicMock(id="stale-unit-dispatch")
+    with patch("dev_health_ops.api.admin.routers.sync.dispatch_sync_run", dispatch):
+        trigger_resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+    assert trigger_resp.status_code == 202, trigger_resp.text
+    assert trigger_resp.json()["total_units"] == 1
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        integration = await session.get(Integration, config.integration_id)
+        assert integration is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "work-items",
+                )
+            )
+        ).scalar_one()
+        assert "fetch_comments" not in config.sync_options
+        assert "fetch_milestones" not in config.sync_options
+        assert "comments_limit" not in config.sync_options
+        assert integration.config["fetch_comments"] is False
+        assert integration.config["fetch_milestones"] is False
+        assert integration.config["comments_limit"] == 7
+        assert dataset.options["fetch_comments"] is False
+        assert dataset.options["fetch_milestones"] is False
+        assert dataset.options["comments_limit"] == 7
+
+        # Keep only the dataset snapshot before the unrelated PATCH. This pins
+        # that durable boundary independently instead of letting the identical
+        # integration copy mask a missing dataset-precedence clause.
+        integration.config = {
+            key: value
+            for key, value in integration.config.items()
+            if key not in runtime_keys
+        }
+        await session.commit()
+
+    monkeypatch.setenv("GITHUB_FETCH_COMMENTS", "true")
+    monkeypatch.setenv("GITHUB_FETCH_MILESTONES", "true")
+    monkeypatch.setenv("GITHUB_COMMENTS_LIMIT", "999")
+    unrelated_update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"is_active": False},
+    )
+    assert unrelated_update_resp.status_code == 200, unrelated_update_resp.text
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        integration = await session.get(Integration, config.integration_id)
+        assert integration is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "work-items",
+                )
+            )
+        ).scalar_one()
+        for durable_options in (
+            config.sync_options,
+            integration.config,
+            dataset.options,
+        ):
+            assert durable_options["fetch_comments"] is False
+            assert durable_options["fetch_milestones"] is False
+            assert durable_options["comments_limit"] == 7
+
+        # The unrelated PATCH repaired all three stores. Keep only the
+        # integration snapshot before the partial runtime PATCH so its
+        # precedence is measured independently, while comments_limit=37 below
+        # still proves explicit PATCH values win over durable state.
+        config.sync_options = {
+            key: value
+            for key, value in config.sync_options.items()
+            if key not in runtime_keys
+        }
+        dataset.options = {
+            key: value
+            for key, value in dataset.options.items()
+            if key not in runtime_keys
+        }
+        await session.commit()
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={
+            "sync_options": {
+                "comments_limit": 37,
+            }
+        },
+    )
+    assert update_resp.status_code == 200, update_resp.text
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        integration = await session.get(Integration, config.integration_id)
+        assert integration is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "work-items",
+                )
+            )
+        ).scalar_one()
+        stale_units = (
+            (
+                await session.execute(
+                    select(SyncRunUnit).where(
+                        SyncRunUnit.integration_id == config.integration_id,
+                        SyncRunUnit.dataset_key == "work-items",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(stale_units) == 1
+    assert config.sync_options["fetch_comments"] is False
+    assert config.sync_options["fetch_milestones"] is False
+    assert config.sync_options["comments_limit"] == 37
+    for durable_options in (integration.config, dataset.options):
+        assert durable_options["fetch_comments"] is False
+        assert durable_options["fetch_milestones"] is False
+        assert durable_options["comments_limit"] == 37
+    assert dataset.options["unrelated"] == "preserve"
+
+
+@pytest.mark.asyncio
 async def test_update_pagerduty_service_mappings_propagates_to_services_dataset(
     client, session_maker
 ):

--- a/tests/test_admin_sync_targets.py
+++ b/tests/test_admin_sync_targets.py
@@ -69,6 +69,32 @@ def test_planner_dataset_options_scopes_mappings_to_pagerduty_services() -> None
     )
 
 
+def test_planner_dataset_options_freezes_github_work_item_runtime_controls() -> None:
+    controls = {
+        "fetch_comments": False,
+        "fetch_milestones": True,
+        "comments_limit": 37,
+    }
+
+    options = _planner_dataset_options("github", "work-items", ["work-items"], controls)
+
+    assert options == {"legacy_targets": ["work-items"], **controls}
+    assert "comments_limit" not in _planner_dataset_options(
+        "github", "prs", ["prs"], controls
+    )
+    assert "comments_limit" not in _planner_dataset_options(
+        "gitlab", "work-items", ["work-items"], controls
+    )
+
+
+def test_planner_dataset_options_freezes_explicit_github_defaults() -> None:
+    options = _planner_dataset_options("github", "work-items", ["work-items"], {})
+
+    assert options["fetch_comments"] is True
+    assert options["fetch_milestones"] is True
+    assert options["comments_limit"] == 500
+
+
 def test_pagerduty_malformed_legacy_target_is_flagged_before_planning() -> None:
     # Given: a pre-existing PagerDuty config that omits the operational target.
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import Mapping
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -43,6 +44,7 @@ def _context(
     source_is_org_wide_placeholder: bool = False,
     processor_flags: dict[str, bool] | None = None,
     credentials: Mapping[str, object] | None = None,
+    dataset_options: dict[str, object] | None = None,
 ) -> SyncTaskContext:
     return SyncTaskContext(
         unit_id="unit-1",
@@ -62,6 +64,7 @@ def _context(
         decrypted_credentials=dict(credentials or {"token": "secret-token"}),
         db_url="clickhouse://localhost/default",
         source_is_org_wide_placeholder=source_is_org_wide_placeholder,
+        dataset_options=dict(dataset_options or {}),
     )
 
 
@@ -1188,6 +1191,56 @@ def test_github_work_items_include_prs_when_prs_dataset_enabled() -> None:
     work_items.assert_called_once()
     assert work_items.call_args.kwargs["include_issues"] is True
     assert work_items.call_args.kwargs["include_pull_requests"] is True
+
+
+def test_github_work_items_threads_frozen_runtime_controls() -> None:
+    ctx = _context(
+        provider="github",
+        dataset_key="work-items",
+        processor_flags=_flags(sync_prs=True),
+        dataset_options={
+            "fetch_comments": False,
+            "fetch_milestones": True,
+            "comments_limit": 37,
+        },
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["fetch_comments"] is False
+    assert kwargs["fetch_milestones"] is True
+    assert kwargs["comments_limit"] == 37
+
+
+@patch.dict(
+    os.environ,
+    {
+        "GITHUB_FETCH_COMMENTS": "false",
+        "GITHUB_FETCH_MILESTONES": "false",
+        "GITHUB_COMMENTS_LIMIT": "7",
+    },
+)
+def test_github_work_items_unrepaired_options_use_safe_defaults_not_live_env() -> None:
+    ctx = _context(
+        provider="github",
+        dataset_key="work-items",
+        processor_flags=_flags(sync_prs=False),
+        dataset_options={},
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["fetch_comments"] is True
+    assert kwargs["fetch_milestones"] is True
+    assert kwargs["comments_limit"] == 500
 
 
 def test_github_work_items_threads_usage_observations_to_result() -> None:

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -1300,6 +1300,59 @@ def test_work_item_options_ctx_overrides_env(mock_status_mapping, mock_identity)
     client.iter_pull_requests.assert_called_once()
 
 
+@patch.dict(os.environ, {"GITHUB_COMMENTS_LIMIT": "999"}, clear=True)
+def test_work_item_options_comments_limit_overrides_env(
+    mock_status_mapping, mock_identity
+):
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    issue = _mock_issue(number=1)
+    client = _options_client()
+    client.iter_issues.return_value = [issue]
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(),
+        work_item_options=WorkItemIngestionOptions(
+            include_pull_requests=False,
+            comments_limit=37,
+        ),
+    )
+
+    provider.ingest(ctx)
+
+    client.iter_issue_comments.assert_called_once_with(issue, limit=37)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "GITHUB_FETCH_COMMENTS": "false",
+        "GITHUB_FETCH_MILESTONES": "false",
+        "GITHUB_COMMENTS_LIMIT": "7",
+    },
+    clear=True,
+)
+def test_github_work_item_runtime_snapshot_preserves_explicit_config() -> None:
+    from dev_health_ops.providers.github.work_item_options import (
+        snapshot_github_work_item_runtime_options,
+    )
+
+    assert snapshot_github_work_item_runtime_options(
+        {
+            "fetch_comments": True,
+            "fetch_milestones": True,
+            "comments_limit": 37,
+        }
+    ) == {
+        "fetch_comments": True,
+        "fetch_milestones": True,
+        "comments_limit": 37,
+    }
+
+
 # ============================================================================
 # active_until windowing — CHAOS-2573 (post-fetch enforcement, no limit drain)
 # ============================================================================

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -551,6 +551,34 @@ def test_dataset_option_overrides_integration_depth(db_session):
     assert abs((since - expected_start).total_seconds()) < 2
 
 
+def test_planner_durably_snapshots_legacy_github_work_item_env(db_session, monkeypatch):
+    monkeypatch.setenv("GITHUB_FETCH_COMMENTS", "false")
+    monkeypatch.setenv("GITHUB_FETCH_MILESTONES", "false")
+    monkeypatch.setenv("GITHUB_COMMENTS_LIMIT", "37")
+    integration = _create_integration(db_session, provider="github")
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    dataset = _create_dataset(db_session, integration, "work-items")
+    dataset.options = {"unrelated": "preserve"}
+    db_session.flush()
+
+    plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    assert dataset.options == {
+        "unrelated": "preserve",
+        "fetch_comments": False,
+        "fetch_milestones": False,
+        "comments_limit": 37,
+    }
+
+
 def test_existing_watermark_incremental_unchanged(db_session):
     """With a watermark row, since_at == watermark (regression guard)."""
     integration = _create_integration(db_session)


### PR DESCRIPTION
## Summary

- add an unregistered GitHub REST collector for repositories, milestones, issues, required issue events, comments, pull-request selection, and pull-request detail payloads
- preserve repository identity from the API, exact active-window filtering, partial earlier pages on later optional failures, typed incompleteness, and physical request evidence
- freeze documented legacy GitHub work-item controls at durable create/repair boundaries and cascade explicit PATCH changes into already-planned live dataset claims
- make PATCH resolve controls in durable precedence order: sync config, integration, work-items dataset, then explicit PATCH; environment values fill only values absent from every durable store
- prove the real Python adapter/provider selection contract with a typed live producer oracle

This is a foundation layer in the Go Worker Migration stack. It deliberately does **not** register routes, effects, watermarks, readiness, deployment switches, or aliases. It targets only `feat/go-worker-runtime-migration`.

## Checklist

- [x] Added/updated tests and governance evidence.
- [x] Ran the authoritative local validation gate after transplanting only this delta onto the current feature head.
- [x] Documented risk and rollback considerations.
- [x] Breaking changes and migrations: none; durable runtime controls are added without route activation.

## Test Evidence

- `bash ci/local_validate.sh`
  - 11,582 passed, 98 skipped, 1 xfailed
  - Ruff and mypy passed across 2,115 sources
  - Go format, vet, tests, race checks, live Python oracles, and build passed
  - River compatibility, ClickHouse scratch migration, and argMax live proof passed
- REST/config mutation plan: 25/25 killed, 0 invalid, 0 survived, with restore verification
- focused transitional inventory contract: 66 passed
- signed transplanted commit verified locally

## Risk Notes

- Blast radius is limited by explicit non-registration tests and the absence of routing/readiness/effect changes.
- Optional non-rate enrichment failures retain earlier rows and emit typed incompleteness; rate limits, required-event failures, cancellation, and lease loss remain hard failures.
- The later composite layer must implement all 16 effects and withhold all alias watermarks until completeness and recovery contracts are satisfied.
- Rollback is the squash commit on the feature branch; this PR must not merge to `main`.

## Optional Context

- Linear: CHAOS-3123
- Stack base: `feat/go-worker-runtime-migration`
