### PR TITLE
feat(ask-dev): surface declared project state and target date in the deterministic §10 answer (CHAOS-3368)

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "91dc5d89676096a86ee4489da6f7ed7fd50aa44d9e7ef735a9d52a09b7cc9188"
+        "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
       },
       "schema_version": "dev_tool_result.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -1689,6 +1689,45 @@
       "title": "Data Health",
       "type": "array"
     },
+    "declared_project_evidence_ref_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 25,
+      "title": "Declared Project Evidence Ref Ids",
+      "type": "array"
+    },
+    "declared_project_state": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Declared Project State"
+    },
+    "declared_project_target_date": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Declared Project Target Date"
+    },
     "deployments": {
       "items": {
         "$ref": "#/$defs/DevDeploymentFact"

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -8,6 +8,7 @@ objects into these models, but must not redeclare their wire shape.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import date
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Self
 
@@ -1051,6 +1052,24 @@ class DevToolResult(ContractModel):
     warnings: list[ShortText] = Field(default_factory=list, max_length=20)
     error: DevError | None = None
     serialized_bytes: int = Field(ge=0, le=65_536)
+    # CHAOS-3368 step 2: the project's own DECLARED lifecycle state / target
+    # date (projects.state/target_date, migration 073), typed -- NEVER
+    # pre-joined display prose -- so the CHAOS-3377 deterministic §10
+    # renderer (status_answer_render.py) can consume it directly instead of
+    # parsing the interim status_facts display text back apart.
+    # ``declared_project_state`` is the RAW provider token (e.g. Linear's
+    # own "started"/"paused"/"completed"), exactly like ``DevCIFact.
+    # conclusion``/``DevPullRequestFact.state`` elsewhere in this contract --
+    # translation through a closed-vocabulary table happens at render time,
+    # never here, so a future provider's own vocabulary needs no wire change.
+    # ``None``/``None`` when the scope is not PROJECT, the catalog row could
+    # not be resolved unambiguously, or the provider populated neither
+    # column.
+    declared_project_state: OpaqueID | None = None
+    declared_project_target_date: date | None = None
+    declared_project_evidence_ref_ids: list[OpaqueID] = Field(
+        default_factory=list, max_length=25
+    )
 
     @model_validator(mode="after")
     def validate_error_state(self) -> Self:
@@ -1091,6 +1110,7 @@ class DevToolResult(ContractModel):
                 referenced.update(blocker.evidence_ref_ids)
             for conflict in self.actual_completion.conflicts:
                 referenced.update(conflict.evidence_ref_ids)
+        referenced.update(self.declared_project_evidence_ref_ids)
         if not referenced <= known:
             raise ValueError(
                 "tool result references evidence IDs missing from its evidence array"

--- a/src/dev_health_ops/api/dev/native_evidence.py
+++ b/src/dev_health_ops/api/dev/native_evidence.py
@@ -174,6 +174,48 @@ _SPECS: dict[str, _SourceSpec] = {
         ORDER BY last_synced DESC LIMIT 1
         """,
     ),
+    # CHAOS-3368 (Codex HIGH fix): declared-state facts must expand through a
+    # real ``projects`` read, not the ``work_items`` adapter's ``work_item_id
+    # = {entity_id}`` identity match -- a project's own catalog id is never a
+    # work_item_id, so that adapter always returned NO_MATCHES for it. This
+    # adapter reads the SAME table CHAOS-3368's declared-state query does.
+    "projects": _SourceSpec(
+        "projects",
+        _COMMON_KINDS | {EntityKind.PROJECT},
+        f"""
+        SELECT id AS entity_id,
+               ifNull(nullIf(name, ''), concat('Project ', id)) AS display_label,
+               concat('Declared state: ', ifNull(nullIf(state, ''), 'unknown'),
+                      '. Target date: ', ifNull(toString(target_date), 'none')) AS excerpt,
+               ifNull(nullIf(provider, ''), 'native') AS provenance,
+               updated_at AS observed_at, last_synced,
+               '' AS repository_id,
+               ifNull(url, '') AS source_url, 0 AS deleted, 1.0 AS confidence
+        FROM projects FINAL
+        WHERE org_id = {{org_id:String}}
+          AND updated_at >= {{start:DateTime64(3, 'UTC')}}
+          AND updated_at < {{end:DateTime64(3, 'UTC')}}
+          AND is_active = 1
+          AND ({_search_predicate(("id", "name", "state"))})
+          AND ({{entity_id:String}} = '' OR id = {{entity_id:String}})
+        ORDER BY updated_at DESC, id
+        LIMIT {{limit:UInt32}}
+        """,
+        """
+        SELECT id AS entity_id,
+               ifNull(nullIf(name, ''), concat('Project ', id)) AS display_label,
+               concat('Declared state: ', ifNull(nullIf(state, ''), 'unknown'),
+                      '. Target date: ', ifNull(toString(target_date), 'none')) AS excerpt,
+               ifNull(nullIf(provider, ''), 'native') AS provenance,
+               updated_at AS observed_at, last_synced,
+               '' AS repository_id,
+               ifNull(url, '') AS source_url, 0 AS deleted, 1.0 AS confidence
+        FROM projects FINAL
+        WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
+          AND ({scope_entity_id:String} = '' OR id = {scope_entity_id:String})
+        ORDER BY last_synced DESC LIMIT 1
+        """,
+    ),
     "pull_requests": _SourceSpec(
         "pull_requests",
         _COMMON_KINDS | {EntityKind.PULL_REQUEST},
@@ -607,6 +649,7 @@ def _pr_number(entity_id: str) -> int:
 def _entity_type(source_system: str) -> str:
     return {
         "work_items": "issue",
+        "projects": "project",
         "work_units": "work_unit",
         "pull_requests": "pull_request",
         "reviews": "review",

--- a/src/dev_health_ops/api/dev/native_evidence.py
+++ b/src/dev_health_ops/api/dev/native_evidence.py
@@ -70,6 +70,13 @@ def default_native_freshness_policies() -> dict[str, SourceFreshnessPolicy]:
             "deployments",
             "incidents",
             "work_graph",
+            # CHAOS-3368: native_status_change._PROJECT_DECLARED_FACTS_SQL
+            # reads the projects catalog under this source name -- without
+            # a policy entry, ``_source_ref`` falls back to
+            # ``FreshnessState.UNKNOWN`` for every project declared-state
+            # read, which is a worse default than the same fallback-grace
+            # policy every other native source here already gets.
+            "projects",
         )
     }
 

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -305,6 +305,37 @@ LIMIT {limit:UInt32}
 """
 )
 
+#: CHAOS-3368: the project's own DECLARED lifecycle state / target date
+#: (``projects.state``/``projects.target_date``, migration 073 -- see
+#: ``metrics.schemas.ProjectRecord``'s own docstring: "the provider's OWN
+#: lifecycle vocabulary, stored verbatim"). Read with the same RMT
+#: discipline every other catalog read in this module uses: ``FINAL`` for
+#: the current row, ``org_id`` in the WHERE, ``is_active = 1`` so a
+#: retired project row does not resurrect a stale declared state. Guarded
+#: by an explicit ``HAVING count() = 1`` for the same reason CHAOS-3374's
+#: ``_PROJECT_IDENTITY_CTE`` guards its own read of this table: the
+#: ReplacingMergeTree key is ``(org_id, provider, id)``, not ``(org_id,
+#: id)``, so a same-org, same-``id`` row minted by two different
+#: providers survives ``FINAL`` as two rows and an unguarded ``LIMIT 1``
+#: would pick one nondeterministically. This read is deliberately
+#: narrower than that CTE: it never resolves which provider a project
+#: SUBJECT belongs to (CHAOS-3374's turf) -- it only reads the declared-
+#: state columns of a subject the scope has ALREADY resolved and
+#: authorized, so an ambiguous match here is grounds to render the
+#: declared-state facts absent (fail closed), never to guess a provider.
+#: Selects ``last_synced`` under that exact alias so ``_read``'s existing
+#: watermark/freshness plumbing applies unchanged -- no bespoke handling
+#: needed here.
+_PROJECT_DECLARED_FACTS_SQL = """
+SELECT any(state) AS state,
+       any(target_date) AS target_date,
+       any(updated_at) AS updated_at,
+       any(last_synced) AS last_synced
+FROM projects FINAL
+WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
+HAVING count() = 1
+"""
+
 _BLOCKER_WATERMARK_SQL = """
 SELECT if(
          countIf(scope_repo_id IS NULL) > 0,
@@ -1509,6 +1540,28 @@ class ClickHouseStatusChangeSource:
                 warnings.append(warning)
 
         declared, children = self._work_item_facts(work_item_rows, scope, source_refs)
+
+        # CHAOS-3368: the project's own declared state/target date, additive
+        # to (never mixed into) `declared`/`children` above -- those still
+        # describe the derived work-item completion tree; this describes
+        # what the provider itself declared for the project as a whole.
+        # Only ever queried for PROJECT scope, mirroring every other
+        # project-only read in this method (_BLOCKERS_SQL's own guard,
+        # just above): an issue/work-unit/team/org/repository scope must
+        # see byte-identical behavior to before this change.
+        project_facts: tuple[StatusFact, ...] = ()
+        if scope.direct_scope is DirectScope.PROJECT:
+            project_rows, project_ref, warning = await self._read(
+                "projects", _PROJECT_DECLARED_FACTS_SQL, common, scope
+            )
+            source_refs.append(project_ref)
+            if warning:
+                warnings.append(warning)
+            if project_rows:
+                project_facts = self._project_declared_facts(
+                    project_rows[0], entity_id, project_ref.ref_id, as_of
+                )
+
         pull_requests = tuple(
             PullRequestFact(
                 entity_id=str(row.get("entity_id") or ""),
@@ -1649,6 +1702,7 @@ class ClickHouseStatusChangeSource:
         return RawStatusSnapshot(
             declared=declared,
             children=children,
+            project_facts=project_facts,
             blockers=tuple(
                 StatusFact(
                     entity_type="issue",
@@ -1986,6 +2040,67 @@ class ClickHouseStatusChangeSource:
         declared = next((fact for fact in facts if fact.entity_id == entity_id), None)
         children = tuple(fact for fact in facts if fact is not declared)
         return declared, children
+
+    @staticmethod
+    def _project_declared_facts(
+        row: dict[str, Any],
+        entity_id: str,
+        source_ref_id: str,
+        as_of: datetime,
+    ) -> tuple[StatusFact, ...]:
+        """The project's own declared state / target date (CHAOS-3368).
+
+        Folded into a SINGLE ``StatusFact`` (never two facts sharing the
+        same ``entity_type``/``entity_id``, which would collide on
+        ``production_runtime.wire_status_fact``'s ``fact_id =
+        f"{entity_type}:{entity_id}"`` convention) -- mirrors the existing
+        one-fact-per-entity shape every other category in this module
+        already uses (one issue = one ``StatusFact`` whose own ``status``
+        conveys its full state). ``status`` never feeds ``_assess`` for
+        this field (see ``RawStatusSnapshot.project_facts``), so combining
+        pieces of text into it is safe here in a way it would not be for a
+        real completion-rule input.
+
+        Present only when the catalog row carries at least one value.
+        ``projects.state`` defaults to ``''`` and ``target_date`` is
+        ``Nullable`` (migration 073) precisely because not every provider
+        populates a lifecycle for every project -- an empty/``NULL``
+        column is a real "the provider declared nothing" and must render
+        as an absent fact, never a fabricated status string or an
+        epoch/zero date (the absence-collapses-to-zero pattern this
+        codebase treats as unsafe). Neither piece is dropped silently when
+        only one is present: the returned text names exactly the piece(s)
+        this project's catalog row actually carries.
+        """
+        observed_at = ClickHouseStatusChangeSource._datetime(
+            row.get("updated_at"), as_of
+        )
+        state = str(row.get("state") or "").strip()
+        target_date = row.get("target_date")
+        target_date_text: str | None = None
+        if target_date is not None:
+            target_date_text = (
+                target_date.isoformat()
+                if hasattr(target_date, "isoformat")
+                else str(target_date)
+            )
+        parts = [
+            *([state] if state else []),
+            *([f"target date {target_date_text}"] if target_date_text else []),
+        ]
+        if not parts:
+            return ()
+        return (
+            StatusFact(
+                entity_type="project",
+                entity_id=entity_id,
+                display_label="Declared status",
+                status="; ".join(parts),
+                observed_at=observed_at,
+                source_ref_id=source_ref_id,
+                evidence_ref_ids=(),
+            ),
+        )
 
     @classmethod
     def _latest_ci_run_rows(cls, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -13,7 +13,7 @@ import json
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 from dev_health_ops.api.graphql.resolvers._membership_run_scope import (
@@ -326,6 +326,18 @@ LIMIT {limit:UInt32}
 #: Selects ``last_synced`` under that exact alias so ``_read``'s existing
 #: watermark/freshness plumbing applies unchanged -- no bespoke handling
 #: needed here.
+#:
+#: Codex adversarial review (MEDIUM, 2026-08-04): ``FINAL`` collapses the
+#: RMT to its single CURRENT row per key -- there is no history left to read
+#: here, so ``updated_at <= {as_of:DateTime64(3, 'UTC')}`` (mirroring every
+#: other as-of-bounded read in this module, e.g. ``_WORK_ITEMS_SQL``) is not
+#: a narrowing filter, it is the difference between "this project's
+#: declared state as of the requested instant" and "whatever it is RIGHT
+#: NOW, mislabeled as of an earlier instant". A project updated after
+#: ``as_of`` is excluded entirely (``count() = 0`` -> absent facts) rather
+#: than answered with its current, not-yet-true-at-as_of state -- this
+#: ticket deliberately does not attempt a real history representation; an
+#: as-of snapshot of a since-changed declared state is simply unavailable.
 _PROJECT_DECLARED_FACTS_SQL = """
 SELECT any(state) AS state,
        any(target_date) AS target_date,
@@ -333,6 +345,7 @@ SELECT any(state) AS state,
        any(last_synced) AS last_synced
 FROM projects FINAL
 WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
+  AND updated_at <= {as_of:DateTime64(3, 'UTC')}
 HAVING count() = 1
 """
 
@@ -1549,7 +1562,16 @@ class ClickHouseStatusChangeSource:
         # project-only read in this method (_BLOCKERS_SQL's own guard,
         # just above): an issue/work-unit/team/org/repository scope must
         # see byte-identical behavior to before this change.
-        project_facts: tuple[StatusFact, ...] = ()
+        #
+        # Codex adversarial review (HIGH, 2026-08-04): kept as TYPED scalars
+        # here, never pre-joined into presentation text -- a renderer that
+        # only ever sees "started; target date 2026-09-01" would have to
+        # parse it back apart to use the pieces independently. Formatting
+        # into a display fact is production_runtime.py's job, sourced from
+        # these typed fields.
+        declared_project_state: str | None = None
+        declared_project_target_date: date | None = None
+        declared_project_observed_at: datetime | None = None
         if scope.direct_scope is DirectScope.PROJECT:
             project_rows, project_ref, warning = await self._read(
                 "projects", _PROJECT_DECLARED_FACTS_SQL, common, scope
@@ -1558,9 +1580,17 @@ class ClickHouseStatusChangeSource:
             if warning:
                 warnings.append(warning)
             if project_rows:
-                project_facts = self._project_declared_facts(
-                    project_rows[0], entity_id, project_ref.ref_id, as_of
-                )
+                row = project_rows[0]
+                state = str(row.get("state") or "").strip()
+                target_date = row.get("target_date")
+                if state or target_date is not None:
+                    declared_project_state = state or None
+                    declared_project_target_date = (
+                        target_date if target_date is not None else None
+                    )
+                    declared_project_observed_at = self._datetime(
+                        row.get("updated_at"), as_of
+                    )
 
         pull_requests = tuple(
             PullRequestFact(
@@ -1702,7 +1732,9 @@ class ClickHouseStatusChangeSource:
         return RawStatusSnapshot(
             declared=declared,
             children=children,
-            project_facts=project_facts,
+            declared_project_state=declared_project_state,
+            declared_project_target_date=declared_project_target_date,
+            declared_project_observed_at=declared_project_observed_at,
             blockers=tuple(
                 StatusFact(
                     entity_type="issue",
@@ -2040,67 +2072,6 @@ class ClickHouseStatusChangeSource:
         declared = next((fact for fact in facts if fact.entity_id == entity_id), None)
         children = tuple(fact for fact in facts if fact is not declared)
         return declared, children
-
-    @staticmethod
-    def _project_declared_facts(
-        row: dict[str, Any],
-        entity_id: str,
-        source_ref_id: str,
-        as_of: datetime,
-    ) -> tuple[StatusFact, ...]:
-        """The project's own declared state / target date (CHAOS-3368).
-
-        Folded into a SINGLE ``StatusFact`` (never two facts sharing the
-        same ``entity_type``/``entity_id``, which would collide on
-        ``production_runtime.wire_status_fact``'s ``fact_id =
-        f"{entity_type}:{entity_id}"`` convention) -- mirrors the existing
-        one-fact-per-entity shape every other category in this module
-        already uses (one issue = one ``StatusFact`` whose own ``status``
-        conveys its full state). ``status`` never feeds ``_assess`` for
-        this field (see ``RawStatusSnapshot.project_facts``), so combining
-        pieces of text into it is safe here in a way it would not be for a
-        real completion-rule input.
-
-        Present only when the catalog row carries at least one value.
-        ``projects.state`` defaults to ``''`` and ``target_date`` is
-        ``Nullable`` (migration 073) precisely because not every provider
-        populates a lifecycle for every project -- an empty/``NULL``
-        column is a real "the provider declared nothing" and must render
-        as an absent fact, never a fabricated status string or an
-        epoch/zero date (the absence-collapses-to-zero pattern this
-        codebase treats as unsafe). Neither piece is dropped silently when
-        only one is present: the returned text names exactly the piece(s)
-        this project's catalog row actually carries.
-        """
-        observed_at = ClickHouseStatusChangeSource._datetime(
-            row.get("updated_at"), as_of
-        )
-        state = str(row.get("state") or "").strip()
-        target_date = row.get("target_date")
-        target_date_text: str | None = None
-        if target_date is not None:
-            target_date_text = (
-                target_date.isoformat()
-                if hasattr(target_date, "isoformat")
-                else str(target_date)
-            )
-        parts = [
-            *([state] if state else []),
-            *([f"target date {target_date_text}"] if target_date_text else []),
-        ]
-        if not parts:
-            return ()
-        return (
-            StatusFact(
-                entity_type="project",
-                entity_id=entity_id,
-                display_label="Declared status",
-                status="; ".join(parts),
-                observed_at=observed_at,
-                source_ref_id=source_ref_id,
-                evidence_ref_ids=(),
-            ),
-        )
 
     @classmethod
     def _latest_ci_run_rows(cls, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -2587,7 +2587,19 @@ class DevOrchestrator:
         # that binding for free (no extra scope check needed: a
         # declared_project_state set on a DIFFERENT tool result could never
         # reach here, since only THIS result's fields are read).
-        declared_project_summary = render_declared_project_summary(status_result)
+        #
+        # ``canonical_evidence_ids`` -- the SAME frozenset already passed to
+        # ``build_deterministic_status_claims`` above -- gates this exactly
+        # like it gates the claim (Codex HIGH, delta review, 2026-08-04):
+        # this run's OWN 25-entry canonical evidence cap
+        # (``Orchestrator._canonical_answer_data``) can truncate the
+        # declared-state evidence out even when its per-tool-call priority
+        # reservation let it survive onto the wire -- without this gate the
+        # summary sentence could assert a declared state with no claim and
+        # no evidence behind it anywhere in the answer.
+        declared_project_summary = render_declared_project_summary(
+            status_result, canonical_evidence_ids
+        )
         if declared_project_summary is not None:
             direct_summary = f"{direct_summary} {declared_project_summary}"
         return status, direct_summary, claims

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -113,6 +113,7 @@ from .prompts import PromptComposer, PromptConversationTurn
 from .status_answer_render import (
     build_deterministic_status_claims,
     deterministic_answer_status,
+    render_declared_project_summary,
     render_verdict_summary,
     status_snapshot_result,
 )
@@ -2579,6 +2580,16 @@ class DevOrchestrator:
                 tool_results
             ),
         )
+        # CHAOS-3368 step 2: the project's own declared state/target date,
+        # appended to the same verdict/summary section -- ``status_result``
+        # is the identical scope-verified DevToolResult
+        # ``status_snapshot_result`` already selected above, so this rides
+        # that binding for free (no extra scope check needed: a
+        # declared_project_state set on a DIFFERENT tool result could never
+        # reach here, since only THIS result's fields are read).
+        declared_project_summary = render_declared_project_summary(status_result)
+        if declared_project_summary is not None:
+            direct_summary = f"{direct_summary} {declared_project_summary}"
         return status, direct_summary, claims
 
     def _deterministic_status_answer(

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1120,6 +1120,9 @@ def _tool_result(
     graph_edges: list[DevGraphEdge] | None = None,
     data_health: list[DevDataHealth] | None = None,
     warnings: list[str] | None = None,
+    declared_project_state: str | None = None,
+    declared_project_target_date: date | None = None,
+    declared_project_evidence_ref_ids: list[str] | None = None,
 ) -> DevToolResult:
     return DevToolResult(
         schema_version="dev_tool_result.v1",
@@ -1142,6 +1145,9 @@ def _tool_result(
         data_health=data_health or [],
         warnings=(warnings or [])[:20],
         serialized_bytes=0,
+        declared_project_state=declared_project_state,
+        declared_project_target_date=declared_project_target_date,
+        declared_project_evidence_ref_ids=declared_project_evidence_ref_ids or [],
     )
 
 
@@ -2039,6 +2045,19 @@ async def _assemble_production_runtime(
             for ref in result.source_refs
         ]
         evidence_by_id.update({key: minted[key] for key in kept_evidence_ids})
+        # CHAOS-3368 step 2: the SAME post-truncation evidence the interim
+        # ``status_facts`` project entry ended up with (never re-minted --
+        # one evidence mint, two consumers: the interim narrated fact above
+        # and this typed wire field the CHAOS-3377 deterministic renderer
+        # reads instead of parsing that fact's display text).
+        declared_project_evidence_ref_ids = next(
+            (
+                list(fact.evidence_ref_ids)
+                for fact in status_facts
+                if fact.fact_id.startswith("project:")
+            ),
+            [],
+        )
         return _tool_result(
             request,
             status=_status(result.state.value),
@@ -2051,6 +2070,9 @@ async def _assemble_production_runtime(
             source_health=source_health,
             evidence=[minted[key] for key in sorted(kept_evidence_ids)],
             warnings=warnings,
+            declared_project_state=result.declared_project_state,
+            declared_project_target_date=result.declared_project_target_date,
+            declared_project_evidence_ref_ids=declared_project_evidence_ref_ids,
         )
 
     async def change_summary(context, request):

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1800,6 +1800,12 @@ async def _assemble_production_runtime(
             for fact in (
                 ([result.declared] if result.declared else [])
                 + list(result.children)
+                # CHAOS-3368: the project's own declared state/target date,
+                # wired through the exact same fact->evidence->status_fact
+                # path as declared/children/blockers so they reach the
+                # model's context (and, through it, the §10 answer)
+                # identically -- no separate rendering path.
+                + list(result.project_facts)
                 + list(result.blockers)
             )
         ]
@@ -1844,6 +1850,16 @@ async def _assemble_production_runtime(
             *(
                 evidence_id
                 for fact in required_children
+                for evidence_id in fact.evidence_ref_ids
+            ),
+            # CHAOS-3368: never let the declared-state/target-date facts be
+            # the ones an unrelated dense scope's evidence truncation
+            # silently drops -- prioritize them exactly like the declared
+            # fact and required children above.
+            *(
+                evidence_id
+                for fact in status_facts
+                if fact.fact_id.startswith("project:")
                 for evidence_id in fact.evidence_ref_ids
             ),
             *(

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1162,7 +1162,11 @@ _STATUS_ENTITY_SOURCE_SYSTEM: Mapping[str, str] = {
     "issue": "work_items",
     "pull_request": "pull_requests",
     "work_unit": "work_units",
-    "project": "work_items",
+    # CHAOS-3368 (Codex HIGH fix): a project's own catalog id is never a
+    # work_item_id, so routing through "work_items" always expanded to
+    # NO_MATCHES. Routes to native_evidence.py's own "projects" adapter,
+    # which reads the same table the declared-state facts came from.
+    "project": "projects",
 }
 _CHANGE_CATEGORY_SOURCE_SYSTEM: Mapping[str, str] = {
     "entity": "work_items",
@@ -1795,17 +1799,66 @@ async def _assemble_production_runtime(
                 evidence_ref_ids=[ref.evidence_ref_id],
             )
 
+        # CHAOS-3368: build the interim display fact HERE, from the typed
+        # ``declared_project_state``/``declared_project_target_date``
+        # scalars on ``result`` -- never pre-joined text from the source
+        # boundary (Codex adversarial review, HIGH, 2026-08-04). A future
+        # deterministic renderer (CHAOS-3377) can consume the same two
+        # typed fields directly once it lands, without parsing this
+        # string back apart.
+        declared_project_fact: StatusFact | None = None
+        if (
+            result.declared_project_state is not None
+            or result.declared_project_target_date is not None
+        ) and (
+            result.declared_project_observed_at is not None
+            and request.scope.entity_refs
+        ):
+            parts = [
+                *(
+                    [result.declared_project_state]
+                    if result.declared_project_state
+                    else []
+                ),
+                *(
+                    ["target date " + result.declared_project_target_date.isoformat()]
+                    if result.declared_project_target_date is not None
+                    else []
+                ),
+            ]
+            # Routes evidence expansion through native_evidence.py's own
+            # "projects" adapter (CHAOS-3368 Codex HIGH fix) -- never the
+            # "work_items" one, whose identity match a project's catalog
+            # id can never satisfy.
+            declared_project_ref_id = next(
+                (
+                    ref.ref_id
+                    for ref in result.source_refs
+                    if ref.source_system == "projects"
+                ),
+                "source:projects-unavailable",
+            )
+            declared_project_fact = StatusFact(
+                entity_type="project",
+                entity_id=request.scope.entity_refs[0].entity_id,
+                display_label="Declared status",
+                status="; ".join(parts),
+                observed_at=result.declared_project_observed_at,
+                source_ref_id=declared_project_ref_id,
+                evidence_ref_ids=(),
+            )
+
         status_facts = [
             wire_status_fact(fact)
             for fact in (
                 ([result.declared] if result.declared else [])
                 + list(result.children)
-                # CHAOS-3368: the project's own declared state/target date,
-                # wired through the exact same fact->evidence->status_fact
-                # path as declared/children/blockers so they reach the
-                # model's context (and, through it, the §10 answer)
-                # identically -- no separate rendering path.
-                + list(result.project_facts)
+                # The project's own declared state/target date, wired
+                # through the exact same fact->evidence->status_fact path
+                # as declared/children/blockers so it reaches the model's
+                # context (and, through it, the §10 answer) identically --
+                # no separate rendering path.
+                + ([declared_project_fact] if declared_project_fact else [])
                 + list(result.blockers)
             )
         ]
@@ -1847,19 +1900,23 @@ async def _assemble_production_runtime(
         }
         priority_ids = [
             *(status_facts[0].evidence_ref_ids if result.declared else []),
-            *(
-                evidence_id
-                for fact in required_children
-                for evidence_id in fact.evidence_ref_ids
-            ),
-            # CHAOS-3368: never let the declared-state/target-date facts be
-            # the ones an unrelated dense scope's evidence truncation
-            # silently drops -- prioritize them exactly like the declared
-            # fact and required children above.
+            # CHAOS-3368 (Codex MEDIUM fix): reserved a slot BEFORE
+            # required_children -- with the old ordering, >=25 required
+            # children alone exhausted the entire ``_MAX_RESULT_EVIDENCE``
+            # budget and silently dropped this fact even though it was
+            # nominally "prioritized" (just prioritized too late to ever
+            # actually be reached). At most one small evidence set, so
+            # reserving it unconditionally here can never meaningfully
+            # starve required_children's own budget.
             *(
                 evidence_id
                 for fact in status_facts
                 if fact.fact_id.startswith("project:")
+                for evidence_id in fact.evidence_ref_ids
+            ),
+            *(
+                evidence_id
+                for fact in required_children
                 for evidence_id in fact.evidence_ref_ids
             ),
             *(

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -217,10 +217,50 @@ def render_verdict_summary(
     return " ".join(parts)
 
 
-def render_declared_project_summary(status_result: DevToolResult) -> str | None:
+def _grounded_declared_project_evidence(
+    status_result: DevToolResult, canonical_evidence_ids: frozenset[str]
+) -> list[str]:
+    """The declared-state/target-date evidence that actually survived this
+    RUN's canonical evidence set (not merely this one tool result's own,
+    per-call evidence budget) -- the single computation both
+    ``render_declared_project_summary`` and
+    ``build_deterministic_status_claims`` read, so the summary clause and
+    its backing claim can never disagree about whether this content is
+    grounded.
+
+    CHAOS-3368 Codex HIGH (2026-08-04, delta review of step 2): a prior
+    revision rendered the summary clause unconditionally while the claim
+    correctly required grounding -- in a run whose EARLIER tool results
+    already filled ``Orchestrator._canonical_answer_data``'s run-wide
+    25-entry cap, the declared-state fact's own evidence could be truncated
+    out of ``canonical_evidence_ids`` there (a cap this function's caller
+    does not control) while the per-tool-call priority reservation in
+    ``production_runtime.py`` still let it survive onto the wire. The
+    result: a summary sentence asserting a declared state with no claim and
+    no evidence behind it anywhere in the answer -- an ungrounded assertion
+    from the ONE renderer that exists to prevent exactly that class of
+    defect. Treated the same as any other externally-sourced fact this
+    renderer touches (mirrors ``outstanding_facts``'s "skip rather than
+    fabricate" rule) rather than like the verdict sentence, which is
+    server-DERIVED and therefore rendered regardless of evidence survival.
+    """
+
+    return [
+        ref
+        for ref in status_result.declared_project_evidence_ref_ids
+        if ref in canonical_evidence_ids
+    ][:25]
+
+
+def render_declared_project_summary(
+    status_result: DevToolResult, canonical_evidence_ids: frozenset[str]
+) -> str | None:
     """The project's own declared state / target date (CHAOS-3368 step 2),
     as a deterministic clause appended to the §10 verdict/summary section --
-    ``None`` when the bound ``status_snapshot.v1`` result has neither.
+    ``None`` when the bound ``status_snapshot.v1`` result has neither, OR
+    when its evidence did not survive this run's canonical evidence set
+    (see ``_grounded_declared_project_evidence`` -- this is never rendered
+    ungrounded, exactly like a blocker/required-child claim).
 
     Reads ``DevToolResult.declared_project_state``/
     ``declared_project_target_date`` -- typed fields on the SAME
@@ -242,6 +282,8 @@ def render_declared_project_summary(status_result: DevToolResult) -> str | None:
         status_result.declared_project_state is None
         and status_result.declared_project_target_date is None
     ):
+        return None
+    if not _grounded_declared_project_evidence(status_result, canonical_evidence_ids):
         return None
     parts: list[str] = []
     if status_result.declared_project_state is not None:
@@ -554,22 +596,30 @@ def build_deterministic_status_claims(
             flags=DevClaimFlags(),
         )
     )
-    declared_project_summary = render_declared_project_summary(status_result)
-    if declared_project_summary is not None:
-        # CHAOS-3368 step 2: grounded independently of the verdict claim
-        # above -- its own evidence, never folded into
-        # ``actual.evidence_ref_ids`` (the declared state is deliberately
-        # never an input to ``_assess``'s completion verdict; see
-        # ``RawStatusSnapshot.declared_project_state``). Skipped, exactly
-        # like an outstanding fact below, if its evidence was truncated out
-        # of this tool result -- an OBSERVED claim requires at least one
-        # reference, and fabricating one would be worse than omitting it.
-        declared_project_evidence = [
-            ref
-            for ref in status_result.declared_project_evidence_ref_ids
-            if ref in canonical_evidence_ids
-        ][:25]
-        if declared_project_evidence:
+    # CHAOS-3368 step 2 (Codex HIGH, delta review): both the CLAIM here and
+    # the SUMMARY clause (``render_declared_project_summary``, called by
+    # ``orchestrator._deterministic_status_render`` against this exact same
+    # ``canonical_evidence_ids``) read ``_grounded_declared_project_evidence``
+    # -- the identical computation -- so the two can never disagree about
+    # whether this content is grounded. Never folded into
+    # ``actual.evidence_ref_ids`` (the declared state is deliberately never
+    # an input to ``_assess``'s completion verdict; see
+    # ``RawStatusSnapshot.declared_project_state``).
+    declared_project_evidence = _grounded_declared_project_evidence(
+        status_result, canonical_evidence_ids
+    )
+    if declared_project_evidence:
+        declared_project_summary = render_declared_project_summary(
+            status_result, canonical_evidence_ids
+        )
+        # Cannot be None here: the same grounding check that made
+        # ``declared_project_evidence`` non-empty is the only evidence-based
+        # gate ``render_declared_project_summary`` applies; the remaining
+        # gate (state/target_date both absent) would have kept
+        # ``declared_project_evidence_ref_ids`` empty in the first place
+        # (production_runtime.py only ever mints declared-state evidence
+        # alongside a non-None state/target_date).
+        if declared_project_summary is not None:
             claims.append(
                 DevClaim(
                     schema_version="dev_claim.v1",

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -62,6 +62,7 @@ from .status_change_service import (
 from .status_completion_copy import (
     INCOMPLETE_DENOMINATOR_DISCLOSURE,
     any_tool_result_withheld_its_completion_denominator,
+    translate_project_state,
     translate_reason_code,
 )
 
@@ -72,6 +73,7 @@ __all__ = [
     "open_blockers",
     "open_required_children",
     "outstanding_facts",
+    "render_declared_project_summary",
     "render_verdict_summary",
     "status_snapshot_result",
     "translate_completion_state",
@@ -212,6 +214,48 @@ def render_verdict_summary(
         parts.append(INCOMPLETE_DENOMINATOR_DISCLOSURE.capitalize() + ".")
     if actual.display_truncated:
         parts.append(DISPLAY_TRUNCATED_DISCLOSURE.capitalize() + ".")
+    return " ".join(parts)
+
+
+def render_declared_project_summary(status_result: DevToolResult) -> str | None:
+    """The project's own declared state / target date (CHAOS-3368 step 2),
+    as a deterministic clause appended to the §10 verdict/summary section --
+    ``None`` when the bound ``status_snapshot.v1`` result has neither.
+
+    Reads ``DevToolResult.declared_project_state``/
+    ``declared_project_target_date`` -- typed fields on the SAME
+    scope-verified tool result ``status_snapshot_result`` already selected
+    (see that function's own scope-binding guarantee), never a re-parse of
+    the interim ``status_facts`` display text.
+
+    ``declared_project_state`` is translated through
+    ``status_completion_copy.translate_project_state`` -- NEVER interpolated
+    raw -- mirroring the exact rule ``outstanding_facts`` documents for
+    every other raw provider field this renderer touches (a provider string
+    is unconstrained and can coincidentally equal an internal denylisted
+    token). ``declared_project_target_date`` is a structured ISO date, not
+    provider vocabulary, so it renders directly -- it cannot coincidentally
+    collide with an underscore-bearing internal token.
+    """
+
+    if (
+        status_result.declared_project_state is None
+        and status_result.declared_project_target_date is None
+    ):
+        return None
+    parts: list[str] = []
+    if status_result.declared_project_state is not None:
+        parts.append(
+            "Declared state: "
+            + translate_project_state(status_result.declared_project_state)
+            + "."
+        )
+    if status_result.declared_project_target_date is not None:
+        parts.append(
+            "Target date: "
+            + status_result.declared_project_target_date.isoformat()
+            + "."
+        )
     return " ".join(parts)
 
 
@@ -510,6 +554,35 @@ def build_deterministic_status_claims(
             flags=DevClaimFlags(),
         )
     )
+    declared_project_summary = render_declared_project_summary(status_result)
+    if declared_project_summary is not None:
+        # CHAOS-3368 step 2: grounded independently of the verdict claim
+        # above -- its own evidence, never folded into
+        # ``actual.evidence_ref_ids`` (the declared state is deliberately
+        # never an input to ``_assess``'s completion verdict; see
+        # ``RawStatusSnapshot.declared_project_state``). Skipped, exactly
+        # like an outstanding fact below, if its evidence was truncated out
+        # of this tool result -- an OBSERVED claim requires at least one
+        # reference, and fabricating one would be worse than omitting it.
+        declared_project_evidence = [
+            ref
+            for ref in status_result.declared_project_evidence_ref_ids
+            if ref in canonical_evidence_ids
+        ][:25]
+        if declared_project_evidence:
+            claims.append(
+                DevClaim(
+                    schema_version="dev_claim.v1",
+                    claim_id=f"status-declared-project:{status_result.tool_call_id}",
+                    kind=ClaimKind.OBSERVED,
+                    text=declared_project_summary,
+                    confidence=1.0,
+                    evidence_ref_ids=declared_project_evidence,
+                    metric_ref_ids=[],
+                    validity_scope=validity_scope,
+                    flags=DevClaimFlags(),
+                )
+            )
     for fact in outstanding_facts(actual, status_result):
         evidence_ids = [
             ref for ref in fact.evidence_ref_ids if ref in canonical_evidence_ids

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -8,7 +8,7 @@ may replace the rule result or widen the requested scope.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import date, datetime
 from enum import StrEnum
 from typing import Protocol
 
@@ -306,16 +306,26 @@ class RawStatusSnapshot:
     children: tuple[StatusFact, ...] = ()
     # CHAOS-3368: the project's own DECLARED lifecycle state / target date
     # (projects.state/target_date, migration 073) for PROJECT scope --
-    # additive display facts alongside the derived completion/blockers
-    # below. Deliberately NEVER read by ``_assess``: these describe what
-    # the PROVIDER declared for the project as a whole, not an input to
-    # the derived actual-completion verdict, and wiring them in would
-    # change that rule's behavior -- out of this ticket's scope. Empty
-    # when the scope is not PROJECT, the catalog row could not be
-    # resolved unambiguously, or the provider populated neither column --
-    # every one of those renders as an absent fact, never a fabricated one
-    # (see native_status_change._project_declared_facts).
-    project_facts: tuple[StatusFact, ...] = ()
+    # additive data alongside the derived completion/blockers below.
+    # Deliberately NEVER read by ``_assess``: these describe what the
+    # PROVIDER declared for the project as a whole, not an input to the
+    # derived actual-completion verdict, and wiring them in would change
+    # that rule's behavior -- out of this ticket's scope. ``None``/``None``
+    # when the scope is not PROJECT, the catalog row could not be resolved
+    # unambiguously, the row was updated after ``as_of`` (no history left
+    # to answer an as-of read from once ``FINAL`` collapses it), or the
+    # provider populated neither column -- every one of those renders as
+    # an absent fact, never a fabricated one.
+    #
+    # Codex adversarial review (HIGH, 2026-08-04): kept as TYPED scalars,
+    # never pre-joined into a single presentation string -- a consumer
+    # (the interim status_facts wiring today, a future deterministic
+    # renderer tomorrow) must be able to use ``declared_project_state`` and
+    # ``declared_project_target_date`` independently without parsing
+    # semicolon-delimited prose back apart.
+    declared_project_state: str | None = None
+    declared_project_target_date: date | None = None
+    declared_project_observed_at: datetime | None = None
     blockers: tuple[StatusFact, ...] = ()
     pull_requests: tuple[PullRequestFact, ...] = ()
     ci: tuple[CIFact, ...] = ()
@@ -384,15 +394,16 @@ class StatusSnapshotResult:
     incidents: tuple[IncidentFact, ...]
     source_refs: tuple[SourceReference, ...]
     warnings: tuple[str, ...]
-    # CHAOS-3368: see RawStatusSnapshot.project_facts -- carried through
-    # unbounded-assessment-then-display-bound identically to children/
-    # blockers above, never consumed by ``_assess``. Defaulted (unlike
-    # every other field on this frozen dataclass) so the many existing
-    # direct ``StatusSnapshotResult(...)`` test fixtures across the
-    # CHAOS-3303 service suite keep constructing valid instances without
-    # being touched by this change -- every one of them predates project
-    # declared-state facts and legitimately has none.
-    project_facts: tuple[StatusFact, ...] = ()
+    # CHAOS-3368: see RawStatusSnapshot's own declared_project_* fields --
+    # carried through unchanged, never consumed by ``_assess``. Defaulted
+    # (unlike every other field on this frozen dataclass) so the many
+    # existing direct ``StatusSnapshotResult(...)`` test fixtures across
+    # the CHAOS-3303 service suite keep constructing valid instances
+    # without being touched by this change -- every one of them predates
+    # project declared-state facts and legitimately has none.
+    declared_project_state: str | None = None
+    declared_project_target_date: date | None = None
+    declared_project_observed_at: datetime | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -560,7 +571,9 @@ class StatusChangeService:
         bounded = replace(
             raw,
             children=self._bounded(raw.children, request.max_items),
-            project_facts=self._bounded(raw.project_facts, request.max_items),
+            # declared_project_* fields are scalars, not a list -- no
+            # truncation bound applies; they pass through `replace`
+            # unchanged since they're not named here.
             blockers=self._bounded(raw.blockers, request.max_items),
             pull_requests=self._bounded(raw.pull_requests, request.max_items),
             ci=self._bounded(raw.ci, request.max_items),
@@ -647,7 +660,9 @@ class StatusChangeService:
             declared=bounded.declared,
             actual=actual,
             children=self._ordered_status(bounded.children),
-            project_facts=self._ordered_status(bounded.project_facts),
+            declared_project_state=bounded.declared_project_state,
+            declared_project_target_date=bounded.declared_project_target_date,
+            declared_project_observed_at=bounded.declared_project_observed_at,
             blockers=self._ordered_status(bounded.blockers),
             pull_requests=tuple(sorted(bounded.pull_requests, key=self._pr_key)),
             ci=tuple(sorted(bounded.ci, key=self._ci_key)),

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -304,6 +304,18 @@ class ActualCompletion:
 class RawStatusSnapshot:
     declared: StatusFact | None
     children: tuple[StatusFact, ...] = ()
+    # CHAOS-3368: the project's own DECLARED lifecycle state / target date
+    # (projects.state/target_date, migration 073) for PROJECT scope --
+    # additive display facts alongside the derived completion/blockers
+    # below. Deliberately NEVER read by ``_assess``: these describe what
+    # the PROVIDER declared for the project as a whole, not an input to
+    # the derived actual-completion verdict, and wiring them in would
+    # change that rule's behavior -- out of this ticket's scope. Empty
+    # when the scope is not PROJECT, the catalog row could not be
+    # resolved unambiguously, or the provider populated neither column --
+    # every one of those renders as an absent fact, never a fabricated one
+    # (see native_status_change._project_declared_facts).
+    project_facts: tuple[StatusFact, ...] = ()
     blockers: tuple[StatusFact, ...] = ()
     pull_requests: tuple[PullRequestFact, ...] = ()
     ci: tuple[CIFact, ...] = ()
@@ -372,6 +384,15 @@ class StatusSnapshotResult:
     incidents: tuple[IncidentFact, ...]
     source_refs: tuple[SourceReference, ...]
     warnings: tuple[str, ...]
+    # CHAOS-3368: see RawStatusSnapshot.project_facts -- carried through
+    # unbounded-assessment-then-display-bound identically to children/
+    # blockers above, never consumed by ``_assess``. Defaulted (unlike
+    # every other field on this frozen dataclass) so the many existing
+    # direct ``StatusSnapshotResult(...)`` test fixtures across the
+    # CHAOS-3303 service suite keep constructing valid instances without
+    # being touched by this change -- every one of them predates project
+    # declared-state facts and legitimately has none.
+    project_facts: tuple[StatusFact, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -539,6 +560,7 @@ class StatusChangeService:
         bounded = replace(
             raw,
             children=self._bounded(raw.children, request.max_items),
+            project_facts=self._bounded(raw.project_facts, request.max_items),
             blockers=self._bounded(raw.blockers, request.max_items),
             pull_requests=self._bounded(raw.pull_requests, request.max_items),
             ci=self._bounded(raw.ci, request.max_items),
@@ -625,6 +647,7 @@ class StatusChangeService:
             declared=bounded.declared,
             actual=actual,
             children=self._ordered_status(bounded.children),
+            project_facts=self._ordered_status(bounded.project_facts),
             blockers=self._ordered_status(bounded.blockers),
             pull_requests=tuple(sorted(bounded.pull_requests, key=self._pr_key)),
             ci=tuple(sorted(bounded.ci, key=self._ci_key)),

--- a/src/dev_health_ops/api/dev/status_completion_copy.py
+++ b/src/dev_health_ops/api/dev/status_completion_copy.py
@@ -26,6 +26,7 @@ __all__ = [
     "any_tool_result_withheld_its_completion_denominator",
     "has_incomplete_denominator_disclosure",
     "is_completion_assessment_untrustworthy",
+    "translate_project_state",
     "translate_reason_code",
 ]
 
@@ -136,3 +137,44 @@ def translate_reason_codes(codes: Sequence[str]) -> list[str]:
             seen.add(text)
             translated.append(text)
     return translated
+
+
+# --- CHAOS-3368 step 2: closed-vocabulary declared PROJECT state -----------
+
+#: Translation for ``DevToolResult.declared_project_state`` -- the raw
+#: provider-declared project lifecycle token (``projects.state``, migration
+#: 073; Linear's own vocabulary today: planned/started/paused/completed/
+#: canceled). UNLIKE ``_REASON_CODE_COPY`` above, this table is deliberately
+#: NOT import-time-total against a pinned closed set: reason codes are
+#: emitted by ``_assess`` (this codebase's own, enumerable vocabulary), but
+#: a declared project state is raw PROVIDER data -- an unrecognized value
+#: (a future provider, a Linear vocabulary addition) is an expected, routine
+#: case, not a bug to raise on at import time.
+#:
+#: Still fail-closed exactly like every other translation table here: a raw
+#: provider string must never reach user-visible prose directly (CHAOS-3377
+#: MEDIUM 4's own rule -- an unconstrained provider string can coincidentally
+#: equal an internal denylisted token, e.g. a hypothetical provider literally
+#: naming a state ``not_ready``, which would flip ``orchestrator.finish()``'s
+#: fail-closed token scan to ``internal_error`` for an otherwise-valid
+#: answer). An unrecognized value renders as ``_DEFAULT_PROJECT_STATE_COPY``.
+_PROJECT_STATE_COPY: Mapping[str, str] = {
+    "planned": "planned",
+    "started": "in progress",
+    "paused": "paused",
+    "completed": "completed",
+    "canceled": "canceled",
+    "cancelled": "canceled",
+}
+_DEFAULT_PROJECT_STATE_COPY = "a declared state outside the known vocabulary"
+
+
+def translate_project_state(state: str) -> str:
+    """The safe, closed-vocabulary phrase for one raw declared project
+    state. Fail-closed: an unrecognized value renders as
+    ``_DEFAULT_PROJECT_STATE_COPY``, never the raw provider string.
+    """
+
+    return _PROJECT_STATE_COPY.get(
+        state.strip().casefold(), _DEFAULT_PROJECT_STATE_COPY
+    )

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, cast
 
 import pytest
@@ -1379,23 +1379,34 @@ async def test_ci_acceptance_checks_on_one_run_do_not_collide(
 # CHAOS-3368: the project's own declared state / target date must surface as
 # a status fact alongside the derived completion/blockers -- through the
 # exact same fact -> evidence -> status_fact wiring CHAOS-3259 pinned above,
-# not a separate rendering path.
+# not a separate rendering path. TYPED at the RawStatusSnapshot/
+# StatusSnapshotResult boundary (Codex adversarial review, HIGH,
+# 2026-08-04) -- never a pre-joined display string -- so this fixture sets
+# ``declared_project_state``/``declared_project_target_date`` directly.
 # ---------------------------------------------------------------------------
 
 
 class _FakeProjectStatusChangeSource(_FakeStatusChangeSource):
-    """Adds ``RawStatusSnapshot.project_facts`` to the otherwise-unchanged
-    ``_FakeStatusChangeSource`` fixture -- exactly the shape
-    ``ClickHouseStatusChangeSource._project_declared_facts`` now produces
-    for PROJECT scope. Every other field (declared/children/pull_requests/
-    ci/incidents) is untouched, so these tests exercise ONLY the new
-    project_facts wiring, not a parallel fixture that could drift from the
-    real one CHAOS-3259 already pins.
+    """Adds the CHAOS-3368 typed declared-state fields to the otherwise-
+    unchanged ``_FakeStatusChangeSource`` fixture. Every other field
+    (declared/children/pull_requests/ci/incidents) is untouched, so these
+    tests exercise ONLY the new wiring, not a parallel fixture that could
+    drift from the real one CHAOS-3259 already pins.
     """
 
-    def __init__(self, *, project_facts: tuple[StatusFact, ...]) -> None:
+    def __init__(
+        self,
+        *,
+        declared_project_state: str | None = None,
+        declared_project_target_date: date | None = None,
+        declared_project_observed_at: datetime | None = None,
+        extra_children: tuple[StatusFact, ...] = (),
+    ) -> None:
         super().__init__()
-        self._project_facts = project_facts
+        self._declared_project_state = declared_project_state
+        self._declared_project_target_date = declared_project_target_date
+        self._declared_project_observed_at = declared_project_observed_at
+        self._extra_children = extra_children
 
     async def status_snapshot(
         self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
@@ -1403,18 +1414,42 @@ class _FakeProjectStatusChangeSource(_FakeStatusChangeSource):
         raw = await super().status_snapshot(
             org_id=org_id, scope=scope, as_of=as_of, limit=limit
         )
-        return replace(raw, project_facts=self._project_facts)
+        return replace(
+            raw,
+            declared_project_state=self._declared_project_state,
+            declared_project_target_date=self._declared_project_target_date,
+            declared_project_observed_at=self._declared_project_observed_at,
+            children=raw.children + self._extra_children,
+        )
 
 
-PROJECT_DECLARED_STATE_FACT = StatusFact(
-    entity_type="project",
-    entity_id="project_01",
-    display_label="Declared status",
-    status="started; target date 2026-09-01",
-    observed_at=FRESH_OBSERVED,
-    source_ref_id="ref:projects",
-    evidence_ref_ids=(),
-)
+def _fake_projects_evidence_query_dicts() -> Any:
+    """Faithful stand-in for ``native_evidence.py``'s own "projects" adapter
+    ``expand_sql`` -- returns real content keyed on the real identity
+    predicate (``entity_id`` = the project's catalog id), never a canned
+    always-available response. Mirrors the file's existing
+    ``_real_native_evidence_query_dicts`` pattern.
+    """
+
+    async def fake_query_dicts(_client: Any, sql: str, params: dict[str, Any]) -> Any:
+        if "FROM projects FINAL" in sql and params.get("entity_id") == "project_01":
+            return [
+                {
+                    "entity_id": "project_01",
+                    "display_label": "Project 01",
+                    "excerpt": "Declared state: started. Target date: 2026-09-01.",
+                    "provenance": "linear",
+                    "observed_at": FRESH_OBSERVED,
+                    "last_synced": FRESH_OBSERVED,
+                    "repository_id": "",
+                    "source_url": "",
+                    "deleted": 0,
+                    "confidence": 1.0,
+                }
+            ]
+        return []
+
+    return fake_query_dicts
 
 
 @pytest.mark.asyncio
@@ -1423,12 +1458,14 @@ async def test_status_snapshot_surfaces_project_declared_state_and_target_date(
 ) -> None:
     """CHAOS-3368 acceptance: a PROJECT-scope status_snapshot call surfaces
     the project's own declared state / target date (projects.state/
-    target_date, migration 073) as a real, grounded status fact -- reaching
-    the tool result the model narrates into the §10 answer -- alongside the
-    derived completion/blockers this file already pins above.
+    target_date, migration 073) as a status fact -- reaching the tool
+    result the model narrates into the §10 answer -- alongside the derived
+    completion/blockers this file already pins above.
     """
     source = _FakeProjectStatusChangeSource(
-        project_facts=(PROJECT_DECLARED_STATE_FACT,)
+        declared_project_state="started",
+        declared_project_target_date=date(2026, 9, 1),
+        declared_project_observed_at=FRESH_OBSERVED,
     )
     runtime = await _build_runtime(monkeypatch, status_source=source)
     scope = _project_scope()
@@ -1455,8 +1492,6 @@ async def test_status_snapshot_surfaces_project_declared_state_and_target_date(
     fact = project_facts[0]
     assert "started" in fact.text
     assert "2026-09-01" in fact.text
-    # Grounded: a real, signer-issued evidence reference, not a bare claim
-    # the model could not independently verify via get_evidence.v1.
     assert fact.evidence_ref_ids
 
     # The pre-existing declared/child facts (CHAOS-3259) are unaffected --
@@ -1464,6 +1499,82 @@ async def test_status_snapshot_surfaces_project_declared_state_and_target_date(
     assert {"issue:issue_parent", "issue:issue_child"} <= {
         f.fact_id for f in result.status_facts
     }
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_evidence_expands_declared_project_state_with_real_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 Codex HIGH fix (confirmed): before this fix, the declared-
+    state fact's evidence was minted through the "work_items" native
+    evidence adapter (``_STATUS_ENTITY_SOURCE_SYSTEM["project"] =
+    "work_items"``), whose ``expand_sql`` requires ``work_item_id =
+    {entity_id}`` where ``entity_id`` is the FACT's own id -- a project's
+    catalog id, which is never a ``work_item_id``. That predicate can never
+    match, so ``get_evidence.v1`` would have returned NO_MATCHES for every
+    real declared-state fact -- while the prior test asserted only
+    ``fact.evidence_ref_ids`` truthy, which is satisfied by ANY signed
+    handle regardless of whether it expands to anything (a measurement
+    that never happened, reading as coverage). See
+    ``test_work_items_adapter_never_matches_a_project_identity`` in
+    test_native_evidence.py for the direct proof of the old failure mode.
+
+    This test performs the real STATUS_SNAPSHOT -> GET_EVIDENCE round trip
+    against the fix (routed through the new "projects" adapter) and asserts
+    the expanded record actually contains the declared state / target date.
+    """
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence.query_dicts",
+        _fake_projects_evidence_query_dicts(),
+    )
+    source = _FakeProjectStatusChangeSource(
+        declared_project_state="started",
+        declared_project_target_date=date(2026, 9, 1),
+        declared_project_observed_at=FRESH_OBSERVED,
+    )
+    runtime = await _build_runtime(monkeypatch, status_source=source)
+    scope = _project_scope()
+
+    status_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    project_fact = next(
+        fact
+        for fact in status_execution.result.status_facts
+        if fact.fact_id == "project:project_01"
+    )
+    evidence_id = project_fact.evidence_ref_ids[0]
+
+    get_execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_02",
+            tool_id=ToolID.GET_EVIDENCE,
+            scope=scope,
+            evidence_ref_ids=[evidence_id],
+            limit=10,
+        ),
+        _context(scope),
+    )
+    result = get_execution.result
+    assert result.status != "unavailable"
+    texts = [fact.text for fact in result.status_facts]
+    assert len(texts) == 1, (
+        f"expected the declared-state evidence to expand, got {result}"
+    )
+    assert "started" in texts[0]
+    assert "2026-09-01" in texts[0]
 
     await runtime.aclose()
 
@@ -1479,7 +1590,7 @@ async def test_status_snapshot_project_declared_state_absent_renders_as_absent(
     fabricated empty-string status or an epoch/zero-date fact. Absence
     must render as absence, not a zero-like value.
     """
-    source = _FakeProjectStatusChangeSource(project_facts=())
+    source = _FakeProjectStatusChangeSource()
     runtime = await _build_runtime(monkeypatch, status_source=source)
     scope = _project_scope()
     execution = await runtime.registry.execute(
@@ -1512,10 +1623,10 @@ async def test_status_snapshot_non_project_scope_unchanged_by_project_facts_wiri
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """CHAOS-3368 negative control: an ISSUE-scope status_snapshot call must
-    never surface a project declared-state fact -- ``RawStatusSnapshot.
-    project_facts`` defaults to empty and the fake source here never sets
-    it, exactly mirroring today's real ``ClickHouseStatusChangeSource``,
-    which only ever populates it for PROJECT scope.
+    never surface a project declared-state fact -- the fake source here
+    never sets ``declared_project_state``/``declared_project_target_date``,
+    exactly mirroring today's real ``ClickHouseStatusChangeSource``, which
+    only ever populates them for PROJECT scope.
     """
     runtime = await _build_runtime(monkeypatch)
     scope = _scope()
@@ -1537,5 +1648,71 @@ async def test_status_snapshot_non_project_scope_unchanged_by_project_facts_wiri
         "issue:issue_parent",
         "issue:issue_child",
     }
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_declared_project_fact_survives_dense_required_child_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 Codex MEDIUM fix (confirmed): ``priority_ids`` previously
+    listed every required child's evidence BEFORE the declared-state
+    fact's -- with >=25 required children (the display bound this test
+    uses, ``limit=25``) alone exhausting ``_MAX_RESULT_EVIDENCE`` (25), the
+    declared-state fact's own evidence was silently filtered out of the
+    result even though it was nominally "prioritized" too late to ever be
+    reached. Reproduces that density and asserts the fact survives.
+    """
+    dense_required_children = tuple(
+        StatusFact(
+            entity_type="issue",
+            entity_id=f"issue_child_{i}",
+            display_label=f"Child issue {i}",
+            status="open",
+            observed_at=FRESH_OBSERVED,
+            source_ref_id="ref:work_items",
+            evidence_ref_ids=(),
+            required=True,
+        )
+        for i in range(30)
+    )
+    source = _FakeProjectStatusChangeSource(
+        declared_project_state="started",
+        declared_project_target_date=date(2026, 9, 1),
+        declared_project_observed_at=FRESH_OBSERVED,
+        extra_children=dense_required_children,
+    )
+    runtime = await _build_runtime(monkeypatch, status_source=source)
+    scope = _project_scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+
+    # Sanity: the reproduction actually hit the truncation path this test
+    # exists to exercise.
+    assert len(result.actual_completion.required_children) >= 25
+    assert "status_snapshot_evidence_result_truncated" in result.warnings
+
+    project_facts = [
+        fact for fact in result.status_facts if fact.fact_id == "project:project_01"
+    ]
+    assert len(project_facts) == 1, (
+        "the declared-state fact was dropped by evidence-budget truncation "
+        f"under {len(result.actual_completion.required_children)} required children"
+    )
+    assert project_facts[0].evidence_ref_ids, (
+        "the declared-state fact survived but with its evidence stripped -- "
+        "still effectively ungrounded"
+    )
 
     await runtime.aclose()

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import secrets
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -1370,5 +1371,171 @@ async def test_ci_acceptance_checks_on_one_run_do_not_collide(
     texts = [fact.text for fact in get_execution.result.status_facts]
     assert len(texts) == 2
     assert all("Status: mixed." in text for text in texts)
+
+    await runtime.aclose()
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3368: the project's own declared state / target date must surface as
+# a status fact alongside the derived completion/blockers -- through the
+# exact same fact -> evidence -> status_fact wiring CHAOS-3259 pinned above,
+# not a separate rendering path.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProjectStatusChangeSource(_FakeStatusChangeSource):
+    """Adds ``RawStatusSnapshot.project_facts`` to the otherwise-unchanged
+    ``_FakeStatusChangeSource`` fixture -- exactly the shape
+    ``ClickHouseStatusChangeSource._project_declared_facts`` now produces
+    for PROJECT scope. Every other field (declared/children/pull_requests/
+    ci/incidents) is untouched, so these tests exercise ONLY the new
+    project_facts wiring, not a parallel fixture that could drift from the
+    real one CHAOS-3259 already pins.
+    """
+
+    def __init__(self, *, project_facts: tuple[StatusFact, ...]) -> None:
+        super().__init__()
+        self._project_facts = project_facts
+
+    async def status_snapshot(
+        self, *, org_id: str, scope: DevScope, as_of: datetime, limit: int
+    ) -> RawStatusSnapshot:
+        raw = await super().status_snapshot(
+            org_id=org_id, scope=scope, as_of=as_of, limit=limit
+        )
+        return replace(raw, project_facts=self._project_facts)
+
+
+PROJECT_DECLARED_STATE_FACT = StatusFact(
+    entity_type="project",
+    entity_id="project_01",
+    display_label="Declared status",
+    status="started; target date 2026-09-01",
+    observed_at=FRESH_OBSERVED,
+    source_ref_id="ref:projects",
+    evidence_ref_ids=(),
+)
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_surfaces_project_declared_state_and_target_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 acceptance: a PROJECT-scope status_snapshot call surfaces
+    the project's own declared state / target date (projects.state/
+    target_date, migration 073) as a real, grounded status fact -- reaching
+    the tool result the model narrates into the §10 answer -- alongside the
+    derived completion/blockers this file already pins above.
+    """
+    source = _FakeProjectStatusChangeSource(
+        project_facts=(PROJECT_DECLARED_STATE_FACT,)
+    )
+    runtime = await _build_runtime(monkeypatch, status_source=source)
+    scope = _project_scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+
+    project_facts = [
+        fact for fact in result.status_facts if fact.fact_id == "project:project_01"
+    ]
+    assert len(project_facts) == 1, (
+        "expected exactly one project declared-state status fact, got "
+        f"status_facts={[fact.fact_id for fact in result.status_facts]}"
+    )
+    fact = project_facts[0]
+    assert "started" in fact.text
+    assert "2026-09-01" in fact.text
+    # Grounded: a real, signer-issued evidence reference, not a bare claim
+    # the model could not independently verify via get_evidence.v1.
+    assert fact.evidence_ref_ids
+
+    # The pre-existing declared/child facts (CHAOS-3259) are unaffected --
+    # this is additive wiring, not a replacement of the existing tree.
+    assert {"issue:issue_parent", "issue:issue_child"} <= {
+        f.fact_id for f in result.status_facts
+    }
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_project_declared_state_absent_renders_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 negative control: a project whose catalog row carries
+    neither a declared state nor a target date (e.g. no migration-073
+    columns populated, or the catalog row itself could not be resolved)
+    must produce NO project declared-state status fact at all -- never a
+    fabricated empty-string status or an epoch/zero-date fact. Absence
+    must render as absence, not a zero-like value.
+    """
+    source = _FakeProjectStatusChangeSource(project_facts=())
+    runtime = await _build_runtime(monkeypatch, status_source=source)
+    scope = _project_scope()
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+
+    assert not any(
+        fact.fact_id.startswith("project:") for fact in result.status_facts
+    ), (
+        "a project with no declared state/target date must not emit a "
+        "project declared-state status fact"
+    )
+    # The rest of the tree is unaffected.
+    assert any(fact.fact_id == "issue:issue_child" for fact in result.status_facts)
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_non_project_scope_unchanged_by_project_facts_wiring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 negative control: an ISSUE-scope status_snapshot call must
+    never surface a project declared-state fact -- ``RawStatusSnapshot.
+    project_facts`` defaults to empty and the fake source here never sets
+    it, exactly mirroring today's real ``ClickHouseStatusChangeSource``,
+    which only ever populates it for PROJECT scope.
+    """
+    runtime = await _build_runtime(monkeypatch)
+    scope = _scope()
+    assert scope.direct_scope is DirectScope.ISSUE
+    execution = await runtime.registry.execute(
+        DevToolRequest(
+            schema_version="dev_tool_request.v1",
+            run_id="run_01",
+            tool_call_id="tool_call_01",
+            tool_id=ToolID.STATUS_SNAPSHOT,
+            scope=scope,
+            limit=25,
+        ),
+        _context(scope),
+    )
+    result = execution.result
+    assert not any(fact.fact_id.startswith("project:") for fact in result.status_facts)
+    assert {fact.fact_id for fact in result.status_facts} == {
+        "issue:issue_parent",
+        "issue:issue_child",
+    }
 
     await runtime.aclose()

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -282,7 +282,8 @@ def test_render_declared_project_summary_translates_state_and_names_target_date(
         declared_project_target_date="2026-09-01",
         declared_project_evidence_ref_ids=("ev_01",),
     )
-    summary = render_declared_project_summary(result)
+    canonical_evidence_ids = frozenset(item.evidence_ref_id for item in result.evidence)
+    summary = render_declared_project_summary(result, canonical_evidence_ids)
     assert summary is not None
     assert "in progress" in summary
     assert "2026-09-01" in summary
@@ -298,7 +299,8 @@ def test_render_declared_project_summary_returns_none_when_absent() -> None:
     result = _tool_result(actual_completion=_actual(state="ready", reason_codes=()))
     assert result.declared_project_state is None
     assert result.declared_project_target_date is None
-    assert render_declared_project_summary(result) is None
+    canonical_evidence_ids = frozenset(item.evidence_ref_id for item in result.evidence)
+    assert render_declared_project_summary(result, canonical_evidence_ids) is None
 
 
 def test_render_declared_project_summary_unknown_state_falls_back_safely() -> None:
@@ -314,10 +316,34 @@ def test_render_declared_project_summary_unknown_state_falls_back_safely() -> No
         declared_project_state="archived",
         declared_project_evidence_ref_ids=("ev_01",),
     )
-    summary = render_declared_project_summary(result)
+    canonical_evidence_ids = frozenset(item.evidence_ref_id for item in result.evidence)
+    summary = render_declared_project_summary(result, canonical_evidence_ids)
     assert summary is not None
     assert "archived" not in summary.casefold()
     assert "outside the known vocabulary" in summary
+
+
+def test_render_declared_project_summary_returns_none_when_evidence_is_not_canonical() -> (
+    None
+):
+    """CHAOS-3368 Codex HIGH fix (delta review, 2026-08-04): a bound
+    status_snapshot.v1 result with a real declared state, but whose
+    evidence did NOT survive this run's canonical evidence set (a run-wide
+    cap this function's caller controls, distinct from this one tool
+    result's own evidence array), must render NO clause -- never an
+    ungrounded assertion with no claim and no evidence behind it anywhere
+    in the final answer.
+    """
+
+    result = _tool_result(
+        actual_completion=_actual(state="ready", reason_codes=()),
+        declared_project_state="started",
+        declared_project_target_date="2026-09-01",
+        declared_project_evidence_ref_ids=("ev_01",),
+    )
+    # Deliberately excludes "ev_01" -- simulates the run-wide canonical
+    # evidence cap having truncated it out before this function ever runs.
+    assert render_declared_project_summary(result, frozenset()) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -29,12 +29,14 @@ from dev_health_ops.api.dev.contracts import (
     DevToolRequest,
     DevToolResult,
 )
+from dev_health_ops.api.dev.no_match_terminal import INTERNAL_TOKEN_DENYLIST
 from dev_health_ops.api.dev.status_answer_render import (
     build_deterministic_status_claims,
     deterministic_answer_status,
     open_blockers,
     open_required_children,
     outstanding_facts,
+    render_declared_project_summary,
     render_verdict_summary,
     status_snapshot_result,
     translate_completion_state,
@@ -44,6 +46,7 @@ from dev_health_ops.api.dev.status_change_service import (
     STATUS_REASON_CODES,
     is_required_child_open,
 )
+from dev_health_ops.api.dev.status_completion_copy import translate_project_state
 
 SCOPE = DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
 OTHER_SCOPE = DevScope.model_validate(
@@ -194,6 +197,9 @@ def _tool_result(
     ci_checks: tuple[DevCIFact, ...] = (),
     deployments: tuple[DevDeploymentFact, ...] = (),
     incidents: tuple[DevIncidentFact, ...] = (),
+    declared_project_state: str | None = None,
+    declared_project_target_date: str | None = None,
+    declared_project_evidence_ref_ids: tuple[str, ...] = (),
 ) -> DevToolResult:
     payload = dict(positive_fixtures()["dev_tool_result.v1"])
     payload["tool_call_id"] = tool_call_id
@@ -205,6 +211,11 @@ def _tool_result(
     payload["ci_checks"] = [item.model_dump(mode="json") for item in ci_checks]
     payload["deployments"] = [item.model_dump(mode="json") for item in deployments]
     payload["incidents"] = [item.model_dump(mode="json") for item in incidents]
+    payload["declared_project_state"] = declared_project_state
+    payload["declared_project_target_date"] = declared_project_target_date
+    payload["declared_project_evidence_ref_ids"] = list(
+        declared_project_evidence_ref_ids
+    )
     # DevToolResult.validate_evidence_closure requires every evidence ID any
     # fact references to be present in `evidence` -- mint a stub for
     # whatever `actual_completion`/the category facts above reference so
@@ -220,6 +231,7 @@ def _tool_result(
     for group in (pull_requests, ci_checks, deployments, incidents):
         for item in group:
             referenced.update(item.evidence_ref_ids)
+    referenced.update(declared_project_evidence_ref_ids)
     payload["evidence"] = [_evidence_stub(ref_id) for ref_id in sorted(referenced)]
     return DevToolResult.model_validate(payload)
 
@@ -250,6 +262,166 @@ def test_unknown_reason_code_fails_closed_to_generic_copy() -> None:
     translated = translate_reason_code("some_future_reason_code_v7")
     assert translated == "an unresolved requirement"
     assert "some_future_reason_code_v7" not in translated
+
+
+# --- CHAOS-3368 step 2: declared project state/target date in §10 ---------
+
+
+def test_render_declared_project_summary_translates_state_and_names_target_date() -> (
+    None
+):
+    """CHAOS-3368 acceptance: a bound status_snapshot.v1 result carrying a
+    declared project state/target date renders both into the verdict/
+    summary section -- the state TRANSLATED (never the raw provider token),
+    the date as a plain ISO string (structured data, not vocabulary).
+    """
+
+    result = _tool_result(
+        actual_completion=_actual(state="ready", reason_codes=()),
+        declared_project_state="started",
+        declared_project_target_date="2026-09-01",
+        declared_project_evidence_ref_ids=("ev_01",),
+    )
+    summary = render_declared_project_summary(result)
+    assert summary is not None
+    assert "in progress" in summary
+    assert "2026-09-01" in summary
+    assert "started" not in summary.casefold()
+
+
+def test_render_declared_project_summary_returns_none_when_absent() -> None:
+    """CHAOS-3368 negative control: no declared state/target date at all
+    (the RawStatusSnapshot layer's own absence case) renders no clause --
+    never a fabricated 'Declared state: None.' or similar.
+    """
+
+    result = _tool_result(actual_completion=_actual(state="ready", reason_codes=()))
+    assert result.declared_project_state is None
+    assert result.declared_project_target_date is None
+    assert render_declared_project_summary(result) is None
+
+
+def test_render_declared_project_summary_unknown_state_falls_back_safely() -> None:
+    """CHAOS-3368: a provider state outside the known vocabulary (a future
+    Linear addition, or a different provider entirely) must render through
+    the safe generic fallback, never the raw token -- ``translate_project_state``
+    is deliberately NOT total/closed against a pinned set (unlike reason
+    codes), since this is external provider data.
+    """
+
+    result = _tool_result(
+        actual_completion=_actual(state="ready", reason_codes=()),
+        declared_project_state="archived",
+        declared_project_evidence_ref_ids=("ev_01",),
+    )
+    summary = render_declared_project_summary(result)
+    assert summary is not None
+    assert "archived" not in summary.casefold()
+    assert "outside the known vocabulary" in summary
+
+
+@pytest.mark.parametrize(
+    "raw_state", ["planned", "started", "paused", "completed", "canceled", "cancelled"]
+)
+def test_project_state_translation_covers_the_known_linear_vocabulary(
+    raw_state: str,
+) -> None:
+    """Every state Linear's own API can report today translates to
+    non-empty, deterministic copy -- not a fabricated pass-through of
+    whatever the caller supplied, and not the fail-closed default (which is
+    reserved for values this table has genuinely never seen).
+    """
+
+    translated = translate_project_state(raw_state)
+    assert translated
+    assert translated != "a declared state outside the known vocabulary"
+
+
+def test_declared_project_state_translation_never_produces_a_denylisted_token() -> None:
+    """CHAOS-3368 (Codex point 4, this fix round): the exact failure mode
+    that bit CHAOS-3377's own renderer -- a legitimate value colliding with
+    an internal denylisted token and flipping the answer to
+    ``internal_error`` -- must not be reachable through this table. Every
+    known translation, AND the fail-closed default, must be clear of every
+    ``no_match_terminal.INTERNAL_TOKEN_DENYLIST`` member.
+    """
+
+    candidates = [
+        translate_project_state(state)
+        for state in ("planned", "started", "paused", "completed", "canceled")
+    ] + [translate_project_state("some_future_provider_state")]
+    for text in candidates:
+        lowered = text.casefold()
+        for token in INTERNAL_TOKEN_DENYLIST:
+            assert token not in lowered, (
+                f"translated declared-project-state copy {text!r} contains "
+                f"the denylisted token {token!r}"
+            )
+
+
+def test_build_deterministic_status_claims_includes_declared_project_claim_when_grounded() -> (
+    None
+):
+    """CHAOS-3368: the declared-state/target-date content reaches the §10
+    claims list as its own grounded, translated claim -- not only folded
+    into the verdict sentence.
+    """
+
+    actual = _actual(state="ready", reason_codes=())
+    result = _tool_result(
+        actual_completion=actual,
+        declared_project_state="paused",
+        declared_project_target_date="2026-12-25",
+        declared_project_evidence_ref_ids=("ev_02",),
+    )
+    canonical_evidence_ids = frozenset(item.evidence_ref_id for item in result.evidence)
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=result,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=canonical_evidence_ids,
+    )
+    declared_claims = [
+        claim
+        for claim in claims
+        if claim.claim_id.startswith("status-declared-project:")
+    ]
+    assert len(declared_claims) == 1
+    claim = declared_claims[0]
+    assert "paused" in claim.text
+    assert "2026-12-25" in claim.text
+    assert claim.evidence_ref_ids == ["ev_02"]
+
+
+def test_build_deterministic_status_claims_skips_declared_project_claim_when_evidence_is_truncated() -> (
+    None
+):
+    """CHAOS-3368: mirrors ``test_blocker_claim_skipped_rather_than_fabricated_when_evidence_is_truncated``
+    -- an outstanding declared-state clause whose own evidence was
+    truncated out of ``canonical_evidence_ids`` must be omitted from claims
+    entirely, never emitted ungrounded. The verdict/summary TEXT still
+    names it (``render_declared_project_summary`` has no evidence
+    dependency), but no claim backs it -- a caller wiring only claims would
+    correctly see nothing here.
+    """
+
+    actual = _actual(state="ready", reason_codes=())
+    result = _tool_result(
+        actual_completion=actual,
+        declared_project_state="paused",
+        declared_project_evidence_ref_ids=("ev_02",),
+    )
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=result,
+        validity_scope=SCOPE,
+        # Deliberately excludes "ev_02" -- simulates the fact that minted
+        # it having been truncated out of this run's canonical evidence set.
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    assert not any(
+        claim.claim_id.startswith("status-declared-project:") for claim in claims
+    )
 
 
 def test_verdict_summary_never_contains_raw_state_or_reason_tokens() -> None:

--- a/tests/api/dev/test_native_evidence.py
+++ b/tests/api/dev/test_native_evidence.py
@@ -68,6 +68,9 @@ def test_launch_native_evidence_class_registry_is_explicit() -> None:
     assert {item.source_system for item in native_evidence_adapters(object())} == {
         "work_units",
         "work_items",
+        # CHAOS-3368: declared-state facts expand through their own read of
+        # the projects catalog, not the work_items adapter.
+        "projects",
         "pull_requests",
         "reviews",
         "commits",
@@ -150,3 +153,142 @@ async def test_native_expansion_uses_exact_entity_and_repository_parameters() ->
         "scope_pr_number": 0,
     }
     assert record is not None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3368: declared-state facts must expand through the "projects"
+# adapter, not "work_items" (Codex adversarial review, HIGH, 2026-08-04).
+# ---------------------------------------------------------------------------
+
+
+class _PredicateEvaluatingSink:
+    """Unlike ``FakeSink`` above (a canned-row stub used only to prove a
+    query's own SQL text/params shape), this evaluates the real identity
+    predicate against two disjoint row stores -- needed to prove ABSENCE,
+    not merely to observe a query was issued. A canned-row fake cannot show
+    that ``work_item_id = {entity_id:String}`` never matches a project id;
+    only an evaluator that can also return NO rows can.
+    """
+
+    def __init__(self) -> None:
+        self.work_items: dict[str, dict[str, Any]] = {
+            "issue-1": {
+                "entity_id": "issue-1",
+                "display_label": "Release blocker",
+                "excerpt": "Status: open",
+                "provenance": "jira",
+                "observed_at": NOW,
+                "last_synced": NOW,
+                "repository_id": "repo-a",
+                "source_url": "",
+                "deleted": 0,
+                "confidence": 1.0,
+            }
+        }
+        self.projects: dict[str, dict[str, Any]] = {
+            "project_01": {
+                "entity_id": "project_01",
+                "display_label": "Project 01",
+                "excerpt": "Declared state: started. Target date: 2026-09-01.",
+                "provenance": "linear",
+                "observed_at": NOW,
+                "last_synced": NOW,
+                "repository_id": "",
+                "source_url": "",
+                "deleted": 0,
+                "confidence": 1.0,
+            }
+        }
+
+    def query_dicts(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        entity_id = str(params.get("entity_id") or "")
+        if "FROM work_items FINAL" in query:
+            row = self.work_items.get(entity_id)
+            return [row] if row else []
+        if "FROM projects FINAL" in query:
+            row = self.projects.get(entity_id)
+            return [row] if row else []
+        return []
+
+
+def _project_evidence_ref(*, source_system: str) -> Any:
+    from dev_health_ops.api.dev.contracts import DevEvidenceFlags, DevEvidenceRef
+
+    return DevEvidenceRef(
+        schema_version="dev_evidence_ref.v1",
+        evidence_ref_id="ev1_0123456789012345678901234567890123456789",
+        source_system=source_system,
+        source_version="native.v1",
+        entity_type="project",
+        entity_id="project_01",
+        display_label="Declared status",
+        observed_at=NOW,
+        freshness=FreshnessState.FRESH,
+        provenance="native",
+        confidence=1,
+        repository_ids=[],
+        valid_entity_ids=[],
+        flags=DevEvidenceFlags(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_work_items_adapter_never_matches_a_project_identity() -> None:
+    """CHAOS-3368 Codex HIGH (confirmed): pins WHY routing a declared-state
+    fact's evidence through the "work_items" adapter (the pre-fix
+    ``_STATUS_ENTITY_SOURCE_SYSTEM["project"] = "work_items"``) was a false
+    pass. That adapter's ``expand_sql`` requires ``work_item_id =
+    {entity_id:String}`` -- a project's own catalog id (this fixture:
+    "project_01") is never a ``work_item_id``, so it can never match, and
+    ``get_evidence.v1`` for such a fact would always come back NO_MATCHES
+    (``expand()`` returns ``None``). A prior test asserted only
+    ``fact.evidence_ref_ids`` truthy on the minted handle -- satisfied
+    regardless of whether the handle actually expands to anything, i.e. a
+    measurement that never happened, reading as coverage.
+    """
+    sink = _PredicateEvaluatingSink()
+    work_items_adapter = ClickHouseEvidenceSource(
+        sink,
+        "work_items",
+        policy=SourceFreshnessPolicy("work_items", "work-items-sync.v1", None),
+        now=NOW,
+    )
+
+    record = await work_items_adapter.expand(
+        org_id="org-a",
+        scope=_resolution(),
+        evidence=_project_evidence_ref(source_system="work_items"),
+    )
+
+    assert record is None, (
+        "the 'work_items' adapter unexpectedly matched a project id -- if "
+        "this now passes, the false-pass this test documents may no "
+        "longer apply and the test itself needs revisiting"
+    )
+
+
+@pytest.mark.asyncio
+async def test_projects_adapter_expands_a_declared_state_evidence_ref() -> None:
+    """CHAOS-3368 Codex HIGH fix: the "projects" adapter (what
+    ``_STATUS_ENTITY_SOURCE_SYSTEM["project"]`` now routes to) genuinely
+    expands a declared-state fact's evidence, unlike "work_items" above.
+    """
+    sink = _PredicateEvaluatingSink()
+    projects_adapter = ClickHouseEvidenceSource(
+        sink,
+        "projects",
+        policy=SourceFreshnessPolicy("projects", "projects-sync.v1", None),
+        now=NOW,
+    )
+
+    record = await projects_adapter.expand(
+        org_id="org-a",
+        scope=_resolution(),
+        evidence=_project_evidence_ref(source_system="projects"),
+    )
+
+    assert record is not None
+    assert record.entity_id == "project_01"
+    assert record.entity_type == "project"
+    assert "started" in (record.raw_excerpt or "")
+    assert "2026-09-01" in (record.raw_excerpt or "")

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -1560,6 +1560,123 @@ async def test_agent_refusal_after_status_snapshot_is_never_refused() -> None:
 
 
 @pytest.mark.asyncio
+async def test_status_snapshot_declared_project_state_reaches_the_final_verdict() -> (
+    None
+):
+    """CHAOS-3368 step 2 fail->pass, full orchestrator run: a status_snapshot.v1
+    result carrying a declared project state/target date (projects.state/
+    target_date, migration 073) must reach the final §10 answer's
+    direct_summary AND its own grounded claim -- translated (never the raw
+    provider token) -- riding the exact same scope-verified DevToolResult
+    the deterministic renderer already selects for the verdict/blockers.
+    """
+
+    script_id = "status-snapshot-declared-project"
+
+    async def status_snapshot(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "actual_completion": _scope_shaped_status_completion(
+                    direct_scope=request.scope.direct_scope.value
+                ),
+                "declared_project_state": "started",
+                "declared_project_target_date": "2026-09-01",
+                "declared_project_evidence_ref_ids": ["ev_01"],
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(decision=AgentRefusal(code="unsupported", message="no")),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    summary = result.answer.direct_summary
+    assert "Declared state: in progress." in summary
+    assert "Target date: 2026-09-01." in summary
+    # The raw provider token never reaches user-visible copy.
+    assert "started" not in summary.casefold()
+    assert any(
+        claim.claim_id.startswith("status-declared-project:")
+        for claim in result.answer.claims
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_snapshot_no_declared_project_state_renders_no_extra_clause() -> (
+    None
+):
+    """CHAOS-3368 negative control: a status_snapshot.v1 result with no
+    declared project state/target date (an ISSUE-scope run, or a PROJECT
+    scope whose catalog row carried neither) must not append any clause to
+    the deterministic verdict -- the pre-existing CHAOS-3377 verdict text
+    stays exactly as it was before this ticket.
+    """
+
+    script_id = "status-snapshot-no-declared-project"
+
+    async def status_snapshot(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "actual_completion": _scope_shaped_status_completion(
+                    direct_scope=request.scope.direct_scope.value
+                ),
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(decision=AgentRefusal(code="unsupported", message="no")),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert "Declared state:" not in result.answer.direct_summary
+    assert "Target date:" not in result.answer.direct_summary
+    assert not any(
+        claim.claim_id.startswith("status-declared-project:")
+        for claim in result.answer.claims
+    )
+
+
+@pytest.mark.asyncio
 async def test_budget_exhaustion_after_status_snapshot_renders_the_deterministic_verdict() -> (
     None
 ):

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -1738,6 +1738,203 @@ async def test_budget_exhaustion_after_status_snapshot_renders_the_deterministic
     )
 
 
+def _declared_project_truncation_registry() -> AskDevToolRegistry:
+    """First status_snapshot.v1 call ('tool_call_01') fills the run-wide
+    canonical evidence cap (``Orchestrator._limits.evidence_refs`` == 25)
+    with 25 evidence refs; the SECOND status_snapshot.v1 call
+    ('tool_call_02') -- the one that actually carries ``actual_completion``
+    and is bound to the run's final resolved scope -- carries a declared
+    project state/target date backed by evidence NOT among those 25, so it
+    must be truncated out of the run-wide canonical evidence set (CHAOS-3368
+    Codex HIGH, delta review, 2026-08-04).
+
+    ``"ev_01"`` -- the evidence id ``_scope_shaped_status_completion``'s
+    verdict/blocker facts reference -- is deliberately INCLUDED among the
+    25 (not left to compete with the 26th slot), so this fixture isolates
+    ONLY the declared-project truncation this test exists to exercise: the
+    pre-existing verdict/blocker claims must keep behaving exactly as they
+    do in ``test_agent_refusal_after_status_snapshot_is_never_refused`` and
+    siblings, unaffected by this fixture's added filler evidence.
+    """
+
+    filler_ids = ["ev_01", *(f"ev_fill_{i:02d}" for i in range(24))]
+
+    def _evidence_stub(eid: str) -> dict:
+        return {
+            **positive_fixtures()["dev_tool_result.v1"]["evidence"][0],
+            "evidence_ref_id": eid,
+        }
+
+    async def status_snapshot(_context, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        if request.tool_call_id == "tool_call_01":
+            payload["evidence"] = [_evidence_stub(eid) for eid in filler_ids]
+        else:
+            payload["actual_completion"] = _scope_shaped_status_completion(
+                direct_scope=request.scope.direct_scope.value
+            )
+            payload["declared_project_state"] = "paused"
+            payload["declared_project_target_date"] = "2026-12-25"
+            payload["declared_project_evidence_ref_ids"] = ["ev_declared"]
+            payload["evidence"] = [
+                _evidence_stub(eid) for eid in ("ev_01", "ev_declared")
+            ]
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+
+
+def _assert_declared_project_state_fully_absent(answer) -> None:
+    """The consistency invariant this fix round exists to enforce: the
+    summary clause, its claim, AND its evidence must be omitted TOGETHER --
+    never a summary sentence asserting a declared state with no claim and
+    no evidence anywhere in the answer backing it.
+    """
+
+    assert "Declared state:" not in answer.direct_summary
+    assert "Target date:" not in answer.direct_summary
+    assert not any(
+        claim.claim_id.startswith("status-declared-project:") for claim in answer.claims
+    )
+    assert "ev_declared" not in {item.evidence_ref_id for item in answer.evidence}
+
+
+@pytest.mark.asyncio
+async def test_declared_project_state_omitted_together_when_run_wide_cap_truncates_it_final_answer() -> (
+    None
+):
+    """CHAOS-3368 Codex HIGH fix, AgentFinalAnswer terminal."""
+
+    script_id = "declared-project-truncation-final-answer"
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=_declared_project_truncation_registry(),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    # The verdict itself still renders -- only the declared-project content
+    # is gated, not the whole deterministic override.
+    assert "not ready" in result.answer.direct_summary.casefold()
+    _assert_declared_project_state_fully_absent(result.answer)
+
+
+@pytest.mark.asyncio
+async def test_declared_project_state_omitted_together_when_run_wide_cap_truncates_it_agent_refusal() -> (
+    None
+):
+    """CHAOS-3368 Codex HIGH fix, AgentRefusal terminal."""
+
+    script_id = "declared-project-truncation-refusal"
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                ),
+                ScriptedStep(decision=AgentRefusal(code="unsupported", message="no")),
+            ],
+            script_id=script_id,
+            registry=_declared_project_truncation_registry(),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status.value != "refused"
+    assert "not ready" in result.answer.direct_summary.casefold()
+    _assert_declared_project_state_fully_absent(result.answer)
+
+
+@pytest.mark.asyncio
+async def test_declared_project_state_omitted_together_when_run_wide_cap_truncates_it_budget_exhaustion() -> (
+    None
+):
+    """CHAOS-3368 Codex HIGH fix, BudgetExceeded terminal."""
+
+    script_id = "declared-project-truncation-budget"
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    ),
+                    # Explicit zero, not the ``AgentUsage`` default (``None``
+                    # cost, which the budget check falls back to estimating
+                    # at ``estimated_cost_per_call_microusd`` -- that would
+                    # exhaust the budget after this FIRST call alone, before
+                    # ``tool_call_02`` (the one this test needs) ever runs).
+                    usage=AgentUsage(estimated_cost_microusd=0),
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_02",
+                    ),
+                    usage=AgentUsage(estimated_cost_microusd=600_000),
+                ),
+            ],
+            script_id=script_id,
+            registry=_declared_project_truncation_registry(),
+            limits=DevRunLimits(
+                max_estimated_cost_microusd=1_500_000,
+                estimated_cost_per_call_microusd=1_000_000,
+            ),
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    assert result.answer.status.value != "refused"
+    assert "not ready" in result.answer.direct_summary.casefold()
+    _assert_declared_project_state_fully_absent(result.answer)
+
+
 @pytest.mark.asyncio
 async def test_unresolved_named_entity_never_falls_back_to_organization_scope() -> None:
     """An explicit reference that resolves to nothing must never leave the

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -38,13 +38,19 @@ not a stand-in for it.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import pytest
 
 from dev_health_ops.api.dev import native_status_change, scope_catalog
-from dev_health_ops.api.dev.contracts import DirectScope
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+)
 from dev_health_ops.api.dev.native_status_change import ClickHouseStatusChangeSource
 from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
 from dev_health_ops.api.dev.scope_service import (
@@ -1050,3 +1056,192 @@ async def test_empty_project_id_never_issues_a_derivation_query(
 
     assert derived == []
     assert fake.sql == []
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3368: the project's own declared state / target date
+# (projects.state/target_date, migration 073) must surface as status facts
+# for a committed PROJECT subject, additive to (never a substitute for) the
+# derived work-item completion tree this file already pins above.
+# ---------------------------------------------------------------------------
+
+
+def _install_status_client_with_project_row(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    project_row: dict[str, Any] | None,
+) -> _FakeWorkItems:
+    """``_install_status_client`` plus a controllable ``projects`` catalog
+    read, without touching ``_FakeWorkItems`` itself (every other test in
+    this file depends on its existing, unmodified behavior -- an unhandled
+    query there already falls through to an empty result, which is exactly
+    what "no project row" needs, so only the new query is intercepted here).
+
+    Matched on ``"any(state) AS state"`` -- CHAOS-3368's
+    ``_PROJECT_DECLARED_FACTS_SQL`` own, unique SELECT list -- rather than
+    the broader ``"FROM projects FINAL"``: CHAOS-3374's
+    ``_PROJECT_IDENTITY_CTE`` is now spliced into EVERY project-scoped arm
+    (``_WORK_ITEMS_SQL``, ``PROJECT_REPOSITORIES_SQL``, ``_BLOCKERS_SQL``,
+    ...) and that CTE also reads ``FROM projects FINAL``, so the broader
+    substring would wrongly intercept those queries too and starve
+    ``_FakeWorkItems`` of the calls it needs to answer them.
+    """
+
+    fake = _FakeWorkItems()
+
+    async def wrapped(_client: object, sql: str, params: dict[str, Any]) -> Any:
+        if "any(state) AS state" in sql:
+            fake.sql.append(sql)
+            fake.params.append(dict(params))
+            if (
+                project_row is None
+                or params.get("org_id") != ORG_ID
+                or params.get("entity_id") != PROJECT_ID
+            ):
+                return []
+            return [project_row]
+        return await fake(_client, sql, params)
+
+    monkeypatch.setattr(native_status_change, "query_dicts", wrapped)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_surfaces_declared_state_and_target_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 acceptance: a committed PROJECT subject whose catalog row
+    carries both a declared state and a target date surfaces both as a
+    status fact, alongside (not instead of) the derived work-item tree this
+    file already pins in
+    ``test_committed_project_scope_status_snapshot_reads_its_work_items``.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    fake = _install_status_client_with_project_row(
+        monkeypatch,
+        project_row={
+            "state": "started",
+            "target_date": date(2026, 9, 1),
+            "updated_at": NOW,
+            "last_synced": NOW,
+        },
+    )
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert len(snapshot.project_facts) == 1
+    fact = snapshot.project_facts[0]
+    assert fact.entity_type == "project"
+    assert fact.entity_id == PROJECT_ID
+    assert "started" in fact.status
+    assert "2026-09-01" in fact.status
+    # The pre-existing derived work-item tree is unaffected.
+    assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
+    # The declared-state read really was issued with this project's identity.
+    assert fake.sql, "the projects catalog read was never issued"
+    assert fake.params[0]["entity_id"] == PROJECT_ID
+    assert fake.params[0]["org_id"] == ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_declared_state_absent_when_catalog_row_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 negative control: no matching ``projects`` catalog row (the
+    RED case on ``main`` today -- this ticket's whole premise is that the
+    column data exists since #1450 but nothing reads it) must render as an
+    absent fact, never a fabricated one, and must not disturb the derived
+    tree.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    _install_status_client_with_project_row(monkeypatch, project_row=None)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert snapshot.project_facts == ()
+    assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_declared_state_absent_when_columns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 negative control: a real catalog row that carries neither a
+    declared state nor a target date (``state`` defaults to ``''``,
+    ``target_date`` is ``NULL`` -- most providers today) must not fabricate
+    an empty-string status or an epoch/zero date fact.
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+
+    _install_status_client_with_project_row(
+        monkeypatch,
+        project_row={
+            "state": "",
+            "target_date": None,
+            "updated_at": NOW,
+            "last_synced": NOW,
+        },
+    )
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert snapshot.project_facts == ()
+
+
+@pytest.mark.asyncio
+async def test_issue_scope_never_queries_the_projects_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 negative control: an ISSUE-scope status_snapshot call must
+    behave byte-identically to before this change -- in particular, it must
+    never issue the new declared-state read at all.
+    """
+
+    entity_id = next(iter(IN_SCOPE_WORK_ITEM_IDS))
+    scope = DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=DirectScope.ISSUE,
+        repositories=[LINEAR_NO_REPOSITORY_ID],
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.ISSUE,
+                entity_id=entity_id,
+                display_label=entity_id,
+                repository_id=LINEAR_NO_REPOSITORY_ID,
+            )
+        ],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+    )
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert snapshot.project_facts == ()
+    # Matched on the declared-state read's own unique SELECT list, not the
+    # broader "FROM projects FINAL" -- CHAOS-3374's _PROJECT_IDENTITY_CTE is
+    # spliced into _WORK_ITEMS_SQL itself now, so that substring legitimately
+    # appears even for an ISSUE-scope call that never reaches CHAOS-3368's
+    # own query.
+    assert not any("any(state) AS state" in sql for sql in fake.sql)

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -1085,6 +1085,13 @@ def _install_status_client_with_project_row(
     ...) and that CTE also reads ``FROM projects FINAL``, so the broader
     substring would wrongly intercept those queries too and starve
     ``_FakeWorkItems`` of the calls it needs to answer them.
+
+    Evaluates the ``updated_at <= {as_of:DateTime64(3, 'UTC')}`` predicate
+    against ``params["as_of"]`` (Codex adversarial review, MEDIUM,
+    2026-08-04) rather than always returning the canned row -- a fake that
+    ignores this predicate could not catch a regression that dropped it
+    from the real SQL and started leaking a future-dated declared state
+    into an as-of snapshot.
     """
 
     fake = _FakeWorkItems()
@@ -1097,6 +1104,12 @@ def _install_status_client_with_project_row(
                 project_row is None
                 or params.get("org_id") != ORG_ID
                 or params.get("entity_id") != PROJECT_ID
+            ):
+                return []
+            if (
+                "updated_at <= {as_of:DateTime64(3, 'UTC')}" in sql
+                and project_row.get("updated_at") is not None
+                and project_row["updated_at"] > params["as_of"]
             ):
                 return []
             return [project_row]
@@ -1135,12 +1148,9 @@ async def test_committed_project_scope_surfaces_declared_state_and_target_date(
         ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
     )
 
-    assert len(snapshot.project_facts) == 1
-    fact = snapshot.project_facts[0]
-    assert fact.entity_type == "project"
-    assert fact.entity_id == PROJECT_ID
-    assert "started" in fact.status
-    assert "2026-09-01" in fact.status
+    assert snapshot.declared_project_state == "started"
+    assert snapshot.declared_project_target_date == date(2026, 9, 1)
+    assert snapshot.declared_project_observed_at is not None
     # The pre-existing derived work-item tree is unaffected.
     assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
     # The declared-state read really was issued with this project's identity.
@@ -1170,7 +1180,8 @@ async def test_committed_project_scope_declared_state_absent_when_catalog_row_mi
         ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
     )
 
-    assert snapshot.project_facts == ()
+    assert snapshot.declared_project_state is None
+    assert snapshot.declared_project_target_date is None
     assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS
 
 
@@ -1202,7 +1213,8 @@ async def test_committed_project_scope_declared_state_absent_when_columns_empty(
         ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
     )
 
-    assert snapshot.project_facts == ()
+    assert snapshot.declared_project_state is None
+    assert snapshot.declared_project_target_date is None
 
 
 @pytest.mark.asyncio
@@ -1238,10 +1250,50 @@ async def test_issue_scope_never_queries_the_projects_catalog(
         ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
     )
 
-    assert snapshot.project_facts == ()
+    assert snapshot.declared_project_state is None
+    assert snapshot.declared_project_target_date is None
     # Matched on the declared-state read's own unique SELECT list, not the
     # broader "FROM projects FINAL" -- CHAOS-3374's _PROJECT_IDENTITY_CTE is
     # spliced into _WORK_ITEMS_SQL itself now, so that substring legitimately
     # appears even for an ISSUE-scope call that never reaches CHAOS-3368's
     # own query.
     assert not any("any(state) AS state" in sql for sql in fake.sql)
+
+
+@pytest.mark.asyncio
+async def test_committed_project_scope_declared_state_absent_for_future_dated_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3368 Codex MEDIUM fix (confirmed): ``_PROJECT_DECLARED_FACTS_SQL``
+    read the current ``FINAL`` row with no ``updated_at <= as_of`` bound --
+    an as-of snapshot strictly BEFORE the project's last declared-state
+    update would have reported that (not-yet-true-at-as_of) state anyway.
+    Since ``FINAL`` collapses all history, there is nothing earlier to
+    answer with; the correct behavior is absence, not an anachronistic
+    answer -- asserted here with an update timestamp strictly after the
+    snapshot's own ``as_of`` (which defaults to ``scope.time_range.end``).
+    """
+
+    _install_catalog_client(monkeypatch)
+    scope = await _committed_project_scope()
+    assert scope.time_range.end < NOW + timedelta(days=1)
+
+    _install_status_client_with_project_row(
+        monkeypatch,
+        project_row={
+            "state": "started",
+            "target_date": date(2026, 9, 1),
+            "updated_at": scope.time_range.end + timedelta(days=1),
+            "last_synced": scope.time_range.end + timedelta(days=1),
+        },
+    )
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert snapshot.declared_project_state is None
+    assert snapshot.declared_project_target_date is None
+    # The rest of the tree (bounded by the same as_of) is unaffected.
+    assert {child.entity_id for child in snapshot.children} == IN_SCOPE_WORK_ITEM_IDS


### PR DESCRIPTION
## Summary

Fixes CHAOS-3368: the §10 project-status answer now surfaces the project's declared state and target date (the columns migration 073 added), rendered deterministically — never narrated raw.

- `_PROJECT_DECLARED_FACTS_SQL` reads `projects.state`/`target_date` (FINAL, org-scoped, `is_active=1`, `HAVING count()=1` fail-closed, `updated_at <= as_of` so historical snapshots never disclose future state). PROJECT scopes only; other scopes issue no query.
- Typed wire fields `declared_project_state` (raw provider token) / `declared_project_target_date` / `declared_project_evidence_ref_ids` on `DevToolResult`; contract artifacts regenerated. Rendering translates through a closed vocabulary with a fail-closed fallback — raw provider states never reach prose.
- New `projects` evidence adapter: the declared-state fact is grounded against the table it came from (the previous generic wiring minted handles that expanded to no match — caught in review, pinned by a STATUS_SNAPSHOT→GET_EVIDENCE round-trip test).
- Grounding consistency: summary clause, claim, and evidence are computed from one shared grounding check — retained or omitted together across all three deterministic terminals (final answer, refusal, budget), pinned by per-terminal truncation tests. The fact's evidence gets a reserved priority slot so dense required-child/blocker sets can't silently starve it.
- Absent values render as absent — never empty strings, epoch dates, or fabricated facts.

Post-merge follow-up: web's `scripts/ask-dev-contracts.mjs` `SOURCE_COMMIT` pin needs bumping to pick up the new `dev_tool_result.v1` fields.

## Testing

- Full `tests/api/dev` + `tests/api/graphql`: 2231 passed, 19 skipped, 1 xfailed, 0 failed.
- Two codex review rounds (full + focused delta); every finding fail→pass verified, including the false-pass evidence proof and the three-terminal consistency scenarios.
- ruff + mypy clean; contract drift check green (73 artifacts).
