### PR TITLE
CHAOS-3408/3409/3421: honest readiness denominators, zero-denominator copy, graceful bare-name leak routing

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
+        "sha256": "7e596208a1c2711a4d6b7d2e6ba202b971a1ae8eae0af215e06aa01511f3e07e"
       },
       "schema_version": "dev_tool_result.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -102,6 +102,11 @@
           "title": "Required Children",
           "type": "array"
         },
+        "required_children_not_applicable": {
+          "default": false,
+          "title": "Required Children Not Applicable",
+          "type": "boolean"
+        },
         "rule_id": {
           "maxLength": 128,
           "minLength": 1,

--- a/scripts/acceptance/wave31_manifest.py
+++ b/scripts/acceptance/wave31_manifest.py
@@ -1871,6 +1871,140 @@ def _mutation_proofs() -> tuple[ManifestItem, ...]:
     )
 
 
+def _readiness_and_resolution_safety_defects() -> tuple[ManifestItem, ...]:
+    """CHAOS-3408/3409/3421: the live "org-pinned wrong-subject + 0-of-0
+    readiness answer" investigation's three closed defects, each a codex
+    adversarial-review-prescribed fix over its own initial round (not
+    reviewer-prescribed fixes in the same sense as an ordinary review
+    round -- this is a genuinely new changeset with its own review).
+
+    Codex adversarial review finding (MED-2, confirmed): the initial cut of
+    these three fixes had NO manifest entries at all -- the readiness
+    report's executed-evidence set never touched them, so removing any of
+    the new guards (the explicit ``required_children_not_applicable``
+    field, the dedicated prompt branch, the leak-scan reroute) would leave
+    the report green. These three rows close that gap.
+    """
+
+    return (
+        ManifestItem(
+            id="defect.organization-readiness-honest-denominator",
+            category="readiness_and_resolution_safety_defect_reproduction",
+            description=(
+                "CHAOS-3408/3409: an ORGANIZATION/TEAM-scoped readiness "
+                "question must never report a fabricated '0 of 0 required "
+                "items are complete' -- the denominator is withheld via an "
+                "explicit, non-inferred signal (never conflated with a "
+                "genuine source truncation), and the real production "
+                "render/validation wiring (not just an isolated renderer "
+                "call) must render the distinct structural copy without "
+                "pairing it with the truncation disclosure."
+            ),
+            status="proven_unit",
+            evidence=(
+                "src/dev_health_ops/api/dev/status_change_service.py",
+                "src/dev_health_ops/api/dev/status_completion_copy.py",
+                "src/dev_health_ops/api/dev/status_answer_render.py",
+                "src/dev_health_ops/api/dev/contracts.py",
+                "src/dev_health_ops/api/dev/production_runtime.py",
+                "tests/api/dev/test_status_change_service.py",
+                "tests/api/dev/test_status_completion_copy.py",
+                "tests/api/dev/test_chaos_3377_status_answer_render.py",
+            ),
+            content_markers=("required_children_not_applicable",),
+            test_nodeids=(
+                "tests/api/dev/test_status_change_service.py::"
+                "test_organization_and_team_scope_withhold_the_required_child_denominator[_org_scope]",
+                "tests/api/dev/test_status_change_service.py::"
+                "test_organization_and_team_scope_withhold_the_required_child_denominator[_team_scope]",
+                "tests/api/dev/test_status_change_service.py::"
+                "test_project_scope_with_genuinely_zero_required_children_is_a_real_zero",
+                "tests/api/dev/test_status_completion_copy.py::"
+                "test_structural_non_applicability_is_trustworthy_not_untrustworthy",
+                "tests/api/dev/test_status_completion_copy.py::"
+                "test_a_genuine_source_truncation_is_untrustworthy",
+                "tests/api/dev/test_chaos_3377_status_answer_render.py::"
+                "test_production_wiring_never_pairs_the_scope_copy_with_the_truncation_disclosure",
+                "tests/api/dev/test_chaos_3377_status_answer_render.py::"
+                "test_production_wiring_still_discloses_a_genuine_truncation",
+            ),
+        ),
+        ManifestItem(
+            id="defect.bare-name-prompt-allowlist-consistency",
+            category="readiness_and_resolution_safety_defect_reproduction",
+            description=(
+                "CHAOS-3421 MED-1: the unresolved-bare-name organization-"
+                "wide-fallback preflight branch withholds resolve_scope.v1 "
+                "from allowed_tools, so the composed prompt must never "
+                "instruct the model to call it -- a dedicated prompt "
+                "section states resolution is unavailable and names the "
+                "permitted (organization-wide) fallback instead, and the "
+                "advertised tool registry and the prompt copy are proven "
+                "to agree, not merely asserted to."
+            ),
+            status="proven_unit",
+            evidence=(
+                "src/dev_health_ops/api/dev/prompts/composer.py",
+                "src/dev_health_ops/api/dev/subject_preflight.py",
+                "src/dev_health_ops/api/dev/orchestrator.py",
+                "tests/api/dev/test_prompt_composer.py",
+                "tests/api/dev/test_chaos_3292_review_findings.py",
+                "tests/api/dev/test_subject_preflight.py",
+            ),
+            content_markers=("resolution_unavailable",),
+            test_nodeids=(
+                "tests/api/dev/test_prompt_composer.py::"
+                "test_resolution_unavailable_never_instructs_calling_the_withheld_tool",
+                "tests/api/dev/test_prompt_composer.py::"
+                "test_resolution_unavailable_false_is_the_ordinary_uncommitted_section",
+                "tests/api/dev/test_prompt_composer.py::"
+                "test_subject_committed_wins_over_resolution_unavailable",
+                "tests/api/dev/test_chaos_3292_review_findings.py::"
+                "test_an_unresolved_bare_name_run_keeps_the_v1_prompt",
+                "tests/api/dev/test_chaos_3292_review_findings.py::"
+                "test_an_unresolved_bare_name_run_gets_a_dedicated_unavailable_section",
+                "tests/api/dev/test_subject_preflight.py::"
+                "test_an_unresolved_bare_name_withholds_resolve_scope",
+            ),
+        ),
+        ManifestItem(
+            id="defect.bare-name-leak-graceful-terminal",
+            category="readiness_and_resolution_safety_defect_reproduction",
+            description=(
+                "CHAOS-3421: a model that leaks the raw forbidden_or_"
+                "not_found outcome token (what resolve_scope.v1 returns "
+                "for a named subject the catalog cannot confirm) on the "
+                "organization-wide-fallback path must never fail the run "
+                "closed to a generic internal_error -- the leak scan "
+                "reroutes to the SAME graceful scope_not_found terminal "
+                "the legacy narration guard already ships for this exact "
+                "scenario class, reusing its copy verbatim rather than "
+                "forcing the stricter FORBIDDEN_OR_NOT_FOUND no-match "
+                "terminal open. Replicated directly against the real live-"
+                "incident question shape and the real CHAOS-3388 fixture "
+                "entity, with subject matching (CHAOS-3407) deliberately "
+                "left unfixed -- the run still misses, but never crashes."
+            ),
+            status="proven_unit",
+            evidence=(
+                "src/dev_health_ops/api/dev/orchestrator.py",
+                "src/dev_health_ops/api/dev/subject_preflight.py",
+                "src/dev_health_ops/api/dev/no_match_terminal.py",
+                "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py",
+            ),
+            content_markers=("legacy_guard_required", "scope_not_found"),
+            test_nodeids=(
+                "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::"
+                "test_a_leaked_resolution_outcome_on_a_bare_name_fallback_is_graceful",
+                "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::"
+                "test_an_unrelated_leak_off_this_branch_still_fails_closed",
+                "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::"
+                "test_the_live_incident_question_never_crashes_even_though_it_still_misses",
+            ),
+        ),
+    )
+
+
 def _build_manifest() -> tuple[ManifestItem, ...]:
     return (
         _core_defect_reproductions()
@@ -1880,6 +2014,7 @@ def _build_manifest() -> tuple[ManifestItem, ...]:
         + _blocking_matrix_blocked()
         + _gates()
         + _mutation_proofs()
+        + _readiness_and_resolution_safety_defects()
     )
 
 

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -963,6 +963,21 @@ class DevActualCompletion(ContractModel):
     # consumer applies its own openness predicate rather than trusting one
     # it cannot verify.
     blockers: list[DevRequiredChildFact] = Field(default_factory=list, max_length=100)
+    # CHAOS-3409 codex adversarial review (HIGH): a withheld
+    # (``required_child_total is None``) denominator has two structurally
+    # distinct causes -- a genuine source truncation (real required items
+    # exist, not all were fetched) and CHAOS-3408's structural non-
+    # applicability (ORGANIZATION/TEAM scope has no required-child concept
+    # at all) -- and reason_codes cannot safely carry that distinction: any
+    # new code added there becomes an "unknown reason" that forces
+    # ``state`` to INDETERMINATE (status_change_service._assess), which is
+    # correct for a real truncation but WRONG for a structural absence
+    # (the state/reason codes ARE fully real there; only the required-
+    # child count is inapplicable). This is therefore its own, inert
+    # field: never read by ``_assess``'s state computation, only by
+    # ``is_completion_assessment_untrustworthy``/``render_verdict_summary``
+    # to choose the correct copy without conflating the two.
+    required_children_not_applicable: bool = False
 
     @model_validator(mode="after")
     def validate_required_child_counts(self) -> Self:

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -920,15 +920,46 @@ class DevOrchestrator:
                     token=leaked_token,
                     terminal_kind=terminal_kind,
                 ).inc()
-                state = RunState.FAILED
                 answer = None
-                error = DevError(
-                    schema_version="dev_error.v1",
-                    request_id=request.request_id,
-                    code="internal_error",
-                    safe_message="The request could not be completed.",
-                    retryable=False,
-                )
+                # CHAOS-3421: a leak on the ONE preflight branch that sets
+                # `legacy_guard_required` (subject_preflight's
+                # `unresolved_untyped` -> `proceeded_unresolved_bare_name`,
+                # an intentional, disclosed organization-wide fallback for a
+                # named subject the catalog could not confirm) is not a
+                # producer defect to hide behind a generic, opaque
+                # `internal_error` -- it is very often exactly the model
+                # echoing the raw `forbidden_or_not_found` outcome
+                # `resolve_scope.v1` returned for that same unresolved name
+                # (live incident). That run was always heading toward the
+                # legacy guard's own `resolve_scope_not_found` terminal
+                # (`_LEGACY_GUARD_TERMINALS`) -- reachable today only when
+                # the model's prose happens to NARRATE the unresolved name
+                # (`_legacy_named_entity_guard_reason`'s own text-similarity
+                # check), not when it leaks the raw outcome token instead.
+                # This closes that gap at the one shared choke-point every
+                # terminal passes through, rather than trying to anticipate
+                # every shape a leak on this branch could take.
+                if (
+                    preflight_result is not None
+                    and preflight_result.legacy_guard_required
+                ):
+                    state = RunState.INSUFFICIENT_EVIDENCE
+                    error = DevError(
+                        schema_version="dev_error.v1",
+                        request_id=request.request_id,
+                        code="scope_not_found",
+                        safe_message="The requested scope was not found.",
+                        retryable=False,
+                    )
+                else:
+                    state = RunState.FAILED
+                    error = DevError(
+                        schema_version="dev_error.v1",
+                        request_id=request.request_id,
+                        code="internal_error",
+                        safe_message="The request could not be completed.",
+                        retryable=False,
+                    )
             # CHAOS-3297 Codex review round 3 Finding 2: materialize and
             # validate the terminal error input before any record_*() write
             # is attempted -- not after answer/frame are already flushed on

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1639,6 +1639,16 @@ class DevOrchestrator:
                             preflight_result is not None
                             and preflight_result.has_committed_subject
                         ),
+                        # CHAOS-3421 codex adversarial review (MED-1): the
+                        # ONE preflight branch that sets legacy_guard_required
+                        # (subject_preflight's proceeded_unresolved_bare_name)
+                        # withholds resolve_scope.v1 from allowed_tools -- the
+                        # prompt must say so, never instruct the model to
+                        # call a tool the registry will reject.
+                        resolution_unavailable=(
+                            preflight_result is not None
+                            and preflight_result.legacy_guard_required
+                        ),
                     )
                 except ValueError as exc:
                     # A synthetic repair turn (CHAOS-3288) added on top of an

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -2035,6 +2035,13 @@ async def _assemble_production_runtime(
             conflicts=conflicts,
             evidence_ref_ids=aggregate_evidence_ids,
             blockers=blockers,
+            # CHAOS-3409: threads the domain object's own structural-vs-
+            # truncation signal onto the wire, so status_answer_render/
+            # status_completion_copy see the SAME distinction the real
+            # assessment computed, not a re-derived guess.
+            required_children_not_applicable=(
+                result.actual.required_children_not_applicable
+            ),
         )
         source_health = [
             DevSourceHealth(

--- a/src/dev_health_ops/api/dev/prompts/composer.py
+++ b/src/dev_health_ops/api/dev/prompts/composer.py
@@ -74,6 +74,33 @@ _COMMITTED_SUBJECT_SECTION = (
     "unavailable for this run.",
 )
 
+# CHAOS-3421 codex adversarial review (MED-1): a THIRD, distinct state from
+# the two above -- the server named a subject in the question but could NOT
+# confirm it against the authorized catalog (subject_preflight's
+# unresolved_untyped -> proceeded_unresolved_bare_name: a bare name with no
+# adjacent kind noun, or one the catalog does not confirm). That branch
+# withholds resolve_scope.v1 from allowed_tools -- the SAME leak-closing
+# reasoning the committed-subject branch already uses (its own resolve_scope
+# call could only ever repeat the identical failed lookup and surface the
+# raw forbidden_or_not_found outcome for the model to echo). The ordinary
+# _UNCOMMITTED_SUBJECT_SECTION instructing "call resolve_scope.v1" would
+# therefore be actively wrong here -- a compliant model's call is rejected
+# by the registry as unavailable, burning a tool turn on a request that can
+# never succeed. This section says so explicitly and names the permitted
+# fallback (answer organization-wide with the tools actually listed),
+# rather than leaving the model to discover the missing tool by trial and
+# error.
+_RESOLUTION_UNAVAILABLE_SECTION = (
+    "named_entity_resolution_unavailable",
+    "The server could not confirm a specific project, repository, issue, pull request, "
+    "or work unit named in this question against the authorized catalog. "
+    "resolve_scope.v1 is unavailable for this request -- do not request it. Answer "
+    "organization-wide instead, using only the tools this prompt lists, and never "
+    "present an answer that describes or attributes findings to the named entity as "
+    "though it were confirmed; say plainly that it could not be confirmed if the "
+    "question depends on it.",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class PromptConversationTurn:
@@ -107,6 +134,7 @@ class PromptComposer:
         tool_results: tuple[DevToolResult, ...] = (),
         allowed_tools: Collection[ToolID] | None = None,
         subject_committed: bool = False,
+        resolution_unavailable: bool = False,
     ) -> ComposedPrompt:
         if not question.strip():
             raise ValueError("question is required")
@@ -129,11 +157,19 @@ class PromptComposer:
             raise ValueError("tool context exceeds prompt budget")
 
         version = PROMPT_VERSION if subject_committed else LEGACY_PROMPT_VERSION
-        subject_section = (
-            _COMMITTED_SUBJECT_SECTION
-            if subject_committed
-            else _UNCOMMITTED_SUBJECT_SECTION
-        )
+        # CHAOS-3421 codex adversarial review (MED-1): resolution_unavailable
+        # is checked before the ordinary uncommitted branch -- both leave
+        # subject_committed False (this flow never commits a subject), but
+        # the ordinary section's "call resolve_scope.v1" instruction would be
+        # actively wrong here, since that exact tool is withheld from
+        # allowed_tools for this flow (see _RESOLUTION_UNAVAILABLE_SECTION's
+        # own comment for why).
+        if subject_committed:
+            subject_section = _COMMITTED_SUBJECT_SECTION
+        elif resolution_unavailable:
+            subject_section = _RESOLUTION_UNAVAILABLE_SECTION
+        else:
+            subject_section = _UNCOMMITTED_SUBJECT_SECTION
         system_payload = {
             "prompt_version": version,
             "policy_sections": [

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -70,6 +70,7 @@ from .status_completion_copy import (
 
 __all__ = [
     "DISPLAY_TRUNCATED_DISCLOSURE",
+    "NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE",
     "build_deterministic_status_claims",
     "deterministic_answer_status",
     "open_blockers",
@@ -170,6 +171,29 @@ DISPLAY_TRUNCATED_DISCLOSURE = (
     "more than this answer's display limit"
 )
 
+#: CHAOS-3409: a withheld denominator (``required_child_total is None``) has
+#: two structurally distinct causes, and rendering them identically to a
+#: source truncation is actively misleading -- ``status_change_service``
+#: withholds ORGANIZATION/TEAM's denominator (CHAOS-3408) because the
+#: required-child concept has no single declared/children completion tree
+#: for those scopes AT ALL, never because real required items exist but
+#: were not all fetched. "No required items are recorded for this scope"
+#: says exactly that, and is deliberately never combined with the N-of-M
+#: numeric claim (there is no real denominator to cite) or with
+#: ``INCOMPLETE_DENOMINATOR_DISCLOSURE`` (that sentence claims a
+#: verification attempt was made and came up short, which is not true
+#: here).
+NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE = "No required items are recorded for this scope."
+
+#: Reason codes that, when present alongside a withheld
+#: (``required_child_total is None``) denominator, mean the withholding is a
+#: genuine source TRUNCATION -- real required items exist and were not all
+#: fetched -- rather than CHAOS-3408's structural non-applicability. Kept as
+#: an explicit closed set (not "any reason code at all") so a future
+#: unrelated reason code co-occurring with a withheld denominator can never
+#: silently suppress the scope-not-applicable copy by accident.
+_DENOMINATOR_TRUNCATION_REASON_CODES = frozenset({"assessment_source_limit_reached"})
+
 
 def render_verdict_summary(
     actual: DevActualCompletion, *, denominator_withheld: bool = False
@@ -193,6 +217,13 @@ def render_verdict_summary(
     disclosure for a DIFFERENT truncation: not a withheld denominator, but a
     real denominator whose full required-item/blocker LIST does not fit in
     one display page (CHAOS-3377 hotfix).
+
+    CHAOS-3409: ``actual.required_child_total is None`` with none of
+    ``_DENOMINATOR_TRUNCATION_REASON_CODES`` present is CHAOS-3408's
+    structural-non-applicability flavor (ORGANIZATION/TEAM scope) -- this
+    gets ``NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE`` instead of a numeric N-of-M
+    claim, computed purely from ``actual``'s own fields (never requires the
+    caller to also pass ``denominator_withheld`` correctly).
     """
 
     parts = [translate_completion_state(actual.state)]
@@ -204,6 +235,10 @@ def render_verdict_summary(
             f"{actual.required_child_complete} of {actual.required_child_total} "
             "required items are complete."
         )
+    elif actual.required_child_total is None and not (
+        _DENOMINATOR_TRUNCATION_REASON_CODES & set(actual.reason_codes)
+    ):
+        parts.append(NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE)
     seen: set[str] = set()
     reasons: list[str] = []
     for code in actual.reason_codes:

--- a/src/dev_health_ops/api/dev/status_answer_render.py
+++ b/src/dev_health_ops/api/dev/status_answer_render.py
@@ -185,15 +185,6 @@ DISPLAY_TRUNCATED_DISCLOSURE = (
 #: here).
 NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE = "No required items are recorded for this scope."
 
-#: Reason codes that, when present alongside a withheld
-#: (``required_child_total is None``) denominator, mean the withholding is a
-#: genuine source TRUNCATION -- real required items exist and were not all
-#: fetched -- rather than CHAOS-3408's structural non-applicability. Kept as
-#: an explicit closed set (not "any reason code at all") so a future
-#: unrelated reason code co-occurring with a withheld denominator can never
-#: silently suppress the scope-not-applicable copy by accident.
-_DENOMINATOR_TRUNCATION_REASON_CODES = frozenset({"assessment_source_limit_reached"})
-
 
 def render_verdict_summary(
     actual: DevActualCompletion, *, denominator_withheld: bool = False
@@ -218,12 +209,20 @@ def render_verdict_summary(
     real denominator whose full required-item/blocker LIST does not fit in
     one display page (CHAOS-3377 hotfix).
 
-    CHAOS-3409: ``actual.required_child_total is None`` with none of
-    ``_DENOMINATOR_TRUNCATION_REASON_CODES`` present is CHAOS-3408's
-    structural-non-applicability flavor (ORGANIZATION/TEAM scope) -- this
-    gets ``NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE`` instead of a numeric N-of-M
-    claim, computed purely from ``actual``'s own fields (never requires the
-    caller to also pass ``denominator_withheld`` correctly).
+    CHAOS-3409 (codex adversarial review, HIGH: the ORIGINAL version of
+    this inferred the structural flavor from reason-code ABSENCE, which
+    missed that the production ``denominator_withheld`` wiring -- driven by
+    ``is_completion_assessment_untrustworthy``, which used to treat every
+    withheld total identically -- paired this copy with the truncation
+    disclosure below on the real orchestrator path): ``actual.
+    required_children_not_applicable`` is CHAOS-3408's own EXPLICIT signal
+    for the structural-non-applicability flavor (ORGANIZATION/TEAM scope)
+    -- this gets ``NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE`` instead of a
+    numeric N-of-M claim, computed purely from ``actual``'s own fields
+    (never requires the caller to also pass ``denominator_withheld``
+    correctly, and -- now that ``is_completion_assessment_untrustworthy``
+    also reads this same field -- never co-occurs with the truncation
+    disclosure below for this flavor).
     """
 
     parts = [translate_completion_state(actual.state)]
@@ -235,8 +234,8 @@ def render_verdict_summary(
             f"{actual.required_child_complete} of {actual.required_child_total} "
             "required items are complete."
         )
-    elif actual.required_child_total is None and not (
-        _DENOMINATOR_TRUNCATION_REASON_CODES & set(actual.reason_codes)
+    elif (
+        actual.required_child_total is None and actual.required_children_not_applicable
     ):
         parts.append(NO_REQUIRED_ITEMS_RECORDED_FOR_SCOPE)
     seen: set[str] = set()

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -298,6 +298,18 @@ class ActualCompletion:
     # so the ~10 existing direct-construction call sites across the test
     # suite (predating this field) do not have to be touched.
     blockers: tuple[StatusFact, ...] = ()
+    # CHAOS-3409 codex adversarial review (HIGH): distinguishes CHAOS-3408's
+    # structural non-applicability (ORGANIZATION/TEAM scope) from a genuine
+    # required_child_total-withholding source truncation -- both null out
+    # required_child_total/complete identically, but only a real truncation
+    # is "untrustworthy" (is_completion_assessment_untrustworthy,
+    # status_completion_copy.py). Deliberately NOT a reason code: reasons
+    # feeds state computation (any code not in contradiction_codes forces
+    # CompletionState.INDETERMINATE), and a structural absence must never
+    # do that -- the state/reason codes computed from real PR/CI/deployment/
+    # incident evidence for an org/team subject are fully trustworthy on
+    # their own.
+    required_children_not_applicable: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -1058,6 +1070,12 @@ class StatusChangeService:
             source_ref_ids=used_source_ids,
             evidence_ref_ids=self._fact_evidence(raw),
             blockers=blockers,
+            # CHAOS-3409: True ONLY for the structural flavor -- never set
+            # merely because the total is None, and never set for a real
+            # source truncation (children_source_truncated).
+            required_children_not_applicable=(
+                not required_children_applicable and not children_source_truncated
+            ),
         )
 
     @staticmethod

--- a/src/dev_health_ops/api/dev/status_change_service.py
+++ b/src/dev_health_ops/api/dev/status_change_service.py
@@ -601,6 +601,12 @@ class StatusChangeService:
                 DirectScope.WORK_UNIT,
                 DirectScope.PULL_REQUEST,
             },
+            # CHAOS-3408: ORGANIZATION/TEAM have no single declared/children
+            # completion tree (native_status_change.TEAM_NOT_APPLICABLE_
+            # SOURCES) -- withhold the denominator rather than report the
+            # structurally-empty ``raw.children`` as a real zero.
+            required_children_applicable=request.scope.direct_scope
+            not in {DirectScope.ORGANIZATION, DirectScope.TEAM},
         )
         actual = replace(
             actual,
@@ -861,6 +867,25 @@ class StatusChangeService:
         *,
         assessment_source_limit_reached: bool = False,
         children_source_truncated: bool = False,
+        # CHAOS-3408: an ORGANIZATION or TEAM subject has no single
+        # declared/children completion tree at all -- a deliberate,
+        # structural design (native_status_change.TEAM_NOT_APPLICABLE_
+        # SOURCES: "_WORK_ITEMS_SQL produces a single declared/children
+        # completion tree ... neither concept maps onto a team cohort of
+        # repositories"), never a data gap -- so ``raw.children`` is always
+        # empty for these two scopes. Left at the default ``True``
+        # (applicable), that structural absence and a genuinely-computed
+        # real zero were indistinguishable: both produced
+        # ``required_child_total = len(()) = 0``, a fabricated-looking
+        # "0 of 0 required items are complete" for every org-wide/team-wide
+        # readiness question (the live incident this closes). ``False``
+        # withholds the denominator exactly like ``children_source_
+        # truncated`` does -- but WITHOUT the ``assessment_source_limit_
+        # reached`` reason code that truncation carries, so a consumer
+        # (``status_answer_render.render_verdict_summary``) can render a
+        # distinct, honest "not applicable to this scope" copy instead of
+        # the truncation-specific disclosure (CHAOS-3409).
+        required_children_applicable: bool = True,
         declared_optional: bool = False,
         release_evidence_required: bool = False,
     ) -> ActualCompletion:
@@ -1007,10 +1032,14 @@ class StatusChangeService:
         # (``None``, never a fabricated count) when the required-child
         # source itself was truncated -- an honest "unknown" beats a
         # count that looks complete only because the omitted children
-        # were never fetched.
+        # were never fetched -- OR (CHAOS-3408) when the required-child
+        # concept is not applicable to this scope at all (ORGANIZATION/
+        # TEAM), which is structurally identical to truncation from this
+        # count's own point of view: either way, ``0`` would be a claim
+        # about data that was never real.
         required_child_total: int | None
         required_child_complete: int | None
-        if children_source_truncated:
+        if children_source_truncated or not required_children_applicable:
             required_child_total = None
             required_child_complete = None
         else:

--- a/src/dev_health_ops/api/dev/status_completion_copy.py
+++ b/src/dev_health_ops/api/dev/status_completion_copy.py
@@ -54,10 +54,22 @@ _ASSESSMENT_SOURCE_LIMIT_REACHED = "assessment_source_limit_reached"
 
 
 def is_completion_assessment_untrustworthy(actual: DevActualCompletion) -> bool:
+    """Whether this specific completion assessment cannot ground a
+    completion claim -- a genuine source truncation, never CHAOS-3408's
+    structural non-applicability (CHAOS-3409 codex adversarial review,
+    HIGH: before this fix, EVERY withheld ``required_child_total`` was
+    "untrustworthy" regardless of why, so an ORGANIZATION/TEAM subject --
+    whose state/reason codes ARE fully real, only the required-child count
+    does not apply -- was forced through the same disclosure obligation as
+    a run that genuinely could not verify its total). See
+    ``DevActualCompletion.required_children_not_applicable``'s own
+    docstring for why that signal lives outside ``reason_codes``.
+    """
+
     return (
         actual.required_child_total is None
-        or _ASSESSMENT_SOURCE_LIMIT_REACHED in actual.reason_codes
-    )
+        and not actual.required_children_not_applicable
+    ) or _ASSESSMENT_SOURCE_LIMIT_REACHED in actual.reason_codes
 
 
 def any_tool_result_withheld_its_completion_denominator(

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -618,7 +618,17 @@ class SubjectPreflight:
                 ),
                 answer=None,
                 outcome=None,
-                allowed_tools=ALL_TOOLS,
+                # CHAOS-3421: a bare name already failed to resolve here --
+                # the model's own resolve_scope.v1 call could only ever
+                # repeat that exact failed lookup, and its raw
+                # forbidden_or_not_found outcome reaching the model is
+                # precisely the leak channel the committed-subject branch's
+                # own ALL_TOOLS - {RESOLVE_SCOPE} closes below (see that
+                # branch's comment). Withheld here for the identical reason:
+                # there is nothing left for the model to productively
+                # resolve, subject-bearing tools still execute against the
+                # organization scope just committed.
+                allowed_tools=ALL_TOOLS - {ToolID.RESOLVE_SCOPE},
                 blocking_mention_ids=blocking_ids,
                 legacy_guard_required=True,
                 unresolved_name_spans=frozenset(

--- a/tests/acceptance/test_wave31_manifest.py
+++ b/tests/acceptance/test_wave31_manifest.py
@@ -220,6 +220,11 @@ def test_every_blocking_matrix_category_is_represented() -> None:
         "blocking_matrix",
         "gate",
         "mutation_proof",
+        # CHAOS-3408/3409/3421: the later "org-pinned wrong-subject +
+        # 0-of-0 readiness answer" investigation's own defect set --
+        # deliberately a distinct category from original_defect_
+        # reproduction (CHAOS-3292's), not folded into it.
+        "readiness_and_resolution_safety_defect_reproduction",
     }
 
 

--- a/tests/acceptance/wave31-manifest-report.v1.json
+++ b/tests/acceptance/wave31-manifest-report.v1.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "wave_3_1_proof_gate_manifest.v1",
-  "item_count": 64,
+  "item_count": 67,
   "status_counts": {
-    "blocked": 4,
+    "blocked": 3,
     "deferred": 7,
     "proven_e2e": 14,
-    "proven_unit": 39
+    "proven_unit": 43
   },
   "category_counts": {
     "attack": 7,
@@ -13,11 +13,139 @@
     "gate": 7,
     "mutation_proof": 12,
     "original_defect_reproduction": 5,
+    "readiness_and_resolution_safety_defect_reproduction": 3,
     "real_project_positive_control": 1
   },
   "proven_e2e_claim_limits": "A proven_e2e row means: a live scenario was run by an operator, its per-assertion results were recorded by the scenario itself, and the script and shared fixture surface it ran against still match this tree. It does NOT mean the validator has established that the run happened. Execution artifacts are unsigned JSON and the validator recomputes exactly the values a forger would compute, so a fabricated artifact validates clean; occurrence rests on operator-recorded evidence and on re-running scenarios, not on this check. commit_sha is metadata only -- shape-checked, never resolved, so a well-formed id naming no commit is accepted. Product code under src/ is outside the digested surface, so for product changes these rows are historical records of a past run rather than statements about the current tree.",
-  "stale_row_count": 0,
-  "stale_rows": {},
+  "stale_row_count": 14,
+  "stale_rows": {
+    "attack.team-attribution.e2e-blocked-by-live-defect": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "attack.unrelated-evidence.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "defect.ask-dev-exact-commit.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "defect.ask-dev-not-found.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "gate.plan-registry-gap-is-loud.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.data-trust-organization-wide": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.exact-project-complete": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.multi-metric-comparison-organization-wide": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.operational-deficiency.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.registered-metric-catalog": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.remaining-work-exact-project": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.team-health.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "matrix.team-workload-balance.e2e-live-validated": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ],
+    "positive-control.real-project-status": [
+      "compose.yml",
+      "pyproject.toml",
+      "scripts/acceptance/acceptance_artifact.py",
+      "scripts/acceptance/prepare_ask_dev_acceptance.py",
+      "scripts/acceptance/run_ask_dev_compose.sh",
+      "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+      "tests/acceptance/compose.ask-dev.yml"
+    ]
+  },
   "items": [
     {
       "id": "attack.missing-data",
@@ -90,7 +218,15 @@
         "metrics_empty_for_team_scope",
         "limitation_names_unavailable_metric_source"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "attack.unrelated-evidence.availability",
@@ -129,7 +265,15 @@
         "named_repository_committed",
         "unrelated_repo_excluded_from_named_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "attack.unrelated-evidence.exclusion",
@@ -200,7 +344,15 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.exact-project-complete",
@@ -220,7 +372,15 @@
         "evidence_is_linked_to_the_committed_subject",
         "answer_status_not_error"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.legitimate-org-wide-status",
@@ -288,7 +448,15 @@
         "answer_status_not_error",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.multi-metric-comparison-stale-source",
@@ -377,16 +545,33 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.organization-portfolio-status",
       "category": "blocking_matrix",
       "description": "Organization portfolio status.",
-      "status": "blocked",
-      "evidence": [],
-      "blocked_reason": "PORTFOLIO_STATUS is deliberately, not accidentally, unwired this wave -- wave_3_1_plans.py's own module docstring: PlanExecutor's StepContext carries exactly one DevScope, but PortfolioStatusService.evaluate_portfolio needs several project scopes at once, a real gap that needs a StepContext-widening decision before this can be wired (tracked on the CHAOS-3297 Linear issue). The closest existing test, test_chaos_3303_portfolio_status_service.py::test_evaluate_portfolio_all_provisional_registry_reports_no_elevated_state, is service-layer only and does not exercise the plan/orchestrator path this row's claim needs -- not cited as proof it would be overclaiming. The GAP itself being handled honestly (loud, non-terminal fallback) is a separate, already-proven claim -- see gate.plan-registry-gap-is-loud and its e2e-live-validated sibling.",
-      "test_nodeids": [],
+      "status": "proven_unit",
+      "evidence": [
+        "tests/api/dev/test_chaos_3393_portfolio_orchestrator.py",
+        "tests/api/dev/test_chaos_3393_portfolio_preflight.py"
+      ],
+      "blocked_reason": null,
+      "test_nodeids": [
+        "tests/api/dev/test_chaos_3393_portfolio_orchestrator.py::test_named_project_cohort_batches_both_projects_through_the_portfolio_step",
+        "tests/api/dev/test_chaos_3393_portfolio_orchestrator.py::test_partial_failure_is_disclosed_never_fabricated_or_refused",
+        "tests/api/dev/test_chaos_3393_portfolio_preflight.py::test_organization_wide_portfolio_commits_a_bounded_project_set",
+        "tests/api/dev/test_chaos_3393_portfolio_preflight.py::test_organization_wide_portfolio_with_no_projects_falls_back_cleanly",
+        "tests/api/dev/test_chaos_3393_portfolio_preflight.py::test_organization_wide_portfolio_discloses_truncation_past_the_cap"
+      ],
       "requires_live_infra": false,
       "execution_artifact": null,
       "required_assertion_names": [],
@@ -561,7 +746,15 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.remaining-work-exact-project",
@@ -581,7 +774,15 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.struggling-teams-insufficient-sample",
@@ -673,7 +874,15 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.team-workload-balance.e2e-live-validated",
@@ -697,7 +906,15 @@
         "claimed_plan_step_completed",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "matrix.unwired-intent-safe-fallback",
@@ -798,7 +1015,15 @@
         "stream_terminated_as_answer",
         "warnings_present_but_not_a_plan_registry_gap_signal"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "gate.repeated-certified-provider",
@@ -1063,7 +1288,15 @@
         "answer_status_not_error",
         "stream_terminated_as_answer"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "defect.ask-dev-not-found",
@@ -1103,7 +1336,15 @@
         "no_answer_produced",
         "safe_message_does_not_name_subject"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     },
     {
       "id": "defect.no-org-fallback-or-blank",
@@ -1118,6 +1359,85 @@
       "test_nodeids": [
         "tests/api/dev/test_chaos_3292_mutations.py::test_m2_no_authorized_match_must_not_fall_through_to_organization_scope",
         "tests/api/dev/test_chaos_3292_mutations.py::test_m3a_leaky_canonical_copy_cannot_be_constructed_at_all"
+      ],
+      "requires_live_infra": false,
+      "execution_artifact": null,
+      "required_assertion_names": [],
+      "stale_dependencies": []
+    },
+    {
+      "id": "defect.bare-name-leak-graceful-terminal",
+      "category": "readiness_and_resolution_safety_defect_reproduction",
+      "description": "CHAOS-3421: a model that leaks the raw forbidden_or_not_found outcome token (what resolve_scope.v1 returns for a named subject the catalog cannot confirm) on the organization-wide-fallback path must never fail the run closed to a generic internal_error -- the leak scan reroutes to the SAME graceful scope_not_found terminal the legacy narration guard already ships for this exact scenario class, reusing its copy verbatim rather than forcing the stricter FORBIDDEN_OR_NOT_FOUND no-match terminal open. Replicated directly against the real live-incident question shape and the real CHAOS-3388 fixture entity, with subject matching (CHAOS-3407) deliberately left unfixed -- the run still misses, but never crashes.",
+      "status": "proven_unit",
+      "evidence": [
+        "src/dev_health_ops/api/dev/orchestrator.py",
+        "src/dev_health_ops/api/dev/subject_preflight.py",
+        "src/dev_health_ops/api/dev/no_match_terminal.py",
+        "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py"
+      ],
+      "blocked_reason": null,
+      "test_nodeids": [
+        "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::test_a_leaked_resolution_outcome_on_a_bare_name_fallback_is_graceful",
+        "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::test_an_unrelated_leak_off_this_branch_still_fails_closed",
+        "tests/api/dev/test_chaos_3421_leak_graceful_terminal.py::test_the_live_incident_question_never_crashes_even_though_it_still_misses"
+      ],
+      "requires_live_infra": false,
+      "execution_artifact": null,
+      "required_assertion_names": [],
+      "stale_dependencies": []
+    },
+    {
+      "id": "defect.bare-name-prompt-allowlist-consistency",
+      "category": "readiness_and_resolution_safety_defect_reproduction",
+      "description": "CHAOS-3421 MED-1: the unresolved-bare-name organization-wide-fallback preflight branch withholds resolve_scope.v1 from allowed_tools, so the composed prompt must never instruct the model to call it -- a dedicated prompt section states resolution is unavailable and names the permitted (organization-wide) fallback instead, and the advertised tool registry and the prompt copy are proven to agree, not merely asserted to.",
+      "status": "proven_unit",
+      "evidence": [
+        "src/dev_health_ops/api/dev/prompts/composer.py",
+        "src/dev_health_ops/api/dev/subject_preflight.py",
+        "src/dev_health_ops/api/dev/orchestrator.py",
+        "tests/api/dev/test_prompt_composer.py",
+        "tests/api/dev/test_chaos_3292_review_findings.py",
+        "tests/api/dev/test_subject_preflight.py"
+      ],
+      "blocked_reason": null,
+      "test_nodeids": [
+        "tests/api/dev/test_prompt_composer.py::test_resolution_unavailable_never_instructs_calling_the_withheld_tool",
+        "tests/api/dev/test_prompt_composer.py::test_resolution_unavailable_false_is_the_ordinary_uncommitted_section",
+        "tests/api/dev/test_prompt_composer.py::test_subject_committed_wins_over_resolution_unavailable",
+        "tests/api/dev/test_chaos_3292_review_findings.py::test_an_unresolved_bare_name_run_keeps_the_v1_prompt",
+        "tests/api/dev/test_chaos_3292_review_findings.py::test_an_unresolved_bare_name_run_gets_a_dedicated_unavailable_section",
+        "tests/api/dev/test_subject_preflight.py::test_an_unresolved_bare_name_withholds_resolve_scope"
+      ],
+      "requires_live_infra": false,
+      "execution_artifact": null,
+      "required_assertion_names": [],
+      "stale_dependencies": []
+    },
+    {
+      "id": "defect.organization-readiness-honest-denominator",
+      "category": "readiness_and_resolution_safety_defect_reproduction",
+      "description": "CHAOS-3408/3409: an ORGANIZATION/TEAM-scoped readiness question must never report a fabricated '0 of 0 required items are complete' -- the denominator is withheld via an explicit, non-inferred signal (never conflated with a genuine source truncation), and the real production render/validation wiring (not just an isolated renderer call) must render the distinct structural copy without pairing it with the truncation disclosure.",
+      "status": "proven_unit",
+      "evidence": [
+        "src/dev_health_ops/api/dev/status_change_service.py",
+        "src/dev_health_ops/api/dev/status_completion_copy.py",
+        "src/dev_health_ops/api/dev/status_answer_render.py",
+        "src/dev_health_ops/api/dev/contracts.py",
+        "src/dev_health_ops/api/dev/production_runtime.py",
+        "tests/api/dev/test_status_change_service.py",
+        "tests/api/dev/test_status_completion_copy.py",
+        "tests/api/dev/test_chaos_3377_status_answer_render.py"
+      ],
+      "blocked_reason": null,
+      "test_nodeids": [
+        "tests/api/dev/test_status_change_service.py::test_organization_and_team_scope_withhold_the_required_child_denominator[_org_scope]",
+        "tests/api/dev/test_status_change_service.py::test_organization_and_team_scope_withhold_the_required_child_denominator[_team_scope]",
+        "tests/api/dev/test_status_change_service.py::test_project_scope_with_genuinely_zero_required_children_is_a_real_zero",
+        "tests/api/dev/test_status_completion_copy.py::test_structural_non_applicability_is_trustworthy_not_untrustworthy",
+        "tests/api/dev/test_status_completion_copy.py::test_a_genuine_source_truncation_is_untrustworthy",
+        "tests/api/dev/test_chaos_3377_status_answer_render.py::test_production_wiring_never_pairs_the_scope_copy_with_the_truncation_disclosure",
+        "tests/api/dev/test_chaos_3377_status_answer_render.py::test_production_wiring_still_discloses_a_genuine_truncation"
       ],
       "requires_live_infra": false,
       "execution_artifact": null,
@@ -1143,7 +1463,15 @@
         "answer_status_not_error",
         "answer_summary_not_empty"
       ],
-      "stale_dependencies": []
+      "stale_dependencies": [
+        "compose.yml",
+        "pyproject.toml",
+        "scripts/acceptance/acceptance_artifact.py",
+        "scripts/acceptance/prepare_ask_dev_acceptance.py",
+        "scripts/acceptance/run_ask_dev_compose.sh",
+        "src/dev_health_ops/llm/agent/scripted_openai_service.py",
+        "tests/acceptance/compose.ask-dev.yml"
+      ]
     }
   ]
 }

--- a/tests/api/dev/test_chaos_3292_review_findings.py
+++ b/tests/api/dev/test_chaos_3292_review_findings.py
@@ -7,6 +7,7 @@ detail.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -308,6 +309,58 @@ async def test_an_unresolved_bare_name_run_keeps_the_v1_prompt() -> None:
     system_text = output.provider.system_texts[0]
     assert '"prompt_version":"' + LEGACY_PROMPT_VERSION in system_text
     assert "named_entity_resolution" in system_text
+    # CHAOS-3421 codex adversarial review (MED-1): this exact branch
+    # (subject_preflight's unresolved_untyped -> proceeded_unresolved_
+    # bare_name) withholds resolve_scope.v1 from allowed_tools (the leak-
+    # closing fix) -- the prompt must never INSTRUCT the model to call a
+    # tool that is not actually advertised to it (naming it as explicitly
+    # UNAVAILABLE, as the dedicated section below does, is fine -- that is
+    # the opposite instruction), or a compliant model burns a tool turn on
+    # a request the registry rejects as unavailable.
+    assert "call resolve_scope.v1" not in system_text
+    tool_ids = {
+        tool["tool_id"] for tool in json.loads(system_text)["tool_registry"]["tools"]
+    }
+    assert "resolve_scope.v1" not in tool_ids
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_bare_name_run_gets_a_dedicated_unavailable_section() -> (
+    None
+):
+    """MED-1's own fix: a dedicated prompt branch for this flow, distinct
+    from BOTH the ordinary uncommitted-subject section (which still tells
+    the model to call resolve_scope.v1 -- correct for every OTHER
+    uncommitted run) and the committed-subject section (false here: no
+    subject was committed). States resolution is unavailable and names the
+    permitted fallback, without re-advertising the withheld tool.
+    """
+
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="prompt-bare-unavailable",
+    )
+    assert output.provider is not None
+    system_text = output.provider.system_texts[0]
+    sections = {
+        section["id"]: section["text"]
+        for section in json.loads(system_text)["policy_sections"]
+    }
+    # Never the ordinary uncommitted section (it instructs resolve_scope.v1)
+    # and never the committed one (no subject was committed).
+    assert "committed_subject" not in sections
+    resolution_section = next(
+        text for section_id, text in sections.items() if "named_entity" in section_id
+    )
+    # The dedicated section still NAMES resolve_scope.v1 -- explicitly, as
+    # unavailable, which is more useful to the model than silence -- but
+    # never as an instruction to call it.
+    assert "call resolve_scope.v1" not in resolution_section
+    assert "resolve_scope.v1" in resolution_section
+    assert "unavailable" in resolution_section.casefold()
+    # Describes the permitted fallback, not just a bare prohibition.
+    assert "organization" in resolution_section.casefold()
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -46,7 +46,10 @@ from dev_health_ops.api.dev.status_change_service import (
     STATUS_REASON_CODES,
     is_required_child_open,
 )
-from dev_health_ops.api.dev.status_completion_copy import translate_project_state
+from dev_health_ops.api.dev.status_completion_copy import (
+    any_tool_result_withheld_its_completion_denominator,
+    translate_project_state,
+)
 
 SCOPE = DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
 OTHER_SCOPE = DevScope.model_validate(
@@ -64,6 +67,7 @@ def _actual(
     required_child_total: int | None = 69,
     required_child_complete: int | None = 39,
     evidence_ref_ids: tuple[str, ...] = ("ev_01",),
+    required_children_not_applicable: bool = False,
 ) -> DevActualCompletion:
     return DevActualCompletion(
         state=state,
@@ -77,6 +81,7 @@ def _actual(
         display_truncated=False,
         conflicts=[],
         evidence_ref_ids=list(evidence_ref_ids),
+        required_children_not_applicable=required_children_not_applicable,
     )
 
 
@@ -994,18 +999,19 @@ def test_verdict_carries_the_disclosure_when_denominator_withheld() -> None:
 
 
 def test_a_withheld_denominator_not_applicable_to_scope_gets_distinct_copy() -> None:
-    """CHAOS-3408's own non-applicability flavor: ``required_child_total``
-    is ``None`` and NOT because of a source truncation (no
-    ``assessment_source_limit_reached`` reason code) -- the distinct,
-    honest copy fires even with no other unknown/blocking reasons and no
-    caller-supplied ``denominator_withheld``, purely from ``actual``'s own
-    fields."""
+    """CHAOS-3408's own non-applicability flavor: an EXPLICIT signal
+    (``required_children_not_applicable``, never inferred from reason-code
+    absence -- codex adversarial review, HIGH: an inference misses the
+    production path entirely, see the end-to-end test below) -- the
+    distinct, honest copy fires purely from ``actual``'s own fields, with
+    no caller-supplied ``denominator_withheld`` needed."""
 
     actual = _actual(
         state="indeterminate",
         reason_codes=(),
         required_child_total=None,
         required_child_complete=None,
+        required_children_not_applicable=True,
     )
     summary = render_verdict_summary(actual)
 
@@ -1016,16 +1022,17 @@ def test_a_withheld_denominator_not_applicable_to_scope_gets_distinct_copy() -> 
 
 def test_a_withheld_denominator_from_truncation_does_not_get_the_scope_copy() -> None:
     """The other flavor of ``required_child_total is None`` -- a genuine
-    source truncation -- must render its OWN existing disclosure, never
-    CHAOS-3409's "not applicable to this scope" copy (that would be a
-    false claim: real required items exist, they were merely not all
-    fetched)."""
+    source truncation, ``required_children_not_applicable`` stays False --
+    must render its OWN existing disclosure, never CHAOS-3409's "not
+    applicable to this scope" copy (that would be a false claim: real
+    required items exist, they were merely not all fetched)."""
 
     actual = _actual(
         state="indeterminate",
         reason_codes=("assessment_source_limit_reached",),
         required_child_total=None,
         required_child_complete=None,
+        required_children_not_applicable=False,
     )
     summary = render_verdict_summary(actual, denominator_withheld=True)
 
@@ -1051,4 +1058,81 @@ def test_a_real_zero_denominator_still_renders_the_real_n_of_m_claim() -> None:
     summary = render_verdict_summary(actual)
 
     assert "0 of 0 required items are complete" in summary
+    assert "no required items are recorded for this scope" not in summary.casefold()
+
+
+# --- CHAOS-3409 codex adversarial review (HIGH, confirmed): the isolated
+# render_verdict_summary tests above never exercised the PRODUCTION
+# denominator_withheld wiring (any_tool_result_withheld_its_completion_
+# denominator, which status_change_service._assess's structural None and a
+# genuine source truncation BOTH satisfied identically before this fix) --
+# so the real orchestrator path emitted BOTH the new structural copy AND
+# the truncation disclosure together for ORGANIZATION/TEAM scope. These
+# drive the exact same production entry points orchestrator.py calls
+# (build_deterministic_status_claims / render_verdict_summary with
+# denominator_withheld computed from tool_results, never hand-supplied).
+
+
+def test_production_wiring_never_pairs_the_scope_copy_with_the_truncation_disclosure() -> (
+    None
+):
+    actual = _actual(
+        state="ready",
+        reason_codes=(),
+        required_child_total=None,
+        required_child_complete=None,
+        required_children_not_applicable=True,
+    )
+    status_result = _tool_result(actual_completion=actual)
+
+    claims = build_deterministic_status_claims(
+        actual=actual,
+        status_result=status_result,
+        validity_scope=SCOPE,
+        canonical_evidence_ids=frozenset({"ev_01"}),
+        tool_results=(status_result,),
+    )
+    summary = render_verdict_summary(
+        actual,
+        denominator_withheld=any_tool_result_withheld_its_completion_denominator(
+            (status_result,)
+        ),
+    )
+
+    verdict_claim = next(
+        claim for claim in claims if claim.claim_id.startswith("status-verdict:")
+    )
+    for text in (summary, verdict_claim.text):
+        assert "no required items are recorded for this scope" in text.casefold()
+        assert (
+            "the required-work completion total could not be fully verified"
+            not in text.casefold()
+        )
+
+
+def test_production_wiring_still_discloses_a_genuine_truncation() -> None:
+    """No regression on the other side of the same fix: a REAL source
+    truncation must still carry the truncation disclosure through the
+    exact same production wiring."""
+
+    actual = _actual(
+        state="indeterminate",
+        reason_codes=("assessment_source_limit_reached",),
+        required_child_total=None,
+        required_child_complete=None,
+        required_children_not_applicable=False,
+    )
+    status_result = _tool_result(actual_completion=actual)
+
+    summary = render_verdict_summary(
+        actual,
+        denominator_withheld=any_tool_result_withheld_its_completion_denominator(
+            (status_result,)
+        ),
+    )
+
+    assert (
+        "the required-work completion total could not be fully verified"
+        in summary.casefold()
+    )
     assert "no required items are recorded for this scope" not in summary.casefold()

--- a/tests/api/dev/test_chaos_3377_status_answer_render.py
+++ b/tests/api/dev/test_chaos_3377_status_answer_render.py
@@ -984,3 +984,71 @@ def test_verdict_carries_the_disclosure_when_denominator_withheld() -> None:
         "the required-work completion total could not be fully verified"
         in summary.casefold()
     )
+
+
+# --- CHAOS-3409: distinct copy for a withheld (never a fabricated real)
+# zero denominator -- "0 of 0 required items are complete" must never
+# render identically whether required-work tracking was structurally
+# absent for this scope (CHAOS-3408: ORGANIZATION/TEAM) or the subject
+# genuinely has zero required items. ---
+
+
+def test_a_withheld_denominator_not_applicable_to_scope_gets_distinct_copy() -> None:
+    """CHAOS-3408's own non-applicability flavor: ``required_child_total``
+    is ``None`` and NOT because of a source truncation (no
+    ``assessment_source_limit_reached`` reason code) -- the distinct,
+    honest copy fires even with no other unknown/blocking reasons and no
+    caller-supplied ``denominator_withheld``, purely from ``actual``'s own
+    fields."""
+
+    actual = _actual(
+        state="indeterminate",
+        reason_codes=(),
+        required_child_total=None,
+        required_child_complete=None,
+    )
+    summary = render_verdict_summary(actual)
+
+    assert "no required items are recorded for this scope" in summary.casefold()
+    # Never the N-of-M numeric claim -- there is no real denominator to cite.
+    assert "required items are complete" not in summary.casefold()
+
+
+def test_a_withheld_denominator_from_truncation_does_not_get_the_scope_copy() -> None:
+    """The other flavor of ``required_child_total is None`` -- a genuine
+    source truncation -- must render its OWN existing disclosure, never
+    CHAOS-3409's "not applicable to this scope" copy (that would be a
+    false claim: real required items exist, they were merely not all
+    fetched)."""
+
+    actual = _actual(
+        state="indeterminate",
+        reason_codes=("assessment_source_limit_reached",),
+        required_child_total=None,
+        required_child_complete=None,
+    )
+    summary = render_verdict_summary(actual, denominator_withheld=True)
+
+    assert "no required items are recorded for this scope" not in summary.casefold()
+    assert (
+        "the required-work completion total could not be fully verified"
+        in summary.casefold()
+    )
+
+
+def test_a_real_zero_denominator_still_renders_the_real_n_of_m_claim() -> None:
+    """No regression: a genuinely-computed real zero (e.g. PROJECT scope, a
+    real query that found zero required children) must still render the
+    real "0 of 0" claim -- never CHAOS-3409's withheld-scope copy, which
+    would be dishonest about a real, meaningful zero."""
+
+    actual = _actual(
+        state="ready",
+        reason_codes=(),
+        required_child_total=0,
+        required_child_complete=0,
+    )
+    summary = render_verdict_summary(actual)
+
+    assert "0 of 0 required items are complete" in summary
+    assert "no required items are recorded for this scope" not in summary.casefold()

--- a/tests/api/dev/test_chaos_3421_leak_graceful_terminal.py
+++ b/tests/api/dev/test_chaos_3421_leak_graceful_terminal.py
@@ -1,0 +1,220 @@
+"""CHAOS-3421: a model that leaks a raw internal outcome token (e.g.
+``forbidden_or_not_found``, what ``resolve_scope.v1`` returns for a named
+subject the catalog does not confirm) on an organization-wide-fallback run
+must never fail closed to the generic ``internal_error`` -- it must land on
+the SAME graceful, honest terminal the legacy narration guard already ships
+for this exact scenario class (``resolve_scope_not_found``).
+
+Live incident: a prior turn's clarification named "Dev Health Agent Context
+Runtime (Context Fabric)"; the user asked again with that exact, unquoted
+label. The catalog-matching gap (CHAOS-3407, currently paused -- see that
+ticket) is untouched here and this run still MISSES the subject -- the
+question this file answers is only "does a miss on this specific path fail
+SAFELY", not "does it resolve".
+
+Two closely related but distinct failure classes exist on this exact
+preflight branch (``subject_preflight.py``'s ``unresolved_untyped`` ->
+``proceeded_unresolved_bare_name``), and both are covered:
+
+1. The model's answer NARRATES the unresolved bare name in its own prose --
+   already covered, unchanged, by the legacy backstop's
+   ``narrated_unresolved_entity`` guard (test_chaos_3292_review_findings.py).
+2. The model calls ``resolve_scope.v1`` (still in ``allowed_tools`` on this
+   branch before this fix), gets back the raw ``forbidden_or_not_found``
+   enum value, and echoes it into its own summary/claim text WITHOUT
+   narrating the bare name itself -- the narration guard's own text-
+   similarity check never fires (nothing about "Nightfall" appears in the
+   leaked text), so the run reaches the unconditional completion path,
+   where the internal-token leak scan is the ONLY thing left to catch it --
+   and used to fail closed generically. This file's own defect.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.llm.agent.contracts import AgentFinalAnswer
+from dev_health_ops.llm.agent.scripted import ScriptedStep
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    CHAOS_3388_ACR_PROJECT,
+    ORG_ID,
+    grounded_answer_payload,
+    run_preflight_orchestrator,
+    scope_dict,
+    status_then_answer,
+)
+
+#: The exact internal outcome token this incident leaked -- a real member of
+#: ``ScopeResolutionOutcome``, never invented for this test.
+_LEAKED_TOKEN = "forbidden_or_not_found"
+
+
+def _leaking_but_not_narrating(script_id: str) -> list[ScriptedStep]:
+    """A scripted final answer that echoes the raw resolve_scope.v1 outcome
+    token, but never mentions the bare name itself -- so the legacy guard's
+    own ``narrated_unresolved_entity`` text-similarity check has nothing to
+    catch, and only the internal-token leak scan is left standing between
+    this and the wire.
+    """
+
+    steps = status_then_answer(script_id)
+    steps[-1] = ScriptedStep(
+        decision=AgentFinalAnswer(
+            grounded_answer_payload(
+                script_id=script_id,
+                summary=(
+                    f"The scope resolution tool returned {_LEAKED_TOKEN} for "
+                    "the requested subject."
+                ),
+                validity_scope=scope_dict(),
+            )
+        )
+    )
+    return steps
+
+
+@pytest.mark.asyncio
+async def test_a_leaked_resolution_outcome_on_a_bare_name_fallback_is_graceful() -> (
+    None
+):
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script=_leaking_but_not_narrating,
+        script_id="leak-not-narrate",
+    )
+
+    # The setup control: this run really did take the unresolved-bare-name
+    # organization-wide-fallback branch, and the narration guard really did
+    # NOT fire (proving the leak scan, not the guard, is what this test
+    # exercises).
+    assert output.preflight_outcomes() == ("proceeded_unresolved_bare_name",)
+    assert output.guard_reasons() == ()
+
+    # The graceful terminal, never the generic fail-closed one.
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.state is not RunState.FAILED
+    assert output.result.error is not None
+    assert output.result.error.code == "scope_not_found"
+    assert output.result.error.code != "internal_error"
+    assert output.result.error.safe_message == "The requested scope was not found."
+
+    # The load-bearing negative: the raw token itself never reaches
+    # anything persisted or returned -- not the discarded answer (there
+    # must not even BE one), not the error, not the run's own error code.
+    assert output.result.answer is None
+    assert _LEAKED_TOKEN not in output.result.error.safe_message
+    assert _LEAKED_TOKEN not in output.result.error.code
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_leak_off_this_branch_still_fails_closed() -> None:
+    """Anti-vacuity: the graceful reroute is scoped to the ONE preflight
+    branch that sets ``legacy_guard_required`` (``proceeded_unresolved_
+    bare_name``) -- a leak on an ordinary, fully-resolved run must still
+    fail closed exactly as before. Claims dropped entirely (rather than
+    reusing the stock fixture's own claim) so this stays focused on the
+    leak-routing decision, never an unrelated grounding-floor/validity-
+    scope mismatch on a committed PROJECT scope.
+    """
+
+    def leaking_on_a_resolved_run(script_id: str) -> list[ScriptedStep]:
+        steps = status_then_answer(script_id)
+        payload = grounded_answer_payload(
+            script_id=script_id,
+            summary=f"Evaluation returned {_LEAKED_TOKEN} unexpectedly.",
+            validity_scope=scope_dict(),
+        )
+        payload["claims"] = []
+        steps[-1] = ScriptedStep(decision=AgentFinalAnswer(payload))
+        return steps
+
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script=leaking_on_a_resolved_run,
+        script_id="leak-resolved-run",
+    )
+
+    assert output.preflight_outcomes() == ("proceeded_committed_subject",)
+    assert output.result.state is RunState.FAILED
+    assert output.result.error is not None
+    assert output.result.error.code == "internal_error"
+
+
+# ---------------------------------------------------------------------------
+# The kill shot: the live incident, replicated end to end. Matching itself
+# (CHAOS-3407) is PAUSED by explicit user directive -- this run still MISSES
+# the subject, on purpose, exactly as team-lead's revised scope describes.
+# What must be true regardless: the miss lands on a graceful, disclosed
+# organization-wide fallback, never a crash.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_live_incident_question_never_crashes_even_though_it_still_misses() -> (
+    None
+):
+    """A prior turn's clarification named the real CHAOS-3388 fixture entity
+    ("Dev Health Agent Context Runtime (Context Fabric)"); the user asks
+    again with that exact, unquoted label + "project". Preflight runs
+    unconditionally every turn (CHAOS-3407's own diagnosis), so a single-
+    turn run exercises the identical preflight/orchestrator code path a
+    multi-turn conversation would -- no conversation history is required to
+    prove this.
+
+    With matching paused, the parenthetical still breaks kind-noun
+    adjacency (unchanged), the truncated bare-name span still fuzzy-matches
+    the one real project as a SOLE, non-exact candidate (proven empirically
+    against the real ScopeResolutionService/SeededCatalog: this lands on
+    ``proceeded_unresolved_bare_name``, the same organization-wide-fallback
+    branch as the "Nightfall" cases above), and the model still calls
+    resolve_scope.v1 in the pre-CHAOS-3421 world and leaks its raw outcome.
+    Post-3421: RESOLVE_SCOPE is withheld on this branch (nothing to leak
+    from that source), and even a leak reaching the wire some other way
+    routes to the graceful ``scope_not_found`` terminal, never
+    ``internal_error``.
+    """
+
+    label = CHAOS_3388_ACR_PROJECT.label
+
+    def leaking_on_the_real_incident_shape(script_id: str) -> list[ScriptedStep]:
+        steps = status_then_answer(script_id)
+        steps[-1] = ScriptedStep(
+            decision=AgentFinalAnswer(
+                grounded_answer_payload(
+                    script_id=script_id,
+                    summary=(
+                        f"The scope resolution tool returned {_LEAKED_TOKEN} "
+                        "for the requested subject."
+                    ),
+                    validity_scope=scope_dict(),
+                )
+            )
+        )
+        return steps
+
+    output = await run_preflight_orchestrator(
+        question=f"What is the status of the {label} project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, CHAOS_3388_ACR_PROJECT)],
+        script=leaking_on_the_real_incident_shape,
+        script_id="killshot-live-incident",
+    )
+
+    # The miss, by design and disclosed: an organization-wide fallback, not
+    # a clarification or a resolved subject -- CHAOS-3407 (matching) stays
+    # untouched and unfixed here on purpose.
+    assert output.preflight_outcomes() == ("proceeded_unresolved_bare_name",)
+
+    # The graceful landing CHAOS-3421 guarantees, never a crash and never
+    # the raw enum anywhere on the wire.
+    assert output.result.state is not RunState.FAILED
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code != "internal_error"
+    assert output.result.error.code == "scope_not_found"
+    assert _LEAKED_TOKEN not in output.result.error.safe_message
+    assert _LEAKED_TOKEN not in output.result.error.code
+    assert output.result.answer is None

--- a/tests/api/dev/test_prompt_composer.py
+++ b/tests/api/dev/test_prompt_composer.py
@@ -46,3 +46,70 @@ def test_prompt_manifest_contains_only_the_canonical_nine_tools() -> None:
     assert len(prompt.system_text.encode("utf-8")) < 64 * 1024
     assert "sql" in prompt.system_text.casefold()
     assert "private reasoning" in prompt.system_text.casefold()
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3421 codex adversarial review (MED-1): resolution_unavailable is a
+# THIRD, distinct prompt branch from subject_committed's True/False -- unit
+# coverage at the composer level, independent of the full orchestrator
+# E2E suite (test_chaos_3292_review_findings.py).
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_unavailable_never_instructs_calling_the_withheld_tool() -> None:
+    prompt = PromptComposer(_registry()).compose(
+        question="How is Nightfall doing?",
+        scope=_scope(),
+        allowed_tools=frozenset(ToolID) - {ToolID.RESOLVE_SCOPE},
+        subject_committed=False,
+        resolution_unavailable=True,
+    )
+    system = json.loads(prompt.system_text)
+    tool_ids = {tool["tool_id"] for tool in system["tool_registry"]["tools"]}
+    assert "resolve_scope.v1" not in tool_ids
+
+    sections = {section["id"]: section["text"] for section in system["policy_sections"]}
+    assert "committed_subject" not in sections
+    assert "named_entity_resolution_unavailable" in sections
+    # The advertised tools (no resolve_scope.v1) and the prompt copy
+    # (explicitly says it is unavailable) agree -- the whole point.
+    assert (
+        "call resolve_scope.v1" not in sections["named_entity_resolution_unavailable"]
+    )
+    assert "unavailable" in sections["named_entity_resolution_unavailable"].casefold()
+
+
+def test_resolution_unavailable_false_is_the_ordinary_uncommitted_section() -> None:
+    """No regression: every OTHER uncommitted-subject run (the default,
+    resolution_unavailable=False) keeps the ordinary section that DOES
+    instruct the model to call resolve_scope.v1 -- that tool really is
+    available for those runs."""
+
+    prompt = PromptComposer(_registry()).compose(
+        question="What's the status of the Ask Dev project?",
+        scope=_scope(),
+        subject_committed=False,
+    )
+    system = json.loads(prompt.system_text)
+    sections = {section["id"]: section["text"] for section in system["policy_sections"]}
+    assert "named_entity_resolution_unavailable" not in sections
+    assert "call resolve_scope.v1" in sections["named_entity_resolution"]
+
+
+def test_subject_committed_wins_over_resolution_unavailable() -> None:
+    """Defensive: if a caller ever passed both flags True (should never
+    happen -- has_committed_subject and legacy_guard_required are mutually
+    exclusive by construction), the committed-subject section -- the one
+    that actually matches a real committed scope -- takes precedence."""
+
+    prompt = PromptComposer(_registry()).compose(
+        question="What's the status of the Ask Dev project?",
+        scope=_scope(),
+        subject_committed=True,
+        resolution_unavailable=True,
+    )
+    system = json.loads(prompt.system_text)
+    sections = {section["id"] for section in system["policy_sections"]}
+    assert "committed_subject" in sections
+    assert "named_entity_resolution_unavailable" not in sections
+    assert "named_entity_resolution" not in sections

--- a/tests/api/dev/test_status_change_service.py
+++ b/tests/api/dev/test_status_change_service.py
@@ -608,6 +608,126 @@ async def test_membership_source_truncation_signal_also_withholds_the_denominato
     assert result.actual.required_child_complete is None
 
 
+# ---------------------------------------------------------------------------
+# CHAOS-3408: required-children/blockers have NO single declared/children
+# completion tree for an ORGANIZATION or TEAM subject (a deliberate CHAOS-
+# 3303 design -- native_status_change.TEAM_NOT_APPLICABLE_SOURCES -- never a
+# data gap). ``RawStatusSnapshot.children`` is therefore always structurally
+# empty for these two scopes, and treating that the same as a genuinely-
+# computed real zero produced a fabricated-looking "0 of 0 required items
+# are complete" for every org-wide/team-wide readiness question. The
+# denominator must be WITHHELD (None) here, exactly like a truncated source
+# -- but distinguishably so: never carrying
+# ``assessment_source_limit_reached`` (this is not a truncation, and must
+# never be confused with one downstream).
+# ---------------------------------------------------------------------------
+
+
+def _org_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.ORGANIZATION,
+        repositories=["repo-a"],
+        entity_refs=[],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=NOW - timedelta(days=14),
+            end=NOW - timedelta(days=7),
+            timezone="UTC",
+        ),
+    )
+
+
+def _team_scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id="org-a",
+        direct_scope=DirectScope.TEAM,
+        repositories=[],
+        entity_refs=[
+            DevEntityRef(
+                entity_type=EntityType.TEAM,
+                entity_id="team-platform",
+                display_label="Platform",
+            )
+        ],
+        team_ids=["team-platform"],
+        time_range=DevTimeRange(start=NOW - timedelta(days=7), end=NOW, timezone="UTC"),
+        comparison_range=DevTimeRange(
+            start=NOW - timedelta(days=14),
+            end=NOW - timedelta(days=7),
+            timezone="UTC",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope_factory", [_org_scope, _team_scope])
+async def test_organization_and_team_scope_withhold_the_required_child_denominator(
+    scope_factory,
+) -> None:
+    """The live repro: an organization-wide (or team-wide) readiness
+    question must never report a fabricated "0 of 0 required items are
+    complete" -- the denominator is withheld (None), exactly as if the
+    source had reported a real truncation, but WITHOUT the truncation
+    reason code (this is a structural non-applicability, not a source
+    limit)."""
+
+    service = StatusChangeService(
+        Source(
+            RawStatusSnapshot(
+                declared=None,
+                children=(),
+                deployments=(_deployment(),),
+                source_refs=(_source_ref(),),
+            )
+        )
+    )
+
+    result = await service.status_snapshot(
+        "org-a", "permission-v1", StatusSnapshotRequest(scope_factory(), as_of=NOW)
+    )
+
+    assert result.actual.required_child_total is None
+    assert result.actual.required_child_complete is None
+    # Never confused with a real source truncation downstream (the
+    # "assessment hit a display limit" copy would be actively misleading
+    # here -- nothing was ever attempted, let alone limited).
+    assert "assessment_source_limit_reached" not in result.actual.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_project_scope_with_genuinely_zero_required_children_is_a_real_zero() -> (
+    None
+):
+    """No regression: PROJECT/ISSUE/WORK_UNIT scope's required-child
+    concept IS applicable and IS queried -- a real query that genuinely
+    finds zero required children must still report a REAL ``0``, never
+    withheld, and this must stay distinguishable from CHAOS-3408's
+    organization/team non-applicability."""
+
+    service = StatusChangeService(
+        Source(
+            RawStatusSnapshot(
+                declared=_fact("project-1", "done"),
+                children=(),
+                deployments=(_deployment(),),
+                source_refs=(_source_ref(),),
+            )
+        )
+    )
+
+    result = await service.status_snapshot(
+        "org-a",
+        "permission-v1",
+        StatusSnapshotRequest(_scope(DirectScope.PROJECT), as_of=NOW),
+    )
+
+    assert result.actual.required_child_total == 0
+    assert result.actual.required_child_complete == 0
+
+
 def _many_blockers(n: int) -> tuple[StatusFact, ...]:
     return tuple(_fact(f"blocker-{i:04d}", "resolved") for i in range(n))
 

--- a/tests/api/dev/test_status_change_service.py
+++ b/tests/api/dev/test_status_change_service.py
@@ -695,6 +695,11 @@ async def test_organization_and_team_scope_withhold_the_required_child_denominat
     # "assessment hit a display limit" copy would be actively misleading
     # here -- nothing was ever attempted, let alone limited).
     assert "assessment_source_limit_reached" not in result.actual.reason_codes
+    # CHAOS-3409 codex adversarial review (HIGH): the explicit signal
+    # render_verdict_summary/is_completion_assessment_untrustworthy read --
+    # never inferred from reason-code absence, which missed the real
+    # denominator_withheld production wiring entirely.
+    assert result.actual.required_children_not_applicable is True
 
 
 @pytest.mark.asyncio
@@ -726,6 +731,7 @@ async def test_project_scope_with_genuinely_zero_required_children_is_a_real_zer
 
     assert result.actual.required_child_total == 0
     assert result.actual.required_child_complete == 0
+    assert result.actual.required_children_not_applicable is False
 
 
 def _many_blockers(n: int) -> tuple[StatusFact, ...]:

--- a/tests/api/dev/test_status_completion_copy.py
+++ b/tests/api/dev/test_status_completion_copy.py
@@ -1,0 +1,97 @@
+"""Unit coverage for ``status_completion_copy``'s shared "is this completion
+assessment trustworthy" predicate (CHAOS-3297 s2 round 9's own module).
+
+CHAOS-3409 codex adversarial review (HIGH, confirmed): before this fix,
+``is_completion_assessment_untrustworthy`` treated EVERY withheld
+(``required_child_total is None``) denominator identically -- a genuine
+source truncation (real required items exist, not all were fetched) and
+CHAOS-3408's structural non-applicability (ORGANIZATION/TEAM scope has no
+required-child concept at all) both satisfied the SAME ``required_child_total
+is None`` clause, so both were "untrustworthy": both forced the model-facing
+``INCOMPLETE_DENOMINATOR_DISCLOSURE`` obligation (``answer_validator.py``),
+both drove ``render_verdict_summary``'s truncation disclosure, and CHAOS-3409's
+own render tests never caught it because they called ``render_verdict_summary``
+directly, with a hand-supplied ``denominator_withheld``, never through this
+shared predicate the real orchestrator wiring actually calls.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.api.dev.contracts import DevActualCompletion
+from dev_health_ops.api.dev.status_completion_copy import (
+    is_completion_assessment_untrustworthy,
+)
+
+
+def _actual(
+    *,
+    required_child_total: int | None,
+    reason_codes: tuple[str, ...] = (),
+    required_children_not_applicable: bool = False,
+) -> DevActualCompletion:
+    return DevActualCompletion(
+        state="ready",
+        rule_id="actual-completion",
+        rule_version="actual-completion.v4",
+        reason_codes=list(reason_codes),
+        required_children=[],
+        blockers=[],
+        required_child_total=required_child_total,
+        required_child_complete=required_child_total,
+        display_truncated=False,
+        conflicts=[],
+        evidence_ref_ids=[],
+        required_children_not_applicable=required_children_not_applicable,
+    )
+
+
+def test_a_real_denominator_is_trustworthy() -> None:
+    assert is_completion_assessment_untrustworthy(_actual(required_child_total=3)) is (
+        False
+    )
+
+
+def test_a_real_zero_denominator_is_trustworthy() -> None:
+    assert (
+        is_completion_assessment_untrustworthy(_actual(required_child_total=0)) is False
+    )
+
+
+def test_a_genuine_source_truncation_is_untrustworthy() -> None:
+    actual = _actual(
+        required_child_total=None,
+        reason_codes=("assessment_source_limit_reached",),
+        required_children_not_applicable=False,
+    )
+    assert is_completion_assessment_untrustworthy(actual) is True
+
+
+def test_structural_non_applicability_is_trustworthy_not_untrustworthy() -> None:
+    """The load-bearing distinction: CHAOS-3408's ORGANIZATION/TEAM
+    structural absence is NOT a verification failure -- the state/reason
+    codes it carries are fully real, only the required-child concept does
+    not apply. Treating it as "untrustworthy" is exactly what forced the
+    model to disclose a truncation that never happened.
+    """
+
+    actual = _actual(
+        required_child_total=None,
+        reason_codes=(),
+        required_children_not_applicable=True,
+    )
+    assert is_completion_assessment_untrustworthy(actual) is False
+
+
+def test_a_withheld_denominator_with_no_signal_at_all_stays_untrustworthy() -> None:
+    """Defensive: ``required_child_total is None`` with NEITHER the
+    truncation reason code NOR the structural flag set must still fail
+    closed to "untrustworthy" -- an unrecognized withholding is exactly
+    the kind of "unknown" this predicate exists to catch, never silently
+    treated as safe."""
+
+    actual = _actual(
+        required_child_total=None,
+        reason_codes=(),
+        required_children_not_applicable=False,
+    )
+    assert is_completion_assessment_untrustworthy(actual) is True

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -110,6 +110,36 @@ async def test_an_organization_wide_question_keeps_every_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_an_unresolved_bare_name_withholds_resolve_scope() -> None:
+    """CHAOS-3421: unlike the names-nothing case above, this branch DID
+    name something -- a bare span the catalog could not confirm under any
+    kind. Model-called ``resolve_scope.v1`` on that exact name can only
+    ever repeat the preflight's own failed lookup, returning the raw
+    ``forbidden_or_not_found`` outcome for the model to (as the live
+    incident did) echo verbatim into its own answer text. Withholding the
+    tool here closes that leak channel at its source, mirroring the
+    committed-subject branch's own ``ALL_TOOLS - {RESOLVE_SCOPE}`` (a
+    subject already failed to resolve here just as surely as it succeeded
+    there -- in neither case is there anything left for the model to
+    productively resolve).
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("How is Nightfall doing?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "proceeded_unresolved_bare_name"
+    assert result.legacy_guard_required is True
+    assert result.allowed_tools == frozenset(ToolID) - {ToolID.RESOLVE_SCOPE}
+    # Every OTHER subject-bearing tool stays available -- this withholds
+    # exactly the one tool that could re-derive and leak the same failed
+    # resolution, never the whole subject-bearing surface.
+    assert SUBJECT_BEARING_TOOLS <= result.allowed_tools
+
+
+@pytest.mark.asyncio
 async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> None:
     """Two real subjects: v1 ``DevScope`` names one, so neither is guessed.
 


### PR DESCRIPTION
## Scope

Three defects from the live "org-pinned wrong-subject + 0-of-0 readiness answer" investigation. CHAOS-3407 (parenthetical mention-grammar matching) was implemented but is PAUSED by explicit user directive — all fuzzy/regex-grammar matching work is paused, direction pivots to LLM-backed subject resolution (discovery CHAOS-3389/3425). That work is parked on `wip/chaos-3407-parenthetical-grammar-paused` (commit 48ecfc11b), not part of this PR.

## The three defects

**CHAOS-3408 — structural 0-of-0 readiness denominator** (`status_change_service.py`): `required_child_total`/`complete` were computed as a real `0` for ORGANIZATION/TEAM scope, indistinguishable from a genuinely-computed zero — but ORGANIZATION/TEAM has no single declared/children completion tree at all (a deliberate CHAOS-3303 design, `native_status_change.TEAM_NOT_APPLICABLE_SOURCES`), so `len(())==0` was a fabricated-looking "0 of 0 required items are complete" for every org-wide/team-wide readiness question. Fixed via a new `required_children_applicable`/`required_children_not_applicable` signal, withholding the denominator (`None`) exactly like a source truncation does, but without the truncation reason code. Deliberately did NOT add real org/team work-item SQL arms — that would contradict CHAOS-3303's own documented rationale.

**CHAOS-3409 — zero-denominator copy** (`status_answer_render.py`): `render_verdict_summary` had no branch for a withheld (`None`) denominator distinct from truncation. Added a distinct closed-vocabulary sentence ("No required items are recorded for this scope.") for the structural flavor, never combined with the numeric N-of-M claim or the truncation disclosure.

**CHAOS-3421 — graceful bare-name leak routing** (`subject_preflight.py`, `orchestrator.py`, `prompts/composer.py`): the unresolved-bare-name organization-wide-fallback preflight branch was the only PROCEED exit still keeping `resolve_scope.v1` in `allowed_tools`. Live consequence: the model called `resolve_scope.v1`, got back the raw `forbidden_or_not_found` outcome, and echoed it into `direct_summary` (never scrubbed by design), tripping the internal-token leak scan and failing the whole run closed to a generic `internal_error`. Fixed in three seams: the tool allowlist now withholds `resolve_scope.v1` on this branch (mirroring the committed-subject branch's own reasoning); the leak scan's fail-closed branch reroutes to the existing graceful `scope_not_found` terminal (reused verbatim from `_LEGACY_GUARD_TERMINALS`) instead of `internal_error`; and the composed prompt gets a dedicated section stating resolution is unavailable and naming the permitted (organization-wide) fallback, so it never instructs the model to call a tool the registry will reject.

## Codex adversarial review round (reviewer-prescribed, no fresh round)

- **HIGH** (`status_answer_render.py`/`status_completion_copy.py`): the production render/validation wiring (`build_deterministic_status_claims`/`render_verdict_summary`, driven by `is_completion_assessment_untrustworthy` off `tool_results`, never a hand-supplied flag) paired CHAOS-3409's new structural copy with the truncation disclosure for org/team scope, and forced the model's own prose through the same false disclosure obligation (`answer_validator.py`). Fixed with a genuinely explicit signal — `DevActualCompletion.required_children_not_applicable` (wire) / `ActualCompletion.required_children_not_applicable` (domain) — deliberately NOT a reason code (traced through `_assess`'s state computation: a new reason code would flip `CompletionState` to `INDETERMINATE` via `unknown_reasons`, which is correct for a real truncation but wrong for a structural absence that says nothing about whether the underlying evidence is trustworthy). `is_completion_assessment_untrustworthy` and `render_verdict_summary` both read the field directly now, so the validator's repair-detail obligation is fixed for free via the same shared predicate.
- **MED-1** (`prompts/composer.py`/`orchestrator.py`): reproduced live — the composed prompt for a bare-name-fallback run instructed "call `resolve_scope.v1`" while the tool was already absent from the advertised registry (CHAOS-3421's own fix). Added a dedicated third prompt branch (`resolution_unavailable`, driven by `preflight_result.legacy_guard_required`) that states resolution is unavailable and names the fallback, never re-adding the tool.
- **MED-2** (`scripts/acceptance/wave31_manifest.py`): the wave31 readiness manifest never cited the new tests, so removing any of the three new guards would have left the report green. Added three `proven_unit` manifest items (a new `readiness_and_resolution_safety_defect_reproduction` category) naming the dedicated `test_nodeids`, regenerated `wave31-manifest-report.v1.json` via the manifest's own `build_report`/`execute_manifest` (every cited node id across the whole 67-item manifest actually executed and passed).

## Contract-artifact regen (found by the gate, not the review)

The HIGH fix's new `DevActualCompletion.required_children_not_applicable` field drifted the checked-in JSON Schema/manifest artifacts under `contracts/ask-dev/v1/`. Regenerated via `python -m dev_health_ops.api.dev.export_contracts write` — exactly `schemas/dev_tool_result.v1.schema.json` (new optional boolean field) and `manifest.json` (checksum), nothing else touched.

## Gate evidence

`bash ci/local_validate.sh` @ 0c3e07ecc, rebased onto `origin/main@d25438b33`:

- lint: ruff format --check — PASS
- lint: ruff check — PASS
- typecheck: mypy — PASS (2063+ files)
- ClickHouse scratch create / migrate — PASS
- unit suite (full): 11774 passed, 100 skipped, 1 xfailed, **16 failed — exactly the pre-authorized CHAOS-3405 machine-local baseline** (env drift: LICENSE_PRIVATE_KEY seed-length, uuid org_id=None signatures; files: test_register.py, admin/test_integrations.py, test_credential_resolver.py, test_new_user_journey.py, test_cli_preflight.py, test_org_deletion.py, test_linear_provider.py). No 17th failure (the contract-artifact drift found on the first gate run was fixed before this run).

Every fix RED-first; reproduced both the HIGH production-wiring co-occurrence and the MED-1 prompt/allowlist mismatch live before implementing the fix.

Merge is team-lead's call.
