### PR TITLE
feat(ask-dev): sync GitLab projects into the subject catalog with immutable-id identity (CHAOS-3380)

### DIFF
--- a/scripts/ask_dev_project_subject_oracle.py
+++ b/scripts/ask_dev_project_subject_oracle.py
@@ -18,17 +18,43 @@ the Ask Dev symptom — a user names a real project and gets
 READ-ONLY. It issues a single ``SELECT``; it never writes, and it is safe to
 point at the dev ``default`` database.
 
-Two providers, two id spaces (CHAOS-3380 round 2, matching
-``native_status_change._project_identity_match``): Linear's catalog ``id`` IS
-the raw ``work_items.project_id`` (a project's own id never changes), so the
-join below matches directly. Jira's and GitLab's catalog ``id`` is prefixed/
-opaque (``{org}:<provider>:<native_id>``, immutable) because their own native
-project identity is a KEY (Jira) or a MUTABLE path (GitLab) rather than a
-stable id work_items itself carries — for those, the join instead matches
-``work_items.project_id`` (which stays the raw key/path, unchanged from
-before) against the catalog row's own ``project_key`` column. A project id
-this oracle cannot join by either arm is a genuine gap, not a false negative
-of the join itself.
+Three providers, three id spaces, all matched through the SAME 3-arm logic
+``native_status_change._project_identity_match`` uses (CHAOS-3380 round 3):
+
+1. Linear's catalog ``id`` IS the raw ``work_items.project_id`` (a project's
+   own id never changes) -- direct id match.
+2. Jira's catalog ``id`` is prefixed/opaque (``{org}:jira:{key}``); its own
+   native identity is a KEY, which Jira writes onto ``work_items.
+   project_key`` (never ``project_id``, which stays empty for every Jira
+   row) -- key-to-key match against the catalog's own ``project_key``.
+3. GitLab's catalog ``id`` is ALSO prefixed/opaque (``{org}:gitlab:{numeric_
+   id}``, its own immutable numeric id); its own native identity is a
+   MUTABLE PATH, which GitLab writes onto ``work_items.project_id`` (never
+   ``project_key``, which stays empty for every GitLab row) -- the
+   compatibility arm, work_item project_id against the catalog's CURRENT
+   ``project_key``.
+
+CHAOS-3380 round 3 (Codex MEDIUM) fixed two real holes in an earlier
+2-provider version of this file that assumed "Linear references by
+project_id, everyone else by project_key is safe to ignore":
+
+* Jira work items NEVER carry a non-empty ``project_id`` (the raw key lives
+  in ``project_key`` only) -- the OLD reference side filtered on
+  ``project_id != ''``, so NO Jira work item was ever referenced at all and
+  ``project_subject_gaps(provider="jira", ...)`` would unconditionally raise
+  ``OracleNotMeasured``. The reference side now reads BOTH columns and
+  references a project by whichever one is non-empty.
+* The join's arm 3 (GitLab's path-compatibility arm, matching a MUTABLE
+  value) can bind two DIFFERENT projects across time if a path is reused
+  after the original project is deleted -- an old, un-resynced work item's
+  own ``project_id`` could then match an unrelated NEW catalog row that
+  later claimed the same path (see ``workers/team_autoimport_gitlab.
+  _gitlab_project_catalog_rows``'s own docstring for the full analysis).
+  Rather than silently reporting this as a clean match (a false green), a
+  row that resolves ONLY through arm 3 -- never through the immutable id or
+  native-key arms -- is now flagged ``kind="path_match_unverified"``: it IS
+  a match, but not one this oracle can vouch for as durably correct the way
+  an immutable-id or native-key match is.
 
 GitLab epics are explicitly EXCLUDED from the reference side (a named,
 tested carve-out, not silence): ``providers/gitlab/normalize.
@@ -86,17 +112,33 @@ _COMPARED_PROJECT_FIELDS = frozenset(
 # (org_id, repo_id, work_item_id). A plain DISTINCT would resurrect the OLD
 # project of any item that moved between projects, inventing references that
 # no longer exist — hence the per-item argMax, which is the full key inside one
-# org, followed by a per-project argMax to pick the name from the most recently
-# synced item that still points at it.
+# org, followed by a per-(project_id, project_key) argMax to pick the name
+# from the most recently synced item that still points at it.
 #
 # ``type != 'epic'`` excludes GitLab's group-path epic references (see module
 # docstring) — a no-op for every other provider, none of which ever write
 # ``type = 'epic'`` (only ``providers/gitlab/normalize.py`` does).
 #
+# ``referenced`` keeps BOTH raw columns (never conflated into one "native id"
+# value): Jira references ONLY through project_key (its own project_id is
+# always empty), GitLab ONLY through project_id (its own project_key is
+# always empty), Linear ONLY through project_id. A row is referenced when
+# EITHER is non-empty -- the old ``project_id != ''`` filter silently
+# excluded every Jira work item from ever being measured at all.
+#
+# The 3-arm join mirrors native_status_change._project_identity_match
+# exactly: (1) direct id match (Linear), (2) native key-to-key match (Jira),
+# (3) the path-compatibility match (GitLab) -- referenced.project_id against
+# the catalog's OWN project_key. ``path_only`` recomputes which arm(s) fired
+# from the SAME columns already in scope after the join (ClickHouse has no
+# per-disjunct provenance from an ``OR`` inside ``ON``), so a row that
+# resolves ONLY through arm 3 can be told apart from one an immutable id or
+# native key actually vouches for.
+#
 # The emptiness test on ``catalog_id`` is unambiguous because ``referenced``
-# excludes ``project_id = ''``: the join key is never the empty string, so a
-# LEFT JOIN can never bind to a catalog row whose id is genuinely empty, and an
-# empty ``catalog_id`` can only mean "no match".
+# only ever contains rows with at least one non-empty raw column, and the
+# join's own arms only ever match on a non-empty value against a non-empty
+# catalog column -- an empty ``catalog_id`` can only mean "no match".
 #
 # The invariant is deliberately one-directional: every REFERENCED project must
 # be in the catalog. A catalog project with no work items is not a gap.
@@ -104,6 +146,7 @@ _GAP_QUERY = """
 WITH latest_items AS (
     SELECT
         argMax(project_id, last_synced) AS project_id,
+        argMax(ifNull(project_key, ''), last_synced) AS project_key,
         argMax(project_name, last_synced) AS project_name,
         max(last_synced) AS synced_at
     FROM work_items
@@ -112,10 +155,13 @@ WITH latest_items AS (
     GROUP BY repo_id, work_item_id
 ),
 referenced AS (
-    SELECT project_id, argMax(project_name, synced_at) AS project_name
+    SELECT
+        project_id,
+        project_key,
+        argMax(project_name, synced_at) AS project_name
     FROM latest_items
-    WHERE project_id != ''
-    GROUP BY project_id
+    WHERE project_id != '' OR project_key != ''
+    GROUP BY project_id, project_key
 ),
 catalog AS (
     SELECT id, name, is_active, ifNull(project_key, '') AS project_key
@@ -129,16 +175,23 @@ active_labels AS (
     GROUP BY label
 )
 SELECT
-    r.project_id AS project_id,
+    if(r.project_id != '', r.project_id, r.project_key) AS project_id,
     r.project_name AS project_name,
     c.id AS catalog_id,
     c.name AS catalog_name,
     c.is_active AS catalog_is_active,
-    l.label_rows AS active_label_rows
+    l.label_rows AS active_label_rows,
+    (
+        c.id != ''
+        AND NOT (r.project_id != '' AND r.project_id = c.id)
+        AND NOT (c.project_key != '' AND r.project_key != '' AND r.project_key = c.project_key)
+        AND (c.project_key != '' AND r.project_id != '' AND r.project_id = c.project_key)
+    ) AS path_only_match
 FROM referenced AS r
 LEFT JOIN catalog AS c
-  ON r.project_id = c.id
-  OR (c.project_key != '' AND r.project_id = c.project_key)
+  ON (r.project_id != '' AND r.project_id = c.id)
+  OR (c.project_key != '' AND r.project_key != '' AND r.project_key = c.project_key)
+  OR (c.project_key != '' AND r.project_id != '' AND r.project_id = c.project_key)
 LEFT JOIN active_labels AS l ON lowerUTF8(r.project_name) = l.label
 ORDER BY project_id
 """
@@ -193,8 +246,8 @@ def project_subject_gaps(
     rows = _rows(client, org_id, provider)
     if not rows:
         raise OracleNotMeasured(
-            f"no {provider} work item in org {org_id} carries a project_id; there "
-            "is nothing to compare, so this run proves nothing."
+            f"no {provider} work item in org {org_id} carries a project_id or "
+            "project_key; there is nothing to compare, so this run proves nothing."
         )
 
     referenced_ids = {str(row["project_id"]) for row in rows}
@@ -219,6 +272,28 @@ def project_subject_gaps(
                 )
             )
             continue
+        # CHAOS-3380 round 3 (Codex MEDIUM): this row matched ONLY through
+        # the mutable path-compatibility arm -- never through an immutable
+        # id or a native key. Surfaced explicitly rather than reported as an
+        # ordinary clean match: an old, un-resynced work item's project_id
+        # can bind to an UNRELATED catalog row if the path was reused after
+        # the original project was deleted (see workers/team_autoimport_
+        # gitlab.py's own docstring). Not necessarily wrong -- GitLab has no
+        # other identity arm available at all -- but not something this
+        # oracle can vouch for the way it can an id/key match.
+        if bool(row.get("path_only_match")):
+            gaps.append(
+                ProjectGap(
+                    project_id=project_id,
+                    referenced_name=referenced_name,
+                    kind="path_match_unverified",
+                    detail=(
+                        "resolved only via the mutable path-compatibility arm; "
+                        "cannot rule out a reused-path collision with an "
+                        "unrelated project"
+                    ),
+                )
+            )
         if str(row["catalog_name"]) != referenced_name:
             gaps.append(
                 ProjectGap(

--- a/scripts/ask_dev_project_subject_oracle.py
+++ b/scripts/ask_dev_project_subject_oracle.py
@@ -1,27 +1,50 @@
 #!/usr/bin/env python3
-"""Differential oracle: every referenced Linear project is a resolvable subject.
+"""Differential oracle: every referenced project is a resolvable subject.
 
 Two independent producers write the two sides:
 
-* the **work-item sync** writes ``work_items.project_id`` / ``project_name``
-  (``providers/linear/normalize.py``), and
+* the **work-item sync** writes ``work_items.project_id`` / ``project_key`` /
+  ``project_name`` (``providers/<provider>/normalize.py``), and
 * the **team auto-import** writes ``projects`` rows
-  (``workers/team_autoimport_linear.py``, CHAOS-3365).
+  (``workers/team_autoimport_<provider>.py``, CHAOS-3365/CHAOS-3380).
 
 Nothing in the schema forces them to agree, and no type checker or code index
 can tell you whether they do — so this compares them by execution. The
 invariant: **every project id any work item currently points at must exist in
 the catalog, under the same name, and be resolvable.** A gap here is exactly
-the Ask Dev symptom — a user names a real Linear project and gets
+the Ask Dev symptom — a user names a real project and gets
 ``NO_AUTHORIZED_MATCH``.
 
 READ-ONLY. It issues a single ``SELECT``; it never writes, and it is safe to
 point at the dev ``default`` database.
 
+Two providers, two id spaces (CHAOS-3380 round 2, matching
+``native_status_change._project_identity_match``): Linear's catalog ``id`` IS
+the raw ``work_items.project_id`` (a project's own id never changes), so the
+join below matches directly. Jira's and GitLab's catalog ``id`` is prefixed/
+opaque (``{org}:<provider>:<native_id>``, immutable) because their own native
+project identity is a KEY (Jira) or a MUTABLE path (GitLab) rather than a
+stable id work_items itself carries — for those, the join instead matches
+``work_items.project_id`` (which stays the raw key/path, unchanged from
+before) against the catalog row's own ``project_key`` column. A project id
+this oracle cannot join by either arm is a genuine gap, not a false negative
+of the join itself.
+
+GitLab epics are explicitly EXCLUDED from the reference side (a named,
+tested carve-out, not silence): ``providers/gitlab/normalize.
+gitlab_epic_to_work_item`` sets ``work_items.project_id`` to the GROUP path,
+not a PROJECT path — a wholly different identity space with, deliberately,
+no catalog entity of its own in this ticket (CHAOS-3380 covers GitLab
+PROJECTS; group/epic subjects are an explicit follow-up). Comparing a group
+path against the project catalog would report a permanent, un-closeable
+"missing" gap for every org with epics enabled — a false signal about a
+carve-out, not a real defect.
+
 What it deliberately does NOT check, so nobody reads more into a green run than
 is there: it does not execute the async resolver itself (the equivalent
 ``EXACT_MATCH`` assertion lives in
-``tests/test_ask_dev_linear_project_subject_live.py``), and it has no catalog
+``tests/test_ask_dev_linear_project_subject_live.py`` /
+``tests/test_ask_dev_gitlab_project_subject_live.py``), and it has no catalog
 freshness floor — a row that stopped being refreshed still reads as present.
 
 Usage::
@@ -53,8 +76,11 @@ DEFAULT_ACCEPTANCE_PROJECT_IDS = ("13e65c04-40ec-4a95-8216-f7c2ce233244",)
 
 #: The catalog-side fields this oracle compares. Asserted against the real
 #: ``ProjectRecord`` so a rename breaks the oracle loudly instead of quietly
-#: comparing nothing.
-_COMPARED_PROJECT_FIELDS = frozenset({"id", "name", "is_active", "provider", "org_id"})
+#: comparing nothing. ``project_key`` (CHAOS-3380 round 2) is the join arm
+#: Jira/GitLab resolve through -- comparing it too, not just reading it.
+_COMPARED_PROJECT_FIELDS = frozenset(
+    {"id", "name", "is_active", "provider", "org_id", "project_key"}
+)
 
 # ``work_items`` is a ReplacingMergeTree(last_synced) keyed
 # (org_id, repo_id, work_item_id). A plain DISTINCT would resurrect the OLD
@@ -62,6 +88,10 @@ _COMPARED_PROJECT_FIELDS = frozenset({"id", "name", "is_active", "provider", "or
 # no longer exist — hence the per-item argMax, which is the full key inside one
 # org, followed by a per-project argMax to pick the name from the most recently
 # synced item that still points at it.
+#
+# ``type != 'epic'`` excludes GitLab's group-path epic references (see module
+# docstring) — a no-op for every other provider, none of which ever write
+# ``type = 'epic'`` (only ``providers/gitlab/normalize.py`` does).
 #
 # The emptiness test on ``catalog_id`` is unambiguous because ``referenced``
 # excludes ``project_id = ''``: the join key is never the empty string, so a
@@ -78,6 +108,7 @@ WITH latest_items AS (
         max(last_synced) AS synced_at
     FROM work_items
     WHERE org_id = {org_id:String} AND provider = {provider:String}
+      AND type != 'epic'
     GROUP BY repo_id, work_item_id
 ),
 referenced AS (
@@ -87,7 +118,7 @@ referenced AS (
     GROUP BY project_id
 ),
 catalog AS (
-    SELECT id, name, is_active
+    SELECT id, name, is_active, ifNull(project_key, '') AS project_key
     FROM projects FINAL
     WHERE org_id = {org_id:String} AND provider = {provider:String}
 ),
@@ -105,7 +136,9 @@ SELECT
     c.is_active AS catalog_is_active,
     l.label_rows AS active_label_rows
 FROM referenced AS r
-LEFT JOIN catalog AS c ON r.project_id = c.id
+LEFT JOIN catalog AS c
+  ON r.project_id = c.id
+  OR (c.project_key != '' AND r.project_id = c.project_key)
 LEFT JOIN active_labels AS l ON lowerUTF8(r.project_name) = l.label
 ORDER BY project_id
 """

--- a/src/dev_health_ops/api/dev/_project_identity.py
+++ b/src/dev_health_ops/api/dev/_project_identity.py
@@ -1,0 +1,83 @@
+"""Shared provider-aware project identity CTE + match predicate.
+
+Extracted out of ``native_status_change.py`` (CHAOS-3380 round 3, Codex
+HIGH) so ``native_evidence.py`` can reuse the EXACT SAME predicate for its
+own project-scoped ``work_items`` search/expand queries, instead of a
+hand-copied variant that silently drifted from the one
+``native_status_change.py`` actually uses (which is exactly what had
+happened: ``native_evidence.py``'s ``work_items`` source compared
+``project_id``/``project_key`` directly against the resolved entity id,
+never through this identity join at all -- broken for any provider whose
+catalog id isn't the raw value ``work_items`` carries, i.e. Jira since
+CHAOS-3374 and GitLab since CHAOS-3380, not just GitLab).
+
+A plain module with no dependency on either caller, specifically to avoid a
+circular import: ``native_status_change.py`` already imports from
+``native_evidence.py`` (``SourceFreshnessPolicy``,
+``default_native_freshness_policies``), so ``native_evidence.py`` cannot
+import identity helpers back out of ``native_status_change.py`` directly.
+Both modules import from here instead; ``native_status_change.py``
+re-exports these under its own historical private names
+(``_PROJECT_IDENTITY_CTE`` / ``_project_identity_cte`` /
+``_project_identity_match``) so every existing internal usage and test
+assertion against ``native_status_change.<name>`` keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+
+def project_identity_cte(entity_param: str = "entity_id") -> str:
+    """The ``project`` CTE: resolves one catalog row's provider + native key.
+
+    ``entity_param`` is the ClickHouse query-parameter name (interpreted
+    server-side by clickhouse-connect, never by Python string formatting)
+    holding the id to look up -- ``native_status_change.py``'s own queries
+    always use ``"entity_id"``; ``native_evidence.py``'s ``expand`` query
+    uses ``"scope_entity_id"`` instead (a differently-named parameter for
+    the SAME concept: the currently-authorized scope's committed entity).
+    """
+    return f"""project AS (
+  SELECT any(provider) AS catalog_provider,
+         any(ifNull(project_key, '')) AS catalog_project_key
+  FROM projects FINAL
+  WHERE org_id = {{org_id:String}} AND id = {{{entity_param}:String}} AND is_active = 1
+  HAVING count() = 1
+)"""
+
+
+def project_identity_match(alias: str = "", entity_param: str = "entity_id") -> str:
+    """Provider + native-key aware match against a work_items-shaped row.
+
+    ``alias`` is the table prefix (e.g. ``"item."``, ``"blocked."``) for a
+    joined reference; ``""`` for a bare, unaliased ``work_items`` FROM.
+    ``entity_param`` must match whatever was passed to
+    ``project_identity_cte`` for the SAME query.
+
+    Three arms, all provider-guarded by the leading
+    ``{alias}provider = catalog_provider``, so none of them can ever
+    cross-match a different provider's row even on a coincidental
+    id/key/path string collision:
+
+    1. ``{alias}project_id = {{entity_param}}`` -- the raw-id space Linear's
+       catalog id lives in (a Linear project's catalog id IS its own
+       ``work_items.project_id``).
+    2. ``{alias}project_key = catalog_project_key`` -- the native-key space
+       Jira's catalog lives in (``providers/jira/normalize.py`` writes the
+       raw Jira key onto ``work_items.project_key``; the catalog's
+       ``project_key`` is that same raw key).
+    3. ``{alias}project_id = catalog_project_key`` -- GitLab's compatibility
+       arm (CHAOS-3380 round 3): GitLab's catalog id is an opaque, prefixed,
+       IMMUTABLE numeric id (never equal to any raw ``work_items`` column),
+       but ``work_items.project_id`` carries the raw, MUTABLE path for
+       every GitLab row regardless of when it was synced, and the catalog's
+       ``project_key`` carries that SAME current path -- so this arm is what
+       makes both historical (pre-CHAOS-3380) and freshly-synced GitLab rows
+       resolve identically, with no dependency on when a row was ingested.
+    """
+    return (
+        "ifNull(catalog_provider, '') != ''"
+        f" AND {alias}provider = catalog_provider"
+        f" AND ({alias}project_id = {{{entity_param}:String}}"
+        f" OR (catalog_project_key != '' AND {alias}project_key = catalog_project_key)"
+        f" OR (catalog_project_key != '' AND {alias}project_id = catalog_project_key))"
+    )

--- a/src/dev_health_ops/api/dev/_project_identity.py
+++ b/src/dev_health_ops/api/dev/_project_identity.py
@@ -73,6 +73,38 @@ def project_identity_match(alias: str = "", entity_param: str = "entity_id") -> 
        ``project_key`` carries that SAME current path -- so this arm is what
        makes both historical (pre-CHAOS-3380) and freshly-synced GitLab rows
        resolve identically, with no dependency on when a row was ingested.
+
+       ACCEPTED RESIDUAL RISK (CHAOS-3380 round 4, Codex HIGH -- draw-the-line
+       closure, not a fix): this arm matches on a MUTABLE value, so it can
+       cross-attribute. The window: project A is renamed/transferred off a
+       path; project B later claims that exact freed path; an OLD work item
+       from A, never resynced since the rename (so its own ``project_id``
+       still carries the vacated path), now satisfies this arm against B's
+       CURRENT ``project_key`` and reads as B's history. Requires a specific
+       provider-side event sequence (rename + reclaim + a stale, never-
+       resynced row) -- not reachable from any app write path, and not
+       something a request handler can trigger.
+       ``ask_dev_project_subject_oracle.py`` DISCLOSES a row that resolves
+       ONLY through this arm as ``kind="path_match_unverified"`` -- but that
+       is an offline diagnostic, read by nobody at query time. PRODUCTION
+       QUERIES (this predicate, live, inside every project-scoped fact arm
+       and ``PROJECT_REPOSITORIES_SQL``) ACCEPT such a match same as any
+       other; there is no query-time equivalent of the oracle's flag, and
+       adding one by failing closed on a path-only match would disable
+       GitLab project resolution entirely -- every GitLab work item is
+       path-only today, so "fail closed on path-only" and "fail closed on
+       GitLab" are the same statement. Two Codex rounds already ruled out
+       the alternatives at the query layer; this is not a candidate for a
+       fourth pass here. CHAOS-3383 (immutable numeric id threaded through
+       ``work_items.project_id`` itself, plus a backfill of existing rows)
+       is the filed, structural fix that retires this arm outright by
+       removing the mutable value it depends on; until it lands, this
+       residual is accepted and pinned by
+       ``tests/test_ask_dev_gitlab_project_subject_live.py::
+       test_path_reuse_cross_attribution_is_a_known_residual_until_chaos_3383``,
+       whose assertion is written to FAIL once CHAOS-3383 closes this gap --
+       forcing that implementer to consciously retire the pin rather than
+       leave a stale one behind.
     """
     return (
         "ifNull(catalog_provider, '') != ''"

--- a/src/dev_health_ops/api/dev/native_evidence.py
+++ b/src/dev_health_ops/api/dev/native_evidence.py
@@ -14,6 +14,7 @@ from typing import Any
 from dev_health_ops.api.queries.client import query_dicts
 from dev_health_ops.api.services.sync_coverage import STALE_FALLBACK_GRACE
 
+from ._project_identity import project_identity_cte, project_identity_match
 from .contracts import DevEvidenceRef, FreshnessState
 from .evidence_service import (
     EvidenceAvailability,
@@ -136,34 +137,49 @@ _SPECS: dict[str, _SourceSpec] = {
     "work_items": _SourceSpec(
         "work_items",
         _COMMON_KINDS | {EntityKind.PROJECT, EntityKind.ISSUE},
+        # CHAOS-3380 round 3 (Codex HIGH): the project match below joins
+        # through the SAME provider-aware identity CTE
+        # native_status_change.py uses (dev_health_ops.api.dev.
+        # _project_identity), rather than comparing work_items.project_id/
+        # project_key directly against the resolved entity id -- which can
+        # never match for any provider whose catalog id isn't the raw value
+        # work_items carries (Jira since CHAOS-3374, GitLab since CHAOS-3380).
+        # ``LEFT JOIN`` (not INNER): a project-identity miss must not blank
+        # out ISSUE/ORGANIZATION/REPOSITORY-scoped results this same spec
+        # also serves -- only the project arm's own predicate is gated
+        # (``ifNull(catalog_provider, '') != ''`` inside project_identity_match).
         f"""
+        WITH {project_identity_cte()}
         SELECT work_item_id AS entity_id, title AS display_label,
                concat('Status: ', status, '. ', ifNull(description, '')) AS excerpt,
                provider AS provenance, updated_at AS observed_at,
                last_synced, toString(repo_id) AS repository_id,
                url AS source_url, 0 AS deleted, 1.0 AS confidence
         FROM work_items FINAL
+        LEFT JOIN project ON 1 = 1
         WHERE org_id = {{org_id:String}}
           AND updated_at >= {{start:DateTime64(3, 'UTC')}}
           AND updated_at < {{end:DateTime64(3, 'UTC')}}
           AND ({_search_predicate(("work_item_id", "title", "description", "status"))})
           AND (empty({{repository_ids:Array(String)}}) OR toString(repo_id) IN {{repository_ids:Array(String)}})
           AND ({{entity_id:String}} = '' OR work_item_id = {{entity_id:String}}
-               OR project_id = {{entity_id:String}} OR project_key = {{entity_id:String}})
+               OR ({project_identity_match()}))
         ORDER BY updated_at DESC, work_item_id
         LIMIT {{limit:UInt32}}
         """,
-        """
+        f"""
+        WITH {project_identity_cte("scope_entity_id")}
         SELECT work_item_id AS entity_id, title AS display_label,
                concat('Status: ', status, '. ', ifNull(description, '')) AS excerpt,
                provider AS provenance, updated_at AS observed_at,
                last_synced, toString(repo_id) AS repository_id,
                url AS source_url, 0 AS deleted, 1.0 AS confidence
         FROM work_items FINAL
-        WHERE org_id = {org_id:String} AND work_item_id = {entity_id:String}
-          AND (empty({repository_ids:Array(String)}) OR toString(repo_id) IN {repository_ids:Array(String)})
-          AND ({scope_entity_id:String} = '' OR work_item_id = {scope_entity_id:String}
-               OR project_id = {scope_entity_id:String} OR project_key = {scope_entity_id:String})
+        LEFT JOIN project ON 1 = 1
+        WHERE org_id = {{org_id:String}} AND work_item_id = {{entity_id:String}}
+          AND (empty({{repository_ids:Array(String)}}) OR toString(repo_id) IN {{repository_ids:Array(String)}})
+          AND ({{scope_entity_id:String}} = '' OR work_item_id = {{scope_entity_id:String}}
+               OR ({project_identity_match(entity_param="scope_entity_id")}))
         ORDER BY last_synced DESC LIMIT 1
         """,
     ),

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -23,6 +23,10 @@ from dev_health_ops.api.graphql.resolvers._membership_run_scope import (
 )
 from dev_health_ops.api.queries.client import query_dicts
 
+from ._project_identity import (
+    project_identity_cte,
+    project_identity_match,
+)
 from .contracts import ClaimKind, DevScope, DirectScope, FreshnessState
 from .native_evidence import (
     SourceFreshnessPolicy,
@@ -184,14 +188,48 @@ LIMIT {{limit:UInt32}}
 #: ``team_autoimport_gitlab.py``'s catalog ``id`` is GitLab's own IMMUTABLE
 #: numeric project id, prefixed like Jira's (``f"{org_id}:gitlab:{numeric_id}"``);
 #: ``project_key`` carries the CURRENT ``path_with_namespace``, refreshed on
-#: every discovery run. ``providers/gitlab/normalize.py`` writes that SAME
-#: current path onto ``work_items.project_key`` (not just ``project_id``, as
-#: of the same change) -- so a GitLab project resolves through the
-#: ``project_key`` arm, never the plain ``project_id = {entity_id:String}``
-#: one (the entity id is the prefixed numeric id, never equal to any raw
-#: ``work_items.project_id``, which stays the path). The provider guard keeps
-#: a same-org, same-string GitLab path from being answered by another
-#: provider's catalog row (or vice versa) if the two ever coincided.
+#: every discovery run.
+#:
+#: CHAOS-3380 round 3 (Codex HIGH -- incremental sync strands historical
+#: GitLab rows): unlike Jira, ``providers/gitlab/normalize.py`` does NOT
+#: write anything onto ``work_items.project_key`` -- it stays empty for
+#: EVERY GitLab row, old and new alike (an earlier revision of this comment
+#: had normalize.py mirror the path onto ``project_key`` too; reverted --
+#: pointless once the arm below exists, and it would have made "did this row
+#: sync after the cutover" a THIRD identity dimension for no reason).
+#: ``work_items.project_id`` is, and always has been, the raw path for every
+#: GitLab issue/MR row regardless of when it was synced -- ``updated_after``
+#: incremental syncs never rewrite a row that has not itself changed, so
+#: "before this ticket" and "after" rows are IDENTICAL in shape. The two arms
+#: above (raw id match, key-to-key match) both miss this: GitLab's entity id
+#: is prefixed (never equals any raw ``project_id``) and its ``project_key``
+#: is always empty (never satisfies ``catalog_project_key != ''`` on its own
+#: side). A THIRD arm closes it: ``{alias}project_id = catalog_project_key``
+#: (guarded by the same ``catalog_project_key != ''``) -- the work item's raw
+#: path against the catalog's CURRENT path, independent of when the row was
+#: synced. Provider-guarded like the other two, so it cannot cross-match:
+#: a Jira row's ``project_id`` is always empty (``providers/jira/normalize``
+#: never sets it), so it can never equal a non-empty ``catalog_project_key``;
+#: a Linear native project row's ``project_key`` is empty (this arm is a
+#: no-op for it), but a Linear TEAM-derived catalog row's ``project_key`` IS
+#: a real value (the team key) -- this arm still cannot false-match it in
+#: practice, since no Linear work item's ``project_id`` (Linear's own project
+#: UUID) is ever going to literally equal a short team-key string, but the
+#: claim "Linear's project_key is always empty" from the previous revision of
+#: this comment was not true of every catalog row Linear writes, only the
+#: native-project ones -- corrected here rather than left as a latent false
+#: assumption (see ``ask_dev_project_subject_oracle.py`` for where believing
+#: it uncritically actually mattered).
+#:
+#: ``_project_identity_cte``/``_project_identity_match`` both take an
+#: ``entity_param`` (default ``"entity_id"``, this module's own parameter
+#: name everywhere below) so ``native_evidence.py`` can reuse the EXACT same
+#: predicate text keyed off ITS OWN differently-named scope parameter
+#: (``scope_entity_id``) instead of hand-copying a variant that could drift
+#: (CHAOS-3380 round 3, Codex HIGH -- native_evidence project search/expand
+#: compared work_items directly against a prefixed catalog id and could never
+#: match a real row for any provider using the prefixed-id model, not just
+#: GitLab).
 #:
 #: ``LEFT JOIN`` (every arm that also serves 'issue'/'work_unit'/'team'/
 #: 'organization'/'repository' scope types): a project-identity lookup miss must
@@ -227,32 +265,23 @@ LIMIT {{limit:UInt32}}
 #:    than assumed from ``FINAL`` alone, since retirement is a data state
 #:    (``is_active``), not a version-ordering property ``FINAL`` enforces on
 #:    its own.
-_PROJECT_IDENTITY_CTE = """project AS (
-  SELECT any(provider) AS catalog_provider,
-         any(ifNull(project_key, '')) AS catalog_project_key
-  FROM projects FINAL
-  WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
-  HAVING count() = 1
-)"""
+#: Both helpers live in ``_project_identity.py`` (CHAOS-3380 round 3) so
+#: ``native_evidence.py`` can reuse them without a circular import (this
+#: module already imports FROM ``native_evidence.py``). Re-exported here
+#: under their historical private names -- every internal usage below, and
+#: the test assertions against ``native_status_change._PROJECT_IDENTITY_CTE``
+#: / ``native_status_change._project_identity_match``, keep working
+#: unchanged.
+_project_identity_cte = project_identity_cte
+_project_identity_match = project_identity_match
 
-
-def _project_identity_match(alias: str = "") -> str:
-    """Provider + native-key aware match against a work_items-shaped row.
-
-    ``alias`` is the table prefix (e.g. ``"item."``, ``"blocked."``) for a joined
-    reference; ``""`` for a bare, unaliased ``work_items`` FROM. Every
-    project-scoped arm splices this EXACT text (never a hand-copied variant),
-    joined against ``_PROJECT_IDENTITY_CTE`` as ``project``, so the derivation
-    (``PROJECT_REPOSITORIES_SQL``) can never admit a repository the fact queries
-    it bounds would not themselves draw from -- pinned by
-    ``test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do``.
-    """
-    return (
-        "ifNull(catalog_provider, '') != ''"
-        f" AND {alias}provider = catalog_provider"
-        f" AND ({alias}project_id = {{entity_id:String}}"
-        f" OR (catalog_project_key != '' AND {alias}project_key = catalog_project_key))"
-    )
+#: The default-parameterized text, used verbatim by every arm in THIS module
+#: (all of which key off ``{entity_id:String}``) -- a plain string constant so
+#: existing ``_PROJECT_IDENTITY_CTE + "..."`` splices and ``in`` assertions
+#: keep working unchanged. ``native_evidence.py`` calls
+#: ``project_identity_cte("scope_entity_id")`` directly instead, for its own
+#: differently-named parameter.
+_PROJECT_IDENTITY_CTE = _project_identity_cte()
 
 
 def _project_scope_arm(alias: str = "") -> str:

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -177,14 +177,21 @@ LIMIT {{limit:UInt32}}
 #: real ``work_items`` column -- CHAOS-3374 requires this explicitly: GitLab's own
 #: ``work_items.project_id`` is a bare repo full path, e.g. "group/project", which
 #: could otherwise coincidentally equal another provider's project id/key string in
-#: the same org). CHAOS-3380 is that case made real: ``team_autoimport_gitlab.py``
-#: now calls ``write_projects`` with ``id`` set to the RAW ``path_with_namespace``
-#: (the same value space as ``work_items.project_id``, mirroring Linear's raw-id
-#: catalog rows rather than Jira's prefixed one) and ``project_key`` always
-#: ``None`` -- so a GitLab project resolves through the plain ``project_id =
-#: {entity_id:String}`` arm above, and the provider guard is what keeps a
-#: same-org, same-string GitLab path from being answered by another provider's
-#: catalog row (or vice versa) if the two ever coincided.
+#: the same org). CHAOS-3380 is that case made real, and (round 2, Codex HIGH)
+#: mints the catalog identity Jira-style rather than Linear-style for exactly
+#: the reason this paragraph names: a GitLab project's PATH is mutable
+#: (rename, group transfer) while Linear's/Jira's own ids are not.
+#: ``team_autoimport_gitlab.py``'s catalog ``id`` is GitLab's own IMMUTABLE
+#: numeric project id, prefixed like Jira's (``f"{org_id}:gitlab:{numeric_id}"``);
+#: ``project_key`` carries the CURRENT ``path_with_namespace``, refreshed on
+#: every discovery run. ``providers/gitlab/normalize.py`` writes that SAME
+#: current path onto ``work_items.project_key`` (not just ``project_id``, as
+#: of the same change) -- so a GitLab project resolves through the
+#: ``project_key`` arm, never the plain ``project_id = {entity_id:String}``
+#: one (the entity id is the prefixed numeric id, never equal to any raw
+#: ``work_items.project_id``, which stays the path). The provider guard keeps
+#: a same-org, same-string GitLab path from being answered by another
+#: provider's catalog row (or vice versa) if the two ever coincided.
 #:
 #: ``LEFT JOIN`` (every arm that also serves 'issue'/'work_unit'/'team'/
 #: 'organization'/'repository' scope types): a project-identity lookup miss must

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -177,11 +177,14 @@ LIMIT {{limit:UInt32}}
 #: real ``work_items`` column -- CHAOS-3374 requires this explicitly: GitLab's own
 #: ``work_items.project_id`` is a bare repo full path, e.g. "group/project", which
 #: could otherwise coincidentally equal another provider's project id/key string in
-#: the same org). GitLab does not populate ``projects`` today -- no ``write_projects``
-#: call anywhere in ``workers/team_autoimport_gitlab.py`` (audited separately,
-#: CHAOS-3374) -- so a GitLab project subject remains unresolvable at scope-commit
-#: time and never reaches these queries at all; the provider guard here is defense
-#: in depth for whenever that lands, not a fix for an observed GitLab collision.
+#: the same org). CHAOS-3380 is that case made real: ``team_autoimport_gitlab.py``
+#: now calls ``write_projects`` with ``id`` set to the RAW ``path_with_namespace``
+#: (the same value space as ``work_items.project_id``, mirroring Linear's raw-id
+#: catalog rows rather than Jira's prefixed one) and ``project_key`` always
+#: ``None`` -- so a GitLab project resolves through the plain ``project_id =
+#: {entity_id:String}`` arm above, and the provider guard is what keeps a
+#: same-org, same-string GitLab path from being answered by another provider's
+#: catalog row (or vice versa) if the two ever coincided.
 #:
 #: ``LEFT JOIN`` (every arm that also serves 'issue'/'work_unit'/'team'/
 #: 'organization'/'repository' scope types): a project-identity lookup miss must

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -29,6 +29,14 @@ logger = logging.getLogger(__name__)
 # calls; cap the walk and log when results are truncated.
 MAX_GITLAB_DISCOVERY_SUBGROUPS = 500
 MAX_GITLAB_DISCOVERY_PROJECTS = 500
+#: CHAOS-3380 (Codex HIGH round 2): the project catalog walk below is a
+#: SEPARATE, flatter enumeration from the per-group ``MAX_GITLAB_DISCOVERY_
+#: PROJECTS`` walk above (which the ``teams``/``repo_patterns`` walk still
+#: uses, unchanged) -- it lists every project under the ENTIRE root group
+#: tree, including grandchild subgroups, in one paginated call
+#: (``include_subgroups=True``), so it needs its own, larger bound rather
+#: than reusing the per-group one.
+MAX_GITLAB_DISCOVERY_ALL_PROJECTS = 5000
 
 
 def _bounded_list(
@@ -58,16 +66,48 @@ def _bounded_list(
     return items
 
 
+@dataclass(frozen=True)
+class GitLabDiscoveredProject:
+    """One GitLab project as returned by a group's project LISTING call.
+
+    CHAOS-3380: sourced entirely from the listing response (``GET /groups/
+    :id/projects``, which GitLab's API documents as returning the same rich
+    project representation the single-project ``GET /projects/:id`` does --
+    ``id``, ``path_with_namespace``, ``name``, ``archived``, and ``web_url``
+    are all present on it), never from a per-project follow-up GET -- see
+    ``discover_gitlab``'s ``include_subgroups=True`` listing call below.
+
+    ``id`` is GitLab's own IMMUTABLE numeric project id (as a string) --
+    ``sync/discovery.py``'s ``_map_gitlab_tuple`` already documents this as
+    "the canonical GitLab identifier" and keys ``IntegrationSource.
+    external_id`` on it. ``path_with_namespace`` is the CURRENT, MUTABLE
+    slug -- renaming or transferring a project changes it without changing
+    ``id``.
+    """
+
+    id: str
+    path_with_namespace: str
+    name: str
+    archived: bool
+    web_url: str
+
+
 @dataclass
 class GitLabDiscoveryResult:
     """Outcome of a GitLab team discovery walk.
 
     ``truncated`` is True when any subgroup/project listing hit the discovery
-    pagination bound, meaning ``teams`` (or their ``repo_patterns``) are a
-    partial view; ``warnings`` carries the human-readable details.
+    pagination bound (either the per-group ``teams`` walk or the flat
+    ``projects`` walk below), meaning ``teams`` (or their ``repo_patterns``)
+    or ``projects`` are a partial view; ``warnings`` carries the
+    human-readable details.
     """
 
     teams: list[DiscoveredTeam]
+    #: CHAOS-3380. Additive: existing callers (``api/admin/routers/teams.py``,
+    #: ``workers/team_drift_sync.py``) read only ``teams``/``truncated``/
+    #: ``warnings`` and are unaffected by this new field.
+    projects: list[GitLabDiscoveredProject] = field(default_factory=list)
     truncated: bool = False
     warnings: list[str] = field(default_factory=list)
 
@@ -155,11 +195,33 @@ class TeamDiscoveryService:
         group_path: str,
         url: str = "https://gitlab.com",
     ) -> GitLabDiscoveryResult:
-        """Discover groups/subgroups from GitLab.
+        """Discover groups/subgroups (as teams) and projects from GitLab.
 
         Returns a :class:`GitLabDiscoveryResult`; ``truncated`` is set when
-        the subgroup/project walk hit the discovery pagination bounds, so
-        callers can tell a partial import apart from a complete one.
+        any walk below hit its discovery pagination bound, so callers can
+        tell a partial import apart from a complete one.
+
+        Two SEPARATE walks, deliberately not unified (CHAOS-3380, Codex HIGH
+        round 2):
+
+        * ``teams`` -- root + DIRECT subgroups only (unchanged from before
+          CHAOS-3380), each carrying its OWN ``projects.list()`` page as
+          ``repo_patterns``. Existing behavior for existing callers
+          (``api/admin/routers/teams.py``, ``workers/team_drift_sync.py``,
+          and this worker's OWN ``_project_ownership_rows``) is preserved
+          byte-for-byte -- this walk still misses grandchild subgroups, a
+          PRE-EXISTING limitation this change does not touch or expand the
+          blast radius of.
+        * ``projects`` -- the full project catalog CHAOS-3380 needs, listed
+          in ONE recursive, paginated call via ``include_subgroups=True``
+          (a real, documented ``GroupProjectManager`` list filter --
+          ``gitlab/v4/objects/projects.py``'s ``GroupProjectManager.
+          _list_filters`` includes it) against the ROOT group only. This
+          covers grandchildren and below with no manual subgroup recursion,
+          and reads project metadata (``id``, ``path_with_namespace``,
+          ``name``, ``archived``, ``web_url``) straight off the listing
+          response -- no per-project follow-up GET, so no N+1 fan-out
+          regardless of how many projects a large install has.
         """
 
         def _discover() -> GitLabDiscoveryResult:
@@ -203,8 +265,31 @@ class TeamDiscoveryService:
                     )
                 )
 
+            all_projects_raw = _bounded_list(
+                root_group.projects.list(
+                    include_subgroups=True, per_page=100, iterator=True
+                ),
+                MAX_GITLAB_DISCOVERY_ALL_PROJECTS,
+                what="projects (including all subgroups)",
+                scope=group_path,
+                warnings=warnings,
+            )
+            projects = [
+                GitLabDiscoveredProject(
+                    id=str(project_id),
+                    path_with_namespace=str(path),
+                    name=str(getattr(raw, "name", "") or path),
+                    archived=bool(getattr(raw, "archived", False)),
+                    web_url=str(getattr(raw, "web_url", "") or ""),
+                )
+                for raw in all_projects_raw
+                if (project_id := getattr(raw, "id", None)) is not None
+                and (path := (getattr(raw, "path_with_namespace", "") or "")).strip()
+            ]
+
             return GitLabDiscoveryResult(
                 teams=teams,
+                projects=projects,
                 truncated=bool(warnings),
                 warnings=warnings,
             )

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -167,7 +167,16 @@ def gitlab_issue_to_work_item(
         provider="gitlab",
         repo_id=repo_id,
         native_team_key=None,
-        project_key=None,
+        # CHAOS-3380 round 2: the SAME current project path as project_id
+        # below, not a distinct key. GitLab has no separate "project key"
+        # concept -- this exists so the project subject catalog
+        # (workers/team_autoimport_gitlab.py, whose catalog id is GitLab's
+        # immutable numeric project id, not this mutable path) can resolve
+        # via native_status_change._project_identity_match's project_key
+        # arm, matching a catalog row by CURRENT path rather than by an id
+        # space this column was never in. None when project_full_path is
+        # unavailable (mirrors project_id's own fallback below).
+        project_key=str(project_full_path) if project_full_path else None,
         # For work tracking metrics, treat the GitLab project path as the "project" scope.
         project_id=str(project_full_path)
         if project_full_path
@@ -324,7 +333,9 @@ def gitlab_mr_to_work_item(
         provider="gitlab",
         repo_id=repo_id,
         native_team_key=None,
-        project_key=None,
+        # CHAOS-3380 round 2: see gitlab_issue_to_work_item's identical field
+        # for why this mirrors project_id rather than staying None.
+        project_key=str(project_full_path) if project_full_path else None,
         project_id=str(project_full_path) if project_full_path else None,
         title=str(title),
         description=str(description) if description else None,

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -167,16 +167,14 @@ def gitlab_issue_to_work_item(
         provider="gitlab",
         repo_id=repo_id,
         native_team_key=None,
-        # CHAOS-3380 round 2: the SAME current project path as project_id
-        # below, not a distinct key. GitLab has no separate "project key"
-        # concept -- this exists so the project subject catalog
-        # (workers/team_autoimport_gitlab.py, whose catalog id is GitLab's
-        # immutable numeric project id, not this mutable path) can resolve
-        # via native_status_change._project_identity_match's project_key
-        # arm, matching a catalog row by CURRENT path rather than by an id
-        # space this column was never in. None when project_full_path is
-        # unavailable (mirrors project_id's own fallback below).
-        project_key=str(project_full_path) if project_full_path else None,
+        # GitLab has no separate "project key" concept -- project_id (below)
+        # carries the raw path, which is ALL the project subject catalog
+        # (workers/team_autoimport_gitlab.py, CHAOS-3380) needs: its identity
+        # match's compatibility arm (native_status_change._project_identity_
+        # match) compares this row's project_id directly against the
+        # catalog's CURRENT path, so nothing about work_items -- old rows or
+        # new -- ever needs to change for that join to resolve.
+        project_key=None,
         # For work tracking metrics, treat the GitLab project path as the "project" scope.
         project_id=str(project_full_path)
         if project_full_path
@@ -333,9 +331,9 @@ def gitlab_mr_to_work_item(
         provider="gitlab",
         repo_id=repo_id,
         native_team_key=None,
-        # CHAOS-3380 round 2: see gitlab_issue_to_work_item's identical field
-        # for why this mirrors project_id rather than staying None.
-        project_key=str(project_full_path) if project_full_path else None,
+        # See gitlab_issue_to_work_item's identical field for why this stays
+        # None rather than mirroring project_id.
+        project_key=None,
         project_id=str(project_full_path) if project_full_path else None,
         title=str(title),
         description=str(description) if description else None,

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -21,10 +21,12 @@ from dev_health_ops.api.services.configuration.team_membership import (
     TeamMembershipService,
 )
 from dev_health_ops.metrics.schemas import (
+    ProjectRecord,
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.gitlab.client import GitLabAuth, GitLabWorkClient
 from dev_health_ops.providers.identity import IdentityResolver, load_identity_resolver
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 from dev_health_ops.storage.clickhouse import ClickHouseStore
@@ -115,6 +117,37 @@ async def _populate_async(
     resolver = load_identity_resolver()
     team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
     project_rows = _project_ownership_rows(org_id=org_id, teams=teams, now=now)
+    # CHAOS-3380: import GitLab PROJECTS as their own catalog rows -- mirrors
+    # Linear's CHAOS-3365 native project import -- so a GitLab project name
+    # resolves as an Ask Dev subject. Kept independent of the ownership rows
+    # above: a metadata-fetch failure for one project must not discard team
+    # ownership, and vice versa.
+    native_project_rows: list[ProjectRecord] = []
+    native_projects_complete = True
+    project_paths = _unique_project_paths(teams)
+    if project_paths:
+        try:
+            native_project_rows, native_projects_complete = await asyncio.to_thread(
+                _gitlab_project_records,
+                org_id=org_id,
+                token=token,
+                url=url,
+                project_paths=project_paths,
+                now=now,
+                strict=strict,
+            )
+        except Exception as exc:
+            if strict:
+                raise
+            logger.warning(
+                "GitLab project catalog import failed for org_id=%s group=%s: %s",
+                org_id,
+                group_path,
+                exc,
+                exc_info=True,
+            )
+            native_project_rows = []
+            native_projects_complete = False
     membership_rows, _, observed_team_ids = await _membership_rows(
         org_id=org_id,
         token=token,
@@ -146,12 +179,22 @@ async def _populate_async(
     )
     sink.write_team_project_ownership(project_rows)
     sink.write_team_memberships(membership_rows)
+    catalog_projects = _dedupe_projects(native_project_rows)
+    if hasattr(sink, "write_projects"):
+        sink.write_projects(catalog_projects)
 
     summary: dict[str, Any] = {
         "teams_imported": len(team_rows),
         "reference_team_keys": [str(row["native_team_key"]) for row in team_rows],
         "reference_sprint_ids": [],
         "projects_imported": len({row.project_id for row in project_rows}),
+        # The Ask Dev subject catalog rows written via write_projects(), distinct
+        # from "projects_imported" above (team-ownership project paths).
+        "native_projects_imported": len(catalog_projects),
+        # False when GitLab project metadata fetch failed for at least one
+        # discovered project path -- so a partial catalog is never recorded as
+        # a full one (mirrors Linear's native_projects_complete).
+        "native_projects_complete": native_projects_complete,
         "members_imported": len({row.member_id for row in membership_rows}),
         "team_memberships_imported": len(membership_rows),
         "team_project_ownership_imported": len(project_rows),
@@ -259,6 +302,108 @@ def _project_ownership_rows(
                 )
             )
     return rows
+
+
+def _unique_project_paths(teams: Iterable[Any]) -> list[str]:
+    """The distinct GitLab project full paths discovered across every team.
+
+    Each ``DiscoveredTeam`` from ``discover_gitlab`` carries its OWN group's
+    projects in ``associations["repo_patterns"]`` (``team_discovery.
+    discover_gitlab``: ``repo_patterns = [p.path_with_namespace for p in
+    projects]``) -- the same walk that already backs
+    ``_project_ownership_rows``. Reusing it here (rather than re-walking
+    groups/subgroups a second time) means the project catalog covers exactly
+    the projects team ownership already resolved, order-preserving so the
+    metadata fetch below is deterministic across runs.
+    """
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        for path in _strings(associations.get("repo_patterns")):
+            if path not in seen:
+                seen.add(path)
+                ordered.append(path)
+    return ordered
+
+
+def _gitlab_project_records(
+    *,
+    org_id: str,
+    token: str,
+    url: str,
+    project_paths: Iterable[str],
+    now: datetime,
+    strict: bool,
+) -> tuple[list[ProjectRecord], bool]:
+    """Fetch GitLab project metadata for the Ask Dev subject catalog.
+
+    ``id`` is the RAW ``path_with_namespace`` requested -- deliberately the
+    SAME string ``providers/gitlab/normalize.gitlab_issue_to_work_item`` and
+    ``gitlab_mr_to_work_item`` write onto ``work_items.project_id``
+    (normalize.py: "For work tracking metrics, treat the GitLab project path
+    as the 'project' scope.") -- so a scope committed against one of these
+    rows selects work items with no query change, exactly like Linear's
+    raw-id catalog rows (``_linear_project_records``). The id is the path we
+    ASKED for, not ``project.path_with_namespace`` off the response: a
+    renamed project can still resolve its old path via GitLab's redirect,
+    which would otherwise mint a catalog row under a path no work item was
+    ever attributed to.
+
+    ``project_key`` is always ``None``: GitLab work items never set
+    ``project_key`` (normalize.py sets it to ``None`` for issues, merge
+    requests, and epics alike) -- so the identity join
+    (``native_status_change._project_identity_match``, CHAOS-3374) can only
+    ever resolve a GitLab project through the raw ``project_id`` arm, never
+    through the ``project_key`` arm.
+
+    Only what GitLab's project resource genuinely exposes is mapped:
+    ``archived`` retires the row (mirrors Linear's archived/trashed --
+    CHAOS-3372's absence-based retirement remains explicitly out of scope,
+    so a project that stops being discovered keeps its last-seen state
+    rather than being tombstoned), and ``web_url`` is the URL. GitLab
+    projects carry no lifecycle vocabulary beyond archived and no target
+    date, so ``state``/``target_date`` are left at their empty defaults
+    rather than inventing values.
+    """
+
+    client = GitLabWorkClient(auth=GitLabAuth(token=token, base_url=url), org_id=org_id)
+    rows: list[ProjectRecord] = []
+    complete = True
+    for path in project_paths:
+        try:
+            project = client.get_project(path)
+        except Exception as exc:
+            complete = False
+            if strict:
+                raise
+            logger.info(
+                "Skipping GitLab project catalog row for org_id=%s path=%s: %s",
+                org_id,
+                path,
+                exc,
+            )
+            continue
+        archived = bool(getattr(project, "archived", False))
+        rows.append(
+            ProjectRecord(
+                id=path,
+                org_id=org_id,
+                provider=PROVIDER,
+                project_key=None,
+                name=str(getattr(project, "name", None) or path),
+                is_active=0 if archived else 1,
+                updated_at=now,
+                last_synced=now,
+                url=str(getattr(project, "web_url", "") or ""),
+            )
+        )
+    return rows, complete
+
+
+def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:
+    return list({(row.org_id, row.provider, row.id): row for row in rows}.values())
 
 
 async def _membership_rows(

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.services.configuration.clickhouse_team_drift_projector i
     project_team_rows_with_store,
 )
 from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveredProject,
     TeamDiscoveryService,
 )
 from dev_health_ops.api.services.configuration.team_membership import (
@@ -26,7 +27,6 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.providers.gitlab.client import GitLabAuth, GitLabWorkClient
 from dev_health_ops.providers.identity import IdentityResolver, load_identity_resolver
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 from dev_health_ops.storage.clickhouse import ClickHouseStore
@@ -119,35 +119,46 @@ async def _populate_async(
     project_rows = _project_ownership_rows(org_id=org_id, teams=teams, now=now)
     # CHAOS-3380: import GitLab PROJECTS as their own catalog rows -- mirrors
     # Linear's CHAOS-3365 native project import -- so a GitLab project name
-    # resolves as an Ask Dev subject. Kept independent of the ownership rows
-    # above: a metadata-fetch failure for one project must not discard team
-    # ownership, and vice versa.
-    native_project_rows: list[ProjectRecord] = []
-    native_projects_complete = True
-    project_paths = _unique_project_paths(teams)
-    if project_paths:
-        try:
-            native_project_rows, native_projects_complete = await asyncio.to_thread(
-                _gitlab_project_records,
-                org_id=org_id,
-                token=token,
-                url=url,
-                project_paths=project_paths,
-                now=now,
-                strict=strict,
-            )
-        except Exception as exc:
-            if strict:
-                raise
-            logger.warning(
-                "GitLab project catalog import failed for org_id=%s group=%s: %s",
-                org_id,
-                group_path,
-                exc,
-                exc_info=True,
-            )
-            native_project_rows = []
-            native_projects_complete = False
+    # resolves as an Ask Dev subject. Sourced entirely from ``result.projects``
+    # (the flat, recursive listing ``discover_gitlab`` already fetched -- no
+    # separate network call here, so nothing in this block can fail on its
+    # own; a total discovery failure is already handled by the try/except
+    # around ``discover_gitlab`` above).
+    #
+    # CHAOS-3380 round 2 (Codex MEDIUM): a sync run only ever SYNCS the
+    # projects its enabled ``IntegrationSource`` rows selected, but discovery
+    # can see (and, before this filter, would catalog) every project the
+    # credential has read access to -- an unselected project would become a
+    # resolvable Ask Dev subject with retained-but-unsynced work items
+    # queryable through it. ``source_external_ids`` (populated by the
+    # reference-discovery scope, ``workers/reference_discovery.py``
+    # ``_load_discovery_context``) carries exactly the enabled sources'
+    # ``IntegrationSource.external_id`` values -- GitLab's numeric project id
+    # (``sync/discovery.py._map_gitlab_tuple``'s own docstring: "the
+    # canonical GitLab identifier"), the SAME id this worker mints the
+    # catalog row's id from. When present, only discovered projects whose
+    # numeric id is in that set are cataloged.
+    #
+    # Residual gap, reported rather than silently left: the more common
+    # POST-SYNC trigger (``workers/team_autoimport.py.
+    # run_post_sync_team_autoimport``) does not thread ``source_external_ids``
+    # into scope today, so this filter is a no-op on that path -- closing it
+    # there needs a change to that SHARED dispatcher (all 4 providers), out
+    # of this ticket's scope.
+    source_external_ids = _source_external_ids(scope)
+    native_project_rows = _gitlab_project_catalog_rows(
+        org_id=org_id,
+        projects=result.projects,
+        source_external_ids=source_external_ids,
+        now=now,
+    )
+    native_projects_filtered_by_selection = len(result.projects) - len(
+        native_project_rows
+    )
+    # Truncation on EITHER walk (teams/repo_patterns or the flat projects
+    # listing) means the catalog this run wrote may be a partial view -- a
+    # partial catalog must never be recorded as a complete one.
+    native_projects_complete = not result.truncated
     membership_rows, _, observed_team_ids = await _membership_rows(
         org_id=org_id,
         token=token,
@@ -191,10 +202,15 @@ async def _populate_async(
         # The Ask Dev subject catalog rows written via write_projects(), distinct
         # from "projects_imported" above (team-ownership project paths).
         "native_projects_imported": len(catalog_projects),
-        # False when GitLab project metadata fetch failed for at least one
-        # discovered project path -- so a partial catalog is never recorded as
-        # a full one (mirrors Linear's native_projects_complete).
+        # False when either discovery walk (teams or the flat projects
+        # listing) hit its pagination bound -- so a partial catalog is never
+        # recorded as a full one (mirrors Linear's native_projects_complete).
         "native_projects_complete": native_projects_complete,
+        # Discovered-but-uncataloged projects, almost entirely from the
+        # source-selection filter above (a malformed listing entry is
+        # already dropped inside discover_gitlab itself). Observability for
+        # the intersection, not a correctness signal on its own.
+        "native_projects_filtered_by_selection": native_projects_filtered_by_selection,
         "members_imported": len({row.member_id for row in membership_rows}),
         "team_memberships_imported": len(membership_rows),
         "team_project_ownership_imported": len(project_rows),
@@ -304,102 +320,102 @@ def _project_ownership_rows(
     return rows
 
 
-def _unique_project_paths(teams: Iterable[Any]) -> list[str]:
-    """The distinct GitLab project full paths discovered across every team.
+def _project_id(org_id: str, provider: str, native_id: str) -> str:
+    return f"{org_id}:{provider}:{native_id}"
 
-    Each ``DiscoveredTeam`` from ``discover_gitlab`` carries its OWN group's
-    projects in ``associations["repo_patterns"]`` (``team_discovery.
-    discover_gitlab``: ``repo_patterns = [p.path_with_namespace for p in
-    projects]``) -- the same walk that already backs
-    ``_project_ownership_rows``. Reusing it here (rather than re-walking
-    groups/subgroups a second time) means the project catalog covers exactly
-    the projects team ownership already resolved, order-preserving so the
-    metadata fetch below is deterministic across runs.
+
+def _source_external_ids(scope: Mapping[str, Any]) -> set[str] | None:
+    """The enabled ``IntegrationSource.external_id`` set for this sync run.
+
+    ``None`` (not an empty set) means "not scoped" -- catalog everything
+    discovery can see, today's behavior for the common post-sync trigger
+    path, which does not populate this key at all (see the caller's own
+    comment). An explicit empty list, in contrast, means the reference-
+    discovery scope enumerated zero enabled sources -- filter everything out,
+    not everything in.
     """
 
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for team in teams:
-        associations = _mapping(getattr(team, "associations", None))
-        for path in _strings(associations.get("repo_patterns")):
-            if path not in seen:
-                seen.add(path)
-                ordered.append(path)
-    return ordered
+    raw = scope.get("source_external_ids")
+    if raw is None:
+        return None
+    return {str(value) for value in raw if str(value).strip()}
 
 
-def _gitlab_project_records(
+def _gitlab_project_catalog_rows(
     *,
     org_id: str,
-    token: str,
-    url: str,
-    project_paths: Iterable[str],
+    projects: Iterable[GitLabDiscoveredProject],
+    source_external_ids: set[str] | None,
     now: datetime,
-    strict: bool,
-) -> tuple[list[ProjectRecord], bool]:
-    """Fetch GitLab project metadata for the Ask Dev subject catalog.
+) -> list[ProjectRecord]:
+    """Map discovered GitLab projects to Ask Dev subject catalog rows.
 
-    ``id`` is the RAW ``path_with_namespace`` requested -- deliberately the
-    SAME string ``providers/gitlab/normalize.gitlab_issue_to_work_item`` and
-    ``gitlab_mr_to_work_item`` write onto ``work_items.project_id``
-    (normalize.py: "For work tracking metrics, treat the GitLab project path
-    as the 'project' scope.") -- so a scope committed against one of these
-    rows selects work items with no query change, exactly like Linear's
-    raw-id catalog rows (``_linear_project_records``). The id is the path we
-    ASKED for, not ``project.path_with_namespace`` off the response: a
-    renamed project can still resolve its old path via GitLab's redirect,
-    which would otherwise mint a catalog row under a path no work item was
-    ever attributed to.
+    CHAOS-3380 round 2 (Codex HIGH -- mutable path as canonical identity):
+    ``id`` is GitLab's own IMMUTABLE numeric project id, prefixed like Jira's
+    catalog id (``team_autoimport_jira._project_id``) rather than raw like
+    Linear's -- because unlike Linear's project id, a GitLab project's PATH
+    is mutable (rename, group transfer) while its numeric id never changes.
+    ``project_key`` carries the CURRENT ``path_with_namespace`` instead, and
+    resolves through ``native_status_change._project_identity_match``'s
+    project_key arm: ``providers/gitlab/normalize.py``'s
+    ``gitlab_issue_to_work_item``/``gitlab_mr_to_work_item`` now write that
+    SAME current path onto ``work_items.project_key`` (a CHAOS-3380 round 2
+    change to that module too), so a scope committed against this row's id
+    selects work items via project_key equality, never via the plain
+    ``project_id = {entity_id}`` arm (which only ever matches a raw id in the
+    SAME space as the entity id -- GitLab's entity id is now the prefixed
+    numeric id, never equal to any ``work_items.project_id``, which stays the
+    path).
 
-    ``project_key`` is always ``None``: GitLab work items never set
-    ``project_key`` (normalize.py sets it to ``None`` for issues, merge
-    requests, and epics alike) -- so the identity join
-    (``native_status_change._project_identity_match``, CHAOS-3374) can only
-    ever resolve a GitLab project through the raw ``project_id`` arm, never
-    through the ``project_key`` arm.
+    Rename/transfer/reuse, made explicit rather than assumed correct:
 
-    Only what GitLab's project resource genuinely exposes is mapped:
-    ``archived`` retires the row (mirrors Linear's archived/trashed --
-    CHAOS-3372's absence-based retirement remains explicitly out of scope,
-    so a project that stops being discovered keeps its last-seen state
-    rather than being tombstoned), and ``web_url`` is the URL. GitLab
-    projects carry no lifecycle vocabulary beyond archived and no target
-    date, so ``state``/``target_date`` are left at their empty defaults
-    rather than inventing values.
+    * RENAME or TRANSFER (path changes, numeric id doesn't): the NEXT sync's
+      discovery reports the NEW path under the SAME numeric id, so this
+      function updates the SAME catalog row's ``project_key`` in place (a
+      new ReplacingMergeTree version, same ``(org_id, provider, id)`` key).
+      Work items already ingested under the OLD path (``project_key`` baked
+      in at ingestion time, and for GitLab the work_item_id itself is
+      path-derived -- ``f"gitlab:{path}#{iid}"`` -- a pre-existing,
+      out-of-scope characteristic of GitLab work-item identity) stop
+      matching this catalog row until the provider sync re-ingests them
+      under the new path. This ORPHANS old history rather than merging it
+      into anything -- the fail-safe direction Codex asked for -- at the
+      cost of a resolution gap until the next full provider sync catches
+      up; a smaller ticket than reconciling path aliases across a rename.
+    * PATH REUSE (an unrelated NEW project claims the exact string an OLD,
+      deleted project used to hold): the two mint DISTINCT catalog rows
+      (different numeric ids), so no two catalog rows ever collide. The
+      residual risk is at the WORK-ITEM level, not the catalog level: OLD
+      work items still on disk with the reused path baked into their own
+      ``project_key`` (from before the delete) would match the NEW catalog
+      row's ``project_key`` if they are never resynced -- because
+      ``work_items.project_key`` records what a path meant AT INGESTION
+      TIME, and nothing here rewrites historical rows when a path is
+      reassigned elsewhere. Closing this fully needs GitLab's immutable
+      numeric id threaded through ``work_items.project_id`` itself (not just
+      the catalog), a materially larger provider-identity change deferred
+      out of this ticket -- flagged for a follow-up rather than silently
+      left as an assumed non-issue.
     """
 
-    client = GitLabWorkClient(auth=GitLabAuth(token=token, base_url=url), org_id=org_id)
     rows: list[ProjectRecord] = []
-    complete = True
-    for path in project_paths:
-        try:
-            project = client.get_project(path)
-        except Exception as exc:
-            complete = False
-            if strict:
-                raise
-            logger.info(
-                "Skipping GitLab project catalog row for org_id=%s path=%s: %s",
-                org_id,
-                path,
-                exc,
-            )
+    for project in projects:
+        if source_external_ids is not None and project.id not in source_external_ids:
             continue
-        archived = bool(getattr(project, "archived", False))
         rows.append(
             ProjectRecord(
-                id=path,
+                id=_project_id(org_id, PROVIDER, project.id),
                 org_id=org_id,
                 provider=PROVIDER,
-                project_key=None,
-                name=str(getattr(project, "name", None) or path),
-                is_active=0 if archived else 1,
+                project_key=project.path_with_namespace,
+                name=project.name or project.path_with_namespace,
+                is_active=0 if project.archived else 1,
                 updated_at=now,
                 last_synced=now,
-                url=str(getattr(project, "web_url", "") or ""),
+                url=project.web_url,
             )
         )
-    return rows, complete
+    return rows
 
 
 def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -155,10 +155,28 @@ async def _populate_async(
     native_projects_filtered_by_selection = len(result.projects) - len(
         native_project_rows
     )
+    # CHAOS-3380 round 3 (Codex MEDIUM -- stale selected-source set reads as
+    # complete): the filter above only ever narrows discovered -> selected.
+    # A selected id that discovery did NOT return at all (the project was
+    # deleted/renamed out of reach, access was revoked, or discovery's own
+    # pagination bound was hit before reaching it) silently vanishes from
+    # the catalog with no signal -- a first import writes nothing for it, a
+    # re-import leaves whatever catalog row already existed stale, and
+    # neither was visible in native_projects_complete, which only reflected
+    # PAGINATION truncation, not a selected id going unaccounted for.
+    # Computed BEFORE writing, so the summary is honest about this run even
+    # though the (possibly partial) catalog write below still happens.
+    discovered_ids = {project.id for project in result.projects}
+    missing_selected_source_ids = (
+        sorted(source_external_ids - discovered_ids)
+        if source_external_ids is not None
+        else []
+    )
     # Truncation on EITHER walk (teams/repo_patterns or the flat projects
-    # listing) means the catalog this run wrote may be a partial view -- a
-    # partial catalog must never be recorded as a complete one.
-    native_projects_complete = not result.truncated
+    # listing), OR a selected source discovery never returned, means the
+    # catalog this run wrote may be a partial view -- a partial catalog must
+    # never be recorded as a complete one.
+    native_projects_complete = not result.truncated and not missing_selected_source_ids
     membership_rows, _, observed_team_ids = await _membership_rows(
         org_id=org_id,
         token=token,
@@ -203,7 +221,8 @@ async def _populate_async(
         # from "projects_imported" above (team-ownership project paths).
         "native_projects_imported": len(catalog_projects),
         # False when either discovery walk (teams or the flat projects
-        # listing) hit its pagination bound -- so a partial catalog is never
+        # listing) hit its pagination bound, OR a selected source id never
+        # showed up in discovery at all -- so a partial catalog is never
         # recorded as a full one (mirrors Linear's native_projects_complete).
         "native_projects_complete": native_projects_complete,
         # Discovered-but-uncataloged projects, almost entirely from the
@@ -211,6 +230,11 @@ async def _populate_async(
         # already dropped inside discover_gitlab itself). Observability for
         # the intersection, not a correctness signal on its own.
         "native_projects_filtered_by_selection": native_projects_filtered_by_selection,
+        # A selected IntegrationSource id discovery never returned -- the
+        # inverse gap from the filter above (selected but absent, not
+        # discovered but unselected). Surfaced by id so a caller can act on
+        # exactly which source is unaccounted for, not just a count.
+        "native_projects_missing_selected_source_ids": missing_selected_source_ids,
         "members_imported": len({row.member_id for row in membership_rows}),
         "team_memberships_imported": len(membership_rows),
         "team_project_ownership_imported": len(project_rows),
@@ -355,17 +379,21 @@ def _gitlab_project_catalog_rows(
     catalog id (``team_autoimport_jira._project_id``) rather than raw like
     Linear's -- because unlike Linear's project id, a GitLab project's PATH
     is mutable (rename, group transfer) while its numeric id never changes.
-    ``project_key`` carries the CURRENT ``path_with_namespace`` instead, and
-    resolves through ``native_status_change._project_identity_match``'s
-    project_key arm: ``providers/gitlab/normalize.py``'s
-    ``gitlab_issue_to_work_item``/``gitlab_mr_to_work_item`` now write that
-    SAME current path onto ``work_items.project_key`` (a CHAOS-3380 round 2
-    change to that module too), so a scope committed against this row's id
-    selects work items via project_key equality, never via the plain
-    ``project_id = {entity_id}`` arm (which only ever matches a raw id in the
-    SAME space as the entity id -- GitLab's entity id is now the prefixed
-    numeric id, never equal to any ``work_items.project_id``, which stays the
-    path).
+    ``project_key`` carries the CURRENT ``path_with_namespace`` instead.
+
+    CHAOS-3380 round 3 (Codex HIGH -- incremental sync strands historical
+    rows): a scope committed against this row's id resolves work items
+    through ``native_status_change._project_identity_match``'s compatibility
+    arm -- ``work_items.project_id = catalog.project_key`` -- NOT a
+    project_key-to-project_key match. ``providers/gitlab/normalize.py``
+    deliberately does NOT write anything onto ``work_items.project_key``
+    (stays empty, exactly as before this ticket); it never needed to, since
+    ``project_id`` already carries the raw path for every GitLab row, old and
+    new alike (an ``updated_after`` incremental sync never rewrites a row
+    that has not itself changed on the provider side). Comparing THAT
+    directly against this catalog row's current path is what makes rename
+    and incremental-sync history keep resolving without any change to
+    ``work_items`` at all -- see below.
 
     Rename/transfer/reuse, made explicit rather than assumed correct:
 
@@ -373,9 +401,9 @@ def _gitlab_project_catalog_rows(
       discovery reports the NEW path under the SAME numeric id, so this
       function updates the SAME catalog row's ``project_key`` in place (a
       new ReplacingMergeTree version, same ``(org_id, provider, id)`` key).
-      Work items already ingested under the OLD path (``project_key`` baked
+      Work items already ingested under the OLD path (``project_id`` baked
       in at ingestion time, and for GitLab the work_item_id itself is
-      path-derived -- ``f"gitlab:{path}#{iid}"`` -- a pre-existing,
+      ALSO path-derived -- ``f"gitlab:{path}#{iid}"`` -- a pre-existing,
       out-of-scope characteristic of GitLab work-item identity) stop
       matching this catalog row until the provider sync re-ingests them
       under the new path. This ORPHANS old history rather than merging it
@@ -387,15 +415,17 @@ def _gitlab_project_catalog_rows(
       (different numeric ids), so no two catalog rows ever collide. The
       residual risk is at the WORK-ITEM level, not the catalog level: OLD
       work items still on disk with the reused path baked into their own
-      ``project_key`` (from before the delete) would match the NEW catalog
+      ``project_id`` (from before the delete) would match the NEW catalog
       row's ``project_key`` if they are never resynced -- because
-      ``work_items.project_key`` records what a path meant AT INGESTION
+      ``work_items.project_id`` records what a path meant AT INGESTION
       TIME, and nothing here rewrites historical rows when a path is
       reassigned elsewhere. Closing this fully needs GitLab's immutable
       numeric id threaded through ``work_items.project_id`` itself (not just
       the catalog), a materially larger provider-identity change deferred
       out of this ticket -- flagged for a follow-up rather than silently
-      left as an assumed non-issue.
+      left as an assumed non-issue. (``ask_dev_project_subject_oracle.py``
+      surfaces this same residual risk explicitly, per-row, as the
+      ``"path_match_unverified"`` gap kind -- CHAOS-3380 round 3, MEDIUM 3.)
     """
 
     rows: list[ProjectRecord] = []

--- a/tests/api/admin/test_teams_discover_org_group.py
+++ b/tests/api/admin/test_teams_discover_org_group.py
@@ -19,6 +19,7 @@ import os
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -490,3 +491,136 @@ async def test_discover_gitlab_not_truncated_under_bound(monkeypatch):
     assert result.truncated is False
     assert result.warnings == []
     assert len(result.teams) == 1
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3380 round 2 (Codex HIGH): the flat, recursive project listing
+# ---------------------------------------------------------------------------
+
+
+def _projects_list_side_effect(
+    *, per_group: list[SimpleNamespace], flat: list[SimpleNamespace]
+):
+    """``group.projects.list(...)`` returns different pages depending on
+    ``include_subgroups`` -- exactly what a real GitLab server does: the
+    per-group teams walk asks for one group's own projects (no kwarg), the
+    new flat catalog walk asks for the whole tree (``include_subgroups=True``).
+    """
+
+    def _side_effect(*args: object, **kwargs: object) -> Any:
+        return iter(flat if kwargs.get("include_subgroups") else per_group)
+
+    return _side_effect
+
+
+@pytest.mark.asyncio
+async def test_discover_gitlab_projects_walk_reaches_grandchild_subgroups(
+    monkeypatch,
+):
+    """The teams walk (root + DIRECT subgroups only) cannot see a project
+    under a grandchild subgroup nested two levels down -- ``result.projects``
+    must, via the ``include_subgroups=True`` flat listing, with no manual
+    recursion into that grandchild subgroup at all.
+    """
+    from dev_health_ops.api.services.configuration import team_discovery as td
+
+    root_group = MagicMock()
+    root_group.full_path = "root"
+    root_group.name = "Root"
+    root_group.description = None
+    # No direct subgroups discovered -- the OLD walk would see only root's
+    # own direct projects.
+    root_group.subgroups.list.return_value = iter([])
+    root_group.projects.list.side_effect = _projects_list_side_effect(
+        per_group=[SimpleNamespace(path_with_namespace="root/direct")],
+        flat=[
+            SimpleNamespace(
+                id=1,
+                path_with_namespace="root/direct",
+                name="Direct",
+                archived=False,
+                web_url="https://gitlab.example/root/direct",
+            ),
+            # Lives under root/child/grandchild -- a subgroup the teams walk
+            # above never enumerated at all.
+            SimpleNamespace(
+                id=2,
+                path_with_namespace="root/child/grandchild/deep-project",
+                name="Deep Project",
+                archived=True,
+                web_url="https://gitlab.example/root/child/grandchild/deep-project",
+            ),
+        ],
+    )
+
+    fake_gl = MagicMock()
+    fake_gl.groups.get.return_value = root_group
+
+    with patch("gitlab.Gitlab", return_value=fake_gl):
+        svc = td.TeamDiscoveryService(None, ORG_ID)
+        result = await svc.discover_gitlab(token="t", group_path="root")
+
+    # The teams walk is UNCHANGED: only root's own direct project.
+    assert result.teams[0].associations["repo_patterns"] == ["root/direct"]
+    # The flat projects walk covers the grandchild-nested project too.
+    assert {p.path_with_namespace for p in result.projects} == {
+        "root/direct",
+        "root/child/grandchild/deep-project",
+    }
+    deep = next(
+        p
+        for p in result.projects
+        if p.path_with_namespace == "root/child/grandchild/deep-project"
+    )
+    assert deep.id == "2"
+    assert deep.archived is True
+    assert deep.web_url == "https://gitlab.example/root/child/grandchild/deep-project"
+
+
+@pytest.mark.asyncio
+async def test_discover_gitlab_projects_walk_flags_truncation_independently(
+    monkeypatch,
+):
+    """A truncated FLAT projects walk must be reported even when the
+    per-group teams walk stays comfortably under ITS OWN bound -- the two
+    walks are separate calls with separate bounds, and either one hitting its
+    limit must mark the whole result truncated.
+    """
+    from dev_health_ops.api.services.configuration import team_discovery as td
+
+    monkeypatch.setattr(td, "MAX_GITLAB_DISCOVERY_ALL_PROJECTS", 2)
+    monkeypatch.setattr(td, "MAX_GITLAB_DISCOVERY_PROJECTS", 100)
+
+    root_group = MagicMock()
+    root_group.full_path = "big-group"
+    root_group.name = "Big Group"
+    root_group.description = None
+    root_group.subgroups.list.return_value = iter([])
+    root_group.projects.list.side_effect = _projects_list_side_effect(
+        per_group=[SimpleNamespace(path_with_namespace="big-group/only")],
+        flat=[
+            SimpleNamespace(
+                id=i,
+                path_with_namespace=f"big-group/p{i}",
+                name=f"P{i}",
+                archived=False,
+                web_url="",
+            )
+            for i in range(5)
+        ],
+    )
+
+    fake_gl = MagicMock()
+    fake_gl.groups.get.return_value = root_group
+
+    with patch("gitlab.Gitlab", return_value=fake_gl):
+        svc = td.TeamDiscoveryService(None, ORG_ID)
+        result = await svc.discover_gitlab(token="t", group_path="big-group")
+
+    assert result.truncated is True
+    assert any(
+        "truncated projects (including all subgroups)" in w for w in result.warnings
+    )
+    assert len(result.projects) == 2
+    # The per-group teams walk, well under ITS bound, is untouched.
+    assert result.teams[0].associations["repo_patterns"] == ["big-group/only"]

--- a/tests/api/dev/test_project_scope_clickhouse_live.py
+++ b/tests/api/dev/test_project_scope_clickhouse_live.py
@@ -714,8 +714,10 @@ async def test_every_derivation_clause_changes_the_real_result(
         ),
         "project_id arm": (
             "(project_id = {entity_id:String}"
-            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
-            "(catalog_project_key != '' AND project_key = catalog_project_key)",
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key)"
+            " OR (catalog_project_key != '' AND project_id = catalog_project_key))",
+            "(catalog_project_key != '' AND project_key = catalog_project_key"
+            " OR (catalog_project_key != '' AND project_id = catalog_project_key))",
         ),
         "repos authorization arm": (
             "    toString(repo_id) = '00000000-0000-0000-0000-000000000000'\n"
@@ -765,14 +767,17 @@ async def test_every_jira_identity_clause_changes_the_real_result(
         ),
         "native project_key arm": (
             "(project_id = {entity_id:String}"
-            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key)"
+            " OR (catalog_project_key != '' AND project_id = catalog_project_key))",
             "(project_id = {entity_id:String})",
         ),
         "project disjunction (OR -> AND)": (
             "(project_id = {entity_id:String}"
-            " OR (catalog_project_key != '' AND project_key = catalog_project_key))",
+            " OR (catalog_project_key != '' AND project_key = catalog_project_key)"
+            " OR (catalog_project_key != '' AND project_id = catalog_project_key))",
             "(project_id = {entity_id:String}"
-            " AND (catalog_project_key != '' AND project_key = catalog_project_key))",
+            " AND (catalog_project_key != '' AND project_key = catalog_project_key)"
+            " AND (catalog_project_key != '' AND project_id = catalog_project_key))",
         ),
     }
 

--- a/tests/api/dev/test_project_scope_status_snapshot_repositories.py
+++ b/tests/api/dev/test_project_scope_status_snapshot_repositories.py
@@ -88,6 +88,13 @@ COLLIDING_PROJECT_ID = f"{ORG_ID}:collide:MULTI"
 #: retired (a newer ``is_active = 0`` row) before the identity read runs.
 RETIRED_PROJECT_ID = f"{ORG_ID}:jira:RETIRED"
 RETIRED_RAW_PROJECT_KEY = "RETIRED"
+#: CHAOS-3380 round 3 (Codex HIGH): GitLab's catalog id is prefixed and
+#: IMMUTABLE (its own numeric project id), while ``work_items.project_id``
+#: carries the RAW, mutable path -- neither the raw-id arm nor the
+#: key-to-key arm can match a GitLab row; only the compatibility arm
+#: (``project_id = catalog_project_key``) can.
+GITLAB_PROJECT_ID = f"{ORG_ID}:gitlab:501"
+GITLAB_CURRENT_PATH = "ops-group/ask-dev-service"
 
 #: Linear work items carry no repository: the sync lands them under the zero
 #: UUID, which has no ``repos`` row at all (verified against the live dev
@@ -116,6 +123,8 @@ MULTI_PROVIDER_REPOSITORY_ID = "11111111-0000-0000-0000-000000000007"
 #: Round 2: where ``RETIRED_PROJECT_ID``'s own (would-be, if the ``is_active``
 #: guard failed) work item lives.
 RETIRED_PROJECT_REPOSITORY_ID = "22222222-0000-0000-0000-000000000008"
+#: CHAOS-3380 round 3: where the GitLab-shaped project's own work item lives.
+GITLAB_KEYED_REPOSITORY_ID = "33333333-0000-0000-0000-000000000009"
 
 #: The org-scoped ``repos`` catalog. The zero UUID is deliberately absent: it
 #: is the repository-*less* sentinel, not a repository.
@@ -126,6 +135,7 @@ REPOS_CATALOG = {
         COLLISION_REPOSITORY_ID,
         MULTI_PROVIDER_REPOSITORY_ID,
         RETIRED_PROJECT_REPOSITORY_ID,
+        GITLAB_KEYED_REPOSITORY_ID,
     },
     OTHER_ORG_ID: {FOREIGN_REPOSITORY_ID},
 }
@@ -154,11 +164,15 @@ PROJECTS_CATALOG: dict[tuple[str, str], list[dict[str, Any]]] = {
             "is_active": 0,
         }
     ],
+    (ORG_ID, GITLAB_PROJECT_ID): [
+        {"provider": "gitlab", "project_key": GITLAB_CURRENT_PATH}
+    ],
     # GHOST_PROJECT_ID deliberately absent.
 }
 
 EXPECTED_DERIVED_REPOSITORY_IDS = sorted({LINEAR_NO_REPOSITORY_ID})
 JIRA_EXPECTED_REPOSITORY_IDS = sorted({KEYED_REPOSITORY_ID})
+GITLAB_EXPECTED_REPOSITORY_IDS = sorted({GITLAB_KEYED_REPOSITORY_ID})
 
 NO_REPOSITORY_SET_WARNING = (
     "Status reads require the complete authorized repository set; "
@@ -309,6 +323,20 @@ WORK_ITEM_STORE = [
         project_id="88888",
         project_key=RETIRED_RAW_PROJECT_KEY,
     ),
+    # CHAOS-3380 round 3: the GitLab project's own work item -- reached ONLY
+    # via the compatibility arm (project_id, the raw path, against the
+    # catalog's project_key, the SAME current path). project_key stays empty,
+    # exactly like every real GitLab work item (providers/gitlab/normalize.py
+    # never sets it).
+    _row(
+        work_item_id="gitlab:ops-group/ask-dev-service#42",
+        title="GitLab compatibility-arm attribution",
+        status="in_progress",
+        repository_id=GITLAB_KEYED_REPOSITORY_ID,
+        provider="gitlab",
+        project_id=GITLAB_CURRENT_PATH,
+        project_key="",
+    ),
 ]
 
 IN_SCOPE_WORK_ITEM_IDS = {
@@ -318,6 +346,10 @@ IN_SCOPE_WORK_ITEM_IDS = {
 
 JIRA_IN_SCOPE_WORK_ITEM_IDS = {
     "jira:ASK-9",
+}
+
+GITLAB_IN_SCOPE_WORK_ITEM_IDS = {
+    "gitlab:ops-group/ask-dev-service#42",
 }
 
 #: The collision rows above must never surface for EITHER scope.
@@ -425,6 +457,15 @@ class _FakeWorkItems:
                 lambda row: (
                     bool(catalog_project_key)
                     and row["project_key"] == catalog_project_key
+                )
+            )
+        # CHAOS-3380 round 3: GitLab's compatibility arm -- the work item's
+        # RAW project_id against the catalog's CURRENT path (project_key).
+        if "project_id = catalog_project_key" in sql:
+            arms.append(
+                lambda row: (
+                    bool(catalog_project_key)
+                    and row["project_id"] == catalog_project_key
                 )
             )
         # Legacy substring, kept so a regression back to comparing project_key
@@ -567,12 +608,22 @@ def test_derivation_matches_projects_exactly_as_the_queries_it_bounds_do() -> No
     match the catalog row's provider, and either the raw id or the raw native
     key to match -- never the catalog's (possibly provider-prefixed) id
     against a raw column on the other side of an OR.
+
+    CHAOS-3380 round 3 (Codex HIGH): a THIRD arm was added --
+    ``project_id = catalog_project_key`` -- GitLab's compatibility arm: its
+    catalog id is a prefixed, opaque, immutable numeric id (never equal to
+    any raw ``work_items`` column, so the first arm above can never match a
+    GitLab row), and ``work_items.project_key`` is always empty for GitLab
+    (so the second arm can't either) -- but ``work_items.project_id`` carries
+    the raw path for every GitLab row regardless of when it was synced, and
+    the catalog's own ``project_key`` carries that SAME current path.
     """
 
     project_predicate = (
         "ifNull(catalog_provider, '') != '' AND provider = catalog_provider"
         " AND (project_id = {entity_id:String}"
-        " OR (catalog_project_key != '' AND project_key = catalog_project_key))"
+        " OR (catalog_project_key != '' AND project_key = catalog_project_key)"
+        " OR (catalog_project_key != '' AND project_id = catalog_project_key))"
     )
     assert project_predicate in native_status_change.PROJECT_REPOSITORIES_SQL
     assert project_predicate in native_status_change._WORK_ITEMS_SQL
@@ -605,8 +656,8 @@ def test_derivation_sql_structure_is_pinned() -> None:
     assert (
         "  AND ifNull(catalog_provider, '') != '' AND provider = catalog_provider"
         " AND (project_id = {entity_id:String}"
-        " OR (catalog_project_key != '' AND project_key = catalog_project_key))\n"
-        in sql
+        " OR (catalog_project_key != '' AND project_key = catalog_project_key)"
+        " OR (catalog_project_key != '' AND project_id = catalog_project_key))\n" in sql
     )
     # No bound anywhere in this query: a truncated authorization set would be
     # a silently narrowed read, not a smaller page. The identity CTE bounds
@@ -804,6 +855,47 @@ async def test_jira_shaped_project_resolves_via_provider_scoped_identity(
     } == JIRA_IN_SCOPE_WORK_ITEM_IDS
     # None of the cross-provider collision rows sharing Jira's raw key (or,
     # adversarially, its prefixed catalog id) may leak in.
+    assert not COLLISION_WORK_ITEM_IDS & {
+        child.entity_id for child in snapshot.children
+    }
+
+
+@pytest.mark.asyncio
+async def test_gitlab_shaped_project_resolves_via_the_compatibility_arm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3380 round 3 (Codex HIGH): GitLab resolves through the THIRD arm.
+
+    Neither of the two arms CHAOS-3374 introduced can match a GitLab row: the
+    raw-id arm needs ``work_items.project_id`` to equal the catalog's
+    (here, prefixed) id, which it never does since GitLab's ``project_id`` is
+    the raw path; the key-to-key arm needs ``work_items.project_key`` to be
+    non-empty, which it never is for GitLab (``providers/gitlab/normalize.py``
+    leaves it unset for every row, old and new alike). Only the
+    compatibility arm -- the work item's raw ``project_id`` against the
+    catalog's CURRENT ``project_key`` (the path) -- resolves it, and this is
+    the same shape a HISTORICAL GitLab row (synced before this ticket) has:
+    proving this scenario is proving incremental-sync compatibility, not just
+    a today's-format one.
+    """
+
+    _install_catalog_client(monkeypatch, project_id=GITLAB_PROJECT_ID)
+    scope = await _committed_project_scope(project_id=GITLAB_PROJECT_ID)
+    assert scope.entity_refs[0].entity_id == GITLAB_PROJECT_ID
+
+    fake = _install_status_client(monkeypatch)
+    service = StatusChangeService(ClickHouseStatusChangeSource(object(), now=NOW))
+
+    snapshot = await service.status_snapshot(
+        ORG_ID, "permission-fingerprint", StatusSnapshotRequest(scope)
+    )
+
+    assert NO_REPOSITORY_SET_WARNING not in snapshot.warnings
+    bound = fake.work_item_read_params()["repository_ids"]
+    assert sorted(bound) == GITLAB_EXPECTED_REPOSITORY_IDS
+    assert {
+        child.entity_id for child in snapshot.children
+    } == GITLAB_IN_SCOPE_WORK_ITEM_IDS
     assert not COLLISION_WORK_ITEM_IDS & {
         child.entity_id for child in snapshot.children
     }

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -21,13 +21,19 @@ Identity choice under test (CHAOS-3380 round 2, Codex HIGH -- mutable path
 as canonical identity): GitLab's catalog id is GitLab's own IMMUTABLE
 numeric project id, prefixed like Jira's (``f"{org_id}:gitlab:{numeric_id}"``)
 -- NOT the raw, MUTABLE ``path_with_namespace`` a first cut of this ticket
-used. ``project_key`` carries the CURRENT path instead, and
-``providers/gitlab/normalize.py`` now writes that SAME current path onto
-``work_items.project_key`` (not just ``project_id``) -- so a GitLab project
-resolves through ``native_status_change._project_identity_match``'s
-project_key arm, mirroring Jira rather than Linear. This is because a
-GitLab project's PATH is mutable (rename, group transfer) while Linear's and
-Jira's own native ids are not.
+used. ``project_key`` carries the CURRENT path instead.
+
+Round 3 (Codex HIGH -- incremental sync strands historical rows) corrects
+round 2's own follow-through: ``providers/gitlab/normalize.py`` does NOT
+write anything onto ``work_items.project_key`` (it stays empty, exactly as
+before this ticket ever existed) -- a GitLab project instead resolves
+through ``native_status_change._project_identity_match``'s THIRD,
+compatibility arm: the work item's raw ``project_id`` (the path, unchanged
+regardless of when the row was synced) against the catalog's CURRENT
+``project_key``. Round 2's normalize.py change (writing the path onto
+project_key for newly-synced rows only) would have made "was this row
+synced before or after the cutover" a real, silent failure mode -- reverted
+rather than kept as an unnecessary second identity dimension.
 
 CHAOS-3374 (``native_status_change._PROJECT_IDENTITY_CTE`` /
 ``_project_identity_match``) merged to main as 61aae46af (#1460): every

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -8,8 +8,8 @@ migrated ClickHouse:
   normalizer) → ``ClickHouseMetricsSink.write_work_items``;
 * catalog side — ``team_autoimport_gitlab.populate`` (the production worker,
   CHAOS-3380) → ``ClickHouseMetricsSink.write_projects``, driven by the real
-  ``TeamDiscoveryService.discover_gitlab`` group/subgroup walk with only the
-  HTTP round trip replaced (``GitLabWorkClient.get_project``).
+  ``TeamDiscoveryService.discover_gitlab`` flat, recursive project listing,
+  with only the HTTP round trip replaced.
 
 and the comparison itself is the shipped oracle
 (``scripts/ask_dev_project_subject_oracle.py``), parametrized to
@@ -17,27 +17,28 @@ and the comparison itself is the shipped oracle
 exercised here rather than duplicated, so a change to the oracle's contract
 cannot silently stop applying to one provider.
 
-Identity choice under test: GitLab's catalog id is the RAW
-``path_with_namespace`` (``providers/gitlab/normalize.py``: "For work
-tracking metrics, treat the GitLab project path as the 'project' scope."),
-the SAME id space ``work_items.project_id`` already carries — mirroring
-Linear's raw-UUID catalog id, NOT Jira's ``{org}:jira:{key}`` prefixed id
-(CHAOS-3374). This is why the plain ``project_id = {entity_id}`` predicate
-already matched a GitLab project even before CHAOS-3374 landed (unlike
-Jira, which needed the provider-scoped identity join to resolve at all).
+Identity choice under test (CHAOS-3380 round 2, Codex HIGH -- mutable path
+as canonical identity): GitLab's catalog id is GitLab's own IMMUTABLE
+numeric project id, prefixed like Jira's (``f"{org_id}:gitlab:{numeric_id}"``)
+-- NOT the raw, MUTABLE ``path_with_namespace`` a first cut of this ticket
+used. ``project_key`` carries the CURRENT path instead, and
+``providers/gitlab/normalize.py`` now writes that SAME current path onto
+``work_items.project_key`` (not just ``project_id``) -- so a GitLab project
+resolves through ``native_status_change._project_identity_match``'s
+project_key arm, mirroring Jira rather than Linear. This is because a
+GitLab project's PATH is mutable (rename, group transfer) while Linear's and
+Jira's own native ids are not.
 
 CHAOS-3374 (``native_status_change._PROJECT_IDENTITY_CTE`` /
-``_project_identity_match``) merged as of this revision (main 61aae46af,
-#1460): every project-scoped fact arm and ``PROJECT_REPOSITORIES_SQL`` now
-join through the catalog's own ``provider``/``project_key`` columns rather
-than comparing ``work_items.project_id``/``project_key`` to the entity id
-directly.
+``_project_identity_match``) merged to main as 61aae46af (#1460): every
+project-scoped fact arm and ``PROJECT_REPOSITORIES_SQL`` join through the
+catalog's own ``provider``/``project_key`` columns rather than comparing
+``work_items.project_id``/``project_key`` to the entity id directly.
 ``test_gitlab_project_resolves_end_to_end_through_the_native_status_change_join``
 below exercises that merged join directly (``ScopeResolutionService.
 resolve_contract`` → ``StatusChangeService.status_snapshot``, both reading
 through ``native_status_change.py``) with a REAL catalog row from this
-ticket's worker — the "only works once 3374 merges" caveat from the original
-handoff no longer applies and this test is the evidence.
+ticket's worker.
 
 Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
 ``-m "not benchmark and not clickhouse"`` in BOTH ``unit_tests()`` and
@@ -50,7 +51,7 @@ from __future__ import annotations
 import asyncio
 import os
 import uuid
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock
@@ -74,6 +75,7 @@ from dev_health_ops.api.dev.status_change_service import (
     StatusSnapshotRequest,
 )
 from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveredProject,
     GitLabDiscoveryResult,
 )
 from dev_health_ops.metrics.schemas import ProjectRecord
@@ -97,8 +99,10 @@ pytestmark = [
     ),
 ]
 
+GITLAB_PROJECT_NUMERIC_ID = "9001"
 GITLAB_PROJECT_PATH = "full-chaos/dev-health"
 GITLAB_PROJECT_NAME = "Dev Health"
+OTHER_PROJECT_NUMERIC_ID = "9002"
 OTHER_PROJECT_PATH = "full-chaos/platform"
 OTHER_PROJECT_NAME = "Platform"
 
@@ -107,6 +111,10 @@ OTHER_PROJECT_NAME = "Platform"
 #: importing from another test module would make this file's protection
 #: depend on that module continuing to exist unchanged.
 _PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _catalog_id(org_id: str, numeric_id: str) -> str:
+    return f"{org_id}:gitlab:{numeric_id}"
 
 
 def _scratch_database(dsn: str) -> str:
@@ -185,30 +193,12 @@ def _seed_reference_side(sink: Any, org_id: str) -> None:
     sink.write_work_items(work_items)
 
 
-@dataclass
-class _FakeGitLabProject:
-    name: str
-    archived: bool = False
-    web_url: str = ""
-
-
-def _fake_gitlab_work_client_cls(projects: dict[str, _FakeGitLabProject]) -> type:
-    class _FakeGitLabWorkClient:
-        def __init__(self, *, auth: Any, org_id: str | None = None) -> None:
-            self.auth = auth
-            self.org_id = org_id
-
-        def get_project(self, project_id_or_path: str) -> _FakeGitLabProject:
-            return projects[project_id_or_path]
-
-    return _FakeGitLabWorkClient
-
-
 async def _run_autoimport(
     monkeypatch: pytest.MonkeyPatch,
     org_id: str,
     *,
-    projects: dict[str, _FakeGitLabProject],
+    projects: list[GitLabDiscoveredProject],
+    source_external_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Run the production worker with only GitLab's HTTP round trips replaced.
 
@@ -229,11 +219,12 @@ async def _run_autoimport(
                     provider_team_id="full-chaos",
                     name="Full Chaos",
                     associations={
-                        "repo_patterns": list(projects.keys()),
+                        "repo_patterns": [p.path_with_namespace for p in projects],
                         "provider_org": group_path,
                     },
                 )
-            ]
+            ],
+            projects=projects,
         )
 
     async def discover_members_gitlab(
@@ -251,22 +242,20 @@ async def _run_autoimport(
         "discover_members_gitlab",
         discover_members_gitlab,
     )
-    monkeypatch.setattr(
-        team_autoimport_gitlab,
-        "GitLabWorkClient",
-        _fake_gitlab_work_client_cls(projects),
-    )
 
     assert CLICKHOUSE_URI is not None
+    scope: dict[str, Any] = {
+        "mode": "sync_config",
+        "analytics_db": CLICKHOUSE_URI,
+        "sync_options": {"auto_import_teams": True},
+    }
+    if source_external_ids is not None:
+        scope["source_external_ids"] = source_external_ids
     return await asyncio.to_thread(
         team_autoimport_gitlab.populate,
         org_id=org_id,
         credentials={"token": "gl-token", "group_path": "full-chaos"},
-        scope={
-            "mode": "sync_config",
-            "analytics_db": CLICKHOUSE_URI,
-            "sync_options": {"auto_import_teams": True},
-        },
+        scope=scope,
     )
 
 
@@ -310,16 +299,22 @@ async def test_gitlab_project_becomes_a_resolvable_subject(
         summary = await _run_autoimport(
             monkeypatch,
             org_id,
-            projects={
-                GITLAB_PROJECT_PATH: _FakeGitLabProject(
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
                     name=GITLAB_PROJECT_NAME,
+                    archived=False,
                     web_url=f"https://gitlab.com/{GITLAB_PROJECT_PATH}",
                 ),
-                OTHER_PROJECT_PATH: _FakeGitLabProject(
+                GitLabDiscoveredProject(
+                    id=OTHER_PROJECT_NUMERIC_ID,
+                    path_with_namespace=OTHER_PROJECT_PATH,
                     name=OTHER_PROJECT_NAME,
+                    archived=False,
                     web_url=f"https://gitlab.com/{OTHER_PROJECT_PATH}",
                 ),
-            },
+            ],
         )
         assert summary["native_projects_imported"] == 2
         assert summary["native_projects_complete"] is True
@@ -331,16 +326,16 @@ async def test_gitlab_project_becomes_a_resolvable_subject(
             acceptance_project_ids=(GITLAB_PROJECT_PATH,),
         )
         # "missing"/"inactive"/"name_ambiguous" must be fully cleared -- those
-        # are what CHAOS-3380 exists to fix. "name_mismatch" survives here as
-        # a PRE-EXISTING, orthogonal gap: unlike Linear's issue normalizer
-        # (which caches project.name straight off the issue payload),
+        # are what CHAOS-3380 exists to fix, and the oracle now resolves a
+        # GitLab reference through project_key (CHAOS-3380 round 2), not raw
+        # id equality. "name_mismatch" survives here as a PRE-EXISTING,
+        # orthogonal gap: unlike Linear's issue normalizer (which caches
+        # project.name straight off the issue payload),
         # ``gitlab_issue_to_work_item`` never sets ``WorkItem.project_name``
-        # at all (providers/gitlab/normalize.py has no such assignment), so
-        # ``work_items.project_name`` is always empty for GitLab today. That
-        # is a gap in the WORK-ITEM producer, not the catalog this ticket
-        # adds -- and it does not affect subject resolution, which reads the
-        # catalog's OWN name (proved by resolve_mention below, not by
-        # work_items.project_name).
+        # at all, so ``work_items.project_name`` is always empty for GitLab
+        # today. That is a gap in the WORK-ITEM producer, not the catalog
+        # this ticket adds -- and it does not affect subject resolution,
+        # which reads the catalog's OWN name (proved below).
         assert {gap.kind for gap in after} == {"name_mismatch"}, (
             f"catalog still incomplete after autoimport: {after}"
         )
@@ -354,7 +349,9 @@ async def test_gitlab_project_becomes_a_resolvable_subject(
         )
         assert resolution.outcome is ResolutionOutcome.EXACT_MATCH
         assert resolution.entity is not None
-        assert resolution.entity.canonical_id == GITLAB_PROJECT_PATH
+        assert resolution.entity.canonical_id == _catalog_id(
+            org_id, GITLAB_PROJECT_NUMERIC_ID
+        )
         assert resolution.entity.label == GITLAB_PROJECT_NAME
     finally:
         _cleanup(raw_client, org_id)
@@ -364,18 +361,15 @@ async def test_gitlab_project_becomes_a_resolvable_subject(
 async def test_gitlab_project_id_selects_the_projects_work_items(
     sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The resolved canonical id must be usable as a ``work_items`` filter.
+    """The resolved subject's underlying identity must select real work items.
 
-    Deliberately checked with the SAME plain predicate
-    ``native_status_change._WORK_ITEMS_SQL`` uses on current ``main``
-    (``project_id = {entity_id} OR project_key = {entity_id}``) rather than
-    calling into that module: this repo has a sibling lane
-    (CHAOS-3374/chaos-3374-jira-project-identity, not merged as of this test)
-    reworking that file's project-identity join for Jira's PREFIXED catalog
-    id. GitLab's catalog id is the RAW path, the same id space Linear already
-    used successfully with this exact predicate, so this assertion holds
-    against ``main`` today and is expected to keep holding once 3374 merges
-    (its own CTE preserves the ``project_id = {entity_id}`` arm verbatim).
+    The resolved canonical id (``{org}:gitlab:{numeric_id}``) never appears
+    literally on ``work_items`` -- only the catalog row's OWN ``project_key``
+    (the current path) does, which is what the real
+    ``native_status_change._project_identity_match`` join actually compares
+    (proved end to end in the next test). This test isolates that one
+    property: the catalog row this subject resolved to carries a
+    ``project_key`` that genuinely selects the seeded work item.
     """
 
     org_id = f"chaos-3380-scope-{uuid.uuid4().hex[:12]}"
@@ -384,10 +378,22 @@ async def test_gitlab_project_id_selects_the_projects_work_items(
         await _run_autoimport(
             monkeypatch,
             org_id,
-            projects={
-                GITLAB_PROJECT_PATH: _FakeGitLabProject(name=GITLAB_PROJECT_NAME),
-                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
-            },
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
+                    name=GITLAB_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+                GitLabDiscoveredProject(
+                    id=OTHER_PROJECT_NUMERIC_ID,
+                    path_with_namespace=OTHER_PROJECT_PATH,
+                    name=OTHER_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+            ],
         )
 
         service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
@@ -399,16 +405,24 @@ async def test_gitlab_project_id_selects_the_projects_work_items(
         )
         assert resolution.entity is not None
         entity_id = resolution.entity.canonical_id
-        assert entity_id == GITLAB_PROJECT_PATH
+        assert entity_id == _catalog_id(org_id, GITLAB_PROJECT_NUMERIC_ID)
+
+        project_key_row = raw_client.query(
+            "SELECT project_key FROM projects FINAL "
+            "WHERE org_id = {org_id:String} AND id = {pid:String}",
+            parameters={"org_id": org_id, "pid": entity_id},
+        ).result_rows
+        assert project_key_row == [(GITLAB_PROJECT_PATH,)]
+        project_key = project_key_row[0][0]
 
         matched = raw_client.query(
             "SELECT count() FROM work_items WHERE org_id = {org_id:String} "
-            "AND (project_id = {entity_id:String} OR project_key = {entity_id:String})",
-            parameters={"org_id": org_id, "entity_id": entity_id},
+            "AND (project_id = {key:String} OR project_key = {key:String})",
+            parameters={"org_id": org_id, "key": project_key},
         ).result_rows[0][0]
         assert matched == 1, (
-            "the resolved project id selects no work items; the subject resolves "
-            "but every answer about it would be empty"
+            "the resolved project's catalog project_key selects no work items; "
+            "the subject resolves but every answer about it would be empty"
         )
     finally:
         _cleanup(raw_client, org_id)
@@ -425,16 +439,14 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
     ``PROJECT_REPOSITORIES_SQL``, and the rest -- to join through
     ``_PROJECT_IDENTITY_CTE`` / ``_project_identity_match`` (catalog
     ``provider`` + native key) instead of comparing ``work_items.project_id``/
-    ``project_key`` to the entity id directly. Before this ticket, GitLab
-    never reached that join at all: no catalog row existed, so
-    ``ScopeResolutionService`` returned ``NO_AUTHORIZED_MATCH`` before
-    ``native_status_change.py`` was ever queried. This test goes past
-    resolution (already covered above) into the SAME two calls the sibling
-    Jira live test uses (``resolve_contract`` then ``status_snapshot``) to
-    prove the merged join actually joins for a GitLab project: a work item
-    committed against it comes back in the snapshot, and a work item under a
-    DIFFERENT GitLab project (same provider, so the provider guard alone
-    can't be what excludes it) does not.
+    ``project_key`` to the entity id directly. This test uses the SAME two
+    calls the sibling Jira live test uses (``resolve_contract`` then
+    ``status_snapshot``) to prove the merged join actually joins for a
+    GitLab project THROUGH THE PROJECT_KEY ARM (CHAOS-3380 round 2's
+    immutable-id model): a work item committed against it comes back in the
+    snapshot, and a work item under a DIFFERENT GitLab project (same
+    provider, so the provider guard alone can't be what excludes it) does
+    not.
     """
 
     org_id = f"chaos-3380-e2e-{uuid.uuid4().hex[:12]}"
@@ -443,18 +455,30 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
         await _run_autoimport(
             monkeypatch,
             org_id,
-            projects={
-                GITLAB_PROJECT_PATH: _FakeGitLabProject(name=GITLAB_PROJECT_NAME),
-                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
-            },
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
+                    name=GITLAB_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+                GitLabDiscoveredProject(
+                    id=OTHER_PROJECT_NUMERIC_ID,
+                    path_with_namespace=OTHER_PROJECT_PATH,
+                    name=OTHER_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+            ],
         )
+        entity_id = _catalog_id(org_id, GITLAB_PROJECT_NUMERIC_ID)
 
         # The merged CHAOS-3374 join REQUIRES work_items.provider = the
         # catalog row's own provider (native_status_change._project_identity_
-        # match: "provider = catalog_provider"). Verified here against the
-        # REAL rows this test just wrote, not assumed: both producers must
-        # agree on the literal string "gitlab", or every assertion below
-        # would pass or fail for the wrong reason.
+        # match: "provider = catalog_provider"), AND (round 2) matches
+        # through project_key, not id. Verified here against the REAL rows
+        # this test just wrote, not assumed.
         work_item_providers = {
             row[0]
             for row in raw_client.query(
@@ -463,16 +487,13 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
                 parameters={"org_id": org_id},
             ).result_rows
         }
-        catalog_providers = {
-            row[0]
-            for row in raw_client.query(
-                "SELECT DISTINCT provider FROM projects FINAL "
-                "WHERE org_id = {org_id:String} AND id = {pid:String}",
-                parameters={"org_id": org_id, "pid": GITLAB_PROJECT_PATH},
-            ).result_rows
-        }
+        catalog_row = raw_client.query(
+            "SELECT provider, project_key FROM projects FINAL "
+            "WHERE org_id = {org_id:String} AND id = {pid:String}",
+            parameters={"org_id": org_id, "pid": entity_id},
+        ).result_rows
         assert work_item_providers == {"gitlab"}, work_item_providers
-        assert catalog_providers == {"gitlab"}, catalog_providers
+        assert catalog_row == [("gitlab", GITLAB_PROJECT_PATH)], catalog_row
 
         catalog = ClickHouseAuthorizedEntityCatalog(sink)
         service = ScopeResolutionService(catalog)
@@ -480,7 +501,7 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
             org_id,
             "permission-live",
             ScopeResolveRequest(
-                explicit_refs=(ScopeRef(EntityKind.PROJECT, GITLAB_PROJECT_PATH),)
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, entity_id),)
             ),
         )
         assert resolution.outcome.value == "exact"
@@ -519,18 +540,29 @@ async def test_archived_gitlab_project_is_not_resolvable(
         await _run_autoimport(
             monkeypatch,
             org_id,
-            projects={
-                GITLAB_PROJECT_PATH: _FakeGitLabProject(
-                    name=GITLAB_PROJECT_NAME, archived=True
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
+                    name=GITLAB_PROJECT_NAME,
+                    archived=True,
+                    web_url="",
                 ),
-                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
-            },
+                GitLabDiscoveredProject(
+                    id=OTHER_PROJECT_NUMERIC_ID,
+                    path_with_namespace=OTHER_PROJECT_PATH,
+                    name=OTHER_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+            ],
         )
+        entity_id = _catalog_id(org_id, GITLAB_PROJECT_NUMERIC_ID)
 
         row = raw_client.query(
             "SELECT is_active FROM projects FINAL "
             "WHERE org_id = {org_id:String} AND id = {pid:String} AND provider = 'gitlab'",
-            parameters={"org_id": org_id, "pid": GITLAB_PROJECT_PATH},
+            parameters={"org_id": org_id, "pid": entity_id},
         ).result_rows
         assert row == [(0,)]
 
@@ -552,7 +584,7 @@ async def test_archived_gitlab_project_is_not_resolvable(
             org_id,
             "permission-live",
             ScopeResolveRequest(
-                explicit_refs=(ScopeRef(EntityKind.PROJECT, GITLAB_PROJECT_PATH),)
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, entity_id),)
             ),
         )
         assert contract.outcome.value != "exact", (
@@ -564,33 +596,35 @@ async def test_archived_gitlab_project_is_not_resolvable(
 
 
 @pytest.mark.asyncio
-async def test_gitlab_project_id_colliding_with_a_jira_catalog_id_stays_distinct(
+async def test_gitlab_project_key_colliding_with_a_jira_catalog_key_stays_distinct(
     sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """CHAOS-3380 cross-provider coverage.
+    """CHAOS-3380 round 2 cross-provider coverage.
 
-    ``projects``' ReplacingMergeTree key is ``(org_id, provider, id)``
-    (native_status_change._PROJECT_IDENTITY_CTE's own comment on the sibling
-    CHAOS-3374 branch) -- ``id`` alone is only unique WITHIN one provider. A
-    GitLab project's raw path can coincidentally equal another provider's raw
-    catalog id in the SAME org (nothing enforces cross-provider id
-    uniqueness); this pins that BOTH rows survive ``FINAL`` as distinct rows
-    scoped by provider, rather than one silently replacing the other.
+    Both Jira and GitLab now resolve through the SAME identity arm
+    (``project_key``, CHAOS-3380 round 2's immutable-id model mirrors
+    Jira's). A raw string shared between a GitLab project's current path and
+    a Jira project's raw key (nothing prevents this -- they are independent
+    id spaces) must never let one provider's project resolve into the
+    other's rows. The catalog ``id`` column itself can no longer collide
+    cross-provider now that GitLab's id is prefixed like Jira's (different
+    provider segment in the same string), so the meaningful collision surface
+    moved entirely to ``project_key`` -- this is that test, not a
+    ``id``-collision repeat of the pre-round-2 version.
     """
 
     org_id = f"chaos-3380-collide-{uuid.uuid4().hex[:10]}"
     now = datetime.now(timezone.utc)
-    colliding_id = f"collide-{uuid.uuid4().hex[:8]}"
+    colliding_key = f"collide-{uuid.uuid4().hex[:8]}"
     try:
-        # A Jira-provider row using the colliding string as its (prefixed-in-
-        # production, but here deliberately bare) id.
+        # A Jira-provider row using the colliding string as its raw key.
         sink.write_projects(
             [
                 ProjectRecord(
-                    id=colliding_id,
+                    id=f"{org_id}:jira:{colliding_key}",
                     org_id=org_id,
                     provider="jira",
-                    project_key="COLLIDE",
+                    project_key=colliding_key,
                     name="Jira Side",
                     is_active=1,
                     updated_at=now,
@@ -598,24 +632,145 @@ async def test_gitlab_project_id_colliding_with_a_jira_catalog_id_stays_distinct
                 )
             ]
         )
-        # A GitLab project whose raw path happens to be the SAME string,
+        # A GitLab project whose CURRENT path happens to be the same string,
         # written through the production worker.
         await _run_autoimport(
             monkeypatch,
             org_id,
-            projects={colliding_id: _FakeGitLabProject(name="GitLab Side")},
+            projects=[
+                GitLabDiscoveredProject(
+                    id="7001",
+                    path_with_namespace=colliding_key,
+                    name="GitLab Side",
+                    archived=False,
+                    web_url="",
+                )
+            ],
         )
 
         rows = sorted(
             raw_client.query(
                 "SELECT provider, name FROM projects FINAL "
-                "WHERE org_id = {org_id:String} AND id = {pid:String}",
-                parameters={"org_id": org_id, "pid": colliding_id},
+                "WHERE org_id = {org_id:String} AND project_key = {key:String}",
+                parameters={"org_id": org_id, "key": colliding_key},
             ).result_rows
         )
         assert rows == [("gitlab", "GitLab Side"), ("jira", "Jira Side")], (
-            "the two providers' rows did not both survive FINAL as distinct rows: "
-            f"{rows}"
+            "the two providers' rows did not both survive as distinct rows "
+            f"keyed by project_key: {rows}"
+        )
+
+        # And the resolver-visible property: naming the shared key resolves
+        # AMBIGUOUS (two active catalog rows share... no, they have DIFFERENT
+        # names here, so each name resolves to exactly its own provider's row.
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        gitlab_resolution = await service.resolve_mention(
+            org_id,
+            "permission-live",
+            lookup_text="GitLab Side",
+            kinds=(EntityKind.PROJECT,),
+        )
+        assert gitlab_resolution.outcome is ResolutionOutcome.EXACT_MATCH
+        assert gitlab_resolution.entity is not None
+        assert gitlab_resolution.entity.canonical_id == _catalog_id(org_id, "7001")
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_gitlab_source_selection_filters_unselected_projects_live(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CHAOS-3380 round 2 (Codex MEDIUM), verified against real ClickHouse
+    rows rather than only the fake-sink unit test: an unselected project
+    never becomes a resolvable Ask Dev subject."""
+
+    org_id = f"chaos-3380-selection-{uuid.uuid4().hex[:10]}"
+    try:
+        summary = await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
+                    name=GITLAB_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+                GitLabDiscoveredProject(
+                    id=OTHER_PROJECT_NUMERIC_ID,
+                    path_with_namespace=OTHER_PROJECT_PATH,
+                    name=OTHER_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+            ],
+            source_external_ids=[GITLAB_PROJECT_NUMERIC_ID],
+        )
+        assert summary["native_projects_imported"] == 1
+
+        rows = raw_client.query(
+            "SELECT id FROM projects FINAL WHERE org_id = {org_id:String}",
+            parameters={"org_id": org_id},
+        ).result_rows
+        assert {r[0] for r in rows} == {_catalog_id(org_id, GITLAB_PROJECT_NUMERIC_ID)}
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        unselected = await service.resolve_mention(
+            org_id,
+            "permission-live",
+            lookup_text=OTHER_PROJECT_NAME,
+            kinds=(EntityKind.PROJECT,),
+        )
+        assert unselected.outcome is ResolutionOutcome.NO_AUTHORIZED_MATCH, (
+            "an unselected GitLab project resolved as an Ask Dev subject"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_oracle_does_not_flag_a_gitlab_epic_group_path_as_missing(
+    sink: Any, raw_client: Any
+) -> None:
+    """CHAOS-3380 round 2 (Codex MEDIUM, group-epics carve-out).
+
+    ``providers/gitlab/normalize.gitlab_epic_to_work_item`` sets
+    ``work_items.project_id`` to the GROUP path and ``type='epic'`` -- a
+    wholly different identity space with NO catalog entity in this ticket.
+    The oracle must not report that group path as a "missing" gap (it is a
+    documented carve-out, not a defect), while a genuine uncataloged
+    PROJECT-path reference still IS reported -- proving the exclusion is
+    precise, not a blanket "ignore everything" that would hide real gaps too.
+    """
+
+    org_id = f"chaos-3380-epic-{uuid.uuid4().hex[:10]}"
+    now = datetime.now(timezone.utc)
+    try:
+        sink.org_id = org_id
+        epic_group_path = "full-chaos/platform-group"
+        uncataloged_project = replace(
+            _normalize(1, "full-chaos/no-catalog-row"), org_id=org_id
+        )
+        epic_item = replace(
+            uncataloged_project,
+            work_item_id=f"gitlab:{epic_group_path}:epic:1",
+            project_id=epic_group_path,
+            project_key=None,
+            type="epic",
+            updated_at=now,
+        )
+        sink.write_work_items([uncataloged_project, epic_item])
+
+        gaps = project_subject_gaps(raw_client, org_id=org_id, provider="gitlab")
+        gap_ids = {gap.project_id for gap in gaps}
+        assert epic_group_path not in gap_ids, (
+            "the epic's group path was reported as a gap; it is an explicit, "
+            "out-of-scope carve-out, not a defect"
+        )
+        assert "full-chaos/no-catalog-row" in gap_ids, (
+            "the exclusion swallowed a genuine, uncataloged PROJECT reference too"
         )
     finally:
         _cleanup(raw_client, org_id)

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -327,18 +327,26 @@ async def test_gitlab_project_becomes_a_resolvable_subject(
         )
         # "missing"/"inactive"/"name_ambiguous" must be fully cleared -- those
         # are what CHAOS-3380 exists to fix, and the oracle now resolves a
-        # GitLab reference through project_key (CHAOS-3380 round 2), not raw
-        # id equality. "name_mismatch" survives here as a PRE-EXISTING,
-        # orthogonal gap: unlike Linear's issue normalizer (which caches
-        # project.name straight off the issue payload),
-        # ``gitlab_issue_to_work_item`` never sets ``WorkItem.project_name``
-        # at all, so ``work_items.project_name`` is always empty for GitLab
-        # today. That is a gap in the WORK-ITEM producer, not the catalog
-        # this ticket adds -- and it does not affect subject resolution,
-        # which reads the catalog's OWN name (proved below).
-        assert {gap.kind for gap in after} == {"name_mismatch"}, (
-            f"catalog still incomplete after autoimport: {after}"
-        )
+        # GitLab reference through the path-compatibility arm (CHAOS-3380
+        # round 3), not raw id equality. Two kinds survive here, both
+        # PRE-EXISTING/EXPECTED, not catalog defects:
+        # * "name_mismatch": unlike Linear's issue normalizer (which caches
+        #   project.name straight off the issue payload),
+        #   ``gitlab_issue_to_work_item`` never sets ``WorkItem.project_name``
+        #   at all, so ``work_items.project_name`` is always empty for GitLab
+        #   today -- a gap in the WORK-ITEM producer, not the catalog this
+        #   ticket adds, and it does not affect subject resolution, which
+        #   reads the catalog's OWN name (proved below).
+        # * "path_match_unverified": GitLab has no immutable-id or native-key
+        #   arm available at all (CHAOS-3380 round 3) -- every GitLab match
+        #   resolves ONLY through the mutable path-compatibility arm, by
+        #   construction. This is the oracle honestly disclosing that
+        #   provider's identity model is inherently weaker than Linear's/
+        #   Jira's, not a defect this run introduced.
+        assert {gap.kind for gap in after} == {
+            "name_mismatch",
+            "path_match_unverified",
+        }, f"catalog still incomplete after autoimport: {after}"
 
         service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
         resolution = await service.resolve_mention(
@@ -522,6 +530,102 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
         assert any(child.endswith(own_work_item_id) for child in seen), seen
         assert not any(child.endswith(other_work_item_id) for child in seen), (
             "a different GitLab project's work item leaked into this project's scope",
+            seen,
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_gitlab_incremental_sync_never_strands_history(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CHAOS-3380 round 3 (Codex HIGH -- incremental sync strands historical
+    rows), the reviewer-specified live test.
+
+    The original concern: a round-2 revision of ``providers/gitlab/
+    normalize.py`` wrote the current path onto ``work_items.project_key`` for
+    NEWLY-synced rows only, so an ALREADY-INGESTED row (never rewritten by a
+    subsequent ``updated_after`` incremental sync, since it has not itself
+    changed on GitLab's side) would carry empty ``project_key`` forever and
+    stop matching once the catalog's identity moved to the prefixed numeric
+    id. The fix taken here is stronger than "handle two shapes": ``providers/
+    gitlab/normalize.py`` writes NOTHING onto ``project_key`` for GitLab, not
+    for old rows and not for new ones -- so there is no "old shape" vs "new
+    shape" to reconcile at all. Every GitLab work item, regardless of when it
+    was ingested, resolves through ONE mechanism: ``work_items.project_id``
+    (the raw path, unchanged since before this ticket existed) against the
+    catalog's current ``project_key``.
+
+    Modeled here as two independently-ingested items under the SAME project
+    (an ``updated_after`` incremental sync run would produce exactly this:
+    one row from a prior full sync, one freshly touched) -- both must resolve
+    together, proving the join is insensitive to WHEN a row arrived.
+    """
+
+    org_id = f"chaos-3380-incremental-{uuid.uuid4().hex[:10]}"
+    try:
+        sink.org_id = org_id
+        # Simulates a row from a PRIOR sync (never rewritten since), and one
+        # from THIS run's incremental sync -- both produced by the same
+        # normalizer, so both carry the identical shape (project_id=path,
+        # project_key=None) that is the actual point of this test.
+        older_item = replace(
+            _normalize(1, GITLAB_PROJECT_PATH),
+            org_id=org_id,
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        newer_item = replace(
+            _normalize(2, GITLAB_PROJECT_PATH),
+            org_id=org_id,
+            updated_at=datetime.now(timezone.utc),
+        )
+        assert older_item.project_key is None
+        assert newer_item.project_key is None
+        sink.write_work_items([older_item, newer_item])
+
+        await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects=[
+                GitLabDiscoveredProject(
+                    id=GITLAB_PROJECT_NUMERIC_ID,
+                    path_with_namespace=GITLAB_PROJECT_PATH,
+                    name=GITLAB_PROJECT_NAME,
+                    archived=False,
+                    web_url="",
+                ),
+            ],
+        )
+        entity_id = _catalog_id(org_id, GITLAB_PROJECT_NUMERIC_ID)
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, entity_id),)
+            ),
+        )
+        assert resolution.outcome.value == "exact"
+        scope = resolution.resolved_scope
+        assert scope is not None
+
+        snapshot = await StatusChangeService(
+            ClickHouseStatusChangeSource(sink)
+        ).status_snapshot(org_id, "permission-live", StatusSnapshotRequest(scope))
+
+        seen = {child.entity_id for child in snapshot.children}
+        assert any(
+            child.endswith(f"gitlab:{GITLAB_PROJECT_PATH}#1") for child in seen
+        ), (
+            "the OLDER (never-rewritten) row did not resolve",
+            seen,
+        )
+        assert any(
+            child.endswith(f"gitlab:{GITLAB_PROJECT_PATH}#2") for child in seen
+        ), (
+            "the NEWER (freshly-synced) row did not resolve",
             seen,
         )
     finally:
@@ -771,6 +875,161 @@ async def test_oracle_does_not_flag_a_gitlab_epic_group_path_as_missing(
         )
         assert "full-chaos/no-catalog-row" in gap_ids, (
             "the exclusion swallowed a genuine, uncataloged PROJECT reference too"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_oracle_measures_a_jira_project_referenced_only_by_key(
+    sink: Any, raw_client: Any
+) -> None:
+    """CHAOS-3380 round 3 (Codex MEDIUM) acceptance-set counterexample: Jira.
+
+    Before this fix, ``referenced`` filtered on ``project_id != ''`` alone --
+    but ``providers/jira/normalize.canonical_jira_issue_to_work_item`` NEVER
+    sets ``project_id`` (it stays empty for every Jira row; the raw key lives
+    in ``project_key`` only). So no Jira work item was EVER referenced, and
+    ``project_subject_gaps(provider="jira", ...)`` would unconditionally
+    raise ``OracleNotMeasured`` -- a latent bug this ticket's own fix
+    (reading BOTH columns on the reference side) surfaced and closed. This
+    must keep being true: a Jira project referenced only by its raw key, with
+    a real catalog row, measures with NO ``path_match_unverified`` (Jira
+    matches via the native key-to-key arm, an authoritative match, not the
+    mutable path-compatibility one) and NO "missing" gap. "name_mismatch"
+    is expected and orthogonal: ``atlassian.JiraIssue`` (the real producer's
+    input type) carries no project-name field at all, so
+    ``work_items.project_name`` is always empty for Jira, same latent gap in
+    the WORK-ITEM producer this file's GitLab tests already document -- not
+    a catalog defect and not what this test exists to prove.
+    """
+    from atlassian import JiraIssue
+
+    from dev_health_ops.providers.jira.normalize import (
+        canonical_jira_issue_to_work_item,
+    )
+
+    org_id = f"chaos-3380-jira-key-{uuid.uuid4().hex[:10]}"
+    now = datetime.now(timezone.utc)
+    try:
+        identity = MagicMock(spec=IdentityResolver)
+        identity.resolve.side_effect = lambda **kwargs: "user:dev@example.com"
+        status_mapping = MagicMock(spec=StatusMapping)
+        status_mapping.normalize_status.return_value = "in_progress"
+        status_mapping.normalize_type.return_value = "task"
+        issue = JiraIssue(
+            cloud_id="cloud-live",
+            key="ASK-1",
+            project_key="ASK",
+            issue_type="Task",
+            status="In Progress",
+            created_at=now.isoformat(),
+            updated_at=now.isoformat(),
+        )
+        jira_item = replace(
+            canonical_jira_issue_to_work_item(
+                issue=issue,
+                status_mapping=status_mapping,
+                identity=identity,
+                repo_id=None,
+            ),
+            org_id=org_id,
+            updated_at=now,
+        )
+        assert jira_item.project_id in (None, "")
+        assert jira_item.project_key == "ASK"
+        sink.org_id = org_id
+        sink.write_work_items([jira_item])
+
+        before = project_subject_gaps(raw_client, org_id=org_id, provider="jira")
+        assert {gap.project_id for gap in before} == {"ASK"}
+        assert {gap.kind for gap in before} == {"missing"}
+
+        sink.write_projects(
+            [
+                ProjectRecord(
+                    id=f"{org_id}:jira:ASK",
+                    org_id=org_id,
+                    provider="jira",
+                    project_key="ASK",
+                    name="Ask Dev (Jira)",
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            ]
+        )
+
+        after = project_subject_gaps(raw_client, org_id=org_id, provider="jira")
+        assert {gap.kind for gap in after} == {"name_mismatch"}, (
+            f"a key-referenced Jira project shows unexpected gaps: {after}"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_oracle_flags_a_reused_gitlab_path_as_unverified_not_a_clean_match(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CHAOS-3380 round 3 (Codex MEDIUM) acceptance-set counterexample: reuse.
+
+    Pins the residual risk ``workers/team_autoimport_gitlab.
+    _gitlab_project_catalog_rows`` documents rather than silently assuming
+    it away: project A (numeric id) is renamed away from a path; project B
+    (a DIFFERENT numeric id) later claims that exact, now-free path. An OLD
+    work item -- never resynced, still carrying the original path in its own
+    ``project_id`` -- resolves to project B's catalog row (an unrelated
+    project) via the path-compatibility arm. This IS a false attribution,
+    and this test proves it happens -- but the oracle must never report it as
+    an ordinary clean match: it must carry ``kind="path_match_unverified"``,
+    so the ambiguity is visible rather than silently swallowed as a green
+    result.
+    """
+
+    org_id = f"chaos-3380-reuse-{uuid.uuid4().hex[:10]}"
+    now = datetime.now(timezone.utc)
+    reused_path = "grp/reused-slot"
+    try:
+        sink.org_id = org_id
+        # The OLD work item, never resynced after project A's rename -- its
+        # own project_id still carries the path project B now holds.
+        stale_item = replace(_normalize(1, reused_path), org_id=org_id)
+        sink.write_work_items([stale_item])
+
+        # Project A: renamed away, no longer at reused_path.
+        sink.write_projects(
+            [
+                ProjectRecord(
+                    id=f"{org_id}:gitlab:111",
+                    org_id=org_id,
+                    provider="gitlab",
+                    project_key="grp/project-a-renamed",
+                    name="Project A (renamed away)",
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                ),
+                # Project B: a DIFFERENT project that now claims the freed path.
+                ProjectRecord(
+                    id=f"{org_id}:gitlab:222",
+                    org_id=org_id,
+                    provider="gitlab",
+                    project_key=reused_path,
+                    name="Project B (new claimant)",
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                ),
+            ]
+        )
+
+        gaps = project_subject_gaps(raw_client, org_id=org_id, provider="gitlab")
+        reuse_gaps = [gap for gap in gaps if gap.project_id == reused_path]
+        assert reuse_gaps, "the reused-path reference produced no gap row at all"
+        assert {gap.kind for gap in reuse_gaps} >= {"path_match_unverified"}, (
+            "the reused-path match was reported clean, hiding a false "
+            f"attribution to an unrelated project: {reuse_gaps}"
         )
     finally:
         _cleanup(raw_client, org_id)

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -449,6 +449,31 @@ async def test_gitlab_project_resolves_end_to_end_through_the_native_status_chan
             },
         )
 
+        # The merged CHAOS-3374 join REQUIRES work_items.provider = the
+        # catalog row's own provider (native_status_change._project_identity_
+        # match: "provider = catalog_provider"). Verified here against the
+        # REAL rows this test just wrote, not assumed: both producers must
+        # agree on the literal string "gitlab", or every assertion below
+        # would pass or fail for the wrong reason.
+        work_item_providers = {
+            row[0]
+            for row in raw_client.query(
+                "SELECT DISTINCT provider FROM work_items "
+                "WHERE org_id = {org_id:String}",
+                parameters={"org_id": org_id},
+            ).result_rows
+        }
+        catalog_providers = {
+            row[0]
+            for row in raw_client.query(
+                "SELECT DISTINCT provider FROM projects FINAL "
+                "WHERE org_id = {org_id:String} AND id = {pid:String}",
+                parameters={"org_id": org_id, "pid": GITLAB_PROJECT_PATH},
+            ).result_rows
+        }
+        assert work_item_providers == {"gitlab"}, work_item_providers
+        assert catalog_providers == {"gitlab"}, catalog_providers
+
         catalog = ClickHouseAuthorizedEntityCatalog(sink)
         service = ScopeResolutionService(catalog)
         resolution = await service.resolve_contract(
@@ -518,6 +543,21 @@ async def test_archived_gitlab_project_is_not_resolvable(
         )
         assert resolution.outcome is ResolutionOutcome.NO_AUTHORIZED_MATCH, (
             "an archived GitLab project is still resolvable"
+        )
+
+        # And the OTHER entry point: an explicit committed ref (the path
+        # native_status_change.py's own _PROJECT_IDENTITY_CTE is-active
+        # guard exists for), not just name lookup -- both must fail closed.
+        contract = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, GITLAB_PROJECT_PATH),)
+            ),
+        )
+        assert contract.outcome.value != "exact", (
+            "an archived GitLab project still resolves as an explicit scope ref",
+            contract.outcome,
         )
     finally:
         _cleanup(raw_client, org_id)

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -576,6 +576,14 @@ async def test_gitlab_incremental_sync_never_strands_history(
         # from THIS run's incremental sync -- both produced by the same
         # normalizer, so both carry the identical shape (project_id=path,
         # project_key=None) that is the actual point of this test.
+        # Fixed, safely-past timestamps -- NOT ``datetime.now(timezone.utc)``
+        # at write time, which lost a race against this test's own read-time
+        # ``as_of`` (computed independently, moments later, by
+        # ``StatusChangeService``) on this ClickHouse/driver's apparent
+        # timezone handling: a "now" written here landed several hours in
+        # ClickHouse's future relative to the "now" the read path computed
+        # right after, so ``updated_at <= {as_of}`` silently excluded it.
+        # "newer" only needs to be AFTER "older", not actually current time.
         older_item = replace(
             _normalize(1, GITLAB_PROJECT_PATH),
             org_id=org_id,
@@ -584,7 +592,7 @@ async def test_gitlab_incremental_sync_never_strands_history(
         newer_item = replace(
             _normalize(2, GITLAB_PROJECT_PATH),
             org_id=org_id,
-            updated_at=datetime.now(timezone.utc),
+            updated_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
         )
         assert older_item.project_key is None
         assert newer_item.project_key is None
@@ -975,22 +983,48 @@ async def test_oracle_measures_a_jira_project_referenced_only_by_key(
 
 
 @pytest.mark.asyncio
-async def test_oracle_flags_a_reused_gitlab_path_as_unverified_not_a_clean_match(
+async def test_path_reuse_cross_attribution_is_a_known_residual_until_chaos_3383(
     sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """CHAOS-3380 round 3 (Codex MEDIUM) acceptance-set counterexample: reuse.
+    """CHAOS-3380 round 4 (Codex HIGH): ACCEPTED residual, not a bug to fix here.
 
-    Pins the residual risk ``workers/team_autoimport_gitlab.
-    _gitlab_project_catalog_rows`` documents rather than silently assuming
-    it away: project A (numeric id) is renamed away from a path; project B
-    (a DIFFERENT numeric id) later claims that exact, now-free path. An OLD
-    work item -- never resynced, still carrying the original path in its own
-    ``project_id`` -- resolves to project B's catalog row (an unrelated
-    project) via the path-compatibility arm. This IS a false attribution,
-    and this test proves it happens -- but the oracle must never report it as
-    an ordinary clean match: it must carry ``kind="path_match_unverified"``,
-    so the ambiguity is visible rather than silently swallowed as a green
-    result.
+    Third review round on the same identity class. Draw-the-line closure per
+    the orchestrator's ruling: both reviewer remedies are out of scope or
+    self-defeating here --
+
+    * threading GitLab's immutable numeric id through ``work_items.
+      project_id`` itself (plus a backfill of existing rows) is exactly
+      CHAOS-3383, already filed as the structural fix; and
+    * failing closed on a path-only match at the query layer would disable
+      GitLab project resolution entirely, since every GitLab work item is
+      path-only today (see ``_project_identity.project_identity_match``'s
+      own "ACCEPTED RESIDUAL RISK" comment on arm 3) -- "fail closed on
+      path-only" and "fail closed on GitLab" are the same statement.
+
+    The exploit window (project A renamed off a path, project B later claims
+    it, an OLD work item from A never resynced since) requires a specific
+    PROVIDER-SIDE event sequence, not an app write path -- accepted as a
+    residual rather than chased through a fourth patch attempt.
+
+    This test is the acceptance-set discipline the ruling calls for: it pins
+    BOTH halves of the residual precisely, so CHAOS-3383's implementer must
+    rediscover and consciously retire it rather than leave a stale pin
+    behind --
+
+    1. the OFFLINE diagnostic (``ask_dev_project_subject_oracle.py``) DOES
+       disclose the match as ``kind="path_match_unverified"``, never a clean
+       green; and
+    2. PRODUCTION QUERIES (the same identity predicate, live, inside every
+       project-scoped fact arm) DO NOT consult that flag and ACCEPT the
+       cross-attribution -- proved here by actually resolving project B's
+       scope and reading project A's stale work item back out of its
+       snapshot, not merely asserting the oracle's opinion about it.
+
+    When CHAOS-3383 lands, assertion (2) below must FLIP: the stale item
+    must stop appearing in project B's snapshot. That flip -- a red
+    assertion where this test currently asserts green -- IS the signal this
+    pin exists to produce; do not delete this test to make the suite pass,
+    convert its assertions to prove the fix instead.
     """
 
     org_id = f"chaos-3380-reuse-{uuid.uuid4().hex[:10]}"
@@ -1004,10 +1038,12 @@ async def test_oracle_flags_a_reused_gitlab_path_as_unverified_not_a_clean_match
         sink.write_work_items([stale_item])
 
         # Project A: renamed away, no longer at reused_path.
+        project_a_id = f"{org_id}:gitlab:111"
+        project_b_id = f"{org_id}:gitlab:222"
         sink.write_projects(
             [
                 ProjectRecord(
-                    id=f"{org_id}:gitlab:111",
+                    id=project_a_id,
                     org_id=org_id,
                     provider="gitlab",
                     project_key="grp/project-a-renamed",
@@ -1018,7 +1054,7 @@ async def test_oracle_flags_a_reused_gitlab_path_as_unverified_not_a_clean_match
                 ),
                 # Project B: a DIFFERENT project that now claims the freed path.
                 ProjectRecord(
-                    id=f"{org_id}:gitlab:222",
+                    id=project_b_id,
                     org_id=org_id,
                     provider="gitlab",
                     project_key=reused_path,
@@ -1030,12 +1066,43 @@ async def test_oracle_flags_a_reused_gitlab_path_as_unverified_not_a_clean_match
             ]
         )
 
+        # (1) The offline diagnostic discloses it, not as a clean match.
         gaps = project_subject_gaps(raw_client, org_id=org_id, provider="gitlab")
         reuse_gaps = [gap for gap in gaps if gap.project_id == reused_path]
         assert reuse_gaps, "the reused-path reference produced no gap row at all"
         assert {gap.kind for gap in reuse_gaps} >= {"path_match_unverified"}, (
             "the reused-path match was reported clean, hiding a false "
             f"attribution to an unrelated project: {reuse_gaps}"
+        )
+
+        # (2) Production queries do NOT consult that flag: resolving project
+        # B's scope for real and reading its snapshot returns project A's
+        # stale item. THIS is the accepted residual, proved rather than
+        # assumed -- and the assertion CHAOS-3383 must invert.
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, project_b_id),)
+            ),
+        )
+        assert resolution.outcome.value == "exact"
+        scope = resolution.resolved_scope
+        assert scope is not None
+
+        snapshot = await StatusChangeService(
+            ClickHouseStatusChangeSource(sink)
+        ).status_snapshot(org_id, "permission-live", StatusSnapshotRequest(scope))
+
+        seen = {child.entity_id for child in snapshot.children}
+        assert any(child.endswith(f"gitlab:{reused_path}#1") for child in seen), (
+            "the accepted residual did not reproduce: project A's stale item "
+            "no longer leaks into project B's snapshot -- if CHAOS-3383 (or "
+            "any other change) closed this gap, RETIRE this pin consciously "
+            "(update this docstring and assertion) rather than treating a "
+            "newly-green run as nothing to look at",
+            seen,
         )
     finally:
         _cleanup(raw_client, org_id)

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -23,8 +23,21 @@ tracking metrics, treat the GitLab project path as the 'project' scope."),
 the SAME id space ``work_items.project_id`` already carries — mirroring
 Linear's raw-UUID catalog id, NOT Jira's ``{org}:jira:{key}`` prefixed id
 (CHAOS-3374). This is why the plain ``project_id = {entity_id}`` predicate
-below already matches a GitLab project on ``main``, with no dependency on the
-CHAOS-3374 identity-join fix landing first (unlike Jira).
+already matched a GitLab project even before CHAOS-3374 landed (unlike
+Jira, which needed the provider-scoped identity join to resolve at all).
+
+CHAOS-3374 (``native_status_change._PROJECT_IDENTITY_CTE`` /
+``_project_identity_match``) merged as of this revision (main 61aae46af,
+#1460): every project-scoped fact arm and ``PROJECT_REPOSITORIES_SQL`` now
+join through the catalog's own ``provider``/``project_key`` columns rather
+than comparing ``work_items.project_id``/``project_key`` to the entity id
+directly.
+``test_gitlab_project_resolves_end_to_end_through_the_native_status_change_join``
+below exercises that merged join directly (``ScopeResolutionService.
+resolve_contract`` → ``StatusChangeService.status_snapshot``, both reading
+through ``native_status_change.py``) with a REAL catalog row from this
+ticket's worker — the "only works once 3374 merges" caveat from the original
+handoff no longer applies and this test is the evidence.
 
 Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
 ``-m "not benchmark and not clickhouse"`` in BOTH ``unit_tests()`` and
@@ -46,8 +59,20 @@ import pytest
 
 from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
 from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome
+from dev_health_ops.api.dev.native_status_change import (
+    ClickHouseStatusChangeSource,
+)
 from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
-from dev_health_ops.api.dev.scope_service import EntityKind, ScopeResolutionService
+from dev_health_ops.api.dev.scope_service import (
+    EntityKind,
+    ScopeRef,
+    ScopeResolutionService,
+    ScopeResolveRequest,
+)
+from dev_health_ops.api.dev.status_change_service import (
+    StatusChangeService,
+    StatusSnapshotRequest,
+)
 from dev_health_ops.api.services.configuration.team_discovery import (
     GitLabDiscoveryResult,
 )
@@ -384,6 +409,74 @@ async def test_gitlab_project_id_selects_the_projects_work_items(
         assert matched == 1, (
             "the resolved project id selects no work items; the subject resolves "
             "but every answer about it would be empty"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_gitlab_project_resolves_end_to_end_through_the_native_status_change_join(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The full CHAOS-3380 + CHAOS-3374 chain, exercised together.
+
+    CHAOS-3374 (merged, main 61aae46af / #1460) reworked EVERY project-scoped
+    arm in ``native_status_change.py`` -- ``_WORK_ITEMS_SQL``,
+    ``PROJECT_REPOSITORIES_SQL``, and the rest -- to join through
+    ``_PROJECT_IDENTITY_CTE`` / ``_project_identity_match`` (catalog
+    ``provider`` + native key) instead of comparing ``work_items.project_id``/
+    ``project_key`` to the entity id directly. Before this ticket, GitLab
+    never reached that join at all: no catalog row existed, so
+    ``ScopeResolutionService`` returned ``NO_AUTHORIZED_MATCH`` before
+    ``native_status_change.py`` was ever queried. This test goes past
+    resolution (already covered above) into the SAME two calls the sibling
+    Jira live test uses (``resolve_contract`` then ``status_snapshot``) to
+    prove the merged join actually joins for a GitLab project: a work item
+    committed against it comes back in the snapshot, and a work item under a
+    DIFFERENT GitLab project (same provider, so the provider guard alone
+    can't be what excludes it) does not.
+    """
+
+    org_id = f"chaos-3380-e2e-{uuid.uuid4().hex[:12]}"
+    try:
+        _seed_reference_side(sink, org_id)
+        await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects={
+                GITLAB_PROJECT_PATH: _FakeGitLabProject(name=GITLAB_PROJECT_NAME),
+                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
+            },
+        )
+
+        catalog = ClickHouseAuthorizedEntityCatalog(sink)
+        service = ScopeResolutionService(catalog)
+        resolution = await service.resolve_contract(
+            org_id,
+            "permission-live",
+            ScopeResolveRequest(
+                explicit_refs=(ScopeRef(EntityKind.PROJECT, GITLAB_PROJECT_PATH),)
+            ),
+        )
+        assert resolution.outcome.value == "exact"
+        scope = resolution.resolved_scope
+        assert scope is not None
+        # Repo-less, like every GitLab issue/MR today (providers/gitlab/
+        # provider.py passes repo_id=None at normalize time) -- the zero-UUID
+        # sentinel bucket, exactly like Linear, not a real repos row.
+        assert scope.repositories == []
+
+        snapshot = await StatusChangeService(
+            ClickHouseStatusChangeSource(sink)
+        ).status_snapshot(org_id, "permission-live", StatusSnapshotRequest(scope))
+
+        seen = {child.entity_id for child in snapshot.children}
+        own_work_item_id = f"gitlab:{GITLAB_PROJECT_PATH}#1"
+        other_work_item_id = f"gitlab:{OTHER_PROJECT_PATH}#1"
+        assert any(child.endswith(own_work_item_id) for child in seen), seen
+        assert not any(child.endswith(other_work_item_id) for child in seen), (
+            "a different GitLab project's work item leaked into this project's scope",
+            seen,
         )
     finally:
         _cleanup(raw_client, org_id)

--- a/tests/test_ask_dev_gitlab_project_subject_live.py
+++ b/tests/test_ask_dev_gitlab_project_subject_live.py
@@ -1,0 +1,511 @@
+"""CHAOS-3380 live-ClickHouse proof: a GitLab project resolves as a subject.
+
+Mirrors ``tests/test_ask_dev_linear_project_subject_live.py`` (CHAOS-3365).
+Both sides of the comparison come from REAL producers running against a real
+migrated ClickHouse:
+
+* reference side — ``gitlab_issue_to_work_item`` (the production GitLab issue
+  normalizer) → ``ClickHouseMetricsSink.write_work_items``;
+* catalog side — ``team_autoimport_gitlab.populate`` (the production worker,
+  CHAOS-3380) → ``ClickHouseMetricsSink.write_projects``, driven by the real
+  ``TeamDiscoveryService.discover_gitlab`` group/subgroup walk with only the
+  HTTP round trip replaced (``GitLabWorkClient.get_project``).
+
+and the comparison itself is the shipped oracle
+(``scripts/ask_dev_project_subject_oracle.py``), parametrized to
+``provider="gitlab"`` — the SAME oracle CHAOS-3365 proved against Linear,
+exercised here rather than duplicated, so a change to the oracle's contract
+cannot silently stop applying to one provider.
+
+Identity choice under test: GitLab's catalog id is the RAW
+``path_with_namespace`` (``providers/gitlab/normalize.py``: "For work
+tracking metrics, treat the GitLab project path as the 'project' scope."),
+the SAME id space ``work_items.project_id`` already carries — mirroring
+Linear's raw-UUID catalog id, NOT Jira's ``{org}:jira:{key}`` prefixed id
+(CHAOS-3374). This is why the plain ``project_id = {entity_id}`` predicate
+below already matches a GitLab project on ``main``, with no dependency on the
+CHAOS-3374 identity-join fix landing first (unlike Jira).
+
+Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
+``-m "not benchmark and not clickhouse"`` in BOTH ``unit_tests()`` and
+``ci_tests()``): ``pytest -m clickhouse`` with ``CLICKHOUSE_URI`` pointing at a
+SCRATCH database — never the dev ``default``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.api.dev.contracts_v2 import ResolutionOutcome
+from dev_health_ops.api.dev.scope_catalog import ClickHouseAuthorizedEntityCatalog
+from dev_health_ops.api.dev.scope_service import EntityKind, ScopeResolutionService
+from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveryResult,
+)
+from dev_health_ops.metrics.schemas import ProjectRecord
+from dev_health_ops.providers.gitlab.normalize import gitlab_issue_to_work_item
+from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.status_mapping import StatusMapping
+from dev_health_ops.workers import team_autoimport_gitlab
+from scripts.ask_dev_project_subject_oracle import (
+    OracleNotMeasured,
+    project_subject_gaps,
+)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires a migrated SCRATCH CLICKHOUSE_URI "
+        "(e.g. clickhouse://ch:ch@localhost:8123/chaos3380_scratch)",
+    ),
+]
+
+GITLAB_PROJECT_PATH = "full-chaos/dev-health"
+GITLAB_PROJECT_NAME = "Dev Health"
+OTHER_PROJECT_PATH = "full-chaos/platform"
+OTHER_PROJECT_NAME = "Platform"
+
+#: Database names this file refuses to touch — same guard as CHAOS-3365's
+#: sibling file, duplicated deliberately rather than imported: a shared helper
+#: importing from another test module would make this file's protection
+#: depend on that module continuing to exist unchanged.
+_PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _scratch_database(dsn: str) -> str:
+    from urllib.parse import urlparse
+
+    database = urlparse(dsn).path.lstrip("/")
+    if database.strip().lower() in _PROTECTED_DATABASES:
+        raise RuntimeError(
+            "refusing to run schema migrations against ClickHouse database "
+            f"{database or '<unset>'!r}: this suite calls ensure_schema(force=True), "
+            "which rebuilds and drops tables. Point CLICKHOUSE_URI at a named "
+            "SCRATCH database (e.g. .../chaos3380_scratch)."
+        )
+    return database
+
+
+@pytest.fixture(scope="module")
+def sink() -> Any:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    _scratch_database(CLICKHOUSE_URI)
+    metrics_sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    metrics_sink.ensure_schema(force=True)
+    yield metrics_sink
+    metrics_sink.close()
+
+
+@pytest.fixture
+def raw_client() -> Any:
+    import clickhouse_connect
+
+    assert CLICKHOUSE_URI is not None
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _normalize(iid: int, project_full_path: str) -> Any:
+    """Build one work item through the production GitLab issue normalizer."""
+
+    identity = MagicMock(spec=IdentityResolver)
+    identity.resolve.side_effect = lambda **kwargs: "user:dev@example.com"
+    status_mapping = MagicMock(spec=StatusMapping)
+    status_mapping.normalize_status.return_value = "in_progress"
+    status_mapping.normalize_type.return_value = "task"
+
+    issue = {
+        "iid": iid,
+        "title": f"Issue {project_full_path}#{iid}",
+        "state": "opened",
+        "created_at": "2026-07-01T10:00:00Z",
+        "updated_at": "2026-07-30T12:00:00Z",
+        "labels": [],
+        "assignees": [],
+        "author": None,
+    }
+    work_item, _ = gitlab_issue_to_work_item(
+        issue=issue,
+        project_full_path=project_full_path,
+        repo_id=None,
+        status_mapping=status_mapping,
+        identity=identity,
+    )
+    return work_item
+
+
+def _seed_reference_side(sink: Any, org_id: str) -> None:
+    work_items = [
+        replace(_normalize(1, GITLAB_PROJECT_PATH), org_id=org_id),
+        replace(_normalize(1, OTHER_PROJECT_PATH), org_id=org_id),
+    ]
+    sink.org_id = org_id
+    sink.write_work_items(work_items)
+
+
+@dataclass
+class _FakeGitLabProject:
+    name: str
+    archived: bool = False
+    web_url: str = ""
+
+
+def _fake_gitlab_work_client_cls(projects: dict[str, _FakeGitLabProject]) -> type:
+    class _FakeGitLabWorkClient:
+        def __init__(self, *, auth: Any, org_id: str | None = None) -> None:
+            self.auth = auth
+            self.org_id = org_id
+
+        def get_project(self, project_id_or_path: str) -> _FakeGitLabProject:
+            return projects[project_id_or_path]
+
+    return _FakeGitLabWorkClient
+
+
+async def _run_autoimport(
+    monkeypatch: pytest.MonkeyPatch,
+    org_id: str,
+    *,
+    projects: dict[str, _FakeGitLabProject],
+) -> dict[str, Any]:
+    """Run the production worker with only GitLab's HTTP round trips replaced.
+
+    ``team_autoimport_gitlab.populate`` calls ``asyncio.run(...)`` directly
+    (unlike Jira/Linear's thread-hopping ``_run()`` helper), which raises
+    "cannot be called from a running event loop" when invoked from inside an
+    ``async def`` test. Run it in its own thread so IT owns the event loop it
+    creates, exactly like a Celery worker thread would.
+    """
+
+    async def discover_gitlab(
+        self: object, token: str, group_path: str, url: str
+    ) -> GitLabDiscoveryResult:
+        return GitLabDiscoveryResult(
+            teams=[
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos",
+                    name="Full Chaos",
+                    associations={
+                        "repo_patterns": list(projects.keys()),
+                        "provider_org": group_path,
+                    },
+                )
+            ]
+        )
+
+    async def discover_members_gitlab(
+        self: object, token: str, group_path: str, url: str
+    ) -> list[DiscoveredMember]:
+        return []
+
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamDiscoveryService,
+        "discover_gitlab",
+        discover_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamMembershipService,
+        "discover_members_gitlab",
+        discover_members_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab,
+        "GitLabWorkClient",
+        _fake_gitlab_work_client_cls(projects),
+    )
+
+    assert CLICKHOUSE_URI is not None
+    return await asyncio.to_thread(
+        team_autoimport_gitlab.populate,
+        org_id=org_id,
+        credentials={"token": "gl-token", "group_path": "full-chaos"},
+        scope={
+            "mode": "sync_config",
+            "analytics_db": CLICKHOUSE_URI,
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+
+def _cleanup(client: Any, org_id: str) -> None:
+    for table in (
+        "work_items",
+        "projects",
+        "teams",
+        "members",
+        "team_memberships",
+        "team_project_ownership",
+    ):
+        client.command(
+            f"ALTER TABLE {table} DELETE WHERE org_id = {{org_id:String}}",
+            parameters={"org_id": org_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_gitlab_project_becomes_a_resolvable_subject(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The observable pair: oracle RED before the autoimport, GREEN after."""
+
+    org_id = f"chaos-3380-{uuid.uuid4().hex[:16]}"
+    try:
+        _seed_reference_side(sink, org_id)
+
+        before = project_subject_gaps(
+            raw_client,
+            org_id=org_id,
+            provider="gitlab",
+            acceptance_project_ids=(GITLAB_PROJECT_PATH,),
+        )
+        assert {gap.project_id for gap in before} == {
+            GITLAB_PROJECT_PATH,
+            OTHER_PROJECT_PATH,
+        }
+        assert {gap.kind for gap in before} == {"missing"}
+
+        summary = await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects={
+                GITLAB_PROJECT_PATH: _FakeGitLabProject(
+                    name=GITLAB_PROJECT_NAME,
+                    web_url=f"https://gitlab.com/{GITLAB_PROJECT_PATH}",
+                ),
+                OTHER_PROJECT_PATH: _FakeGitLabProject(
+                    name=OTHER_PROJECT_NAME,
+                    web_url=f"https://gitlab.com/{OTHER_PROJECT_PATH}",
+                ),
+            },
+        )
+        assert summary["native_projects_imported"] == 2
+        assert summary["native_projects_complete"] is True
+
+        after = project_subject_gaps(
+            raw_client,
+            org_id=org_id,
+            provider="gitlab",
+            acceptance_project_ids=(GITLAB_PROJECT_PATH,),
+        )
+        # "missing"/"inactive"/"name_ambiguous" must be fully cleared -- those
+        # are what CHAOS-3380 exists to fix. "name_mismatch" survives here as
+        # a PRE-EXISTING, orthogonal gap: unlike Linear's issue normalizer
+        # (which caches project.name straight off the issue payload),
+        # ``gitlab_issue_to_work_item`` never sets ``WorkItem.project_name``
+        # at all (providers/gitlab/normalize.py has no such assignment), so
+        # ``work_items.project_name`` is always empty for GitLab today. That
+        # is a gap in the WORK-ITEM producer, not the catalog this ticket
+        # adds -- and it does not affect subject resolution, which reads the
+        # catalog's OWN name (proved by resolve_mention below, not by
+        # work_items.project_name).
+        assert {gap.kind for gap in after} == {"name_mismatch"}, (
+            f"catalog still incomplete after autoimport: {after}"
+        )
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_mention(
+            org_id,
+            "permission-live",
+            lookup_text=GITLAB_PROJECT_NAME,
+            kinds=(EntityKind.PROJECT,),
+        )
+        assert resolution.outcome is ResolutionOutcome.EXACT_MATCH
+        assert resolution.entity is not None
+        assert resolution.entity.canonical_id == GITLAB_PROJECT_PATH
+        assert resolution.entity.label == GITLAB_PROJECT_NAME
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_gitlab_project_id_selects_the_projects_work_items(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resolved canonical id must be usable as a ``work_items`` filter.
+
+    Deliberately checked with the SAME plain predicate
+    ``native_status_change._WORK_ITEMS_SQL`` uses on current ``main``
+    (``project_id = {entity_id} OR project_key = {entity_id}``) rather than
+    calling into that module: this repo has a sibling lane
+    (CHAOS-3374/chaos-3374-jira-project-identity, not merged as of this test)
+    reworking that file's project-identity join for Jira's PREFIXED catalog
+    id. GitLab's catalog id is the RAW path, the same id space Linear already
+    used successfully with this exact predicate, so this assertion holds
+    against ``main`` today and is expected to keep holding once 3374 merges
+    (its own CTE preserves the ``project_id = {entity_id}`` arm verbatim).
+    """
+
+    org_id = f"chaos-3380-scope-{uuid.uuid4().hex[:12]}"
+    try:
+        _seed_reference_side(sink, org_id)
+        await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects={
+                GITLAB_PROJECT_PATH: _FakeGitLabProject(name=GITLAB_PROJECT_NAME),
+                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
+            },
+        )
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_mention(
+            org_id,
+            "permission-live",
+            lookup_text=GITLAB_PROJECT_NAME,
+            kinds=(EntityKind.PROJECT,),
+        )
+        assert resolution.entity is not None
+        entity_id = resolution.entity.canonical_id
+        assert entity_id == GITLAB_PROJECT_PATH
+
+        matched = raw_client.query(
+            "SELECT count() FROM work_items WHERE org_id = {org_id:String} "
+            "AND (project_id = {entity_id:String} OR project_key = {entity_id:String})",
+            parameters={"org_id": org_id, "entity_id": entity_id},
+        ).result_rows[0][0]
+        assert matched == 1, (
+            "the resolved project id selects no work items; the subject resolves "
+            "but every answer about it would be empty"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_archived_gitlab_project_is_not_resolvable(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``archived`` retires the row; ``scope_catalog`` filters ``is_active = 1``."""
+
+    org_id = f"chaos-3380-archived-{uuid.uuid4().hex[:12]}"
+    try:
+        _seed_reference_side(sink, org_id)
+        await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects={
+                GITLAB_PROJECT_PATH: _FakeGitLabProject(
+                    name=GITLAB_PROJECT_NAME, archived=True
+                ),
+                OTHER_PROJECT_PATH: _FakeGitLabProject(name=OTHER_PROJECT_NAME),
+            },
+        )
+
+        row = raw_client.query(
+            "SELECT is_active FROM projects FINAL "
+            "WHERE org_id = {org_id:String} AND id = {pid:String} AND provider = 'gitlab'",
+            parameters={"org_id": org_id, "pid": GITLAB_PROJECT_PATH},
+        ).result_rows
+        assert row == [(0,)]
+
+        service = ScopeResolutionService(ClickHouseAuthorizedEntityCatalog(sink))
+        resolution = await service.resolve_mention(
+            org_id,
+            "permission-live",
+            lookup_text=GITLAB_PROJECT_NAME,
+            kinds=(EntityKind.PROJECT,),
+        )
+        assert resolution.outcome is ResolutionOutcome.NO_AUTHORIZED_MATCH, (
+            "an archived GitLab project is still resolvable"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+@pytest.mark.asyncio
+async def test_gitlab_project_id_colliding_with_a_jira_catalog_id_stays_distinct(
+    sink: Any, raw_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CHAOS-3380 cross-provider coverage.
+
+    ``projects``' ReplacingMergeTree key is ``(org_id, provider, id)``
+    (native_status_change._PROJECT_IDENTITY_CTE's own comment on the sibling
+    CHAOS-3374 branch) -- ``id`` alone is only unique WITHIN one provider. A
+    GitLab project's raw path can coincidentally equal another provider's raw
+    catalog id in the SAME org (nothing enforces cross-provider id
+    uniqueness); this pins that BOTH rows survive ``FINAL`` as distinct rows
+    scoped by provider, rather than one silently replacing the other.
+    """
+
+    org_id = f"chaos-3380-collide-{uuid.uuid4().hex[:10]}"
+    now = datetime.now(timezone.utc)
+    colliding_id = f"collide-{uuid.uuid4().hex[:8]}"
+    try:
+        # A Jira-provider row using the colliding string as its (prefixed-in-
+        # production, but here deliberately bare) id.
+        sink.write_projects(
+            [
+                ProjectRecord(
+                    id=colliding_id,
+                    org_id=org_id,
+                    provider="jira",
+                    project_key="COLLIDE",
+                    name="Jira Side",
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            ]
+        )
+        # A GitLab project whose raw path happens to be the SAME string,
+        # written through the production worker.
+        await _run_autoimport(
+            monkeypatch,
+            org_id,
+            projects={colliding_id: _FakeGitLabProject(name="GitLab Side")},
+        )
+
+        rows = sorted(
+            raw_client.query(
+                "SELECT provider, name FROM projects FINAL "
+                "WHERE org_id = {org_id:String} AND id = {pid:String}",
+                parameters={"org_id": org_id, "pid": colliding_id},
+            ).result_rows
+        )
+        assert rows == [("gitlab", "GitLab Side"), ("jira", "Jira Side")], (
+            "the two providers' rows did not both survive FINAL as distinct rows: "
+            f"{rows}"
+        )
+    finally:
+        _cleanup(raw_client, org_id)
+
+
+def test_the_suite_refuses_to_migrate_a_protected_database() -> None:
+    with pytest.raises(RuntimeError, match="refusing to run schema migrations"):
+        _scratch_database("clickhouse://ch:ch@localhost:8123/default")
+
+
+def test_the_guard_still_admits_a_named_scratch_database() -> None:
+    assert (
+        _scratch_database("clickhouse://ch:ch@localhost:8123/chaos3380_scratch")
+        == "chaos3380_scratch"
+    )
+
+
+def test_oracle_refuses_to_pass_for_gitlab_when_nothing_was_compared(
+    raw_client: Any,
+) -> None:
+    with pytest.raises(OracleNotMeasured, match="nothing to compare"):
+        project_subject_gaps(
+            raw_client,
+            org_id=f"empty-{uuid.uuid4().hex[:12]}",
+            provider="gitlab",
+        )

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -737,6 +737,94 @@ def test_gitlab_source_selection_absent_catalogs_everything(
     assert len(sink.projects) == 2
 
 
+def test_gitlab_selected_source_missing_from_discovery_marks_the_catalog_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3380 round 3 (Codex MEDIUM -- stale selected-source set reads as
+    complete): the inverse gap from the filtering tests above. A selected id
+    that discovery never returned at all (deleted, access revoked, or simply
+    never reached before a pagination bound) must not vanish from the catalog
+    with ``native_projects_complete`` staying ``True`` -- the ORIGINAL bug
+    this fix closes: "first import creates nothing; re-import leaves a stale
+    row; the run still reports complete."
+    """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/present"],
+        projects=[_discovered_project("701", "full-chaos/present")],
+    )
+
+    # "702" is selected but discovery never returned it.
+    summary = _populate_gitlab(source_external_ids=["701", "702"])
+
+    assert summary["native_projects_imported"] == 1
+    assert {row.id for row in sink.projects} == {"org-1:gitlab:701"}
+    assert summary["native_projects_missing_selected_source_ids"] == ["702"]
+    assert summary["native_projects_complete"] is False, (
+        "a selected-but-undiscovered source must mark the catalog incomplete"
+    )
+
+
+def test_gitlab_selected_source_present_in_discovery_stays_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The positive case beside the one above: every selected id IS
+    discovered -> no missing ids, catalog stays complete."""
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/present"],
+        projects=[_discovered_project("801", "full-chaos/present")],
+    )
+
+    summary = _populate_gitlab(source_external_ids=["801"])
+
+    assert summary["native_projects_imported"] == 1
+    assert {row.id for row in sink.projects} == {"org-1:gitlab:801"}
+    assert summary["native_projects_missing_selected_source_ids"] == []
+    assert summary["native_projects_complete"] is True
+
+
+def test_gitlab_selection_explicit_empty_has_no_missing_selected_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty selection (nothing enabled) trivially has no
+    MISSING selected source either -- vacuously complete, distinguished from
+    the stale-source case, which has at least one selected id to go missing."""
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/a"],
+        projects=[_discovered_project("901", "full-chaos/a")],
+    )
+
+    summary = _populate_gitlab(source_external_ids=[])
+
+    assert sink.projects == []
+    assert summary["native_projects_missing_selected_source_ids"] == []
+    assert summary["native_projects_complete"] is True
+
+
+def test_gitlab_selection_absent_key_has_no_missing_selected_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``source_external_ids`` key at all (the common post-sync path) ->
+    nothing is "selected" in the first place, so nothing can be missing."""
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/a"],
+        projects=[_discovered_project("902", "full-chaos/a")],
+    )
+
+    summary = _populate_gitlab()
+
+    assert len(sink.projects) == 1
+    assert summary["native_projects_missing_selected_source_ids"] == []
+    assert summary["native_projects_complete"] is True
+
+
 def test_gitlab_truncated_discovery_marks_the_catalog_incomplete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -14,11 +14,49 @@ from dev_health_ops.workers import team_autoimport_github, team_autoimport_gitla
 
 
 @dataclass
+class _FakeGitLabProject:
+    """Stand-in for a python-gitlab ``Project`` RESTObject: attribute access only."""
+
+    name: str
+    archived: bool = False
+    web_url: str = ""
+
+
+def _fake_gitlab_work_client_cls(
+    projects: dict[str, _FakeGitLabProject],
+    *,
+    fail_paths: frozenset[str] = frozenset(),
+) -> type:
+    """A ``GitLabWorkClient`` stand-in keyed by the SAME path used to fetch it.
+
+    Never makes a network call -- unit tests must not depend on GitLab being
+    reachable. ``fail_paths`` models a project whose metadata fetch fails
+    (e.g. a 404 for a project deleted since discovery ran) without touching
+    every other discovered project.
+    """
+
+    class _FakeGitLabWorkClient:
+        def __init__(self, *, auth: Any, org_id: str | None = None) -> None:
+            self.auth = auth
+            self.org_id = org_id
+
+        def get_project(self, project_id_or_path: str) -> _FakeGitLabProject:
+            if project_id_or_path in fail_paths:
+                raise RuntimeError(
+                    f"simulated GitLab fetch failure: {project_id_or_path}"
+                )
+            return projects[project_id_or_path]
+
+    return _FakeGitLabWorkClient
+
+
+@dataclass
 class RecordingSink:
     teams: list[dict[str, Any]] = field(default_factory=list)
     repo_ownership: list[Any] = field(default_factory=list)
     project_ownership: list[Any] = field(default_factory=list)
     memberships: list[Any] = field(default_factory=list)
+    projects: list[Any] = field(default_factory=list)
     manual_repo_ownership: list[dict[str, Any]] = field(
         default_factory=lambda: [
             {
@@ -42,6 +80,9 @@ class RecordingSink:
 
     def write_team_memberships(self, rows: list[Any]) -> None:
         self.memberships.extend(rows)
+
+    def write_projects(self, rows: list[Any]) -> None:
+        self.projects.extend(rows)
 
 
 def test_github_org_import_writes_provider_access_repo_grants_and_nested_specificity(
@@ -343,6 +384,20 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     monkeypatch.setattr(
         team_autoimport_gitlab, "load_identity_resolver", lambda: resolver
     )
+    monkeypatch.setattr(
+        team_autoimport_gitlab,
+        "GitLabWorkClient",
+        _fake_gitlab_work_client_cls(
+            {
+                "full-chaos/platform": _FakeGitLabProject(
+                    name="Platform", web_url="https://gitlab.com/full-chaos/platform"
+                ),
+                "full-chaos/dev-health/api": _FakeGitLabProject(
+                    name="API", web_url="https://gitlab.com/full-chaos/dev-health/api"
+                ),
+            }
+        ),
+    )
 
     summary = team_autoimport_gitlab.populate(
         org_id="org-1",
@@ -356,6 +411,24 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     assert summary["teams_imported"] == 2
     assert summary["projects_imported"] == 2
     assert summary["team_project_ownership_imported"] == 2
+    # CHAOS-3380: the projects catalog rows, distinct from "projects_imported"
+    # above (which counts team-ownership project PATHS, not catalog rows).
+    assert summary["native_projects_imported"] == 2
+    assert summary["native_projects_complete"] is True
+    assert {row.id for row in sink.projects} == {
+        "full-chaos/platform",
+        "full-chaos/dev-health/api",
+    }
+    assert {row.provider for row in sink.projects} == {"gitlab"}
+    # project_key is ALWAYS None: GitLab work items never set project_key
+    # (providers/gitlab/normalize.py), so the id is the only identity arm the
+    # native_status_change join (CHAOS-3374) can ever match a GitLab project
+    # through.
+    assert {row.project_key for row in sink.projects} == {None}
+    assert {row.is_active for row in sink.projects} == {1}
+    platform_row = next(row for row in sink.projects if row.id == "full-chaos/platform")
+    assert platform_row.name == "Platform"
+    assert platform_row.url == "https://gitlab.com/full-chaos/platform"
     assert {row["id"] for row in sink.teams} == {
         "gl:full-chaos",
         "gl:full-chaos/dev-health",
@@ -452,3 +525,162 @@ def test_github_personal_account_or_unsupported_response_skips_without_touching_
     assert summary["team_repo_ownership_imported"] == 0
     assert summary["team_memberships_imported"] == 0
     assert sink.manual_repo_ownership == manual_before
+
+
+def _patch_single_group_gitlab_discovery(
+    monkeypatch: pytest.MonkeyPatch, *, repo_patterns: list[str]
+) -> RecordingSink:
+    """Common CHAOS-3380 fixture: one GitLab group owning ``repo_patterns``."""
+
+    sink = RecordingSink()
+    resolver = IdentityResolver(alias_to_canonical={})
+
+    async def discover_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> GitLabDiscoveryResult:
+        return GitLabDiscoveryResult(
+            teams=[
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos",
+                    name="Full Chaos",
+                    associations={
+                        "repo_patterns": repo_patterns,
+                        "provider_org": group_path,
+                    },
+                ),
+            ]
+        )
+
+    async def discover_members_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> list[DiscoveredMember]:
+        return []
+
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamDiscoveryService,
+        "discover_gitlab",
+        discover_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamMembershipService,
+        "discover_members_gitlab",
+        discover_members_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab, "ClickHouseMetricsSink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab, "load_identity_resolver", lambda: resolver
+    )
+    return sink
+
+
+def test_gitlab_archived_project_is_written_as_retired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3380: mirrors #1450's Linear archivedAt/trashed handling.
+
+    ``archived`` is the only retirement signal GitLab's project resource
+    exposes; a project retired this way must land ``is_active=0`` so
+    ``scope_catalog`` (which filters ``is_active = 1``) stops serving it as an
+    Ask Dev subject -- the same contract Linear's archived/trashed projects
+    get, deliberately WITHOUT the absence-based retirement CHAOS-3372 leaves
+    open (a project simply not re-discovered this run keeps its last-written
+    state rather than being tombstoned).
+    """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch, repo_patterns=["full-chaos/legacy"]
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab,
+        "GitLabWorkClient",
+        _fake_gitlab_work_client_cls(
+            {"full-chaos/legacy": _FakeGitLabProject(name="Legacy", archived=True)}
+        ),
+    )
+
+    summary = team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["native_projects_imported"] == 1
+    assert sink.projects[0].id == "full-chaos/legacy"
+    assert sink.projects[0].is_active == 0
+
+
+def test_gitlab_project_metadata_fetch_failure_skips_only_that_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single project's metadata fetch failing must not discard the rest.
+
+    Mirrors Linear's ``native_projects_complete`` contract: a partial catalog
+    is reported INCOMPLETE rather than silently passing as a full one, but
+    team ownership (independent of the catalog fetch) is unaffected.
+    """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/ok", "full-chaos/gone"],
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab,
+        "GitLabWorkClient",
+        _fake_gitlab_work_client_cls(
+            {"full-chaos/ok": _FakeGitLabProject(name="OK")},
+            fail_paths=frozenset({"full-chaos/gone"}),
+        ),
+    )
+
+    summary = team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["native_projects_imported"] == 1
+    assert summary["native_projects_complete"] is False
+    assert {row.id for row in sink.projects} == {"full-chaos/ok"}
+    # Team ownership is a separate fetch and must survive the partial catalog.
+    assert summary["team_project_ownership_imported"] == 2
+
+
+def test_gitlab_no_discovered_projects_skips_the_metadata_fetch_entirely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No repo_patterns discovered -> no GitLab API call is even attempted.
+
+    ``GitLabWorkClient`` is patched to raise on construction, so this fails
+    loudly if the "nothing to fetch" guard is ever removed.
+    """
+
+    sink = _patch_single_group_gitlab_discovery(monkeypatch, repo_patterns=[])
+
+    def _explode(*, auth: Any, org_id: str | None = None) -> Any:
+        raise AssertionError(
+            "no project paths were discovered; GitLabWorkClient must not be constructed"
+        )
+
+    monkeypatch.setattr(team_autoimport_gitlab, "GitLabWorkClient", _explode)
+
+    summary = team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["native_projects_imported"] == 0
+    assert summary["native_projects_complete"] is True
+    assert sink.projects == []

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -7,47 +7,34 @@ import pytest
 
 from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
 from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveredProject,
     GitLabDiscoveryResult,
 )
 from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.workers import team_autoimport_github, team_autoimport_gitlab
 
 
-@dataclass
-class _FakeGitLabProject:
-    """Stand-in for a python-gitlab ``Project`` RESTObject: attribute access only."""
-
-    name: str
-    archived: bool = False
-    web_url: str = ""
-
-
-def _fake_gitlab_work_client_cls(
-    projects: dict[str, _FakeGitLabProject],
+def _discovered_project(
+    id: str,
+    path: str,
     *,
-    fail_paths: frozenset[str] = frozenset(),
-) -> type:
-    """A ``GitLabWorkClient`` stand-in keyed by the SAME path used to fetch it.
-
-    Never makes a network call -- unit tests must not depend on GitLab being
-    reachable. ``fail_paths`` models a project whose metadata fetch fails
-    (e.g. a 404 for a project deleted since discovery ran) without touching
-    every other discovered project.
+    name: str | None = None,
+    archived: bool = False,
+    web_url: str = "",
+) -> GitLabDiscoveredProject:
+    """A ``GitLabDiscoveredProject`` exactly as ``discover_gitlab``'s flat,
+    recursive listing call produces it (CHAOS-3380 round 2): ``id`` is
+    GitLab's own immutable numeric project id, ``path`` is the CURRENT
+    ``path_with_namespace``.
     """
 
-    class _FakeGitLabWorkClient:
-        def __init__(self, *, auth: Any, org_id: str | None = None) -> None:
-            self.auth = auth
-            self.org_id = org_id
-
-        def get_project(self, project_id_or_path: str) -> _FakeGitLabProject:
-            if project_id_or_path in fail_paths:
-                raise RuntimeError(
-                    f"simulated GitLab fetch failure: {project_id_or_path}"
-                )
-            return projects[project_id_or_path]
-
-    return _FakeGitLabWorkClient
+    return GitLabDiscoveredProject(
+        id=id,
+        path_with_namespace=path,
+        name=name or path,
+        archived=archived,
+        web_url=web_url,
+    )
 
 
 @dataclass
@@ -354,7 +341,21 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
                         "provider_org": group_path,
                     },
                 ),
-            ]
+            ],
+            projects=[
+                _discovered_project(
+                    "101",
+                    "full-chaos/platform",
+                    name="Platform",
+                    web_url="https://gitlab.com/full-chaos/platform",
+                ),
+                _discovered_project(
+                    "102",
+                    "full-chaos/dev-health/api",
+                    name="API",
+                    web_url="https://gitlab.com/full-chaos/dev-health/api",
+                ),
+            ],
         )
 
     async def discover_members_gitlab(
@@ -384,20 +385,6 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     monkeypatch.setattr(
         team_autoimport_gitlab, "load_identity_resolver", lambda: resolver
     )
-    monkeypatch.setattr(
-        team_autoimport_gitlab,
-        "GitLabWorkClient",
-        _fake_gitlab_work_client_cls(
-            {
-                "full-chaos/platform": _FakeGitLabProject(
-                    name="Platform", web_url="https://gitlab.com/full-chaos/platform"
-                ),
-                "full-chaos/dev-health/api": _FakeGitLabProject(
-                    name="API", web_url="https://gitlab.com/full-chaos/dev-health/api"
-                ),
-            }
-        ),
-    )
 
     summary = team_autoimport_gitlab.populate(
         org_id="org-1",
@@ -415,18 +402,25 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     # above (which counts team-ownership project PATHS, not catalog rows).
     assert summary["native_projects_imported"] == 2
     assert summary["native_projects_complete"] is True
+    assert summary["native_projects_filtered_by_selection"] == 0
+    # CHAOS-3380 round 2 (Codex HIGH): the catalog id is GitLab's IMMUTABLE
+    # numeric project id, prefixed like Jira's -- never the mutable path.
     assert {row.id for row in sink.projects} == {
+        "org-1:gitlab:101",
+        "org-1:gitlab:102",
+    }
+    assert {row.provider for row in sink.projects} == {"gitlab"}
+    # project_key carries the CURRENT path -- the identity join
+    # (native_status_change._project_identity_match, CHAOS-3374) resolves a
+    # GitLab project through THIS arm, matching providers/gitlab/normalize.py
+    # now writing the SAME path onto work_items.project_key.
+    assert {row.project_key for row in sink.projects} == {
         "full-chaos/platform",
         "full-chaos/dev-health/api",
     }
-    assert {row.provider for row in sink.projects} == {"gitlab"}
-    # project_key is ALWAYS None: GitLab work items never set project_key
-    # (providers/gitlab/normalize.py), so the id is the only identity arm the
-    # native_status_change join (CHAOS-3374) can ever match a GitLab project
-    # through.
-    assert {row.project_key for row in sink.projects} == {None}
     assert {row.is_active for row in sink.projects} == {1}
-    platform_row = next(row for row in sink.projects if row.id == "full-chaos/platform")
+    platform_row = next(row for row in sink.projects if row.id == "org-1:gitlab:101")
+    assert platform_row.project_key == "full-chaos/platform"
     assert platform_row.name == "Platform"
     assert platform_row.url == "https://gitlab.com/full-chaos/platform"
     assert {row["id"] for row in sink.teams} == {
@@ -528,7 +522,12 @@ def test_github_personal_account_or_unsupported_response_skips_without_touching_
 
 
 def _patch_single_group_gitlab_discovery(
-    monkeypatch: pytest.MonkeyPatch, *, repo_patterns: list[str]
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repo_patterns: list[str],
+    projects: list[GitLabDiscoveredProject] | None = None,
+    truncated: bool = False,
+    warnings: list[str] | None = None,
 ) -> RecordingSink:
     """Common CHAOS-3380 fixture: one GitLab group owning ``repo_patterns``."""
 
@@ -549,7 +548,10 @@ def _patch_single_group_gitlab_discovery(
                         "provider_org": group_path,
                     },
                 ),
-            ]
+            ],
+            projects=projects or [],
+            truncated=truncated,
+            warnings=warnings or [],
         )
 
     async def discover_members_gitlab(
@@ -576,6 +578,19 @@ def _patch_single_group_gitlab_discovery(
     return sink
 
 
+def _populate_gitlab(**scope_overrides: Any) -> dict[str, Any]:
+    scope: dict[str, Any] = {
+        "analytics_db": "clickhouse://test",
+        "sync_options": {"auto_import_teams": True},
+    }
+    scope.update(scope_overrides)
+    return team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope=scope,
+    )
+
+
 def test_gitlab_archived_project_is_written_as_retired(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -591,95 +606,172 @@ def test_gitlab_archived_project_is_written_as_retired(
     """
 
     sink = _patch_single_group_gitlab_discovery(
-        monkeypatch, repo_patterns=["full-chaos/legacy"]
-    )
-    monkeypatch.setattr(
-        team_autoimport_gitlab,
-        "GitLabWorkClient",
-        _fake_gitlab_work_client_cls(
-            {"full-chaos/legacy": _FakeGitLabProject(name="Legacy", archived=True)}
-        ),
+        monkeypatch,
+        repo_patterns=["full-chaos/legacy"],
+        projects=[_discovered_project("201", "full-chaos/legacy", archived=True)],
     )
 
-    summary = team_autoimport_gitlab.populate(
-        org_id="org-1",
-        credentials={"token": "secret", "group_path": "full-chaos"},
-        scope={
-            "analytics_db": "clickhouse://test",
-            "sync_options": {"auto_import_teams": True},
-        },
-    )
+    summary = _populate_gitlab()
 
     assert summary["native_projects_imported"] == 1
-    assert sink.projects[0].id == "full-chaos/legacy"
+    assert sink.projects[0].id == "org-1:gitlab:201"
+    assert sink.projects[0].project_key == "full-chaos/legacy"
     assert sink.projects[0].is_active == 0
 
 
-def test_gitlab_project_metadata_fetch_failure_skips_only_that_project(
+def test_gitlab_project_rename_updates_the_same_catalog_row_by_immutable_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A single project's metadata fetch failing must not discard the rest.
+    """CHAOS-3380 round 2 (Codex HIGH): rename/transfer, made explicit.
 
-    Mirrors Linear's ``native_projects_complete`` contract: a partial catalog
-    is reported INCOMPLETE rather than silently passing as a full one, but
-    team ownership (independent of the catalog fetch) is unaffected.
+    The SAME numeric project id, discovered under a NEW path on a later run
+    (a rename or a group transfer), must mint a catalog row with the SAME
+    ``id`` -- so the ReplacingMergeTree row this becomes in production is a
+    new VERSION of the same subject, not a second, unrelated one -- with
+    ``project_key`` updated to the new path. Work items ingested under the
+    OLD path are NOT reattached by this (their own ``project_key`` was baked
+    in at ingestion time, and GitLab's own work_item_id is path-derived,
+    pre-existing and out of this ticket's scope) -- they simply stop
+    matching until the provider sync re-ingests them under the new path.
+    That is the fail-safe direction: orphaned, never silently merged into an
+    unrelated project's history.
     """
 
     sink = _patch_single_group_gitlab_discovery(
         monkeypatch,
-        repo_patterns=["full-chaos/ok", "full-chaos/gone"],
+        repo_patterns=["full-chaos/old-name"],
+        projects=[_discovered_project("301", "full-chaos/old-name")],
     )
-    monkeypatch.setattr(
-        team_autoimport_gitlab,
-        "GitLabWorkClient",
-        _fake_gitlab_work_client_cls(
-            {"full-chaos/ok": _FakeGitLabProject(name="OK")},
-            fail_paths=frozenset({"full-chaos/gone"}),
-        ),
+    before = _populate_gitlab()
+    assert sink.projects[-1].id == "org-1:gitlab:301"
+    assert sink.projects[-1].project_key == "full-chaos/old-name"
+
+    sink2 = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/new-name"],
+        projects=[_discovered_project("301", "full-chaos/new-name")],
     )
+    after = _populate_gitlab()
 
-    summary = team_autoimport_gitlab.populate(
-        org_id="org-1",
-        credentials={"token": "secret", "group_path": "full-chaos"},
-        scope={
-            "analytics_db": "clickhouse://test",
-            "sync_options": {"auto_import_teams": True},
-        },
-    )
-
-    assert summary["native_projects_imported"] == 1
-    assert summary["native_projects_complete"] is False
-    assert {row.id for row in sink.projects} == {"full-chaos/ok"}
-    # Team ownership is a separate fetch and must survive the partial catalog.
-    assert summary["team_project_ownership_imported"] == 2
+    assert before["native_projects_imported"] == 1
+    assert after["native_projects_imported"] == 1
+    # SAME catalog id across the rename.
+    assert sink2.projects[-1].id == "org-1:gitlab:301"
+    # project_key tracks the CURRENT path.
+    assert sink2.projects[-1].project_key == "full-chaos/new-name"
 
 
-def test_gitlab_no_discovered_projects_skips_the_metadata_fetch_entirely(
+def test_gitlab_source_selection_filters_unselected_projects_from_the_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No repo_patterns discovered -> no GitLab API call is even attempted.
+    """CHAOS-3380 round 2 (Codex MEDIUM): only ENABLED sources get cataloged.
 
-    ``GitLabWorkClient`` is patched to raise on construction, so this fails
-    loudly if the "nothing to fetch" guard is ever removed.
+    ``source_external_ids`` (populated by the reference-discovery scope,
+    ``workers/reference_discovery.py``) carries the enabled
+    ``IntegrationSource.external_id`` values -- GitLab's numeric project id.
+    A project the credential can see but this sync run did not select must
+    never become a resolvable Ask Dev subject.
     """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/selected", "full-chaos/unselected"],
+        projects=[
+            _discovered_project("401", "full-chaos/selected"),
+            _discovered_project("402", "full-chaos/unselected"),
+        ],
+    )
+
+    summary = _populate_gitlab(source_external_ids=["401"])
+
+    assert summary["native_projects_imported"] == 1
+    assert summary["native_projects_filtered_by_selection"] == 1
+    assert {row.id for row in sink.projects} == {"org-1:gitlab:401"}
+    assert "full-chaos/unselected" not in {row.project_key for row in sink.projects}
+
+
+def test_gitlab_source_selection_empty_list_catalogs_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit EMPTY enabled-sources list means "select none", not
+    "no restriction" -- distinguished from the key being absent entirely
+    (see the next test)."""
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/a"],
+        projects=[_discovered_project("501", "full-chaos/a")],
+    )
+
+    summary = _populate_gitlab(source_external_ids=[])
+
+    assert summary["native_projects_imported"] == 0
+    assert sink.projects == []
+
+
+def test_gitlab_source_selection_absent_catalogs_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Documents the residual gap explicitly rather than leaving it silent:
+    the common POST-SYNC trigger (workers/team_autoimport.py.
+    run_post_sync_team_autoimport) does not populate ``source_external_ids``
+    in scope at all today, so this filter is a no-op on that path -- every
+    discovered project is cataloged, exactly as before this change. Closing
+    it there needs a change to that shared dispatcher (all 4 providers),
+    out of this ticket's scope.
+    """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/a", "full-chaos/b"],
+        projects=[
+            _discovered_project("601", "full-chaos/a"),
+            _discovered_project("602", "full-chaos/b"),
+        ],
+    )
+
+    summary = _populate_gitlab()  # no source_external_ids key at all
+
+    assert summary["native_projects_imported"] == 2
+    assert summary["native_projects_filtered_by_selection"] == 0
+    assert len(sink.projects) == 2
+
+
+def test_gitlab_truncated_discovery_marks_the_catalog_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3380 round 2 (Codex HIGH): a truncated discovery walk (either
+    the teams walk or the flat projects listing hitting its pagination
+    bound) must never be recorded as a complete catalog.
+    """
+
+    sink = _patch_single_group_gitlab_discovery(
+        monkeypatch,
+        repo_patterns=["full-chaos/a"],
+        projects=[_discovered_project("701", "full-chaos/a")],
+        truncated=True,
+        warnings=["GitLab team discovery truncated projects (...) at 5000 results"],
+    )
+
+    summary = _populate_gitlab()
+
+    assert summary["native_projects_complete"] is False
+    # The rows discovery DID return are still cataloged -- truncation means
+    # "possibly incomplete", not "discard everything we got".
+    assert summary["native_projects_imported"] == 1
+    assert sink.projects[0].project_key == "full-chaos/a"
+
+
+def test_gitlab_no_discovered_projects_writes_no_catalog_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No projects in the discovery result -> nothing written, no network
+    call attempted (the catalog rows are mapped straight off ``result.
+    projects``, never fetched separately per project)."""
 
     sink = _patch_single_group_gitlab_discovery(monkeypatch, repo_patterns=[])
 
-    def _explode(*, auth: Any, org_id: str | None = None) -> Any:
-        raise AssertionError(
-            "no project paths were discovered; GitLabWorkClient must not be constructed"
-        )
-
-    monkeypatch.setattr(team_autoimport_gitlab, "GitLabWorkClient", _explode)
-
-    summary = team_autoimport_gitlab.populate(
-        org_id="org-1",
-        credentials={"token": "secret", "group_path": "full-chaos"},
-        scope={
-            "analytics_db": "clickhouse://test",
-            "sync_options": {"auto_import_teams": True},
-        },
-    )
+    summary = _populate_gitlab()
 
     assert summary["native_projects_imported"] == 0
     assert summary["native_projects_complete"] is True


### PR DESCRIPTION
## Summary

Fixes CHAOS-3380: GitLab projects now sync into the Ask Dev subject catalog, so GitLab project subjects resolve and answer end-to-end (previously `team_autoimport_gitlab.py` never wrote catalog rows and GitLab projects were unresolvable).

- Catalog identity: immutable numeric GitLab project id (`{org}:gitlab:{numeric_id}`, Jira-style), current `path_with_namespace` in `project_key`; rename/transfer updates the same row. A provider-guarded compatibility arm (`work_items.project_id = catalog.project_key`) resolves GitLab work items, which carry only path identity today.
- Enumeration: one paginated `include_subgroups=True` listing (covers grandchild subgroups, no per-project N+1 fan-out); metadata read from the list payload; `archived → is_active`; truncation and selected-but-undiscovered sources both propagate into `native_projects_complete` (missing ids surfaced by id).
- Source selection: discovered projects intersect the run's enabled `source_external_ids` when the scope carries them (common post-sync path doesn't populate the key yet — CHAOS-3382).
- Shared `_project_identity.py`: the provider-scoped identity CTE/predicate now also backs `native_evidence`'s work_items search/expand (fixes a pre-existing bug where prefixed catalog ids — Jira's since #1460 — could never match evidence).
- Oracle: reference side reads both identity columns with per-provider semantics (Jira-by-key was silently unmeasurable before); path-only matches report `path_match_unverified`, explicitly non-authoritative.

**Accepted residual (reviewed, pinned):** after a GitLab path rename + reclamation, a stale never-resynced work item can cross-attribute to the new path owner. Both in-scope remedies are self-defeating (all GitLab work items are path-only today; failing closed disables GitLab entirely). Documented at the compat arm and pinned by `test_path_reuse_cross_attribution_is_a_known_residual_until_chaos_3383`, which must flip when CHAOS-3383 (immutable id through `work_items` + backfill) lands. Group-scoped epics carve-out: CHAOS-3381.

## Testing

- 539 scoped tests green (all four providers' autoimports, gitlab normalize, team discovery, native_evidence, data-health, both live project-subject suites against real migrated ClickHouse, CHAOS-3374/3375/3377 suites).
- Live e2e proves the full chain (real normalizer → worker → scope resolve → status snapshot), provider-agreement asserted on real rows, dual-entry-point retirement fail-closed, cross-provider collision isolation.
- Four codex adversarial rounds; every fix fail→pass verified. ruff + mypy clean.
