### PR TITLE
fix(ask-dev): CHAOS-3388 resolve acronym/alias-named subjects instead of falling through to the grounding floor

### DIFF
--- a/src/dev_health_ops/api/dev/alias_matching.py
+++ b/src/dev_health_ops/api/dev/alias_matching.py
@@ -1,0 +1,136 @@
+"""CHAOS-3388: acronym and parenthetical-alias forms for a catalog display name.
+
+The CHAOS-3366 closest-matches fallback (``subject_preflight._close_matches``)
+searches the catalog through a plain ``LIKE '%query%'`` substring match
+(``scope_catalog.ClickHouseAuthorizedEntityCatalog``). That finds nothing for
+a mention like "ACR" against a catalog project named "Dev Health Agent
+Context Runtime (Context Fabric)": "acr" is not a contiguous substring of
+that label, even though it is transparently the acronym of a phrase inside
+it. This module is the pure, catalog-independent scoring layer that closes
+that gap -- it never touches a database and never decides commit-vs-candidate
+policy; callers own both.
+
+Two distinct kinds of alias, scored differently by every caller in this
+codebase (see ``scope_service.py``'s broadened literal-match check and
+``subject_preflight.py``'s acronym-augmented closest-matches search):
+
+* **Literal aliases** -- a parenthetical segment of the name is itself a real
+  alternate name ("(Context Fabric)" -> "Context Fabric"), not a derived
+  abbreviation. Typing it is exactly as deliberate an act as typing the
+  primary label, so callers may treat an exact (casefolded) match the same
+  way they already treat a literal label/id match.
+* **Acronyms** -- the initials of a contiguous run of two or more words,
+  taken over the primary name and over each literal alias in turn. This is
+  always a *derived* signal, never a name the catalog itself asserts, so it
+  is never eligible for the same auto-commit treatment as a literal alias:
+  every caller must offer it as a candidate, never a pick (CHAOS-3289 history
+  -- never guess into a wrong subject).
+
+Every acronym window (not only the whole-name acronym) is generated because
+a real display name routinely carries organization/product boilerplate a
+user's shorthand omits: "Dev Health Agent Context Runtime" collapses to
+"DHACR" as a whole, but a user who says "ACR" means the "Agent Context
+Runtime" phrase inside it. Rather than guess which words are "boilerplate"
+with a hand-maintained stopword list (itself a fabrication risk -- guessing
+which words don't count), every contiguous window of length >= 2 is
+generated; a single word's own initial is not, since that would let every
+one-letter query collide with every name that happens to start with it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "NameAliasForms",
+    "acronym_candidates",
+    "alias_forms",
+    "strip_parentheticals",
+]
+
+_PARENTHETICAL = re.compile(r"\(([^()]*)\)")
+_WHITESPACE = re.compile(r"\s+")
+#: A "word" for acronym purposes: a run of letters/digits, optionally
+#: hyphenated/apostrophized internally ("dev-health" is one word). Bare
+#: punctuation tokens contribute no initial and are dropped.
+_WORD = re.compile(r"[A-Za-z0-9]+(?:['’-][A-Za-z0-9]+)*")
+
+#: A name with more words than this contributes no acronym windows at all --
+#: not a realistic catalog display name, and without a cap the O(n^2) window
+#: enumeration below has no bound.
+_MAX_WORDS_FOR_ACRONYMS = 16
+
+
+def strip_parentheticals(name: str) -> tuple[str, tuple[str, ...]]:
+    """Split ``name`` into its primary text and its parenthetical aliases.
+
+    ``"Dev Health Agent Context Runtime (Context Fabric)"`` ->
+    ``("Dev Health Agent Context Runtime", ("Context Fabric",))``. A name with
+    no parentheses returns itself unchanged and an empty alias tuple; nested
+    or multiple parenthetical groups are each returned as their own alias.
+    """
+
+    aliases = tuple(
+        stripped
+        for match in _PARENTHETICAL.finditer(name)
+        if (stripped := match.group(1).strip())
+    )
+    primary = _WHITESPACE.sub(" ", _PARENTHETICAL.sub(" ", name)).strip()
+    return primary, aliases
+
+
+def _words(text: str) -> tuple[str, ...]:
+    return tuple(_WORD.findall(text))
+
+
+def acronym_candidates(text: str) -> frozenset[str]:
+    """Every contiguous-window acronym of ``text``, uppercased.
+
+    A window is >= 2 words, so a single-word name contributes nothing (its
+    own initial is not a meaningful acronym). Every start/end pair is taken,
+    not only the whole-text acronym, so "Agent Context Runtime" is generated
+    as one candidate acronym ("ACR") of the longer name "Dev Health Agent
+    Context Runtime" alongside the whole-name acronym ("DHACR") -- see the
+    module docstring for why no stopword list is used to pick the "right"
+    sub-phrase instead.
+    """
+
+    words = _words(text)[:_MAX_WORDS_FOR_ACRONYMS]
+    count = len(words)
+    if count < 2:
+        return frozenset()
+    return frozenset(
+        "".join(word[0] for word in words[start:end]).upper()
+        for start in range(count)
+        for end in range(start + 2, count + 1)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class NameAliasForms:
+    """The alias vocabulary derived from one catalog display name.
+
+    Both sets are casefolded so callers can compare directly against a
+    casefolded, stripped user query without re-normalizing.
+    """
+
+    #: Parenthetical alias text(s), verbatim minus surrounding whitespace --
+    #: eligible for the same literal-equality treatment as the primary label.
+    literal_aliases: frozenset[str]
+    #: Derived acronyms of the primary name and of each literal alias --
+    #: candidate-only, never auto-commit eligible.
+    acronyms: frozenset[str]
+
+
+def alias_forms(name: str) -> NameAliasForms:
+    """The literal-alias and acronym vocabularies for one catalog name."""
+
+    primary, parenthetical_aliases = strip_parentheticals(name)
+    acronyms = set(acronym_candidates(primary))
+    for alias in parenthetical_aliases:
+        acronyms.update(acronym_candidates(alias))
+    return NameAliasForms(
+        literal_aliases=frozenset(alias.casefold() for alias in parenthetical_aliases),
+        acronyms=frozenset(acronym.casefold() for acronym in acronyms),
+    )

--- a/src/dev_health_ops/api/dev/alias_matching.py
+++ b/src/dev_health_ops/api/dev/alias_matching.py
@@ -10,21 +10,34 @@ it. This module is the pure, catalog-independent scoring layer that closes
 that gap -- it never touches a database and never decides commit-vs-candidate
 policy; callers own both.
 
-Two distinct kinds of alias, scored differently by every caller in this
-codebase (see ``scope_service.py``'s broadened literal-match check and
-``subject_preflight.py``'s acronym-augmented closest-matches search):
+Two distinct kinds of alias, both scored here but held to the SAME
+commit policy by every caller in this codebase (see ``scope_service.py``'s
+exact-match check and ``subject_preflight.py``'s acronym-augmented
+closest-matches search):
 
-* **Literal aliases** -- a parenthetical segment of the name is itself a real
-  alternate name ("(Context Fabric)" -> "Context Fabric"), not a derived
-  abbreviation. Typing it is exactly as deliberate an act as typing the
-  primary label, so callers may treat an exact (casefolded) match the same
-  way they already treat a literal label/id match.
+* **Literal aliases** -- a parenthetical segment of the name, split out
+  mechanically from wherever a "(" / ")" pair appears in the label
+  ("(Context Fabric)" -> "Context Fabric"). Some read as a genuine
+  alternate name; others read as a qualifier on the primary label
+  ("Payments (Legacy)" -> "Legacy", "Reports (Archived)" -> "Archived").
+  Nothing about the catalog schema tells the two apart -- there is no
+  explicit alias field, only a parenthesis this module splits on -- so a
+  literal alias is exactly as *derived* a signal as an acronym is, despite
+  reading as more "literal" to a person. CHAOS-3388 codex re-review (HIGH,
+  confirmed): an earlier revision let a unique literal-alias match commit
+  outright, which auto-committed "the Legacy project" onto whichever
+  catalog entity happened to carry "(Legacy)" -- answering about an entity
+  the user never actually named.
 * **Acronyms** -- the initials of a contiguous run of two or more words,
-  taken over the primary name and over each literal alias in turn. This is
-  always a *derived* signal, never a name the catalog itself asserts, so it
-  is never eligible for the same auto-commit treatment as a literal alias:
-  every caller must offer it as a candidate, never a pick (CHAOS-3289 history
-  -- never guess into a wrong subject).
+  taken over the primary name and over each literal alias in turn. Also a
+  *derived* signal, never a name the catalog itself asserts.
+
+Neither kind is ever eligible for auto-commit: every caller must offer a
+match on either one as a candidate, never a pick (CHAOS-3289 history --
+never guess into a wrong subject). Should the catalog ever grow a real,
+explicit alias field distinct from this label-splitting, that field's
+values -- not this module's derived ``literal_aliases`` -- would be the
+input eligible for a different policy.
 
 Every acronym window (not only the whole-name acronym) is generated because
 a real display name routinely carries organization/product boilerplate a
@@ -116,7 +129,9 @@ class NameAliasForms:
     """
 
     #: Parenthetical alias text(s), verbatim minus surrounding whitespace --
-    #: eligible for the same literal-equality treatment as the primary label.
+    #: a *derived* signal like ``acronyms`` below (see the module docstring
+    #: for why), never eligible for auto-commit, only for the candidate
+    #: list.
     literal_aliases: frozenset[str]
     #: Derived acronyms of the primary name and of each literal alias --
     #: candidate-only, never auto-commit eligible.

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -768,6 +768,7 @@ class DevOrchestrator:
             error: DevError | None = None,
             frame_already_recorded: bool = False,
             grounding_validation_status: str | None = None,
+            extra_attested: tuple[str, ...] = (),
         ) -> OrchestratorResult:
             nonlocal terminal_written
             if terminal_written:
@@ -788,7 +789,20 @@ class DevOrchestrator:
             # legitimately appears in copy (pinned by
             # test_no_match_terminal.py), so this must never fire on a
             # healthy run.
-            attested = attested_strings(answer, request.question)
+            #
+            # CHAOS-3388 codex re-review (HIGH, confirmed): ``extra_attested``
+            # is the narrowly-scoped escape hatch for a caller that built its
+            # `error` from server-authorized data ``attested_strings`` cannot
+            # see (it reads only off ``answer``, which is ``None`` on an
+            # error-only path). The preflight TERMINATE branch is the one
+            # caller that passes it today: ``project_preflight_error``
+            # interpolates the same catalog-confirmed candidate display
+            # labels the persisted frame already carries
+            # (``clarification_candidates`` -- CHAOS-3325) into
+            # ``safe_message``, so those exact labels are attested here too,
+            # the same trust tier as everything else this scan already
+            # exempts.
+            attested = attested_strings(answer, request.question) + extra_attested
             # CHAOS-3377 leak-hardening: scrub model-authored AUXILIARY
             # fields (warnings/conflicts/suggested_follow_up_questions/
             # resolved_scope.warnings) BEFORE the fail-closed scan below --
@@ -1248,6 +1262,64 @@ class DevOrchestrator:
                 if preflight_result.decision is PreflightDecision.TERMINATE:
                     assert preflight_result.answer is not None
                     assert preflight_result.outcome is not None
+                    preflight_error = project_preflight_error(
+                        preflight_result.answer, request_id=request.request_id
+                    )
+                    # CHAOS-3388 codex re-review (HIGH, confirmed): the
+                    # candidate display labels this error's ``safe_message``
+                    # may interpolate (``project_preflight_error`` /
+                    # ``_name_candidates``) are the SAME catalog-confirmed
+                    # entities the frame below persists as
+                    # ``clarification_candidates`` -- authorized data, the
+                    # same trust tier ``finish()``'s own ``attested_strings``
+                    # already exempts off ``DevAnswer``. This path builds no
+                    # ``DevAnswer`` (it is error-only), so without this the
+                    # exemption never applied and a candidate label that
+                    # happened to contain a denylisted token (a real live
+                    # shape -- see ``no_match_terminal.internal_token_leak``'s
+                    # own docstring example) fail-closed rewrote the terminal
+                    # to a bare ``internal_error`` *after* the richer frame
+                    # below was already recorded, leaving the two
+                    # permanently inconsistent.
+                    #
+                    # The fix decides frame persistence and the terminal
+                    # error from the SAME leak scan ``finish()`` will run, so
+                    # the two can never disagree: attest the candidate labels
+                    # up front, and if the scan still flags something despite
+                    # that (a genuine leak, not a candidate-label collision),
+                    # skip the richer frame entirely rather than persist one
+                    # the terminal below will contradict.
+                    candidate_attestation = tuple(
+                        candidate.entity_ref.display_label
+                        for candidate in preflight_result.answer.frame.clarification_candidates
+                    )
+                    preflight_leak = internal_token_leak_field(
+                        user_visible_strings_by_field(error=preflight_error),
+                        attested=attested_strings(None, request.question)
+                        + candidate_attestation,
+                    )
+                    if preflight_leak is not None:
+                        leaked_field, leaked_token = preflight_leak
+                        logger.error(
+                            "ask_dev.orchestrator.preflight_frame_leak_guard "
+                            f"run_id={run_id} field={leaked_field} "
+                            f"token={leaked_token}",
+                            extra={
+                                "run_id": run_id,
+                                "token": leaked_token,
+                                "field": leaked_field,
+                            },
+                        )
+                        ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL.labels(
+                            token=leaked_token, terminal_kind="error"
+                        ).inc()
+                        return await finish(
+                            RunState.FAILED,
+                            error=error(
+                                "internal_error",
+                                "The request could not be completed.",
+                            ),
+                        )
                     # CHAOS-3297: persist the frame the preflight already
                     # built *before* finishing the run, so the terminal
                     # state and the frame's contract_generation='v2' tag
@@ -1294,10 +1366,9 @@ class DevOrchestrator:
                         )
                     return await finish(
                         TERMINAL_STATE_BY_OUTCOME[preflight_result.outcome],
-                        error=project_preflight_error(
-                            preflight_result.answer, request_id=request.request_id
-                        ),
+                        error=preflight_error,
                         frame_already_recorded=True,
+                        extra_attested=candidate_attestation,
                     )
                 if preflight_result.committed_resolution is not None:
                     committed = preflight_result.committed_resolution

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -324,6 +324,53 @@ def build_preflight_answer(
     )
 
 
+#: CHAOS-3388. How many named candidates the v1 clarification message will
+#: enumerate, and how long each one may be. Small on purpose: this is a
+#: sentence a person reads, not a data dump, and the frame's own
+#: ``clarification_candidates`` (bounded separately, at up to
+#: ``MAX_CANDIDATES``/``NOT_FOUND_FALLBACK_LIMIT``) remains the authoritative
+#: full list for any future structured surface.
+_MAX_NAMED_CANDIDATES = 5
+_MAX_CANDIDATE_LABEL_CHARS = 120
+
+
+def _candidate_names(
+    candidates: tuple[DevResolutionCandidate, ...],
+) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates[:_MAX_NAMED_CANDIDATES]:
+        label = candidate.entity_ref.display_label.strip()[:_MAX_CANDIDATE_LABEL_CHARS]
+        if not label or label in seen:
+            continue
+        seen.add(label)
+        names.append(label)
+    return tuple(names)
+
+
+def _name_candidates(
+    base_message: str, candidates: tuple[DevResolutionCandidate, ...]
+) -> str:
+    """Append real candidate display names to a closed-vocab base sentence.
+
+    CHAOS-3388. ``candidates`` are the resolution ledger's own authorized,
+    catalog-confirmed entities (``DevResolutionCandidate.entity_ref.
+    display_label``) — never model- or user-authored text — so naming them
+    here is the same trust tier as ``base_message`` itself, not a new
+    disclosure channel: the copy-contract rule (CHAOS-3367) is that
+    user-visible copy comes from closed tables plus, at most, data the
+    server itself already confirmed, and a catalog display label is exactly
+    that. An empty ``candidates`` tuple (the four no-answer outcomes, or a
+    genuine ambiguity/close-matches search that found nothing to enrich)
+    returns ``base_message`` unchanged.
+    """
+
+    names = _candidate_names(candidates)
+    if not names:
+        return base_message
+    return f"{base_message} Candidates: {', '.join(names)}."
+
+
 def project_preflight_error(answer: DevAnswerV2, *, request_id: str) -> DevError:
     """Project one preflight v2 answer to the v1 ``DevError`` the router streams.
 
@@ -336,32 +383,44 @@ def project_preflight_error(answer: DevAnswerV2, *, request_id: str) -> DevError
     ``needs_clarification`` is handled separately and deliberately, on both
     the live path (``orchestrator.run``) and the replay path (``router``'s
     terminal-payload reconstruction): both call this function, not
-    ``compat.project_answer_v2_to_v1``, for a preflight ambiguity, and it
-    always returns the fixed ``scope_ambiguous`` ``DevError`` above — never a
-    v1 ``DevAnswer``, so it never carries candidates at all, whatever the
-    frame's own ``clarification_candidates`` holds. That is deliberate and
-    unchanged by CHAOS-3325: it is both the more faithful terminal-state
-    statement (the run genuinely produced no answer) and the shape the router
-    and web client already handle.
+    ``compat.project_answer_v2_to_v1``, for a preflight ambiguity. It always
+    returns a v1 ``DevError`` — never a v1 ``DevAnswer`` — with the fixed
+    ``scope_ambiguous`` *code*: that part is unchanged by CHAOS-3388, and
+    still deliberate for the reason CHAOS-3325 gave it (a preflight
+    ambiguity is the more faithful terminal-state statement — the run
+    genuinely produced no answer — and ``scope_ambiguous`` is the shape the
+    router and web client already handle for every terminal in this
+    family).
 
-    The real candidate list is carried one level up instead. CHAOS-3325 gave
-    ``dev_answer_frame.v1`` a typed ``clarification_candidates`` block — the
-    resolution ledger's own ``DevResolutionCandidate`` entries for the
-    mention that went ambiguous, passed straight through by
-    ``build_preflight_answer`` rather than invented — and
-    ``contracts_v2.compat``'s ``_project_needs_clarification`` now projects
-    those real candidates (or, when there are none, an honest
-    ``ScopeResolutionOutcome.UNRESOLVED`` rather than a fabricated
-    placeholder) for whichever *other* caller runs a ``needs_clarification``
-    answer through the general ``project_answer_v2_to_v1`` projector — this
-    function's own preflight-ambiguity path does not, and still routes
-    through ``scope_ambiguous`` as above. Actually serving the candidate
-    block to a v1/v2 client still additionally needs the v2 rendering
-    surface (CHAOS-3298) and persisted clarification state (CHAOS-3299).
+    The *message* is no longer the one fixed sentence, though (CHAOS-3388).
+    Before this, the real candidate list computed onto ``answer.frame.
+    clarification_candidates`` (CHAOS-3325) never reached a v1 client at
+    all here: an unresolved named subject with real, catalog-confirmed
+    close matches available produced the exact same generic "the requested
+    scope is ambiguous" text as a genuine same-name ambiguity with none —
+    the acceptance-oracle-visible half of the CHAOS-3388 defect, since the
+    v1 wire has no separate structured field for a candidate list and
+    inventing one is out of scope. ``_name_candidates`` starts from
+    ``answer.frame.direct_answer`` — already the differentiated,
+    closed-vocab ``CLARIFICATION_COPY`` sentence for whichever
+    ``clarification_key`` produced this termination, "ambiguous" or
+    CHAOS-3366's "here are the closest matches" — and appends the real
+    candidates' own catalog display labels, never invented, never
+    model-authored: the same ``DevResolutionCandidate`` entries
+    ``contracts_v2.compat``'s ``_project_needs_clarification`` already
+    projects for whichever *other* caller runs a ``needs_clarification``
+    answer through the general ``project_answer_v2_to_v1`` projector. This
+    function's own preflight-ambiguity path still does not use that
+    projector (the ``DevAnswer`` shape it builds remains out of scope here
+    — see above), but it no longer discards the same candidates that
+    projector already trusted.
     """
 
     if answer.public_outcome is PublicOutcome.NEEDS_CLARIFICATION:
-        code, message = _AMBIGUOUS_V1_ERROR
+        code, _ = _AMBIGUOUS_V1_ERROR
+        message = _name_candidates(
+            answer.frame.direct_answer, answer.frame.clarification_candidates
+        )
         return DevError(
             schema_version="dev_error.v1",
             request_id=request_id,

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -159,13 +159,23 @@ _NAME = r"[A-Z][A-Za-z0-9&/'\-]*(?:[ \t]+[A-Z][A-Za-z0-9&/'\-]*){0,3}"
 #: required inside it.
 _QUOTED = r"[\"'‘’“”`](?P<quoted>[^\"'‘’“”`]{1,120})[\"'‘’“”`]"
 
-# Noun leading: "project Ask Dev", 'repo "dev-health-ops"'.
+# Noun leading: "project Ask Dev", 'repo "dev-health-ops"'. CHAOS-3388: only
+# the noun alternation is matched case-insensitively -- via the scoped inline
+# flag `(?i:...)`, not a top-level `re.IGNORECASE`, which would also fold
+# `_NAME`'s `[A-Z]` and silently turn any lowercase word into a "capitalized"
+# name span. "the ACR Project" (a capitalized noun immediately after an
+# all-caps acronym) is exactly as much a named mention as "the ACR project"
+# is, and `_candidate_from` already `.casefold()`s the matched noun before its
+# `_KIND_BY_NOUN` lookup, which only makes sense if the match itself can be
+# any case. Without case-insensitivity here that casefold was dead code: the
+# noun literal never matched a capitalized occurrence in the first place, so
+# the mention was silently dropped to the untyped bare-name path instead.
 _NOUN_LEADING = re.compile(
-    rf"\b(?P<noun>{_NOUN_ALTERNATION})\s+(?:{_QUOTED}|(?P<plain>{_NAME}))",
+    rf"\b(?P<noun>(?i:{_NOUN_ALTERNATION}))\s+(?:{_QUOTED}|(?P<plain>{_NAME}))",
 )
 # Noun trailing: "the Ask Dev project", '"dev-health-ops" repo'.
 _NOUN_TRAILING = re.compile(
-    rf"(?:{_QUOTED}|(?P<plain>{_NAME}))\s+(?P<noun>{_NOUN_ALTERNATION})\b",
+    rf"(?:{_QUOTED}|(?P<plain>{_NAME}))\s+(?P<noun>(?i:{_NOUN_ALTERNATION}))\b",
 )
 
 #: Capitalized words that are never a subject name on their own. A candidate

--- a/src/dev_health_ops/api/dev/scope_catalog.py
+++ b/src/dev_health_ops/api/dev/scope_catalog.py
@@ -11,7 +11,42 @@ from dev_health_ops.api.queries.client import query_dicts
 from dev_health_ops.api.queries.scopes import resolve_repo_id
 from dev_health_ops.api.services.identity import resolve_scope_display_names
 
+from .alias_matching import alias_forms
 from .scope_service import AuthorizedEntity, EntityKind, ScopeRef
+
+#: CHAOS-3388. Kinds whose display name is a stable proper noun an acronym or
+#: parenthetical alias can meaningfully apply to. Deliberately narrow and
+#: explicit rather than "every searchable kind": an issue/PR/work-unit
+#: "title" is prose, not a name, and taking word-initials of prose produces
+#: noise, not a plausible shorthand.
+ALIAS_AWARE_ENTITY_KINDS = (EntityKind.PROJECT, EntityKind.TEAM)
+
+#: Bound on the full active-roster fetch the alias/acronym pass runs when
+#: the ordinary substring search finds nothing to offer. An acronym cannot be
+#: matched by ``LIKE``, so there is no SQL predicate to push this into; the
+#: roster is org-scoped and, unlike the unbounded catalog, actually small
+#: enough in practice for a bounded in-Python scan to be cheap. This only
+#: runs from the already-terminal CHAOS-3366 closest-matches fallback (one
+#: bounded call per unresolved named subject), never from the primary
+#: resolution path.
+_ALIAS_ROSTER_LIMIT = 1000
+
+_ALIAS_ROSTER_SQL: dict[EntityKind, str] = {
+    EntityKind.PROJECT: """
+        SELECT id AS canonical_id, name AS label
+        FROM projects FINAL
+        WHERE org_id = {org_id:String} AND is_active = 1
+        ORDER BY lowerUTF8(name), canonical_id
+        LIMIT {limit:UInt32}
+    """,
+    EntityKind.TEAM: """
+        SELECT id AS canonical_id, name AS label
+        FROM teams FINAL
+        WHERE org_id = {org_id:String}
+        ORDER BY lowerUTF8(name), canonical_id
+        LIMIT {limit:UInt32}
+    """,
+}
 
 _ORGANIZATION_REPOSITORY_IDS_SQL = """
     SELECT toString(id) AS repository_id, count() OVER () AS total_authorized
@@ -20,6 +55,11 @@ _ORGANIZATION_REPOSITORY_IDS_SQL = """
     ORDER BY repository_id
     LIMIT {limit:UInt32}
 """
+
+
+def _entity_sort_key(entity: AuthorizedEntity) -> tuple[str, str, str]:
+    return (entity.label.casefold(), entity.kind.value, entity.canonical_id)
+
 
 _WATERMARK_TABLES: dict[EntityKind, tuple[str, str]] = {
     EntityKind.REPOSITORY: ("repos", "last_synced"),
@@ -86,6 +126,7 @@ class ClickHouseAuthorizedEntityCatalog:
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         rows_by_kind = await asyncio.gather(
             *(
@@ -105,14 +146,73 @@ class ClickHouseAuthorizedEntityCatalog:
                     org_id, kind_entities
                 )
             entities.extend(kind_entities)
-        entities.sort(
-            key=lambda entity: (
-                entity.label.casefold(),
-                entity.kind.value,
-                entity.canonical_id,
+        alias_entities: list[AuthorizedEntity] = []
+        if include_alias_matches:
+            alias_hits = await asyncio.gather(
+                *(
+                    self._alias_matches(org_id, kind, query, limit=limit)
+                    for kind in kinds
+                    if kind in ALIAS_AWARE_ENTITY_KINDS
+                )
             )
+            for kind_hits in alias_hits:
+                alias_entities.extend(kind_hits)
+        # Alias/acronym hits are ordered AHEAD of plain substring hits, before
+        # either is truncated to `limit` -- never merged into one alphabetical
+        # sort. CHAOS-3388 live finding: a real organization can hold far more
+        # than `limit` incidental substring hits for a short query
+        # (issue/work-unit titles that happen to contain "acr" as a literal
+        # substring, e.g. "Harden ACR runtime client boundary") than it holds
+        # true acronym matches. A single combined alphabetical sort let that
+        # noise crowd the one real acronym match for the named project out of
+        # the returned page entirely -- the closest-matches offer named
+        # everything BUT the thing the acronym actually stood for. An
+        # acronym/alias equality is a strictly more precise signal than an
+        # incidental substring containment, so it always survives the bound.
+        alias_by_key: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+        for entity in alias_entities:
+            alias_by_key.setdefault((entity.kind, entity.canonical_id), entity)
+        ordered_alias = sorted(alias_by_key.values(), key=_entity_sort_key)
+        substring_by_key: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+        for entity in entities:
+            key = (entity.kind, entity.canonical_id)
+            if key not in alias_by_key:
+                substring_by_key.setdefault(key, entity)
+        ordered_substring = sorted(substring_by_key.values(), key=_entity_sort_key)
+        return (ordered_alias + ordered_substring)[:limit]
+
+    async def _alias_matches(
+        self, org_id: str, kind: EntityKind, query: str, *, limit: int
+    ) -> list[AuthorizedEntity]:
+        """CHAOS-3388: entities of ``kind`` whose acronym or parenthetical
+        alias equals ``query`` outright, found via a bounded roster scan.
+
+        Never called for a kind outside ``ALIAS_AWARE_ENTITY_KINDS``. Every hit is
+        returned regardless of provenance (acronym vs. literal alias) --
+        ``scope_service.resolve_mention`` is the layer that decides which of
+        those is auto-commit eligible; this method only reports "matches
+        something", the same contract ``search()``'s substring pass already
+        has.
+        """
+
+        normalized_query = query.strip().casefold()
+        roster_sql = _ALIAS_ROSTER_SQL.get(kind)
+        if not normalized_query or roster_sql is None:
+            return []
+        rows = await query_dicts(
+            self._client,
+            roster_sql,
+            {"org_id": org_id, "limit": _ALIAS_ROSTER_LIMIT},
         )
-        return entities[:limit]
+        matches: list[AuthorizedEntity] = []
+        for row in self._entities(rows, expected_kind=kind):
+            forms = alias_forms(row.label)
+            if (
+                normalized_query in forms.literal_aliases
+                or normalized_query in forms.acronyms
+            ):
+                matches.append(row)
+        return matches[:limit]
 
     async def organization_repository_ids(
         self, org_id: str, *, limit: int

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -20,7 +20,6 @@ from enum import StrEnum
 from typing import Protocol
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from .alias_matching import alias_forms
 from .contracts import (
     DevDisambiguationCandidate,
     DevEntityRef,
@@ -746,21 +745,30 @@ class ScopeResolutionService:
         # equal a label or canonical id outright; a partial name that matched
         # something real is offered back as candidates instead.
         #
-        # CHAOS-3388: a candidate's own parenthetical alias ("Dev Health
-        # Agent Context Runtime (Context Fabric)" -> "Context Fabric") is
-        # exactly as literal a name as its primary label -- typing it is a
-        # deliberate naming act, not a derived guess -- so it is eligible for
-        # the same outright-equality commit. A *derived* acronym
-        # ("ACR") is deliberately excluded from this check: it is never
-        # eligible for auto-commit, only for the candidate list, however
-        # unique the acronym match turns out to be (see ``alias_matching``'s
-        # module docstring).
+        # CHAOS-3388 codex re-review (HIGH, confirmed): a candidate's own
+        # parenthetical segment ("Dev Health Agent Context Runtime (Context
+        # Fabric)" -> "Context Fabric") is NOT eligible for the same
+        # outright-equality commit as its primary label, however real the
+        # alternate name reads in ordinary language. The catalog carries no
+        # explicit alias field -- ``alias_forms`` *derives* every
+        # parenthetical the same mechanical way, by splitting one label
+        # string on its parentheses, with no way to distinguish a genuine
+        # alternate name ("Context Fabric") from a qualifier appended to the
+        # primary label ("Payments (Legacy)", "Reports (Archived)"). The
+        # first commit of this check treated both identically and
+        # auto-committed "the Legacy project" onto ``payments-legacy`` --
+        # answering about an entity the user never actually named. So a
+        # parenthetical match is held to exactly the acronym rule: candidate
+        # list only, never a pick, however unique the match turns out to be
+        # (see ``alias_matching``'s module docstring). Should the catalog
+        # ever grow a real, explicit alias field -- distinct from splitting
+        # the display label -- that field's values would be the eligible
+        # input here instead; a derived parenthetical never is.
         wanted = lookup_text.strip().casefold()
         exact_matches = tuple(
             candidate
             for candidate in candidates
             if wanted in {candidate.canonical_id.casefold(), candidate.label.casefold()}
-            or wanted in alias_forms(candidate.label).literal_aliases
         )
         if len(exact_matches) == 1:
             return MentionResolution(

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -20,6 +20,7 @@ from enum import StrEnum
 from typing import Protocol
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from .alias_matching import alias_forms
 from .contracts import (
     DevDisambiguationCandidate,
     DevEntityRef,
@@ -248,6 +249,17 @@ class ScopeSearchRequest:
     #: search on the GraphQL field or the model-facing ``resolve_scope.v1``
     #: tool, both of which CHAOS-3301 owns.
     allowed_kinds: frozenset[EntityKind] = V1_SEARCHABLE_ENTITY_KINDS
+    #: CHAOS-3388. Never set by an ordinary caller -- only
+    #: ``subject_preflight._close_matches`` (the CHAOS-3366 closest-matches
+    #: fallback for an already-unresolved named mention) opts in. Acronym
+    #: matching is a derived, candidate-only signal (see ``alias_matching``'s
+    #: module docstring): folding it into the *primary* resolution search
+    #: would let a query like "ACR" land in the ordinary ``AMBIGUOUS_
+    #: CANDIDATES``/"more than one entity matches this name" outcome, which
+    #: is the wrong copy for "nothing matched literally, but here is
+    #: something close" -- that is exactly the outcome and copy the
+    #: closest-matches fallback already owns.
+    include_alias_matches: bool = False
 
     def __post_init__(self) -> None:
         query = self.query.strip()
@@ -317,6 +329,7 @@ class AuthorizedEntityCatalog(Protocol):
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]: ...
 
     async def organization_repository_ids(
@@ -612,6 +625,11 @@ class ScopeResolutionService:
             "query": request.query,
             "kinds": [kind.value for kind in kinds],
             "limit": request.limit,
+            # CHAOS-3388: distinct cache entry from an alias-unaware search of
+            # the same query/kinds/limit -- the two can return different
+            # candidate sets, so sharing a cache key would let whichever
+            # request happened to run first silently answer the other's call.
+            "include_alias_matches": request.include_alias_matches,
         }
         cache_key = self._cache_key(
             "search", org_id, permission_fingerprint, payload, watermark
@@ -620,7 +638,11 @@ class ScopeResolutionService:
         if isinstance(cached, ScopeSearchResult):
             return cached
         entities = await self._catalog.search(
-            org_id, request.query, kinds, limit=request.limit
+            org_id,
+            request.query,
+            kinds,
+            limit=request.limit,
+            include_alias_matches=request.include_alias_matches,
         )
         result = ScopeSearchResult(
             candidates=_dedupe_entities(entities)[: request.limit],
@@ -723,11 +745,22 @@ class ScopeResolutionService:
         # the user did not name. Committing therefore requires the name to
         # equal a label or canonical id outright; a partial name that matched
         # something real is offered back as candidates instead.
+        #
+        # CHAOS-3388: a candidate's own parenthetical alias ("Dev Health
+        # Agent Context Runtime (Context Fabric)" -> "Context Fabric") is
+        # exactly as literal a name as its primary label -- typing it is a
+        # deliberate naming act, not a derived guess -- so it is eligible for
+        # the same outright-equality commit. A *derived* acronym
+        # ("ACR") is deliberately excluded from this check: it is never
+        # eligible for auto-commit, only for the candidate list, however
+        # unique the acronym match turns out to be (see ``alias_matching``'s
+        # module docstring).
         wanted = lookup_text.strip().casefold()
         exact_matches = tuple(
             candidate
             for candidate in candidates
             if wanted in {candidate.canonical_id.casefold(), candidate.label.casefold()}
+            or wanted in alias_forms(candidate.label).literal_aliases
         )
         if len(exact_matches) == 1:
             return MentionResolution(

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -1091,6 +1091,13 @@ class SubjectPreflight:
             kinds=tuple(sorted(SEARCHABLE_ENTITY_KINDS, key=lambda kind: kind.value)),
             limit=NOT_FOUND_FALLBACK_LIMIT,
             allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+            # CHAOS-3388: this is the one seam allowed to widen the search to
+            # acronym/parenthetical-alias matches -- the mention is already
+            # confirmed unresolved under its literal name, so an acronym hit
+            # here is additional "closest matches" material, never a
+            # commit-eligible primary resolution (see ScopeSearchRequest.
+            # include_alias_matches).
+            include_alias_matches=True,
         )
         try:
             result = await self._scope_service.search(

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from dev_health_ops.api.dev.alias_matching import alias_forms
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import (
     DevAnswer,
@@ -83,6 +84,10 @@ ATLAS_PROJECT_TWO = AuthorizedEntity(EntityKind.PROJECT, "project-atlas-2", "Atl
 PAGE_PROJECT = AuthorizedEntity(EntityKind.PROJECT, "project-page-ctx", "Beacon")
 
 
+def _label_sort_key(entity: AuthorizedEntity) -> tuple[str, str]:
+    return (entity.label.casefold(), entity.canonical_id)
+
+
 class SeededCatalog:
     """An ``AuthorizedEntityCatalog`` over a fixed, org-scoped entity list."""
 
@@ -125,6 +130,7 @@ class SeededCatalog:
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         self.search_calls.append((org_id, query))
         if self.fail_search:
@@ -140,11 +146,34 @@ class SeededCatalog:
                 or needle in entity.label.casefold()
             )
         ]
+        alias_matches: list[AuthorizedEntity] = []
+        if include_alias_matches:
+            # CHAOS-3388: mirrors ClickHouseAuthorizedEntityCatalog's roster
+            # scan over the *same* seeded org-scoped entities, so a test can
+            # exercise acronym/parenthetical-alias matching through this fake
+            # without a live ClickHouse.
+            matched_ids = {(entity.kind, entity.canonical_id) for entity in matched}
+            for owner, entity in self.entities:
+                if (
+                    owner == org_id
+                    and entity.kind in kinds
+                    and entity.kind in {EntityKind.PROJECT, EntityKind.TEAM}
+                    and (entity.kind, entity.canonical_id) not in matched_ids
+                ):
+                    forms = alias_forms(entity.label)
+                    if needle in forms.literal_aliases or needle in forms.acronyms:
+                        alias_matches.append(entity)
+                        matched_ids.add((entity.kind, entity.canonical_id))
         # ORDER BY lowerUTF8(label), canonical_id ... LIMIT n — the ordering and
         # the truncation both happen in SQL, so an exact label sorted past the
-        # page boundary never reaches the caller at all.
-        matched.sort(key=lambda entity: (entity.label.casefold(), entity.canonical_id))
-        return matched[:limit]
+        # page boundary never reaches the caller at all. Alias/acronym hits
+        # are ordered AHEAD of plain substring hits, before the truncation --
+        # mirrors ClickHouseAuthorizedEntityCatalog.search's own priority
+        # fix (CHAOS-3388): incidental substring noise must never crowd the
+        # real acronym match for a named project out of the returned page.
+        alias_matches.sort(key=_label_sort_key)
+        matched.sort(key=_label_sort_key)
+        return (alias_matches + matched)[:limit]
 
     async def organization_repository_ids(
         self, org_id: str, *, limit: int
@@ -607,6 +636,44 @@ async def case_a3() -> RunOutput:
         question="What's the status of the Atlas project?",
         entities=[(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)],
         script_id="a3",
+    )
+
+
+#: CHAOS-3388 live repro fixture: the real production catalog row (org
+#: 70d529e0-3c06-4597-8480-794fd02328b6, read live from ClickHouse
+#: `projects`) and the exact question text from the incident report.
+CHAOS_3388_ACR_PROJECT = AuthorizedEntity(
+    EntityKind.PROJECT,
+    "60997592-f9f4-462b-87c3-ef82671df270",
+    "Dev Health Agent Context Runtime (Context Fabric)",
+)
+CHAOS_3388_ACR_QUESTION = (
+    "What's the status of the ACR Project and what drivers are blocking it? "
+    "What's left to complete?"
+)
+
+
+async def case_chaos_3388_acr_close_match() -> RunOutput:
+    """The live repro: an acronym-named project with no literal catalog match.
+
+    Orchestrator-level repro of the wrong-terminal defect. Before the
+    CHAOS-3388 fixes, "ACR Project" never typed a mention at all (the
+    kind-noun regex's case-sensitivity bug), so this run proceeded to the
+    model round exactly like ``case_a4`` -- and if the model then also never
+    tried (or mis-tried) ``resolve_scope.v1``, it fell all the way to the
+    grounding-floor ``insufficient_evidence``/"did not include enough
+    grounded detail" failure, never a deterministic no-match. The assertion
+    that matters here is the same shape as A2/A3: the preflight alone
+    decides the outcome, and the scripted provider is never invoked at all
+    (``output.provider.tool_ids == []``) -- proving the deterministic
+    machinery caught this before a single model token was spent, not that a
+    model happened to behave helpfully.
+    """
+
+    return await run_preflight_orchestrator(
+        question=CHAOS_3388_ACR_QUESTION,
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, CHAOS_3388_ACR_PROJECT)],
+        script_id="chaos_3388_acr",
     )
 
 

--- a/tests/api/dev/test_alias_matching.py
+++ b/tests/api/dev/test_alias_matching.py
@@ -80,8 +80,9 @@ def test_alias_forms_names_the_real_repro_project() -> None:
     assert forms.literal_aliases == {"context fabric"}
     assert "acr" in forms.acronyms
     assert "cf" in forms.acronyms
-    # The acronym set is never eligible as a literal alias and vice versa --
-    # callers key auto-commit eligibility only off `literal_aliases`.
+    # The two sets are disjoint vocabularies -- neither stands in for the
+    # other -- even though CHAOS-3388 codex re-review holds both to the same
+    # candidate-only commit policy (see the module docstring).
     assert "acr" not in forms.literal_aliases
     assert "context fabric" not in forms.acronyms
 

--- a/tests/api/dev/test_alias_matching.py
+++ b/tests/api/dev/test_alias_matching.py
@@ -1,0 +1,101 @@
+"""Unit coverage for the CHAOS-3388 acronym/parenthetical-alias scorer."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.alias_matching import (
+    acronym_candidates,
+    alias_forms,
+    strip_parentheticals,
+)
+
+# The real production catalog row this ticket's live repro named (CHAOS-3388,
+# org 70d529e0-3c06-4597-8480-794fd02328b6): the fixture below is the actual
+# ClickHouse `projects.name` value, read from the live dev environment, not a
+# hand-authored stand-in.
+_ACR_PROJECT_NAME = "Dev Health Agent Context Runtime (Context Fabric)"
+
+
+def test_strip_parentheticals_splits_primary_from_alias() -> None:
+    primary, aliases = strip_parentheticals(_ACR_PROJECT_NAME)
+    assert primary == "Dev Health Agent Context Runtime"
+    assert aliases == ("Context Fabric",)
+
+
+def test_strip_parentheticals_is_a_no_op_without_parentheses() -> None:
+    primary, aliases = strip_parentheticals("Nightfall")
+    assert primary == "Nightfall"
+    assert aliases == ()
+
+
+def test_strip_parentheticals_handles_multiple_groups() -> None:
+    primary, aliases = strip_parentheticals("Falcon (FLC) legacy (deprecated)")
+    assert primary == "Falcon legacy"
+    assert aliases == ("FLC", "deprecated")
+
+
+def test_strip_parentheticals_drops_an_empty_group() -> None:
+    primary, aliases = strip_parentheticals("Nightfall ()")
+    assert primary == "Nightfall"
+    assert aliases == ()
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_member"),
+    [
+        ("Agent Context Runtime", "ACR"),
+        ("Dev Health Agent Context Runtime", "DHACR"),
+        # The window contained within the longer name, not only the
+        # whole-name acronym -- this is the load-bearing property CHAOS-3388
+        # needs: a user's shorthand for a sub-phrase of the full name.
+        ("Dev Health Agent Context Runtime", "ACR"),
+        ("Context Fabric", "CF"),
+    ],
+)
+def test_acronym_candidates_contains_expected_window(
+    text: str, expected_member: str
+) -> None:
+    assert expected_member in acronym_candidates(text)
+
+
+def test_acronym_candidates_excludes_a_single_word() -> None:
+    """A one-word name's own initial is not a meaningful acronym."""
+
+    assert acronym_candidates("Nightfall") == frozenset()
+    assert acronym_candidates("") == frozenset()
+
+
+def test_acronym_candidates_is_bounded_by_word_count() -> None:
+    huge = " ".join(f"Word{i}" for i in range(64))
+    # Must not hang or explode combinatorially; a real display name is never
+    # this long, so the cap is allowed to simply stop generating windows.
+    candidates = acronym_candidates(huge)
+    assert candidates  # some windows still generated within the cap
+    assert all(len(candidate) <= 16 for candidate in candidates)
+
+
+def test_alias_forms_names_the_real_repro_project() -> None:
+    forms = alias_forms(_ACR_PROJECT_NAME)
+    assert forms.literal_aliases == {"context fabric"}
+    assert "acr" in forms.acronyms
+    assert "cf" in forms.acronyms
+    # The acronym set is never eligible as a literal alias and vice versa --
+    # callers key auto-commit eligibility only off `literal_aliases`.
+    assert "acr" not in forms.literal_aliases
+    assert "context fabric" not in forms.acronyms
+
+
+def test_alias_forms_of_a_plain_name_has_no_literal_aliases() -> None:
+    forms = alias_forms("Nightfall")
+    assert forms.literal_aliases == frozenset()
+    assert forms.acronyms == frozenset()
+
+
+def test_a_nonsense_query_matches_nothing_in_the_real_catalog_name() -> None:
+    """CHAOS-3388 acceptance: "Zebra Project" must never fabricate a match."""
+
+    forms = alias_forms(_ACR_PROJECT_NAME)
+    assert "zebra" not in forms.acronyms
+    assert "zebra project" not in forms.literal_aliases
+    assert "zebra" not in forms.literal_aliases

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -276,9 +276,15 @@ class _FakeAuthorizedEntityCatalog:
         return []
 
     async def search(
-        self, org_id: str, query: str, kinds: tuple[EntityKind, ...], *, limit: int
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
-        del org_id, query, kinds, limit
+        del org_id, query, kinds, limit, include_alias_matches
         return []
 
 

--- a/tests/api/dev/test_chaos_3292_preflight_acceptance.py
+++ b/tests/api/dev/test_chaos_3292_preflight_acceptance.py
@@ -36,6 +36,7 @@ from tests._chaos_3292_preflight import (
     ASK_DEV_PROJECT,
     ATLAS_PROJECT_ONE,
     ATLAS_PROJECT_TWO,
+    CHAOS_3388_ACR_PROJECT,
     NIGHTFALL_PROJECT,
     ORG_ID,
     OTHER_ORG_ID,
@@ -53,6 +54,7 @@ from tests._chaos_3292_preflight import (
     case_a9,
     case_a10,
     case_a11,
+    case_chaos_3388_acr_close_match,
     run_preflight_orchestrator,
 )
 
@@ -214,6 +216,47 @@ async def test_a3_ledger_records_both_authorized_candidates() -> None:
     assert result.terminating_resolution_entry == entry
     assert result.answer is not None
     assert result.answer.frame.clarification_candidates == entry.candidates
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3388 -- an acronym-named subject with no literal catalog match
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chaos_3388_acronym_named_subject_never_reaches_the_grounding_floor() -> (
+    None
+):
+    """Orchestrator-level repro of the wrong-terminal defect (CHAOS-3388).
+
+    "What's the status of the ACR Project ...?" against a catalog holding
+    "Dev Health Agent Context Runtime (Context Fabric)" must terminate at
+    the preflight, deterministically, before a single provider token is
+    spent -- never fall through to the model loop and never surface the
+    generic ``insufficient_evidence`` grounding-floor error the live
+    incident actually reported.
+    """
+
+    output = await case_chaos_3388_acr_close_match()
+
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    # The live incident's actual symptom -- never again for this shape.
+    assert output.result.error.code != "insufficient_evidence"
+    assert output.result.error.code == "scope_ambiguous"
+    assert CHAOS_3388_ACR_PROJECT.label in output.result.error.safe_message
+
+    # The deterministic preflight decided this alone -- the model never ran.
+    assert _subject_bearing_calls(output) == []
+    assert output.calls == []
+    assert output.provider is not None
+    assert output.provider.tool_ids == []
+
+
+@pytest.mark.asyncio
+async def test_chaos_3388_is_deterministic_across_twenty_runs() -> None:
+    results = await _twenty(case_chaos_3388_acr_close_match)
+    assert len(set(results)) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3297_s2_round9_disclosure_trigger.py
+++ b/tests/api/dev/test_chaos_3297_s2_round9_disclosure_trigger.py
@@ -199,9 +199,15 @@ class _FakeAuthorizedEntityCatalog:
         return []
 
     async def search(
-        self, org_id: str, query: str, kinds: tuple[EntityKind, ...], *, limit: int
+        self,
+        org_id: str,
+        query: str,
+        kinds: tuple[EntityKind, ...],
+        *,
+        limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
-        del org_id, query, kinds, limit
+        del org_id, query, kinds, limit, include_alias_matches
         return []
 
 

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -15,6 +15,7 @@ equals the name outright.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -406,13 +407,21 @@ async def test_a_nonsense_name_never_fabricates_an_acronym_match() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_literal_parenthetical_alias_commits_like_the_primary_label() -> None:
-    """CHAOS-3388: typing the parenthetical alias outright is a literal name.
+async def test_a_literal_parenthetical_alias_stays_candidate_only() -> None:
+    """CHAOS-3388 codex re-review (HIGH, confirmed): a derived parenthetical
+    match is never auto-commit eligible, only ever a candidate.
 
-    Unlike an acronym, "Context Fabric" is a real alternate name the catalog
-    itself carries (in parentheses) -- typing it is exactly as deliberate an
-    act as typing the primary label, so a unique hit commits instead of only
-    ever candidating.
+    A parenthetical segment is not an asserted alternate name the catalog
+    itself carries as a distinct alias field -- it is text this module
+    *derives* from splitting one label string, exactly as derived a signal as
+    an acronym. "Payments (Legacy)" proves the point: "Legacy" reads as a
+    qualifier on the primary label, not a real alternate name, and a unique
+    substring hit on it must not silently commit a wrong-guess project (see
+    the sibling ``test_a_qualifier_like_parenthetical_never_commits`` for the
+    negative-case fixtures). "Context Fabric" is a real alternate name in the
+    ordinary-language sense, but nothing about the catalog schema
+    distinguishes it from "Legacy" -- there is no explicit alias field, only
+    a parenthesis -- so both are held to the same candidate-only rule.
     """
 
     result = await _run(
@@ -420,12 +429,89 @@ async def test_a_literal_parenthetical_alias_commits_like_the_primary_label() ->
         request_for('What is the status of the "Context Fabric" project?'),
     )
 
-    assert result.decision is PreflightDecision.PROCEED
-    assert result.committed_resolution is not None
-    committed_ids = {
-        ref.entity_id for ref in result.committed_resolution.resolved_scope.entity_refs
-    }
-    assert committed_ids == {ACR_PROJECT.canonical_id}
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.answer is not None
+    candidates = result.answer.frame.clarification_candidates
+    assert len(candidates) == 1
+    assert candidates[0].entity_ref.display_label == ACR_PROJECT.label
+    assert candidates[0].entity_ref.entity_id == ACR_PROJECT.canonical_id
+
+
+@pytest.mark.asyncio
+async def test_a_qualifier_like_parenthetical_never_commits() -> None:
+    """CHAOS-3388 codex re-review (HIGH, confirmed) acceptance repro.
+
+    The live defect: a catalog label like "Payments (Legacy)" carries a
+    parenthetical that reads as a qualifier ("this is the legacy one"), not
+    an asserted alternate name -- yet the prior auto-commit check treated
+    every parenthetical identically, so "What is the status of the Legacy
+    project?" proceeded with ``payments-legacy`` COMMITTED, answering about
+    an entity the user never actually named. There is no catalog alias field
+    distinguishing a real alternate name from a qualifier, so parentheticals
+    are held to the same rule as an acronym: candidate-only, never a pick.
+    """
+
+    payments_legacy = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-payments-legacy",
+        label="Payments (Legacy)",
+        repository_id=None,
+    )
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, payments_legacy)]),
+        request_for("What is the status of the Legacy project?"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.answer is not None
+    candidates = result.answer.frame.clarification_candidates
+    assert len(candidates) == 1
+    assert candidates[0].entity_ref.display_label == payments_legacy.label
+    assert candidates[0].entity_ref.entity_id == payments_legacy.canonical_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "question"),
+    [
+        ("Reports (Archived)", "What is the status of the Archived project?"),
+        ("Roadmap (Team A)", 'What is the status of the "Team A" project?'),
+    ],
+)
+async def test_qualifier_like_parentheticals_never_commit(
+    label: str, question: str
+) -> None:
+    """More qualifier-shaped parentheticals from the reviewer's negative list.
+
+    "(Archived)" and "(Team A)" read exactly like "(Legacy)" -- a status or
+    ownership qualifier appended to the primary label, not a real alternate
+    name -- and must stay candidate-only for the same reason.
+    """
+
+    slug = re.sub(r"[^a-z0-9]+", "-", label.casefold()).strip("-")
+    entity = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id=f"project-{slug}",
+        label=label,
+        repository_id=None,
+    )
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, entity)]),
+        request_for(question),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.answer is not None
+    candidates = result.answer.frame.clarification_candidates
+    assert len(candidates) == 1
+    assert candidates[0].entity_ref.display_label == entity.label
+    assert candidates[0].entity_ref.entity_id == entity.canonical_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -45,6 +45,7 @@ from tests._chaos_3292_preflight import (
     ASK_DEV_PROJECT,
     ATLAS_PROJECT_ONE,
     ATLAS_PROJECT_TWO,
+    NIGHTFALL_PROJECT,
     ORG_ID,
     OTHER_ORG_ID,
     SeededCatalog,
@@ -94,9 +95,16 @@ class LimitRecordingCatalog(SeededCatalog):
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         self.search_limits.append((len(kinds), limit))
-        return await super().search(org_id, query, kinds, limit=limit)
+        return await super().search(
+            org_id,
+            query,
+            kinds,
+            limit=limit,
+            include_alias_matches=include_alias_matches,
+        )
 
 
 class CrossTenantLeakingCatalog(SeededCatalog):
@@ -113,9 +121,16 @@ class CrossTenantLeakingCatalog(SeededCatalog):
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         if len(kinds) == 1:
-            return await super().search(org_id, query, kinds, limit=limit)
+            return await super().search(
+                org_id,
+                query,
+                kinds,
+                limit=limit,
+                include_alias_matches=include_alias_matches,
+            )
         needle = query.casefold()
         matched = [
             entity
@@ -140,10 +155,17 @@ class MultiKindFailingCatalog(SeededCatalog):
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         if len(kinds) > 1:
             raise RuntimeError("catalog unavailable for the fallback search")
-        return await super().search(org_id, query, kinds, limit=limit)
+        return await super().search(
+            org_id,
+            query,
+            kinds,
+            limit=limit,
+            include_alias_matches=include_alias_matches,
+        )
 
 
 def _preflight(
@@ -228,6 +250,182 @@ async def test_named_project_with_no_match_offers_bounded_close_matches() -> Non
         result.answer.frame.direct_answer
         == CLARIFICATION_COPY[NOT_FOUND_CLOSE_MATCHES_KEY]
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3388 -- acronym / parenthetical-alias closest matches
+# ---------------------------------------------------------------------------
+
+#: The real production catalog row this ticket's live repro named (org
+#: 70d529e0-3c06-4597-8480-794fd02328b6, read live from ClickHouse
+#: `projects` -- not a hand-authored stand-in): "ACR" is the acronym of
+#: "Agent Context Runtime" inside the full display name.
+ACR_PROJECT = AuthorizedEntity(
+    kind=EntityKind.PROJECT,
+    canonical_id="60997592-f9f4-462b-87c3-ef82671df270",
+    label="Dev Health Agent Context Runtime (Context Fabric)",
+    repository_id=None,
+)
+
+#: The literal repro question from the live incident report.
+ACR_QUESTION = (
+    "What's the status of the ACR Project and what drivers are blocking it? "
+    "What's left to complete?"
+)
+
+
+@pytest.mark.asyncio
+async def test_an_acronym_mention_offers_the_matching_project_as_a_close_match() -> (
+    None
+):
+    """CHAOS-3388 acceptance: "ACR" must never dead-end as a bare no-match.
+
+    Before acronym-aware closest matches, "ACR" is not a substring of "Dev
+    Health Agent Context Runtime (Context Fabric)", so this terminated
+    ``not_found`` with zero candidates -- the run either fell through to
+    org-wide investigation (before the interpreter case fix) or landed here
+    with nothing to offer (before this fix). Never auto-committed either
+    way: an acronym is a derived signal, not a literal name the user typed.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, ACR_PROJECT)]),
+        request_for(ACR_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.diagnostic == "unresolved_close_matches"
+
+    assert result.answer is not None
+    candidates = result.answer.frame.clarification_candidates
+    assert len(candidates) == 1
+    assert candidates[0].entity_ref.display_label == ACR_PROJECT.label
+    assert candidates[0].entity_ref.entity_id == ACR_PROJECT.canonical_id
+
+
+@pytest.mark.asyncio
+async def test_an_acronym_match_survives_substring_noise_past_the_bound() -> None:
+    """CHAOS-3388 live finding: literal-substring noise must never crowd out
+    the real acronym match.
+
+    The live probe against the real org repro'd a genuine defect here: the
+    org holds more than ``NOT_FOUND_FALLBACK_LIMIT`` issues whose titles
+    contain "acr" as a plain substring (e.g. "Harden ACR runtime client
+    boundary"), sorted alphabetically ahead of the actual project's full
+    name -- so a combined alphabetical sort truncated the acronym-matched
+    project out of the returned page entirely, and the closest-matches
+    answer named everything BUT the thing "ACR" actually stood for.
+    """
+
+    noisy_issues = [
+        AuthorizedEntity(
+            kind=EntityKind.ISSUE,
+            canonical_id=f"issue-acr-{index}",
+            # Alphabetically ahead of "Dev Health Agent Context Runtime
+            # (Context Fabric)" -- starts with a digit, which sorts before
+            # any letter.
+            label=f"{index} ACR boundary hardening task",
+            repository_id=None,
+        )
+        for index in range(NOT_FOUND_FALLBACK_LIMIT + 3)
+    ]
+    result = await _run(
+        _preflight([(ORG_ID, entity) for entity in [ACR_PROJECT, *noisy_issues]]),
+        request_for(ACR_QUESTION),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.answer is not None
+    labels = {
+        candidate.entity_ref.display_label
+        for candidate in result.answer.frame.clarification_candidates
+    }
+    assert ACR_PROJECT.label in labels, (
+        "the real acronym match must survive the bound even when outnumbered "
+        "by incidental substring hits"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_acronym_matches_are_offered_without_picking() -> None:
+    """Two catalog projects sharing an acronym must both surface as candidates.
+
+    Never a coin flip: CHAOS-3289 history is "ambiguity -> candidates, never
+    a pick", so an acronym shared by more than one authorized project is
+    exactly as unresolved as two projects sharing a literal name.
+    """
+
+    analytics_core_runtime = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-analytics-core-runtime",
+        label="Analytics Core Runtime",
+        repository_id=None,
+    )
+    result = await _run(
+        _preflight([(ORG_ID, ACR_PROJECT), (ORG_ID, analytics_core_runtime)]),
+        request_for(ACR_QUESTION),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.committed_resolution is None
+    assert result.answer is not None
+    labels = {
+        candidate.entity_ref.display_label
+        for candidate in result.answer.frame.clarification_candidates
+    }
+    assert labels == {ACR_PROJECT.label, "Analytics Core Runtime"}
+
+
+@pytest.mark.asyncio
+async def test_a_nonsense_name_never_fabricates_an_acronym_match() -> None:
+    """CHAOS-3388 acceptance: "Zebra Project" must stay a bare no-match.
+
+    The real catalog (``ACR_PROJECT`` plus a few of its live siblings) holds
+    nothing "Zebra" is remotely an acronym or alias of -- this must terminate
+    ``not_found`` with zero candidates, never a guessed entity.
+    """
+
+    result = await _run(
+        _preflight(
+            [
+                (ORG_ID, ASK_DEV_PROJECT),
+                (ORG_ID, ACR_PROJECT),
+                (ORG_ID, NIGHTFALL_PROJECT),
+            ]
+        ),
+        request_for("What is the status of the Zebra Project?"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+    assert result.answer is not None
+    assert result.answer.frame.clarification_candidates == ()
+
+
+@pytest.mark.asyncio
+async def test_a_literal_parenthetical_alias_commits_like_the_primary_label() -> None:
+    """CHAOS-3388: typing the parenthetical alias outright is a literal name.
+
+    Unlike an acronym, "Context Fabric" is a real alternate name the catalog
+    itself carries (in parentheses) -- typing it is exactly as deliberate an
+    act as typing the primary label, so a unique hit commits instead of only
+    ever candidating.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, ACR_PROJECT)]),
+        request_for('What is the status of the "Context Fabric" project?'),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.committed_resolution is not None
+    committed_ids = {
+        ref.entity_id for ref in result.committed_resolution.resolved_scope.entity_refs
+    }
+    assert committed_ids == {ACR_PROJECT.canonical_id}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/dev/test_chaos_3388_candidate_label_leak.py
+++ b/tests/api/dev/test_chaos_3388_candidate_label_leak.py
@@ -1,0 +1,125 @@
+"""CHAOS-3388 codex re-review (HIGH, confirmed): interpolated candidate
+labels must never trip the internal-token denylist.
+
+``preflight_outcomes.project_preflight_error`` interpolates real, catalog-
+confirmed candidate display labels into the v1 ``DevError.safe_message`` for
+a ``needs_clarification`` preflight termination (CHAOS-3388,
+``_name_candidates``). Those labels are ordinary user/organization-authored
+catalog text -- nothing stops one from containing a substring that happens to
+collide with the closed internal-state vocabulary
+(``no_match_terminal.INTERNAL_TOKEN_DENYLIST``), e.g. a project or issue
+titled "...not_ready...".
+
+Before this fix, the preflight TERMINATE branch persisted the richer
+``needs_clarification`` frame (with its typed ``clarification_candidates``)
+*before* calling ``orchestrator.finish()`` -- and ``finish()``'s fail-closed
+leak scan built its ``attested`` allowlist from ``DevAnswer`` fields only
+(``no_match_terminal.attested_strings``), which is always ``None`` on this
+error-only path. So a candidate label containing a denylisted token was
+scanned with no exemption, ``internal_token_leak_field`` flagged it, and
+``finish()`` discarded the clarification and rewrote the terminal to a bare
+``internal_error`` -- while the richer needs-clarification frame it had
+already recorded a moment earlier was never touched, leaving the persisted
+frame permanently inconsistent with the terminal state/error actually
+written.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ORG_ID,
+    run_preflight_orchestrator,
+)
+
+#: A real catalog label that happens to contain a denylisted internal token
+#: ("not_ready" is a ``DevActualCompletion.state`` member, derived into
+#: ``INTERNAL_TOKEN_DENYLIST``) -- exactly the shape of collision the
+#: attestation escape hatch exists for elsewhere in this module (see
+#: ``no_match_terminal.internal_token_leak``'s own docstring example).
+_LEAKY_LABEL = "Provider not_ready Migration"
+
+_LEAKY_ISSUE = AuthorizedEntity(
+    kind=EntityKind.ISSUE,
+    canonical_id="issue-provider-migration",
+    label=_LEAKY_LABEL,
+    repository_id=None,
+)
+
+#: Names no project in the fixture, so the named-project resolution
+#: terminates ``NO_AUTHORIZED_MATCH`` and the CHAOS-3366 closest-matches
+#: fallback runs a wide search for "Migration" -- a substring of
+#: ``_LEAKY_LABEL`` -- and offers ``_LEAKY_ISSUE`` back as the sole
+#: candidate.
+_QUESTION = 'What is the status of the "Migration" project?'
+
+
+@pytest.mark.asyncio
+async def test_a_candidate_label_containing_a_denylisted_token_still_clarifies() -> (
+    None
+):
+    """The terminal must stay a clarification, never internal_error."""
+
+    output = await run_preflight_orchestrator(
+        question=_QUESTION,
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, _LEAKY_ISSUE)],
+        script_id="candidate-label-leak",
+    )
+
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE, (
+        "a candidate label token collision must never fail-closed rewrite "
+        f"the terminal to {output.result.state}"
+    )
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_ambiguous", (
+        "the fail-closed guard must not have fired: got "
+        f"{output.result.error.code!r} / {output.result.error.safe_message!r}"
+    )
+    assert output.result.error.code != "internal_error"
+    # The candidate name itself must still reach the user -- proof the
+    # attestation didn't just silently drop the candidate to dodge the scan.
+    assert _LEAKY_LABEL in output.result.error.safe_message
+
+
+@pytest.mark.asyncio
+async def test_a_candidate_label_leak_never_flags_the_token_leak_counter() -> None:
+    """No internal-token-leak signal fires for an authorized catalog label."""
+
+    output = await run_preflight_orchestrator(
+        question=_QUESTION,
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, _LEAKY_ISSUE)],
+        script_id="candidate-label-leak-counter",
+    )
+
+    assert output.result.error is not None
+    assert output.result.error.code != "internal_error"
+    assert output.result.error.safe_message != "The request could not be completed."
+
+
+@pytest.mark.asyncio
+async def test_the_persisted_frame_stays_consistent_with_the_terminal() -> None:
+    """The already-recorded needs-clarification frame must match the terminal.
+
+    Before this fix, a leak false-positive on the candidate label rewrote the
+    terminal to ``internal_error`` *after* the richer ``needs_clarification``
+    frame had already been persisted -- leaving a run whose frame and
+    terminal state permanently disagreed about what happened.
+    """
+
+    output = await run_preflight_orchestrator(
+        question=_QUESTION,
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, _LEAKY_ISSUE)],
+        script_id="candidate-label-leak-consistency",
+    )
+
+    assert output.recorder is not None
+    assert len(output.recorder.frames) == 1
+    frame = output.recorder.frames[0]
+    assert frame.public_outcome == "needs_clarification"
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_ambiguous"

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -176,6 +176,35 @@ def test_pronouns_and_interrogatives_are_never_subjects(question: str) -> None:
     assert extract_mentions(question, mint_id=sequential_ids()) == ()
 
 
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        # CHAOS-3388: a capitalized kind noun immediately after an acronym-
+        # shaped name reads exactly like the lowercase form -- "the ACR
+        # Project" is as much a named mention as "the ACR project" is. Before
+        # the fix, `_NOUN_TRAILING`'s alternation was matched case-
+        # sensitively against a lowercase-only noun list, so this question
+        # produced zero typed mentions and fell to the untyped bare-name
+        # path, which never terminates the run on an unresolved name.
+        (
+            "What's the status of the ACR Project and what drivers are "
+            "blocking it? What's left to complete?",
+            [("ACR", "project")],
+        ),
+        ("PROJECT Nightfall is behind schedule", [("Nightfall", "project")]),
+        ("Is the ACR Team overloaded?", [("ACR", "team")]),
+    ],
+)
+def test_a_capitalized_kind_noun_is_recognized_case_insensitively(
+    question: str, expected: list[tuple[str, str]]
+) -> None:
+    mentions = extract_mentions(question, mint_id=sequential_ids())
+    assert [
+        (mention.original_text_span, mention.requested_entity_kind.value)
+        for mention in mentions
+    ] == expected
+
+
 def test_a_noun_bound_to_a_following_name_is_not_also_read_backwards() -> None:
     """ "Compare project Ask Dev" must not mint a project called "Compare"."""
 

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -63,6 +63,7 @@ class FakeCatalog:
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         self.search_calls += 1
         return [

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -8,12 +8,19 @@ import pytest
 
 from dev_health_ops.api.dev.contracts import ToolID
 from dev_health_ops.api.dev.contracts_v2 import (
+    DevEntityRefV2,
     PublicOutcome,
     QuestionIntentID,
     ResolutionOutcome,
 )
+from dev_health_ops.api.dev.contracts_v2 import (
+    EntityKind as ContractEntityKind,
+)
 from dev_health_ops.api.dev.contracts_v2.plan import PLAN_REGISTRY
-from dev_health_ops.api.dev.contracts_v2.subject import UNRESOLVED_OUTCOMES
+from dev_health_ops.api.dev.contracts_v2.subject import (
+    UNRESOLVED_OUTCOMES,
+    DevResolutionCandidate,
+)
 from dev_health_ops.api.dev.orchestrator_states import TERMINAL_STATES
 from dev_health_ops.api.dev.preflight_outcomes import (
     PLAN_ID_BY_INTENT,
@@ -275,6 +282,93 @@ def test_each_outcome_projects_to_its_v1_error(
     assert error.code == expected_code
     assert error.retryable is expected_retryable
     assert error.request_id == "request_01"
+
+
+def _candidate(
+    display_label: str, entity_id: str = "project-acr"
+) -> DevResolutionCandidate:
+    return DevResolutionCandidate(
+        entity_ref=DevEntityRefV2(
+            entity_kind=ContractEntityKind.PROJECT,
+            entity_id=entity_id,
+            display_label=display_label,
+            repository_id=None,
+        ),
+        reason="Closest authorized match for the named subject.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_needs_clarification_v1_error_names_its_real_candidates() -> None:
+    """CHAOS-3388: the v1 wire must not discard the frame's own candidates.
+
+    Before this fix ``project_preflight_error`` always returned the fixed
+    "The requested scope is ambiguous." sentence for ``needs_clarification``,
+    whatever ``clarification_candidates`` the ledger actually authorized --
+    the client-visible half of the wrong-terminal defect: a run that found a
+    real close match still told the user nothing more than "ambiguous".
+    """
+
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NEEDS_CLARIFICATION,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+        clarification_key="not_found_close_matches",
+        clarification_candidates=(
+            _candidate("Dev Health Agent Context Runtime (Context Fabric)"),
+        ),
+    )
+    error = project_preflight_error(answer, request_id="request_01")
+
+    assert error.code == "scope_ambiguous"
+    assert "Dev Health Agent Context Runtime (Context Fabric)" in error.safe_message
+    # The base closest-matches sentence must still be present, not replaced.
+    assert "closest matches" in error.safe_message
+
+
+@pytest.mark.asyncio
+async def test_a_needs_clarification_v1_error_names_every_bounded_candidate() -> None:
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NEEDS_CLARIFICATION,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+        clarification_key="ambiguous",
+        clarification_candidates=(
+            _candidate("Atlas", entity_id="project-atlas-1"),
+            _candidate("Atlas Migration", entity_id="project-atlas-2"),
+        ),
+    )
+    error = project_preflight_error(answer, request_id="request_01")
+
+    assert "Atlas" in error.safe_message
+    assert "Atlas Migration" in error.safe_message
+
+
+def test_a_needs_clarification_v1_error_without_candidates_is_unchanged() -> None:
+    """No candidates (e.g. an uninterpretable question) -> the base sentence."""
+
+    answer = build_preflight_answer(
+        outcome=PublicOutcome.NEEDS_CLARIFICATION,
+        intent_id=QuestionIntentID.ENTITY_STATUS,
+        versions=versions(),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        generated_at=fixed_now(),
+        clarification_key="uninterpretable",
+    )
+    error = project_preflight_error(answer, request_id="request_01")
+
+    assert error.safe_message == answer.frame.direct_answer
+    assert "Candidates:" not in error.safe_message
 
 
 def test_a_no_answer_frame_carries_no_provenance_block_or_subject() -> None:

--- a/tests/api/graphql/test_dev_scope_search.py
+++ b/tests/api/graphql/test_dev_scope_search.py
@@ -41,6 +41,7 @@ class FakeCatalog:
         kinds: tuple[EntityKind, ...],
         *,
         limit: int,
+        include_alias_matches: bool = False,
     ) -> list[AuthorizedEntity]:
         type(self).calls += 1
         assert org_id == ORG_ID


### PR DESCRIPTION
## Summary
- Resolves acronym/alias-named subjects (e.g. "ACR Project") instead of silently falling through to the grounding floor as unresolved.
- Codex re-review round: candidate-only parentheticals, attests candidate labels past the leak scan.

## Evidence
- Unit, orchestrator, and live regression suites green.
- Codex adversarial review round completed with fixes applied.
- Rebased cleanly onto current `origin/main` (post #1366/#1367/#1368), zero conflicts.