### PR TITLE
Revert "ci: replace licensed Gitleaks action with OSS binary (#1321)"

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -125,78 +125,22 @@ jobs:
   gitleaks:
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
+    continue-on-error: true
+    # Gitleaks needs:
+    #   - security-events: write — upload SARIF findings to code-scanning
+    #   - pull-requests: write — post the scan summary comment on the PR
     permissions:
       contents: read
-      pull-requests: read
+      security-events: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Determine pull request commit range
-        id: pr-range
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          mapfile -t commits < <(
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" \
-              --jq '.[].sha'
-          )
-          if (( ${#commits[@]} == 0 )); then
-            echo "::error::The pull request has no commits to scan"
-            exit 1
-          fi
-          printf 'base=%s\nhead=%s\n' \
-            "${commits[0]}" "${commits[${#commits[@]}-1]}" >> "$GITHUB_OUTPUT"
-
-      - name: Install Gitleaks
-        env:
-          GITLEAKS_VERSION: "8.24.3"
-        run: |
-          set -euo pipefail
-          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          release_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
-          curl --fail --silent --show-error --location \
-            "${release_url}/${archive}" \
-            --output "$RUNNER_TEMP/$archive"
-          curl --fail --silent --show-error --location \
-            "${release_url}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
-            --output "$RUNNER_TEMP/checksums.txt"
-          (
-            cd "$RUNNER_TEMP"
-            sha256sum --ignore-missing --check --strict checksums.txt
-          )
-          tar --extract --gzip --file "$RUNNER_TEMP/$archive" \
-            --directory "$RUNNER_TEMP" gitleaks
-          chmod +x "$RUNNER_TEMP/gitleaks"
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-          "$RUNNER_TEMP/gitleaks" version
-
       - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
-          BASE_REF: ${{ steps.pr-range.outputs.base }}
-          HEAD_REF: ${{ steps.pr-range.outputs.head }}
-        run: |
-          set -euo pipefail
-          gitleaks detect \
-            --redact \
-            -v \
-            --exit-code=2 \
-            --report-format=sarif \
-            --report-path=results.sarif \
-            --log-level=debug \
-            --gitleaks-ignore-path=. \
-            --log-opts="--no-merges --first-parent ${BASE_REF}^..${HEAD_REF}"
-
-      - name: Upload Gitleaks SARIF
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: gitleaks-results.sarif
-          path: results.sarif
-          if-no-files-found: ignore
-          retention-days: 30
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
#1321 replaced the org-licensed gitleaks-action with an OSS binary invocation whose commit-range step only works on pull_request events. On push to main, `github.event.pull_request.number` is empty, so BASE_REF/HEAD_REF resolve to literal `{`/`}` and the scan hard-fails — first failing run: https://github.com/full-chaos/dev-health-ops/actions/runs/31021224285 (main @ 6e84a9daa).

Straight revert back to the org-scoped `gitleaks/gitleaks-action@v3` with `GITLEAKS_LICENSE`, restoring the previously green behavior on both PR and push events.