### PR TITLE
fix(ask-dev): collapse blocker edges before limiting and un-shadow the declared-state alias (CHAOS-3386)

### DIFF
--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -429,39 +429,71 @@ HAVING countIf(scope_repo_id IS NULL) > 0
        = length({repository_ids:Array(String)})
 """
 
+#: CHAOS-3377 residual defect (Codex adversarial review HIGH, live
+#: acceptance probe 2026-08-04): this query used to ``SELECT`` directly off
+#: the ``edge``/``blocker``/``blocked`` join with no ``GROUP BY`` -- one row
+#: PER MATCHING EDGE, not per blocker. A blocker whose ``blocks`` edges
+#: target several blocked issues in the SAME project scope therefore
+#: returned its own entity ``N`` times (once per edge), and ``ORDER BY`` /
+#: ``LIMIT`` applied to those MULTIPLIED rows -- so a blocker with more
+#: edges than the page ``limit`` could fill the ENTIRE result page by
+#: itself, silently crowding out every other, genuinely distinct blocker
+#: (and the evidence minted from it) with no way for anything downstream
+#: (the renderer's own defense-in-depth dedup included) to recover what the
+#: page never contained. ``matched_edges`` now holds the pre-collapse,
+#: one-row-per-edge result the query used to return directly; the outer
+#: ``SELECT ... GROUP BY entity_id`` collapses it to one row per blocker
+#: BEFORE ``ORDER BY``/``LIMIT`` ever run, so a page of ``limit`` rows can
+#: hold up to ``limit`` DISTINCT blockers again, exactly as intended.
+#: ``max()`` (not ``any()``) for the three non-key columns: ``display_label``
+#: and ``status`` are properties of the ONE blocker work-item row joined
+#: repeatedly (identical across every duplicate, so any aggregate is
+#: equivalent in practice, but ``max()`` is deterministic even if that ever
+#: stops being true), while ``observed_at`` (a ``greatest()`` of two
+#: timestamps per edge) genuinely differs per edge and must take the
+#: latest, matching this query's own pre-existing "most recently observed"
+#: intent for ``ORDER BY``.
 _BLOCKERS_SQL = (
     "WITH "
     + _PROJECT_IDENTITY_CTE
-    + """
-SELECT blocker.work_item_id AS entity_id,
-       blocker.title AS display_label,
-       blocker.status,
-       greatest(blocker.updated_at, edge.event_ts) AS observed_at,
-       greatest(blocker.last_synced, edge.last_synced) AS last_synced
-FROM work_graph_edges AS edge FINAL
-INNER JOIN work_items AS blocker FINAL
-  ON blocker.org_id = edge.org_id AND blocker.work_item_id = edge.source_id
-INNER JOIN work_items AS blocked FINAL
-  ON blocked.org_id = edge.org_id AND blocked.work_item_id = edge.target_id
-LEFT JOIN project ON 1 = 1
-WHERE edge.org_id = {org_id:String}
-  AND edge.source_type = 'issue'
-  AND edge.target_type = 'issue'
-  AND edge.edge_type = 'blocks'
-  AND edge.provenance = 'native'
-  AND toString(blocker.repo_id) IN {repository_ids:Array(String)}
-  AND toString(blocked.repo_id) IN {repository_ids:Array(String)}
-  AND edge.event_ts <= {as_of:DateTime64(3, 'UTC')}
-  AND blocker.updated_at <= {as_of:DateTime64(3, 'UTC')}
-  AND blocked.updated_at <= {as_of:DateTime64(3, 'UTC')}
-  AND (
-    ({scope_type:String} = 'issue' AND edge.target_id = {entity_id:String})
-    OR """
+    + """, matched_edges AS (
+  SELECT blocker.work_item_id AS entity_id,
+         blocker.title AS display_label,
+         blocker.status AS status,
+         greatest(blocker.updated_at, edge.event_ts) AS observed_at,
+         greatest(blocker.last_synced, edge.last_synced) AS last_synced
+  FROM work_graph_edges AS edge FINAL
+  INNER JOIN work_items AS blocker FINAL
+    ON blocker.org_id = edge.org_id AND blocker.work_item_id = edge.source_id
+  INNER JOIN work_items AS blocked FINAL
+    ON blocked.org_id = edge.org_id AND blocked.work_item_id = edge.target_id
+  LEFT JOIN project ON 1 = 1
+  WHERE edge.org_id = {org_id:String}
+    AND edge.source_type = 'issue'
+    AND edge.target_type = 'issue'
+    AND edge.edge_type = 'blocks'
+    AND edge.provenance = 'native'
+    AND toString(blocker.repo_id) IN {repository_ids:Array(String)}
+    AND toString(blocked.repo_id) IN {repository_ids:Array(String)}
+    AND edge.event_ts <= {as_of:DateTime64(3, 'UTC')}
+    AND blocker.updated_at <= {as_of:DateTime64(3, 'UTC')}
+    AND blocked.updated_at <= {as_of:DateTime64(3, 'UTC')}
+    AND (
+      ({scope_type:String} = 'issue' AND edge.target_id = {entity_id:String})
+      OR """
     + _project_scope_arm("blocked.")
     + """
-    OR ({scope_type:String} = 'work_unit'
-      AND edge.target_id IN {member_issue_ids:Array(String)})
-  )
+      OR ({scope_type:String} = 'work_unit'
+        AND edge.target_id IN {member_issue_ids:Array(String)})
+    )
+)
+SELECT entity_id,
+       max(display_label) AS display_label,
+       max(status) AS status,
+       max(observed_at) AS observed_at,
+       max(last_synced) AS last_synced
+FROM matched_edges
+GROUP BY entity_id
 ORDER BY observed_at DESC, entity_id
 LIMIT {limit:UInt32}
 """

--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -377,10 +377,30 @@ LIMIT {limit:UInt32}
 #: than answered with its current, not-yet-true-at-as_of state -- this
 #: ticket deliberately does not attempt a real history representation; an
 #: as-of snapshot of a since-changed declared state is simply unavailable.
+#: CHAOS-3377 residual defect (live acceptance probe, 2026-08-04): the
+#: aggregate below was originally aliased ``AS updated_at`` -- the SAME name
+#: as the raw column the ``WHERE`` clause filters on two lines down.
+#: ClickHouse resolves a bare ``WHERE`` identifier against a same-named
+#: ``SELECT`` alias in preference to the source column, so ``WHERE
+#: updated_at <= {as_of:...}`` was silently rewritten to filter on
+#: ``any(updated_at)`` -- an aggregate function, which ``WHERE`` (unlike
+#: ``HAVING``) can never contain. The result was ``Code: 184
+#: (ILLEGAL_AGGREGATION)`` raised on EVERY invocation of this query,
+#: unconditionally (never a timestamp-skew or evidence-cap artifact).
+#: ``_read`` (below) catches that exception and reports the ``projects``
+#: source as merely "unavailable" -- indistinguishable, from every caller's
+#: perspective, from a genuinely absent declared state, which is exactly why
+#: this went unnoticed: the declared-state clause simply never rendered, for
+#: any project, on any run. Aliased to ``declared_updated_at`` instead so the
+#: ``WHERE`` clause's ``updated_at`` reference stays bound to the raw
+#: column -- the fix is the rename alone; ``state``/``target_date``/
+#: ``last_synced`` are left untouched (not aggregation-clause hazards, since
+#: nothing filters on them) so ``_read``'s own generic
+#: ``row.get("last_synced")`` watermark lookup keeps working unchanged.
 _PROJECT_DECLARED_FACTS_SQL = """
 SELECT any(state) AS state,
        any(target_date) AS target_date,
-       any(updated_at) AS updated_at,
+       any(updated_at) AS declared_updated_at,
        any(last_synced) AS last_synced
 FROM projects FINAL
 WHERE org_id = {org_id:String} AND id = {entity_id:String} AND is_active = 1
@@ -1628,7 +1648,7 @@ class ClickHouseStatusChangeSource:
                         target_date if target_date is not None else None
                     )
                     declared_project_observed_at = self._datetime(
-                        row.get("updated_at"), as_of
+                        row.get("declared_updated_at"), as_of
                     )
 
         pull_requests = tuple(

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -486,6 +486,53 @@ def _incident_facts(incidents: Sequence[DevIncidentFact]) -> list[_OutstandingFa
     return facts
 
 
+def _deduplicated_facts(
+    facts: Sequence[_OutstandingFact],
+) -> list[_OutstandingFact]:
+    """Collapse outstanding facts to one per (category, entity), first
+    occurrence wins.
+
+    CHAOS-3377 residual defect (live acceptance probe, 2026-08-04): a single
+    project-scope blocker with ``blocks`` edges to several blocked issues IN
+    SCOPE produces one row PER EDGE from ``_BLOCKERS_SQL``
+    (``native_status_change.py``) -- nothing between that query and here
+    (``status_change_service._ordered_status`` only sorts; it never
+    dedupes) collapses those rows back to one per blocker entity. The live
+    answer rendered the identical "Blocked: ..." claim 5 times, each citing
+    the SAME evidence ref, for a single blocker that happened to block 5
+    in-scope issues.
+
+    ``claim_id_suffix`` is already ``f"{category}:{entity_or_fact_id}"``
+    (see ``outstanding_facts`` below) for every category this renderer
+    knows about, so it is exactly the (category, entity) key without
+    re-deriving either half -- and de-duplicating on it here closes the gap
+    regardless of WHICH upstream category produced the repeat (an edge-count
+    artifact today, any other duplicate source tomorrow), not just the one
+    arm the live probe happened to exercise.
+
+    Order is preserved and deterministic: every category's own fact list is
+    already produced in a fixed, sorted order (``status_change_service``'s
+    ``_ordered_status``/``_pr_key``/etc.), and categories are always visited
+    in the same fixed sequence below -- so "first occurrence wins" always
+    picks the same one across identical inputs.
+
+    A dedup key is scoped to ONE category by construction (the suffix
+    always starts with that category's own prefix), so the SAME entity
+    appearing in two DIFFERENT categories -- e.g. both a required child AND
+    a blocker, which are independently meaningful (CHAOS-3377 HIGH 3) --
+    still yields two distinct claims, never collapsed into one.
+    """
+
+    seen: set[str] = set()
+    deduplicated: list[_OutstandingFact] = []
+    for fact in facts:
+        if fact.claim_id_suffix in seen:
+            continue
+        seen.add(fact.claim_id_suffix)
+        deduplicated.append(fact)
+    return deduplicated
+
+
 def outstanding_facts(
     actual: DevActualCompletion, status_result: DevToolResult
 ) -> list[_OutstandingFact]:
@@ -538,7 +585,7 @@ def outstanding_facts(
     facts.extend(_ci_facts(status_result.ci_checks))
     facts.extend(_deployment_facts(status_result.deployments))
     facts.extend(_incident_facts(status_result.incidents))
-    return facts
+    return _deduplicated_facts(facts)
 
 
 def build_deterministic_status_claims(

--- a/tests/api/dev/test_chaos_3377_blockers_edge_multiplication_live.py
+++ b/tests/api/dev/test_chaos_3377_blockers_edge_multiplication_live.py
@@ -1,0 +1,296 @@
+"""Live-ClickHouse proof for CHAOS-3377's residual blocker-duplication defect.
+
+The live acceptance probe found the SAME blocker rendered 5 times in one
+§10 answer, each backed by the SAME evidence -- root-caused to
+``_BLOCKERS_SQL`` (``native_status_change.py``): under PROJECT scope it
+joins ``work_graph_edges`` with NO ``GROUP BY``, so a single blocker with
+``blocks`` edges to N different blocked issues in scope returns N identical-
+entity rows. ``ORDER BY``/``LIMIT`` then apply to those MULTIPLIED rows, not
+to distinct blockers.
+
+Codex adversarial review on the first fix (a renderer-side dedup in
+``status_answer_render.py``) correctly flagged that seam as too late: SQL
+``LIMIT`` and evidence minting both happen BEFORE the renderer ever runs, so
+a blocker with more edges than the page size can fill the entire result
+page and push OTHER, genuinely distinct blockers out of the answer
+entirely -- unrecoverable by any dedup downstream. The real fix collapses
+duplicate rows to one per blocker INSIDE the SQL, before ``ORDER BY``/
+``LIMIT``.
+
+This test proves that collapse against a REAL engine with REAL rows (a unit
+fake is a predicate evaluator, not a SQL engine, and cannot see a query
+plan's actual row multiplication): one blocker wired to more blocked issues
+than the page ``limit``, plus a second, genuinely distinct blocker, and
+asserts the second blocker's row -- and therefore its evidence -- survives.
+
+Opt-in (filtered from unit/CI by ``ci/run_tests.sh``'s
+``-m "not benchmark and not clickhouse"``): ``pytest -m clickhouse`` with
+``CLICKHOUSE_URI`` pointing at a SCRATCH database -- never the dev ``default``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.dev.native_status_change import _BLOCKERS_SQL
+from dev_health_ops.api.queries.client import query_dicts
+from dev_health_ops.metrics.schemas import ProjectRecord, WorkGraphEdgeRecord
+from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.linear.normalize import linear_issue_to_work_item
+from dev_health_ops.providers.status_mapping import StatusMapping
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+NOW = datetime.now(UTC).replace(microsecond=0)
+
+#: Mirrors test_project_scope_clickhouse_live.py's own guard verbatim -- this
+#: file writes rows too, and must never touch the dev ``default`` database.
+_PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _database_of(dsn: str | None) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(dsn or "").path.lstrip("/").strip().lower()
+
+
+_SKIP_REASON = (
+    "Requires a migrated SCRATCH CLICKHOUSE_URI "
+    "(e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate); "
+    f"got database {_database_of(CLICKHOUSE_URI) or '<unset>'!r}, which this "
+    "suite refuses to seed"
+)
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI or _database_of(CLICKHOUSE_URI) in _PROTECTED_DATABASES,
+        reason=_SKIP_REASON,
+    ),
+]
+
+
+@pytest.fixture
+def sink() -> Any:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    metrics_sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    try:
+        yield metrics_sink
+    finally:
+        metrics_sink.close()
+
+
+def _work_item(
+    identifier: str,
+    *,
+    org_id: str,
+    project_id: str | None,
+    repo_id: uuid.UUID,
+    updated_at: datetime,
+) -> Any:
+    """One work item through the real Linear normalizer (never hand-built)."""
+
+    identity = MagicMock(spec=IdentityResolver)
+    identity.resolve.side_effect = lambda **kwargs: "user:dev@example.com"
+    status_mapping = MagicMock(spec=StatusMapping)
+    status_mapping.normalize_status.return_value = "in_progress"
+    status_mapping.normalize_type.return_value = "task"
+
+    issue = {
+        "id": f"issue-{identifier}",
+        "identifier": identifier,
+        "title": f"Work item {identifier}",
+        "createdAt": (updated_at - timedelta(days=1)).isoformat(),
+        "updatedAt": updated_at.isoformat(),
+        "state": {"id": "s1", "name": "In Progress", "type": "started"},
+        "team": {"id": "t1", "key": "CHAOS", "name": "Fullchaos"},
+        **(
+            {"project": {"id": project_id, "name": "Blockers Live Project"}}
+            if project_id
+            else {}
+        ),
+    }
+    item, _ = linear_issue_to_work_item(
+        issue=issue, status_mapping=status_mapping, identity=identity
+    )
+    return replace(item, org_id=org_id, repo_id=repo_id, updated_at=updated_at)
+
+
+def _edge(
+    *,
+    source_id: str,
+    target_id: str,
+    repo_id: uuid.UUID,
+    org_id: str,
+    event_ts: datetime,
+) -> WorkGraphEdgeRecord:
+    return WorkGraphEdgeRecord(
+        edge_id=f"blocks:{source_id}:{target_id}",
+        source_type="issue",
+        source_id=source_id,
+        target_type="issue",
+        target_id=target_id,
+        edge_type="blocks",
+        repo_id=repo_id,
+        provider="linear",
+        provenance="native",
+        confidence=1.0,
+        evidence="{}",
+        discovered_at=event_ts,
+        last_synced=event_ts,
+        event_ts=event_ts,
+        day=event_ts.date(),
+        org_id=org_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_blocker_with_more_edges_than_limit_never_hides_a_distinct_blocker(
+    sink: Any,
+) -> None:
+    """Fail->pass repro for the Codex HIGH finding.
+
+    One blocker (``over-limit-blocker``) has ``blocks`` edges to 4 different
+    blocked issues in the SAME project scope -- more than the page
+    ``limit`` (3) below. A second, genuinely distinct blocker
+    (``second-blocker``) blocks just one of the same issues.
+
+    Pre-fix: ``_BLOCKERS_SQL`` returns 4 identical ``over-limit-blocker``
+    rows (one per edge) ordered ahead of the 1 ``second-blocker`` row (its
+    edges/updates are deliberately older); ``LIMIT 3`` keeps 3 of those 4
+    duplicate rows and ``second-blocker`` never appears at all -- an
+    actionable, distinct blocker silently dropped by a duplicate-inflated
+    page, unrecoverable by any dedup downstream of the SQL.
+
+    Post-fix: the SQL collapses to one row per blocker BEFORE ``LIMIT``, so
+    both distinct blockers (2 rows total) fit under ``limit=3`` and
+    ``second-blocker`` survives.
+    """
+
+    org_id = f"chaos-3377-blockers-{uuid.uuid4().hex[:16]}"
+    project_id = str(uuid.uuid4())
+    repo_id = uuid.uuid4()
+
+    older = NOW - timedelta(days=5)
+    newer = NOW - timedelta(hours=1)
+    # The query-side ``as_of`` bound is intentionally NOT "now": a known,
+    # pre-existing ClickHouse/driver quirk on this stack (see the 3380
+    # lane's flaky-test finding) can land sink-written timestamps hours
+    # ahead of the wall clock a query parameter is bound against, which is
+    # exactly the kind of accidental exclusion this test must not be
+    # sensitive to -- it is testing row COLLAPSE, not freshness bounding.
+    # Fixed far in the future so every seeded row is unambiguously "in the
+    # past" relative to it, regardless of that skew's direction or size.
+    query_as_of = datetime(2030, 1, 1, tzinfo=UTC)
+
+    blocked_identifiers = [f"BLOCKED-{index}" for index in range(4)]
+    over_limit_blocker_identifier = "OVER-LIMIT-BLOCKER"
+    second_blocker_identifier = "SECOND-BLOCKER"
+
+    sink.write_projects(
+        [
+            ProjectRecord(
+                id=project_id,
+                org_id=org_id,
+                provider="linear",
+                name="Blockers Live Project",
+                is_active=1,
+                updated_at=NOW,
+                last_synced=NOW,
+            )
+        ]
+    )
+
+    sink.write_work_items(
+        [
+            *(
+                _work_item(
+                    identifier,
+                    org_id=org_id,
+                    project_id=project_id,
+                    repo_id=repo_id,
+                    updated_at=newer,
+                )
+                for identifier in blocked_identifiers
+            ),
+            _work_item(
+                over_limit_blocker_identifier,
+                org_id=org_id,
+                project_id=None,
+                repo_id=repo_id,
+                updated_at=newer,
+            ),
+            _work_item(
+                second_blocker_identifier,
+                org_id=org_id,
+                project_id=None,
+                repo_id=repo_id,
+                updated_at=older,
+            ),
+        ]
+    )
+
+    # The real producer (linear_issue_to_work_item) mints
+    # ``work_item_id = f"linear:{identifier}"`` -- derive every id from that
+    # SAME rule rather than hand-guessing the format.
+    over_limit_blocker_id = f"linear:{over_limit_blocker_identifier}"
+    second_blocker_id = f"linear:{second_blocker_identifier}"
+    blocked_work_item_ids = [
+        f"linear:{identifier}" for identifier in blocked_identifiers
+    ]
+
+    sink.write_work_graph_edges(
+        [
+            *(
+                _edge(
+                    source_id=over_limit_blocker_id,
+                    target_id=blocked_id,
+                    repo_id=repo_id,
+                    org_id=org_id,
+                    event_ts=newer,
+                )
+                for blocked_id in blocked_work_item_ids
+            ),
+            _edge(
+                source_id=second_blocker_id,
+                target_id=blocked_work_item_ids[0],
+                repo_id=repo_id,
+                org_id=org_id,
+                event_ts=older,
+            ),
+        ]
+    )
+
+    assert CLICKHOUSE_URI is not None
+    rows = await query_dicts(
+        sink.client,
+        _BLOCKERS_SQL,
+        {
+            "org_id": org_id,
+            "entity_id": project_id,
+            "scope_type": "project",
+            "repository_ids": [str(repo_id)],
+            "member_issue_ids": [],
+            "as_of": query_as_of,
+            "limit": 3,
+        },
+    )
+
+    entity_ids = [row["entity_id"] for row in rows]
+    assert len(entity_ids) == len(set(entity_ids)), (
+        f"_BLOCKERS_SQL returned duplicate entity_id rows: {entity_ids}"
+    )
+    assert second_blocker_id in entity_ids, (
+        "the second, genuinely distinct blocker was crowded out of the "
+        f"page by the over-limit blocker's duplicate rows: {entity_ids}"
+    )
+    assert over_limit_blocker_id in entity_ids
+    assert set(entity_ids) == {over_limit_blocker_id, second_blocker_id}

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -730,6 +730,92 @@ def test_outstanding_facts_never_interpolates_raw_status_fields() -> None:
         assert "not_ready" not in fact.text
 
 
+# --- CHAOS-3377 residual defect (live acceptance probe): the same work
+# item entering a category's source list more than once (e.g. a project-
+# scope blocker with `blocks` edges to several blocked issues in scope --
+# `_BLOCKERS_SQL` in native_status_change.py returns one row PER EDGE) must
+# never render the same claim more than once. ---
+
+
+def test_outstanding_facts_deduplicates_the_same_blocker_seen_via_multiple_edges() -> (
+    None
+):
+    """Fail->pass repro: the live probe's blocker list carried the SAME
+    blocker entity 5 times (one row per `blocks` edge to a different blocked
+    issue in the project scope), each an identical ``DevRequiredChildFact``
+    (same ``fact_id``, ``text``, ``evidence_ref_ids``). A single duplicated
+    entity must produce exactly ONE outstanding fact, not one per edge.
+    """
+
+    duplicate_blocker = _child(
+        "issue:linear:CHAOS-3203",
+        "Ask Dev Wave 0: Audit graph, metric, evidence, and data-freshness "
+        "coverage for launch questions",
+        "open",
+        ("ev1_f9689b2af649f8b55017ddf4e0d6325a50c1e159",),
+    )
+    actual = _actual(blockers=(duplicate_blocker,) * 5)
+    status_result = _tool_result(actual_completion=actual)
+    facts = outstanding_facts(actual, status_result)
+    matching = [
+        f for f in facts if f.claim_id_suffix == "blocker:issue:linear:CHAOS-3203"
+    ]
+    assert len(matching) == 1
+
+
+def test_build_deterministic_status_claims_never_repeats_the_same_claim_id() -> None:
+    """Same repro, one level up: the WIRE claims list must never contain the
+    same ``claim_id`` (and therefore never the same text/evidence) twice,
+    regardless of how many duplicate rows the upstream source produced for
+    one entity.
+    """
+
+    duplicate_blocker = _child(
+        "issue:linear:CHAOS-3203",
+        "Ask Dev Wave 0: Audit graph, metric, evidence, and data-freshness "
+        "coverage for launch questions",
+        "open",
+        ("ev_01",),
+    )
+    actual = _actual(blockers=(duplicate_blocker,) * 5)
+    status_result = _tool_result(actual_completion=actual)
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=status_result,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+    )
+    claim_ids = [c.claim_id for c in claims]
+    assert len(claim_ids) == len(set(claim_ids)), (
+        f"duplicate claim_id(s) rendered: {claim_ids}"
+    )
+    blocker_claims = [c for c in claims if c.claim_id.startswith("status-blocker:")]
+    assert len(blocker_claims) == 1
+
+
+def test_outstanding_facts_dedup_is_scoped_per_category_not_global() -> None:
+    """The SAME entity appearing as both a required child AND a blocker
+    (two genuinely distinct categories -- see the CHAOS-3377 HIGH 3 comment
+    on why blockers and required children are independent sources) must
+    still produce TWO claims, not be collapsed into one -- dedup keys on
+    (category, entity), never entity alone.
+    """
+
+    shared_fact_id = "issue:linear:CHAOS-9999"
+    actual = _actual(
+        reason_codes=("open_blocker", "required_child_incomplete"),
+        required_children=(_child(shared_fact_id, "Shared work item", "open"),),
+        blockers=(_child(shared_fact_id, "Shared work item", "open"),),
+    )
+    status_result = _tool_result(actual_completion=actual)
+    facts = outstanding_facts(actual, status_result)
+    suffixes = {f.claim_id_suffix for f in facts}
+    assert suffixes == {
+        f"child:{shared_fact_id}",
+        f"blocker:{shared_fact_id}",
+    }
+
+
 def test_claims_built_across_multiple_categories_at_once() -> None:
     """A verdict caused by several categories at once gets a claim for
     EACH, not just the first one found.

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev import native_status_change as _native_status_change_module
 from dev_health_ops.api.dev.contracts import (
     DevEntityRef,
     DevScope,
@@ -24,6 +26,111 @@ from dev_health_ops.api.dev.status_change_service import (
 )
 
 NOW = datetime(2026, 7, 28, 12, tzinfo=UTC)
+
+
+# --- CHAOS-3377 residual defect (Codex adversarial review MEDIUM): the
+# alias-collision regression that actually caught the live defect
+# (test_status_change_clickhouse_live.py::
+# test_project_declared_facts_query_parses_against_production_schema) is
+# ``@pytest.mark.clickhouse``-gated -- opted OUT of every mandatory gate
+# (``ci/run_tests.sh`` and local validation both run ``-m "not clickhouse"``).
+# The exact defect class (an aggregate aliased to the SAME name as a raw
+# column its own WHERE clause filters on -- ClickHouse resolves the WHERE
+# reference to the alias, not the source column, and rejects an aggregate
+# there with ILLEGAL_AGGREGATION) could be reintroduced in ANY of this
+# module's SQL constants and pass every required gate. This is a plain
+# string-level structural check -- no live engine needed -- generic across
+# every ``*_SQL`` constant the module defines, so it closes the whole CLASS
+# of defect rather than re-pinning the one instance the live probe found.
+_AGGREGATE_ALIAS_RE = re.compile(
+    r"\b(?:any|anyLast|max|min|sum|avg|argMax|argMin|greatest|least)\s*\(\s*([\w.]+)\s*\)\s+AS\s+(\w+)",
+    re.IGNORECASE,
+)
+_WHERE_CLAUSE_RE = re.compile(
+    r"\bWHERE\b(.*?)(?:\bGROUP BY\b|\bHAVING\b|\bORDER BY\b|\bLIMIT\b|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _paren_depths(sql: str) -> list[int]:
+    """Parenthesis nesting depth active at (i.e. immediately after) each
+    character -- used to keep an aggregate alias from being compared
+    against a WHERE clause that belongs to a DIFFERENT, nested subquery
+    (e.g. a CTE's own ``SELECT ... WHERE ...`` one paren level deeper than
+    the outer query that reads FROM it). Only same-depth pairs are in the
+    same query scope and can actually collide the way ClickHouse resolves
+    identifiers; a naive whole-string search would false-positive on an
+    outer aggregate that happens to share a name with an inner CTE's own
+    (unrelated, differently-scoped) WHERE-filtered column.
+    """
+
+    depths = [0] * len(sql)
+    depth = 0
+    for index, char in enumerate(sql):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        depths[index] = depth
+    return depths
+
+
+def _self_named_aggregate_aliases_filtered_in_where(sql: str) -> list[str]:
+    """Aggregate aliases in ``sql`` that reuse their OWN input column's bare
+    name, where that same bare name is ALSO referenced (unqualified) inside
+    a WHERE clause AT THE SAME PAREN-NESTING DEPTH -- the exact CHAOS-3377
+    defect shape: ``any(updated_at) AS updated_at`` alongside
+    ``WHERE updated_at <= ...`` in the SAME (not a nested) query.
+    """
+
+    findings: list[str] = []
+    depths = _paren_depths(sql)
+    where_clauses = [
+        (match.group(1), depths[match.start()])
+        for match in _WHERE_CLAUSE_RE.finditer(sql)
+    ]
+    for match in _AGGREGATE_ALIAS_RE.finditer(sql):
+        raw_expr, alias = match.groups()
+        raw_col = raw_expr.rsplit(".", 1)[-1]
+        if raw_col.casefold() != alias.casefold():
+            continue
+        alias_depth = depths[match.start()]
+        bare_reference = re.compile(rf"(?<![.\w]){re.escape(alias)}\b(?!\s*\()")
+        if any(
+            bare_reference.search(clause)
+            for clause, where_depth in where_clauses
+            if where_depth == alias_depth
+        ):
+            findings.append(alias)
+    return findings
+
+
+def test_no_sql_constant_aliases_an_aggregate_to_its_own_filtered_column_name() -> None:
+    """Structural, unmarked regression for the CHAOS-3377 alias-collision
+    defect class -- runs in the plain unit suite, never opted out by
+    ``-m "not clickhouse"``. Scans every ``*_SQL`` string constant this
+    module defines (not just the one the live probe found broken), so a
+    future SQL constant introducing the same shape fails here immediately,
+    long before it could ever reach a live engine.
+    """
+
+    offenders: dict[str, list[str]] = {}
+    for name in dir(_native_status_change_module):
+        if not name.endswith("_SQL"):
+            continue
+        value = getattr(_native_status_change_module, name)
+        if not isinstance(value, str):
+            continue
+        findings = _self_named_aggregate_aliases_filtered_in_where(value)
+        if findings:
+            offenders[name] = findings
+    assert not offenders, (
+        "SQL constant(s) alias an aggregate to the SAME name as a raw "
+        f"column their own WHERE clause filters on: {offenders}. "
+        "ClickHouse resolves the WHERE reference to the alias (an "
+        "aggregate), not the source column, and rejects it with "
+        "ILLEGAL_AGGREGATION (CHAOS-3377) -- rename the alias."
+    )
 
 
 def _scope(

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -2929,3 +2929,67 @@ async def test_partial_unlinked_activity_alongside_linked_facts_stays_clean(
         "elsewhere in the team's repos) is the documented, deferred "
         "policy -- must NOT be flagged in this round"
     )
+
+
+# --- CHAOS-3377 residual defect (live acceptance probe, 2026-08-04): the
+# declared-state/target-date read must reach RawStatusSnapshot end to end for
+# a real PROJECT-scope call -- a fake-client unit test, unlike the live
+# ClickHouse EXPLAIN-PLAN test in test_status_change_clickhouse_live.py,
+# cannot see a SQL alias collision, but it DOES catch the complementary
+# failure mode: the Python side reading the wrong column key out of the row
+# (e.g. a rename on one side of the SQL/Python boundary without the other).
+# Together the two tests cover both halves of this fix. ---
+
+
+@pytest.mark.asyncio
+async def test_native_project_scope_surfaces_declared_state_and_target_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Deliberately distinct from ``as_of`` (below) -- ``_datetime``'s
+    # fallback-to-``as_of`` behavior for a missing/None value would
+    # otherwise mask a Python-side column-key mismatch: if the code read
+    # the wrong dict key, ``row.get(...)`` returns ``None`` and
+    # ``declared_project_observed_at`` would silently become ``as_of``
+    # rather than surfacing as wrong.
+    declared_updated_at = NOW.replace(hour=9)
+
+    async def fake_query(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        # NOTE: ``_PROJECT_IDENTITY_CTE`` (embedded in
+        # ``PROJECT_REPOSITORIES_SQL`` below) ALSO contains the substring
+        # "FROM projects FINAL" -- match the declared-facts query's own
+        # unique ``SELECT`` clause first, or this branch wrongly answers
+        # the repository-derivation query too.
+        if "SELECT any(state) AS state" in sql:
+            return [
+                {
+                    "state": "started",
+                    "target_date": None,
+                    "declared_updated_at": declared_updated_at,
+                    "last_synced": NOW,
+                }
+            ]
+        if "INNER JOIN project ON 1 = 1" in sql:
+            # PROJECT_REPOSITORIES_SQL: derives the project's own
+            # repository set from its (sentinel, repo-less) work items.
+            return [{"repository_id": "00000000-0000-0000-0000-000000000000"}]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_status_change.query_dicts", fake_query
+    )
+    source = ClickHouseStatusChangeSource(object(), now=NOW)
+    scope = _scope(
+        DirectScope.PROJECT,
+        entity_id="project-1",
+        repositories=[],
+    )
+    raw = await source.status_snapshot(
+        org_id="org-a", scope=scope, as_of=NOW, limit=100
+    )
+
+    assert raw.declared_project_state == "started"
+    assert raw.declared_project_target_date is None
+    assert raw.declared_project_observed_at == declared_updated_at.replace(tzinfo=UTC)
+    assert not any("projects" in warning for warning in raw.warnings)

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.dev.native_status_change import (
     _DEPLOYMENTS_SQL,
     _INCIDENT_CHANGES_SQL,
     _INCIDENTS_SQL,
+    _PROJECT_DECLARED_FACTS_SQL,
     _PULL_REQUEST_CHANGES_SQL,
     _PULL_REQUESTS_SQL,
     _RELATIONSHIPS_SQL,
@@ -137,6 +138,45 @@ def test_project_repository_derivation_parses_against_production_schema(
             f"project_repositories EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
         )
     assert plan.result_rows, "project_repositories returned an empty query plan"
+
+
+def test_project_declared_facts_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_PROJECT_DECLARED_FACTS_SQL``
+    (CHAOS-3377 residual defect, live acceptance probe 2026-08-04).
+
+    The live acceptance probe never rendered a "Declared state: ..." clause
+    for a project whose catalog row unambiguously carried one. Root cause:
+    this query's ``SELECT`` aliased its aggregate to the SAME name as the
+    raw column the ``WHERE`` clause filters on (``any(updated_at) AS
+    updated_at``) -- ClickHouse resolves the ``WHERE`` reference against
+    that alias rather than the raw column, and rejects an aggregate
+    function inside ``WHERE`` with ``Code: 184
+    (ILLEGAL_AGGREGATION)``, on EVERY invocation, unconditionally (never a
+    timestamp-skew or evidence-cap artifact -- the unit fake in
+    ``test_chaos_3377_status_answer_render.py`` is a predicate evaluator,
+    not a SQL engine, so it could not have caught this; only the real
+    engine can). ``native_status_change.py``'s ``_read`` helper catches the
+    exception and reports the ``projects`` source as merely "unavailable" --
+    indistinguishable, from the caller's perspective, from a genuinely
+    absent declared state, which is exactly why this went unnoticed.
+    """
+
+    sql = _PROJECT_DECLARED_FACTS_SQL
+    assert "{org_id:String}" in sql, "declared-facts read lacks a tenant predicate"
+    params: dict[str, object] = {
+        "org_id": ORG_ID,
+        "entity_id": "project-target",
+        "as_of": NOW,
+    }
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"project_declared_facts EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
+        )
+    assert plan.result_rows, "project_declared_facts returned an empty query plan"
 
 
 def test_direct_work_item_precedes_children_before_limit() -> None:


### PR DESCRIPTION
## Summary

Fixes CHAOS-3386 — the two residuals found by the post-merge live acceptance probe:

- **Duplicate blocker claims**: `_BLOCKERS_SQL` emitted one row per blocking edge, so a blocker with N edges rendered N identical claims — and worse, multiplied rows consumed the ORDER BY/LIMIT page and the evidence budget before rendering, letting one many-edged blocker crowd out distinct actionable blockers entirely. Fixed at the SQL seam: edges collapse to one row per blocker (GROUP BY inside the query, deterministic max() aggregates) before ordering/limiting; renderer-level dedup retained as defense-in-depth. Live-ClickHouse regression proves a >limit-edge blocker no longer hides its neighbors (red-first verified).
- **Declared state dead on arrival**: `_PROJECT_DECLARED_FACTS_SQL` aliased its aggregate `AS updated_at`, shadowing the raw column its own WHERE filtered on — ClickHouse resolved the filter against the aggregate and threw `ILLEGAL_AGGREGATION` on every invocation, which `_read()` swallowed as "source unavailable". The CHAOS-3368 declared-state feature never rendered live. Fixed by renaming the alias; live-verified end to end ("Declared state: in progress." now renders with its own grounded evidence).
- **Class guard**: a new un-marked structural test scans every SQL constant in the module and rejects any aggregate aliased to a column its own WHERE clause (same nesting depth) filters on — so the alias-shadowing class is caught by the plain unit gate, without needing the opt-in live suite (whose broken fixture, CHAOS-3376, is exactly why the original bug shipped undetected).

## Testing

- Full `tests/api/dev`: 1967 passed, 50 skipped, 1 xfailed, 0 failed; scoped re-run green post-rebase.
- Live scratch-ClickHouse regressions (edge-multiplication crowd-out; EXPLAIN parse of the declared-facts query) red-first verified; live browser verification via the documented test-mode recipe (worktree API + `pnpm dev`) passed both assertions against real org data.
- Structural alias test fail→pass verified by reintroducing the original bug. ruff + mypy clean.
