### PR TITLE
fix(testops): reconcile missing integration datasets

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2481,12 +2481,12 @@
       "notes": "grep-evading form; POST /webhooks/pagerduty/{binding_id}"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:465",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:475",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 465
+        "line": 475
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2505,12 +2505,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/sync"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:537",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:547",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 537
+        "line": 547
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2602,12 +2602,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:414",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:424",
       "surface": "POST /integrations/{integration_id}/sync",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 414
+        "line": 424
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2627,12 +2627,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:486",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:496",
       "surface": "POST /integrations/{integration_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 486
+        "line": 496
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -35,6 +35,7 @@ from dev_health_ops.api.services.integrations import (
 from dev_health_ops.sync.canonical_incident_gate import (
     CanonicalIncidentFeatureDisabledError,
 )
+from dev_health_ops.sync.datasets import get_dataset_spec
 from dev_health_ops.sync.discovery import discover_sources_for_integration
 from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
 from dev_health_ops.sync.trigger_routing import map_sync_mode
@@ -390,7 +391,8 @@ async def update_integration_datasets(
 ) -> list[IntegrationDatasetResponse]:
     """Enable or disable dataset rows by dataset_key."""
     int_svc = IntegrationService(session, org_id)
-    if await int_svc.get_by_id(integration_id) is None:
+    integration = await int_svc.get_by_id(integration_id)
+    if integration is None:
         raise HTTPException(status_code=404, detail="Integration not found")
 
     svc = IntegrationDatasetService(session, org_id)
@@ -398,11 +400,19 @@ async def update_integration_datasets(
     for item in payload.datasets:
         dataset = await svc.get_by_key(integration_id, item.dataset_key)
         if dataset is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Dataset '{item.dataset_key}' not found",
+            if get_dataset_spec(str(integration.provider), item.dataset_key) is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Dataset '{item.dataset_key}' not found",
+                )
+            dataset = await svc.create(
+                integration.id,
+                item.dataset_key,
+                item.is_enabled,
             )
-        updated.append(await svc.set_enabled(dataset, item.is_enabled))
+        else:
+            dataset = await svc.set_enabled(dataset, item.is_enabled)
+        updated.append(dataset)
     return [_dataset_to_response(d) for d in updated]
 
 

--- a/src/dev_health_ops/api/services/integrations.py
+++ b/src/dev_health_ops/api/services/integrations.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -223,8 +224,15 @@ class IntegrationDatasetService:
             is_enabled=is_enabled,
             options={},
         )
-        self._session.add(dataset)
-        await self._session.flush()
+        try:
+            async with self._session.begin_nested():
+                self._session.add(dataset)
+                await self._session.flush()
+        except IntegrityError:
+            existing = await self.get_by_key(str(integration_id), dataset_key)
+            if existing is None:
+                raise
+            return await self.set_enabled(existing, is_enabled)
         return dataset
 
     async def get_by_key(

--- a/src/dev_health_ops/api/services/integrations.py
+++ b/src/dev_health_ops/api/services/integrations.py
@@ -210,6 +210,23 @@ class IntegrationDatasetService:
         await self._session.flush()
         return dataset
 
+    async def create(
+        self,
+        integration_id: uuid.UUID,
+        dataset_key: str,
+        is_enabled: bool,
+    ) -> IntegrationDataset:
+        dataset = IntegrationDataset(
+            org_id=self._org_id,
+            integration_id=integration_id,
+            dataset_key=dataset_key,
+            is_enabled=is_enabled,
+            options={},
+        )
+        self._session.add(dataset)
+        await self._session.flush()
+        return dataset
+
     async def get_by_key(
         self, integration_id: str, dataset_key: str
     ) -> IntegrationDataset | None:

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING
 
+from sqlalchemy.exc import IntegrityError
+
 from dev_health_ops.backfill.chunker import chunk_date_range
 from dev_health_ops.credentials.fingerprint import (
     AUTH_SOURCE_ENVIRONMENT,
@@ -178,6 +180,7 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
             mode=mode,
             reason=repair_outcome,
         )
+    _reconcile_explicit_requested_datasets(session, integration, request)
     gate_datasets = _load_enabled_datasets(session, integration, request.dataset_keys)
     if sync_datasets_require_canonical_incident_feature(
         str(integration.provider),
@@ -420,6 +423,79 @@ def _load_enabled_sources(
     return list(query.order_by(IntegrationSource.full_name, IntegrationSource.id).all())
 
 
+def _reconcile_explicit_requested_datasets(
+    session: Session,
+    integration: Integration,
+    request: SyncPlanRequest,
+) -> None:
+    dataset_keys = request.dataset_keys
+    if dataset_keys is None:
+        return
+
+    provider = str(integration.provider).lower()
+    if (
+        provider in _CODE_HOST_SECURITY_PROVIDERS
+        and request.triggered_by == _SCHEDULED_SECURITY_TRIGGER
+    ):
+        dataset_keys = tuple(
+            dataset_key
+            for dataset_key in dataset_keys
+            if dataset_key != DatasetKey.SECURITY.value
+        )
+    requested_keys = {
+        dataset_key
+        for dataset_key in dataset_keys
+        if (spec := get_dataset_spec(provider, dataset_key)) is not None
+        and spec.supported
+    }
+    if not requested_keys:
+        return
+
+    existing_keys = {
+        dataset.dataset_key
+        for dataset in session.query(IntegrationDataset)
+        .filter(
+            IntegrationDataset.org_id == integration.org_id,
+            IntegrationDataset.integration_id == integration.id,
+            IntegrationDataset.dataset_key.in_(requested_keys),
+        )
+        .all()
+    }
+    for dataset_key in requested_keys - existing_keys:
+        _insert_dataset_if_missing(
+            session,
+            IntegrationDataset(
+                org_id=integration.org_id,
+                integration_id=integration.id,
+                dataset_key=dataset_key,
+                is_enabled=True,
+                options={},
+            ),
+        )
+
+
+def _insert_dataset_if_missing(
+    session: Session,
+    dataset: IntegrationDataset,
+) -> None:
+    try:
+        with session.begin_nested():
+            session.add(dataset)
+            session.flush()
+    except IntegrityError:
+        existing = (
+            session.query(IntegrationDataset)
+            .filter(
+                IntegrationDataset.org_id == dataset.org_id,
+                IntegrationDataset.integration_id == dataset.integration_id,
+                IntegrationDataset.dataset_key == dataset.dataset_key,
+            )
+            .one_or_none()
+        )
+        if existing is None:
+            raise
+
+
 _CODE_HOST_SECURITY_PROVIDERS = frozenset({"github", "gitlab"})
 _SCHEDULED_SECURITY_TRIGGER = "schedule"
 
@@ -457,16 +533,16 @@ def _ensure_security_dataset_for_scheduled_code_host_sync(
         .one_or_none()
     )
     if security_dataset is None:
-        session.add(
+        _insert_dataset_if_missing(
+            session,
             IntegrationDataset(
                 org_id=integration.org_id,
                 integration_id=integration.id,
                 dataset_key=DatasetKey.SECURITY.value,
                 is_enabled=True,
                 options={"auto_enabled_by": "scheduled_code_host_sync"},
-            )
+            ),
         )
-        session.flush()
     return requested
 
 

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -618,6 +618,70 @@ async def test_patch_missing_dataset_rejects_provider_unsupported_key(
     assert dataset is None
 
 
+@pytest.mark.asyncio
+async def test_patch_missing_dataset_recovers_from_concurrent_insert(
+    client, session_maker, seeded_state, monkeypatch
+):
+    # Given: another transaction inserted a disabled tests row after the route's read.
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    await _seed_dataset(
+        session_maker,
+        seeded_state["org_id"],
+        integration_id,
+        dataset_key="tests",
+        is_enabled=False,
+    )
+    original_get_by_key = (
+        integrations_router_module.IntegrationDatasetService.get_by_key
+    )
+    read_count = 0
+
+    async def stale_once_get_by_key(service, requested_integration_id, dataset_key):
+        nonlocal read_count
+        read_count += 1
+        if read_count == 1:
+            return None
+        return await original_get_by_key(
+            service,
+            requested_integration_id,
+            dataset_key,
+        )
+
+    monkeypatch.setattr(
+        integrations_router_module.IntegrationDatasetService,
+        "get_by_key",
+        stale_once_get_by_key,
+    )
+
+    # When: the operator explicitly enables tests through the stale route state.
+    resp = await ac.patch(
+        f"/api/v1/admin/integrations/{integration_id}/datasets",
+        json={"datasets": [{"dataset_key": "tests", "is_enabled": True}]},
+    )
+
+    # Then: the conflict is recovered and the operator's requested state wins.
+    assert resp.status_code == 200, resp.text
+    assert resp.json()[0]["is_enabled"] is True
+    async with session_maker() as session:
+        datasets = (
+            (
+                await session.execute(
+                    select(IntegrationDataset).where(
+                        IntegrationDataset.org_id == seeded_state["org_id"],
+                        IntegrationDataset.integration_id == uuid.UUID(integration_id),
+                        IntegrationDataset.dataset_key == "tests",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(datasets) == 1
+    assert datasets[0].is_enabled is True
+
+
 # ---------------------------------------------------------------------------
 # Sync trigger tests
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -172,7 +172,14 @@ async def _seed_source(session_maker, org_id: str, integration_id: str) -> str:
     return str(source_id)
 
 
-async def _seed_dataset(session_maker, org_id: str, integration_id: str) -> str:
+async def _seed_dataset(
+    session_maker,
+    org_id: str,
+    integration_id: str,
+    *,
+    dataset_key: str = "git",
+    is_enabled: bool = True,
+) -> str:
     """Directly insert an IntegrationDataset row and return its id."""
     dataset_id = uuid.uuid4()
     async with session_maker() as session:
@@ -180,8 +187,8 @@ async def _seed_dataset(session_maker, org_id: str, integration_id: str) -> str:
             id=dataset_id,
             org_id=org_id,
             integration_id=uuid.UUID(integration_id),
-            dataset_key="git",
-            is_enabled=True,
+            dataset_key=dataset_key,
+            is_enabled=is_enabled,
             options={},
         )
         session.add(dataset)
@@ -545,6 +552,70 @@ async def test_patch_datasets_not_found(client):
         json={"datasets": [{"dataset_key": "nonexistent", "is_enabled": False}]},
     )
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_enabled", [True, False])
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+async def test_patch_missing_dataset_upserts_requested_state(
+    client, session_maker, seeded_state, provider, is_enabled
+):
+    # Given: an existing integration created before the tests dataset existed.
+    ac, _ = client
+    created = await _create_integration(ac, provider=provider)
+    integration_id = created["id"]
+
+    # When: the caller updates the missing tests dataset row.
+    resp = await ac.patch(
+        f"/api/v1/admin/integrations/{integration_id}/datasets",
+        json={"datasets": [{"dataset_key": "tests", "is_enabled": is_enabled}]},
+    )
+
+    # Then: the row is created with the explicitly requested enabled state.
+    assert resp.status_code == 200, resp.text
+    assert resp.json()[0]["dataset_key"] == "tests"
+    assert resp.json()[0]["is_enabled"] is is_enabled
+    async with session_maker() as session:
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.org_id == seeded_state["org_id"],
+                    IntegrationDataset.integration_id == uuid.UUID(integration_id),
+                    IntegrationDataset.dataset_key == "tests",
+                )
+            )
+        ).scalar_one()
+    assert dataset.is_enabled is is_enabled
+
+
+@pytest.mark.asyncio
+async def test_patch_missing_dataset_rejects_provider_unsupported_key(
+    client, session_maker, seeded_state
+):
+    # Given: a Jira integration with no tests dataset row.
+    ac, _ = client
+    created = await _create_integration(ac, provider="jira")
+    integration_id = created["id"]
+
+    # When: the caller requests a dataset that exists but Jira does not support.
+    resp = await ac.patch(
+        f"/api/v1/admin/integrations/{integration_id}/datasets",
+        json={"datasets": [{"dataset_key": "tests", "is_enabled": True}]},
+    )
+
+    # Then: the API rejects the request without materializing the row.
+    assert resp.status_code == 404
+    async with session_maker() as session:
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.org_id == seeded_state["org_id"],
+                    IntegrationDataset.integration_id == uuid.UUID(integration_id),
+                    IntegrationDataset.dataset_key == "tests",
+                )
+            )
+        ).scalar_one_or_none()
+    assert dataset is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -373,6 +373,112 @@ def test_disabled_dataset_produces_zero_units_without_hydrating_credentials(
     assert _planned_units(db_session, plan.sync_run_id) == []
 
 
+@pytest.mark.parametrize(
+    ("existing_enabled", "expected_units"),
+    [(None, 1), (False, 0)],
+    ids=["missing-row-is-enabled", "disabled-row-stays-disabled"],
+)
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+def test_requested_tests_dataset_reconciles_missing_row_without_overriding_disabled(
+    db_session,
+    provider: str,
+    existing_enabled: bool | None,
+    expected_units: int,
+):
+    # Given: an existing code-host integration with a source and either no tests
+    # row or an explicitly disabled tests row.
+    integration = _create_integration(db_session, provider)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    if existing_enabled is not None:
+        _create_dataset(
+            db_session,
+            integration,
+            "tests",
+            is_enabled=existing_enabled,
+        )
+
+    # When: the planner is asked to run the newly supported tests dataset.
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            dataset_keys=("tests",),
+        ),
+    )
+
+    # Then: a missing row becomes enabled and executable, while an explicit
+    # disabled row remains disabled and produces no unit.
+    dataset = (
+        db_session.query(IntegrationDataset)
+        .filter_by(integration_id=integration.id, dataset_key="tests")
+        .one_or_none()
+    )
+    assert dataset is not None
+    assert dataset.is_enabled is (existing_enabled is not False)
+    assert plan.total_units == expected_units
+    assert {
+        unit.dataset_key for unit in _planned_units(db_session, plan.sync_run_id)
+    } == ({"tests"} if expected_units else set())
+
+
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+def test_unrequested_tests_dataset_is_not_reconciled(db_session, provider: str):
+    # Given: an existing code-host integration with no persisted dataset rows.
+    integration = _create_integration(db_session, provider)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+
+    # When: the planner receives no explicit dataset selection.
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    # Then: tests remains opt-in and no dataset row or unit is created.
+    assert (
+        db_session.query(IntegrationDataset)
+        .filter_by(integration_id=integration.id, dataset_key="tests")
+        .one_or_none()
+        is None
+    )
+    assert plan.total_units == 0
+    assert _planned_units(db_session, plan.sync_run_id) == []
+
+
+def test_insert_dataset_if_missing_preserves_concurrent_disabled_row(db_session):
+    # Given: another transaction has already inserted the requested dataset as disabled.
+    integration = _create_integration(db_session)
+    existing = _create_dataset(db_session, integration, "tests", is_enabled=False)
+
+    # When: stale planner state attempts the same insert.
+    planner._insert_dataset_if_missing(
+        db_session,
+        IntegrationDataset(
+            org_id=integration.org_id,
+            integration_id=integration.id,
+            dataset_key="tests",
+            is_enabled=True,
+            options={},
+        ),
+    )
+
+    # Then: the uniqueness conflict is isolated and the disabled row is unchanged.
+    datasets = (
+        db_session.query(IntegrationDataset)
+        .filter_by(integration_id=integration.id, dataset_key="tests")
+        .all()
+    )
+    assert [dataset.id for dataset in datasets] == [existing.id]
+    assert datasets[0].is_enabled is False
+
+
 def test_incremental_window_starts_at_dataset_watermark(db_session):
     integration = _create_integration(db_session)
     source = _create_source(


### PR DESCRIPTION
## Summary
- reconcile explicitly requested provider-supported datasets before sync planning while preserving explicit disabled state
- allow the admin dataset update endpoint to materialize missing rows for GitHub and GitLab
- recover concurrent dataset creation with savepoint-scoped conflict handling and keep transitional inventory anchors current

## Validation
- `bash ci/local_validate.sh`
  - Ruff format and lint passed
  - mypy passed
  - 11,540 tests passed, 98 skipped, 1 expected failure
  - scratch ClickHouse migrations and live argMax proof passed
- isolated API-to-planner manual QA produced an enabled `tests` dataset and one planned GitHub `tests` unit
- deterministic stale-read regression covers uniqueness-conflict recovery; live PostgreSQL concurrency tests were unavailable

SCREENSHOT-WAIVER: Backend-only API and planner change; no rendered UI is affected.