### PR TITLE
ci(ops): CHAOS-3401 publish coverage.xml + JUnit artifacts with 90-day retention

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,7 +58,7 @@ jobs:
           name: integration-junit
           path: test-results/junit/integration.xml
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 90
 
       - name: Upload integration logs on failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: ["**"]
   merge_group:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -153,7 +154,7 @@ jobs:
           name: junit-${{ matrix.python-version }}
           path: test-results/junit/*.xml
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 90
 
       - name: Upload pytest logs on failure
         if: failure()
@@ -245,10 +246,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: junit-coverage
+          # Named for what it actually is: JUnit output from the
+          # coverage-gated `ci` tier, not a coverage report. (See
+          # coverage-py312 below for the actual coverage artifact.)
+          name: junit-ci-gated
           path: test-results/junit/*.xml
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 90
 
       - name: Upload pytest logs on failure
         if: failure()
@@ -260,6 +264,15 @@ jobs:
             **/pytest.log
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Upload coverage.xml artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-py312
+          path: coverage.xml
+          if-no-files-found: ignore
+          retention-days: 90
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -247,7 +247,7 @@ ci_tests() {
   local cov_args=(tests -v --tb=short -m "not benchmark and not clickhouse"
     --ignore=tests/test_connectors_integration.py
     --ignore=tests/test_private_repo_access.py
-    --cov=. --cov-report=xml --cov-report=term-missing
+    --cov=. --cov-report=xml:coverage.xml --cov-report=term-missing
     --cov-fail-under="${coverage_threshold}")
   # pytest-cov aggregates per-worker coverage automatically under xdist, so the
   # --cov-fail-under gate still evaluates the combined total across workers.


### PR DESCRIPTION
## CHAOS-3401

`/testops/coverage` has never shown data because `coverage_snapshots` in ClickHouse is empty: no repo in the estate publishes a coverage artifact the TestOps ingester's `classify_report` can parse. This PR makes ops publish one.

### Changes

- **`ci/run_tests.sh`** (`ci_tests()`): make pytest-cov's XML output path explicit — `--cov-report=xml:coverage.xml` instead of relying on the implicit default — so it's documented and stable.
- **`.github/workflows/test.yml`** (`coverage` job):
  - Upload `coverage.xml` as a new artifact `coverage-py312` (retention 90 days).
  - Rename the `junit-coverage` artifact to `junit-ci-gated` (it's JUnit output from the coverage-gated `ci` tier, not a coverage report — the old name was actively misleading) and bump its retention to 90 days.
  - Bump the matrix `junit-${{ matrix.python-version }}` artifact retention to 90 days.
  - Add `workflow_dispatch:` to the `on:` block so the `coverage` job (gated off `pull_request`, only push-to-main / `merge_group`) can be triggered manually for verification. The `coverage` job's `if:` gating itself is unchanged — it still does not run on plain `pull_request` events, which is correct: the TestOps ingester only scans default-branch workflow runs (`_fetch_github_test_artifacts_sync` passes `branch=default_branch`), so PR-branch runs would be filtered server-side before any parser saw them.
- **`.github/workflows/integration.yml`**: bump `integration-junit` artifact retention to 90 days.

`pytest-logs-*` and any build/release artifact retention are untouched — this is scoped to test/coverage artifacts only.

### Verification

Pushed this branch and triggered `gh workflow run "Tests" --ref chaos-3401-coverage-artifacts`, then downloaded the real `coverage-py312` and `junit-ci-gated` artifacts GitHub produced. Ran them through the actual production entrypoint (`ingest_report_members`, not just `classify_report` in isolation) with `PYTHONPATH=src`:

- `classify_report("coverage.xml", ...)` → `"coverage"`, `classify_report("junit.xml", ...)` → `"junit"`.
- `ingest_report_members(...)` on the real files → non-empty `suite_rows`, `case_rows`, and `coverage_rows` (i.e. the coverage row survives `_coverage_is_coherent`, not just gets classified).
- Negative control: a copy of `coverage.xml` renamed to `coverage.badext` is rejected by `_is_report_name` (the actual ZIP-filter production rejection point used in `iter_zip_members`), and a real ZIP built with `[coverage.xml, junit.xml, coverage.badext]` run through `iter_zip_members(name_filter=_is_report_name)` admits exactly `[coverage.xml, junit.xml]` — confirmed end-to-end that feeding the filtered members into `ingest_report_members` contributes zero extra coverage rows for the bad-extension file.

Local gate (`ci/local_validate.sh`): PASSED — 11660 passed, 98 skipped, 1 xfailed, all 7 stages green (lint, mypy, ClickHouse migrate, full unit suite, live argMax proof).