### PR TITLE
CHAOS-3419: fix GitLab CI + docs Python-version gaps left by #1499

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ variables:
 
 pipeline:validate:
   stage: lint
-  image: python:3.12
+  image: python:3.14
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_PIPELINE_SOURCE == "merge_train"
@@ -121,7 +121,7 @@ pipeline:validate:
 lint:
   extends: .python_job
   stage: lint
-  image: python:3.12
+  image: python:3.14
   rules: &code_rules
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -149,7 +149,7 @@ lint:
 typecheck:mypy:
   extends: .python_job
   stage: lint
-  image: python:3.12
+  image: python:3.14
   rules: *code_rules
   script:
     - mypy --install-types --non-interactive .
@@ -162,7 +162,7 @@ test:
   rules: *code_rules
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.14"]
   services:
     - name: postgres:17.4
       alias: postgres
@@ -208,11 +208,12 @@ test:
 # threshold + integration/e2e). Kept OFF the per-MR critical path: runs on the
 # merge train (before code reaches the default branch) and on the default
 # branch (post-merge verification), never on a plain merge_request_event.
-# Reassigned from the retired 3.11 leg to 3.12 and parallelized (CHAOS-2586).
+# Reassigned from the retired 3.11 leg to 3.12 and parallelized (CHAOS-2586);
+# moved to 3.14 to match the shipped interpreter (CHAOS-3419).
 coverage:
   extends: .python_job
   stage: test
-  image: python:3.12
+  image: python:3.14
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "merge_train"
@@ -248,7 +249,7 @@ coverage:
     - mkdir -p test-results/logs
     - |
       set -o pipefail
-      ./ci/run_tests.sh ci 2>&1 | tee "test-results/logs/ci-3.12.log"
+      ./ci/run_tests.sh ci 2>&1 | tee "test-results/logs/ci-3.14.log"
   artifacts:
     when: always
     expire_in: 14 days
@@ -324,7 +325,7 @@ live-e2e:
 
 security:pip-audit:
   stage: security
-  image: python:3.12
+  image: python:3.14
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/docs/contribute/start/development-environment.md
+++ b/docs/contribute/start/development-environment.md
@@ -22,7 +22,7 @@ Use this guide for a source checkout. Production configuration, secrets, sizing,
 
 ## Prerequisites
 
-- Python 3.12 or newer. The project currently declares support for Python 3.12, 3.13, and 3.14.
+- Python 3.14. The project declares `requires-python = ">=3.14"` and containers ship 3.14 (`docker/Dockerfile`); older interpreters are not tested (CHAOS-3419).
 - Docker with Compose.
 - Git.
 - A supported Node.js release only when the change touches JavaScript tooling, Wrangler, or a related frontend repository.
@@ -35,7 +35,7 @@ Read the root `AGENTS.md` and the nearest directory-level contributor guidance b
 git clone https://github.com/full-chaos/dev-health-ops.git
 cd dev-health-ops
 
-python3.12 -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e '.[dev]'

--- a/tests/compatibility/river/README.md
+++ b/tests/compatibility/river/README.md
@@ -19,31 +19,41 @@ touch the repository's development PostgreSQL or ClickHouse data.
 - a Go installation with automatic toolchain selection enabled; the runner
   builds both CLIs with and asserts the exact candidate runtime Go 1.25.9;
 - `jq`;
-- the repository virtual environment synchronized with the locked dev
-  dependencies on Python 3.13.14, including `riverqueue`, SQLAlchemy, and
-  `asyncpg`.
+- a standalone Python 3.13.14 environment with `riverqueue`, SQLAlchemy, and
+  `asyncpg` installed at the exact versions below. This is intentionally
+  independent of the repository's own virtual environment: the main project
+  now requires Python >=3.14 (CHAOS-3419), so `.venv` at the repo root is a
+  3.14 interpreter and `uv sync` against the repository lock can no longer
+  produce a 3.13.14 one. river-compatibility is a Phase 0 probe for a
+  *rejected* production option, pinned to the last interpreter it was proven
+  against; it is not expected to track the project's floor.
 
-Prepare that exact interpreter and frozen environment with:
+Prepare that exact interpreter and environment with:
 
 ```bash
 uv python install 3.13.14
-uv sync --python 3.13.14 --frozen --all-extras --dev
+uv venv --python 3.13.14 .venv-river-compat
+uv pip install --python .venv-river-compat/bin/python \
+  asyncpg==0.31.0 riverqueue==0.7.0 SQLAlchemy==2.0.49
 ```
 
-The runner fails closed if the Python patch version or the pinned
-`riverqueue`, SQLAlchemy, or `asyncpg` versions drift.
+(matches the pinned dependency install in `.github/workflows/go.yml`'s
+`river-compatibility` job). The runner fails closed if the Python patch
+version or the pinned `riverqueue`, SQLAlchemy, or `asyncpg` versions drift.
 
-The default Python executable is `.venv/bin/python`. Set
-`RIVER_COMPAT_PYTHON` to another fully prepared Python executable when the
-virtual environment lives elsewhere. The runner does not install or download
-Python dependencies.
+The default Python executable is `.venv/bin/python` at the repo root, which
+is now a 3.14 interpreter and will fail the runner's version check. Set
+`RIVER_COMPAT_PYTHON` to the standalone environment prepared above, e.g.
+`RIVER_COMPAT_PYTHON=$(pwd)/.venv-river-compat/bin/python`. The runner does
+not install or download Python dependencies.
 
 ## Run
 
 From the `dev-health-ops` repository root:
 
 ```bash
-tests/compatibility/river/run.sh > "${TMPDIR:-/tmp}/river-compat-result.json"
+RIVER_COMPAT_PYTHON=$(pwd)/.venv-river-compat/bin/python \
+  tests/compatibility/river/run.sh > "${TMPDIR:-/tmp}/river-compat-result.json"
 ```
 
 Stdout contains exactly one combined, sanitized JSON document after every


### PR DESCRIPTION
## Summary

Fast-follow to #1499. #1499 was merged by the repo owner while a Codex adversarial review (run against its pushed branch) was still turning up findings — the review's fixes were reported and pushed only minutes after the merge, so they missed it and never reached `main`. This PR lands them directly against `main`.

**Was live on `main`** (now fixed by this PR): `requires-python = ">=3.14"` landed via #1499, but `.gitlab-ci.yml` still ran `pipeline:validate`/`lint`/`typecheck:mypy`/`coverage`/`security:pip-audit` on `python:3.12` and `test` on a 3.12/3.13/3.14 matrix. Since `requirements.txt` installs `-e .[dev]`, every one of those GitLab jobs would fail `pip install` on the incompatible interpreter.

**This is more than a would-have-broken-CI catch.** Confirmed with the operator: `.gitlab-ci.yml` is the **disaster-recovery pipeline** — the fallback for when GitHub is down. So this divergence wasn't a stale duplicate; it was the fallback silently broken, the kind of break that surfaces during a GitHub outage, exactly when there's no capacity to debug it.

It also explains why nobody caught the drift: `.gitlab-ci.yml`'s own `pipeline:validate` job, which prints "GitLab pipeline parity jobs are present," reads **its own file** and greps for eleven job names — it never opens `.github/workflows/` to compare against. It would pass with every job body empty, and it passed for the entire period the two pipelines ran different Python versions. Filed as **CHAOS-3426** to replace it with a real cross-file check, with the acceptance criterion that the replacement must be observed *failing* against the pre-this-PR tree (a free test case with a known-correct answer).

## Changes (cherry-picked verbatim from the #1499 branch, already gated clean there before this PR existed)

- **`.gitlab-ci.yml`** [finding 1 of 3, high — DR pipeline, see above]: an active parity pipeline mirroring `.github/workflows/{lint,typecheck,test,security-scan}.yml` exactly, including its own (as it turns out, non-functional) "GitLab pipeline parity jobs" self-check — outside the original CHAOS-3419 inventory, which only enumerated `.github/workflows/`. Applied the identical fix as the GitHub sweep: every bare `python:3.12` image bumped to `3.14`, test matrix collapsed to `["3.14"]`, coverage log renamed `ci-3.12.log` → `ci-3.14.log`. `integration`/`live-e2e` were already `3.14`, left alone.
- **`docs/contribute/start/development-environment.md`** [finding 2 of 3, medium]: told contributors to create a Python 3.12 venv and declared support for 3.12/3.13/3.14 — now guaranteed to fail at `pip install -e .[dev]`. Updated to 3.14.
- **`tests/compatibility/river/README.md`** [finding 3 of 3, medium]: documented preparing the river-compat harness's pinned Python 3.13.14 via `uv sync --python 3.13.14 --frozen --all-extras --dev` against the main project lock. Verified live this now hard-fails (`resolved to Python 3.13.14, which is incompatible with the project's Python requirement: >=3.14`). That command was always slightly inconsistent with what `go.yml`'s `river-compatibility` job actually does (three pinned `pip install`s, no project lock at all, kept deliberately at 3.13.14 — see #1499's reasoning); the `requires-python` bump converted a latent inconsistency into a hard failure rather than creating a new one. Rewrote the prep steps to build an independent `uv venv` + `uv pip install` of the same three pinned packages the CI job installs, decoupled from the main project lock, and pointed `RIVER_COMPAT_PYTHON` at it explicitly since the repo-root `.venv` is now a 3.14 interpreter. Verified live: the standalone venv builds, installs cleanly, and reports `platform.python_version() == 3.13.14`, matching `run.sh`'s hardcoded assertion.

## Verification

- `bash ci/local_validate.sh`: lint/mypy/ch-migrate pass; unit suite failures (11) match the pre-existing CHAOS-3402/3405-class ambient-env baseline exactly (confirmed via a clean-`origin/main` control run in #1499) — this diff touches no Python source, so no new failures are possible here.
- **Matrix negative control**, re-confirmed on this PR's own real run (not inherited from #1499): `gh run view` on the pushed branch's "Tests" workflow shows `changes ✓`, `test-matrix (3.14) ✓`, `coverage` skipped (correct — pull_request, not merge_group/push), `test ✓`. No 3.12/3.13 jobs.
- All CI checks green on this PR: Build Docker images, Governance Gate, Docs Cloudflare, Docs Guards, Security Scan, Lint, Live Backend E2E, Typecheck, CodeQL, Tests.
- Live-tested the river-compat venv build/install/version-check by hand (see commit message).
- Post-merge: verified `main` has zero `image: python:3.12` occurrences remaining in `.gitlab-ci.yml`.
