### PR TITLE
fix(ask-dev): CHAOS-3392 thread resolved_at into scope resolution time_range

### DIFF
--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -472,13 +472,29 @@ class ScopeResolutionService:
         *,
         now: datetime | None = None,
     ) -> ScopeResolution:
-        """Resolve ``request`` as of ``now`` (default: the wall clock).
+        """Resolve ``request`` as of ``now`` (defaults to the real current
+        instant -- production callers never pass this explicitly).
 
-        ``now`` governs the *whole* resolution, not just part of it. A preset
-        window is anchored on the caller's instant, so a resolution that took
-        its window from the wall clock while its caller believed it had pinned
-        the instant was reproducible only for as long as the two agreed --
-        which, for a preset, means until the next local midnight.
+        ``now`` governs the *whole* resolution, not just part of it: a
+        preset window must be anchored on the SAME instant the caller
+        believes it pinned. CHAOS-3392: ``now`` used to be silently dropped
+        here -- every preset-relative ``time_range`` (the common case;
+        explicit ``start_date``/``end_date`` was unaffected) was always
+        computed against the REAL wall clock even when a caller resolved an
+        otherwise fully deterministic, watermark-cached result via
+        ``resolve_contract(resolved_at=...)`` (below), so a resolution that
+        took its window from the wall clock while its caller believed it
+        had pinned the instant was reproducible only until the next local
+        midnight. Threading ``now`` through closes that leak; the default
+        keeps today's production behavior (resolve against the actual
+        current moment) byte-for-byte unchanged.
+
+        (An independently-diagnosed fix for this same defect landed on
+        main as #1366 while this branch's own codex-hardened fix was in
+        flight; reconciled here onto this branch's semantics -- see the
+        cache-key comment below for why, and its ``resolved_at``-anchors-
+        the-window / two-instants-do-not-collide tests are kept alongside
+        this branch's own three.)
         """
         if not org_id or not permission_fingerprint:
             raise ValueError("Tenant and permission fingerprint are required")
@@ -494,6 +510,13 @@ class ScopeResolutionService:
                 key=lambda kind: kind.value,
             )
         )
+        # Resolved once, up front: the catalog-failure branch below, the
+        # cache key, and the eventual ``ScopeResolution.time_range`` all
+        # share this SAME value, so a transient catalog failure on a
+        # SECOND, microseconds-later call in the same request can never
+        # observe a different ``time_range`` than a first call that already
+        # succeeded and was cached (see the cache-key comment below).
+        time_range = self.resolve_time_range(request.time_range, now=now)
         try:
             watermark = await self._catalog.watermark(org_id, relevant_kinds)
         except Exception:
@@ -502,26 +525,51 @@ class ScopeResolutionService:
                 entities=(),
                 team_filters=(),
                 candidates=(),
-                time_range=self.resolve_time_range(request.time_range, now=now),
+                time_range=time_range,
                 warnings=("catalog_unavailable",),
             )
+        payload = _request_payload(request)
+        if request.time_range.start_date is None or request.time_range.end_date is None:
+            # Preset-relative window: ``now`` DOES affect the result, but
+            # the raw instant must never be the cache key material itself.
+            # CHAOS-3392 codex MEDIUM: keying on ``now.isoformat()`` (as
+            # main's independent #1366 fix for this same defect did too --
+            # reconciled here onto this branch's semantics, not main's) gave
+            # every call within one request its own microsecond-distinct
+            # key (``resolve_contract`` always resolves a concrete instant,
+            # even for callers who never pin one), which defeated the
+            # request-local cache entirely for the common, unpinned
+            # production path -- repeated calls in one request each re-hit
+            # the catalog instead of reusing the first result, and a
+            # transient catalog failure on that SECOND call could flip an
+            # already-resolved, already-cacheable request from exact to
+            # unresolved. Keyed instead by the EFFECTIVE resolved boundary
+            # (``time_range.utc_start``/``utc_end``): two calls landing on
+            # the same local day -- the only thing a preset window is
+            # actually sensitive to -- collapse onto the SAME cache entry,
+            # exactly like two calls with no ``now`` divergence at all did
+            # before CHAOS-3392 threaded ``now`` through in the first place.
+            payload = {
+                **payload,
+                "resolved_utc_start": time_range.utc_start.isoformat(),
+                "resolved_utc_end": time_range.utc_end.isoformat(),
+            }
+        # Absolute ``start_date``/``end_date`` ranges are left untouched:
+        # ``now`` cannot affect their result (``resolve_time_range`` never
+        # reads it in that branch), so the cache key stays byte-for-byte
+        # identical to pre-CHAOS-3392 -- no needless cache-busting for the
+        # case this ticket was never about.
         cache_key = self._cache_key(
             "resolve",
             org_id,
             permission_fingerprint,
-            _request_payload(request),
+            payload,
             watermark,
-            # A preset window is derived from the instant, so two resolutions
-            # of the same request at different instants are different results
-            # and must not share an entry. Production passes ``now=None`` and
-            # keys on the literal ``None``, exactly as before.
-            now.isoformat() if now is not None else None,
         )
         cached = self._cache.get(cache_key)
         if isinstance(cached, ScopeResolution):
             return cached
 
-        time_range = self.resolve_time_range(request.time_range, now=now)
         if not active_refs:
             result = ScopeResolution(
                 outcome=ScopeResolutionOutcome.UNRESOLVED,
@@ -980,10 +1028,14 @@ class ScopeResolutionService:
     ) -> DevScopeResolution:
         """Resolve ``resolve_scope.v1`` into the canonical CHAOS-3223 contract.
 
-        ``resolved_at`` is the instant the resolution is *made at*, so it also
-        anchors the resolved preset window -- it is not merely a label applied
-        to a window taken from a second, unrelated clock. Production callers
-        pass ``None`` and get the wall clock for both, unchanged.
+        ``resolved_at`` is the instant the resolution is *made at*, so it
+        also anchors the resolved preset window -- it is not merely a
+        label applied to a window taken from a second, unrelated clock.
+        Resolved early (was previously computed only for the OUTPUT
+        ``resolved_at`` field, at the very end of this method) so the SAME
+        instant also pins ``domain.time_range`` via ``self.resolve`` below
+        -- see that method's docstring. Production callers pass ``None``
+        and get the wall clock for both, unchanged.
         """
         resolved_at = resolved_at or datetime.now(timezone.utc)
         domain = await self.resolve(
@@ -1050,6 +1102,8 @@ class ScopeResolutionService:
             candidates=candidates,
             fallbacks=list(domain.fallbacks),
             warnings=warnings,
+            # Already resolved above (and threaded into ``self.resolve`` as
+            # ``now``) -- always non-None by this point.
             resolved_at=resolved_at,
         )
 
@@ -1315,8 +1369,19 @@ class ScopeResolutionService:
         permission_fingerprint: str,
         payload: dict[str, object],
         watermark: str,
-        resolved_as_of: str | None = None,
     ) -> str:
+        # CHAOS-3392 codex MEDIUM: a caller-pinned instant (``resolve``'s
+        # ``now``) must NOT be folded into this key as a raw timestamp --
+        # main's independent #1366 fix for this same defect did exactly
+        # that (a ``resolved_as_of`` parameter here, keyed on
+        # ``now.isoformat()``), reintroducing the round-1 flaw this
+        # branch's own codex review round refuted: ``resolve_contract``
+        # always resolves a concrete instant, even for callers who never
+        # pin one, so every "unpinned" production call got its own
+        # microsecond-distinct key and the request-local cache never hit.
+        # ``resolve``'s caller instead folds the EFFECTIVE resolved
+        # boundary into ``payload`` itself when it matters (preset-relative
+        # windows only) -- see that method's cache-key comment.
         raw = json.dumps(
             {
                 "operation": operation,
@@ -1325,7 +1390,6 @@ class ScopeResolutionService:
                 "input": payload,
                 "query_version": QUERY_VERSION,
                 "watermark": watermark,
-                "resolved_as_of": resolved_as_of,
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone, tzinfo
+from typing import Self
 
 import pytest
 
+from dev_health_ops.api.dev import scope_service as scope_service_module
 from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
@@ -15,6 +17,42 @@ from dev_health_ops.api.dev.scope_service import (
     ScopeSearchRequest,
     TimeRangeRequest,
 )
+
+
+class _ScriptedNow(datetime):
+    """A ``datetime`` subclass whose ``.now()`` pops from a scripted queue
+    instead of reading the real system clock.
+
+    CHAOS-3392 codex MEDIUM: ``ScopeResolutionService.resolve_contract``'s
+    "caller omitted ``resolved_at``" fallback is
+    ``resolved_at or datetime.now(timezone.utc)`` -- the REAL wall clock,
+    called fresh on every invocation. A test that wants to deterministically
+    prove two such "unpinned" calls collide (or don't) on the request-local
+    cache can't rely on real elapsed microseconds between two lines of test
+    code; monkeypatching ``scope_service.datetime`` to this subclass lets a
+    test script exactly which instant each ``datetime.now()`` call inside
+    the module returns while every OTHER ``datetime`` usage in that module
+    (``datetime.combine``, the ``datetime(...)`` constructor, etc.) keeps
+    working unchanged, since this class inherits the real implementation of
+    everything except ``now`` itself.
+    """
+
+    _queue: list[datetime] = []
+
+    @classmethod
+    def now(cls, tz: tzinfo | None = None) -> Self:
+        value = cls._queue.pop(0)
+        result = value if tz is None else value.astimezone(tz)
+        return cls(
+            result.year,
+            result.month,
+            result.day,
+            result.hour,
+            result.minute,
+            result.second,
+            result.microsecond,
+            tzinfo=result.tzinfo,
+        )
 
 
 class FakeCatalog:
@@ -565,6 +603,131 @@ async def test_request_local_cache_is_partitioned_by_permission_and_watermark() 
     assert first == second == third
     assert catalog.exact_calls == 2
     assert catalog.watermark_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_resolve_contract_unpinned_repeated_calls_share_one_cache_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3392 codex MEDIUM regression (RED on commit 0e029a122):
+    production callers of ``resolve_contract`` never pass ``resolved_at``
+    -- it falls back to ``datetime.now(timezone.utc)`` INSIDE
+    ``resolve_contract`` itself, so two calls in the SAME request each got
+    their own fresh, microsecond-distinct instant even though neither
+    caller asked to pin anything. The fixed commit folded that raw instant
+    directly into ``resolve()``'s request-local cache key, so two such
+    "unpinned" calls never shared a cache entry -- defeating the whole
+    point of a request-local cache for the overwhelming majority
+    (unpinned) production callers. Scripted instants a few hundred
+    microseconds apart, same calendar day -- exactly what two real,
+    back-to-back ``datetime.now()`` calls in one request would produce.
+    """
+
+    repository = _entity(EntityKind.REPOSITORY, "repo-a", "full-chaos/dev-health")
+    catalog = FakeCatalog([repository])
+    service = ScopeResolutionService(catalog)
+    request = ScopeResolveRequest(
+        explicit_refs=(ScopeRef(EntityKind.REPOSITORY, repository.canonical_id),)
+    )
+    _ScriptedNow._queue = [
+        datetime(2026, 7, 28, 10, 0, 0, 111111, tzinfo=timezone.utc),
+        datetime(2026, 7, 28, 10, 0, 0, 999999, tzinfo=timezone.utc),
+    ]
+    monkeypatch.setattr(scope_service_module, "datetime", _ScriptedNow)
+
+    first = await service.resolve_contract("org-a", "perm-a", request)
+    second = await service.resolve_contract("org-a", "perm-a", request)
+
+    assert first.outcome is ScopeResolutionOutcome.EXACT
+    assert second.outcome is ScopeResolutionOutcome.EXACT
+    assert catalog.exact_calls == 1, (
+        "two unpinned calls in one request must share one cache entry, "
+        f"not each hit the catalog (exact_calls={catalog.exact_calls})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_contract_different_effective_days_do_not_collide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cache-key fix must not COLLAPSE genuinely different preset
+    windows onto one entry -- two calls whose effective local day differs
+    (24h apart here) must each resolve, and cache, independently."""
+
+    repository = _entity(EntityKind.REPOSITORY, "repo-a", "full-chaos/dev-health")
+    catalog = FakeCatalog([repository])
+    service = ScopeResolutionService(catalog)
+    request = ScopeResolveRequest(
+        explicit_refs=(ScopeRef(EntityKind.REPOSITORY, repository.canonical_id),)
+    )
+    _ScriptedNow._queue = [
+        datetime(2026, 7, 28, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc),
+    ]
+    monkeypatch.setattr(scope_service_module, "datetime", _ScriptedNow)
+
+    first = await service.resolve_contract("org-a", "perm-a", request)
+    second = await service.resolve_contract("org-a", "perm-a", request)
+
+    assert catalog.exact_calls == 2, (
+        "two calls landing on DIFFERENT effective days must not share a "
+        f"cache entry (exact_calls={catalog.exact_calls})"
+    )
+    assert first.resolved_scope is not None
+    assert second.resolved_scope is not None
+    assert (
+        first.resolved_scope.time_range.end != second.resolved_scope.time_range.end
+    ), "the two resolutions must carry genuinely different time windows"
+
+
+@pytest.mark.asyncio
+async def test_transient_catalog_failure_on_second_call_cannot_flip_a_cached_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3392 codex MEDIUM behavioral repro (RED on commit 0e029a122):
+    before the cache-key fix, two unpinned calls in one request never
+    shared a cache entry, so a TRANSIENT catalog failure on the SECOND
+    call re-ran full entity resolution (``exact()``, which only ever
+    fires on a cache MISS -- ``watermark()`` itself is intentionally
+    re-queried on every call regardless of caching, precisely so the
+    cache invalidates the instant the catalog's data changes; a
+    transient failure THERE can never be masked by any cache-key fix,
+    which is why this repro targets ``exact()`` instead) and flipped an
+    already-successfully-resolved, already-cacheable request from EXACT
+    to UNRESOLVED/``catalog_unavailable`` -- even though the first call,
+    microseconds earlier, had already proven the catalog reachable and
+    the resolution EXACT. A request-local cache exists precisely to make
+    this impossible: a cache HIT must never re-touch ``exact()`` at all.
+    """
+
+    repository = _entity(EntityKind.REPOSITORY, "repo-a", "full-chaos/dev-health")
+    catalog = FakeCatalog([repository])
+    service = ScopeResolutionService(catalog)
+    request = ScopeResolveRequest(
+        explicit_refs=(ScopeRef(EntityKind.REPOSITORY, repository.canonical_id),)
+    )
+    _ScriptedNow._queue = [
+        datetime(2026, 7, 28, 10, 0, 0, 111111, tzinfo=timezone.utc),
+        datetime(2026, 7, 28, 10, 0, 0, 999999, tzinfo=timezone.utc),
+    ]
+    monkeypatch.setattr(scope_service_module, "datetime", _ScriptedNow)
+
+    first = await service.resolve_contract("org-a", "perm-a", request)
+    assert first.outcome is ScopeResolutionOutcome.EXACT
+
+    catalog.fail_exact = True
+    second = await service.resolve_contract("org-a", "perm-a", request)
+
+    assert second.outcome is ScopeResolutionOutcome.EXACT, (
+        "a transient catalog failure on a second, cache-hit call must "
+        f"never surface -- got outcome={second.outcome!r} "
+        f"warnings={second.warnings!r}"
+    )
+    assert "catalog_unavailable" not in second.warnings
+    assert catalog.exact_calls == 1, (
+        "the second call must be a cache HIT and never re-invoke exact() "
+        f"at all (exact_calls={catalog.exact_calls})"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Threads `resolved_at` into `ScopeResolutionService.resolve`/`resolve_contract`'s preset-window `time_range`, and keys the request-local cache by the effective resolved boundary instead of the raw instant.

## Supersedes an unticketed fix bundled into #1366
origin/main's #1366 ("fix(helm): use process-only API liveness") independently bundled an unticketed fix for the same defect, in a commit titled "fix(scope): anchor the resolved window on the caller's instant" — round-1 shape: keys the request cache on raw `now.isoformat()`, and `resolve_contract` materializes `resolved_at or datetime.now(timezone.utc)` before calling `resolve()`.

That shape has a codex-caught regression: every production call gets a microsecond-unique cache key, defeating the request-local cache entirely for all unpinned production callers, and letting a transient catalog failure on a second, cache-should-have-hit call flip an already-resolved EXACT result to UNRESOLVED.

### Evidence (failing against main's round-1 shape)
Ran this branch's two cache regression tests against main's (#1366) version of `scope_service.py` directly:

```
test_resolve_contract_unpinned_repeated_calls_share_one_cache_entry — FAILED
  AssertionError: two unpinned calls in one request must share one cache entry,
  not each hit the catalog (exact_calls=2)
  assert 2 == 1

test_transient_catalog_failure_on_second_call_cannot_flip_a_cached_resolution — FAILED
  AssertionError: a transient catalog failure on a second, cache-hit call must
  never surface -- got outcome=UNRESOLVED warnings=['catalog_unavailable']
  assert UNRESOLVED is EXACT
```

`test_relative_time_range_uses_local_day_boundaries_across_dst` passes unaffected in both shapes.

This branch (round-2 shape) instead keys the cache on the *effective resolved boundary* (`time_range.utc_start`/`utc_end`), so two calls landing on the same local day collapse onto one cache entry — closing the regression while still anchoring the window on the caller's instant.

## Compatibility
- Keeps #1366's unrelated helm/liveness changes byte-identical (deploy/helm/dev-health/values.yaml, src/dev_health_ops/api/main.py, tests/test_helm_api_probes.py, tests/api/test_main_app_integration.py — untouched).
- Retains both of #1366's new scope tests (`test_resolved_at_anchors_the_window_it_stamps`, `test_two_instants_do_not_share_one_cached_resolution`) — both pass under this branch's implementation.

## Verification (post-reconciliation rebase onto current origin/main)
- 72/72 scope tests, including main's 2 new ones.
- 23/23 snapshot tests, including the +1yr advanced-clock case.
- Full 449-test regression sweep green.
- ruff/mypy clean; lefthook pre-push green.