### PR TITLE
fix(ask-dev): CHAOS-3376 repair live EXPLAIN fixture, fix _PULL_REQUESTS_SQL alias, guard alias-shadow class closures

### DIFF
--- a/src/dev_health_ops/api/dev/native_status_change.py
+++ b/src/dev_health_ops/api/dev/native_status_change.py
@@ -499,6 +499,40 @@ LIMIT {limit:UInt32}
 """
 )
 
+#: CHAOS-3376 residual defect (live EXPLAIN fixture repair, 2026-08-04; root
+#: cause corrected in codex review round 2, 2026-08-04): the ``latest_reviews``
+#: CTE below used to alias its per-reviewer watermark
+#: ``max(submitted_at) AS submitted_at`` -- the SAME name as the raw
+#: ``git_pull_request_reviews.submitted_at`` column it aggregates -- in the
+#: SAME SELECT LIST as ``argMax(state, (submitted_at, last_synced,
+#: review_id)) AS state``, which passes that bare ``submitted_at`` as one of
+#: ITS OWN arguments. ClickHouse resolves every bare identifier across a
+#: WHOLE SELECT list against any alias defined ANYWHERE in that SAME list
+#: as one order-independent unit (NOT sequentially/textually -- verified
+#: directly: the self-collision reproduces standalone, with no ``WITH`` CTE
+#: involved at all, and conversely a genuinely cross-CTE reference to a
+#: same-named column with NO same-list collision does not reproduce it), so
+#: the ``submitted_at`` argument inside ``argMax(state, (submitted_at, ...))``
+#: -- textually BEFORE the ``max(submitted_at) AS submitted_at`` alias it
+#: collides with -- resolved to that ALIASED aggregate expression instead of
+#: the plain column, nesting one aggregate function inside another, which
+#: ClickHouse rejects unconditionally with ``Code: 184 (ILLEGAL_AGGREGATION)``
+#: on every invocation. (The originally-shipped fix diagnosed this as a
+#: cross-CTE "WITH is inlined, not materialized" hazard -- reproduction
+#: disproved that: the ``reviews`` CTE's own, unrelated reference to
+#: ``state``/``latest_submitted_at`` from ``latest_reviews`` is completely
+#: safe, exactly because it is a DIFFERENT SELECT list / query block.) Exactly
+#: the same alias-shadowing hazard CLASS as ``_PROJECT_DECLARED_FACTS_SQL``'s
+#: CHAOS-3377 fix (WHERE resolving to a same-named aggregate alias instead of
+#: the raw column) -- here the collision is with a SIBLING SELECT-list
+#: expression instead of a WHERE predicate, in the SAME query block. Never
+#: reached by the unit fake (a predicate evaluator, not a SQL engine); only
+#: surfaced once the live EXPLAIN fixture's shared ``common`` params dict
+#: actually supplied every placeholder this query's text binds (CHAOS-3376)
+#: and the query ran against the real engine for the first time. Fixed by
+#: renaming the alias to ``latest_submitted_at`` so every reference to it --
+#: within ``latest_reviews`` itself and from ``reviews`` below -- stays bound
+#: to a plain per-row column, not the aggregate that produced it.
 _PULL_REQUESTS_SQL = (
     "WITH "
     + _PROJECT_IDENTITY_CTE
@@ -527,7 +561,7 @@ _PULL_REQUESTS_SQL = (
 ), latest_reviews AS (
   SELECT toString(repo_id) AS repository_id, number, reviewer,
          argMax(state, (submitted_at, last_synced, review_id)) AS state,
-         max(submitted_at) AS submitted_at
+         max(submitted_at) AS latest_submitted_at
   FROM git_pull_request_reviews FINAL
   WHERE org_id = {org_id:String}
     AND toString(repo_id) IN {repository_ids:Array(String)}
@@ -539,7 +573,7 @@ _PULL_REQUESTS_SQL = (
            'CHANGES_REQUESTED',
            countIf(upper(state) = 'APPROVED') > 0,
            'APPROVED',
-           argMax(state, submitted_at)
+           argMax(state, latest_submitted_at)
          ) AS review_state,
          countIf(upper(state) = 'CHANGES_REQUESTED') AS changes_requested
   FROM latest_reviews

--- a/tests/api/dev/test_native_status_change.py
+++ b/tests/api/dev/test_native_status_change.py
@@ -28,109 +28,499 @@ from dev_health_ops.api.dev.status_change_service import (
 NOW = datetime(2026, 7, 28, 12, tzinfo=UTC)
 
 
-# --- CHAOS-3377 residual defect (Codex adversarial review MEDIUM): the
-# alias-collision regression that actually caught the live defect
-# (test_status_change_clickhouse_live.py::
-# test_project_declared_facts_query_parses_against_production_schema) is
-# ``@pytest.mark.clickhouse``-gated -- opted OUT of every mandatory gate
-# (``ci/run_tests.sh`` and local validation both run ``-m "not clickhouse"``).
-# The exact defect class (an aggregate aliased to the SAME name as a raw
-# column its own WHERE clause filters on -- ClickHouse resolves the WHERE
-# reference to the alias, not the source column, and rejects an aggregate
-# there with ILLEGAL_AGGREGATION) could be reintroduced in ANY of this
-# module's SQL constants and pass every required gate. This is a plain
-# string-level structural check -- no live engine needed -- generic across
-# every ``*_SQL`` constant the module defines, so it closes the whole CLASS
-# of defect rather than re-pinning the one instance the live probe found.
-_AGGREGATE_ALIAS_RE = re.compile(
-    r"\b(?:any|anyLast|max|min|sum|avg|argMax|argMin|greatest|least)\s*\(\s*([\w.]+)\s*\)\s+AS\s+(\w+)",
+# --- CHAOS-3377 / CHAOS-3386 / CHAOS-3376 (three occurrences of one defect
+# class -- generalized here per the "after three fixes of one class, ship a
+# closure argument" rule): an aggregate aliased to the SAME bare name as its
+# own input column, where that name is ALSO referenced, unqualified,
+# somewhere ClickHouse resolves identifiers against SELECT-list aliases
+# instead of (or in addition to) the raw source column, nesting an aggregate
+# inside another expression that rejects one -- ILLEGAL_AGGREGATION
+# (Code 184), unconditionally, on every invocation. Two SEPARATE mechanisms
+# have now each produced this symptom, and a single check only ever caught
+# one of them:
+#   1. WHERE-clause shadowing (CHAOS-3377 ``_PROJECT_DECLARED_FACTS_SQL``,
+#      CHAOS-3386): ``any(updated_at) AS updated_at`` alongside
+#      ``WHERE updated_at <= ...`` in the SAME query -- WHERE evaluates
+#      before the SELECT list exists, so ClickHouse still resolves the bare
+#      name against the alias and rejects the aggregate it names.
+#   2. Same-SELECT-list sibling shadowing (CHAOS-3376 ``_PULL_REQUESTS_SQL``):
+#      ``max(submitted_at) AS submitted_at`` and
+#      ``argMax(state, (submitted_at, ...)) AS state`` in the SAME SELECT
+#      list. ClickHouse resolves every bare identifier across a WHOLE SELECT
+#      list against any alias defined ANYWHERE in that list as one
+#      order-independent unit -- reproduced directly: the collision fires
+#      with NO ``WITH`` CTE involved at all (single ``SELECT`` list, self-
+#      contained), and TEXTUAL ORDER does not matter (the colliding
+#      reference sits BEFORE the alias definition in the source and still
+#      triggers it). A prior diagnosis of this as "WITH is inlined into its
+#      consumer, not materialized" was disproved by the same reproduction: a
+#      genuinely CROSS-CTE reference to a same-named column, with no
+#      same-list collision anywhere, is completely safe. This is exactly
+#      what ``_self_named_aggregate_aliases_filtered_in_where`` (the
+#      original, CHAOS-3377-era check below) could not see: it scans ONLY
+#      inside ``WHERE`` clauses, and this collision lives in a sibling
+#      SELECT-list aggregate argument instead -- confirmed by running the
+#      ORIGINAL checker against the pre-fix ``_PULL_REQUESTS_SQL`` text,
+#      which reported no offenders even though the live EXPLAIN suite
+#      (CHAOS-3376) reproduced Code 184 against it.
+# ``_self_named_aggregate_alias_referenced_in_nested_aggregate`` below closes
+# mechanism 2 the same way the original check closes mechanism 1: a plain,
+# unmarked, string-level structural scan over every ``*_SQL`` constant this
+# module defines, so either shape fails here immediately, long before it
+# could ever reach a live engine. Deliberately NOT a search for "any bare
+# reference anywhere in the same query block": that over-broad version
+# false-positived on ``_BLOCKERS_SQL``'s legitimate
+# ``max(observed_at) AS observed_at`` ... ``ORDER BY observed_at`` --
+# referencing a SELECT-list aggregate alias from ORDER BY is standard, valid
+# SQL (ORDER BY runs AFTER aggregation), not this defect. Scoped instead to
+# "bare reference used as the argument of ANOTHER recognized aggregate call,
+# in the SAME query block as its own definition", which is exactly (and
+# only) the shape that nests an aggregate inside an aggregate.
+#
+# codex review round 2 (HIGH, 2026-08-04): the FIRST version of this guard
+# recognized only ``func(single_identifier) AS alias`` against a fixed,
+# non-combinator function list -- it returned ``[]`` (silently, with no
+# positive control to catch the gap) for ClickHouse's "combinator" suffixed
+# aggregates (``argMaxIf``, ``maxIf``, ...: same hazard, an extra condition
+# argument) and for aggregate families outside that fixed list entirely
+# (``countIf``, ``uniqExact``, ...), and it treated "downstream of the
+# alias's own definition, textually" as the nested-aggregate mechanism's
+# scope, which -- per the corrected root-cause analysis above -- is not
+# actually how ClickHouse resolves this at all (order does not matter; QUERY
+# BLOCK does). ``_AGGREGATE_BASE_FUNCS``/``_AGGREGATE_COMBINATOR_SUFFIXES``
+# widen recognition to combinator-suffixed, multi-argument producers;
+# ``_query_block_spans``/``_query_block_id`` replace "downstream of
+# definition" and raw paren-DEPTH matching (which could not tell a sibling
+# CTE at the same depth from the SAME query block, and separately let a
+# WHERE clause's own end-boundary regex silently swallow text belonging to
+# an OUTER, unrelated query once a CTE's own WHERE had no
+# GROUP BY/HAVING/ORDER BY/LIMIT of its own to stop at) with the actual
+# scope ClickHouse resolves aliases within: same CTE body, or the final/
+# outer statement. ``test_alias_shadow_detectors_catch_every_synthetic_bad_sql_control``
+# below is the positive control codex asked for: parameterized, minimal,
+# KNOWN-BAD synthetic SQL this guard MUST flag, so a future weakening of
+# either the function-name recognition or the block-scoping shows up as a
+# RED test here, not as a silently-empty ``offenders`` dict.
+_AGGREGATE_BASE_FUNCS = (
+    "any",
+    "anyLast",
+    "anyHeavy",
+    "max",
+    "min",
+    "sum",
+    "avg",
+    "argMax",
+    "argMin",
+    "greatest",
+    "least",
+    "count",
+    "uniq",
+    "uniqExact",
+    "uniqCombined",
+    "uniqCombined64",
+    "uniqHLL12",
+    "groupArray",
+    "groupUniqArray",
+    "median",
+    "quantile",
+    "quantileExact",
+    "stddevPop",
+    "stddevSamp",
+    "varPop",
+    "varSamp",
+    "topK",
+)
+#: ClickHouse "combinator" suffixes -- any base aggregate above may carry
+#: ONE of these (``maxIf``, ``argMaxIf``, ``uniqExactIf``, ...). A
+#: combinator changes the argument SHAPE (usually adding a trailing
+#: condition argument) but the function is still a genuine aggregate,
+#: still subject to the same alias-shadowing hazard this guard exists to
+#: catch.
+_AGGREGATE_COMBINATOR_SUFFIXES = (
+    "If",
+    "Array",
+    "Merge",
+    "State",
+    "Distinct",
+    "OrDefault",
+    "OrNull",
+    "Resample",
+    "ForEach",
+    "Simple",
+)
+_AGGREGATE_CALL_START_RE = re.compile(
+    r"\b(?:"
+    + "|".join(_AGGREGATE_BASE_FUNCS)
+    + r")(?:"
+    + "|".join(_AGGREGATE_COMBINATOR_SUFFIXES)
+    + r")*\s*\(",
     re.IGNORECASE,
 )
-_WHERE_CLAUSE_RE = re.compile(
-    r"\bWHERE\b(.*?)(?:\bGROUP BY\b|\bHAVING\b|\bORDER BY\b|\bLIMIT\b|\Z)",
-    re.IGNORECASE | re.DOTALL,
+_CTE_HEADER_RE = re.compile(r"\b(\w+)\s+AS\s*\(", re.IGNORECASE)
+_WHERE_KEYWORD_RE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+_STOP_KEYWORD_RE = re.compile(
+    r"\bGROUP BY\b|\bHAVING\b|\bORDER BY\b|\bLIMIT\b", re.IGNORECASE
 )
 
 
-def _paren_depths(sql: str) -> list[int]:
-    """Parenthesis nesting depth active at (i.e. immediately after) each
-    character -- used to keep an aggregate alias from being compared
-    against a WHERE clause that belongs to a DIFFERENT, nested subquery
-    (e.g. a CTE's own ``SELECT ... WHERE ...`` one paren level deeper than
-    the outer query that reads FROM it). Only same-depth pairs are in the
-    same query scope and can actually collide the way ClickHouse resolves
-    identifiers; a naive whole-string search would false-positive on an
-    outer aggregate that happens to share a name with an inner CTE's own
-    (unrelated, differently-scoped) WHERE-filtered column.
+def _bare_reference_re(alias: str) -> re.Pattern[str]:
+    """A bare (unqualified, non-function-call) occurrence of ``alias``:
+    excludes ``x.alias`` (qualified column refs) and ``alias(`` (alias
+    happening to collide with a function/table name)."""
+
+    return re.compile(rf"(?<![.\w]){re.escape(alias)}\b(?!\s*\()")
+
+
+def _matching_close_paren(sql: str, open_idx: int) -> int:
+    """The index of the ``)`` that closes the ``(`` at ``open_idx``,
+    balancing nested parens (tuples, nested function calls, subqueries)."""
+
+    depth = 0
+    for index in range(open_idx, len(sql)):
+        if sql[index] == "(":
+            depth += 1
+        elif sql[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return open_idx
+
+
+def _call_spans(sql: str, start_re: re.Pattern[str]) -> list[tuple[int, int, int]]:
+    """``(name_start, open_paren_index, matching_close_paren_index)`` for
+    every call matching ``start_re``, balancing nested parens (e.g.
+    ``argMax(state, (submitted_at, last_synced, review_id))``) so a
+    multi-argument or tuple-argument call is still attributed correctly."""
+
+    return [
+        (call.start(), call.end() - 1, _matching_close_paren(sql, call.end() - 1))
+        for call in start_re.finditer(sql)
+    ]
+
+
+def _query_block_spans(sql: str) -> list[tuple[int, int]]:
+    """``(start, end)`` character spans for every CTE body (`` AS ( ... )``
+    introduced directly by ``WITH`` or a top-level comma) plus one trailing
+    span for whatever follows the LAST CTE's closing paren -- the final/
+    outer statement, or the whole string if there are no CTEs at all.
+
+    This is the scope ClickHouse ACTUALLY resolves SELECT-list aliases
+    within (verified by direct reproduction: two sibling CTEs sit at the
+    exact same raw paren-nesting DEPTH yet do not share alias-resolution
+    scope, while two expressions in the SAME CTE body do, regardless of
+    which comes first textually) -- raw paren depth alone cannot
+    distinguish "sibling block, same depth" from "same block".
     """
 
-    depths = [0] * len(sql)
+    spans: list[tuple[int, int]] = []
+    last_close = 0
+    for header in _CTE_HEADER_RE.finditer(sql):
+        prefix = sql[: header.start()].rstrip()
+        if not (prefix.endswith("WITH") or prefix.endswith(",")):
+            continue  # a "name AS (" that isn't actually a CTE introducer
+        open_idx = header.end() - 1
+        close_idx = _matching_close_paren(sql, open_idx)
+        spans.append((open_idx, close_idx))
+        last_close = close_idx + 1
+    spans.append((last_close, len(sql)))
+    return spans
+
+
+def _query_block_id(spans: list[tuple[int, int]], pos: int) -> tuple[int, int] | None:
+    for start, end in spans:
+        if start <= pos <= end:
+            return (start, end)
+    return None
+
+
+def _split_top_level_args(args_text: str) -> list[str]:
+    """Split a function call's argument text on commas at PAREN DEPTH 0,
+    so a tuple argument (``(submitted_at, last_synced, review_id)``)
+    counts as ONE argument, not three."""
+
+    parts: list[str] = []
     depth = 0
-    for index, char in enumerate(sql):
+    current: list[str] = []
+    for char in args_text:
         if char == "(":
             depth += 1
         elif char == ")":
             depth -= 1
-        depths[index] = depth
-    return depths
+        if char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    return parts
+
+
+class _SelfNamedAlias:
+    """One ``<agg>(...args...) AS alias`` match where ``alias`` is the SAME
+    bare name as one of the call's own TOP-LEVEL arguments (case-
+    insensitively) -- the shared precondition both mechanisms below check a
+    same-query-block reference against. ``start``/``end`` bound the WHOLE
+    match (function name through the trailing ``AS alias``), used to locate
+    which query block the definition itself belongs to and to exclude the
+    definition's own occurrence from "is this alias referenced elsewhere"
+    scans.
+    """
+
+    __slots__ = ("start", "end", "alias")
+
+    def __init__(self, start: int, end: int, alias: str) -> None:
+        self.start = start
+        self.end = end
+        self.alias = alias
+
+
+def _self_named_aggregate_aliases(sql: str) -> list[_SelfNamedAlias]:
+    """Every aggregate call (base or combinator-suffixed, single- or
+    multi-argument) in ``sql`` aliased to the SAME bare name as one of its
+    OWN top-level arguments."""
+
+    results: list[_SelfNamedAlias] = []
+    for name_start, open_idx, close_idx in _call_spans(sql, _AGGREGATE_CALL_START_RE):
+        as_match = re.match(r"\s*AS\s+(\w+)", sql[close_idx + 1 :], re.IGNORECASE)
+        if not as_match:
+            continue
+        alias = as_match.group(1)
+        args_text = sql[open_idx + 1 : close_idx]
+        if any(
+            arg.strip().rsplit(".", 1)[-1].casefold() == alias.casefold()
+            for arg in _split_top_level_args(args_text)
+        ):
+            results.append(
+                _SelfNamedAlias(name_start, close_idx + 1 + as_match.end(), alias)
+            )
+    return results
 
 
 def _self_named_aggregate_aliases_filtered_in_where(sql: str) -> list[str]:
     """Aggregate aliases in ``sql`` that reuse their OWN input column's bare
     name, where that same bare name is ALSO referenced (unqualified) inside
-    a WHERE clause AT THE SAME PAREN-NESTING DEPTH -- the exact CHAOS-3377
-    defect shape: ``any(updated_at) AS updated_at`` alongside
-    ``WHERE updated_at <= ...`` in the SAME (not a nested) query.
+    a WHERE clause belonging to the SAME query block -- the exact
+    CHAOS-3377 / CHAOS-3386 defect shape: ``any(updated_at) AS updated_at``
+    alongside ``WHERE updated_at <= ...`` in the SAME (not a sibling) query.
     """
 
+    spans = _query_block_spans(sql)
+    where_clauses: list[tuple[str, tuple[int, int] | None]] = []
+    for keyword in _WHERE_KEYWORD_RE.finditer(sql):
+        block = _query_block_id(spans, keyword.start())
+        block_end = block[1] if block else len(sql)
+        end = block_end
+        for stop in _STOP_KEYWORD_RE.finditer(sql, keyword.end(), block_end):
+            if _query_block_id(spans, stop.start()) == block:
+                end = stop.start()
+                break
+        where_clauses.append((sql[keyword.end() : end], block))
+
     findings: list[str] = []
-    depths = _paren_depths(sql)
-    where_clauses = [
-        (match.group(1), depths[match.start()])
-        for match in _WHERE_CLAUSE_RE.finditer(sql)
-    ]
-    for match in _AGGREGATE_ALIAS_RE.finditer(sql):
-        raw_expr, alias = match.groups()
-        raw_col = raw_expr.rsplit(".", 1)[-1]
-        if raw_col.casefold() != alias.casefold():
-            continue
-        alias_depth = depths[match.start()]
-        bare_reference = re.compile(rf"(?<![.\w]){re.escape(alias)}\b(?!\s*\()")
+    for entry in _self_named_aggregate_aliases(sql):
+        alias_block = _query_block_id(spans, entry.start)
+        bare_reference = _bare_reference_re(entry.alias)
         if any(
             bare_reference.search(clause)
-            for clause, where_depth in where_clauses
-            if where_depth == alias_depth
+            for clause, block in where_clauses
+            if block == alias_block
         ):
-            findings.append(alias)
+            findings.append(entry.alias)
+    return findings
+
+
+def _self_named_aggregate_alias_referenced_in_nested_aggregate(
+    sql: str,
+) -> list[str]:
+    """Aggregate aliases in ``sql`` that reuse their OWN input column's bare
+    name, where that same bare name is ALSO passed as an argument to ANOTHER
+    recognized aggregate call in the SAME query block as the alias's own
+    definition -- the CHAOS-3376 ``_PULL_REQUESTS_SQL`` defect shape:
+    ``max(submitted_at) AS submitted_at`` and
+    ``argMax(state, (submitted_at, ...)) AS state`` in the SAME SELECT list
+    (order does not matter). ``Code: 184 (ILLEGAL_AGGREGATION)`` on every
+    invocation, exactly like the WHERE-clause mechanism above but
+    unreachable by that check (this collision never appears inside a WHERE
+    clause at all). Cross-block references (a downstream CTE reading a
+    same-named PLAIN column from an upstream CTE) are explicitly NOT
+    flagged -- verified safe by direct reproduction.
+    """
+
+    spans = _query_block_spans(sql)
+    call_spans = [
+        (open_idx, close_idx)
+        for _, open_idx, close_idx in _call_spans(sql, _AGGREGATE_CALL_START_RE)
+    ]
+    findings: list[str] = []
+    for entry in _self_named_aggregate_aliases(sql):
+        alias_block = _query_block_id(spans, entry.start)
+        bare_reference = _bare_reference_re(entry.alias)
+        for hit in bare_reference.finditer(sql):
+            hit_pos = hit.start()
+            if entry.start <= hit_pos < entry.end:
+                continue  # the alias's own defining occurrence, not a reference
+            if _query_block_id(spans, hit_pos) != alias_block:
+                continue  # a different query block -- verified safe
+            if any(
+                open_idx < hit_pos < close_idx for open_idx, close_idx in call_spans
+            ):
+                findings.append(entry.alias)
+                break
     return findings
 
 
 def test_no_sql_constant_aliases_an_aggregate_to_its_own_filtered_column_name() -> None:
-    """Structural, unmarked regression for the CHAOS-3377 alias-collision
-    defect class -- runs in the plain unit suite, never opted out by
-    ``-m "not clickhouse"``. Scans every ``*_SQL`` string constant this
-    module defines (not just the one the live probe found broken), so a
-    future SQL constant introducing the same shape fails here immediately,
-    long before it could ever reach a live engine.
+    """Structural, unmarked regression closing the WHERE-clause-shadowing
+    AND same-query-block-sibling-shadowing shapes of the CHAOS-3377 /
+    CHAOS-3386 / CHAOS-3376 alias-collision defect CLASS -- runs in the
+    plain unit suite, never opted out by ``-m "not clickhouse"``. Scans
+    every ``*_SQL`` string constant this module defines (not just the
+    instances the live probe found broken), so a future SQL constant
+    introducing EITHER shape fails here immediately, long before it could
+    ever reach a live engine.
+
+    This closes the class as far as static, string-level detection can go:
+    it does NOT attempt to prove every conceivable identifier-resolution
+    context ClickHouse might shadow an alias in -- that would require a
+    real SQL parser, and an over-broad regex-only version of the
+    nested-aggregate check (any bare reference anywhere in the same query
+    block, not just inside another aggregate call) was tried and rejected
+    here because it false-positived on ``_BLOCKERS_SQL``'s legitimate
+    ``max(observed_at) AS observed_at`` ... ``ORDER BY observed_at`` (valid:
+    ORDER BY runs after aggregation). The live EXPLAIN suite
+    (``test_status_change_clickhouse_live.py``, CHAOS-3376 fixture repair)
+    remains the backstop for whatever shape still slips past both
+    mechanisms here -- but ONLY now that its shared params fixture actually
+    supplies every placeholder each SQL constant's text binds, AND (codex
+    review round 2) now that it covers every ``*_SQL`` constant the module
+    defines, not just 14 of 22; before those two fixes it was
+    green-by-vacancy on both axes: which params each attempt supplied, and
+    which constants it even attempted.
     """
 
+    scanned = [
+        name
+        for name in dir(_native_status_change_module)
+        if name.endswith("_SQL")
+        and isinstance(getattr(_native_status_change_module, name), str)
+    ]
+    # codex review round 2 (HIGH): "a measurement that did not happen must
+    # FAIL, loudly" -- a broken/empty module scan would make the assertion
+    # below vacuously true (zero constants scanned, zero offenders found),
+    # indistinguishable from "every constant is clean".
+    assert scanned, "no *_SQL constants found on the module -- registry scan is broken"
+
     offenders: dict[str, list[str]] = {}
-    for name in dir(_native_status_change_module):
-        if not name.endswith("_SQL"):
-            continue
+    for name in scanned:
         value = getattr(_native_status_change_module, name)
-        if not isinstance(value, str):
-            continue
-        findings = _self_named_aggregate_aliases_filtered_in_where(value)
+        findings = [
+            f"{alias} (WHERE)"
+            for alias in _self_named_aggregate_aliases_filtered_in_where(value)
+        ] + [
+            f"{alias} (same-block nested aggregate)"
+            for alias in _self_named_aggregate_alias_referenced_in_nested_aggregate(
+                value
+            )
+        ]
         if findings:
             offenders[name] = findings
     assert not offenders, (
         "SQL constant(s) alias an aggregate to the SAME name as a raw "
-        f"column their own WHERE clause filters on: {offenders}. "
-        "ClickHouse resolves the WHERE reference to the alias (an "
-        "aggregate), not the source column, and rejects it with "
-        "ILLEGAL_AGGREGATION (CHAOS-3377) -- rename the alias."
+        f"column referenced in a way ClickHouse resolves against the alias "
+        f"instead: {offenders}. ClickHouse rejects the resulting nested/"
+        "pre-aggregation aggregate reference with ILLEGAL_AGGREGATION "
+        "(CHAOS-3377/CHAOS-3386/CHAOS-3376) -- rename the alias."
     )
+
+
+#: codex review round 2 (HIGH): parameterized, minimal, KNOWN-BAD synthetic
+#: SQL snippets the detectors above MUST flag -- a positive control the
+#: original guard never had, so a regex that silently stopped matching
+#: (weakened combinator support, a typo, a future refactor narrowing
+#: ``_AGGREGATE_BASE_FUNCS``/``_AGGREGATE_COMBINATOR_SUFFIXES``, or breaking
+#: the block-scoping in ``_query_block_spans``) would still report an empty
+#: ``offenders`` dict above and the guard would pass anyway, indistinguishable
+#: from "the codebase is actually clean". Verified directly against the
+#: PRE-widening detector: it returned ``[]`` for the ``argMaxIf``/``maxIf``
+#: (multi-arg, combinator-suffixed) and ``countIf``/``uniqExact`` (base name
+#: outside its fixed list) entries below, even though each is the EXACT
+#: self-named-alias shape the live-fixed instances already proved dangerous.
+#: (label, synthetic SQL, which mechanism must catch it)
+_SYNTHETIC_ALIAS_SHADOW_CONTROLS: tuple[tuple[str, str, str], ...] = (
+    (
+        "where/max/single-arg (original CHAOS-3377/3386 shape)",
+        "SELECT max(updated_at) AS updated_at FROM t WHERE updated_at <= now()",
+        "where",
+    ),
+    (
+        "nested/max/single-arg, same block (corrected CHAOS-3376 shape)",
+        "SELECT argMax(state, (submitted_at, x)) AS state, "
+        "max(submitted_at) AS submitted_at FROM t GROUP BY x",
+        "nested",
+    ),
+    (
+        "where/argMaxIf combinator, multi-arg",
+        "SELECT argMaxIf(state, updated_at, is_active) AS state FROM t "
+        "WHERE state = 'x'",
+        "where",
+    ),
+    (
+        "nested/maxIf combinator, multi-arg, same block",
+        "SELECT argMax(y, price) AS y2, maxIf(price, is_active) AS price "
+        "FROM t GROUP BY x",
+        "nested",
+    ),
+    (
+        "where/countIf (base name outside the original fixed list)",
+        "SELECT countIf(flag) AS flag FROM t WHERE flag > 0",
+        "where",
+    ),
+    (
+        "where/uniqExact (base name outside the original fixed list)",
+        "SELECT uniqExact(user_id) AS user_id FROM t WHERE user_id > 0",
+        "where",
+    ),
+    (
+        "cross-CTE reference is SAFE and must NOT be flagged (regression "
+        "guard for the corrected root cause)",
+        "WITH a AS (SELECT argMax(state, x) AS state, max(x) AS watermark "
+        "FROM t GROUP BY y), b AS (SELECT argMax(state, watermark) AS z "
+        "FROM a GROUP BY y) SELECT * FROM b",
+        "nested-safe",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "label,bad_sql,mechanism",
+    _SYNTHETIC_ALIAS_SHADOW_CONTROLS,
+    ids=[label for label, _, _ in _SYNTHETIC_ALIAS_SHADOW_CONTROLS],
+)
+def test_alias_shadow_detectors_catch_every_synthetic_bad_sql_control(
+    label: str, bad_sql: str, mechanism: str
+) -> None:
+    """The positive-control counterpart to the structural guard above --
+    see its module-level docstring for why each entry exists. If you
+    weaken ``_AGGREGATE_BASE_FUNCS``, ``_AGGREGATE_COMBINATOR_SUFFIXES``,
+    or the multi-argument / block-scoping logic in
+    ``_self_named_aggregate_aliases`` or its two callers, watch THIS test
+    go RED before you touch anything else -- that is the point of a
+    positive control.
+    """
+
+    if mechanism == "where":
+        findings = _self_named_aggregate_aliases_filtered_in_where(bad_sql)
+        assert findings, f"{label}: detector failed to catch a known-bad SQL control"
+    elif mechanism == "nested":
+        findings = _self_named_aggregate_alias_referenced_in_nested_aggregate(bad_sql)
+        assert findings, f"{label}: detector failed to catch a known-bad SQL control"
+    else:
+        assert mechanism == "nested-safe"
+        findings = _self_named_aggregate_alias_referenced_in_nested_aggregate(bad_sql)
+        assert not findings, (
+            f"{label}: detector over-flagged a genuinely safe cross-block "
+            f"reference: {findings}"
+        )
 
 
 def _scope(

--- a/tests/api/dev/test_status_change_clickhouse_live.py
+++ b/tests/api/dev/test_status_change_clickhouse_live.py
@@ -8,20 +8,30 @@ from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev import native_status_change as native_status_change_module
 from dev_health_ops.api.dev.native_status_change import (
+    _BLOCKER_PROJECTION_RULE_VERSION,
+    _BLOCKER_WATERMARK_SQL,
+    _BLOCKERS_SQL,
+    _CI_ACCEPTANCE_SQL,
     _CI_CHANGES_SQL,
     _CI_SQL,
     _DEPLOYMENT_CHANGES_SQL,
     _DEPLOYMENTS_SQL,
     _INCIDENT_CHANGES_SQL,
     _INCIDENTS_SQL,
+    _ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL,
     _PROJECT_DECLARED_FACTS_SQL,
     _PULL_REQUEST_CHANGES_SQL,
     _PULL_REQUESTS_SQL,
     _RELATIONSHIPS_SQL,
     _REVIEW_CHANGES_SQL,
+    _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL,
+    _TEAM_REPOSITORIES_SQL,
     _TRANSITIONS_SQL,
     _WORK_ITEMS_SQL,
+    _WORK_UNIT_MEMBERS_SQL,
+    _WORK_UNIT_MEMBERSHIP_WATERMARK_SQL,
     PROJECT_REPOSITORIES_SQL,
 )
 
@@ -59,6 +69,23 @@ def _fixtures() -> tuple[tuple[str, str, dict[str, object]], ...]:
         "start": NOW - timedelta(days=7),
         "end": NOW,
         "limit": 100,
+        # CHAOS-3376: every arm below is ONE query TEXT shared across every
+        # scope_type -- ClickHouse binds every named placeholder that
+        # appears in the text before it ever evaluates which disjunction
+        # arm is true, so the work_unit-only `{member_issue_ids:...}` /
+        # `{member_pr_ids:...}` and the team-only `{team_id:...}` arms
+        # still require a substitution even under `scope_type = 'issue'`
+        # fixtures, exactly as the real runtime's `common` dict in
+        # `ClickHouseStatusChangeSource._raw_status_snapshot` always
+        # supplies all three regardless of the resolved scope (empty
+        # lists / "" for the arms that don't apply). Omitting them let
+        # this guard go green-by-vacancy: pytest never reached a real
+        # EXPLAIN, it failed constructing the fixture-less call before
+        # any SQL text was substituted -- so nothing here ever exercised
+        # the migrated schema at all.
+        "member_issue_ids": [],
+        "member_pr_ids": [],
+        "team_id": "",
     }
     return (
         ("work_items", _WORK_ITEMS_SQL, common),
@@ -68,7 +95,12 @@ def _fixtures() -> tuple[tuple[str, str, dict[str, object]], ...]:
         (
             "incidents",
             _INCIDENTS_SQL,
-            {**common, "deployment_ids": ["deployment-1"]},
+            # _INCIDENTS_SQL binds `{deployment_pairs:Array(Tuple(String,
+            # String))}` (repository_id, entity_id) pairs -- mirroring the
+            # real runtime's `{**common, "deployment_pairs": deployment_pairs}`
+            # call in `_raw_status_snapshot`, NOT a bare `deployment_ids`
+            # list, which is not a placeholder this query's text contains.
+            {**common, "deployment_pairs": [("repo", "deployment-1")]},
         ),
         (
             "work_item_transitions",
@@ -85,6 +117,16 @@ def _fixtures() -> tuple[tuple[str, str, dict[str, object]], ...]:
         ("ci_changes", _CI_CHANGES_SQL, common),
         ("deployment_changes", _DEPLOYMENT_CHANGES_SQL, common),
         ("incident_changes", _INCIDENT_CHANGES_SQL, common),
+        # CHAOS-3376 codex review round 2 (HIGH): this suite covered only 14
+        # of the module's 22 `*_SQL` constants -- these three (and the five
+        # standalone tests below) were among the 8 that had NO live-EXPLAIN
+        # coverage at all before this round. All three carry both the
+        # `{org_id:String}` tenant predicate and the `{limit:UInt32}` page
+        # bound this parametrized inventory asserts, so they join it
+        # directly rather than needing a standalone test.
+        ("work_unit_members", _WORK_UNIT_MEMBERS_SQL, common),
+        ("ci_acceptance_checks", _CI_ACCEPTANCE_SQL, {**common, "pr_numbers": [1]}),
+        ("blockers", _BLOCKERS_SQL, common),
     )
 
 
@@ -177,6 +219,226 @@ def test_project_declared_facts_query_parses_against_production_schema(
             f"project_declared_facts EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
         )
     assert plan.result_rows, "project_declared_facts returned an empty query plan"
+
+
+def test_work_unit_membership_watermark_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_WORK_UNIT_MEMBERSHIP_WATERMARK_SQL``.
+
+    CHAOS-3376 codex review round 2 (HIGH): one of 8 constants this suite
+    had zero live coverage for. A scalar watermark read
+    (``max(completed_at) AS last_synced``), not a page -- kept out of the
+    parametrized inventory above, which asserts a ``{limit:UInt32}`` bound
+    on every entry, exactly like ``PROJECT_REPOSITORIES_SQL`` and
+    ``_PROJECT_DECLARED_FACTS_SQL`` above.
+    """
+
+    sql = _WORK_UNIT_MEMBERSHIP_WATERMARK_SQL
+    assert "{org_id:String}" in sql, "watermark read lacks a tenant predicate"
+    params: dict[str, object] = {"org_id": ORG_ID, "as_of": NOW}
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"work_unit_membership_watermark EXPLAIN failed: {exc}\n"
+            f"params={params!r}\n{sql}"
+        )
+    assert plan.result_rows, (
+        "work_unit_membership_watermark returned an empty query plan"
+    )
+
+
+def test_blocker_watermark_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_BLOCKER_WATERMARK_SQL`` -- another
+    scalar watermark read, not a page (see the docstring immediately
+    above). CHAOS-3376 codex review round 2 (HIGH).
+    """
+
+    sql = _BLOCKER_WATERMARK_SQL
+    assert "{org_id:String}" in sql, "watermark read lacks a tenant predicate"
+    params: dict[str, object] = {
+        "org_id": ORG_ID,
+        "blocker_rule_version": _BLOCKER_PROJECTION_RULE_VERSION,
+        "repository_ids": [REPOSITORY_ID],
+        "as_of": NOW,
+    }
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"blocker_watermark EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
+        )
+    assert plan.result_rows, "blocker_watermark returned an empty query plan"
+
+
+def test_organization_authorized_repositories_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for
+    ``_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL``. CHAOS-3376 codex review
+    round 2 (HIGH). An authorization set, like ``PROJECT_REPOSITORIES_SQL``
+    above: a truncated result would be a silently narrowed read, not a
+    smaller page, so it deliberately carries no ``LIMIT`` of any kind.
+    """
+
+    sql = _ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL
+    assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
+    assert "LIMIT" not in sql.upper(), "an authorization set must not be truncated"
+    params: dict[str, object] = {"org_id": ORG_ID}
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"organization_authorized_repositories EXPLAIN failed: {exc}\n"
+            f"params={params!r}\n{sql}"
+        )
+    assert plan.result_rows, (
+        "organization_authorized_repositories returned an empty query plan"
+    )
+
+
+def test_team_repo_has_unlinked_activity_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL``.
+    CHAOS-3376 codex review round 2 (HIGH). An EXISTS-shaped probe with two
+    literal ``LIMIT 1`` arms (not a server-owned ``{limit:UInt32}`` page
+    bound), so it is tested standalone rather than joining the
+    parametrized inventory above.
+    """
+
+    sql = _TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL
+    assert "{org_id:String}" in sql, "activity probe lacks a tenant predicate"
+    params: dict[str, object] = {
+        "org_id": ORG_ID,
+        "repository_ids": [REPOSITORY_ID],
+        "as_of": NOW,
+    }
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"team_repo_has_unlinked_activity EXPLAIN failed: {exc}\n"
+            f"params={params!r}\n{sql}"
+        )
+    assert plan.result_rows, (
+        "team_repo_has_unlinked_activity returned an empty query plan"
+    )
+
+
+def test_team_repositories_query_parses_against_production_schema(
+    ch_client: Any,
+) -> None:
+    """Real-engine validation for ``_TEAM_REPOSITORIES_SQL``. CHAOS-3376
+    codex review round 2 (HIGH). Also covered by a dedicated mutation-tested
+    live file (``test_team_scope_clickhouse_live.py``) -- included here too
+    so the registry-equality guard below never has to special-case "tested
+    elsewhere" as an exemption from THIS file's inventory; every constant
+    this module defines gets a real EXPLAIN in this one canonical place.
+    """
+
+    sql = _TEAM_REPOSITORIES_SQL
+    assert "{org_id:String}" in sql, "derivation lacks an explicit tenant predicate"
+    params: dict[str, object] = {
+        "org_id": ORG_ID,
+        "team_id": "team-target",
+        "as_of": NOW,
+    }
+    try:
+        plan = ch_client.query("EXPLAIN PLAN " + sql, parameters=params)
+    except Exception as exc:  # noqa: BLE001 - enrich the failing SQL fixture
+        pytest.fail(
+            f"team_repositories EXPLAIN failed: {exc}\nparams={params!r}\n{sql}"
+        )
+    assert plan.result_rows, "team_repositories returned an empty query plan"
+
+
+#: Every ``*_SQL`` constant ``native_status_change`` defines that this file
+#: covers OUTSIDE the parametrized inventory above -- each has its own
+#: standalone test (a different call shape: no ``{limit:UInt32}`` bound, or
+#: extra required params) for the same reason ``PROJECT_REPOSITORIES_SQL``
+#: and ``_PROJECT_DECLARED_FACTS_SQL`` already did. Kept as an explicit,
+#: hand-maintained set (rather than "whatever isn't in `_fixtures()`") so
+#: the registry-equality assertion below can distinguish "a standalone test
+#: really exists for this name" from "this name simply doesn't appear in
+#: `_fixtures()` yet, for no good reason" -- the exact distinction CHAOS-3376
+#: codex review round 2 found missing.
+_STANDALONE_TESTED_SQL_NAMES = frozenset(
+    {
+        "PROJECT_REPOSITORIES_SQL",
+        "_PROJECT_DECLARED_FACTS_SQL",
+        "_WORK_UNIT_MEMBERSHIP_WATERMARK_SQL",
+        "_BLOCKER_WATERMARK_SQL",
+        "_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL",
+        "_TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL",
+        "_TEAM_REPOSITORIES_SQL",
+    }
+)
+
+
+def _all_runtime_sql_constant_names() -> frozenset[str]:
+    """Every ``*_SQL`` string constant ``native_status_change`` currently
+    defines -- the authoritative registry, derived by introspection (the
+    same mechanism the alias-shadowing structural guard in
+    ``test_native_status_change.py`` uses for its own module scan) rather
+    than a hand-maintained list, so a newly added constant is picked up
+    automatically instead of requiring someone to remember to register it
+    here too.
+    """
+
+    return frozenset(
+        name
+        for name in dir(native_status_change_module)
+        if name.endswith("_SQL")
+        and isinstance(getattr(native_status_change_module, name), str)
+    )
+
+
+def _parametrized_inventory_sql_names() -> frozenset[str]:
+    """The constant NAME behind each ``_fixtures()`` entry's SQL text,
+    resolved by object identity against the module's own attributes --
+    ``_fixtures()`` passes the imported constant object directly (not a
+    copy), so ``is`` correctly attributes each entry back to the exact
+    name it came from without a second, driftable hand-maintained mapping.
+    """
+
+    sql_text_to_name = {
+        id(value): name
+        for name, value in vars(native_status_change_module).items()
+        if name.endswith("_SQL") and isinstance(value, str)
+    }
+    return frozenset(sql_text_to_name[id(sql)] for _, sql, _ in _fixtures())
+
+
+def test_every_runtime_sql_constant_is_covered_by_this_live_suite() -> None:
+    """CHAOS-3376 codex review round 2 (HIGH): this suite covered only 14 of
+    the module's 22 ``*_SQL`` constants -- 8 (``_WORK_UNIT_MEMBERSHIP_
+    WATERMARK_SQL``, ``_WORK_UNIT_MEMBERS_SQL``, ``_BLOCKER_WATERMARK_SQL``,
+    ``_BLOCKERS_SQL``, ``_CI_ACCEPTANCE_SQL``,
+    ``_ORGANIZATION_AUTHORIZED_REPOSITORIES_SQL``,
+    ``_TEAM_REPO_HAS_UNLINKED_ACTIVITY_SQL``, ``_TEAM_REPOSITORIES_SQL``)
+    had NO live-EXPLAIN coverage at all, silently -- the exact same
+    "green-by-vacancy" shape as the original CHAOS-3376 defect, just at the
+    level of "which constants this file even attempts" instead of "which
+    params each attempt supplies". This asserts the module's live registry
+    (every ``*_SQL`` constant that exists right now) equals exactly the
+    union of the parametrized inventory and the explicitly-tracked
+    standalone tests -- so a newly added ``*_SQL`` constant that nobody
+    wires into either place fails THIS assertion immediately, rather than
+    silently joining the 8 that went uncovered until this review round.
+    """
+
+    registry = _all_runtime_sql_constant_names()
+    assert registry, "the module defines no *_SQL constants -- registry scan is broken"
+    covered = _parametrized_inventory_sql_names() | _STANDALONE_TESTED_SQL_NAMES
+    assert covered == registry, (
+        f"uncovered by this live suite: {sorted(registry - covered)}; "
+        f"tracked here but no longer exist on the module: "
+        f"{sorted(covered - registry)}"
+    )
 
 
 def test_direct_work_item_precedes_children_before_limit() -> None:


### PR DESCRIPTION
## Summary
- Repairs the live EXPLAIN fixture for status-change queries against a real ClickHouse instance.
- Fixes an alias bug in `_PULL_REQUESTS_SQL`.
- Adds a class-closure guard against alias-shadowing regressions of the same shape.

## Evidence
- Live ClickHouse EXPLAIN fixture: 15/15 green (`test_status_change_clickhouse_live.py`).
- Class-closure guard regression test added and passing.
- Full local validation gate green prior to rebase.
- Rebased cleanly onto current `origin/main` (post #1366/#1367/#1368), zero conflicts.