### PR TITLE
fix(ops): CHAOS-3399 make the tests dataset selectable and repair existing integrations

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2333",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2385",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2333
+        "line": 2385
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2478",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2530",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2478
+        "line": 2530
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2231",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2283",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2231
+        "line": 2283
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2377",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2429",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2377
+        "line": 2429
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2385",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2432",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2385
+        "line": 2432
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2530",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2577",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2530
+        "line": 2577
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2283",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2330",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2283
+        "line": 2330
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2429",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2476",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2429
+        "line": 2476
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -965,8 +965,10 @@ async def _reconcile_dataset_rows_for_sync_targets(
     integration_id: uuid.UUID,
     provider: str,
     sync_targets: list[str],
+    previous_sync_targets: list[str],
 ) -> None:
-    """Retro-create/re-enable ``IntegrationDataset`` rows for newly selected targets.
+    """Make an edited ``sync_targets`` list authoritative over ``IntegrationDataset``
+    rows, in BOTH directions.
 
     ``IntegrationDataset`` rows are only seeded once, at integration-create
     time, from the config's ``sync_targets`` (see ``_planner_dataset_keys``
@@ -980,16 +982,39 @@ async def _reconcile_dataset_rows_for_sync_targets(
     existing integration is a genuine, working enable path -- not just a
     create-time-only one.
 
-    Purely additive: only creates missing rows or re-enables disabled ones
-    for datasets present in the new ``sync_targets``. Never disables a
-    dataset that isn't present anymore -- same non-destructive contract as
-    ``planner.py::_reconcile_explicit_requested_datasets``.
+    Symmetric with removal (Codex adversarial-review finding, round 1): the
+    web edit form's own copy (``formDiff.ts::getDatasetWarnings``) tells the
+    operator that unchecking a dataset "will stop syncing" it. An enable-only
+    reconciliation would leave that a broken promise -- the row stays
+    enabled and the planner keeps running it even though the UI/API now
+    reports it deselected, a real operator-visible control-plane
+    inconsistency, not just a cosmetic one. So: datasets present in
+    ``previous_sync_targets`` but absent from the new ``sync_targets`` are
+    disabled (only if currently enabled; never deleted).
+
+    Both directions run through the SAME ``_planner_dataset_keys`` used at
+    create time, so provider-specific rules (e.g. github/gitlab's
+    git-implies-blame expansion) apply identically to both the old and new
+    computed sets -- removing "git" symmetrically drops "blame" from
+    ``desired_keys`` too, with no special-casing needed. Datasets never
+    exposed as a sync_targets checkbox (e.g. "security", which the platform
+    manages via ``_ensure_security_dataset_for_scheduled_code_host_sync``)
+    have legacy_targets that never appear in an operator-supplied
+    sync_targets list, so they never appear in either the old or new
+    computed set and are untouched by this function either way.
     """
     try:
-        desired_keys = _planner_dataset_keys(provider, sync_targets)
+        desired_keys = set(_planner_dataset_keys(provider, sync_targets))
     except ValueError:
         return
-    if not desired_keys:
+    try:
+        previously_desired_keys = set(
+            _planner_dataset_keys(provider, previous_sync_targets)
+        )
+    except ValueError:
+        previously_desired_keys = set()
+
+    if not desired_keys and not previously_desired_keys:
         return
 
     svc = IntegrationDatasetService(session, org_id)
@@ -999,6 +1024,11 @@ async def _reconcile_dataset_rows_for_sync_targets(
             await svc.create(integration_id, dataset_key, True)
         elif not dataset.is_enabled:
             await svc.set_enabled(dataset, True)
+
+    for dataset_key in previously_desired_keys - desired_keys:
+        dataset = await svc.get_by_key(str(integration_id), dataset_key)
+        if dataset is not None and dataset.is_enabled:
+            await svc.set_enabled(dataset, False)
 
 
 def _planner_source_rows(
@@ -2167,6 +2197,7 @@ async def update_sync_config(
 
     mutable_config = cast(_MutableSyncConfiguration, config)
     if payload.sync_targets is not None:
+        previous_sync_targets = list(getattr(config, "sync_targets") or [])
         mutable_config.sync_targets = payload.sync_targets
         config_integration_id = getattr(config, "integration_id", None)
         if config_integration_id is not None:
@@ -2176,6 +2207,7 @@ async def update_sync_config(
                 config_integration_id,
                 str(getattr(config, "provider", "")),
                 payload.sync_targets,
+                previous_sync_targets,
             )
     if sync_options_provided:
         merged_options = {

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -2200,7 +2200,22 @@ async def update_sync_config(
         previous_sync_targets = list(getattr(config, "sync_targets") or [])
         mutable_config.sync_targets = payload.sync_targets
         config_integration_id = getattr(config, "integration_id", None)
-        if config_integration_id is not None:
+        # IntegrationDataset rows are shared across every SyncConfiguration
+        # that points at the same integration_id (CHAOS-2762: a planner
+        # parent plus its per-repo children can share one Integration).
+        # _load_enabled_datasets (sync/planner.py) always reads that SHARED
+        # row set for the whole integration; only a source_id-scoped CHILD
+        # config additionally narrows which dataset_keys it requests
+        # (trigger_routing.py::_dataset_keys_for_config). So reconciling from
+        # a child's sync_targets would let one repo's edit silently disable a
+        # dataset for every sibling config sharing the integration (Codex
+        # adversarial-review finding, round 2). Only the config that
+        # represents the WHOLE integration (source_id is None) may mutate
+        # the shared rows.
+        if (
+            config_integration_id is not None
+            and getattr(config, "source_id", None) is None
+        ):
             await _reconcile_dataset_rows_for_sync_targets(
                 session,
                 org_id,

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -34,6 +34,7 @@ from dev_health_ops.api.services.configuration import (
     IntegrationCredentialsService,
     SyncConfigurationService,
 )
+from dev_health_ops.api.services.integrations import IntegrationDatasetService
 from dev_health_ops.api.services.licensing import TierLimitService
 from dev_health_ops.api.services.sync_coverage import (
     HISTORY_LOOKBACK_DAYS,
@@ -956,6 +957,48 @@ def _planner_dataset_keys(provider: str, sync_targets: list[str]) -> list[str]:
         for spec in supported_datasets(provider)
         if targets.intersection(spec.legacy_targets)
     ]
+
+
+async def _reconcile_dataset_rows_for_sync_targets(
+    session: AsyncSession,
+    org_id: str,
+    integration_id: uuid.UUID,
+    provider: str,
+    sync_targets: list[str],
+) -> None:
+    """Retro-create/re-enable ``IntegrationDataset`` rows for newly selected targets.
+
+    ``IntegrationDataset`` rows are only seeded once, at integration-create
+    time, from the config's ``sync_targets`` (see ``_planner_dataset_keys``
+    above). The planner (``sync/planner.py::_load_enabled_datasets``) plans
+    strictly from those rows, never from ``sync_targets`` directly, so an
+    operator who edits an *existing* sync configuration to add a target (e.g.
+    ``tests``) previously saw the checkbox flip on with no effect: the
+    dataset was never planned because no row was ever created (CHAOS-3398).
+    This mirrors the admin batch-update endpoint
+    (``PATCH /integrations/{id}/datasets``) so editing sync_targets on an
+    existing integration is a genuine, working enable path -- not just a
+    create-time-only one.
+
+    Purely additive: only creates missing rows or re-enables disabled ones
+    for datasets present in the new ``sync_targets``. Never disables a
+    dataset that isn't present anymore -- same non-destructive contract as
+    ``planner.py::_reconcile_explicit_requested_datasets``.
+    """
+    try:
+        desired_keys = _planner_dataset_keys(provider, sync_targets)
+    except ValueError:
+        return
+    if not desired_keys:
+        return
+
+    svc = IntegrationDatasetService(session, org_id)
+    for dataset_key in desired_keys:
+        dataset = await svc.get_by_key(str(integration_id), dataset_key)
+        if dataset is None:
+            await svc.create(integration_id, dataset_key, True)
+        elif not dataset.is_enabled:
+            await svc.set_enabled(dataset, True)
 
 
 def _planner_source_rows(
@@ -2125,6 +2168,15 @@ async def update_sync_config(
     mutable_config = cast(_MutableSyncConfiguration, config)
     if payload.sync_targets is not None:
         mutable_config.sync_targets = payload.sync_targets
+        config_integration_id = getattr(config, "integration_id", None)
+        if config_integration_id is not None:
+            await _reconcile_dataset_rows_for_sync_targets(
+                session,
+                org_id,
+                config_integration_id,
+                str(getattr(config, "provider", "")),
+                payload.sync_targets,
+            )
     if sync_options_provided:
         merged_options = {
             **dict(getattr(config, "sync_options") or {}),

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -297,6 +297,13 @@ SyncCoverageStatus = Literal[
     "paused",
     "not_scheduled",
     "running",
+    # A dataset the provider supports but that has no enabled
+    # ``IntegrationDataset`` row for this integration -- i.e. never selected
+    # by an operator (or explicitly disabled). Distinct from
+    # "insufficient_data", which means the dataset IS enabled but a sync
+    # hasn't produced any rows yet (CHAOS-3398/3399: both used to render as
+    # an indistinguishable blank page).
+    "not_enabled",
 ]
 
 

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -1682,11 +1682,21 @@ def build_coverage_summary_payload(
     lookback_days: int = HISTORY_LOOKBACK_DAYS,
     latest_successful_run_at_override: datetime | None = None,
     is_truncated: bool = False,
+    not_enabled_dataset_keys: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Build the API coverage payload from persisted unit and backfill windows.
 
     Interval math is evaluated per ``(source_id, dataset_key)`` before summaries
     roll up to dataset, source, and overall levels.
+
+    ``not_enabled_dataset_keys`` (CHAOS-3399) are datasets the provider
+    supports but that have no enabled ``IntegrationDataset`` row -- i.e. never
+    planned, in contrast to a dataset that IS in ``scope.dataset_keys`` but
+    produced zero rows. They are appended to the returned ``datasets`` list
+    with a distinct ``"not_enabled"`` status and empty ranges; they never
+    participate in ``scope``/pair interval math or the overall/source
+    rollups above, so passing this is inert for every existing caller that
+    omits it.
     """
 
     now = ensure_utc(generated_at or datetime.now(timezone.utc))
@@ -1965,6 +1975,19 @@ def build_coverage_summary_payload(
                 ],
             }
             for dataset in datasets
+        ]
+        + [
+            {
+                "dataset_key": dataset_key,
+                "status": "not_enabled",
+                "covered_through": None,
+                "requested_ranges": [],
+                "covered_ranges": [],
+                "gaps": [],
+                "stale_ranges": [],
+                "failed_ranges": [],
+            }
+            for dataset_key in sorted(not_enabled_dataset_keys)
         ],
         "sources": source_payloads,
         "backfill_windows": _canonical_backfill_windows(datasets),
@@ -2023,6 +2046,23 @@ async def _has_coverage_before(
         SyncRunUnit.status == SyncRunUnitStatus.SUCCESS.value,
     )
     return (await session.execute(stmt.limit(1))).scalar_one_or_none() is not None
+
+
+def _not_enabled_dataset_keys(
+    config: SyncConfiguration, scope: EffectiveScope
+) -> frozenset[str]:
+    """Datasets the provider supports but that have no enabled row (CHAOS-3399).
+
+    Only computed for integration-level scope (a parent/planner-managed or
+    legacy whole-integration config): a source-scoped child config's
+    ``dataset_keys`` is an intentional subset of the integration's, not "every
+    dataset that could be enabled", so flagging the rest as not-enabled there
+    would be noise -- the parent config already surfaces it.
+    """
+    if scope.integration_id is None or config.source_id is not None:
+        return frozenset()
+    supported_keys = {spec.dataset_key for spec in supported_datasets(config.provider)}
+    return frozenset(supported_keys - set(scope.dataset_keys))
 
 
 async def rebuild_sync_coverage_projection(
@@ -2087,6 +2127,7 @@ async def rebuild_sync_coverage_projection(
         is_truncated=await _has_coverage_before(
             session, org_id, effective_scope, truncated_before
         ),
+        not_enabled_dataset_keys=_not_enabled_dataset_keys(config, effective_scope),
     )
     projection = (
         await session.execute(

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -956,6 +956,115 @@ async def test_update_sync_config_changes_is_active(client):
     assert data["id"] == config_id
 
 
+async def _tests_dataset_row(session_maker, integration_id: uuid.UUID):
+    async with session_maker() as session:
+        return (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == integration_id,
+                    IntegrationDataset.dataset_key == "tests",
+                )
+            )
+        ).scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+async def test_update_sync_config_adding_tests_target_repairs_dataset_row(
+    client, session_maker
+):
+    """CHAOS-3399: IntegrationDataset rows are seeded once at integration-create
+    time from sync_targets; the planner (`_load_enabled_datasets`) plans strictly
+    from that row, never from sync_targets directly. Before this fix, editing an
+    EXISTING integration's sync_targets to add "tests" updated the Postgres
+    sync_targets column with zero effect on what the planner would ever plan --
+    exactly the CHAOS-3398 root cause. Editing the config now must retro-create
+    (repair) the row, mirroring the admin batch-update endpoint.
+    """
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="repair-path-tests")
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        integration_id = config.integration_id
+
+    # Given: sync_targets=[] at create time (see _create_sync_config) means no
+    # dataset row exists at all yet -- this integration predates "tests".
+    assert await _tests_dataset_row(session_maker, integration_id) is None
+
+    # When: the operator edits sync_targets to add "tests".
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git", "tests"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Then: the row now exists and is enabled -- the planner can plan it.
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None
+    assert dataset.is_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_update_sync_config_without_tests_target_leaves_dataset_row_absent(
+    client, session_maker
+):
+    """Negative control for the repair-path test above: editing sync_targets
+    to add unrelated targets must NOT materialize a "tests" row -- the repair
+    is scoped to what was actually requested, not a blanket enable-everything.
+    """
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="repair-path-negative-control")
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        integration_id = config.integration_id
+
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git", "prs"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert await _tests_dataset_row(session_maker, integration_id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_sync_config_re_enables_previously_disabled_tests_dataset(
+    client, session_maker
+):
+    """An operator who disabled "tests" via the batch endpoint and later
+    re-checks it in the edit form must have the existing row flipped back on,
+    not left disabled while sync_targets claims it's selected.
+    """
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="repair-path-reenable")
+    config_id = uuid.UUID(create_resp.json()["id"])
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        integration_id = config.integration_id
+
+    disable_resp = await ac.patch(
+        f"/api/v1/admin/integrations/{integration_id}/datasets",
+        json={"datasets": [{"dataset_key": "tests", "is_enabled": False}]},
+    )
+    assert disable_resp.status_code == 200, disable_resp.text
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None and dataset.is_enabled is False
+
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git", "tests"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None and dataset.is_enabled is True
+
+
 @pytest.mark.asyncio
 async def test_update_pagerduty_service_mappings_propagates_to_services_dataset(
     client, session_maker

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -1066,6 +1066,98 @@ async def test_update_sync_config_re_enables_previously_disabled_tests_dataset(
 
 
 @pytest.mark.asyncio
+async def test_update_sync_config_removing_tests_target_disables_dataset_row(
+    client, session_maker
+):
+    """Codex adversarial-review finding (round 1): the enable-only version of
+    this reconciliation left a broken promise -- the web edit form's own copy
+    (formDiff.ts::getDatasetWarnings) tells the operator that unchecking a
+    dataset "will stop syncing" it, but the row stayed enabled and the
+    planner kept running it. Selecting "tests" then deselecting it via
+    sync_targets must disable the row, not just leave the checkbox unchecked
+    while the backend keeps planning it.
+    """
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="repair-path-disable-on-removal")
+    config_id = uuid.UUID(create_resp.json()["id"])
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        integration_id = config.integration_id
+
+    # Given: tests was selected and the row is enabled.
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git", "tests"]},
+    )
+    assert resp.status_code == 200, resp.text
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None and dataset.is_enabled is True
+
+    # When: the operator unchecks tests (removes it from sync_targets).
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Then: the row is disabled -- the planner will not plan it, matching
+    # what the UI told the operator would happen.
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None
+    assert dataset.is_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_update_sync_config_removing_git_symmetrically_disables_blame(
+    client, session_maker
+):
+    """The git-implies-blame expansion in _planner_dataset_keys must apply
+    symmetrically on removal too -- blame was auto-added alongside git at
+    create time (sync.py's own _planner_dataset_keys rule), so removing git
+    must drop blame the same way, with no special-casing in the reconcile
+    logic (it reuses _planner_dataset_keys for both the old and new sets).
+    """
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="repair-path-blame-symmetry")
+    config_id = uuid.UUID(create_resp.json()["id"])
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        integration_id = config.integration_id
+
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["git"]},
+    )
+    assert resp.status_code == 200, resp.text
+    async with session_maker() as session:
+        blame = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == integration_id,
+                    IntegrationDataset.dataset_key == "blame",
+                )
+            )
+        ).scalar_one_or_none()
+        assert blame is not None and blame.is_enabled is True
+
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_targets": ["prs"]},
+    )
+    assert resp.status_code == 200, resp.text
+    async with session_maker() as session:
+        blame = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == integration_id,
+                    IntegrationDataset.dataset_key == "blame",
+                )
+            )
+        ).scalar_one_or_none()
+        assert blame is not None and blame.is_enabled is False
+
+
+@pytest.mark.asyncio
 async def test_update_pagerduty_service_mappings_propagates_to_services_dataset(
     client, session_maker
 ):

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -1158,6 +1158,88 @@ async def test_update_sync_config_removing_git_symmetrically_disables_blame(
 
 
 @pytest.mark.asyncio
+async def test_update_source_scoped_child_sync_config_does_not_touch_shared_datasets(
+    client, session_maker
+):
+    """Codex adversarial-review finding (round 2, HIGH): IntegrationDataset
+    rows are shared across every SyncConfiguration pointing at the same
+    integration_id (CHAOS-2762 -- a planner parent plus its per-repo
+    children). The planner (sync/planner.py::_load_enabled_datasets) always
+    reads that SHARED row set for the whole integration; only a
+    source_id-scoped CHILD config additionally narrows which dataset_keys IT
+    requests (trigger_routing.py::_dataset_keys_for_config). So editing one
+    child's sync_targets must NEVER disable (or enable) the shared row --
+    that would silently change what the parent and every sibling child
+    plans too. Only the config with no source_id (the whole-integration
+    view) may reconcile the shared rows.
+    """
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    create_resp = await _create_sync_config(ac, name="shared-integration-parent-2")
+    assert create_resp.status_code == 201, create_resp.text
+    parent_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        parent = await session.get(SyncConfiguration, parent_id)
+        integration_id = parent.integration_id
+
+        source = IntegrationSource(
+            org_id=org_id,
+            integration_id=integration_id,
+            provider="github",
+            source_type="repository",
+            external_id="full-chaos/child-repo",
+            name="child-repo",
+            full_name="full-chaos/child-repo",
+            metadata_={},
+            is_enabled=True,
+        )
+        session.add(source)
+        await session.flush()
+        child = SyncConfiguration(
+            org_id=org_id,
+            name="shared-integration-child-2",
+            provider="github",
+            sync_targets=["tests"],
+            sync_options={},
+            parent_id=parent_id,
+            integration_id=integration_id,
+            source_id=source.id,
+        )
+        session.add(child)
+        await session.commit()
+        child_id = str(child.id)
+
+    # Given: the whole-integration parent enables "tests" for the shared row.
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{parent_id}",
+        json={"sync_targets": ["git", "tests"]},
+    )
+    assert resp.status_code == 200, resp.text
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None and dataset.is_enabled is True
+
+    # When: the source-scoped CHILD is edited to remove "tests" from ITS OWN
+    # sync_targets.
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{child_id}",
+        json={"sync_targets": ["git"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Then: the SHARED "tests" row is untouched -- still enabled, so the
+    # parent and any other sibling sharing this integration keep planning
+    # it. A child's private view must never mutate the shared switch.
+    dataset = await _tests_dataset_row(session_maker, integration_id)
+    assert dataset is not None
+    assert dataset.is_enabled is True, (
+        "a source-scoped child's sync_targets edit must not disable a "
+        "dataset shared by the whole integration"
+    )
+
+
+@pytest.mark.asyncio
 async def test_update_pagerduty_service_mappings_propagates_to_services_dataset(
     client, session_maker
 ):

--- a/tests/test_admin_sync_targets.py
+++ b/tests/test_admin_sync_targets.py
@@ -14,6 +14,29 @@ def test_provider_sync_targets_include_feature_flag_sources():
     assert PROVIDER_SYNC_TARGETS["launchdarkly"] == ["feature-flags"]
 
 
+def test_provider_sync_targets_surface_tests_dataset_for_code_hosts():
+    """CHAOS-3399: `GET /sync-targets` (backed by this constant) is how the
+    dataset-selection UI/API discovers which legacy targets a provider
+    supports. `tests` must be selectable for the two providers the registry
+    supports it for (`datasets.py::_PROVIDER_SUPPORTED_DATASETS`), and must
+    stay absent for providers that never wire up test-report ingestion.
+    """
+    assert "tests" in PROVIDER_SYNC_TARGETS["github"]
+    assert "tests" in PROVIDER_SYNC_TARGETS["gitlab"]
+    assert "tests" not in PROVIDER_SYNC_TARGETS["jira"]
+    assert "tests" not in PROVIDER_SYNC_TARGETS["linear"]
+    assert "tests" not in PROVIDER_SYNC_TARGETS["pagerduty"]
+    assert "tests" not in PROVIDER_SYNC_TARGETS["launchdarkly"]
+
+
+def test_planner_dataset_keys_resolves_tests_target_for_code_hosts():
+    assert _planner_dataset_keys("github", ["tests"]) == ["tests"]
+    assert _planner_dataset_keys("gitlab", ["tests"]) == ["tests"]
+    # Negative control: a sync_targets list that never mentions "tests" must
+    # never plan it -- this is what distinguishes "disabled" from "enabled".
+    assert "tests" not in _planner_dataset_keys("github", ["git", "prs"])
+
+
 def test_pagerduty_operational_target_expands_to_all_operational_datasets() -> None:
     # Given: the backend-owned PagerDuty operational sync target.
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -12,6 +12,7 @@ from dev_health_ops.api.services.sync_coverage import (
     SyncCoverageComplexityError,
     UnitWindow,
     _effective_dataset_keys_for_unit,
+    _not_enabled_dataset_keys,
     _query_dataset_keys_for_scope,
     build_coverage_summary_payload,
     classify_staleness,
@@ -83,6 +84,7 @@ def _summary(
     now: datetime = _dt(2, 1),
     config: SyncConfiguration | None = None,
     scope: EffectiveScope | None = None,
+    not_enabled_dataset_keys: frozenset[str] = frozenset(),
 ) -> dict:
     source_id = uuid.UUID(windows[0].source_id) if windows else uuid.uuid4()
     config = config or _config()
@@ -108,6 +110,7 @@ def _summary(
         active_schedule=schedule,
         has_schedule_row=True,
         generated_at=now,
+        not_enabled_dataset_keys=not_enabled_dataset_keys,
     )
 
 
@@ -204,6 +207,63 @@ def test_complete_summary_is_healthy():
     assert summary["overall"]["health"] == "healthy"
     assert summary["datasets"][0]["status"] == "healthy"
     assert summary["datasets"][0]["gaps"] == []
+
+
+def test_not_enabled_dataset_appended_distinctly_from_zero_row_dataset():
+    """CHAOS-3399: a dataset with an enabled row but zero synced rows must
+    read differently from one that was never enabled at all -- before this,
+    a never-enabled dataset was simply absent from the ``datasets`` list,
+    indistinguishable from one that doesn't apply to this provider.
+    """
+    # "commits" is enabled and has never produced a row -- pre-existing
+    # "insufficient_data" semantics, must be unaffected by the new kwarg.
+    summary = _summary(
+        [],
+        now=_dt(2, 1),
+        not_enabled_dataset_keys=frozenset({"tests"}),
+    )
+
+    by_key = {d["dataset_key"]: d for d in summary["datasets"]}
+    assert by_key["commits"]["status"] == "insufficient_data"
+    assert by_key["tests"]["status"] == "not_enabled"
+    assert by_key["tests"]["covered_ranges"] == []
+    assert by_key["tests"]["requested_ranges"] == []
+
+    # The not-enabled placeholder must not perturb overall health/gap/stale
+    # rollups, which are computed from real (enabled) datasets only.
+    assert summary["overall"]["gap_count"] == 0
+    assert summary["overall"]["stale_dataset_count"] == 0
+
+
+def test_not_enabled_dataset_keys_empty_for_source_scoped_config():
+    """A source/child-scoped config's dataset_keys is an intentional subset
+    of the integration's -- flagging the rest "not_enabled" there would be
+    noise; the parent/integration-level config already surfaces it.
+    """
+    config = _config()
+    config.source_id = uuid.uuid4()
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(),
+        dataset_keys=("commits",),
+    )
+
+    assert _not_enabled_dataset_keys(config, scope) == frozenset()
+
+
+def test_not_enabled_dataset_keys_reports_unplanned_supported_datasets():
+    config = _config()  # planner_managed=True, source_id=None, provider=github
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(),
+        dataset_keys=("git", "commits", "prs"),
+    )
+
+    not_enabled = _not_enabled_dataset_keys(config, scope)
+
+    assert "tests" in not_enabled
+    # Never claim a dataset that IS already in scope is "not enabled".
+    assert "commits" not in not_enabled
 
 
 def test_summary_caps_covered_through_at_generation_time():


### PR DESCRIPTION
CHAOS-3399: Make the `tests` dataset selectable and repair existing integrations

## What changed

1. **Repair path for existing integrations.** `PATCH /sync-configs/{id}` (the endpoint the web edit form calls) now retro-creates/re-enables the corresponding `IntegrationDataset` row(s) whenever `sync_targets` is updated. Previously this endpoint only updated the legacy `SyncConfiguration.sync_targets` Postgres column -- the planner (`_load_enabled_datasets`) reads `IntegrationDataset` rows, never `sync_targets`, so an operator who added `tests` to an *existing* integration's targets saw the checkbox flip on with zero effect (CHAOS-3398's root cause).
   - **Bidirectional** (added after a codex adversarial-review finding, see below): unchecking a dataset now disables the row too, matching what the edit form's own copy already promised (`formDiff.ts::getDatasetWarnings`: "will stop syncing").
   - **Scoped to the whole-integration config only** (added after a second codex finding, see below): `IntegrationDataset` rows are shared across every `SyncConfiguration` pointing at the same `integration_id` (a planner parent plus its per-repo children, CHAOS-2762). Only the config with no `source_id` -- the one representing the whole integration -- may mutate the shared rows, so editing one repo's child config can never silently disable/enable a dataset for its siblings.
2. **Operator-visible empty-state signal.** The sync coverage payload now distinguishes a dataset that has no enabled `IntegrationDataset` row (`status: "not_enabled"`) from one that's enabled but has produced zero rows so far (`status: "insufficient_data"`). Both used to render identically (an absent row), which is exactly what let TestOps being dark hide for months. Additive-only: the new `build_coverage_summary_payload` kwarg defaults to empty, inert for every existing caller/test.
3. **Confirmed already-correct, pinned with regression tests:** `GET /sync-targets`, `get_dataset_spec`/`_planner_dataset_keys`, and the admin batch-update endpoint (`PATCH /integrations/{id}/datasets`) already supported/worked for `tests` on github/gitlab -- that half of CHAOS-3398 was already complete, just unexercised and untested.

## Adversarial review findings (both fixed, both verified)

Two rounds of `codex:adversarial-review` on this branch surfaced real issues, not cosmetic ones:

- **[medium] Enable-only reconciliation was a one-way toggle.** The first version only created/re-enabled rows, never disabled them on removal -- an operator who unchecked `tests` would see the UI say it stopped, while the planner kept running it. Fixed by making the reconciliation bidirectional (item 1 above), verified by temporarily reverting the fix and observing the new regression test fail, then restoring it and observing it pass.
- **[high] Shared-integration blast radius.** The bidirectional version above then let ANY config with an `integration_id` mutate the shared `IntegrationDataset` rows, including a source-scoped *child* config representing just one repo. Since the planner (`_load_enabled_datasets`) always reads the shared row set for the whole integration, one repo's edit could silently disable a dataset for every sibling config sharing that integration. Fixed by scoping the reconciliation to `source_id is None` configs only (item 1 above), verified the same way (guard removed → new regression test fails; guard restored → passes) plus a dedicated regression test reproducing the exact shared-integration scenario (a parent + a source-scoped child).

A third confirmatory adversarial-review pass on the rebased final diff hit a shared-machine `codex` CLI/config issue (`model_reasoning_effort=max` unsupported by the resolved model variant) unrelated to this changeset -- the two substantive rounds above already exercised and fixed the real findings.

## Contract re-anchoring (`contracts/jobs/v1/transitional-inventory.json`)

This diff shifted line numbers for 4 already-tracked call sites in `sync.py` (twice, as the fix grew across the two review rounds): the `POST /sync-configs/{config_id}/trigger` and `.../backfill` endpoints, and their `getattr(dispatch_sync_run, "apply_async")` dispatch call sites. **Same sites, new offsets -- not new or changed surfaces.** Confirmed each time by reading the new line numbers directly and matching them against the pre-existing row's `surface`/`dispatches` fields before re-anchoring, then re-running `ci/check_transitional_inventory.py` to confirm zero UNOWNED/PHANTOM/STALE violations remain.

## Out of scope (per issue, and per a sibling finding)

- No auto-enable rule for `tests` (stays strictly opt-in).
- Did not touch `_ensure_security_dataset_for_scheduled_code_host_sync` (CHAOS-3400's territory) or CI workflow files (CHAOS-3401's territory).
- Did not raise `MAX_RUNS_PER_SYNC` / `MAX_ARTIFACTS_PER_RUN` / `MAX_REPORTS_PER_RUN`, or `SYNC_BUDGET_BUCKET_LIMITS`.
- `coverage_snapshots` / `/testops/coverage` remaining sparse is CHAOS-3401's territory, not a regression here.

## ⚠️ Known material limitation -- filed as CHAOS-3412 (priority 1)

**This fix makes `tests` selectable and the repair path structurally correct, but a scheduled (incremental) sync of a newly-enabled `tests` dataset on an org with a wide `initial_sync_depth` can defer forever and never actually run.** Reproduced live: this org's `initial_sync_depth=90` days pushes `tests`'s REST_CORE budget estimate (`4 × span_days` = 360) over the `SYNC_BUDGET_BUCKET_LIMITS` cap (250). Because there's no watermark yet (first-ever sync), every incremental attempt recomputes the same oversized window and gets deferred again -- and budget-guard deferrals never increment `attempts`, so the reconciler's retry-exhaustion predicate (`retry_count >= max_retries`) is unreachable by construction. There is no exit at either end. **This is not `tests`-specific**: `commit-stats` (4×) and `files` (3×) carry the same coefficients and would hit the identical wall if enabled fresh on an org like this one. CHAOS-3412 has the full mechanism. The live verification below only reached `success` by sidestepping the scheduler with an explicit, narrow-window backfill -- an operator who just flips the toggle and waits will not see the dataset populate until CHAOS-3412 lands.

## Verification (live, against local Docker -- not just unit tests)

Ran the actual admin FastAPI app in-process (unmodified production code, real dependency wiring) against the real dev Postgres/ClickHouse, dispatching onto the same Celery broker the running `dev-health-worker-1`/`dev-health-worker-heavy-1` containers consume from -- the write path and the actual GitHub sync executed for real.

| Step | Result |
| --- | --- |
| `GET /sync-targets` includes `tests` for github/gitlab | confirmed live |
| Baseline: the local GitHub integration has no `tests` `IntegrationDataset` row | confirmed |
| `PATCH /sync-configs/{id}` with `tests` added to `sync_targets` | 200; `tests` row created, `is_enabled=true` |
| Trigger a sync scoped to `dataset_keys=["tests"]` (incremental mode, no watermark yet) | 202 accepted, 4 units planned -- **all 4 permanently stuck in `retrying`** (`deferred by sync budget guard`, `attempts=0`), reproducing CHAOS-3412 live |
| A narrower, explicit 2-day backfill (`POST /integrations/{id}/backfill`) for the same dataset | 202 accepted, 4 units planned, **all 4 reached `success`** |
| `ci_job_runs` (cheapest positive control) | 28 → 989 for the org |
| `test_case_results` / `test_suite_results` | 0 → **195907** / **822** |
| `testops_test_metrics_daily` | ran `dev-hops metrics daily`; 0 → 8 rows, e.g. `total_cases=138944, pass_rate=0.9919` |
| `/testops/tests` (real browser, canonical `admin@devhealth.example` account) | renders **Pass Rate 99%, Failure Rate 0%, Flake Rate 0%, P95 Suite Duration 2.5m** -- matches ClickHouse exactly |
| `sync_watermarks` | correctly absent for the backfill-mode run (by design -- backfill never fast-forwards the incremental cursor past data it didn't cover incrementally; not a defect) |
| **Negative control** (dataset disabled → trigger) | `total_units: 0` -- confirmed live, both before and after re-enabling |

## Rebased onto two PRs that landed mid-flight

`origin/main` moved twice while this branch was in flight and includes both:
- **#1491** (CHAOS-3400, security opt-in) -- removes `_ensure_security_dataset_for_scheduled_code_host_sync` from `sync/planner.py`. This lane's round-2 fix reasons directly about `_load_enabled_datasets` in that same file, so rather than assume the rebase was mechanical, I read the merged `planner.py`: `_load_enabled_datasets` is byte-for-byte unchanged, just shifted from line 549→493 by the removed function above it. The mental model this PR's fix depends on (the planner reads `IntegrationDataset` rows shared by `integration_id`, filtered by `is_enabled` and optionally narrowed by `dataset_keys`) still holds exactly.
- **#1492** (CHAOS-3406, coverage-parser ENAMETOOLONG guard) -- unrelated file (`parsers/coverage.py`), no interaction.

Re-ran `ci/check_transitional_inventory.py` and the affected test files (199 passed) after each rebase to confirm.

## Gates

- `bash ci/local_validate.sh` -- **GATE PASSED** on the final rebased branch (ruff format/check, mypy, ClickHouse scratch-db migrate, full unit suite -- 11671 passed, live-ClickHouse argMax proof).
- Note: an unrelated, pre-existing environment issue (CHAOS-3402: direnv auto-loads a shared, non-worktree `ops/.env` into any shell regardless of `cd`, leaking ~64 vars including `DATABASE_URI`/`JWT_SECRET_KEY`) causes ~16 unrelated test failures (credential-resolver, auth-registration, org-deletion, cli-preflight) unless those vars are explicitly unset before running the gate. Confirmed those failures are pre-existing and unrelated by reproducing them on unmodified `main` and by seeing them disappear once the vars are scrubbed.

