### PR TITLE
fix(ask-dev): scrub auxiliary-field token leaks instead of destroying grounded answers (CHAOS-3377)

### DIFF
--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -71,13 +71,16 @@ __all__ = [
     "WITHHELD_COPY",
     "attested_strings",
     "internal_token_leak",
+    "internal_token_leak_field",
     "named_subject_not_found_answer",
     "no_match_summary",
     "redact_persisted_answer",
     "redact_persisted_error",
+    "scrub_auxiliary_leaks",
     "user_supplied_subject_kind",
     "user_supplied_subject_label",
     "user_visible_strings",
+    "user_visible_strings_by_field",
 ]
 
 
@@ -239,6 +242,41 @@ _SUBJECT_KIND_BY_NOUN: Mapping[str, str] = {
 _MAX_SUBJECT_LABEL_CHARS = 120
 
 
+def internal_token_leak_field(
+    values: Iterable[tuple[str, str | None]], *, attested: Iterable[str | None] = ()
+) -> tuple[str, str] | None:
+    """Like ``internal_token_leak``, but over ``(field, value)`` pairs and
+    returning ``(field, token)`` -- the field-labeled counterpart used at the
+    write-time boundary (``orchestrator.finish()``) so a leak's log line can
+    name WHERE the token was found, not only what it was.
+
+    CHAOS-3377 leak-hardening: a prior incident's log line carried only the
+    literal string ``"ask_dev.orchestrator.internal_token_leak"`` with no
+    detail of which field leaked -- this dev stack runs with ``LOG_JSON=0``,
+    under which a bare-message ``logging.StreamHandler`` silently drops
+    anything passed via ``extra=``, so the token/run_id/field were captured
+    by the log call but never actually reached the log line. Returning the
+    field here lets the caller embed it directly in the message string,
+    which survives regardless of formatter configuration.
+
+    See ``internal_token_leak`` for the matching/attestation semantics this
+    shares in full; this is the single implementation, with
+    ``internal_token_leak`` now a thin field-blind wrapper around it.
+    """
+
+    attested_text = " ".join(text.casefold() for text in attested if text)
+    for field, value in values:
+        if not value:
+            continue
+        lowered = value.casefold()
+        for token in sorted(INTERNAL_TOKEN_DENYLIST):
+            if token not in lowered:
+                continue
+            if token in NEVER_ATTESTABLE_TOKENS or token not in attested_text:
+                return field, token
+    return None
+
+
 def internal_token_leak(
     values: Iterable[str | None], *, attested: Iterable[str | None] = ()
 ) -> str | None:
@@ -265,17 +303,11 @@ def internal_token_leak(
     fails on the leaked one.
     """
 
-    attested_text = " ".join(text.casefold() for text in attested if text)
-    for value in values:
-        if not value:
-            continue
-        lowered = value.casefold()
-        for token in sorted(INTERNAL_TOKEN_DENYLIST):
-            if token not in lowered:
-                continue
-            if token in NEVER_ATTESTABLE_TOKENS or token not in attested_text:
-                return token
-    return None
+    found = internal_token_leak_field(
+        ((str(index), value) for index, value in enumerate(values)),
+        attested=attested,
+    )
+    return found[1] if found is not None else None
 
 
 def attested_strings(
@@ -305,6 +337,49 @@ def attested_strings(
     return tuple(text for text in texts if text)
 
 
+def user_visible_strings_by_field(
+    *, answer: DevAnswer | None = None, error: DevError | None = None
+) -> tuple[tuple[str, str], ...]:
+    """``user_visible_strings``, paired with the field each string came from.
+
+    CHAOS-3377 leak-hardening (operability): a leak log line naming only the
+    bare token forces an operator to grep the whole answer shape by hand to
+    find which field carried it; naming the field turns that into a one-line
+    diagnosis. List-valued fields are indexed (``warnings[0]``) so a specific
+    offending entry, not just its field name, is identifiable. This is the
+    single source of the string content ``user_visible_strings`` returns --
+    see that function for why each field is included.
+    """
+
+    pairs: list[tuple[str, str]] = []
+    if answer is not None:
+        pairs.append(("direct_summary", answer.direct_summary))
+        pairs.extend(
+            (f"warnings[{i}]", value) for i, value in enumerate(answer.warnings)
+        )
+        pairs.extend(
+            (f"claims[{i}].text", claim.text) for i, claim in enumerate(answer.claims)
+        )
+        pairs.extend(
+            (f"conflicts[{i}].summary", conflict.summary)
+            for i, conflict in enumerate(answer.conflicts)
+        )
+        pairs.extend(
+            (f"suggested_follow_up_questions[{i}]", value)
+            for i, value in enumerate(answer.suggested_follow_up_questions)
+        )
+        pairs.extend(
+            (f"resolved_scope.warnings[{i}]", value)
+            for i, value in enumerate(answer.resolved_scope.warnings)
+        )
+    if error is not None:
+        pairs.append(("safe_message", error.safe_message))
+        pairs.extend(
+            (f"remediation[{i}]", value) for i, value in enumerate(error.remediation)
+        )
+    return tuple(pairs)
+
+
 def user_visible_strings(
     *, answer: DevAnswer | None = None, error: DevError | None = None
 ) -> tuple[str, ...]:
@@ -317,18 +392,9 @@ def user_visible_strings(
     already governed by the evidence contract's own safe-excerpt handling.
     """
 
-    strings: list[str] = []
-    if answer is not None:
-        strings.append(answer.direct_summary)
-        strings.extend(answer.warnings)
-        strings.extend(claim.text for claim in answer.claims)
-        strings.extend(conflict.summary for conflict in answer.conflicts)
-        strings.extend(answer.suggested_follow_up_questions)
-        strings.extend(answer.resolved_scope.warnings)
-    if error is not None:
-        strings.append(error.safe_message)
-        strings.extend(error.remediation)
-    return tuple(strings)
+    return tuple(
+        text for _, text in user_visible_strings_by_field(answer=answer, error=error)
+    )
 
 
 def user_supplied_subject_label(question: str, query: str | None) -> str | None:
@@ -547,6 +613,111 @@ def _normalize_refused_with_grounding(answer: DevAnswer) -> DevAnswer:
     )
 
 
+def _clean_or_withhold(value: str, *, attested: Iterable[str | None]) -> str:
+    """``value``, or ``WITHHELD_COPY`` if it carries a leaked token.
+
+    The single per-string cleaning rule both ``redact_persisted_answer``
+    (read-time, every prose field) and ``scrub_auxiliary_leaks`` (write-time,
+    model-authored auxiliary fields only) apply, so the two seams cannot
+    silently diverge on what "cleaned" means for one string.
+    """
+
+    return (
+        value
+        if internal_token_leak([value], attested=attested) is None
+        else WITHHELD_COPY
+    )
+
+
+def scrub_auxiliary_leaks(
+    answer: DevAnswer, *, attested: Iterable[str | None] = ()
+) -> tuple[DevAnswer, tuple[str, ...]]:
+    """Remove a leaked token found ONLY in a model-authored auxiliary field,
+    never in ``direct_summary``/``claims``.
+
+    CHAOS-3377 leak-hardening: ``Orchestrator._deterministic_status_render``
+    overwrites ``status``/``direct_summary``/``claims`` with server-rendered
+    content once a bound ``status_snapshot.v1`` result exists, but
+    ``warnings``, ``conflicts[].summary``, ``suggested_follow_up_questions``,
+    and ``resolved_scope.warnings`` stay fully model-authored -- the model has
+    seen the raw tool-result JSON (``actual_completion.reason_codes`` and
+    friends) and can echo one of those tokens into any of the four, none of
+    which the deterministic override ever touches. ``orchestrator.finish()``'s
+    fail-closed scan then destroys the ENTIRE terminal -- including the safe
+    deterministic core -- over one leaked auxiliary sentence (a live incident:
+    run ``22f97bee-0b8b-44a5-979f-78d7d7a80a82``).
+
+    This runs at the SAME write-time seam, immediately before that scan, and
+    is deliberately narrower than it: only these four fields are eligible for
+    scrubbing. ``direct_summary``/``claims`` are the answer's load-bearing
+    deterministic content (or, absent a bound status_snapshot, the model's
+    only substantive content) -- a leak reaching either of those is a
+    genuine defect the whole-terminal fail-closed check in
+    ``orchestrator.finish()`` must still catch, exactly as before this
+    function existed. Scrubbing them here would silently rescue that case
+    instead of surfacing it.
+
+    Mirrors ``redact_persisted_answer``'s per-field treatment exactly
+    (``warnings``/``conflicts``/``resolved_scope.warnings`` replaced with
+    ``WITHHELD_COPY``, individual ``suggested_follow_up_questions`` entries
+    dropped outright) via the shared ``_clean_or_withhold`` helper, so the
+    write-time and read-time seams cannot describe "cleaned" two different
+    ways. Returns the (possibly updated) answer and the field labels that
+    were touched, empty if none were, so the caller can log what happened
+    without re-deriving it.
+    """
+
+    attested_tuple = tuple(attested)
+    touched: list[str] = []
+
+    def field_leaked(field: str, value: str) -> bool:
+        if internal_token_leak([value], attested=attested_tuple) is None:
+            return False
+        touched.append(field)
+        return True
+
+    warnings = [
+        _clean_or_withhold(value, attested=attested_tuple)
+        if field_leaked(f"warnings[{i}]", value)
+        else value
+        for i, value in enumerate(answer.warnings)
+    ]
+    conflicts = [
+        conflict.model_copy(
+            update={
+                "summary": _clean_or_withhold(conflict.summary, attested=attested_tuple)
+            }
+        )
+        if field_leaked(f"conflicts[{i}].summary", conflict.summary)
+        else conflict
+        for i, conflict in enumerate(answer.conflicts)
+    ]
+    follow_ups = [
+        value
+        for i, value in enumerate(answer.suggested_follow_up_questions)
+        if not field_leaked(f"suggested_follow_up_questions[{i}]", value)
+    ]
+    scope_warnings = [
+        _clean_or_withhold(value, attested=attested_tuple)
+        if field_leaked(f"resolved_scope.warnings[{i}]", value)
+        else value
+        for i, value in enumerate(answer.resolved_scope.warnings)
+    ]
+    if not touched:
+        return answer, ()
+    updated = answer.model_copy(
+        update={
+            "warnings": warnings,
+            "conflicts": conflicts,
+            "suggested_follow_up_questions": follow_ups,
+            "resolved_scope": answer.resolved_scope.model_copy(
+                update={"warnings": scope_warnings}
+            ),
+        }
+    )
+    return updated, tuple(touched)
+
+
 def redact_persisted_answer(
     answer: DevAnswer, *, question: str | None = None
 ) -> DevAnswer:
@@ -587,11 +758,7 @@ def redact_persisted_answer(
         return answer
 
     def clean(value: str) -> str:
-        return (
-            value
-            if internal_token_leak([value], attested=attested) is None
-            else WITHHELD_COPY
-        )
+        return _clean_or_withhold(value, attested=attested)
 
     return answer.model_copy(
         update={

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -97,10 +97,11 @@ from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .no_match_terminal import (
     attested_strings,
-    internal_token_leak,
+    internal_token_leak_field,
     named_subject_not_found_answer,
+    scrub_auxiliary_leaks,
     user_supplied_subject_label,
-    user_visible_strings,
+    user_visible_strings_by_field,
 )
 from .orchestrator_states import TERMINAL_STATES, RunState
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
@@ -787,25 +788,64 @@ class DevOrchestrator:
             # legitimately appears in copy (pinned by
             # test_no_match_terminal.py), so this must never fire on a
             # healthy run.
-            leaked_token = internal_token_leak(
-                user_visible_strings(answer=answer, error=error),
+            attested = attested_strings(answer, request.question)
+            # CHAOS-3377 leak-hardening: scrub model-authored AUXILIARY
+            # fields (warnings/conflicts/suggested_follow_up_questions/
+            # resolved_scope.warnings) BEFORE the fail-closed scan below --
+            # not after. `_deterministic_status_render` overwrites status/
+            # direct_summary/claims once a bound status_snapshot.v1 result
+            # exists, but leaves those four fully model-authored; a model
+            # that has seen a tool result's raw actual_completion.
+            # reason_codes can echo one into any of them, and without this
+            # the scan below would destroy the entire safe, deterministic
+            # answer over one leaked auxiliary sentence (live incident: run
+            # 22f97bee-0b8b-44a5-979f-78d7d7a80a82). direct_summary/claims
+            # are deliberately NOT touched here -- see
+            # `no_match_terminal.scrub_auxiliary_leaks`'s docstring for why
+            # a leak reaching those must still fail the whole terminal
+            # closed, exactly as before this scrub existed.
+            if answer is not None:
+                answer, scrubbed_fields = scrub_auxiliary_leaks(
+                    answer, attested=attested
+                )
+                if scrubbed_fields:
+                    logger.warning(
+                        "ask_dev.orchestrator.internal_token_leak_scrubbed "
+                        f"run_id={run_id} fields={','.join(scrubbed_fields)}",
+                        extra={"run_id": run_id, "fields": scrubbed_fields},
+                    )
+            leaked = internal_token_leak_field(
+                user_visible_strings_by_field(answer=answer, error=error),
                 # Provenance, so an authorized entity whose real name looks
                 # like an enum member does not fail its own answer. See
                 # `no_match_terminal.internal_token_leak`.
-                attested=attested_strings(answer, request.question),
+                attested=attested,
             )
-            if leaked_token is not None:
+            if leaked is not None:
+                leaked_field, leaked_token = leaked
+                terminal_kind = "answer" if answer is not None else "error"
+                # The token AND the field it was found in, embedded directly
+                # in the message string -- not only `extra=`. This dev
+                # stack's own LOG_JSON=0 configuration proved `extra=` keys
+                # are silently dropped by a bare-message StreamHandler (no
+                # formatter references them), which is exactly why the live
+                # incident's log line carried no diagnostic detail at all.
+                # Internal log only: never in `safe_message` or any
+                # persisted user-visible field.
                 logger.error(
-                    "ask_dev.orchestrator.internal_token_leak",
+                    "ask_dev.orchestrator.internal_token_leak "
+                    f"run_id={run_id} field={leaked_field} token={leaked_token} "
+                    f"terminal_kind={terminal_kind}",
                     extra={
                         "run_id": run_id,
                         "token": leaked_token,
-                        "terminal_kind": "answer" if answer is not None else "error",
+                        "field": leaked_field,
+                        "terminal_kind": terminal_kind,
                     },
                 )
                 ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL.labels(
                     token=leaked_token,
-                    terminal_kind="answer" if answer is not None else "error",
+                    terminal_kind=terminal_kind,
                 ).inc()
                 state = RunState.FAILED
                 answer = None

--- a/tests/api/dev/test_chaos_3292_mutations.py
+++ b/tests/api/dev/test_chaos_3292_mutations.py
@@ -317,7 +317,9 @@ async def test_m3c_with_every_server_guardrail_disabled_a8_is_the_net(
         validators_module, "validate_no_internal_leakage", lambda _frame: None
     )
     monkeypatch.setattr(
-        orchestrator_module, "internal_token_leak", lambda _values, **_kwargs: None
+        orchestrator_module,
+        "internal_token_leak_field",
+        lambda _values, **_kwargs: None,
     )
     mutated = await case_a8()
 

--- a/tests/api/dev/test_no_match_terminal.py
+++ b/tests/api/dev/test_no_match_terminal.py
@@ -27,11 +27,14 @@ from dev_health_ops.api.dev.no_match_terminal import (
     WITHHELD_COPY,
     attested_strings,
     internal_token_leak,
+    internal_token_leak_field,
     named_subject_not_found_answer,
     no_match_summary,
     redact_persisted_answer,
+    scrub_auxiliary_leaks,
     user_supplied_subject_label,
     user_visible_strings,
+    user_visible_strings_by_field,
 )
 
 NOW = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
@@ -230,6 +233,119 @@ def test_internal_token_leak_ignores_ordinary_prose() -> None:
         )
         is None
     )
+
+
+def test_internal_token_leak_field_names_the_field_the_token_was_found_in() -> None:
+    """CHAOS-3377 leak-hardening (operability): the field-labeled scan
+    ``orchestrator.finish()`` now uses, so a leak's log line can say WHERE
+    the token was found, not only what it was."""
+
+    found = internal_token_leak_field(
+        [
+            ("direct_summary", "Everything here is fine."),
+            ("warnings[0]", "Rejected with scope_forbidden."),
+        ]
+    )
+    assert found == ("warnings[0]", "scope_forbidden")
+
+
+def test_internal_token_leak_field_is_none_for_clean_input() -> None:
+    assert (
+        internal_token_leak_field([("direct_summary", "Everything here is fine.")])
+        is None
+    )
+
+
+def test_user_visible_strings_by_field_indexes_list_valued_fields() -> None:
+    answer = _answer("What is the status of the Falcon project?", "Falcon").model_copy(
+        update={"warnings": ["first warning", "second warning"]}
+    )
+    pairs = dict(user_visible_strings_by_field(answer=answer))
+    assert pairs["warnings[0]"] == "first warning"
+    assert pairs["warnings[1]"] == "second warning"
+    # And the two functions agree on content -- one is derived from the other.
+    assert user_visible_strings(answer=answer) == tuple(
+        text for _, text in user_visible_strings_by_field(answer=answer)
+    )
+
+
+# --- scrub_auxiliary_leaks (CHAOS-3377 leak-hardening) ---------------------
+#
+# The write-time counterpart of ``redact_persisted_answer``'s per-field
+# cleaning, run at the SAME seam ``orchestrator.finish()`` applies the
+# fail-closed whole-answer scan -- but deliberately narrower: only the four
+# model-authored auxiliary fields (warnings/conflicts/
+# suggested_follow_up_questions/resolved_scope.warnings) are eligible. A
+# leak in direct_summary or claims -- the answer's load-bearing deterministic
+# content -- must still fail the whole terminal closed.
+
+
+def test_scrub_auxiliary_leaks_withholds_a_leaked_warning() -> None:
+    answer = _answer("What is the status of the Falcon project?", "Falcon").model_copy(
+        update={"warnings": ["Rejected with scope_forbidden for this repository."]}
+    )
+    scrubbed, touched = scrub_auxiliary_leaks(answer)
+    assert touched == ("warnings[0]",)
+    assert scrubbed.warnings == [WITHHELD_COPY]
+    assert internal_token_leak(user_visible_strings(answer=scrubbed)) is None
+
+
+def test_scrub_auxiliary_leaks_drops_a_leaked_follow_up_question_outright() -> None:
+    """Unlike warnings/conflicts, a leaked follow-up question is removed from
+    the list entirely rather than replaced with a placeholder -- a suggested
+    question with no real content left is worse than one fewer suggestion,
+    mirroring ``redact_persisted_answer``'s existing treatment of the same
+    field."""
+
+    answer = _answer("What is the status of the Falcon project?", "Falcon").model_copy(
+        update={
+            "suggested_follow_up_questions": [
+                "Why is this required_child_incomplete?",
+                "What repositories are in scope?",
+            ]
+        }
+    )
+    scrubbed, touched = scrub_auxiliary_leaks(answer)
+    assert touched == ("suggested_follow_up_questions[0]",)
+    assert scrubbed.suggested_follow_up_questions == ["What repositories are in scope?"]
+
+
+def test_scrub_auxiliary_leaks_never_touches_direct_summary_or_claims() -> None:
+    """The negative control at the unit level: a leak in direct_summary (the
+    deterministic core, or -- absent a bound status_snapshot -- the model's
+    only substantive content) is NOT this function's job. It must survive
+    scrubbing untouched, so ``orchestrator.finish()``'s whole-terminal
+    fail-closed scan still catches it afterward."""
+
+    leaky_summary = "Scope resolution returned forbidden_or_not_found."
+    answer = _answer("What is the status of the Falcon project?", "Falcon").model_copy(
+        update={"direct_summary": leaky_summary}
+    )
+    scrubbed, touched = scrub_auxiliary_leaks(answer)
+    assert touched == ()
+    assert scrubbed is answer
+    assert scrubbed.direct_summary == leaky_summary
+    assert internal_token_leak([scrubbed.direct_summary]) == "forbidden_or_not_found"
+
+
+def test_scrub_auxiliary_leaks_is_a_noop_on_a_clean_answer() -> None:
+    answer = _answer("What is the status of the Falcon project?", "Falcon")
+    scrubbed, touched = scrub_auxiliary_leaks(answer)
+    assert touched == ()
+    assert scrubbed is answer
+
+
+def test_scrub_auxiliary_leaks_respects_attestation() -> None:
+    """The same provenance escape hatch ``internal_token_leak`` applies
+    elsewhere: an authorized entity genuinely named like a denylisted token
+    is not scrubbed out of a warning that mentions it."""
+
+    answer = _answer("What is the status of the Falcon project?", "Falcon").model_copy(
+        update={"warnings": ["The authorized project not_found has stale data."]}
+    )
+    scrubbed, touched = scrub_auxiliary_leaks(answer, attested=["not_found"])
+    assert touched == ()
+    assert scrubbed is answer
 
 
 # --- the PRD's own sentence ------------------------------------------------

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -3378,6 +3378,254 @@ async def test_substantive_status_answer_is_never_refused_and_never_leaks_intern
     )
 
 
+# --- CHAOS-3377 leak-hardening: the second live-probe failure -------------
+#
+# A run past the acceptance test above (22f97bee-0b8b-44a5-979f-78d7d7a80a82)
+# still terminated as a bare internal_error even though status_snapshot.v1
+# bound a real actual_completion, so the §10 deterministic renderer had
+# already overwritten status/direct_summary/claims with safe content. Two
+# hypotheses were investigated:
+#
+# H1 (confirmed by code-path reading, reproduced below): the renderer never
+# touches warnings/conflicts/suggested_follow_up_questions -- a model echo
+# of the tool result's own raw reason codes into any of those three still
+# trips orchestrator.finish()'s fail-closed scan, which destroyed the WHOLE
+# terminal, safe deterministic core included.
+#
+# H2 (investigated against real production data -- org
+# 70d529e0-3c06-4597-8480-794fd02328b6's ClickHouse work_items.title --
+# which found genuine denylist-token collisions in real titles, e.g. a title
+# literally containing "model_not_found"): REFUTED for the deterministic
+# claims path specifically. status_answer_render.build_deterministic_status_
+# claims already only emits a blocker/required-child claim when its evidence
+# is present in canonical_evidence_ids, which guarantees attested_strings
+# (reading answer.evidence[].display_label) already covers any title text
+# that survives into a claim. Reproduced below as a regression lock, not a
+# fix -- it already passed.
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_field_leak_is_scrubbed_not_the_whole_answer() -> None:
+    """H1, fail-to-pass. Before ``scrub_auxiliary_leaks`` was wired into
+    ``finish()``, this failed: ``result.state`` was ``RunState.FAILED`` and
+    ``result.answer`` was ``None`` -- the model's echoed reason code in
+    ``suggested_follow_up_questions`` destroyed the entire, otherwise-safe,
+    server-rendered answer. After the fix, the leaked follow-up question is
+    dropped and the deterministic core (status/direct_summary/claims,
+    entirely server-rendered once status_snapshot.v1 bound a real
+    actual_completion) survives untouched.
+    """
+
+    script_id = "chaos-3377-leak-hardening-auxiliary"
+    open_evidence_id = "ev1_" + hashlib.sha256(b"aux-open").hexdigest()[:40]
+    verdict_evidence_id = "ev1_" + hashlib.sha256(b"aux-verdict").hexdigest()[:40]
+
+    async def status_snapshot(_context: Any, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "metrics": [],
+                "evidence": [
+                    {
+                        **positive_fixtures()["dev_tool_result.v1"]["evidence"][0],
+                        "evidence_ref_id": eid,
+                    }
+                    for eid in (open_evidence_id, verdict_evidence_id)
+                ],
+                "actual_completion": {
+                    "state": "not_ready",
+                    "rule_id": "actual-completion",
+                    "rule_version": "actual-completion.v4",
+                    "reason_codes": ["required_child_incomplete"],
+                    "required_children": [
+                        {
+                            "fact_id": "issue:OPEN-1",
+                            "text": "Wire the presentation seam",
+                            "status": "in_progress",
+                            "evidence_ref_ids": [open_evidence_id],
+                        }
+                    ],
+                    "required_child_total": 5,
+                    "required_child_complete": 4,
+                    "display_truncated": False,
+                    "conflicts": [],
+                    "evidence_ref_ids": [verdict_evidence_id],
+                },
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+
+    fabricated_answer = _answer(script_id=script_id)
+    fabricated_answer.update(
+        {
+            "status": "complete",
+            "direct_summary": "This placeholder is overwritten by the deterministic renderer.",
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+            "warnings": [],
+            "conflicts": [],
+            # The leak: the model has seen the raw tool-result JSON and
+            # echoes its own reason code into a follow-up question -- a
+            # field the deterministic renderer never touches.
+            "suggested_follow_up_questions": [
+                "Why is required_child_incomplete still blocking this?"
+            ],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(fabricated_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    answer = result.answer
+
+    # The deterministic core survived: it is the server-rendered content,
+    # not the model's fabricated placeholder.
+    assert answer.status is not AnswerStatus.REFUSED
+    assert "4" in answer.direct_summary and "5" in answer.direct_summary
+
+    # The leaked follow-up question is gone -- dropped, not translated into
+    # a WITHHELD_COPY placeholder (a suggested question with no real content
+    # left is worse than one fewer suggestion).
+    assert not answer.suggested_follow_up_questions
+
+    # And the raw token never reached the wire in any field.
+    all_text = " ".join(user_visible_strings(answer=answer))
+    assert "required_child_incomplete" not in all_text
+
+
+@pytest.mark.asyncio
+async def test_attested_real_title_collision_survives_in_a_blocker_claim() -> None:
+    """H2, reproduced against real production data -- REFUTED for the
+    deterministic claims path (regression lock, not a fix: this already
+    passed before this round's changes).
+
+    ``real_title`` is an actual ``work_items.title`` value for org
+    ``70d529e0-3c06-4597-8480-794fd02328b6``, read read-only from the dev
+    ClickHouse stack (never hand-invented), that happens to literally
+    contain the denylisted substring ``not_found``. It flows through the
+    same shape ``production_runtime.wire_required_child`` mints in
+    production: the required-child fact's own ``text`` AND its evidence's
+    ``display_label`` are the identical string, so ``attested_strings``
+    already exempts it once that evidence is canonical.
+    """
+
+    script_id = "chaos-3377-leak-hardening-attested-title"
+    real_title = (
+        "Fail fast on deterministic LLM errors (insufficient_quota / "
+        "invalid_api_key / model_not_found) with classified verdicts"
+    )
+    child_evidence_id = (
+        "ev1_" + hashlib.sha256(b"attested-title-child").hexdigest()[:40]
+    )
+    verdict_evidence_id = (
+        "ev1_" + hashlib.sha256(b"attested-title-verdict").hexdigest()[:40]
+    )
+
+    async def status_snapshot(_context: Any, request: DevToolRequest) -> DevToolResult:
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+                "metrics": [],
+                "evidence": [
+                    {
+                        **positive_fixtures()["dev_tool_result.v1"]["evidence"][0],
+                        "evidence_ref_id": child_evidence_id,
+                        "display_label": real_title,
+                    },
+                    {
+                        **positive_fixtures()["dev_tool_result.v1"]["evidence"][0],
+                        "evidence_ref_id": verdict_evidence_id,
+                    },
+                ],
+                "actual_completion": {
+                    "state": "not_ready",
+                    "rule_id": "actual-completion",
+                    "rule_version": "actual-completion.v4",
+                    "reason_codes": ["required_child_incomplete"],
+                    "required_children": [
+                        {
+                            "fact_id": "issue:REAL-TITLE-1",
+                            "text": real_title,
+                            "status": "in_progress",
+                            "evidence_ref_ids": [child_evidence_id],
+                        }
+                    ],
+                    "required_child_total": 3,
+                    "required_child_complete": 2,
+                    "display_truncated": False,
+                    "conflicts": [],
+                    "evidence_ref_ids": [verdict_evidence_id],
+                },
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    registry = AskDevToolRegistry({tool_id: status_snapshot for tool_id in ToolID})
+
+    fabricated_answer = _answer(script_id=script_id)
+    fabricated_answer.update(
+        {
+            "status": "complete",
+            "direct_summary": "This placeholder is overwritten by the deterministic renderer.",
+            "claims": [],
+            "metrics": [],
+            "evidence": [],
+            "warnings": [],
+            "conflicts": [],
+            "suggested_follow_up_questions": [],
+        }
+    )
+
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(decision=AgentFinalAnswer(fabricated_answer)),
+            ],
+            script_id=script_id,
+            registry=registry,
+        )
+    )
+
+    assert result.state is RunState.COMPLETED
+    assert result.answer is not None
+    answer = result.answer
+    assert answer.status is not AnswerStatus.REFUSED
+    blocker_texts = " ".join(claim.text for claim in answer.claims)
+    assert real_title in blocker_texts
+
+
 @pytest.mark.asyncio
 async def test_genuine_refusal_with_no_grounding_still_completes_as_refused() -> None:
     """Negative control (do not regress CHAOS-3367/#1449 or the CHAOS-3377


### PR DESCRIPTION
## Summary

Second live-probe hardening for the CHAOS-3377 seam: the widened §12 token guard was destroying entire grounded answers over model echoes in auxiliary fields.

- Live incident (dev_runs `22f97bee…`): status snapshot completed, then `finish()`'s fail-closed scan found a reason-code echo in a model-authored auxiliary field and replaced the whole answer with `internal_error`. The deterministic override rewrites `status`/`direct_summary`/`claims` but never touched `warnings`/`conflicts`/`suggested_follow_up_questions`/`resolved_scope.warnings` — and the model sees raw reason codes in tool-result JSON.
- Fix: `scrub_auxiliary_leaks()` runs before the scan — leaking auxiliary fields are withheld/dropped (shared helper with the read-time `redact_persisted_answer` treatment); the deterministic core is untouched. A genuine leak in `direct_summary`/`claims` still fails the terminal closed (negative control pinned).
- Attested-collision hypothesis investigated against the org's real 2,821 work-item titles (two genuine denylist collisions found, e.g. a title containing `model_not_found`): refuted for the claims path — surviving claims are evidence-attested and already exempt; locked with a regression test using the real colliding title.
- Operability: the leak log now names run_id/field/token/terminal_kind in the message body itself (`LOG_JSON=0` stream handlers silently dropped `extra=`) — internal logs only, never user-visible.

## Testing

- Full `tests/api/dev/`: 1931 passed, 19 skipped, 1 xfailed, 0 failed; post-rebase scoped re-run green.
- H1 fail→pass verified against pre-fix code (FAILED/no-answer → COMPLETED with the leaked follow-up dropped); fail-closed negative control unchanged. ruff + mypy clean.
