### PR TITLE
fix(ask-dev): CHAOS-3219 ask-dev-world.v1 adversarial-review fixes + CHAOS-3432 declared residual

### DIFF
--- a/src/dev_health_ops/fixtures/generators/conflicts.py
+++ b/src/dev_health_ops/fixtures/generators/conflicts.py
@@ -1,0 +1,122 @@
+"""CHAOS-3219: conflicting-evidence fixture rows for the ask-dev-world.
+
+Realizes ``sources.json``'s ``conflicting`` terminal state and the corpus
+registry's ``trust.conflicting-evidence`` family: two CI signals for the
+same repository that disagree.
+
+Honesty note on schema fidelity: ``models.git.CiPipelineRun``
+(``ci_pipeline_runs``) has no ``commit_sha``/ref column at all -- a pipeline
+run is keyed by ``(repo_id, run_id)`` only, so "two runs against the exact
+same commit" cannot be expressed at this table's own grain. The realization
+here is the closest honest analog the real schema supports: two runs for the
+SAME repo, queued within the same short window, with opposite ``status``
+values -- two contemporaneous CI signals for the same repository that
+disagree, which is what ``trust.conflicting-evidence``'s question shape
+("Is meridian/web-app's CI passing?") actually asks about. Documented here
+rather than silently claiming commit-level precision the schema cannot back.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictingCiRunPair:
+    repo_id: uuid.UUID
+    run_id_success: str
+    run_id_failed: str
+    queued_at: datetime
+    org_id: str
+
+
+def build_conflicting_ci_runs(
+    *, repo_id: uuid.UUID, org_id: str, as_of: datetime, seed_label: str
+) -> ConflictingCiRunPair:
+    """Two same-repo, same-window, opposite-conclusion CI runs.
+
+    ``as_of`` anchors ``queued_at`` -- always caller-supplied (the world's
+    pinned ``now`` or a repo-specific deterministic offset of it), never
+    ``datetime.now()``.
+    """
+
+    return ConflictingCiRunPair(
+        repo_id=repo_id,
+        run_id_success=f"conflict-{seed_label}-success",
+        run_id_failed=f"conflict-{seed_label}-failed",
+        queued_at=as_of,
+        org_id=org_id,
+    )
+
+
+def to_postgres_ci_pipeline_runs(pair: ConflictingCiRunPair) -> list[Any]:
+    """The pair as :class:`models.git.CiPipelineRun` ORM rows."""
+
+    from dev_health_ops.models.git import CiPipelineRun
+
+    started = pair.queued_at + timedelta(minutes=1)
+    finished_ok = started + timedelta(minutes=8)
+    finished_bad = started + timedelta(minutes=5)
+    return [
+        CiPipelineRun(
+            repo_id=pair.repo_id,
+            run_id=pair.run_id_success,
+            status="success",
+            queued_at=pair.queued_at,
+            started_at=started,
+            finished_at=finished_ok,
+        ),
+        CiPipelineRun(
+            repo_id=pair.repo_id,
+            run_id=pair.run_id_failed,
+            status="failed",
+            queued_at=pair.queued_at + timedelta(minutes=2),
+            started_at=started + timedelta(minutes=2),
+            finished_at=finished_bad,
+        ),
+    ]
+
+
+def to_clickhouse_extended_rows(
+    pair: ConflictingCiRunPair, *, team_id: str | None, service_id: str
+) -> list[dict[str, Any]]:
+    """The pair as ``PipelineRunExtendedRow``-shaped dicts for ClickHouse.
+
+    Mirrors ``fixtures/generators/pipelines.py``
+    ``generate_pipeline_run_extended_rows``'s row shape exactly, so it can be
+    handed straight to :meth:`ClickHouseStore.insert_testops_pipeline_runs`
+    alongside a repo's normally-generated rows.
+    """
+
+    started = pair.queued_at + timedelta(minutes=1)
+    finished_ok = started + timedelta(minutes=8)
+    finished_bad = started + timedelta(minutes=5)
+    base = {
+        "repo_id": pair.repo_id,
+        "provider": "github_actions",
+        "retry_count": 0,
+        "team_id": team_id,
+        "service_id": service_id,
+        "org_id": pair.org_id,
+    }
+    return [
+        {
+            **base,
+            "run_id": pair.run_id_success,
+            "status": "success",
+            "queued_at": pair.queued_at,
+            "started_at": started,
+            "finished_at": finished_ok,
+        },
+        {
+            **base,
+            "run_id": pair.run_id_failed,
+            "status": "failed",
+            "queued_at": pair.queued_at + timedelta(minutes=2),
+            "started_at": started + timedelta(minutes=2),
+            "finished_at": finished_bad,
+        },
+    ]

--- a/src/dev_health_ops/fixtures/generators/projects.py
+++ b/src/dev_health_ops/fixtures/generators/projects.py
@@ -1,0 +1,172 @@
+"""CHAOS-3219: synthetic ``projects`` catalog rows for the ask-dev-world.
+
+The ``projects`` ClickHouse table (``migrations/clickhouse/051_team_attribution_
+dimensions.sql``) backs ``EntityKind.PROJECT`` in the Ask Dev scope catalog
+(``api/dev/scope_catalog.py``) and is one of the two ``ALIAS_AWARE_ENTITY_KINDS``
+CHAOS-3388's acronym/parenthetical-alias resolution reads from. No existing
+fixture generator writes to it -- ``dev-hops fixtures generate`` has never
+needed a PROJECT-kind subject distinct from a REPOSITORY one. The ask-dev-world
+needs it for two registry-required realizations: the acronym-alias subject
+class, and the deleted subject class (a project row whose latest
+ReplacingMergeTree version carries ``is_active = 0``).
+
+Kept intentionally small and standalone (no dependency on
+:class:`~dev_health_ops.fixtures.generator.SyntheticDataGenerator`) so it is
+usable independently of a full repo generation pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+#: Same fixture namespace every other generator in this package derives
+#: deterministic ids from (``generator.py``, ``demo_identity.py``'s callers,
+#: ``runner.py``'s ``_default_org``). A project's own catalog id is pinned to
+#: its ``repo_full_name`` (provider ``synthetic``) so it satisfies arm 1 of
+#: ``_project_identity.project_identity_match`` -- ``work_items.project_id ==
+#: projects.id`` -- against the exact ``project_id`` value
+#: ``fixtures/generators/work_items.py`` already stamps onto every generated
+#: work item for that repo (``project_id=proj`` where ``proj`` is the repo's
+#: full name). No new work-item-side wiring is required.
+FIXTURE_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+#: The provider label every ask-dev-world project row and every synthetic
+#: work item share -- ``_project_identity_match``'s provider guard requires
+#: the two sides to agree, and ``SyntheticDataGenerator``'s default
+#: ``provider`` is already ``"synthetic"``.
+SYNTHETIC_PROVIDER = "synthetic"
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectRecord:
+    """One row of the ``projects`` table (id, org_id, provider, project_key,
+    name, is_active, updated_at, last_synced)."""
+
+    id: str
+    org_id: str
+    name: str
+    provider: str = SYNTHETIC_PROVIDER
+    project_key: str | None = None
+    is_active: bool = True
+    updated_at: datetime | None = None
+    last_synced: datetime | None = None
+
+
+def project_id_for_repo(repo_full_name: str) -> str:
+    """The ``projects.id`` value for a repo-backed project (== repo full name).
+
+    Deliberately the raw repo full name, not a derived UUID: arm 1 of
+    ``_project_identity.project_identity_match`` compares
+    ``work_items.project_id`` directly against ``projects.id`` with no
+    UUID parsing involved, and ``fixtures/generators/work_items.py`` already
+    writes the repo's full name onto ``project_id`` verbatim.
+    """
+
+    return repo_full_name
+
+
+def build_project_record(
+    *,
+    org_id: str,
+    repo_full_name: str,
+    display_name: str | None = None,
+    is_active: bool = True,
+    as_of: datetime,
+) -> ProjectRecord:
+    """One repo-backed PROJECT catalog row, active as of ``as_of``.
+
+    ``as_of`` must be derived from the world's pinned ``now`` by the caller
+    (``fixtures/world.py``) -- never ``datetime.now()`` here, per the
+    CHAOS-3392 no-wall-clock rule for new fixture-world code.
+    """
+
+    return ProjectRecord(
+        id=project_id_for_repo(repo_full_name),
+        org_id=org_id,
+        name=display_name or repo_full_name,
+        provider=SYNTHETIC_PROVIDER,
+        project_key=None,
+        is_active=is_active,
+        updated_at=as_of,
+        last_synced=as_of,
+    )
+
+
+def build_retired_project_version(
+    active_record: ProjectRecord, *, retired_as_of: datetime
+) -> ProjectRecord:
+    """A superseding, ``is_active=0`` version of ``active_record``.
+
+    ``projects`` is a ``ReplacingMergeTree(updated_at)`` keyed on
+    ``(org_id, provider, id)`` -- inserting a second row with the same key
+    and a LATER ``updated_at`` is how a project is "deleted"/archived without
+    ever issuing a DELETE. Realizes ``subjects.json``'s ``deleted`` class.
+    """
+
+    if retired_as_of <= (active_record.updated_at or retired_as_of):
+        raise ValueError(
+            "build_retired_project_version: retired_as_of must be strictly "
+            "after the active record's updated_at, or ReplacingMergeTree "
+            "will not deterministically prefer the retired version"
+        )
+    return ProjectRecord(
+        id=active_record.id,
+        org_id=active_record.org_id,
+        name=active_record.name,
+        provider=active_record.provider,
+        project_key=active_record.project_key,
+        is_active=False,
+        updated_at=retired_as_of,
+        last_synced=retired_as_of,
+    )
+
+
+_PROJECT_COLUMNS = (
+    "id",
+    "org_id",
+    "provider",
+    "project_key",
+    "name",
+    "is_active",
+    "updated_at",
+    "last_synced",
+)
+
+
+def _row_for_insert(record: ProjectRecord) -> list[Any]:
+    updated_at = record.updated_at or datetime.now(timezone.utc)
+    last_synced = record.last_synced or updated_at
+    return [
+        record.id,
+        record.org_id,
+        record.provider,
+        record.project_key,
+        record.name,
+        1 if record.is_active else 0,
+        updated_at,
+        last_synced,
+    ]
+
+
+async def insert_projects(client: Any, records: list[ProjectRecord]) -> None:
+    """Insert ``projects`` rows via the raw clickhouse-connect client.
+
+    Deliberately bypasses ``ClickHouseStore`` (out of Lane 1a's file
+    territory -- ``src/dev_health_ops/storage/**`` belongs to other lanes) and
+    talks to ``client.insert`` directly, the same underlying call
+    ``ClickHouseStore._insert_rows`` makes.
+    """
+
+    if not records:
+        return
+    matrix = [_row_for_insert(record) for record in records]
+    await asyncio.to_thread(
+        client.insert,
+        "projects",
+        matrix,
+        column_names=list(_PROJECT_COLUMNS),
+    )

--- a/src/dev_health_ops/fixtures/generators/retention_conversations.py
+++ b/src/dev_health_ops/fixtures/generators/retention_conversations.py
@@ -1,0 +1,242 @@
+"""CHAOS-3219: retention-aged conversations + validation packets for the
+ask-dev-world (Postgres ``dev_conversations``/``dev_runs``/
+``dev_run_subject_sets`` -- ``models/dev_persistence.py``).
+
+Scope deliberately narrow: only ``DevConversation``, ``DevRun``, and
+``DevRunSubjectSet`` rows are built here, never ``DevMessage`` -- that model
+carries a role-conditional ``CheckConstraint`` (user vs assistant shape) this
+lane does not need to satisfy to realize retention aging, the stale-context
+subject class, or a validation-status "packet". Every row uses a
+deterministic ``uuid.uuid5``-derived id (never ``uuid.uuid4()``) so a second
+generation run ``session.merge()``s the SAME rows instead of duplicating
+them -- the seed-idempotency guarantee ``fixtures world`` proves against a
+live scratch database.
+
+No wall-clock ``datetime.now()``/``utcnow()`` anywhere (CHAOS-3392 lesson):
+every timestamp is derived from a caller-supplied ``pinned_now``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dev_health_ops.models.dev_persistence import (
+        DevConversation,
+        DevRun,
+        DevRunSubjectSet,
+    )
+
+FIXTURE_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+#: The real ``grounding_validation_status`` vocabulary this world seeds.
+#: ``dev_runs.grounding_validation_status`` carries no DB-level CHECK
+#: constraint (free String(32)) -- these three values are the ones
+#: ``scope_service.py``'s own commentary and the ``trust.*`` corpus family
+#: name explicitly (validated / a detected self-contradiction / insufficient
+#: evidence to validate at all).
+VALIDATION_STATUSES: tuple[str, ...] = (
+    "validated",
+    "contradiction_detected",
+    "insufficient_evidence",
+)
+
+
+def _uuid5(*parts: str) -> uuid.UUID:
+    return uuid.uuid5(FIXTURE_NAMESPACE, ":".join(parts))
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationBundle:
+    """A conversation plus its runs and (optionally) one subject set, ready
+    to hand to ``world.py``'s ``session.merge()`` loop."""
+
+    conversation: DevConversation
+    runs: tuple[DevRun, ...]
+    subject_sets: tuple[DevRunSubjectSet, ...]
+
+
+def build_retention_aged_conversation(
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    id_seed: str,
+    retention_days: int,
+    age_days: int,
+    pinned_now: datetime,
+    title: str,
+) -> ConversationBundle:
+    """One conversation created ``age_days`` before ``pinned_now``.
+
+    ``retention_days`` in ``{0, 30}`` (the DB CHECK constraint's only legal
+    values) drives ``expires_at``; ``age_days`` independently controls how
+    far in the PAST ``created_at``/``updated_at`` sit, so a caller can seed
+    both an already-expired-by-policy row (``age_days > retention_days``,
+    ``retention_days > 0``) and a fresh one for the SAME policy.
+    """
+
+    from dev_health_ops.models.dev_persistence import DevConversation
+
+    created_at = pinned_now - timedelta(days=age_days)
+    expires_at = (
+        created_at + timedelta(days=retention_days) if retention_days > 0 else None
+    )
+    conversation = DevConversation(
+        id=_uuid5("conversation", id_seed),
+        org_id=org_id,
+        user_id=user_id,
+        title=title,
+        current_scope={},
+        retention_days=retention_days,
+        created_at=created_at,
+        updated_at=created_at,
+        expires_at=expires_at,
+        deleted_at=None,
+    )
+    return ConversationBundle(conversation=conversation, runs=(), subject_sets=())
+
+
+def build_stale_context_conversation(
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    id_seed: str,
+    repo_full_name: str,
+    pinned_now: datetime,
+    stale_after_days: int = 9,
+) -> ConversationBundle:
+    """A conversation whose turn-1 committed subject predates turn 2 by
+    ``stale_after_days`` -- realizes ``subjects.json``'s ``stale-context``
+    class (mention: "it", referring to the prior turn's subject).
+    """
+
+    from dev_health_ops.models.dev_persistence import (
+        DevConversation,
+        DevRun,
+        DevRunSubjectSet,
+    )
+
+    early_at = pinned_now - timedelta(days=stale_after_days)
+    late_at = pinned_now - timedelta(hours=1)
+
+    conversation = DevConversation(
+        id=_uuid5("conversation", id_seed),
+        org_id=org_id,
+        user_id=user_id,
+        title="stale-context probe",
+        current_scope={"repository": repo_full_name},
+        retention_days=30,
+        created_at=early_at,
+        updated_at=late_at,
+        expires_at=early_at + timedelta(days=30),
+        deleted_at=None,
+    )
+
+    early_run = DevRun(
+        id=_uuid5("run", id_seed, "early"),
+        request_id=_uuid5("request", id_seed, "early"),
+        conversation_id=conversation.id,
+        org_id=org_id,
+        user_id=user_id,
+        state="completed",
+        contract_generation="v2",
+        public_outcome="answered",
+        started_at=early_at,
+        ended_at=early_at,
+        created_at=early_at,
+        tool_call_count=1,
+        citation_count=1,
+    )
+    subject_set = DevRunSubjectSet(
+        id=_uuid5("subject-set", id_seed, "early"),
+        run_id=early_run.id,
+        org_id=org_id,
+        user_id=user_id,
+        set_id=_uuid5("subject-set-committed", id_seed, "early"),
+        entity_kind="repository",
+        cohort_complete=True,
+        fingerprint=f"stale-context:{repo_full_name}",
+        payload={"repo_full_name": repo_full_name},
+        created_at=early_at,
+    )
+    late_run = DevRun(
+        id=_uuid5("run", id_seed, "late"),
+        request_id=_uuid5("request", id_seed, "late"),
+        conversation_id=conversation.id,
+        org_id=org_id,
+        user_id=user_id,
+        state="completed",
+        contract_generation="v2",
+        public_outcome="needs_clarification",
+        started_at=late_at,
+        ended_at=late_at,
+        created_at=late_at,
+        tool_call_count=0,
+        citation_count=0,
+    )
+    return ConversationBundle(
+        conversation=conversation,
+        runs=(early_run, late_run),
+        subject_sets=(subject_set,),
+    )
+
+
+def build_validation_packet(
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    id_seed: str,
+    pinned_now: datetime,
+) -> ConversationBundle:
+    """One conversation with one run per :data:`VALIDATION_STATUSES` value.
+
+    A "packet" in the sense the Lane 1a task description names explicitly:
+    a bounded, versioned set of runs exercising the full
+    ``grounding_validation_status`` vocabulary a single answer can carry,
+    for ``trust.*``/``scope.refused-with-grounding`` corpus cases to assert
+    against.
+    """
+
+    from dev_health_ops.models.dev_persistence import DevConversation, DevRun
+
+    created_at = pinned_now - timedelta(hours=2)
+    conversation = DevConversation(
+        id=_uuid5("conversation", id_seed),
+        org_id=org_id,
+        user_id=user_id,
+        title="validation packet probe",
+        current_scope={},
+        retention_days=30,
+        created_at=created_at,
+        updated_at=created_at,
+        expires_at=created_at + timedelta(days=30),
+        deleted_at=None,
+    )
+    runs = []
+    for offset, status in enumerate(VALIDATION_STATUSES):
+        run_at = created_at + timedelta(minutes=offset)
+        public_outcome = "answered" if status == "validated" else "answered_with_gaps"
+        runs.append(
+            DevRun(
+                id=_uuid5("run", id_seed, status),
+                request_id=_uuid5("request", id_seed, status),
+                conversation_id=conversation.id,
+                org_id=org_id,
+                user_id=user_id,
+                state="completed",
+                contract_generation="v2",
+                public_outcome=public_outcome,
+                grounding_validation_status=status,
+                started_at=run_at,
+                ended_at=run_at,
+                created_at=run_at,
+                tool_call_count=1,
+                citation_count=2 if status != "insufficient_evidence" else 0,
+            )
+        )
+    return ConversationBundle(
+        conversation=conversation, runs=tuple(runs), subject_sets=()
+    )

--- a/src/dev_health_ops/fixtures/generators/source_health.py
+++ b/src/dev_health_ops/fixtures/generators/source_health.py
@@ -1,0 +1,242 @@
+"""CHAOS-3219: ``SyncConfiguration`` rows + watermark aging for the ask-dev-world
+per-source terminal-state matrix (``sources.json``).
+
+Grounded directly in ``api/dev/data_health_service.py``'s
+``NativeDataHealthReader`` -- the real reader ``DataHealthService.inspect``
+delegates to for every Ask Dev "how healthy/fresh is this source" question.
+Every state this module realizes is a direct, documented consequence of a
+signal that reader actually inspects:
+
+* ``configured`` comes from whether an *active* ``SyncConfiguration`` row
+  exists for a provider that ``_provider_supports`` maps onto the requested
+  source (``build_sync_configuration`` / ``PROVIDER_SUPPORTS_SOURCE``).
+* ``active_failure`` comes from ``SyncConfiguration.last_sync_success is
+  False`` (``build_sync_configuration(..., last_sync_success=False)``).
+* ``watermark`` comes from ``max(last_synced)`` over the source's own raw
+  table, scoped by repo -- ``age_source_rows`` deletes and re-inserts each
+  row with that column overwritten (see its own docstring for why a plain
+  ``ALTER TABLE ... UPDATE`` cannot be used) so staleness is driven by the
+  SAME column the reader reads, not by shifting business dates (commit
+  ``authored_date`` etc.), which the reader never looks at.
+
+No wall-clock ``datetime.now()``/``utcnow()`` calls anywhere in this module
+(CHAOS-3392 lesson) -- every timestamp is threaded in by the caller, always
+derived from the world's pinned ``now``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Literal
+
+#: Mirrors ``data_health_service._provider_supports`` verbatim (kept as an
+#: explicit, importable table here rather than re-deriving it, since that
+#: function is private to ``api/dev`` and Lane 1a's territory is
+#: ``fixtures/**`` only -- duplicating the closed, documented mapping is
+#: safer than reaching across the lane boundary to import a private helper).
+PROVIDER_SUPPORTS_SOURCE: dict[str, tuple[str, ...]] = {
+    "work_items": ("jira", "linear", "github", "gitlab"),
+    "work_units": ("jira", "linear", "github", "gitlab"),
+    "incidents": ("pagerduty", "opsgenie", "incident"),
+    "commits": ("github", "gitlab", "local", "git"),
+    "pull_requests": ("github", "gitlab", "local", "git"),
+    "reviews": ("github", "gitlab", "local", "git"),
+    "deployments": ("github", "gitlab", "local", "git"),
+}
+
+#: The two raw-table source keys ``data_health_service._SOURCE_TABLES`` maps
+#: to a ``(table, repo_column, watermark_column)`` triple that this module's
+#: ``age_source_rows``/``zero_out_source`` mutate directly.
+_SOURCE_TABLES: dict[str, tuple[str, str | None, str]] = {
+    "work_items": ("work_items", "repo_id", "last_synced"),
+    "work_units": ("work_unit_investments", "repo_id", "computed_at"),
+    "pull_requests": ("git_pull_requests", "repo_id", "last_synced"),
+    "reviews": ("git_pull_request_reviews", "repo_id", "last_synced"),
+    "commits": ("git_commits", "repo_id", "last_synced"),
+    "ci_runs": ("ci_pipeline_runs", "repo_id", "last_synced"),
+    "deployments": ("deployments", "repo_id", "last_synced"),
+    "incidents": ("operational_incidents", None, "last_synced"),
+}
+
+#: ``sync_coverage.STALE_FALLBACK_GRACE`` verbatim (48h) -- the grace applied
+#: when no ``ScheduledJob`` row exists for the org/provider, which is the
+#: only path this fixture world ever exercises (no ``ScheduledJob`` rows are
+#: seeded). Kept as a literal constant here rather than importing the
+#: private module for the same file-territory reason as
+#: ``PROVIDER_SUPPORTS_SOURCE`` above.
+STALE_FALLBACK_GRACE = timedelta(hours=48)
+
+SyncProviderState = Literal["active_success", "active_failure", "unconfigured"]
+
+
+@dataclass(frozen=True, slots=True)
+class SyncConfigurationSpec:
+    """Declarative shape of one org+provider ``SyncConfiguration`` row.
+
+    ``state='unconfigured'`` means "do not create a row at all" -- callers
+    filter these out before building ORM instances; kept as an explicit enum
+    member (not just an absent dict key) so ``world.json``'s
+    ``sync_providers`` block can name every provider's intended state
+    uniformly, including the ones that resolve to "no row".
+    """
+
+    org_id: str
+    provider: str
+    state: SyncProviderState
+    last_sync_at: datetime | None = None
+
+
+def build_sync_configuration(spec: SyncConfigurationSpec):
+    """One ``models.settings.SyncConfiguration`` ORM row for ``spec``.
+
+    Returns ``None`` for ``state='unconfigured'`` -- the absence of a row
+    IS the fixture (mirrors ``subjects.json``'s no-match convention: absence
+    is deliberate, not an oversight).
+    """
+
+    if spec.state == "unconfigured":
+        return None
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    config = SyncConfiguration(
+        name=f"ask-dev-world-{spec.provider}",
+        provider=spec.provider,
+        org_id=spec.org_id,
+        sync_targets=["*"],
+        is_active=True,
+        planner_managed=False,
+    )
+    config.last_sync_at = spec.last_sync_at
+    config.last_sync_success = spec.state == "active_success"
+    if spec.state == "active_failure":
+        config.last_sync_error = "ask-dev-world fixture: simulated sync failure"
+    return config
+
+
+def build_sync_configurations_for_org(
+    org_id: str,
+    provider_states: dict[str, SyncProviderState],
+    *,
+    as_of: datetime,
+) -> list[Any]:
+    """All non-``unconfigured`` ``SyncConfiguration`` rows for one org.
+
+    ``as_of`` is used as ``last_sync_at`` for every configured provider --
+    the world's pinned "now", never wall-clock time.
+    """
+
+    configs = []
+    for provider, state in provider_states.items():
+        record = build_sync_configuration(
+            SyncConfigurationSpec(
+                org_id=org_id,
+                provider=provider,
+                state=state,
+                last_sync_at=as_of if state != "unconfigured" else None,
+            )
+        )
+        if record is not None:
+            configs.append(record)
+    return configs
+
+
+def sources_configured_for_org(
+    provider_states: dict[str, SyncProviderState],
+) -> set[str]:
+    """Source keys with >=1 *configured* (non-unconfigured) supporting provider."""
+
+    configured_providers = {
+        provider
+        for provider, state in provider_states.items()
+        if state != "unconfigured"
+    }
+    return {
+        source
+        for source, providers in PROVIDER_SUPPORTS_SOURCE.items()
+        if configured_providers & set(providers)
+    }
+
+
+async def age_source_rows(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str,
+    source: str,
+    stale_watermark: datetime,
+) -> None:
+    """Force ``source``'s watermark for ``repo_id`` to ``stale_watermark``.
+
+    Realized as a **delete-and-reinsert**, not an in-place ``ALTER TABLE ...
+    UPDATE``: every affected table (``git_commits``, ``git_pull_requests``,
+    ...) is a ``ReplacingMergeTree`` whose ``ORDER BY`` key INCLUDES
+    ``last_synced`` (empirically confirmed against a live scratch database --
+    the first cut of this function used ``ALTER ... UPDATE`` and ClickHouse
+    rejected it with ``Code: 420 CANNOT_UPDATE_COLUMN`` because a sorting-key
+    column can never be updated in place). Reading every row generically
+    (whatever columns the table actually has), deleting them, and
+    re-inserting the SAME rows with only the watermark column's value
+    swapped works regardless of a table's exact key definition and needs no
+    per-table column list maintained here.
+
+    Both the delete and the reinsert are synchronous
+    (``mutations_sync=1`` / awaited) so the caller can trust the mutation is
+    visible before ``run_fixtures_world``'s digest is computed.
+    """
+
+    table, repo_column, watermark_column = _SOURCE_TABLES[source]
+    if repo_column is None:
+        # incidents carries no repo_id column -- aging is org-wide for it.
+        where = "org_id = {org_id:String}"
+    else:
+        where = f"org_id = {{org_id:String}} AND {repo_column} = {{repo_id:String}}"
+    params = {"org_id": org_id, "repo_id": repo_id}
+
+    result = await asyncio.to_thread(
+        client.query,
+        f"SELECT * FROM {table} FINAL WHERE {where}",  # noqa: S608
+        parameters=params,
+    )
+    column_names = list(result.column_names)
+    rows = [list(row) for row in result.result_rows]
+    if not rows:
+        return
+    watermark_idx = column_names.index(watermark_column)
+    for row in rows:
+        row[watermark_idx] = stale_watermark
+
+    await asyncio.to_thread(
+        client.command,
+        f"ALTER TABLE {table} DELETE WHERE {where} SETTINGS mutations_sync = 1",  # noqa: S608
+        parameters=params,
+    )
+    await asyncio.to_thread(client.insert, table, rows, column_names=column_names)
+
+
+async def zero_out_source(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str,
+    source: str,
+) -> None:
+    """Delete every ``source`` row for ``repo_id`` -- realizes NO_DATA.
+
+    Distinct from ``age_source_rows``: an aged watermark still reads
+    ``STALE`` (the reader saw *something*, just too old); zero rows reads
+    ``NO_DATA`` (the reader's ``watermark is None`` branch).
+    """
+
+    table, repo_column, _watermark_column = _SOURCE_TABLES[source]
+    if repo_column is None:
+        where = "org_id = {org_id:String}"
+    else:
+        where = f"org_id = {{org_id:String}} AND {repo_column} = {{repo_id:String}}"
+    query = f"ALTER TABLE {table} DELETE WHERE {where} SETTINGS mutations_sync = 1"
+    await asyncio.to_thread(
+        client.command,
+        query,
+        parameters={"org_id": org_id, "repo_id": repo_id},
+    )

--- a/src/dev_health_ops/fixtures/generators/source_health.py
+++ b/src/dev_health_ops/fixtures/generators/source_health.py
@@ -159,6 +159,12 @@ def sources_configured_for_org(
     }
 
 
+class SourceAgingWriteError(RuntimeError):
+    """``age_source_rows`` could not confirm the aged replacement rows were
+    durably visible after writing them -- see the function's own docstring
+    (Codex HIGH-5, 2026-08-05) for what this guards against."""
+
+
 async def age_source_rows(
     client: Any,
     *,
@@ -169,21 +175,56 @@ async def age_source_rows(
 ) -> None:
     """Force ``source``'s watermark for ``repo_id`` to ``stale_watermark``.
 
-    Realized as a **delete-and-reinsert**, not an in-place ``ALTER TABLE ...
-    UPDATE``: every affected table (``git_commits``, ``git_pull_requests``,
-    ...) is a ``ReplacingMergeTree`` whose ``ORDER BY`` key INCLUDES
-    ``last_synced`` (empirically confirmed against a live scratch database --
-    the first cut of this function used ``ALTER ... UPDATE`` and ClickHouse
-    rejected it with ``Code: 420 CANNOT_UPDATE_COLUMN`` because a sorting-key
-    column can never be updated in place). Reading every row generically
-    (whatever columns the table actually has), deleting them, and
-    re-inserting the SAME rows with only the watermark column's value
-    swapped works regardless of a table's exact key definition and needs no
-    per-table column list maintained here.
+    Realized as **delete-then-insert**, not an in-place ``ALTER TABLE ...
+    UPDATE`` (every affected table's version column is a protected "key
+    column" for ``ALTER ... UPDATE`` purposes even when it is not part of
+    ``ORDER BY`` -- empirically confirmed live: ``Code: 420
+    CANNOT_UPDATE_COLUMN``), and NOT insert-then-delete either, despite that
+    being the more obvious way to avoid a delete-first zero-row window.
 
-    Both the delete and the reinsert are synchronous
-    (``mutations_sync=1`` / awaited) so the caller can trust the mutation is
-    visible before ``run_fixtures_world``'s digest is computed.
+    Codex HIGH-5 (2026-08-05) history, corrected same-day after a LIVE
+    two-generation run caught a worse bug than the one being fixed: an
+    earlier revision of this function inserted the aged replacement rows
+    BEFORE deleting the originals, reasoning that the worst a mid-operation
+    crash could do is leave both versions present, which a
+    ReplacingMergeTree resolves harmlessly via ``FINAL``. That reasoning
+    missed that this table family is a `ReplacingMergeTree(<watermark
+    column>)` and "aging" a row means writing a LOWER version value than
+    what is already there -- the exact case ReplacingMergeTree's own merge
+    rule (highest version wins) resolves the WRONG way. Live forensics via
+    ``system.part_log`` on a real scratch database caught it directly: the
+    aged INSERT landed (``NewPart``, 39 rows) and a background merge started
+    ~300 MICROSECONDS later, completing in ~2.4ms and silently collapsing
+    the just-inserted lower-version rows back to the pre-existing
+    higher-version ones -- with NO crash, NO exception, under completely
+    normal execution, on a table that already had many parts from earlier
+    inserts in the same generation run (ClickHouse's background merge
+    scheduler merges eagerly once a table accumulates enough small parts).
+    Insert-then-delete is therefore not just crash-unsafe here, it is
+    *plain-execution*-unsafe -- strictly worse than the bug it was meant to
+    fix, and the corruption is silent unless independently verified (which
+    is exactly what caught it: see the postcondition check below).
+
+    Delete-then-insert avoids that hazard structurally: once the higher-
+    version originals are gone, there is no competing row left for a merge
+    to prefer, so whatever the insert writes IS the row, with no version
+    race window at all. What delete-then-insert cannot avoid -- and nothing
+    can, short of ClickHouse gaining cross-statement transactions for
+    MergeTree tables -- is a process crash landing in the gap between the
+    two statements, which does leave zero rows for `org_id`/`repo_id` until
+    the next full regeneration. Given ``fixtures world`` runs exclusively
+    against disposable SCRATCH databases (enforced at the entrypoint) that
+    are always regenerated fresh rather than resumed in place after a
+    failure, that residual window's blast radius is bounded to "this
+    generation run failed and must be re-run," not "a live database is
+    silently wrong forever." The postcondition check below closes the
+    remaining, actually-preventable gap: an insert that returns success but
+    is not yet confirmed durable is now impossible to mistake for a
+    completed aging operation, whatever the underlying cause.
+
+    Both mutations are synchronous (``mutations_sync=1`` / awaited) so the
+    caller can trust the result is visible before ``run_fixtures_world``'s
+    digest is computed.
     """
 
     table, repo_column, watermark_column = _SOURCE_TABLES[source]
@@ -213,6 +254,50 @@ async def age_source_rows(
         parameters=params,
     )
     await asyncio.to_thread(client.insert, table, rows, column_names=column_names)
+
+    observed = await _count_rows_at_watermark(
+        client,
+        table=table,
+        where=where,
+        watermark_column=watermark_column,
+        params=params,
+        stale_watermark=stale_watermark,
+    )
+    if observed < len(rows):
+        raise SourceAgingWriteError(
+            f"age_source_rows: deleted the original rows and inserted "
+            f"{len(rows)} aged row(s) into {table!r} for org_id={org_id!r} "
+            f"repo_id={repo_id!r}, but only {observed} row(s) with "
+            f"{watermark_column}={stale_watermark!r} are visible "
+            "afterward -- the replacement was not confirmed durable. The "
+            "table may currently have zero rows for this org/repo; this "
+            "generation run must be treated as failed and re-run against a "
+            "fresh scratch database, never resumed in place."
+        )
+
+
+async def _count_rows_at_watermark(
+    client: Any,
+    *,
+    table: str,
+    where: str,
+    watermark_column: str,
+    params: dict[str, Any],
+    stale_watermark: datetime,
+) -> int:
+    """How many rows in ``table`` currently match ``where`` AND carry
+    ``watermark_column == stale_watermark`` -- the read-your-write check
+    ``age_source_rows`` uses to confirm its insert landed before it deletes
+    anything. Split out as its own function so a failure-injection test can
+    monkeypatch/stub it independently of the insert/delete calls."""
+
+    result = await asyncio.to_thread(
+        client.query,
+        f"SELECT count() FROM {table} WHERE {where} AND {watermark_column} = "  # noqa: S608
+        "{stale_watermark:DateTime64(3, 'UTC')}",
+        parameters={**params, "stale_watermark": stale_watermark},
+    )
+    return int(result.result_rows[0][0])
 
 
 async def zero_out_source(

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -2509,3 +2509,68 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Deterministic seed (mixed with org_id) for repeatable runs.",
     )
     fix_pt.set_defaults(func=run_product_telemetry_fixtures)
+
+    fix_world = fix_sub.add_parser(
+        "world",
+        help=(
+            "Generate the versioned, deterministic ask-dev-world.v1 "
+            "multi-org fixture world (CHAOS-3219)."
+        ),
+    )
+    fix_world.add_argument(
+        "--manifest",
+        required=True,
+        help=(
+            "Path to world.json (subjects.json/sources.json are read from "
+            "the same directory, e.g. "
+            "tests/acceptance/world/ask-dev-world.v1/world.json)."
+        ),
+    )
+    fix_world.add_argument(
+        "--sink",
+        default=os.getenv("CLICKHOUSE_URI"),
+        help="Analytics sink URI (ClickHouse). Env: CLICKHOUSE_URI",
+    )
+    fix_world.add_argument(
+        "--postgres-uri",
+        default=None,
+        help="Semantic DB URI. Defaults to POSTGRES_URI/DATABASE_URI env.",
+    )
+    fix_world.add_argument(
+        "--digest-path",
+        default=None,
+        help=(
+            "Path to read/write WORLD_DIGEST. Defaults to a WORLD_DIGEST "
+            "file alongside --manifest."
+        ),
+    )
+    fix_world.add_argument(
+        "--verify-digest",
+        action="store_true",
+        dest="verify_digest",
+        default=False,
+        help=(
+            "Recompute the content digest of the live database and compare "
+            "against the pinned WORLD_DIGEST file, failing loudly on drift, "
+            "instead of generating."
+        ),
+    )
+    fix_world.add_argument(
+        "--allow-mixed-org",
+        action="store_true",
+        dest="allow_mixed_org",
+        default=False,
+        help=(
+            "Passed through to each per-repo generation call. Off by "
+            "default -- see `fixtures generate --allow-mixed-org`."
+        ),
+    )
+
+    # Deferred import (not a module-level import of runner.py): world.py
+    # itself imports several names FROM this module, so importing it at
+    # runner.py's own module-load time would be circular. By the time
+    # register_commands() runs (CLI setup, after runner.py has fully
+    # loaded), the cycle is safe to close here.
+    from dev_health_ops.fixtures.world import run_fixtures_world
+
+    fix_world.set_defaults(func=run_fixtures_world)

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1683,6 +1683,14 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                     from_ts=config.from_date,
                     to_ts=config.to_date,
                     org_id=org_id,
+                    # Passthrough only: defaults to 5 (materialize_fixture_
+                    # investments' own default, unchanged for ordinary
+                    # `fixtures generate` callers). `fixtures world` sets
+                    # ns.llm_concurrency=1 to serialize LLM-categorization
+                    # completion order (Codex HIGH-4, 2026-08-05) -- see
+                    # world._generation_namespace and work_graph.runner.
+                    # materialize_fixture_investments's own docstring.
+                    llm_concurrency=getattr(ns, "llm_concurrency", 5),
                 )
         finally:
             builder.close()

--- a/src/dev_health_ops/fixtures/world.py
+++ b/src/dev_health_ops/fixtures/world.py
@@ -1,0 +1,1224 @@
+"""``dev-hops fixtures world`` -- CHAOS-3219 versioned deterministic fixture
+world (``ask-dev-world.v1``).
+
+Loads ``tests/acceptance/world/ask-dev-world.v1/{world,subjects,sources}.json``,
+seeds a multi-org Ask Dev world by REUSING the existing single-repo fixture
+machinery (``fixtures.runner.run_fixtures_generation``, called once per named
+repo -- ``demo_repo_name`` already returns a caller's exact ``--repo-name``
+unchanged whenever ``repo_count <= 1``, so no changes to ``runner.py``'s
+generation loop were needed), then layers world-specific realizations
+(PROJECT catalog rows, per-source sync-health matrix, conflicting-evidence
+CI runs, retention-aged conversations) on top, and finally computes/verifies
+a ``WORLD_DIGEST`` content hash of the generated state.
+
+Determinism (CHAOS-3392 lesson): every identifier is ``uuid.uuid5`` derived
+from ``master_seed``/id-seed strings, and every relative timestamp is
+derived from ``world.json``'s pinned ``now`` -- this module never calls
+``datetime.now()``/``utcnow()`` itself. ``run_fixtures_generation`` (reused,
+not owned by this module) DOES call ``datetime.now(timezone.utc)`` at dozens
+of sites across ``fixtures/generators/*.py``, ``metrics/job_daily.py`` and
+``work_graph/builder.py`` to anchor its own day-window loops -- rewriting
+all of that shared, widely-used generation code to accept an injectable
+clock was judged out of this lane's safe blast radius (it would touch
+every existing caller of ``fixtures generate``, not just this new
+subcommand). Instead, ``_frozen_clock`` (below) freezes ``datetime.now()``
+for the DURATION of each ``run_fixtures_generation`` call by swapping the
+``datetime`` name each of those modules imported at call time -- a
+call-site-local, fully-reverted patch that only ``fixtures world`` ever
+activates; ``fixtures generate`` and every other caller is untouched. This
+was verified empirically against a live scratch database (two full
+generations -> identical WORLD_DIGEST; see the Lane 1a report) rather than
+assumed correct from the source read alone -- both because the module list
+below must stay in sync with wherever ``run_fixtures_generation`` gains a
+new ``datetime.now()`` call site in the future, and because a monkeypatch
+covering the wrong scope would fail exactly the kind of silent-drift
+category CHAOS-3392 itself was.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib
+import json
+import logging
+import os
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from dev_health_ops.fixtures.generators import conflicts as conflicts_gen
+from dev_health_ops.fixtures.generators import projects as projects_gen
+from dev_health_ops.fixtures.generators import retention_conversations as conv_gen
+from dev_health_ops.fixtures.generators import source_health
+from dev_health_ops.fixtures.runner import (
+    _MISSING_TABLE_MARKERS,
+    run_fixtures_generation,
+)
+from dev_health_ops.storage import run_with_store
+
+WORLD_SCHEMA_VERSION = "ask_dev_world.v1"
+
+#: Every module ``run_fixtures_generation`` (transitively) calls that binds
+#: ``datetime.now(timezone.utc)`` to its own module-level ``datetime`` name
+#: (``from datetime import datetime, timezone``) to anchor a day-window loop
+#: or a ``last_synced``/``computed_at`` stamp. Enumerated by grepping
+#: ``fixtures/generators/*.py``, ``fixtures/runner.py``,
+#: ``metrics/job_daily.py`` and ``work_graph/builder.py`` for
+#: ``datetime.now(`` call sites, then confirmed empirically (see
+#: ``_frozen_clock``'s docstring) -- NOT a claim derived from reading alone.
+_CLOCK_PATCHED_MODULES: tuple[str, ...] = (
+    "dev_health_ops.fixtures.generator",
+    "dev_health_ops.fixtures.runner",
+    "dev_health_ops.fixtures.generators.ai_governance",
+    "dev_health_ops.fixtures.generators.ai_workflow",
+    "dev_health_ops.fixtures.generators.commits",
+    "dev_health_ops.fixtures.generators.incidents",
+    "dev_health_ops.fixtures.generators.interactions",
+    "dev_health_ops.fixtures.generators.investments",
+    "dev_health_ops.fixtures.generators.pipelines",
+    "dev_health_ops.fixtures.generators.prs",
+    "dev_health_ops.fixtures.generators.product_telemetry",
+    "dev_health_ops.fixtures.generators.teams",
+    "dev_health_ops.fixtures.generators.work_items",
+    "dev_health_ops.metrics.job_daily",
+    "dev_health_ops.work_graph.builder",
+)
+
+
+class _FrozenDateTime(datetime):
+    """A ``datetime`` subclass whose ``now()``/``utcnow()`` return a single
+    pinned instant, for swapping in as the ``datetime`` name inside another
+    module for the duration of :func:`_frozen_clock`."""
+
+    _frozen_now: datetime
+
+    @classmethod
+    def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+        if tz is not None:
+            return cls._frozen_now.astimezone(tz)
+        return cls._frozen_now.replace(tzinfo=None)
+
+    @classmethod
+    def utcnow(cls) -> datetime:  # type: ignore[override]  # noqa: D102
+        return cls._frozen_now.replace(tzinfo=None)
+
+
+@contextmanager
+def _frozen_clock(pinned_now: datetime):
+    """Freeze ``datetime.now()`` to ``pinned_now`` for every module in
+    :data:`_CLOCK_PATCHED_MODULES`, for the lifetime of the ``with`` block.
+
+    Call-site-local and fully reverted in a ``finally`` even on exception --
+    only ``fixtures world``'s own call to ``run_fixtures_generation`` is
+    ever wrapped in this; ``fixtures generate`` and every other entry point
+    into the same generator modules runs with the real, unpatched
+    ``datetime`` exactly as before.
+
+    KNOWN RESIDUAL GAP (disclosed, not silently dropped): this closes the
+    dominant source of cross-run drift -- verified live, two full
+    generations now reproduce an IDENTICAL WORLD_DIGEST for every Postgres
+    table and for the PRIMARY org's entire ClickHouse content (12 repos,
+    every source-state probe, teams, projects). One narrow gap remains,
+    root-caused but not eliminated: the SIBLING org's single repo's
+    ``ci_pipeline_runs``/``deployments`` row counts still vary run-to-run
+    (e.g. 32 vs 45 rows), even with this clock freeze AND ``PYTHONHASHSEED``
+    pinned identically across both processes. The likely mechanism:
+    ``run_fixtures_generation``'s ``--with-work-graph`` path invokes
+    ``work_graph.runner.materialize_fixture_investments`` with a "mock" LLM
+    provider through ``asyncio.gather``-scheduled concurrent tasks; if that
+    mock path draws from the shared global ``random`` module inside
+    concurrently-scheduled coroutines, real async scheduling/I-O-timing
+    (not the master seed) can interleave those draws in a different order
+    across process runs, desynchronizing the GLOBAL random state for
+    whichever repo generates immediately afterward -- observed to
+    consistently land on the LAST-generated repo (sibling's, in this
+    world's fixed generation order). Fully closing this would mean auditing
+    ``work_graph/runner.py``'s and its mock-LLM dependency's random usage
+    for concurrency-order sensitivity, which is outside this module's
+    territory and this lane's time budget. Tracked, not hidden: see the
+    Lane 1a report's "could not fully realize" list.
+    """
+
+    frozen = type("_FrozenDateTime", (_FrozenDateTime,), {"_frozen_now": pinned_now})
+    originals: dict[str, Any] = {}
+    for module_name in _CLOCK_PATCHED_MODULES:
+        module = importlib.import_module(module_name)
+        if hasattr(module, "datetime"):
+            originals[module_name] = module.datetime
+            setattr(module, "datetime", frozen)  # noqa: B010
+    try:
+        yield
+    finally:
+        for module_name, original in originals.items():
+            module = importlib.import_module(module_name)
+            setattr(module, "datetime", original)  # noqa: B010
+
+
+#: Same fixture namespace every generator in this package derives
+#: deterministic ids from.
+FIXTURE_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+#: Column names excluded from WORLD_DIGEST hashing across every table.
+#: Two categories, both non-seed-derived by construction:
+#: 1. wall-clock artifacts of insertion/sync time (the ``_frozen_clock``
+#:    fix pins these deterministically during generation too, but excluding
+#:    them here is also correct defense-in-depth for any caller of
+#:    ``compute_world_digest`` that runs outside a frozen-clock window,
+#:    e.g. ``--verify-digest`` against a database another process wrote to).
+#: 2. ``feature_id`` -- ``org_feature_overrides.feature_id`` references
+#:    ``feature_flags.id``, a row Alembic migrations 0067/0070 seed with
+#:    ``uuid.uuid4()`` (verified empirically: the SAME migration run against
+#:    two independently-migrated scratch databases produced two DIFFERENT
+#:    ``feature_flags.id`` values for the SAME ``key='ask_dev'`` row). That
+#:    id is environment-specific migration-application entropy, never
+#:    fixture-world content -- excluding it here does not weaken the guard,
+#:    since ``org_feature_overrides.is_enabled``/``reason``/``org_id`` (the
+#:    columns that actually encode this world's content) remain hashed.
+_VOLATILE_COLUMNS = frozenset(
+    {
+        "last_synced",
+        "updated_at",
+        "created_at",
+        "computed_at",
+        "synced_at",
+        "started_at",
+        "ended_at",
+        "queued_at",
+        "finished_at",
+        "last_sync_at",
+        "feature_id",
+    }
+)
+
+#: ClickHouse tables the digest covers, scoped by ``org_id``.
+_CLICKHOUSE_DIGEST_TABLES: tuple[str, ...] = (
+    "repos",
+    "teams",
+    "projects",
+    "work_items",
+    "git_pull_requests",
+    "ci_pipeline_runs",
+    "deployments",
+)
+
+#: Postgres tables the digest covers. ``org_scoped=True`` filters by
+#: ``org_id``; ``id_seed_scoped=True`` filters ``id IN (<world's own ids>)``
+#: (needed for ``users``, which carries no ``org_id`` column of its own).
+_POSTGRES_DIGEST_TABLES: tuple[tuple[str, str], ...] = (
+    ("organizations", "id"),
+    ("users", "id"),
+    ("memberships", "org_id"),
+    ("sync_configurations", "org_id"),
+    ("org_retention_policies", "org_id"),
+    ("org_feature_overrides", "org_id"),
+    ("dev_conversations", "org_id"),
+    ("dev_runs", "org_id"),
+    ("dev_run_subject_sets", "org_id"),
+)
+
+
+class WorldManifestError(ValueError):
+    """The world/subjects/sources manifest failed shape or cross-reference
+    validation -- fail loud before any generation happens."""
+
+
+class WorldDigestDriftError(RuntimeError):
+    """``--verify-digest`` found the live database no longer matches the
+    pinned ``WORLD_DIGEST`` file."""
+
+
+def _parse_dt(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class WorldManifest:
+    manifest_path: Path
+    world: dict[str, Any]
+    subjects: dict[str, Any]
+    sources: dict[str, Any]
+
+    @property
+    def master_seed(self) -> int:
+        return int(self.world["master_seed"])
+
+    @property
+    def pinned_now(self) -> datetime:
+        return _parse_dt(self.world["pinned_now"])
+
+    @property
+    def orgs(self) -> list[dict[str, Any]]:
+        return list(self.world["orgs"])
+
+    def org(self, alias: str) -> dict[str, Any]:
+        for org in self.orgs:
+            if org["alias"] == alias:
+                return org
+        raise WorldManifestError(f"world.json has no org with alias={alias!r}")
+
+    def org_id(self, alias: str) -> uuid.UUID:
+        return derive_id(self.master_seed, self.org(alias)["id_seed"])
+
+    def user_id(self, alias: str) -> uuid.UUID:
+        for user in self.world["users"]:
+            if user["alias"] == alias:
+                return derive_id(self.master_seed, user["id_seed"])
+        raise WorldManifestError(f"world.json has no user with alias={alias!r}")
+
+
+def derive_id(master_seed: int, id_seed: str) -> uuid.UUID:
+    """The one place a world/subjects/sources id_seed string becomes a UUID.
+
+    Namespaced by ``master_seed`` too (not only the id_seed string) so a
+    future ``ask-dev-world.v2`` sharing an id_seed string never collides
+    with v1's ids.
+    """
+
+    return uuid.uuid5(FIXTURE_NAMESPACE, f"{master_seed}:{id_seed}")
+
+
+def derive_repo_seed(master_seed: int, org_alias: str, repo_full_name: str) -> int:
+    """Deterministic per-(org, repo) seed for ``SyntheticDataGenerator``."""
+
+    digest = hashlib.sha256(
+        f"{master_seed}:{org_alias}:{repo_full_name}".encode()
+    ).hexdigest()
+    return int(digest[:8], 16)
+
+
+def load_world_manifest(manifest_path: str | Path) -> WorldManifest:
+    path = Path(manifest_path)
+    world = json.loads(path.read_text())
+    subjects = json.loads((path.parent / "subjects.json").read_text())
+    sources = json.loads((path.parent / "sources.json").read_text())
+    manifest = WorldManifest(
+        manifest_path=path, world=world, subjects=subjects, sources=sources
+    )
+    validate_world_manifest(manifest)
+    return manifest
+
+
+def validate_world_manifest(manifest: WorldManifest) -> None:
+    """Shape + cross-reference validation. Raises :class:`WorldManifestError`.
+
+    Deliberately checked BEFORE any DB connection is opened, matching the
+    project's "fail loud before doing work" convention (``_ensure_org_
+    unpolluted`` et al.).
+    """
+
+    for label, doc in (
+        ("world.json", manifest.world),
+        ("subjects.json", manifest.subjects),
+        ("sources.json", manifest.sources),
+    ):
+        version = doc.get("schema_version")
+        if version != WORLD_SCHEMA_VERSION:
+            raise WorldManifestError(
+                f"{label} schema_version={version!r}, expected {WORLD_SCHEMA_VERSION!r}"
+            )
+
+    org_aliases = {org["alias"] for org in manifest.world.get("orgs", [])}
+    if not org_aliases:
+        raise WorldManifestError("world.json declares zero orgs")
+
+    for subject in manifest.subjects.get("subjects", []):
+        alias = subject.get("org_alias")
+        if alias is not None and alias not in org_aliases:
+            raise WorldManifestError(
+                f"subjects.json subject {subject.get('id')!r} references "
+                f"unknown org_alias={alias!r}"
+            )
+        asked_from = subject.get("asked_from_org_alias")
+        if asked_from is not None and asked_from not in org_aliases:
+            raise WorldManifestError(
+                f"subjects.json subject {subject.get('id')!r} references "
+                f"unknown asked_from_org_alias={asked_from!r}"
+            )
+
+    required_classes = set(
+        manifest.subjects.get("class_coverage_check", {}).get("required_classes", [])
+    )
+    present_classes = {s["class"] for s in manifest.subjects.get("subjects", [])}
+    missing_classes = required_classes - present_classes
+    if missing_classes:
+        raise WorldManifestError(
+            "subjects.json has zero realizing rows for required class(es): "
+            f"{sorted(missing_classes)}"
+        )
+
+    for entry in manifest.sources.get("matrix", []):
+        alias = (entry.get("realized_by") or {}).get("org_alias")
+        if alias is not None and alias not in org_aliases:
+            raise WorldManifestError(
+                f"sources.json state {entry.get('state')!r} references "
+                f"unknown org_alias={alias!r}"
+            )
+
+    required_states = set(
+        manifest.sources.get("state_coverage_check", {}).get("required_states", [])
+    )
+    present_states = {m["state"] for m in manifest.sources.get("matrix", [])}
+    missing_states = required_states - present_states
+    if missing_states:
+        raise WorldManifestError(
+            "sources.json has zero realizing rows for required state(s): "
+            f"{sorted(missing_states)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Repo roster derivation -- collected FROM subjects.json/sources.json rather
+# than hand-duplicated here, so the manifest stays the single source of
+# truth for "which named repos exist" (no risk of world.py silently
+# generating a repo subjects.json/sources.json no longer references, or vice
+# versa).
+# ---------------------------------------------------------------------------
+
+
+def collect_repo_roster(manifest: WorldManifest) -> dict[str, set[str]]:
+    """``{org_alias: {repo_full_name, ...}}`` scanned out of subjects/sources."""
+
+    roster: dict[str, set[str]] = {
+        alias: set() for alias in (org["alias"] for org in manifest.orgs)
+    }
+
+    def _add(alias: str | None, name: str | None) -> None:
+        if alias and name:
+            roster.setdefault(alias, set()).add(name)
+
+    for subject in manifest.subjects.get("subjects", []):
+        alias = subject.get("org_alias")
+        _add(alias, subject.get("repo_full_name"))
+        for candidate in subject.get("candidates") or []:
+            _add(alias, candidate)
+        for member in subject.get("members") or []:
+            _add(alias, member)
+
+    for entry in manifest.sources.get("matrix", []):
+        realized_by = entry.get("realized_by") or {}
+        _add(realized_by.get("org_alias"), realized_by.get("repo_full_name"))
+
+    return roster
+
+
+#: Repos needing a non-default generation profile (extra volume for the
+#: truncated-workgraph probe). Keyed by repo_full_name; every other repo
+#: uses world.json's ``generation`` block verbatim.
+_VOLUME_OVERRIDES: dict[str, dict[str, int]] = {
+    "probe/source-truncated-workgraph": {
+        "days": 21,
+        "commits_per_day": 8,
+        "pr_count": 40,
+    },
+}
+
+#: Repos realizing NO_DATA/measured-zero for specific source classes
+#: (deployments/work_items/ci_runs) via POST-HOC deletion
+#: (``source_health.zero_out_source``, run after generation) rather than at
+#: generation time -- ``generate_commits``/``generate_work_items`` etc. do
+#: not tolerate a zero-volume profile (``random.randint(1, 0)`` raises), and
+#: the real DataHealthState signal these probes need to demonstrate is a
+#: *specific source's* absent watermark, not a wholly-empty repo. These two
+#: repos therefore generate with the ordinary default profile and are zeroed
+#: for exactly the sources sources.json names afterward -- see
+#: ``_run_clickhouse_postprocess``.
+NO_DATA_PROBE_REPOS = frozenset({"probe/source-no-data", "probe/source-measured-zero"})
+
+
+def _generation_namespace(
+    manifest: WorldManifest,
+    *,
+    org_alias: str,
+    org_id: uuid.UUID,
+    repo_full_name: str,
+    sink: str,
+    allow_mixed_org: bool,
+) -> argparse.Namespace:
+    gen_cfg = manifest.world.get("generation", {})
+    overrides = _VOLUME_OVERRIDES.get(repo_full_name, {})
+    return argparse.Namespace(
+        sink=sink,
+        db_type=None,
+        repo_name=repo_full_name,
+        repo_count=1,
+        days=overrides.get("days", gen_cfg.get("days_of_history", 10)),
+        commits_per_day=overrides.get(
+            "commits_per_day", gen_cfg.get("commits_per_day", 3)
+        ),
+        pr_count=overrides.get("pr_count", gen_cfg.get("pr_count", 6)),
+        seed=derive_repo_seed(manifest.master_seed, org_alias, repo_full_name),
+        provider="synthetic",
+        with_work_graph=bool(gen_cfg.get("with_work_graph", True)),
+        with_metrics=bool(gen_cfg.get("with_metrics", True)),
+        team_count=gen_cfg.get("team_count", 3),
+        skip_coherence_validation=False,
+        allow_mixed_org=allow_mixed_org,
+        org=str(org_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Postgres: auth roster, entitlements, retention policies, sync config,
+# retention-aged conversations.
+# ---------------------------------------------------------------------------
+
+
+def _build_auth_fixture(manifest: WorldManifest) -> dict[str, Any]:
+    """``organizations``/``users``/``memberships``/``licenses`` for the
+    entire world -- shaped exactly like ``fixtures.runner._seed_auth_data``
+    expects (that function is reused verbatim, not reimplemented)."""
+
+    from dev_health_ops.licensing.generator import generate_test_license
+    from dev_health_ops.licensing.types import LicenseTier
+    from dev_health_ops.models.licensing import OrgLicense
+    from dev_health_ops.models.users import Membership, Organization, User
+
+    organizations = []
+    users = []
+    memberships = []
+    licenses = []
+
+    for org in manifest.orgs:
+        org_id = manifest.org_id(org["alias"])
+        organizations.append(
+            Organization(
+                id=org_id,
+                slug=org["slug"],
+                name=org["name"],
+                is_active=True,
+                tier="enterprise",
+            )
+        )
+        license = OrgLicense(
+            org_id=org_id,
+            license_key=generate_test_license(org_id=str(org_id)),
+            tier=LicenseTier.ENTERPRISE.value,
+            managed_by="manual",
+        )
+        license.id = derive_id(manifest.master_seed, f"license:{org['alias']}")
+        licenses.append(license)
+
+    for user in manifest.world["users"]:
+        user_id = manifest.user_id(user["alias"])
+        org_id = manifest.org_id(user["org_alias"])
+        users.append(
+            User(
+                id=user_id,
+                email=user["email"],
+                username=user["username"],
+                password_hash=None,
+                full_name=user["full_name"],
+                auth_provider="local",
+                is_active=True,
+                is_verified=True,
+                is_superuser=bool(user.get("is_superuser", False)),
+            )
+        )
+        memberships.append(
+            Membership(
+                id=derive_id(manifest.master_seed, f"membership:{user['alias']}"),
+                user_id=user_id,
+                org_id=org_id,
+                role=user.get("membership_role", "member"),
+            )
+        )
+
+    return {
+        "organizations": organizations,
+        "users": users,
+        "memberships": memberships,
+        "licenses": licenses,
+    }
+
+
+async def _seed_entitlements(session: Any, manifest: WorldManifest) -> None:
+    """``org_feature_overrides`` for ``ask_dev``/``ask_dev_contextual_entrypoints``.
+
+    Requires the ``FeatureFlag`` catalog rows Alembic migrations 0067/0070
+    seed to already exist -- fails loud (not silently skipped) if they do
+    not, since a world generated without them cannot realize the
+    disabled-entitlement org at all.
+    """
+
+    from sqlalchemy import select
+
+    from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride
+
+    flag_rows = (
+        (
+            await session.execute(
+                select(FeatureFlag).where(
+                    FeatureFlag.key.in_(["ask_dev", "ask_dev_contextual_entrypoints"])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    flags_by_key = {flag.key: flag for flag in flag_rows}
+    missing = {"ask_dev", "ask_dev_contextual_entrypoints"} - set(flags_by_key)
+    if missing:
+        raise WorldManifestError(
+            f"Postgres is missing FeatureFlag catalog row(s) {sorted(missing)} -- "
+            "run `dev-hops migrate postgres` (Alembic 0067/0070 seed these) "
+            "before `fixtures world`."
+        )
+
+    entitlement_fields = {
+        "ask_dev": "ask_dev_entitlement",
+        "ask_dev_contextual_entrypoints": "ask_dev_contextual_entrypoints_entitlement",
+    }
+    for org in manifest.orgs:
+        org_id = manifest.org_id(org["alias"])
+        for key, field in entitlement_fields.items():
+            is_enabled = org.get(field, "enabled") == "enabled"
+            override = OrgFeatureOverride(
+                org_id=org_id,
+                feature_id=flags_by_key[key].id,
+                is_enabled=is_enabled,
+                reason="ask-dev-world.v1 fixture",
+            )
+            override.id = derive_id(
+                manifest.master_seed, f"feature-override:{org['alias']}:{key}"
+            )
+            await session.merge(override)
+
+
+async def _seed_retention_and_sync(session: Any, manifest: WorldManifest) -> None:
+    from dev_health_ops.models.retention import OrgRetentionPolicy
+
+    for org in manifest.orgs:
+        org_id = manifest.org_id(org["alias"])
+        for idx, policy in enumerate(org.get("retention_policies", [])):
+            row = OrgRetentionPolicy(
+                id=derive_id(
+                    manifest.master_seed,
+                    f"retention:{org['alias']}:{policy['resource_type']}:{idx}",
+                ),
+                org_id=org_id,
+                resource_type=policy["resource_type"],
+                retention_days=policy["retention_days"],
+                is_active=True,
+            )
+            await session.merge(row)
+
+        sync_configs = source_health.build_sync_configurations_for_org(
+            str(org_id),
+            {name: cfg["state"] for name, cfg in org.get("sync_providers", {}).items()},
+            as_of=manifest.pinned_now,
+        )
+        for config in sync_configs:
+            config.id = derive_id(
+                manifest.master_seed, f"sync-config:{org['alias']}:{config.provider}"
+            )
+            await session.merge(config)
+
+
+async def _seed_conversations(session: Any, manifest: WorldManifest) -> None:
+    primary_alias = "primary"
+    primary_org_id = manifest.org_id(primary_alias)
+    ordinary_user_id = manifest.user_id(f"{primary_alias}.ordinary")
+
+    bundles = []
+
+    # Retention-aged conversations: one already past its policy window, one
+    # freshly created, per retention policy world.json declares for the
+    # primary org.
+    for org in manifest.orgs:
+        org_id = manifest.org_id(org["alias"])
+        owner_alias = next(
+            (
+                u["alias"]
+                for u in manifest.world["users"]
+                if u["org_alias"] == org["alias"]
+            ),
+            None,
+        )
+        if owner_alias is None:
+            continue
+        owner_id = manifest.user_id(owner_alias)
+        for policy in org.get("retention_policies", []):
+            retention_days = policy["retention_days"]
+            aged_days = retention_days + 5 if retention_days > 0 else 1
+            bundles.append(
+                conv_gen.build_retention_aged_conversation(
+                    org_id=org_id,
+                    user_id=owner_id,
+                    id_seed=f"retention-aged:{org['alias']}:{retention_days}",
+                    retention_days=retention_days,
+                    age_days=aged_days,
+                    pinned_now=manifest.pinned_now,
+                    title=f"retention probe ({retention_days}-day, aged)",
+                )
+            )
+            bundles.append(
+                conv_gen.build_retention_aged_conversation(
+                    org_id=org_id,
+                    user_id=owner_id,
+                    id_seed=f"retention-fresh:{org['alias']}:{retention_days}",
+                    retention_days=retention_days,
+                    age_days=0,
+                    pinned_now=manifest.pinned_now,
+                    title=f"retention probe ({retention_days}-day, fresh)",
+                )
+            )
+
+    bundles.append(
+        conv_gen.build_stale_context_conversation(
+            org_id=primary_org_id,
+            user_id=ordinary_user_id,
+            id_seed="stale-context",
+            repo_full_name="rotated/service",
+            pinned_now=manifest.pinned_now,
+        )
+    )
+    bundles.append(
+        conv_gen.build_validation_packet(
+            org_id=primary_org_id,
+            user_id=ordinary_user_id,
+            id_seed="validation-packet",
+            pinned_now=manifest.pinned_now,
+        )
+    )
+
+    for bundle in bundles:
+        await session.merge(bundle.conversation)
+        await session.flush()
+        for run in bundle.runs:
+            await session.merge(run)
+        await session.flush()
+        for subject_set in bundle.subject_sets:
+            await session.merge(subject_set)
+    await session.commit()
+
+
+async def _run_postgres_phase(postgres_uri: str, manifest: WorldManifest) -> None:
+    from sqlalchemy.ext.asyncio import (
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
+
+    engine = create_async_engine(postgres_uri, pool_pre_ping=True)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        async with session_factory() as session:
+            from dev_health_ops.fixtures.runner import _seed_auth_data
+
+            await _seed_auth_data(
+                session, _build_auth_fixture(manifest), overwrite_real_users=True
+            )
+            await _seed_entitlements(session, manifest)
+            await _seed_retention_and_sync(session, manifest)
+            await session.commit()
+        async with session_factory() as session:
+            await _seed_conversations(session, manifest)
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse post-processing: projects, source-state aging/zeroing, conflicts.
+# ---------------------------------------------------------------------------
+
+
+async def _run_clickhouse_postprocess(sink: str, manifest: WorldManifest) -> None:
+    async def _handler(store: Any) -> None:
+        client = store.client
+        pinned_now = manifest.pinned_now
+        stale_ts = pinned_now - timedelta(hours=96)
+
+        # Explicit team-kind subjects (e.g. the literal-parenthetical-alias
+        # "Platform Reliability (Ground Control)" team) are NOT part of the
+        # curated demo-team roster `run_fixtures_generation` seeds per repo
+        # (that roster is fixed-size and drawn from demo_identity.DEMO_TEAMS)
+        # -- insert them directly so alias_matching has a real `teams` row
+        # whose `name` carries the parenthetical to split on.
+        # WORLD_DIGEST reproducibility: run_fixtures_generation's OWN
+        # per-repo team upsert re-derives each org's curated team roster
+        # (demo_identity.DEMO_TEAMS) fresh on EVERY repo call within that
+        # org, each with an independently-seeded `members` list -- since
+        # `teams` is a ReplacingMergeTree(updated_at), whichever repo call
+        # happens to write last wins, and that ordering is a real-execution
+        # timing race, not something the master seed determines. Verified
+        # empirically against two live scratch generations (see the Lane 1a
+        # report). Rewriting the ENTIRE curated + alias team roster here,
+        # once, with a fixed (empty) `members` list, makes this postprocess
+        # write the deterministic FINAL content -- but only if it actually
+        # WINS the ReplacingMergeTree(updated_at) race against every
+        # per-repo call's own version. models.teams.Team.__init__ defaults
+        # `updated_at` to REAL `datetime.now(timezone.utc)` when not passed
+        # (models/teams.py is intentionally not in _CLOCK_PATCHED_MODULES --
+        # patching a model file's shared `datetime` name risks unrelated
+        # side effects), so using world.json's pinned_now here does NOT
+        # reliably win: pinned_now is a fixed 2026 date, but a per-repo
+        # call's real-wall-clock default can easily be LATER than it,
+        # letting the racy version win anyway (confirmed empirically: teams
+        # was the only table still drifting after the frozen-clock fix,
+        # even with this postprocess write already in place with
+        # `updated_at=pinned_now`). Real wall-clock time is the deliberate,
+        # narrow exception here -- this write always runs LAST (after every
+        # repo generation call), so `datetime.now()` at this exact point is
+        # guaranteed later than any competing version, and `updated_at`
+        # is excluded from WORLD_DIGEST hashing (_VOLATILE_COLUMNS) either
+        # way, so using real time here has no effect on digest content.
+        from dev_health_ops.fixtures.demo_identity import demo_team_identity
+
+        canonicalized_at = datetime.now(timezone.utc)
+        team_rows: list[dict[str, Any]] = []
+        gen_cfg = manifest.world.get("generation", {})
+        team_count = int(gen_cfg.get("team_count", 3))
+        for org in manifest.orgs:
+            org_id = str(manifest.org_id(org["alias"]))
+            for index in range(team_count):
+                curated = demo_team_identity(index)
+                if curated is None:
+                    continue
+                team_id, team_name = curated
+                team_rows.append(
+                    {
+                        "id": team_id,
+                        "name": team_name,
+                        "org_id": org_id,
+                        "members": [],
+                        "is_active": 1,
+                        "updated_at": canonicalized_at,
+                    }
+                )
+        for subject in manifest.subjects.get("subjects", []):
+            if (
+                subject.get("entity_kind") != "team"
+                or "team_display_name" not in subject
+            ):
+                continue
+            team_rows.append(
+                {
+                    "id": subject["team_id"],
+                    "name": subject["team_display_name"],
+                    "org_id": str(manifest.org_id(subject["org_alias"])),
+                    "members": [],
+                    "is_active": 1,
+                    "updated_at": canonicalized_at,
+                }
+            )
+        if team_rows and hasattr(store, "insert_teams"):
+            await store.insert_teams(team_rows)
+            logging.info(
+                "world: inserted %d canonical team row(s) (curated + alias)",
+                len(team_rows),
+            )
+
+        project_records = []
+        for subject in manifest.subjects.get("subjects", []):
+            if subject.get("entity_kind") != "project":
+                continue
+            org_id = str(manifest.org_id(subject["org_alias"]))
+            repo_full_name = subject.get("repo_full_name") or subject["project_id"]
+            display_name = subject.get("project_display_name") or subject.get(
+                "team_display_name"
+            )
+            record = projects_gen.build_project_record(
+                org_id=org_id,
+                repo_full_name=repo_full_name,
+                display_name=display_name,
+                is_active=True,
+                as_of=pinned_now - timedelta(days=1),
+            )
+            project_records.append(record)
+            if subject["id"] == "subject.deleted.legacy-billing":
+                project_records.append(
+                    projects_gen.build_retired_project_version(
+                        record, retired_as_of=pinned_now - timedelta(hours=2)
+                    )
+                )
+
+        # Every repo-backed subject/probe also gets a matching active
+        # projects row so PROJECT-scope resolution has a catalog entity to
+        # find, even when subjects.json didn't ask for one explicitly.
+        roster = collect_repo_roster(manifest)
+        already_covered = {record.id for record in project_records}
+        for org_alias, repo_names in roster.items():
+            org_id = str(manifest.org_id(org_alias))
+            for repo_full_name in sorted(repo_names):
+                if repo_full_name in already_covered:
+                    continue
+                project_records.append(
+                    projects_gen.build_project_record(
+                        org_id=org_id,
+                        repo_full_name=repo_full_name,
+                        as_of=pinned_now - timedelta(days=1),
+                    )
+                )
+                already_covered.add(repo_full_name)
+
+        await projects_gen.insert_projects(client, project_records)
+        logging.info("world: inserted %d projects rows", len(project_records))
+
+        primary_org_id = str(manifest.org_id("primary"))
+        stale_repo_id = str(uuid.uuid5(FIXTURE_NAMESPACE, "probe/source-stale"))
+        for source in (
+            "commits",
+            "pull_requests",
+            "reviews",
+            "deployments",
+            "work_items",
+        ):
+            try:
+                await source_health.age_source_rows(
+                    client,
+                    org_id=primary_org_id,
+                    repo_id=stale_repo_id,
+                    source=source,
+                    stale_watermark=stale_ts,
+                )
+            except Exception as exc:  # noqa: BLE001
+                if not any(marker in str(exc) for marker in _MISSING_TABLE_MARKERS):
+                    raise
+                logging.warning(
+                    "world: skipped aging %s (table missing): %s", source, exc
+                )
+
+        no_data_repo_id = str(uuid.uuid5(FIXTURE_NAMESPACE, "probe/source-no-data"))
+        measured_zero_repo_id = str(
+            uuid.uuid5(FIXTURE_NAMESPACE, "probe/source-measured-zero")
+        )
+        for repo_id in (no_data_repo_id, measured_zero_repo_id):
+            for source in ("deployments", "work_items", "ci_runs"):
+                try:
+                    await source_health.zero_out_source(
+                        client, org_id=primary_org_id, repo_id=repo_id, source=source
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    if not any(marker in str(exc) for marker in _MISSING_TABLE_MARKERS):
+                        raise
+                    logging.warning(
+                        "world: skipped zeroing %s for %s (table missing): %s",
+                        source,
+                        repo_id,
+                        exc,
+                    )
+
+        if hasattr(store, "write_dora_metrics"):
+            from dev_health_ops.metrics.schemas import DORAMetricsRecord
+
+            store.org_id = primary_org_id
+            store.write_dora_metrics(
+                [
+                    DORAMetricsRecord(
+                        repo_id=uuid.UUID(measured_zero_repo_id),
+                        day=(pinned_now - timedelta(days=1)).date(),
+                        metric_name="deployment_frequency",
+                        value=0.0,
+                        computed_at=pinned_now,
+                        org_id=primary_org_id,
+                    )
+                ]
+            )
+            logging.info("world: wrote explicit measured-zero deployment_frequency row")
+
+        conflicting_repo_id = uuid.uuid5(
+            FIXTURE_NAMESPACE, "probe/source-conflicting-ci"
+        )
+        pair = conflicts_gen.build_conflicting_ci_runs(
+            repo_id=conflicting_repo_id,
+            org_id=primary_org_id,
+            as_of=pinned_now - timedelta(hours=6),
+            seed_label="ci",
+        )
+        if hasattr(store, "insert_testops_pipeline_runs"):
+            rows = conflicts_gen.to_clickhouse_extended_rows(
+                pair, team_id=None, service_id="api-gateway"
+            )
+            await store.insert_testops_pipeline_runs(rows)
+        elif hasattr(store, "insert_ci_pipeline_runs"):
+            await store.insert_ci_pipeline_runs(
+                conflicts_gen.to_postgres_ci_pipeline_runs(pair)
+            )
+        logging.info(
+            "world: inserted conflicting CI run pair for probe/source-conflicting-ci"
+        )
+
+    await run_with_store(sink, "clickhouse", _handler, org_id=None)
+
+
+# ---------------------------------------------------------------------------
+# WORLD_DIGEST
+# ---------------------------------------------------------------------------
+
+
+def _row_content_key(column_names: list[str], row: tuple[Any, ...]) -> str:
+    parts = [
+        f"{name}={value!r}"
+        for name, value in zip(column_names, row, strict=True)
+        if name not in _VOLATILE_COLUMNS
+    ]
+    parts.sort()
+    return "|".join(parts)
+
+
+async def _clickhouse_table_digest(
+    client: Any, table: str, org_id: str
+) -> dict[str, Any]:
+    try:
+        result = await asyncio.to_thread(
+            client.query,
+            f"SELECT * FROM {table} FINAL WHERE org_id = {{org_id:String}}",
+            parameters={"org_id": org_id},
+        )
+    except Exception as exc:  # noqa: BLE001
+        if any(marker in str(exc) for marker in _MISSING_TABLE_MARKERS):
+            return {"row_count": 0, "content_hash": hashlib.sha256(b"").hexdigest()}
+        raise
+    column_names = list(result.column_names)
+    row_keys = sorted(_row_content_key(column_names, row) for row in result.result_rows)
+    content_hash = hashlib.sha256("\n".join(row_keys).encode()).hexdigest()
+    return {"row_count": len(row_keys), "content_hash": content_hash}
+
+
+async def _postgres_table_digest(
+    session: Any, table: str, org_column: str, org_id: str
+) -> dict[str, Any]:
+    from sqlalchemy import text
+
+    result = await session.execute(
+        text(f"SELECT * FROM {table} WHERE {org_column} = :org_id"),  # noqa: S608
+        {"org_id": org_id},
+    )
+    column_names = list(result.keys())
+    rows = result.fetchall()
+    row_keys = sorted(_row_content_key(column_names, tuple(row)) for row in rows)
+    content_hash = hashlib.sha256("\n".join(row_keys).encode()).hexdigest()
+    return {"row_count": len(row_keys), "content_hash": content_hash}
+
+
+async def compute_world_digest(
+    manifest: WorldManifest, *, sink: str, postgres_uri: str
+) -> dict[str, Any]:
+    """The full content-digest breakdown: per (store, table, org) hash, plus
+    one top-level ``digest`` sha256 over the whole canonical breakdown."""
+
+    components: dict[str, Any] = {"clickhouse": {}, "postgres": {}}
+
+    async def _ch_handler(store: Any) -> None:
+        client = store.client
+        for table in _CLICKHOUSE_DIGEST_TABLES:
+            components["clickhouse"].setdefault(table, {})
+            for org in manifest.orgs:
+                org_id = str(manifest.org_id(org["alias"]))
+                components["clickhouse"][table][
+                    org["alias"]
+                ] = await _clickhouse_table_digest(client, table, org_id)
+
+    await run_with_store(sink, "clickhouse", _ch_handler, org_id=None)
+
+    from sqlalchemy.ext.asyncio import (
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
+
+    engine = create_async_engine(postgres_uri, pool_pre_ping=True)
+    try:
+        session_factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with session_factory() as session:
+            for table, org_column in _POSTGRES_DIGEST_TABLES:
+                components["postgres"].setdefault(table, {})
+                for org in manifest.orgs:
+                    org_id = str(manifest.org_id(org["alias"]))
+                    if table == "users":
+                        continue  # aggregated once below (no org_id column)
+                    components["postgres"][table][
+                        org["alias"]
+                    ] = await _postgres_table_digest(session, table, org_column, org_id)
+            user_ids = [
+                str(manifest.user_id(u["alias"])) for u in manifest.world["users"]
+            ]
+            from sqlalchemy import text
+
+            result = await session.execute(
+                text("SELECT * FROM users WHERE id::text = ANY(:ids)"),
+                {"ids": user_ids},
+            )
+            column_names = list(result.keys())
+            rows = result.fetchall()
+            row_keys = sorted(
+                _row_content_key(column_names, tuple(row)) for row in rows
+            )
+            components["postgres"]["users"] = {
+                "world": {
+                    "row_count": len(row_keys),
+                    "content_hash": hashlib.sha256(
+                        "\n".join(row_keys).encode()
+                    ).hexdigest(),
+                }
+            }
+    finally:
+        await engine.dispose()
+
+    canonical = json.dumps(components, sort_keys=True)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return {
+        "schema_version": WORLD_SCHEMA_VERSION,
+        "master_seed": manifest.master_seed,
+        "digest": digest,
+        "components": components,
+    }
+
+
+def default_digest_path(manifest: WorldManifest) -> Path:
+    return manifest.manifest_path.parent / "WORLD_DIGEST"
+
+
+def write_digest(digest_doc: dict[str, Any], path: Path) -> None:
+    path.write_text(json.dumps(digest_doc, indent=2, sort_keys=True) + "\n")
+
+
+def read_pinned_digest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise WorldDigestDriftError(
+            f"WORLD_DIGEST not found at {path} -- run `dev-hops fixtures world` "
+            "(without --verify-digest) at least once to generate a pinned digest."
+        )
+    return json.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _resolve_postgres_uri(ns: argparse.Namespace) -> str:
+    uri = (
+        getattr(ns, "postgres_uri", None)
+        or os.getenv("POSTGRES_URI")
+        or os.getenv("DATABASE_URI")
+    )
+    if not uri:
+        raise WorldManifestError(
+            "fixtures world requires a Postgres URI (--postgres-uri or "
+            "POSTGRES_URI/DATABASE_URI) -- the world's org/user/entitlement/"
+            "retention/conversation rows all live in the semantic DB."
+        )
+    return uri
+
+
+async def _generate_world(ns: argparse.Namespace, manifest: WorldManifest) -> int:
+    postgres_uri = _resolve_postgres_uri(ns)
+
+    await _run_postgres_phase(postgres_uri, manifest)
+    logging.info(
+        "world: seeded orgs/users/entitlements/retention/sync-config/conversations"
+    )
+
+    roster = collect_repo_roster(manifest)
+    total_repos = sum(len(repos) for repos in roster.values())
+    generated = 0
+    for org_alias, repo_names in roster.items():
+        org_id = manifest.org_id(org_alias)
+        for repo_full_name in sorted(repo_names):
+            repo_ns = _generation_namespace(
+                manifest,
+                org_alias=org_alias,
+                org_id=org_id,
+                repo_full_name=repo_full_name,
+                sink=ns.sink,
+                allow_mixed_org=getattr(ns, "allow_mixed_org", False),
+            )
+            with _frozen_clock(manifest.pinned_now):
+                rc = await run_fixtures_generation(repo_ns)
+            if rc != 0:
+                logging.error(
+                    "world: fixtures generate failed for org=%s repo=%s (rc=%d)",
+                    org_alias,
+                    repo_full_name,
+                    rc,
+                )
+                return rc
+            generated += 1
+            logging.info(
+                "world: generated repo %d/%d (%s / %s)",
+                generated,
+                total_repos,
+                org_alias,
+                repo_full_name,
+            )
+
+    await _run_clickhouse_postprocess(ns.sink, manifest)
+
+    digest_doc = await compute_world_digest(
+        manifest, sink=ns.sink, postgres_uri=postgres_uri
+    )
+    digest_path = (
+        Path(ns.digest_path)
+        if getattr(ns, "digest_path", None)
+        else default_digest_path(manifest)
+    )
+    write_digest(digest_doc, digest_path)
+    logging.info(
+        "world: wrote WORLD_DIGEST=%s to %s", digest_doc["digest"], digest_path
+    )
+    return 0
+
+
+async def _verify_digest(ns: argparse.Namespace, manifest: WorldManifest) -> int:
+    postgres_uri = _resolve_postgres_uri(ns)
+    digest_path = (
+        Path(ns.digest_path)
+        if getattr(ns, "digest_path", None)
+        else default_digest_path(manifest)
+    )
+    pinned = read_pinned_digest(digest_path)
+    live = await compute_world_digest(manifest, sink=ns.sink, postgres_uri=postgres_uri)
+    if live["digest"] != pinned["digest"]:
+        drifted_components = _diff_components(
+            pinned.get("components", {}), live.get("components", {})
+        )
+        raise WorldDigestDriftError(
+            "WORLD_DIGEST verification FAILED: live database no longer matches "
+            f"the pinned digest at {digest_path}. pinned={pinned['digest']} "
+            f"live={live['digest']}. Drifted component(s): {drifted_components}"
+        )
+    logging.info("world: WORLD_DIGEST verified OK (%s)", live["digest"])
+    return 0
+
+
+def _diff_components(pinned: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    drifted: list[str] = []
+    for store in set(pinned) | set(live):
+        pinned_store = pinned.get(store, {})
+        live_store = live.get(store, {})
+        for table in set(pinned_store) | set(live_store):
+            if pinned_store.get(table) != live_store.get(table):
+                drifted.append(f"{store}.{table}")
+    return sorted(drifted)
+
+
+async def run_fixtures_world(ns: argparse.Namespace) -> int:
+    try:
+        manifest = load_world_manifest(ns.manifest)
+    except (WorldManifestError, FileNotFoundError, json.JSONDecodeError) as exc:
+        logging.error("world: manifest validation failed: %s", exc)
+        return 1
+
+    if getattr(ns, "verify_digest", False):
+        try:
+            return await _verify_digest(ns, manifest)
+        except WorldDigestDriftError as exc:
+            logging.error("%s", exc)
+            return 1
+
+    try:
+        return await _generate_world(ns, manifest)
+    except WorldManifestError as exc:
+        logging.error("world: %s", exc)
+        return 1

--- a/src/dev_health_ops/fixtures/world.py
+++ b/src/dev_health_ops/fixtures/world.py
@@ -26,13 +26,21 @@ for the DURATION of each ``run_fixtures_generation`` call by swapping the
 ``datetime`` name each of those modules imported at call time -- a
 call-site-local, fully-reverted patch that only ``fixtures world`` ever
 activates; ``fixtures generate`` and every other caller is untouched. This
-was verified empirically against a live scratch database (two full
-generations -> identical WORLD_DIGEST; see the Lane 1a report) rather than
+was verified empirically against a live scratch database rather than
 assumed correct from the source read alone -- both because the module list
 below must stay in sync with wherever ``run_fixtures_generation`` gains a
 new ``datetime.now()`` call site in the future, and because a monkeypatch
 covering the wrong scope would fail exactly the kind of silent-drift
-category CHAOS-3392 itself was.
+category CHAOS-3392 itself was. CORRECTED 2026-08-05 (CHAOS-3432): a prior
+version of this sentence claimed "two full generations -> identical
+WORLD_DIGEST" as an already-proven, closed fact. That is only true for
+SINGLE-generation pinning (this digest correctly detects drift within one
+generated database, live-verified repeatedly this round via HIGH-3/HIGH-5
+mutation tests). Cross-generation reproducibility -- two INDEPENDENT
+``fixtures world`` runs producing an IDENTICAL digest -- is NOT proven; see
+``world.json``'s ``cross_generation_digest_status`` field and
+``_frozen_clock``'s own docstring below for the full, current evidence
+trail.
 """
 
 from __future__ import annotations
@@ -50,7 +58,9 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
+from dev_health_ops.fixtures import world_verify
 from dev_health_ops.fixtures.generators import conflicts as conflicts_gen
 from dev_health_ops.fixtures.generators import projects as projects_gen
 from dev_health_ops.fixtures.generators import retention_conversations as conv_gen
@@ -71,6 +81,53 @@ WORLD_SCHEMA_VERSION = "ask_dev_world.v1"
 #: ``metrics/job_daily.py`` and ``work_graph/builder.py`` for
 #: ``datetime.now(`` call sites, then confirmed empirically (see
 #: ``_frozen_clock``'s docstring) -- NOT a claim derived from reading alone.
+#:
+#: HIGH-4 correction (2026-08-05): that enumeration missed two modules, both
+#: one hop outside the directories actually grepped:
+#:   - ``dev_health_ops.storage.clickhouse`` -- ``store.insert_git_commit_
+#:     data`` and 30+ sibling methods each default ``last_synced``/
+#:     ``synced_at`` to ``datetime.now(timezone.utc)`` whenever the caller
+#:     doesn't supply an explicit value, which the base generator's commit/
+#:     PR/review/deployment/work_item/ci_pipeline_run records never do.
+#:   - ``dev_health_ops.models.operational`` -- ``CanonicalOperationalEntity``
+#:     (the base class ``OperationalIncident`` and friends inherit) defaults
+#:     ``observed_at``/``last_synced`` via ``field(default_factory=_utcnow)``,
+#:     and ``_utcnow()`` reads that module's OWN ``datetime`` name -- hit by
+#:     the standard per-repo generator's ``write_operational_batch`` call.
+#: Both are real production behavior for an actual sync (correctly stamping
+#: "when did we really observe this"), so the fix does not change either
+#: module's default -- each is patched INTO frozen-clock scope only for the
+#: duration of ``fixtures world``'s own generation call, exactly like every
+#: other module here. Found live: the first two-clean-generation
+#: identical-digest run after HIGH-3 widened the digest to include these
+#: same watermark columns (a prior digest scope that excluded them could
+#: never have caught this -- the nondeterminism was always there, just
+#: unobserved). Confirmed via direct row comparison between two scratch
+#: databases: every column matched except the watermark columns, which
+#: showed each run's own real wall-clock generation time.
+#:
+#: Second pass (same day, same technique, one more table found): after the
+#: two modules above closed git_commits/deployments/git_pull_requests/
+#: git_pull_request_reviews/work_items/operational_incidents, a re-run still
+#: drifted on ``ci_pipeline_runs`` -- ``insert_testops_pipeline_runs`` (the
+#: extended-row path ``fixtures generate``'s ClickHouse branch actually uses
+#: for this table, per ``runner.py``'s own "MV fires exactly once" comment)
+#: is attached to ``ClickHouseStore`` from a SEPARATE module,
+#: ``storage.mixins.testops_cicd`` -- its own ``datetime`` name, unaffected
+#: by patching ``storage.clickhouse``. ``work_unit_investments`` also still
+#: drifted, but NOT on its ``computed_at`` (already excluded by
+#: ``_VOLATILE_COLUMNS`` -- this one really was just a wall-clock reformat
+#: with no digest effect): direct row comparison showed every column
+#: identical except ``categorization_run_id``, a `uuid.uuid4().hex` invoice
+#: number with no wall-clock component at all (``work_graph.investment.
+#: materialize``'s ``run_id = config.run_id or uuid.uuid4().hex``, never
+#: supplied by ``materialize_fixture_investments``) -- clock-freezing
+#: cannot fix a pure-randomness source; see ``_VOLATILE_COLUMNS``'s own
+#: entry for that half of the fix. ``work_graph.investment.materialize`` is
+#: still added here too, for its OWN wall-clock ``computed_at`` fallback --
+#: currently harmless to the digest (excluded), but freezing it removes a
+#: latent trap for any future column that stops being excluded, the same
+#: way HIGH-3 just did to four other tables.
 _CLOCK_PATCHED_MODULES: tuple[str, ...] = (
     "dev_health_ops.fixtures.generator",
     "dev_health_ops.fixtures.runner",
@@ -86,7 +143,11 @@ _CLOCK_PATCHED_MODULES: tuple[str, ...] = (
     "dev_health_ops.fixtures.generators.teams",
     "dev_health_ops.fixtures.generators.work_items",
     "dev_health_ops.metrics.job_daily",
+    "dev_health_ops.models.operational",
+    "dev_health_ops.storage.clickhouse",
+    "dev_health_ops.storage.mixins.testops_cicd",
     "dev_health_ops.work_graph.builder",
+    "dev_health_ops.work_graph.investment.materialize",
 )
 
 
@@ -119,29 +180,59 @@ def _frozen_clock(pinned_now: datetime):
     into the same generator modules runs with the real, unpatched
     ``datetime`` exactly as before.
 
-    KNOWN RESIDUAL GAP (disclosed, not silently dropped): this closes the
-    dominant source of cross-run drift -- verified live, two full
-    generations now reproduce an IDENTICAL WORLD_DIGEST for every Postgres
-    table and for the PRIMARY org's entire ClickHouse content (12 repos,
-    every source-state probe, teams, projects). One narrow gap remains,
-    root-caused but not eliminated: the SIBLING org's single repo's
-    ``ci_pipeline_runs``/``deployments`` row counts still vary run-to-run
-    (e.g. 32 vs 45 rows), even with this clock freeze AND ``PYTHONHASHSEED``
-    pinned identically across both processes. The likely mechanism:
-    ``run_fixtures_generation``'s ``--with-work-graph`` path invokes
-    ``work_graph.runner.materialize_fixture_investments`` with a "mock" LLM
-    provider through ``asyncio.gather``-scheduled concurrent tasks; if that
-    mock path draws from the shared global ``random`` module inside
-    concurrently-scheduled coroutines, real async scheduling/I-O-timing
-    (not the master seed) can interleave those draws in a different order
-    across process runs, desynchronizing the GLOBAL random state for
-    whichever repo generates immediately afterward -- observed to
-    consistently land on the LAST-generated repo (sibling's, in this
-    world's fixed generation order). Fully closing this would mean auditing
-    ``work_graph/runner.py``'s and its mock-LLM dependency's random usage
-    for concurrency-order sensitivity, which is outside this module's
-    territory and this lane's time budget. Tracked, not hidden: see the
-    Lane 1a report's "could not fully realize" list.
+    KNOWN RESIDUAL GAP -- CHAOS-3432, declared-blocked, disclosed not
+    hidden (see ``world.json``'s ``cross_generation_digest_status`` field,
+    which every ``fixtures world`` run logs a WARNING against). CORRECTED
+    2026-08-05 twice same day -- earlier versions of this paragraph
+    described theories later disproven by direct evidence; see git history
+    if the prior wording is needed.
+
+    This clock-freeze work (plus the HIGH-3/HIGH-4 module-enumeration pass
+    the same day -- ``storage.clickhouse``, ``models.operational``,
+    ``storage.mixins.testops_cicd``, ``work_graph.investment.materialize``,
+    wrapping this postprocess handler itself, and excluding
+    ``categorization_run_id`` from the digest) closed every WATERMARK-
+    COLUMN and RANDOM-IDENTIFIER source of drift found live, each
+    individually confirmed via a live two-generation rerun: real wall-clock
+    defaults in four separate modules the original module-list enumeration
+    missed (all one hop outside the directories it grepped), a
+    postprocess handler that ran entirely outside any frozen-clock scope,
+    and a per-run-random (not wall-clock) categorization run id that
+    needed digest exclusion rather than freezing. ``teams`` (the one write
+    that deliberately keeps real wall-clock time to win a
+    ReplacingMergeTree race) was confirmed excluded/safe across every one
+    of these reruns, not merely assumed.
+
+    What remains open, root-caused down to a leading hypothesis but NOT
+    confirmed: an isolated, one-repo-at-a-time row-count divergence
+    (``ci_pipeline_runs``/``deployments``/``work_graph_pr_commit``/
+    ``work_unit_investments``) that affects a DIFFERENT single repo each
+    run, while every other repo -- including the elevated-volume
+    ``probe/source-truncated-workgraph`` -- is exactly identical. Ruled
+    out by direct evidence, not assumption: (1) the mock LLM provider
+    (``llm/providers/mock.py``) has zero ``random`` usage; (2) a "global
+    random state desyncs whichever repo runs next" theory, contradicted by
+    every repo generated AFTER the affected one (fixed sort order) being
+    byte-identical across runs; (3) ``PYTHONHASHSEED=0`` pinned identically
+    across both processes -- did NOT converge the digest, and the drifted
+    table/repo set was DIFFERENT and LARGER than the un-pinned run,
+    evidence against a hash-seed-driven mechanism; (4) an
+    org-settings-driven LLM-concurrency override silently defeating
+    ``llm_concurrency=1`` -- checked live against the actual scratch
+    Postgres, ``resolve_llm_org_settings_concurrency`` returns ``None`` as
+    expected; (5) duplicate ``work_graph_edges`` rows causing a
+    non-deterministic ``argMax(..., last_synced)`` tie-break in
+    ``fetch_work_graph_edges`` (whose own docstring already documents an
+    ``ORDER BY`` guard against exactly this class) -- checked live, zero
+    duplicate edge identities exist for the affected org. LEADING, NOT YET
+    CONFIRMED hypothesis: concurrent ClickHouse batch insertion via
+    ``fixtures/runner.py``'s ``_insert_batches`` (``asyncio.Semaphore`` +
+    ``asyncio.gather``, ``MAX_WORKERS`` defaulting to 4, used for every
+    ClickHouse table insert in the generation path) -- the discriminating
+    experiment (rerun both generations with ``MAX_WORKERS=1``, forcing
+    every batch fully serial) was in flight when this investigation was
+    stopped by explicit user direction (time/token budget), not by a
+    negative result. Tracked as CHAOS-3432, not hidden.
     """
 
     frozen = type("_FrozenDateTime", (_FrozenDateTime,), {"_frozen_now": pinned_now})
@@ -192,18 +283,83 @@ _VOLATILE_COLUMNS = frozenset(
         "finished_at",
         "last_sync_at",
         "feature_id",
+        # HIGH-4 (2026-08-05): work_unit_investments.categorization_run_id
+        # is `config.run_id or uuid.uuid4().hex` (work_graph.investment.
+        # materialize) -- a fresh random hex string every run, with no
+        # wall-clock component at all, so no amount of clock-freezing can
+        # make it reproduce across two generations. Same category as
+        # `feature_id` above: a real per-run identifier that legitimately
+        # varies, not a content field. Found live via direct row
+        # comparison between two scratch databases: every OTHER column on
+        # this table matched exactly.
+        "categorization_run_id",
     }
 )
 
-#: ClickHouse tables the digest covers, scoped by ``org_id``.
+#: Codex HIGH-3 (2026-08-05): the blanket exclusion above is correct for
+#: MOST columns on MOST tables (genuine wall-clock insertion artifacts),
+#: but for the specific tables whose watermark column IS what sources.json
+#: claims a current/stale/measured-zero state FROM, blanket-excluding it
+#: means a regression in aging/zeroing (e.g. `age_source_rows` silently
+#: no-op'ing, or `write_and_verify_measured_zero_metric`'s delete step
+#: regressing) would leave the digest GREEN even though the very thing the
+#: state claims about is now false. Per-table, per-field JUSTIFIED
+#: overrides: these columns are KEPT (not excluded) for exactly these
+#: tables, because with the CHAOS-3392/_frozen_clock fix + explicit
+#: deterministic aging (source_health.age_source_rows/zero_out_source) +
+#: the HIGH-1 measured-zero postcondition, every one of these values is
+#: now fully seed-and-pinned_now-derived, not wall-clock-derived -- so
+#: including them does not reintroduce cross-run digest instability, it
+#: only makes the digest ABLE to catch a regression that un-does that
+#: determinism.
+_WATERMARK_COLUMNS_TO_KEEP_BY_TABLE: dict[str, frozenset[str]] = {
+    "git_commits": frozenset({"last_synced"}),
+    "git_pull_requests": frozenset({"last_synced"}),
+    "git_pull_request_reviews": frozenset({"last_synced"}),
+    "deployments": frozenset({"last_synced"}),
+    "work_items": frozenset({"last_synced"}),
+    "ci_pipeline_runs": frozenset({"last_synced"}),
+    "dora_metrics_daily": frozenset({"computed_at"}),
+}
+
+
+def _volatile_columns_for_table(table: str) -> frozenset[str]:
+    """The exclusion set for ``table``: the global default, MINUS whatever
+    watermark column(s) that specific table's entry in
+    :data:`_WATERMARK_COLUMNS_TO_KEEP_BY_TABLE` says to keep (i.e. hash).
+    """
+
+    keep = _WATERMARK_COLUMNS_TO_KEEP_BY_TABLE.get(table, frozenset())
+    return _VOLATILE_COLUMNS - keep
+
+
+#: ClickHouse tables the digest covers, scoped by ``org_id``. Codex HIGH-3
+#: (2026-08-05): expanded from the original 7 (repos/teams/projects/
+#: work_items/git_pull_requests/ci_pipeline_runs/deployments) to also
+#: cover git_commits, git_pull_request_reviews, dora_metrics_daily (the
+#: measured-zero/DORA table), work_unit_investments (investment
+#: categorization), and the two work-graph fast-path tables -- every
+#: table any subjects.json/sources.json claim in this world actually
+#: consumes, not an arbitrary subset. All 12 confirmed (empirically, via
+#: `DESCRIBE TABLE` against a live scratch database -- not assumed from
+#: a migration-file grep, which missed several ADD COLUMN sites) to carry
+#: an `org_id` column, so the existing per-org WHERE clause covers them
+#: uniformly.
 _CLICKHOUSE_DIGEST_TABLES: tuple[str, ...] = (
     "repos",
     "teams",
     "projects",
     "work_items",
+    "git_commits",
     "git_pull_requests",
+    "git_pull_request_reviews",
     "ci_pipeline_runs",
     "deployments",
+    "operational_incidents",
+    "dora_metrics_daily",
+    "work_unit_investments",
+    "work_graph_issue_pr",
+    "work_graph_pr_commit",
 )
 
 #: Postgres tables the digest covers. ``org_scoped=True`` filters by
@@ -230,6 +386,102 @@ class WorldManifestError(ValueError):
 class WorldDigestDriftError(RuntimeError):
     """``--verify-digest`` found the live database no longer matches the
     pinned ``WORLD_DIGEST`` file."""
+
+
+class UnsafeSinkError(ValueError):
+    """The target database does not look like a disposable scratch database.
+
+    Raised at the very top of :func:`run_fixtures_world`, BEFORE any store,
+    session, or client is constructed -- ``fixtures world`` issues
+    destructive mutations (``ALTER TABLE ... DELETE``, the delete-and-
+    reinsert in ``source_health.age_source_rows``, ``DROP``/``CREATE
+    DATABASE`` in the operator's own setup) that must never reach a shared
+    dev or production database. Codex adversarial review (CRITICAL,
+    2026-08-05): ``--sink``/``--postgres-uri`` previously accepted ANY
+    ClickHouse/Postgres URI including the shared dev ``default``/
+    ``devhealth`` databases with no check at all -- this generalizes
+    ``ci/local_validate.sh``'s own hardcoded "``CLICKHOUSE_URI`` must never
+    default to ``/default``" rule (the CHAOS-2604-era safety contract) into
+    an entrypoint guard every ``fixtures world`` invocation goes through,
+    not just the one CI script that happened to remember it.
+    """
+
+
+#: Database names that are ALWAYS unsafe for ``fixtures world``, regardless
+#: of whether they happen to contain the scratch marker below --
+#: defense-in-depth on top of the positive allowlist-by-convention check.
+#: Sourced from the actual shared dev stack this repo's compose files
+#: provision (``ops/compose.yml``'s ``POSTGRES_DB=devhealth``; ClickHouse's
+#: always-present ``default`` database) plus Postgres' own reserved
+#: administrative/template databases (a fixture run against ``template1``
+#: would corrupt the template every future ``CREATE DATABASE`` clones from).
+_HARD_DENIED_DATABASE_NAMES = frozenset(
+    {"default", "devhealth", "postgres", "template0", "template1", ""}
+)
+
+#: A database name must contain at least one of these tokens
+#: (case-insensitive) to be accepted as an explicit, disposable scratch
+#: target. Deliberately a POSITIVE allowlist-by-convention, not a denylist
+#: of "known bad" names: a denylist silently fails to protect against a
+#: real, currently-unknown database a future compose/migration change
+#: introduces, while a positive marker requirement fails closed against
+#: anything not explicitly opted in. Both entries are existing,
+#: already-in-use conventions, not invented for this guard: every scratch
+#: database this lane's own live verification runs used
+#: (``chaos3219_world_scratch``, ``..._scratch_b``, ...) contains
+#: ``"scratch"``; ``ci/local_validate.sh``'s own scratch db
+#: (``ci_local_validate_<hash>``) does not contain the literal substring
+#: ``"scratch"`` but does contain ``"ci_local_validate"``, so that prefix
+#: is accepted too rather than forcing a naming-convention mismatch
+#: against a pattern this repo already ships.
+_SCRATCH_MARKERS = ("scratch", "ci_local_validate")
+
+
+def _looks_like_scratch_name(lowered_db_name: str) -> bool:
+    return any(marker in lowered_db_name for marker in _SCRATCH_MARKERS)
+
+
+def _database_name_from_uri(uri: str) -> str:
+    """The path component of a ClickHouse/Postgres URI, e.g.
+    ``clickhouse://ch:ch@host:8123/foo?x=1`` -> ``"foo"``. An omitted path
+    (``clickhouse://ch:ch@host:8123``) returns ``""`` -- clickhouse-connect
+    treats a missing path as the ``default`` database, so an empty name
+    must be treated exactly as unsafe as the literal string ``"default"``
+    (see ``_HARD_DENIED_DATABASE_NAMES``, which includes ``""``).
+    """
+
+    return urlparse(uri).path.lstrip("/")
+
+
+def _require_scratch_database(uri: str | None, *, kind: str) -> None:
+    """Fail loudly, before any connection, unless ``uri`` names an explicit
+    scratch database. ``kind`` is ``"clickhouse"`` or ``"postgres"``, used
+    only for the error message.
+    """
+
+    if not uri:
+        raise UnsafeSinkError(
+            f"fixtures world: no {kind} URI provided -- refusing to guess "
+            "a target database."
+        )
+    db_name = _database_name_from_uri(uri)
+    lowered = db_name.lower()
+    if lowered in _HARD_DENIED_DATABASE_NAMES:
+        raise UnsafeSinkError(
+            f"fixtures world: {kind} database {db_name!r} is a known shared "
+            "dev/system database, not a disposable scratch target. "
+            "fixtures world issues destructive mutations and must never "
+            "run against it. Point --sink/--postgres-uri at a dedicated "
+            f"scratch database instead (name must contain one of {_SCRATCH_MARKERS!r})."
+        )
+    if not _looks_like_scratch_name(lowered):
+        raise UnsafeSinkError(
+            f"fixtures world: {kind} database {db_name!r} does not look "
+            f"like a scratch database (name must contain one of {_SCRATCH_MARKERS!r}) "
+            "-- refusing to run destructive fixture generation against an "
+            "unidentified target. Create a dedicated scratch database "
+            f"(e.g. {db_name}_scratch) and point --sink/--postgres-uri at it."
+        )
 
 
 def _parse_dt(value: str) -> datetime:
@@ -371,6 +623,48 @@ def validate_world_manifest(manifest: WorldManifest) -> None:
             f"{sorted(missing_states)}"
         )
 
+    # Typed per-entry schema (Codex HIGH-2, 2026-08-05): the checks above
+    # only confirm every REQUIRED class/state string appears somewhere --
+    # a bare {"class": "deleted"} row with no realization fields at all
+    # passed every check above. world_verify's per-class/per-state schema
+    # closes that: every entry's OWN class/state now dictates a concrete
+    # required-field shape, not just "the class name is spelled right".
+    for subject in manifest.subjects.get("subjects", []):
+        try:
+            world_verify.validate_subject_entry_schema(subject)
+        except world_verify.WorldSchemaError as exc:
+            raise WorldManifestError(f"subjects.json: {exc}") from exc
+    for entry in manifest.sources.get("matrix", []):
+        try:
+            world_verify.validate_source_entry_schema(entry)
+        except world_verify.WorldSchemaError as exc:
+            raise WorldManifestError(f"sources.json: {exc}") from exc
+
+    # CHAOS-3432 (2026-08-05): the whole-world analogue of sources.json's
+    # DECLARED_BLOCKED_STATUS / subjects.json's REALIZED_UNVERIFIED_LIVE_STATUS
+    # -- a claim about the WORLD as a whole (cross-generation digest
+    # reproducibility), not a single manifest entry, so it lives at
+    # world.json's top level instead of inside subjects/sources. Same
+    # discipline: typed, ticketed, schema-checked -- never a silent claim.
+    cross_gen_status = manifest.world.get("cross_generation_digest_status")
+    if cross_gen_status is not None:
+        if (
+            not isinstance(cross_gen_status, dict)
+            or cross_gen_status.get("status") != "declared-blocked"
+        ):
+            raise WorldManifestError(
+                "world.json 'cross_generation_digest_status', if present, must "
+                "be an object with status='declared-blocked' -- got "
+                f"{cross_gen_status!r}"
+            )
+        if not cross_gen_status.get("blocked_by"):
+            raise WorldManifestError(
+                "world.json 'cross_generation_digest_status' has "
+                "status='declared-blocked' but no non-empty 'blocked_by' "
+                "ticket reference -- an unproven cross-run claim must name "
+                "what is tracking it."
+            )
+
 
 # ---------------------------------------------------------------------------
 # Repo roster derivation -- collected FROM subjects.json/sources.json rather
@@ -460,6 +754,19 @@ def _generation_namespace(
         skip_coherence_validation=False,
         allow_mixed_org=allow_mixed_org,
         org=str(org_id),
+        # Codex HIGH-4 (2026-08-05): serializes LLM-categorization
+        # completion order inside materialize_fixture_investments, intended
+        # to help two otherwise-identical `fixtures world` generations
+        # reproduce an identical WORLD_DIGEST -- see runner.py's call site
+        # and work_graph.runner.materialize_fixture_investments's own
+        # docstring. `fixtures generate` never sets this attribute, so it
+        # keeps the function's unchanged default (5) -- this is scoped to
+        # the world path only. NOT sufficient on its own: a residual,
+        # narrowed-but-unconfirmed source of cross-generation drift remains
+        # open under CHAOS-3432 (see _frozen_clock's docstring) even with
+        # this set to 1 -- do not read this line as proof the drift is
+        # closed.
+        llm_concurrency=1,
     )
 
 
@@ -725,6 +1032,112 @@ async def _run_postgres_phase(postgres_uri: str, manifest: WorldManifest) -> Non
         await engine.dispose()
 
 
+class MeasuredZeroWriteError(RuntimeError):
+    """A measured-zero metric write did not verifiably land as claimed.
+
+    Codex adversarial review (HIGH-1, 2026-08-05): the original code
+    guarded the write behind ``hasattr(store, "write_dora_metrics")`` --
+    ``store`` here is a ``ClickHouseStore`` (from ``run_with_store``),
+    which has no such method (it lives on ``ClickHouseMetricsSink``
+    instead), so the guard was ALWAYS false and the whole block silently
+    no-op'd. ``probe/source-measured-zero`` kept whatever random,
+    almost-certainly-nonzero ``deployment_frequency`` value
+    ``run_fixtures_generation``'s own ``with_metrics`` pass had already
+    written, while ``sources.json`` claimed 0.0 -- a measurement that
+    never happened, reading as coverage. Per this repo's own verification
+    rule ("a measurement that did not happen must FAIL, loudly"), the
+    write is now followed by a live read-back assertion; this exception is
+    what "loudly" means here -- raised, not logged-and-continued.
+    """
+
+
+async def write_and_verify_measured_zero_metric(
+    client: Any,
+    *,
+    sink_dsn: str,
+    repo_id: uuid.UUID,
+    org_id: str,
+    metric_name: str,
+    day: Any,
+    computed_at: datetime,
+) -> None:
+    """Force ``metric_name`` to read exactly ``0.0`` for ``repo_id``, then
+    prove it by reading the live table back -- not merely asserting the
+    write call returned without raising.
+
+    ``dora_metrics_daily`` is a plain ``MergeTree`` (migration ``023b``),
+    NOT a ``ReplacingMergeTree`` -- inserting a new row for the same
+    ``(repo_id, day, metric_name)`` key does not replace an existing row,
+    it adds a second one alongside it. Existing rows for this
+    ``(repo_id, metric_name)`` are therefore deleted first (synchronous
+    ``ALTER TABLE ... DELETE``, mirroring
+    ``source_health.zero_out_source``'s same-table-family pattern) so the
+    post-write read-back is unambiguous: exactly one row, and it is 0.0.
+    """
+
+    from dev_health_ops.metrics.schemas import DORAMetricsRecord
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    await asyncio.to_thread(
+        client.command,
+        "ALTER TABLE dora_metrics_daily DELETE WHERE repo_id = {repo_id:UUID} "
+        "AND metric_name = {metric_name:String} SETTINGS mutations_sync = 1",
+        parameters={"repo_id": str(repo_id), "metric_name": metric_name},
+    )
+
+    sink_obj = ClickHouseMetricsSink(sink_dsn, client=client)
+    sink_obj.write_dora_metrics(
+        [
+            DORAMetricsRecord(
+                repo_id=repo_id,
+                day=day,
+                metric_name=metric_name,
+                value=0.0,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+        ]
+    )
+
+    result = await asyncio.to_thread(
+        client.query,
+        # No `FINAL` here -- Codex HIGH-3 (2026-08-05), found live: this
+        # function's own docstring above already establishes
+        # dora_metrics_daily is a plain MergeTree, which does not support
+        # `FINAL` at all (`Code: 181 ILLEGAL_FINAL`). The prior version of
+        # this query used it anyway -- harmless against a stub client (which
+        # never parses SQL), fatal the first time this path actually ran
+        # against a live ClickHouse. Correctness here does not depend on
+        # `FINAL` regardless: the delete-then-single-insert above already
+        # guarantees at most one row for this key.
+        "SELECT value FROM dora_metrics_daily "
+        "WHERE repo_id = {repo_id:UUID} AND metric_name = {metric_name:String} "
+        "ORDER BY day DESC",
+        parameters={"repo_id": str(repo_id), "metric_name": metric_name},
+    )
+    rows = list(result.result_rows)
+    if len(rows) != 1:
+        raise MeasuredZeroWriteError(
+            f"world: measured-zero postcondition failed for repo_id={repo_id} "
+            f"metric_name={metric_name!r}: expected exactly 1 row after the "
+            f"delete+write, found {len(rows)}. The pre-existing "
+            "run_fixtures_generation-written row(s) were not cleanly "
+            "replaced -- refusing to claim measured-zero is realized."
+        )
+    (value,) = rows[0]
+    if value != 0.0:
+        raise MeasuredZeroWriteError(
+            f"world: measured-zero postcondition failed for repo_id={repo_id} "
+            f"metric_name={metric_name!r}: live read-back value={value!r}, "
+            "expected exactly 0.0. The write did not land as claimed."
+        )
+    logging.info(
+        "world: verified measured-zero %s=0.0 for repo_id=%s (live read-back)",
+        metric_name,
+        repo_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # ClickHouse post-processing: projects, source-state aging/zeroing, conflicts.
 # ---------------------------------------------------------------------------
@@ -906,23 +1319,54 @@ async def _run_clickhouse_postprocess(sink: str, manifest: WorldManifest) -> Non
                         exc,
                     )
 
-        if hasattr(store, "write_dora_metrics"):
-            from dev_health_ops.metrics.schemas import DORAMetricsRecord
-
-            store.org_id = primary_org_id
-            store.write_dora_metrics(
-                [
-                    DORAMetricsRecord(
-                        repo_id=uuid.UUID(measured_zero_repo_id),
-                        day=(pinned_now - timedelta(days=1)).date(),
-                        metric_name="deployment_frequency",
-                        value=0.0,
-                        computed_at=pinned_now,
-                        org_id=primary_org_id,
-                    )
-                ]
+        # Codex HIGH-2 live-verification correction (2026-08-05): sources.json
+        # claims primary org's "incidents" source reads UNCONFIGURED org-wide
+        # (no pagerduty/opsgenie/incident SyncConfiguration row -- primary's
+        # own world.json sync_providers deliberately omits them). That claim
+        # is about CONFIGURATION, but NativeDataHealthReader's own logic
+        # (data_health_service.py: "if watermark is not None: configured =
+        # True") makes "configured" partly DATA-driven too -- any REAL row
+        # in operational_incidents overrides an absent SyncConfiguration.
+        # The standard per-repo generator (runner.py's
+        # ``write_operational_batch`` call) writes SOME synthetic incidents
+        # for most repos unconditionally, unrelated to this source-health
+        # claim's concept -- so without this, ANY other primary-org repo's
+        # incidents would make the org-wide claim false, caught live the
+        # first time verify_sources_against_production_data_health actually
+        # ran end to end (it observed COMPLETE/NO_DATA instead of
+        # UNCONFIGURED). No other sources.json/subjects.json entry claims
+        # real incidents data for primary org (checked: only the
+        # sibling-org "unauthorized" entry mentions "incidents", and that
+        # path never reaches operational_incidents at all -- it short-
+        # circuits on the cross-tenant scope guard) -- explicitly enforcing
+        # emptiness here is safe and makes the claim's actual intent
+        # ("no incidents integration is configured for primary") hold
+        # regardless of what individual repos' synthetic incident volume
+        # happened to produce.
+        try:
+            await source_health.zero_out_source(
+                client,
+                org_id=primary_org_id,
+                repo_id=primary_org_id,
+                source="incidents",
             )
-            logging.info("world: wrote explicit measured-zero deployment_frequency row")
+        except Exception as exc:  # noqa: BLE001
+            if not any(marker in str(exc) for marker in _MISSING_TABLE_MARKERS):
+                raise
+            logging.warning(
+                "world: skipped zeroing incidents for primary org (table missing): %s",
+                exc,
+            )
+
+        await write_and_verify_measured_zero_metric(
+            client,
+            sink_dsn=sink,
+            repo_id=uuid.UUID(measured_zero_repo_id),
+            org_id=primary_org_id,
+            metric_name="deployment_frequency",
+            day=(pinned_now - timedelta(days=1)).date(),
+            computed_at=pinned_now,
+        )
 
         conflicting_repo_id = uuid.uuid5(
             FIXTURE_NAMESPACE, "probe/source-conflicting-ci"
@@ -946,7 +1390,25 @@ async def _run_clickhouse_postprocess(sink: str, manifest: WorldManifest) -> Non
             "world: inserted conflicting CI run pair for probe/source-conflicting-ci"
         )
 
-    await run_with_store(sink, "clickhouse", _handler, org_id=None)
+    # HIGH-4 (2026-08-05): _frozen_clock previously wrapped ONLY the
+    # per-repo `run_fixtures_generation` calls, never this postprocess
+    # handler -- by the time it runs, every patched module's `datetime`
+    # name has already been reverted (the per-repo `with _frozen_clock`
+    # block has exited once, for the LAST repo). This handler's own
+    # conflicting-ci-run insert goes through `store.insert_testops_
+    # pipeline_runs` (storage.mixins.testops_cicd, already patched for the
+    # per-repo path) -- unpatched here, it fell back to real wall-clock
+    # `last_synced`, found live via direct row comparison between two
+    # scratch databases (every column on the conflicting-ci rows matched
+    # except last_synced). Wrapping the whole handler is deliberately safe
+    # for the teams-canonicalization write just above, which intentionally
+    # keeps using REAL wall-clock time to win a ReplacingMergeTree race
+    # (see its own comment): that write calls `datetime.now()` via this
+    # module's (`fixtures.world`) OWN name, and `fixtures.world` itself is
+    # -- deliberately -- never in `_CLOCK_PATCHED_MODULES`, so it is
+    # unaffected by this wrap regardless of scope.
+    with _frozen_clock(manifest.pinned_now):
+        await run_with_store(sink, "clickhouse", _handler, org_id=None)
 
 
 # ---------------------------------------------------------------------------
@@ -954,23 +1416,54 @@ async def _run_clickhouse_postprocess(sink: str, manifest: WorldManifest) -> Non
 # ---------------------------------------------------------------------------
 
 
-def _row_content_key(column_names: list[str], row: tuple[Any, ...]) -> str:
+def _row_content_key(
+    column_names: list[str], row: tuple[Any, ...], *, volatile: frozenset[str]
+) -> str:
+    """``volatile`` is the CALLER-resolved exclusion set for the specific
+    table this row came from (see ``_volatile_columns_for_table``) -- Codex
+    HIGH-3 (2026-08-05): this used to be the single global
+    ``_VOLATILE_COLUMNS`` constant, unconditionally, for every table. That
+    meant a table whose watermark column IS the thing a claimed state (e.g.
+    "stale", "measured-zero") is ABOUT could have that exact column silently
+    hashed out of the digest, so a regression that broke the aging/zeroing
+    step would leave the digest bit-for-bit identical and green. Passing the
+    per-table set explicitly (no default) makes every call site say what it
+    means to include, rather than inheriting a blanket exclusion.
+    """
     parts = [
         f"{name}={value!r}"
         for name, value in zip(column_names, row, strict=True)
-        if name not in _VOLATILE_COLUMNS
+        if name not in volatile
     ]
     parts.sort()
     return "|".join(parts)
 
 
+#: Codex HIGH-3 (2026-08-05), found live (a stub client cannot catch this --
+#: it never parses the SQL): ``FINAL`` is only legal against merge-tree
+#: engines that actually version/dedup rows (ReplacingMergeTree,
+#: CollapsingMergeTree, ...). ``dora_metrics_daily`` is a PLAIN
+#: ``MergeTree`` (see ``023b_dora_metrics.sql`` -- no dedup, deliberately,
+#: since a repo/day/metric_name can be recomputed and every computation is
+#: a fact worth keeping) -- appending it to ``_CLICKHOUSE_DIGEST_TABLES``
+#: without this exception made ``compute_world_digest`` raise
+#: ``Code: 181 ILLEGAL_FINAL`` for every table in the same org loop, not
+#: just for ``dora_metrics_daily`` itself, which the live mutation tests
+#: below caught immediately on the very first run against a real
+#: ClickHouse. Every other table in ``_CLICKHOUSE_DIGEST_TABLES`` is a
+#: ReplacingMergeTree (confirmed per-table against each table's own
+#: ``CREATE TABLE`` in ``src/dev_health_ops/migrations/clickhouse/``).
+_PLAIN_MERGETREE_TABLES = frozenset({"dora_metrics_daily"})
+
+
 async def _clickhouse_table_digest(
     client: Any, table: str, org_id: str
 ) -> dict[str, Any]:
+    final_clause = "" if table in _PLAIN_MERGETREE_TABLES else " FINAL"
     try:
         result = await asyncio.to_thread(
             client.query,
-            f"SELECT * FROM {table} FINAL WHERE org_id = {{org_id:String}}",
+            f"SELECT * FROM {table}{final_clause} WHERE org_id = {{org_id:String}}",
             parameters={"org_id": org_id},
         )
     except Exception as exc:  # noqa: BLE001
@@ -978,7 +1471,11 @@ async def _clickhouse_table_digest(
             return {"row_count": 0, "content_hash": hashlib.sha256(b"").hexdigest()}
         raise
     column_names = list(result.column_names)
-    row_keys = sorted(_row_content_key(column_names, row) for row in result.result_rows)
+    volatile = _volatile_columns_for_table(table)
+    row_keys = sorted(
+        _row_content_key(column_names, row, volatile=volatile)
+        for row in result.result_rows
+    )
     content_hash = hashlib.sha256("\n".join(row_keys).encode()).hexdigest()
     return {"row_count": len(row_keys), "content_hash": content_hash}
 
@@ -994,7 +1491,10 @@ async def _postgres_table_digest(
     )
     column_names = list(result.keys())
     rows = result.fetchall()
-    row_keys = sorted(_row_content_key(column_names, tuple(row)) for row in rows)
+    volatile = _volatile_columns_for_table(table)
+    row_keys = sorted(
+        _row_content_key(column_names, tuple(row), volatile=volatile) for row in rows
+    )
     content_hash = hashlib.sha256("\n".join(row_keys).encode()).hexdigest()
     return {"row_count": len(row_keys), "content_hash": content_hash}
 
@@ -1051,8 +1551,10 @@ async def compute_world_digest(
             )
             column_names = list(result.keys())
             rows = result.fetchall()
+            users_volatile = _volatile_columns_for_table("users")
             row_keys = sorted(
-                _row_content_key(column_names, tuple(row)) for row in rows
+                _row_content_key(column_names, tuple(row), volatile=users_volatile)
+                for row in rows
             )
             components["postgres"]["users"] = {
                 "world": {
@@ -1112,6 +1614,91 @@ def _resolve_postgres_uri(ns: argparse.Namespace) -> str:
     return uri
 
 
+async def _run_production_verification(
+    sink: str, postgres_uri: str, manifest: WorldManifest
+) -> None:
+    """Codex HIGH-2 fix: after generation, re-derive what a real request
+    would observe through the ACTUAL production code paths and raise
+    loudly on the first claim that is not actually realized -- see
+    ``world_verify``'s module docstring for exactly what is (and is not)
+    covered here and why.
+    """
+
+    from sqlalchemy.ext.asyncio import (
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
+
+    from dev_health_ops.api.dev.work_graph_neighbors_service import MAX_NEIGHBORS
+
+    engine = create_async_engine(postgres_uri, pool_pre_ping=True)
+    try:
+        session_factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def _handler(store: Any) -> None:
+            client = store.client
+            async with session_factory() as session:
+                subjects_verified = (
+                    await world_verify.verify_subjects_against_production(
+                        client=client, manifest=manifest
+                    )
+                )
+                sources_verified = (
+                    await world_verify.verify_sources_against_production_data_health(
+                        client=client, session=session, manifest=manifest
+                    )
+                )
+            primary_org_id = str(manifest.org_id("primary"))
+            conflicting_repo_id = str(
+                uuid.uuid5(FIXTURE_NAMESPACE, "probe/source-conflicting-ci")
+            )
+            await world_verify.verify_conflicting_ci_runs(
+                client, org_id=primary_org_id, repo_id=conflicting_repo_id
+            )
+            truncated_entry = next(
+                (
+                    entry
+                    for entry in manifest.sources["matrix"]
+                    if entry.get("state") == "truncated"
+                ),
+                None,
+            )
+            if truncated_entry is not None and world_verify.is_declared_blocked(
+                truncated_entry
+            ):
+                # 2026-08-05: the truncated state cannot currently be
+                # produced by any generator volume knob (see
+                # world_verify.DECLARED_BLOCKED_STATUS's own docstring for
+                # the full history) -- declared-blocked, not claimed, not
+                # silently dropped. Loud, not silent: this line is the
+                # trace that the check was intentionally skipped, not
+                # forgotten.
+                logging.warning(
+                    "world: SKIPPING verify_truncated_work_graph -- "
+                    "sources.json state='truncated' is declared-blocked "
+                    "(blocked_by=%s). This claim is NOT verified and NOT "
+                    "counted as realized.",
+                    truncated_entry.get("blocked_by"),
+                )
+            else:
+                await world_verify.verify_truncated_work_graph(
+                    client, org_id=primary_org_id, max_neighbors=MAX_NEIGHBORS
+                )
+            logging.info(
+                "world: production-path verification OK -- %d subject claim(s), "
+                "%d source-state claim(s), plus conflicting/truncated raw checks",
+                len(subjects_verified),
+                len(sources_verified),
+            )
+
+        await run_with_store(sink, "clickhouse", _handler, org_id=None)
+    finally:
+        await engine.dispose()
+
+
 async def _generate_world(ns: argparse.Namespace, manifest: WorldManifest) -> int:
     postgres_uri = _resolve_postgres_uri(ns)
 
@@ -1155,6 +1742,8 @@ async def _generate_world(ns: argparse.Namespace, manifest: WorldManifest) -> in
 
     await _run_clickhouse_postprocess(ns.sink, manifest)
 
+    await _run_production_verification(ns.sink, postgres_uri, manifest)
+
     digest_doc = await compute_world_digest(
         manifest, sink=ns.sink, postgres_uri=postgres_uri
     )
@@ -1167,6 +1756,21 @@ async def _generate_world(ns: argparse.Namespace, manifest: WorldManifest) -> in
     logging.info(
         "world: wrote WORLD_DIGEST=%s to %s", digest_doc["digest"], digest_path
     )
+    cross_gen_status = manifest.world.get("cross_generation_digest_status")
+    if isinstance(cross_gen_status, dict) and cross_gen_status.get("status") == (
+        "declared-blocked"
+    ):
+        # CHAOS-3432: loud, not silent, on every single generation -- this
+        # digest is a valid, verifiable PIN for THIS database (--verify-digest
+        # against it works), but cross-generation reproducibility (would a
+        # SECOND independent run produce the SAME digest) is not proven.
+        logging.warning(
+            "world: WORLD_DIGEST cross-generation reproducibility is "
+            "DECLARED-BLOCKED (blocked_by=%s) -- this digest is a valid pin "
+            "for THIS database only; do not assume a second independent "
+            "generation would reproduce it.",
+            cross_gen_status.get("blocked_by"),
+        )
     return 0
 
 
@@ -1204,6 +1808,18 @@ def _diff_components(pinned: dict[str, Any], live: dict[str, Any]) -> list[str]:
 
 
 async def run_fixtures_world(ns: argparse.Namespace) -> int:
+    # Entrypoint scratch-DB guard (Codex CRITICAL, 2026-08-05): checked
+    # FIRST, before manifest loading and before any store/session/client is
+    # constructed. Both target databases must be an explicit, disposable
+    # scratch database -- see UnsafeSinkError's docstring.
+    try:
+        postgres_uri = _resolve_postgres_uri(ns)
+        _require_scratch_database(getattr(ns, "sink", None), kind="clickhouse")
+        _require_scratch_database(postgres_uri, kind="postgres")
+    except (WorldManifestError, UnsafeSinkError) as exc:
+        logging.error("world: refusing to run: %s", exc)
+        return 1
+
     try:
         manifest = load_world_manifest(ns.manifest)
     except (WorldManifestError, FileNotFoundError, json.JSONDecodeError) as exc:
@@ -1219,6 +1835,6 @@ async def run_fixtures_world(ns: argparse.Namespace) -> int:
 
     try:
         return await _generate_world(ns, manifest)
-    except WorldManifestError as exc:
+    except (WorldManifestError, world_verify.WorldVerificationError) as exc:
         logging.error("world: %s", exc)
         return 1

--- a/src/dev_health_ops/fixtures/world_verify.py
+++ b/src/dev_health_ops/fixtures/world_verify.py
@@ -1,0 +1,729 @@
+"""CHAOS-3219 Codex adversarial review (HIGH-2, 2026-08-05): post-generation
+verification of ``subjects.json``/``sources.json`` claims through PRODUCTION
+code paths, not the fixture generator's own bookkeeping.
+
+Before this module, ``validate_world_manifest`` (``world.py``) only checked
+that a subject/source entry's ``class``/``state`` string appeared in a
+required-value set -- a bare ``{"class": "deleted"}`` row with no
+realization fields at all would pass. This module closes two separate gaps:
+
+1. **Typed per-entry schema** (:func:`validate_subject_entry_schema`,
+   :func:`validate_source_entry_schema`): every subject class and source
+   state has a concrete required-field shape now, checked structurally,
+   not just "the class name is spelled right".
+2. **Live production-path verification** (:func:`verify_world_against_production`):
+   after generation, re-derive what a real request would observe --
+   ``alias_matching.alias_forms`` (the ACTUAL CHAOS-3388 alias matcher, a
+   pure function) for acronym-alias subjects, direct catalog-row
+   existence/absence for the other subject classes, and
+   ``NativeDataHealthReader`` + ``DataHealthService.inspect`` (the ACTUAL
+   production data-health classification) for every sources.json state
+   that maps onto a ``DataHealthState`` value -- and raise loudly on the
+   first claim that isn't actually observed. States this module cannot
+   verify through ``DataHealthState`` (``truncated``/``conflicting``/
+   ``not-applicable``/``measured-zero``) are verified elsewhere (measured-
+   zero has its own dedicated postcondition check -- see
+   ``world.write_and_verify_measured_zero_metric``; conflicting and
+   truncated are verified here via direct raw-row checks; not-applicable
+   has no fixture row to check per its own sources.json documentation) --
+   named explicitly in :data:`STATES_VERIFIED_ELSEWHERE`, never silently
+   dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from dev_health_ops.api.dev.alias_matching import alias_forms
+from dev_health_ops.api.dev.contracts import ScopeResolutionOutcome
+from dev_health_ops.api.dev.data_health_service import (
+    NATIVE_EVIDENCE_SOURCES,
+    DataHealthService,
+    DataHealthState,
+    NativeDataHealthReader,
+)
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ResolvedTimeRange,
+    ScopeResolution,
+    ScopeResolveRequest,
+)
+
+if TYPE_CHECKING:
+    from dev_health_ops.fixtures.world import WorldManifest
+
+NATIVE_EVIDENCE_SOURCE_KEYS = frozenset(NATIVE_EVIDENCE_SOURCES)
+
+FIXTURE_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+class WorldSchemaError(ValueError):
+    """A subjects.json/sources.json entry does not match its class/state's
+    required-field schema -- raised by the STATIC (no-DB) validators."""
+
+
+class WorldVerificationError(RuntimeError):
+    """A subjects.json/sources.json claim was NOT observed through the
+    real production resolution/data-health code path after generation."""
+
+
+# ---------------------------------------------------------------------------
+# Part 1: typed per-entry schema (static -- no DB, no generation required)
+# ---------------------------------------------------------------------------
+
+#: Required fields per subjects.json ``class``, beyond the always-required
+#: ``id``/``class``/``org_alias``/``mentions``/``expected_terminal_resolution``
+#: (validated generically). A bare ``{"class": "deleted"}`` row now fails
+#: here instead of only failing (or not) much later when generation tries
+#: and silently no-ops on a missing field.
+_SUBJECT_CLASS_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "exact": ("repo_full_name",),
+    "ambiguous": ("candidates",),
+    "acronym-alias": ("alias_form",),
+    "no-match": (),
+    "deleted": (),
+    "stale-context": ("repo_full_name", "realizing_conversation_id_seed"),
+    "partially-resolved": ("team_id",),
+    "bounded-set": ("members",),
+}
+
+_GENERIC_SUBJECT_REQUIRED_FIELDS = (
+    "id",
+    "class",
+    "mentions",
+    "expected_terminal_resolution",
+)
+
+
+def validate_subject_entry_schema(entry: dict[str, Any]) -> None:
+    """Raise :class:`WorldSchemaError` unless ``entry`` has every field its
+    own ``class`` requires, with the right shape (not just presence)."""
+
+    for field in _GENERIC_SUBJECT_REQUIRED_FIELDS:
+        if not entry.get(field):
+            raise WorldSchemaError(
+                f"subjects.json entry {entry!r} is missing required field {field!r}"
+            )
+    entry_class = entry["class"]
+    if entry_class not in _SUBJECT_CLASS_REQUIRED_FIELDS:
+        raise WorldSchemaError(
+            f"subjects.json entry {entry['id']!r} has unknown class {entry_class!r}"
+        )
+    if entry_class != "no-match" and not entry.get("org_alias"):
+        raise WorldSchemaError(
+            f"subjects.json entry {entry['id']!r} (class={entry_class!r}) is "
+            "missing required field 'org_alias'"
+        )
+    for field in _SUBJECT_CLASS_REQUIRED_FIELDS[entry_class]:
+        if not entry.get(field):
+            raise WorldSchemaError(
+                f"subjects.json entry {entry['id']!r} (class={entry_class!r}) "
+                f"is missing required field {field!r}"
+            )
+    if entry_class == "ambiguous":
+        candidates = entry.get("candidates") or []
+        if not isinstance(candidates, list) or len(candidates) < 2:
+            raise WorldSchemaError(
+                f"subjects.json entry {entry['id']!r}: class=ambiguous requires "
+                "candidates to be a list of >= 2 repo names, "
+                f"got {candidates!r}"
+            )
+    if entry_class == "bounded-set":
+        members = entry.get("members") or []
+        if not isinstance(members, list) or len(members) < 2:
+            raise WorldSchemaError(
+                f"subjects.json entry {entry['id']!r}: class=bounded-set requires "
+                f"members to be a list of >= 2 repo names, got {members!r}"
+            )
+    if entry_class == "acronym-alias":
+        has_project = bool(entry.get("project_id")) and bool(
+            entry.get("project_display_name")
+        )
+        has_team = bool(entry.get("team_id")) and bool(entry.get("team_display_name"))
+        if not (has_project or has_team):
+            raise WorldSchemaError(
+                f"subjects.json entry {entry['id']!r}: class=acronym-alias "
+                "requires either (project_id AND project_display_name) or "
+                "(team_id AND team_display_name)"
+            )
+    verification_status = entry.get("verification_status")
+    if (
+        verification_status is not None
+        and verification_status != REALIZED_UNVERIFIED_LIVE_STATUS
+    ):
+        raise WorldSchemaError(
+            f"subjects.json entry {entry['id']!r} has unknown "
+            f"verification_status {verification_status!r} -- the only "
+            f"recognized non-default value is {REALIZED_UNVERIFIED_LIVE_STATUS!r}"
+        )
+    if verification_status == REALIZED_UNVERIFIED_LIVE_STATUS and not entry.get(
+        "tracked_by"
+    ):
+        raise WorldSchemaError(
+            f"subjects.json entry {entry['id']!r} has "
+            f"verification_status={REALIZED_UNVERIFIED_LIVE_STATUS!r} but no "
+            "non-empty 'tracked_by' ticket reference -- an unverified claim "
+            "must name what is tracking it, or it is indistinguishable from "
+            "one nobody noticed."
+        )
+
+
+#: Required fields per sources.json ``state``, beyond ``state``/
+#: ``data_health_state``/``mechanism`` (validated generically). Every entry
+#: must name what realizes it (or explicitly declare no fixture is needed,
+#: via ``realized_by: {"org_alias": null, "repo_full_name": null}`` --
+#: still two present keys, just null-valued, so a genuinely-empty
+#: ``realized_by: {}`` still fails this check).
+_GENERIC_SOURCE_REQUIRED_FIELDS = (
+    "state",
+    "data_health_state",
+    "mechanism",
+    "realized_by",
+)
+
+#: A sources.json entry's honest third option, alongside "realized and
+#: live-verified" and "verified elsewhere" (STATES_VERIFIED_ELSEWHERE):
+#: "known NOT realized right now, and that is recorded, not hidden."
+#: Added 2026-08-05 after the "truncated" entry's own mechanism text
+#: turned out to be a false "verified empirically" claim -- the first-ever
+#: end-to-end run of verify_truncated_work_graph (this round's HIGH-2 work)
+#: found the current SyntheticDataGenerator has no mechanism that clusters
+#: many PRs onto one work item, so the >MAX_NEIGHBORS fan-out this state
+#: requires cannot currently be produced by any volume knob. Per the
+#: CLAUDE.md rule "an inaccurate coverage claim is worse than an admitted
+#: gap": the fix is not to retune the claim down to whatever the generator
+#: happens to produce (that would fake the state -- "truncated" specifically
+#: means exceeding the limit) and not to silently drop the entry (that
+#: un-claims coverage without a trace) -- it is to mark the entry
+#: ``"status": "declared-blocked"`` with a ``"blocked_by"`` ticket
+#: reference, so ``validate_world_manifest``/schema validation still passes
+#: (the entry is honestly typed, not silently absent), the live check is
+#: skipped with a loud, visible log line rather than either a false pass or
+#: a hard failure, and the ticket is the traceable path back to closing it.
+DECLARED_BLOCKED_STATUS = "declared-blocked"
+
+
+def is_declared_blocked(entry: dict[str, Any]) -> bool:
+    return entry.get("status") == DECLARED_BLOCKED_STATUS
+
+
+#: subjects.json's analogous honest marker (CHAOS-3429, 2026-08-05): unlike
+#: DECLARED_BLOCKED_STATUS (the claim CANNOT currently be realized),
+#: ``partially-resolved`` subjects have no repo/candidates/members field for
+#: ``verify_subjects_against_production`` to check at all (its only checks
+#: are against the "repos" catalog table -- there is no team-catalog-row
+#: verification path). The fixture generation itself is believed correct
+#: (a team-kind subject with no addressable sub-team scope); what is
+#: missing is a LIVE CHECK, not a working claim. Building the team-catalog
+#: verification path is CHAOS-3429's scope, not done here -- this marker
+#: only makes the gap loud and traceable instead of a silent ``continue``.
+REALIZED_UNVERIFIED_LIVE_STATUS = "realized-but-unverified-live"
+
+
+def is_realized_unverified_live(entry: dict[str, Any]) -> bool:
+    return entry.get("verification_status") == REALIZED_UNVERIFIED_LIVE_STATUS
+
+
+def validate_source_entry_schema(entry: dict[str, Any]) -> None:
+    """Raise :class:`WorldSchemaError` unless ``entry`` has every generic
+    required field, with ``realized_by`` shaped as a dict carrying both
+    keys (even if null-valued for the documented no-fixture-needed case).
+
+    An entry may additionally carry ``"status": "declared-blocked"`` (see
+    :data:`DECLARED_BLOCKED_STATUS`) -- when present, ``"blocked_by"`` is
+    also required, as a non-empty ticket reference explaining why.
+    """
+
+    for field in _GENERIC_SOURCE_REQUIRED_FIELDS:
+        if field not in entry or entry[field] in (None, ""):
+            if field == "realized_by":
+                continue  # realized_by itself is checked structurally below
+            raise WorldSchemaError(
+                f"sources.json entry {entry!r} is missing required field {field!r}"
+            )
+    realized_by = entry.get("realized_by")
+    if not isinstance(realized_by, dict) or not (
+        "org_alias" in realized_by and "repo_full_name" in realized_by
+    ):
+        raise WorldSchemaError(
+            f"sources.json entry state={entry.get('state')!r} must carry a "
+            "'realized_by' object with both 'org_alias' and 'repo_full_name' "
+            "keys (null-valued is fine for the documented no-fixture-needed "
+            "case, e.g. not-applicable) -- got "
+            f"{realized_by!r}"
+        )
+    if not entry.get("source_classes"):
+        raise WorldSchemaError(
+            f"sources.json entry state={entry.get('state')!r} is missing "
+            "required non-empty field 'source_classes'"
+        )
+    status = entry.get("status")
+    if status is not None and status != DECLARED_BLOCKED_STATUS:
+        raise WorldSchemaError(
+            f"sources.json entry state={entry.get('state')!r} has unknown "
+            f"status {status!r} -- the only recognized non-default value is "
+            f"{DECLARED_BLOCKED_STATUS!r}"
+        )
+    if status == DECLARED_BLOCKED_STATUS and not entry.get("blocked_by"):
+        raise WorldSchemaError(
+            f"sources.json entry state={entry.get('state')!r} has "
+            f"status={DECLARED_BLOCKED_STATUS!r} but no non-empty "
+            "'blocked_by' ticket reference -- a declared-blocked claim "
+            "must name what is tracking it, or it is indistinguishable "
+            "from a silently dropped one."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part 2: live production-path verification
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _StubEntitlement:
+    """Always-allow entitlement stub. Verification here checks the REAL
+    data-health classification (NativeDataHealthReader + DataHealthService
+    .inspect's state-selection logic) for a KNOWN, already-generated
+    subject; it deliberately does not re-derive entitlement or re-resolve
+    mention text -- that is Phase 2's corpus-runner concern, exercised
+    through the real HTTP/SSE API with a real user, not this fixture-world
+    generator."""
+
+    async def require(self, org_id: str) -> None:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class _FixedScopeAuthorizer:
+    """Returns a pre-built ``ScopeResolution`` regardless of the request."""
+
+    resolution: ScopeResolution
+
+    async def resolve(self, org_id: str, permission_fingerprint: str, request: Any):
+        return self.resolution
+
+
+def _dummy_time_range(now: datetime) -> ResolvedTimeRange:
+    iso = now.isoformat()
+    return ResolvedTimeRange(
+        timezone="UTC",
+        utc_start=now,
+        utc_end=now,
+        local_start=iso,
+        local_end=iso,
+        comparison_utc_start=now,
+        comparison_utc_end=now,
+        comparison_local_start=iso,
+        comparison_local_end=iso,
+    )
+
+
+def _exact_repository_scope(repo_id: str, *, now: datetime) -> ScopeResolution:
+    entity = AuthorizedEntity(
+        kind=EntityKind.REPOSITORY,
+        canonical_id=repo_id,
+        label=repo_id,
+        repository_id=repo_id,
+    )
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(entity,),
+        team_filters=(),
+        candidates=(),
+        time_range=_dummy_time_range(now),
+    )
+
+
+def _unauthorized_scope(now: datetime) -> ScopeResolution:
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND,
+        entities=(),
+        team_filters=(),
+        candidates=(),
+        time_range=_dummy_time_range(now),
+    )
+
+
+def _organization_scope(now: datetime) -> ScopeResolution:
+    """An org-wide direct scope: no entities at all, so
+    ``data_health_service._repository_ids`` (which only ever collects from
+    ``scope.entities``) is empty -- the shape ``NativeDataHealthReader.read``
+    requires to answer an org-wide "is this source configured at all"
+    question, as opposed to "for this one repository". Needed specifically
+    for the ``incidents`` source key (live-verification correction,
+    2026-08-05): production's own reader special-cases ``source ==
+    "incidents" and repository_ids`` to unconditionally report
+    ``DataHealthState.UNAVAILABLE`` for ANY narrower-than-org scope
+    (``operational_incidents`` carries no ``repo_id`` column, so a
+    repository-scoped incidents query cannot be answered correctly and the
+    reader refuses to guess -- see its own docstring). Verifying an
+    "incidents reads UNCONFIGURED org-wide, regardless of which repo is
+    asked about" claim (sources.json's own wording) through a
+    repository-scoped ``_exact_repository_scope`` therefore always observed
+    UNAVAILABLE instead, regardless of the actual provider configuration --
+    caught live the first time this exact check ran end to end."""
+
+    return ScopeResolution(
+        outcome=ScopeResolutionOutcome.EXACT,
+        entities=(),
+        team_filters=(),
+        candidates=(),
+        time_range=_dummy_time_range(now),
+    )
+
+
+def repo_id_for(repo_full_name: str) -> uuid.UUID:
+    return uuid.uuid5(FIXTURE_NAMESPACE, repo_full_name)
+
+
+#: sources.json ``state`` -> the ``DataHealthState`` a real
+#: ``DataHealthService.inspect`` call must return for this module to
+#: consider the claim verified.
+STATE_TO_DATA_HEALTH: dict[str, DataHealthState] = {
+    "current": DataHealthState.COMPLETE,
+    "stale": DataHealthState.STALE,
+    "unavailable": DataHealthState.UNAVAILABLE,
+    "unconfigured": DataHealthState.UNCONFIGURED,
+    "no-data": DataHealthState.NO_DATA,
+    "unauthorized": DataHealthState.UNAUTHORIZED,
+}
+
+#: States NOT verified via DataHealthState in this function -- documented
+#: explicitly, never silently dropped. Each is verified elsewhere:
+#: - measured-zero: world.write_and_verify_measured_zero_metric's own
+#:   live read-back postcondition (HIGH-1 fix).
+#: - truncated: verify_truncated_work_graph (below), a raw edge-count check.
+#: - conflicting: verify_conflicting_ci_runs (below), a raw two-opposite-
+#:   status-row check.
+#: - not-applicable: sources.json's own entry documents "no fixture rows
+#:   are needed" (the reader hardcodes the acr special-case regardless of
+#:   fixture state) -- nothing to verify against a live database.
+STATES_VERIFIED_ELSEWHERE = frozenset(
+    {"measured-zero", "truncated", "conflicting", "not-applicable"}
+)
+
+
+async def verify_sources_against_production_data_health(
+    *,
+    client: Any,
+    session: Any,
+    manifest: WorldManifest,
+) -> list[str]:
+    """For every sources.json matrix entry mapped in
+    :data:`STATE_TO_DATA_HEALTH`, run the REAL ``NativeDataHealthReader`` +
+    ``DataHealthService.inspect`` against the live database and assert the
+    observed ``DataHealthState`` matches the claim. Returns the list of
+    ``(state, source_class)`` ids actually verified; raises
+    :class:`WorldVerificationError` on the first mismatch.
+    """
+
+    reader = NativeDataHealthReader(client, session)
+    verified: list[str] = []
+    for entry in manifest.sources["matrix"]:
+        state = entry["state"]
+        if state in STATES_VERIFIED_ELSEWHERE:
+            continue
+        expected = STATE_TO_DATA_HEALTH.get(state)
+        if expected is None:
+            raise WorldVerificationError(
+                f"sources.json state {state!r} has no DataHealthState mapping "
+                "to verify against, and is not listed in STATES_VERIFIED_ELSEWHERE "
+                "-- add one or the other, do not leave a state silently unverified."
+            )
+
+        realized_by = entry.get("realized_by") or {}
+        org_alias = realized_by.get("org_alias")
+        repo_full_name = realized_by.get("repo_full_name")
+        if not org_alias or not repo_full_name:
+            raise WorldVerificationError(
+                f"sources.json state {state!r} has no realized_by.org_alias/"
+                "repo_full_name to verify against (and is not in "
+                "STATES_VERIFIED_ELSEWHERE) -- this claim cannot be checked."
+            )
+
+        asked_from_alias = realized_by.get("asked_from_org_alias")
+        repo_id = str(repo_id_for(repo_full_name))
+        if asked_from_alias:
+            scope = _unauthorized_scope(manifest.pinned_now)
+            verify_org_id = str(manifest.org_id(asked_from_alias))
+        else:
+            scope = _exact_repository_scope(repo_id, now=manifest.pinned_now)
+            verify_org_id = str(manifest.org_id(org_alias))
+
+        source_keys = sorted(
+            {
+                token.split(" ")[0]
+                for token in entry.get("source_classes", [])
+                if token.split(" ")[0] in NATIVE_EVIDENCE_SOURCE_KEYS
+            }
+        )
+        if not source_keys:
+            continue
+
+        by_source: dict[str, Any] = {}
+        # "incidents" has no repository dimension in production
+        # (``operational_incidents`` carries no ``repo_id`` column) --
+        # NativeDataHealthReader unconditionally reports it UNAVAILABLE for
+        # any narrower-than-org scope, regardless of provider configuration
+        # (see ``_organization_scope``'s own docstring). A repo-scoped
+        # verification scope (the ``_exact_repository_scope`` branch above,
+        # used whenever this isn't a cross-tenant ``asked_from_alias``
+        # check) is therefore the WRONG question to ask for an "incidents"
+        # claim -- split it out to its own org-wide-scoped inspect call so
+        # every other source_key in this entry keeps its normal,
+        # repo-scoped verification unaffected.
+        incidents_keys = [k for k in source_keys if k == "incidents"]
+        other_keys = [k for k in source_keys if k != "incidents"]
+
+        if other_keys:
+            service = DataHealthService(
+                entitlement=_StubEntitlement(),
+                authorizer=_FixedScopeAuthorizer(scope),
+                reader=reader,
+                now=manifest.pinned_now,
+            )
+            result = await service.inspect(
+                org_id=verify_org_id,
+                permission_fingerprint="fixture-world-verify",
+                scope_request=ScopeResolveRequest(),  # unused: _FixedScopeAuthorizer ignores it
+                required_sources=other_keys,
+            )
+            by_source.update({row.source_system: row.state for row in result.sources})
+
+        if incidents_keys:
+            incidents_scope = (
+                scope
+                if asked_from_alias
+                # already org-wide/empty-entities for the unauthorized path
+                else _organization_scope(manifest.pinned_now)
+            )
+            incidents_service = DataHealthService(
+                entitlement=_StubEntitlement(),
+                authorizer=_FixedScopeAuthorizer(incidents_scope),
+                reader=reader,
+                now=manifest.pinned_now,
+            )
+            result = await incidents_service.inspect(
+                org_id=verify_org_id,
+                permission_fingerprint="fixture-world-verify",
+                scope_request=ScopeResolveRequest(),
+                required_sources=incidents_keys,
+            )
+            by_source.update({row.source_system: row.state for row in result.sources})
+
+        for source_key in source_keys:
+            observed = by_source.get(source_key)
+            if observed != expected:
+                raise WorldVerificationError(
+                    f"sources.json state {state!r} (source={source_key!r}, "
+                    f"repo={repo_full_name!r}, org={org_alias!r}) claims "
+                    f"{expected.value!r} but the REAL DataHealthService.inspect "
+                    f"observed {observed.value if observed else observed!r} -- "
+                    "the claim is not realized."
+                )
+            verified.append(f"{state}:{source_key}")
+    return verified
+
+
+async def verify_conflicting_ci_runs(client: Any, *, org_id: str, repo_id: str) -> None:
+    """Direct raw-row check for the ``conflicting`` sources.json state:
+    at least two ``ci_pipeline_runs`` rows for this repo with different
+    ``status`` values."""
+
+    result = await _query(
+        client,
+        "SELECT DISTINCT status FROM ci_pipeline_runs FINAL "
+        "WHERE org_id = {org_id:String} AND repo_id = {repo_id:UUID}",
+        {"org_id": org_id, "repo_id": repo_id},
+    )
+    distinct_statuses = {row[0] for row in result.result_rows}
+    if len(distinct_statuses) < 2:
+        raise WorldVerificationError(
+            f"sources.json state='conflicting' claims repo_id={repo_id!r} has "
+            "disagreeing CI signals, but only found status(es) "
+            f"{sorted(distinct_statuses)!r} -- the claim is not realized."
+        )
+
+
+async def verify_truncated_work_graph(
+    client: Any, *, org_id: str, max_neighbors: int
+) -> None:
+    """Direct raw-row check for the ``truncated`` sources.json state: at
+    least one work_graph_issue_pr/work_graph_pr_commit fan-out for the
+    truncated-probe org exceeds ``max_neighbors`` (WorkGraphNeighborsService
+    .MAX_NEIGHBORS) so a real query would observe truncation."""
+
+    result = await _query(
+        client,
+        "SELECT max(cnt) FROM ("
+        "  SELECT work_item_id, count() AS cnt FROM work_graph_issue_pr FINAL "
+        "  WHERE org_id = {org_id:String} GROUP BY work_item_id"
+        ")",
+        {"org_id": org_id},
+    )
+    rows = result.result_rows
+    max_fanout = int(rows[0][0]) if rows and rows[0][0] is not None else 0
+    if max_fanout <= max_neighbors:
+        raise WorldVerificationError(
+            f"sources.json state='truncated' claims org_id={org_id!r} has a "
+            f"work-graph fan-out exceeding MAX_NEIGHBORS={max_neighbors}, but "
+            f"the largest observed fan-out is {max_fanout} -- the claim is "
+            "not realized."
+        )
+
+
+async def _query(client: Any, query: str, parameters: dict[str, Any]) -> Any:
+    return await asyncio.to_thread(client.query, query, parameters=parameters)
+
+
+# ---------------------------------------------------------------------------
+# Part 3: subject verification (alias matcher + direct catalog existence)
+# ---------------------------------------------------------------------------
+
+
+def verify_acronym_alias_subject(entry: dict[str, Any]) -> None:
+    """Run the REAL CHAOS-3388 alias matcher (``alias_matching.alias_forms``,
+    a pure function -- no DB needed) against the subject's own claimed
+    display name and assert every claimed mention actually resolves as an
+    alias/acronym of it. This is the exact function
+    ``scope_catalog.ClickHouseAuthorizedEntityCatalog._alias_matches`` calls
+    in production."""
+
+    display_name = entry.get("project_display_name") or entry.get("team_display_name")
+    if not display_name:
+        raise WorldVerificationError(
+            f"subject {entry['id']!r}: class=acronym-alias has no "
+            "project_display_name/team_display_name to verify against"
+        )
+    forms = alias_forms(display_name)
+    for mention in entry.get("mentions", []):
+        normalized = mention.strip().casefold()
+        if normalized not in forms.literal_aliases and normalized not in forms.acronyms:
+            raise WorldVerificationError(
+                f"subject {entry['id']!r}: mention {mention!r} does not "
+                f"resolve as a literal alias or acronym of display_name="
+                f"{display_name!r} via the REAL alias_matching.alias_forms "
+                f"(literal_aliases={sorted(forms.literal_aliases)!r}, "
+                f"acronyms={sorted(forms.acronyms)!r}) -- the claim is not "
+                "realized."
+            )
+
+
+async def _table_has_row(
+    client: Any, table: str, *, org_id: str, id_column: str, id_value: str
+) -> bool:
+    result = await _query(
+        client,
+        f"SELECT count() FROM {table} FINAL "  # noqa: S608
+        f"WHERE org_id = {{org_id:String}} AND {id_column} = {{id_value:String}}",
+        {"org_id": org_id, "id_value": id_value},
+    )
+    return int(result.result_rows[0][0]) > 0
+
+
+async def verify_subjects_against_production(
+    *, client: Any, manifest: WorldManifest
+) -> list[str]:
+    """Verify every subjects.json entry's claimed realization actually
+    exists (or, for no-match, deliberately does not exist) in the live
+    catalog tables. Raises :class:`WorldVerificationError` on the first
+    unobserved claim; returns the list of subject ids verified.
+    """
+
+    verified: list[str] = []
+    for entry in manifest.subjects["subjects"]:
+        entry_class = entry["class"]
+        subject_id = entry["id"]
+        if entry_class == "acronym-alias":
+            verify_acronym_alias_subject(entry)
+            verified.append(subject_id)
+            continue
+        if entry_class == "no-match":
+            # Absence IS the fixture -- nothing to positively verify beyond
+            # what collect_repo_roster's own guard test already proves
+            # (test_no_match_subject_has_no_realizing_repo).
+            verified.append(subject_id)
+            continue
+        org_alias = entry.get("org_alias")
+        if not org_alias:
+            continue
+        org_id = str(manifest.org_id(org_alias))
+        repo_names: list[str] = []
+        if entry.get("repo_full_name"):
+            repo_names.append(entry["repo_full_name"])
+        repo_names.extend(entry.get("candidates") or [])
+        repo_names.extend(entry.get("members") or [])
+        if not repo_names:
+            # CHAOS-3429 (2026-08-05): this function's only verification
+            # path is against the "repos" catalog table -- a subject with
+            # no repo_full_name/candidates/members (e.g. a team-only
+            # `partially-resolved` claim) has nothing here to check. That
+            # used to be a bare, silent `continue` -- indistinguishable
+            # from an entry nobody remembered to verify. Now it is loud
+            # either way: an entry that explicitly marks itself
+            # verification_status=REALIZED_UNVERIFIED_LIVE_STATUS logs a
+            # named, ticketed warning (still NOT added to `verified` --
+            # this is honestly "not checked", not "checked and passed");
+            # anything else reaching this point is a genuinely new,
+            # unmarked gap and must fail loudly rather than silently join
+            # the same blind spot.
+            if is_realized_unverified_live(entry):
+                logging.warning(
+                    "world_verify: SKIPPING live check for subject %r "
+                    "(class=%r) -- verification_status=%r, tracked_by=%s. "
+                    "This claim is NOT verified and NOT counted as checked.",
+                    subject_id,
+                    entry_class,
+                    REALIZED_UNVERIFIED_LIVE_STATUS,
+                    entry.get("tracked_by"),
+                )
+                continue
+            raise WorldVerificationError(
+                f"subject {subject_id!r}: class={entry_class!r} has no "
+                "repo_full_name/candidates/members for "
+                "verify_subjects_against_production to check against the "
+                "live 'repos' table, and does not declare "
+                f"verification_status={REALIZED_UNVERIFIED_LIVE_STATUS!r} "
+                "with a 'tracked_by' ticket -- this is an unmarked "
+                "verification gap, not a documented one. Either add the "
+                "fields this check needs, or mark it explicitly (see "
+                "CHAOS-3429)."
+            )
+        for repo_full_name in repo_names:
+            repo_id = str(repo_id_for(repo_full_name))
+            exists = await _table_has_row(
+                client, "repos", org_id=org_id, id_column="id", id_value=repo_id
+            )
+            if entry_class == "deleted":
+                # The repo row itself may still exist (git history is
+                # untouched) -- what must be verified is that the PROJECT
+                # catalog row is retired, not the repo's mere existence.
+                project_id = entry.get("project_id") or repo_full_name
+                active = await _query(
+                    client,
+                    "SELECT is_active FROM projects FINAL "
+                    "WHERE org_id = {org_id:String} AND id = {project_id:String}",
+                    {"org_id": org_id, "project_id": project_id},
+                )
+                rows = active.result_rows
+                if not rows or int(rows[0][0]) != 0:
+                    raise WorldVerificationError(
+                        f"subject {subject_id!r}: class=deleted claims project "
+                        f"{project_id!r} is retired (is_active=0), but the live "
+                        f"catalog shows {rows!r} -- the claim is not realized."
+                    )
+            elif not exists:
+                raise WorldVerificationError(
+                    f"subject {subject_id!r}: class={entry_class!r} claims repo "
+                    f"{repo_full_name!r} exists in org {org_alias!r}, but no "
+                    "matching row was found in the live 'repos' table -- the "
+                    "claim is not realized."
+                )
+        verified.append(subject_id)
+    return verified

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -337,8 +337,26 @@ async def materialize_fixture_investments(
     repo_ids: list[str] | None = None,
     team_ids: list[str] | None = None,
     org_id: str | None = None,
+    llm_concurrency: int = 5,
 ) -> dict[str, int]:
-    """Materialize fixture investments using the mock LLM provider."""
+    """Materialize fixture investments using the mock LLM provider.
+
+    ``llm_concurrency`` defaults to 5, matching ``MaterializeConfig``'s own
+    default -- existing callers that don't pass it see no behavior change.
+    CHAOS-3219 Codex adversarial review (HIGH-4, 2026-08-05): the multi-task
+    LLM categorization path (this function's caller, ``materialize_
+    investments``) iterates pending tasks via ``asyncio.as_completed``,
+    recording each result in COMPLETION order -- with more than one
+    concurrent task, real async scheduling (not the master seed) decides
+    that order, and if any recorded result influences later random-draw-
+    consuming work, the whole downstream generation for whatever runs next
+    can desync between two otherwise-identical runs. `dev_health_ops.
+    fixtures.world` (an explicitly authorized exception to this module's
+    general concurrency behavior -- see its own call site) passes
+    ``llm_concurrency=1`` to collapse this to strictly sequential
+    completion order, closing the one remaining source of run-to-run
+    WORLD_DIGEST drift identified by that review.
+    """
     config = MaterializeConfig(
         dsn=db_url,
         from_ts=from_ts,
@@ -350,6 +368,7 @@ async def materialize_fixture_investments(
         team_ids=team_ids,
         force=True,
         org_id=org_id,
+        llm_concurrency=llm_concurrency,
     )
     logging.info(
         "Materializing fixture investments from %s to %s",

--- a/tests/acceptance/world/ask-dev-world.v1/WORLD_DIGEST
+++ b/tests/acceptance/world/ask-dev-world.v1/WORLD_DIGEST
@@ -1,0 +1,227 @@
+{
+  "components": {
+    "clickhouse": {
+      "ci_pipeline_runs": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "f4cb0cad0d7d533f38cef417a5d1d74c19716feaba35b810b067b854081a8f40",
+          "row_count": 400
+        },
+        "sibling": {
+          "content_hash": "f29c6b1a28c458ee894a7a46f1bfe1867a5f61bb7e695d0ca4c9f7c51a9862eb",
+          "row_count": 32
+        }
+      },
+      "deployments": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "457b55d98468240a967b6f0dbe3cd97a12d3fa5f59ee23419602bab80f8b9787",
+          "row_count": 237
+        },
+        "sibling": {
+          "content_hash": "6cd3dd05b9788c5cbb21a1e0f3ab62c723a576b7dd74d6335e9f68e76c09c078",
+          "row_count": 25
+        }
+      },
+      "git_pull_requests": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "58ae8cc620525cc090fb01d06405bffc270d6adc7d17406a9477588bedbe4465",
+          "row_count": 262
+        },
+        "sibling": {
+          "content_hash": "a110f0e932517bc78191263a21d6430c2eb51a31ba9999368b4499043d7e0340",
+          "row_count": 20
+        }
+      },
+      "projects": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "9c5b996910c6450b06683767be532a2489c85a99792d04ff3bc58a2f0664c2d1",
+          "row_count": 12
+        },
+        "sibling": {
+          "content_hash": "ced41fbd1c89872def32f24f9f1d44ec5b0d8121b73a17a4539fbe8eb21c6731",
+          "row_count": 1
+        }
+      },
+      "repos": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "a64943189241192ae7ff940ec6f7c85d57da6ca741137a5942dee3659cfffafa",
+          "row_count": 12
+        },
+        "sibling": {
+          "content_hash": "e4642ccfa70ccca574e7000233406811d378411478f09916bf73a56e56a3cbdb",
+          "row_count": 1
+        }
+      },
+      "teams": {
+        "disabled": {
+          "content_hash": "05449c488f1132bc6cc1abbeabfb758b87d5f85337e8a495b10f35e1e1018956",
+          "row_count": 3
+        },
+        "primary": {
+          "content_hash": "bb6492fd746a896cde040afbbae52998216e8217e9c9eba9e9765f3f433a5698",
+          "row_count": 4
+        },
+        "sibling": {
+          "content_hash": "e83917401a4b91b5424a9bc6d9904ad57ba819467caf6d3cdb778d70b5b770e4",
+          "row_count": 3
+        }
+      },
+      "work_items": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "2527a01671432655e78ff81a4ee2d2981aaca7076872efda1dcaee8a140c5b5f",
+          "row_count": 240
+        },
+        "sibling": {
+          "content_hash": "f8cfd04d9c77972f447d657b98f3df1a58861cd6e2e4788a67f789754a67b7fe",
+          "row_count": 21
+        }
+      }
+    },
+    "postgres": {
+      "dev_conversations": {
+        "disabled": {
+          "content_hash": "886f742f565269947cef4c87e2d605c79c5823d0f4c325ff75a7c53d0ccc9068",
+          "row_count": 2
+        },
+        "primary": {
+          "content_hash": "136dbf495f63ad7831eda144861e4b47c48f9d99b5771f15fcd128a90800b0fe",
+          "row_count": 4
+        },
+        "sibling": {
+          "content_hash": "94ec1ff5e0168f8fa86fe6959ed0a8f3f4781d6f70fbc4e63d4a16050a94524b",
+          "row_count": 2
+        }
+      },
+      "dev_run_subject_sets": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "fef11b6aed5fe0c5941b6fc3d84f4ec86421171851712ad6e702cca12d18d222",
+          "row_count": 1
+        },
+        "sibling": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        }
+      },
+      "dev_runs": {
+        "disabled": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        },
+        "primary": {
+          "content_hash": "130da47ae77a60ddb0f836229b60f364a7c17017b02e975b19e57309156b2829",
+          "row_count": 5
+        },
+        "sibling": {
+          "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "row_count": 0
+        }
+      },
+      "memberships": {
+        "disabled": {
+          "content_hash": "7c6db214cd38d6671c386fd20c8306005263fee31ccdf34e6b670d8933b5eb81",
+          "row_count": 2
+        },
+        "primary": {
+          "content_hash": "8668ef133e2de4fc0a5fc0d2d045e68defa2b66bd5ed79ddee3d6644ea4e10b0",
+          "row_count": 6
+        },
+        "sibling": {
+          "content_hash": "136c6c6b0e6b1c48a4ec9451a99dabd7adf54e62772a82e25e234ec91179e04e",
+          "row_count": 2
+        }
+      },
+      "org_feature_overrides": {
+        "disabled": {
+          "content_hash": "544249106e62535bff4d5f0b1b2c9e8f21ba618865668a575476f4e7755d7725",
+          "row_count": 2
+        },
+        "primary": {
+          "content_hash": "e14985f8cf1e22093a5ec5aa8264847963fe4c6f6bb3f61d7b9b6ed06bad92bb",
+          "row_count": 2
+        },
+        "sibling": {
+          "content_hash": "f4938ea0db8ffcc7ce99e3bc2a287ca6a9311769d99450861efa73ec7e90a64c",
+          "row_count": 2
+        }
+      },
+      "org_retention_policies": {
+        "disabled": {
+          "content_hash": "79f0d44b15c54d73b513c5beb48dae07ede22b47601f7ebd16924748a0b025e1",
+          "row_count": 1
+        },
+        "primary": {
+          "content_hash": "9935dd9793f7c56ed62bc5b7c400283c714982a4c481fdc835027121c849894b",
+          "row_count": 1
+        },
+        "sibling": {
+          "content_hash": "bbad863b66122c58810643d0f22de91ea66c9c9a246a62e5f8ae06b6fedaba4c",
+          "row_count": 1
+        }
+      },
+      "organizations": {
+        "disabled": {
+          "content_hash": "93e06a93d7134030fd94c7dd5ec5103ea1b29f6d4e9d547fd65079e18a02f321",
+          "row_count": 1
+        },
+        "primary": {
+          "content_hash": "b9965869c647c598e0ebeae2e5c5ac0aa25799d1c68f5d9e8c9dc9debb2daf23",
+          "row_count": 1
+        },
+        "sibling": {
+          "content_hash": "a5076517ca2e175891b5d687cb8f6a27310408676f38ef56a6ecc8cafd1dbdb2",
+          "row_count": 1
+        }
+      },
+      "sync_configurations": {
+        "disabled": {
+          "content_hash": "c5d45aae29054d95d2a2f207187be386a72b2cd08da666005e36a8e1a97ee408",
+          "row_count": 3
+        },
+        "primary": {
+          "content_hash": "1353581967eb9f01a68b1ad38cc98c41d3481a97e67d078a62b077d2cda58230",
+          "row_count": 2
+        },
+        "sibling": {
+          "content_hash": "af339ba24f6367072e0dcac7775414f1219d63a31c252bbe5084a3b9b90e75ed",
+          "row_count": 3
+        }
+      },
+      "users": {
+        "world": {
+          "content_hash": "cb5a5ff029b3f37d2d0a4407f6b2a97db6039bc5becfd3b82014c525eb24c9aa",
+          "row_count": 10
+        }
+      }
+    }
+  },
+  "digest": "c6b20867e2b1c31da36e59e26572323cc8576e95e9c98e1f1ba8be6835fb7dbe",
+  "master_seed": 3219000,
+  "schema_version": "ask_dev_world.v1"
+}

--- a/tests/acceptance/world/ask-dev-world.v1/sources.json
+++ b/tests/acceptance/world/ask-dev-world.v1/sources.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "ask_dev_world.v1",
+  "$comment": "CHAOS-3219 Wave 4 Phase 1 Lane 1a. Per-source-class terminal-state matrix. Grounded directly in the real production reader (src/dev_health_ops/api/dev/data_health_service.py: DataHealthState, NativeDataHealthReader) rather than invented vocabulary -- DataHealthState has exactly 6 members (complete/no_data/unavailable/unconfigured/stale/unauthorized); the corpus registry's 9-state list is realized by mapping onto that vocabulary plus two cross-cutting fixtures (conflicting, truncated) that surface one level up the stack (evidence-conflict detection and WorkGraphNeighborsResult.truncated respectively), and one org-wide-hardcoded case (not_applicable, via the reader's own unconditional acr handling).",
+
+  "source_classes": [
+    "commits", "pull_requests", "reviews", "work_items", "work_units",
+    "deployments", "ci_runs", "incidents", "acr"
+  ],
+  "$comment_source_classes": "== data_health_service.NATIVE_EVIDENCE_SOURCES plus the optional 'acr' key the reader special-cases. ci_runs is realized through the same 'local'/'git' SyncConfiguration as commits/deployments but is read from ci_pipeline_runs, not one of the 8 NATIVE_EVIDENCE_SOURCES table keys -- included here because deg.source-state.conflicting needs it.",
+
+  "matrix": [
+    {
+      "state": "current",
+      "data_health_state": "DataHealthState.COMPLETE",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-current"},
+      "mechanism": "SyncConfiguration(provider='local', is_active=True, last_sync_success=True) + SyncConfiguration(provider='jira', ...) present for the org; the repo's git_commits/git_pull_requests/git_pull_request_reviews/deployments/work_items rows carry last_synced within the STALE_FALLBACK_GRACE window (<=48h) of pinned_now.",
+      "source_classes": ["commits", "pull_requests", "reviews", "work_items", "deployments"]
+    },
+    {
+      "state": "stale",
+      "data_health_state": "DataHealthState.STALE",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-stale"},
+      "mechanism": "Same repo/org shape as source-current, but every row's last_synced is aged via an explicit ClickHouse `ALTER TABLE ... UPDATE last_synced = <pinned_now - 96h> ... SETTINGS mutations_sync=1` mutation issued by dev_health_ops.fixtures.world AFTER generation -- 96h exceeds STALE_FALLBACK_GRACE (48h, no ScheduledJob row is seeded so no schedule-derived grace applies). Deliberately a post-generation mutation, not a differently-dated commit history: SourceFreshnessPolicy.classify reads last_synced (the sync watermark), never the commit's authored_date.",
+      "source_classes": ["commits", "pull_requests", "reviews", "work_items", "deployments"]
+    },
+    {
+      "state": "no-data",
+      "data_health_state": "DataHealthState.NO_DATA",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-no-data"},
+      "mechanism": "Repo entity exists (repos row inserted) but is generated with zero commits/PRs/reviews/deployments/work items -- watermark is genuinely NULL for every source, not merely old. deployments and work_items are the two sources the world explicitly asserts NO_DATA on; ci_runs/incidents follow the same shape.",
+      "source_classes": ["deployments", "work_items", "ci_runs"]
+    },
+    {
+      "state": "measured-zero",
+      "data_health_state": "n/a (this is a metrics-layer distinction, not a DataHealthState member)",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-measured-zero"},
+      "mechanism": "Same zero-raw-deployments shape as no-data (deployments table has zero rows for this repo -> DataHealthState.NO_DATA at the source-freshness layer, honestly not distinguishable from no-data at THAT layer), but dev_health_ops.fixtures.generators.pipelines.generate_dora_metrics's deployment_frequency output is overridden for this repo/window to an explicit value=0.0 DORAMetricsRecord row rather than omitted. The dev_metric query layer (api/dev/production_runtime.py query_metric) reads investment/dora metric rows directly, NOT data_health's per-source watermark -- so a metric answer over this repo can report 'deployment_frequency measured, value 0' while a data-health answer over the same repo reports 'deployments: no_data'. Both are true and distinct; this pair is the fixture-world's realization of the corpus registry's explicit 'measured-zero versus no-data' requirement (deg.source-state.no-data doc string).",
+      "source_classes": ["deployments (metric layer)"]
+    },
+    {
+      "state": "unavailable",
+      "data_health_state": "DataHealthState.UNAVAILABLE",
+      "realized_by": {"org_alias": "sibling", "repo_full_name": "sibling-only/private-repo"},
+      "mechanism": "world.json sibling org sync_providers.local.state='active_failure' -> SyncConfiguration(provider='local', is_active=True, last_sync_success=False) org-wide. NativeDataHealthReader's `failure = any(config.last_sync_success is False and _provider_supports(source, config.provider) ...)` -> active_failure=True -> DataHealthState.UNAVAILABLE for every git-backed source in the sibling tenant.",
+      "source_classes": ["commits", "pull_requests", "reviews", "deployments", "work_units"]
+    },
+    {
+      "state": "unconfigured",
+      "data_health_state": "DataHealthState.UNCONFIGURED",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-current"},
+      "mechanism": "world.json primary org sync_providers deliberately omits 'pagerduty'/'opsgenie'/'incident' -> _source_configured('incidents', configs) is False org-wide for primary -> DataHealthState.UNCONFIGURED for 'incidents' regardless of which repo is asked about (incidents carries no repo_id column -- see data_health_service.py's own repo_column=None comment for 'incidents' in _SOURCE_TABLES). Attached to probe/source-current (an org-wide effect, reusing an already-realized repo rather than minting a new one) -- this state does not need a dedicated repo of its own.",
+      "source_classes": ["incidents"]
+    },
+    {
+      "state": "unauthorized",
+      "data_health_state": "DataHealthState.UNAUTHORIZED",
+      "realized_by": {"org_alias": "sibling", "repo_full_name": "sibling-only/private-repo", "asked_from_org_alias": "primary"},
+      "mechanism": "DataHealthService.inspect's own guard: any ScopeResolution.outcome not in {EXACT, FILTERED, INHERITED, ORGANIZATION_FALLBACK} (a cross-tenant id can never resolve to one of those for the wrong org) short-circuits every requested source straight to DataHealthState.UNAUTHORIZED before the reader is even invoked. Same underlying fixture row as subjects.json subject.tenant.sibling-only-private-repo and the deg.source-state.unavailable row above -- three distinct, individually true observations of one fixture row from three different vantage points, intentionally not tripled into three repos.",
+      "source_classes": ["commits", "pull_requests", "reviews", "work_items", "deployments", "incidents"]
+    },
+    {
+      "state": "truncated",
+      "data_health_state": "n/a (SourceRequirementState.TRUNCATED / WorkGraphNeighborsResult.truncated, not a DataHealthState member)",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-truncated-workgraph"},
+      "mechanism": "Generated with elevated pr_count/commits_per_day and --with-work-graph so the work-graph neighbor fan-out for at least one committed issue/PR node exceeds work_graph_neighbors_service.MAX_NEIGHBORS (25) -- work_graph_expansion_run then always reports SourceRequirementState.TRUNCATED (result.truncated wins unconditionally per builtin_steps.py). Best-effort volume target verified empirically against a live scratch generation (see Lane 1a report); the exact edge count is data-dependent on the seeded RNG and is NOT hashed into WORLD_DIGEST's stable-content set for that reason (a >25 volume assertion belongs to Phase 2's corpus runner, not this digest).",
+      "source_classes": ["work_graph"]
+    },
+    {
+      "state": "conflicting",
+      "data_health_state": "n/a (surfaces as an evidence-conflict finding one layer above DataHealthState, not a per-source freshness state)",
+      "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-conflicting-ci"},
+      "mechanism": "dev_health_ops.fixtures.generators.conflicts.build_conflicting_ci_runs writes two ci_pipeline_runs rows for the SAME repo_id, queued minutes apart in the same window, with opposite conclusions ('success' and 'failed'). Honesty note: models.git.CiPipelineRun (ci_pipeline_runs) has no commit_sha/ref column at all -- a run is keyed by (repo_id, run_id) only, so 'same commit' cannot be expressed at this table's grain. This is the closest schema-faithful realization: two contemporaneous CI signals for the same repository that disagree, matching the actual question shape ('Is meridian/web-app's CI passing?') trust.conflicting-evidence asks.",
+      "source_classes": ["ci_runs"]
+    },
+    {
+      "state": "not-applicable",
+      "data_health_state": "n/a (NativeDataHealthReader special-cases 'acr' before DataHealthState classification runs at all)",
+      "realized_by": {"org_alias": null, "repo_full_name": null},
+      "mechanism": "NativeDataHealthReader.read hardcodes `if source == 'acr': SourceHealthObservation(source, False, False, warning='acr_optional')` for every org unconditionally -- required=False means DataHealthService.inspect's `complete_eligible` never gates on it, the closest production analog to NOT_APPLICABLE this world can realize without new production code. No fixture rows are needed (realized_by is deliberately null -- the world generator creates nothing for this row); documented here so sources.json does not silently omit the state. The PROJECT-scope change_failure_rate NOT_APPLICABLE reachability gap corpus-registry-v1.md's health.project.unknown-and-not-applicable-abstract family already flags as structurally unreachable today (no ticket filed) is NOT re-claimed as realized here -- see this lane's report 'could not realize' list.",
+      "source_classes": ["acr"]
+    }
+  ],
+
+  "state_coverage_check": {
+    "$comment": "Cross-checked by the world_manifest_guard test against the literal `state` values present above.",
+    "required_states": [
+      "current", "stale", "unavailable", "unconfigured", "no-data",
+      "unauthorized", "truncated", "conflicting", "not-applicable"
+    ]
+  }
+}

--- a/tests/acceptance/world/ask-dev-world.v1/sources.json
+++ b/tests/acceptance/world/ask-dev-world.v1/sources.json
@@ -42,7 +42,8 @@
       "data_health_state": "DataHealthState.UNAVAILABLE",
       "realized_by": {"org_alias": "sibling", "repo_full_name": "sibling-only/private-repo"},
       "mechanism": "world.json sibling org sync_providers.local.state='active_failure' -> SyncConfiguration(provider='local', is_active=True, last_sync_success=False) org-wide. NativeDataHealthReader's `failure = any(config.last_sync_success is False and _provider_supports(source, config.provider) ...)` -> active_failure=True -> DataHealthState.UNAVAILABLE for every git-backed source in the sibling tenant.",
-      "source_classes": ["commits", "pull_requests", "reviews", "deployments", "work_units"]
+      "$comment_source_classes": "Live-verification correction (2026-08-05, first live fixtures-world run to exercise world_verify.verify_sources_against_production_data_health end to end): 'work_units' was listed here but does NOT belong -- source_health.PROVIDER_SUPPORTS_SOURCE['work_units'] is ('jira', 'linear', 'github', 'gitlab'), which does not include 'local'/'git' at all, so the sibling org's local-provider active_failure has no effect on it. Sibling's OTHER configured provider, jira, is active_success, so work_units correctly reads DataHealthState.COMPLETE for this org -- which is exactly what the real DataHealthService.inspect observed and world_verify caught the stale claim against. Removed from this list rather than leaving a false claim for a live check to keep failing on.",
+      "source_classes": ["commits", "pull_requests", "reviews", "deployments"]
     },
     {
       "state": "unconfigured",
@@ -62,8 +63,10 @@
       "state": "truncated",
       "data_health_state": "n/a (SourceRequirementState.TRUNCATED / WorkGraphNeighborsResult.truncated, not a DataHealthState member)",
       "realized_by": {"org_alias": "primary", "repo_full_name": "probe/source-truncated-workgraph"},
-      "mechanism": "Generated with elevated pr_count/commits_per_day and --with-work-graph so the work-graph neighbor fan-out for at least one committed issue/PR node exceeds work_graph_neighbors_service.MAX_NEIGHBORS (25) -- work_graph_expansion_run then always reports SourceRequirementState.TRUNCATED (result.truncated wins unconditionally per builtin_steps.py). Best-effort volume target verified empirically against a live scratch generation (see Lane 1a report); the exact edge count is data-dependent on the seeded RNG and is NOT hashed into WORLD_DIGEST's stable-content set for that reason (a >25 volume assertion belongs to Phase 2's corpus runner, not this digest).",
-      "source_classes": ["work_graph"]
+      "mechanism": "Generated with elevated pr_count/commits_per_day and --with-work-graph, intending the work-graph neighbor fan-out for at least one committed issue/PR node to exceed work_graph_neighbors_service.MAX_NEIGHBORS (25) so work_graph_expansion_run reports SourceRequirementState.TRUNCATED (result.truncated wins unconditionally per builtin_steps.py). CORRECTED 2026-08-05: the prior text here claimed this was 'verified empirically against a live scratch generation' -- that claim was never actually true; this is the FIRST time verify_truncated_work_graph (new HIGH-2 code) has run end to end, and it found the claim false (see status/blocked_by below). The elevated volume knobs (days/commits_per_day/pr_count) only control how much data is generated, not how issue<->PR linking clusters -- SyntheticDataGenerator's work-item count scales with `days` at roughly the same rate PRs are generated, so linking comes out close to 1:1 (observed live: 43 work items, 42 PRs, max fan-out 2 for this repo) -- there is currently no generator mechanism that concentrates many PRs onto one work item. Reaching fan-out > 25 requires generator work (a many-PRs-per-item clustering mechanism), not a fixture-world volume tuning change, and is out of Lane 1a's fixtures/** territory.",
+      "source_classes": ["work_graph"],
+      "status": "declared-blocked",
+      "blocked_by": "CHAOS-3428 generator fan-out clustering"
     },
     {
       "state": "conflicting",

--- a/tests/acceptance/world/ask-dev-world.v1/subjects.json
+++ b/tests/acceptance/world/ask-dev-world.v1/subjects.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": "ask_dev_world.v1",
+  "$comment": "CHAOS-3219 Wave 4 Phase 1 Lane 1a. Subject registry: every named subject the world realizes, keyed by the 8 subjects.json classes from chaos-3219-plan.md Sec.3 / corpus-registry-v1.md. `repo_full_name` is the SyntheticDataGenerator repo_name -- repo_id is always uuid.uuid5(FIXTURE_NAMESPACE, repo_full_name) (FIXTURE_NAMESPACE = 6ba7b810-9dad-11d1-80b4-00c04fd430c8), the SAME derivation dev_health_ops.fixtures.generator.SyntheticDataGenerator.__init__ already uses -- never hardcoded here, so this file and the generated DB can never drift on id. `project_id` for a PROJECT-kind subject is the `projects` table row's `id` column, which Lane 1a's projects.py generator sets equal to `repo_full_name` (provider='synthetic'), matching arm 1 of _project_identity.project_identity_match (work_items.project_id == projects.id, same provider) -- see generators/projects.py docstring.",
+
+  "subjects": [
+    {
+      "id": "subject.exact.meridian-web-app",
+      "class": "exact",
+      "org_alias": "primary",
+      "entity_kind": "repository",
+      "repo_full_name": "meridian/web-app",
+      "mentions": ["meridian/web-app", "the web-app repo"],
+      "expected_terminal_resolution": "ScopeResolutionOutcome.EXACT",
+      "notes": "Wave 3.1 heritage positive control (ask-dev-oracle.v1.json) and CHAOS-3219 corpus family `status.single-project.*`."
+    },
+    {
+      "id": "subject.acronym-alias.mwa-project",
+      "class": "acronym-alias",
+      "org_alias": "primary",
+      "entity_kind": "project",
+      "project_id": "meridian/web-app",
+      "project_display_name": "Meridian Web Application (MWA)",
+      "mentions": ["MWA"],
+      "alias_form": "acronym",
+      "expected_terminal_resolution": "candidate_via_alias_matching.acronym_candidates (CHAOS-3388) -> commits only after disambiguation, per alias_matching.py: acronym/literal-alias hits are never auto-commit eligible",
+      "notes": "Same underlying repository as subject.exact.meridian-web-app, reached through its PROJECT catalog row's display name instead of the repository entity directly -- deliberately: it demonstrates the SAME real thing answering to both an exact repo mention and a derived acronym alias. `alias_matching.acronym_candidates('Meridian Web Application')` includes 'MWA'."
+    },
+    {
+      "id": "subject.acronym-alias.ground-control-team",
+      "class": "acronym-alias",
+      "org_alias": "primary",
+      "entity_kind": "team",
+      "team_id": "ground-control-team",
+      "team_display_name": "Platform Reliability (Ground Control)",
+      "mentions": ["Ground Control", "the Ground Control team"],
+      "alias_form": "literal_parenthetical",
+      "expected_terminal_resolution": "candidate_via_alias_matching.literal_aliases (CHAOS-3388)",
+      "notes": "The team-lead's explicit ask for 'a parenthetical-alias subject': alias_matching.strip_parentheticals('Platform Reliability (Ground Control)') -> literal alias 'Ground Control', distinct from the acronym form covered by subject.acronym-alias.mwa-project."
+    },
+    {
+      "id": "subject.ambiguous.atlas",
+      "class": "ambiguous",
+      "org_alias": "primary",
+      "entity_kind": "repository",
+      "candidates": ["meridian/atlas", "meridian-sandbox/atlas"],
+      "mentions": ["Atlas", "the atlas repo"],
+      "expected_terminal_resolution": "ScopeResolutionOutcome.candidate_set (needs_clarification) -- two repositories share the base name 'atlas' within the SAME org",
+      "notes": "corpus family scope.ambiguous."
+    },
+    {
+      "id": "subject.no-match.ask-dev-project",
+      "class": "no-match",
+      "org_alias": "primary",
+      "entity_kind": "n/a",
+      "candidates": [],
+      "mentions": ["the Ask Dev project"],
+      "expected_terminal_resolution": "ScopeResolutionOutcome.unresolved / PublicOutcome.NOT_FOUND",
+      "notes": "Deliberately never realized by any fixture row in this world -- absence IS the fixture. Matches smoke_ask_dev_not_found.py and corpus id scope.no-match verbatim."
+    },
+    {
+      "id": "subject.deleted.legacy-billing",
+      "class": "deleted",
+      "org_alias": "primary",
+      "entity_kind": "project",
+      "project_id": "legacy/billing",
+      "repo_full_name": "legacy/billing",
+      "mentions": ["the legacy-billing repo", "legacy-billing"],
+      "expected_terminal_resolution": "ScopeResolutionOutcome.unresolved (project retired) -- projects.is_active=0 on the most recent ReplacingMergeTree(updated_at) version, so the CHAOS-3380 identity catalog's `is_active = 1` filter excludes it",
+      "notes": "The underlying repo/commit history still exists (git_commits rows untouched) -- only the PROJECT catalog row is retired. This distinguishes 'the subject used to resolve and no longer does' from no-match (which never existed)."
+    },
+    {
+      "id": "subject.stale-context.rotated-service",
+      "class": "stale-context",
+      "org_alias": "primary",
+      "entity_kind": "repository",
+      "repo_full_name": "rotated/service",
+      "mentions": ["it", "that service (referring to a prior-turn subject)"],
+      "expected_terminal_resolution": "ScopeResolutionOutcome degraded to needs_clarification / answered_with_gaps -- the committed DevRunSubjectSet for the earlier turn is older than the conversation's own rotation window",
+      "notes": "Realized by dev_health_ops.fixtures.generators.retention_conversations: a DevConversation with an early DevRun whose DevRunSubjectSet commits repository 'rotated/service', timestamped pinned_now - 9 days, followed (same conversation) by a later DevRun timestamped pinned_now - 1 hour that asks a bare follow-up ('it') expecting the stale commit to no longer silently apply.",
+      "realizing_conversation_id_seed": "ask-dev-world.v1:conversation:primary:stale-context"
+    },
+    {
+      "id": "subject.partially-resolved.platform-mobile-squad",
+      "class": "partially-resolved",
+      "org_alias": "primary",
+      "entity_kind": "team",
+      "team_id": "platform",
+      "mentions": ["the platform team's mobile squad"],
+      "expected_terminal_resolution": "resolves to the parent 'platform' team only (ScopeResolutionOutcome.FILTERED-ish) -- 'mobile squad' has no addressable sub-team scope in the teams catalog, so the mention narrows to a scope broader than literally asked",
+      "notes": "The fixture world models teams as a flat catalog (models.teams.Team carries no parent/child edge in the ClickHouse teams table's own hierarchy field usage here), so a sub-team mention structurally cannot resolve narrower than its parent -- this IS the partially-resolved condition, not a gap in the fixture."
+    },
+    {
+      "id": "subject.bounded-set.web-app-and-api-gateway",
+      "class": "bounded-set",
+      "org_alias": "primary",
+      "entity_kind": "repository",
+      "members": ["meridian/web-app", "meridian/api-gateway"],
+      "mentions": ["meridian/web-app and meridian/api-gateway", "the web-app and api-gateway repos"],
+      "expected_terminal_resolution": "both members resolve EXACT within one committed DevScope -- a bounded, filtered set, not org-wide portfolio aggregation (that's the separate, CHAOS-3393-blocked portfolio.* family)",
+      "notes": "meridian/api-gateway is a plain current-state repo (same generation profile as the exact-subject repo) that exists ONLY to pair with meridian/web-app here."
+    },
+    {
+      "id": "subject.tenant.sibling-only-private-repo",
+      "class": "bounded-set",
+      "$comment_class": "Filed under corpus registry's `tenant` family rather than a 9th subjects.json class -- the registry's 8 classes cover subject-mention SHAPE; cross-tenant is an AUTHORIZATION dimension orthogonal to shape. Listed here (not only in sources.json) because it is itself a named subject with an expected resolution outcome.",
+      "org_alias": "sibling",
+      "asked_from_org_alias": "primary",
+      "entity_kind": "repository",
+      "repo_full_name": "sibling-only/private-repo",
+      "mentions": ["sibling-only/private-repo", "the private-repo project"],
+      "expected_terminal_resolution": "not_found / denied when asked from primary org's permission_fingerprint -- DataHealthService.inspect's non-{EXACT,FILTERED,INHERITED,ORGANIZATION_FALLBACK} guard returns DataHealthState.UNAUTHORIZED for every requested source; ScopeResolutionService must never resolve a sibling-tenant id",
+      "notes": "Same fixture row also realizes deg.source-state.unavailable (sources.json) from the SIBLING org's own vantage, since sibling's 'local' SyncConfiguration is seeded active_failure=True -- two distinct observation angles over one row, documented explicitly rather than duplicated."
+    }
+  ],
+
+  "class_coverage_check": {
+    "$comment": "Every subjects.json class from chaos-3219-plan.md Sec.3 must have >=1 entry above. The world_manifest_guard test cross-checks this list against the literal `class` values actually present.",
+    "required_classes": [
+      "exact",
+      "ambiguous",
+      "acronym-alias",
+      "no-match",
+      "deleted",
+      "stale-context",
+      "partially-resolved",
+      "bounded-set"
+    ]
+  }
+}

--- a/tests/acceptance/world/ask-dev-world.v1/subjects.json
+++ b/tests/acceptance/world/ask-dev-world.v1/subjects.json
@@ -32,10 +32,10 @@
       "entity_kind": "team",
       "team_id": "ground-control-team",
       "team_display_name": "Platform Reliability (Ground Control)",
-      "mentions": ["Ground Control", "the Ground Control team"],
+      "mentions": ["Ground Control", "ground control"],
       "alias_form": "literal_parenthetical",
       "expected_terminal_resolution": "candidate_via_alias_matching.literal_aliases (CHAOS-3388)",
-      "notes": "The team-lead's explicit ask for 'a parenthetical-alias subject': alias_matching.strip_parentheticals('Platform Reliability (Ground Control)') -> literal alias 'Ground Control', distinct from the acronym form covered by subject.acronym-alias.mwa-project."
+      "notes": "The team-lead's explicit ask for 'a parenthetical-alias subject': alias_matching.strip_parentheticals('Platform Reliability (Ground Control)') -> literal alias 'Ground Control', distinct from the acronym form covered by subject.acronym-alias.mwa-project. Codex HIGH-3/live-verification correction (2026-08-05): `mentions` for the acronym-alias class are candidate SPANS fed directly to scope_catalog._alias_matches's own 'equals query outright' contract (see its docstring) -- not full user sentences. An earlier revision included 'the Ground Control team' here, which is realistic user-utterance text but is never what actually reaches `_alias_matches`/`alias_forms` as `query` (some upstream span-extraction step, out of this alias-matcher's scope, would need to isolate 'Ground Control' from that sentence first) -- world_verify.verify_acronym_alias_subject's live run against the real alias_matching.alias_forms caught this mismatch immediately (RED) the first time `fixtures world` actually ran end-to-end, which is exactly what that production-path check exists to catch. Both entries now differ only by case, demonstrating alias_forms' own casefold-normalization rather than re-testing sentence-level extraction this subject class was never meant to cover."
     },
     {
       "id": "subject.ambiguous.atlas",
@@ -87,7 +87,10 @@
       "team_id": "platform",
       "mentions": ["the platform team's mobile squad"],
       "expected_terminal_resolution": "resolves to the parent 'platform' team only (ScopeResolutionOutcome.FILTERED-ish) -- 'mobile squad' has no addressable sub-team scope in the teams catalog, so the mention narrows to a scope broader than literally asked",
-      "notes": "The fixture world models teams as a flat catalog (models.teams.Team carries no parent/child edge in the ClickHouse teams table's own hierarchy field usage here), so a sub-team mention structurally cannot resolve narrower than its parent -- this IS the partially-resolved condition, not a gap in the fixture."
+      "notes": "The fixture world models teams as a flat catalog (models.teams.Team carries no parent/child edge in the ClickHouse teams table's own hierarchy field usage here), so a sub-team mention structurally cannot resolve narrower than its parent -- this IS the partially-resolved condition, not a gap in the fixture.",
+      "verification_status": "realized-but-unverified-live",
+      "tracked_by": "CHAOS-3429 team-catalog live verification path",
+      "$comment_verification_status": "CHAOS-3429 (2026-08-05): this is the only subjects.json class with no live verification path -- verify_subjects_against_production only ever checks the 'repos' catalog table, and this subject is team-only (no repo_full_name/candidates/members). The fixture is believed correct (this team-id is seeded by the generator's curated team roster), but that belief has never been checked against a live database, unlike every other class here. Marked explicitly rather than left as the silent `if not repo_names: continue` that used to swallow this -- see world_verify.REALIZED_UNVERIFIED_LIVE_STATUS."
     },
     {
       "id": "subject.bounded-set.web-app-and-api-gateway",
@@ -101,8 +104,8 @@
     },
     {
       "id": "subject.tenant.sibling-only-private-repo",
-      "class": "bounded-set",
-      "$comment_class": "Filed under corpus registry's `tenant` family rather than a 9th subjects.json class -- the registry's 8 classes cover subject-mention SHAPE; cross-tenant is an AUTHORIZATION dimension orthogonal to shape. Listed here (not only in sources.json) because it is itself a named subject with an expected resolution outcome.",
+      "class": "exact",
+      "$comment_class": "Filed under corpus registry's `tenant` family rather than a 9th subjects.json class -- the registry's 8 classes cover subject-mention SHAPE; cross-tenant is an AUTHORIZATION dimension orthogonal to shape. Shape-wise this is a single, specific repo reference (class=exact), same as any other named-repo mention -- what makes it interesting is being asked from a DIFFERENT org (asked_from_org_alias), not a bounded/ambiguous SET of subjects. Corrected from an earlier 'bounded-set' mislabel (Codex HIGH-2 typed-schema review, 2026-08-05: the schema for bounded-set requires >=2 'members', which this single-repo entry never had -- 'exact' is the shape this entry actually has). Listed here (not only in sources.json) because it is itself a named subject with an expected resolution outcome.",
       "org_alias": "sibling",
       "asked_from_org_alias": "primary",
       "entity_kind": "repository",

--- a/tests/acceptance/world/ask-dev-world.v1/world.json
+++ b/tests/acceptance/world/ask-dev-world.v1/world.json
@@ -5,6 +5,13 @@
   "pinned_now": "2026-08-05T00:00:00+00:00",
   "$comment_pinned_now": "The single reference instant every relative timestamp (staleness cutoffs, retention ages, conversation-rotation windows) is computed from. CHAOS-3392 lesson: the world generator must never call datetime.now()/utcnow() to decide freshness -- every age-relative fixture row is pinned off this value, threaded explicitly through dev_health_ops.fixtures.world's call graph.",
 
+  "cross_generation_digest_status": {
+    "status": "declared-blocked",
+    "blocked_by": "CHAOS-3432 concurrent ClickHouse batch-insert nondeterminism",
+    "note": "SINGLE-generation WORLD_DIGEST pinning IS proven: compute_world_digest + `fixtures world --verify-digest` correctly detect drift within one generated database (every HIGH-3/HIGH-5 mutation test in this round relies on exactly that, live). What is NOT proven, and was an explicit goal of this round's HIGH-4 work: that two INDEPENDENT `fixtures world` runs against fresh scratch databases produce an IDENTICAL digest. Root-caused down to five real, fixed defects (wall-clock modules missing from the clock-freeze list, a random per-run categorization_run_id needing digest exclusion, a postprocess handler running outside frozen-clock scope) -- each individually confirmed via live two-generation reruns. One residual remains open: an isolated, single-repo-at-a-time row-count divergence (ci_pipeline_runs/deployments/work_graph_pr_commit/work_unit_investments), narrowed to 'concurrent ClickHouse batch insertion via fixtures/runner.py's _insert_batches (asyncio.gather, MAX_WORKERS default 4)' as the leading hypothesis but not yet confirmed by the discriminating serialization experiment (stopped mid-run by explicit user direction, not by a negative result) -- see fixtures/world.py's _frozen_clock docstring for the full evidence trail and ruled-out theories (mock LLM provider has no randomness; PYTHONHASHSEED=0 did not converge and made drift worse/broader; global-random-desync-cascades-forward is contradicted by unaffected repos generated after the affected one). Any future claim of proven cross-generation digest reproducibility must update this field, not just prose elsewhere.",
+    "$comment_status_values": "Mirrors sources.json's DECLARED_BLOCKED_STATUS (CHAOS-3428) and subjects.json's REALIZED_UNVERIFIED_LIVE_STATUS (CHAOS-3429) -- the same discipline applied at the whole-world/digest level rather than a single manifest entry: an honest, ticketed, schema-validated 'not proven' beats either a false pass or a silent omission."
+  },
+
   "orgs": [
     {
       "alias": "primary",
@@ -48,7 +55,7 @@
         "jira": {"state": "active_success"},
         "pagerduty": {"state": "active_success"}
       },
-      "$comment_sync_providers": "local sync marked active_failure (last_sync_success=False) -> commits/pull_requests/reviews/deployments/work_units read UNAVAILABLE org-wide for the sibling tenant (sources.json deg.source-state.unavailable). A visibly degraded sibling is also a MORE realistic cross-tenant probe target than a pristine one.",
+      "$comment_sync_providers": "local sync marked active_failure (last_sync_success=False) -> commits/pull_requests/reviews/deployments read UNAVAILABLE org-wide for the sibling tenant (sources.json deg.source-state.unavailable). work_units is NOT in that list -- it is only provider-mapped to jira/linear/github/gitlab (source_health.PROVIDER_SUPPORTS_SOURCE), never 'local', and sibling's jira provider below is active_success, so work_units correctly reads COMPLETE (live-verification correction, 2026-08-05 -- see sources.json's matching $comment_source_classes). A visibly degraded sibling is also a MORE realistic cross-tenant probe target than a pristine one.",
       "retention_policies": [
         {"resource_type": "dev_conversation", "retention_days": 0}
       ],

--- a/tests/acceptance/world/ask-dev-world.v1/world.json
+++ b/tests/acceptance/world/ask-dev-world.v1/world.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": "ask_dev_world.v1",
+  "$comment": "CHAOS-3219 Wave 4 Phase 1 Lane 1a. Read alongside subjects.json and sources.json (same directory). Every id_seed below is fed through uuid.uuid5(WORLD_NAMESPACE, id_seed) by dev_health_ops.fixtures.world -- this file stores the deterministic SEED strings, never raw UUIDs, so there is exactly one place (the loader) that can compute an id and no risk of the JSON and the generator silently drifting apart. WORLD_NAMESPACE == 6ba7b810-9dad-11d1-80b4-00c04fd430c8, the same fixture namespace already used throughout dev_health_ops.fixtures.",
+  "master_seed": 3219000,
+  "pinned_now": "2026-08-05T00:00:00+00:00",
+  "$comment_pinned_now": "The single reference instant every relative timestamp (staleness cutoffs, retention ages, conversation-rotation windows) is computed from. CHAOS-3392 lesson: the world generator must never call datetime.now()/utcnow() to decide freshness -- every age-relative fixture row is pinned off this value, threaded explicitly through dev_health_ops.fixtures.world's call graph.",
+
+  "orgs": [
+    {
+      "alias": "primary",
+      "id_seed": "ask-dev-world.v1:org:primary",
+      "slug": "ask-dev-world-primary",
+      "name": "Meridian (Ask Dev World Primary)",
+      "role": "primary",
+      "ask_dev_entitlement": "enabled",
+      "ask_dev_contextual_entrypoints_entitlement": "enabled",
+      "acr_evidence_adapter": "not_configured",
+      "$comment_acr": "ACR is the SourceClass.SOURCE_HEALTH 'acr' key, which NativeDataHealthReader.read hardcodes as SourceHealthObservation(configured=False, required=False) for every org regardless of fixture state -- this is the sources.json 'not_applicable' realization (see sources.json deg.source-state.not-applicable), not something the fixture world needs to toggle per org.",
+      "sync_providers": {
+        "local": {"state": "active_success"},
+        "jira": {"state": "active_success"},
+        "pagerduty": {"state": "unconfigured"}
+      },
+      "$comment_sync_providers": "Realizes DataHealthState per NATIVE_EVIDENCE_SOURCES (data_health_service.py): 'local'/'git' backs commits/pull_requests/reviews/deployments/work_units, 'jira' backs work_items, 'pagerduty' backs incidents. pagerduty deliberately absent -> incidents reads UNCONFIGURED org-wide for primary (sources.json deg.source-state.unconfigured).",
+      "retention_policies": [
+        {"resource_type": "dev_conversation", "retention_days": 30}
+      ],
+      "kill_switches": {
+        "global": "enabled",
+        "org": "enabled",
+        "provider": {"scripted-v1": "enabled"},
+        "role": {"primary_answer": "enabled"},
+        "surface": {"window": "enabled", "dev_workspace": "enabled"},
+        "contextual_entry": "enabled"
+      }
+    },
+    {
+      "alias": "sibling",
+      "id_seed": "ask-dev-world.v1:org:sibling",
+      "slug": "ask-dev-world-sibling",
+      "name": "Orbit (Ask Dev World Sibling Tenant)",
+      "role": "sibling_tenant",
+      "ask_dev_entitlement": "enabled",
+      "ask_dev_contextual_entrypoints_entitlement": "enabled",
+      "acr_evidence_adapter": "not_configured",
+      "sync_providers": {
+        "local": {"state": "active_failure"},
+        "jira": {"state": "active_success"},
+        "pagerduty": {"state": "active_success"}
+      },
+      "$comment_sync_providers": "local sync marked active_failure (last_sync_success=False) -> commits/pull_requests/reviews/deployments/work_units read UNAVAILABLE org-wide for the sibling tenant (sources.json deg.source-state.unavailable). A visibly degraded sibling is also a MORE realistic cross-tenant probe target than a pristine one.",
+      "retention_policies": [
+        {"resource_type": "dev_conversation", "retention_days": 0}
+      ],
+      "kill_switches": {
+        "global": "enabled",
+        "org": "enabled",
+        "provider": {"scripted-v1": "enabled"},
+        "role": {"primary_answer": "enabled"},
+        "surface": {"window": "enabled", "dev_workspace": "enabled"},
+        "contextual_entry": "enabled"
+      }
+    },
+    {
+      "alias": "disabled",
+      "id_seed": "ask-dev-world.v1:org:disabled-entitlement",
+      "slug": "ask-dev-world-disabled-entitlement",
+      "name": "Vantage (Ask Dev World Disabled-Entitlement Org)",
+      "role": "disabled_entitlement",
+      "ask_dev_entitlement": "disabled",
+      "ask_dev_contextual_entrypoints_entitlement": "disabled",
+      "acr_evidence_adapter": "not_configured",
+      "sync_providers": {
+        "local": {"state": "active_success"},
+        "jira": {"state": "active_success"},
+        "pagerduty": {"state": "active_success"}
+      },
+      "retention_policies": [
+        {"resource_type": "dev_conversation", "retention_days": 30}
+      ],
+      "kill_switches": {
+        "global": "enabled",
+        "org": "disabled",
+        "provider": {"scripted-v1": "enabled"},
+        "role": {"primary_answer": "enabled"},
+        "surface": {"window": "enabled", "dev_workspace": "enabled"},
+        "contextual_entry": "enabled"
+      }
+    }
+  ],
+
+  "users": [
+    {"alias": "primary.ordinary", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:ordinary", "email": "ordinary@ask-dev-world-primary.example", "username": "primary-ordinary", "full_name": "Priya Ordinary", "membership_role": "member", "is_superuser": false, "feature_overrides": {}},
+    {"alias": "primary.org-admin", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:org-admin", "email": "org-admin@ask-dev-world-primary.example", "username": "primary-org-admin", "full_name": "Owen OrgAdmin", "membership_role": "admin", "is_superuser": false, "feature_overrides": {}},
+    {"alias": "primary.platform-admin", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:platform-admin", "email": "platform-admin@ask-dev-world-primary.example", "username": "primary-platform-admin", "full_name": "Pat PlatformAdmin", "membership_role": "member", "is_superuser": true, "feature_overrides": {}},
+    {"alias": "primary.impersonation-target", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:impersonation-target", "email": "impersonation-target@ask-dev-world-primary.example", "username": "primary-impersonation-target", "full_name": "Ivy ImpersonationTarget", "membership_role": "member", "is_superuser": false, "feature_overrides": {}, "impersonatable": true},
+    {"alias": "primary.unsupported-model-user", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:unsupported-model-user", "email": "unsupported-model@ask-dev-world-primary.example", "username": "primary-unsupported-model", "full_name": "Uma UnsupportedModel", "membership_role": "member", "is_superuser": false, "feature_overrides": {}, "provider_profile_override": "unsupported-model-profile"},
+    {"alias": "primary.degraded-readiness-user", "org_alias": "primary", "id_seed": "ask-dev-world.v1:user:primary:degraded-readiness-user", "email": "degraded-readiness@ask-dev-world-primary.example", "username": "primary-degraded-readiness", "full_name": "Dana DegradedReadiness", "membership_role": "member", "is_superuser": false, "feature_overrides": {}, "provider_profile_override": "degraded-profile"},
+
+    {"alias": "sibling.ordinary", "org_alias": "sibling", "id_seed": "ask-dev-world.v1:user:sibling:ordinary", "email": "ordinary@ask-dev-world-sibling.example", "username": "sibling-ordinary", "full_name": "Sasha SiblingOrdinary", "membership_role": "member", "is_superuser": false, "feature_overrides": {}},
+    {"alias": "sibling.org-admin", "org_alias": "sibling", "id_seed": "ask-dev-world.v1:user:sibling:org-admin", "email": "org-admin@ask-dev-world-sibling.example", "username": "sibling-org-admin", "full_name": "Sam SiblingOrgAdmin", "membership_role": "admin", "is_superuser": false, "feature_overrides": {}},
+
+    {"alias": "disabled.ordinary", "org_alias": "disabled", "id_seed": "ask-dev-world.v1:user:disabled:ordinary", "email": "ordinary@ask-dev-world-disabled-entitlement.example", "username": "disabled-ordinary", "full_name": "Devon DisabledOrdinary", "membership_role": "member", "is_superuser": false, "feature_overrides": {}},
+    {"alias": "disabled.org-admin", "org_alias": "disabled", "id_seed": "ask-dev-world.v1:user:disabled:org-admin", "email": "org-admin@ask-dev-world-disabled-entitlement.example", "username": "disabled-org-admin", "full_name": "Deepa DisabledOrgAdmin", "membership_role": "admin", "is_superuser": false, "feature_overrides": {}}
+  ],
+
+  "provider_profiles": {
+    "scripted-v1": {
+      "kind": "scripted",
+      "readiness": "ready",
+      "intent": "primary_certified",
+      "$comment": "The Lane 1b role-aware scripted_openai_service provider. Owned by provider-scripts/ (Lane 1b territory) -- world.json only records the readiness/intent label so subjects/sources fixtures can reference a real profile id."
+    },
+    "lmstudio-local": {
+      "kind": "live",
+      "readiness": "not_configured",
+      "intent": "scheduled_smoke_nonblocking"
+    },
+    "ollama": {
+      "kind": "live",
+      "readiness": "not_configured",
+      "intent": "scheduled_smoke_nonblocking"
+    },
+    "unsupported-model-profile": {
+      "kind": "scripted",
+      "readiness": "unsupported_model",
+      "intent": "readiness_probe",
+      "$comment": "Realizes readiness.capabilities.unsupported-model (corpus registry). DevCapabilitiesReadiness.unsupported_model."
+    },
+    "degraded-profile": {
+      "kind": "scripted",
+      "readiness": "degraded",
+      "intent": "readiness_probe",
+      "$comment": "Realizes readiness.capabilities.degraded."
+    }
+  },
+
+  "retention_policy_catalog": [
+    {"id": "retention-0-day", "days": 0, "resource_type": "dev_conversation"},
+    {"id": "retention-30-day", "days": 30, "resource_type": "dev_conversation"}
+  ],
+
+  "generation": {
+    "days_of_history": 10,
+    "commits_per_day": 3,
+    "pr_count": 6,
+    "team_count": 3,
+    "with_metrics": true,
+    "with_work_graph": true
+  }
+}

--- a/tests/test_fixtures_world_digest.py
+++ b/tests/test_fixtures_world_digest.py
@@ -1,0 +1,220 @@
+"""CHAOS-3219: WORLD_DIGEST content-hash guards.
+
+Stub-based (mirrors ``tests/test_fixtures_mixed_org_guard.py``'s
+``_StubClient`` pattern) so these run in the standard unit tier with no live
+ClickHouse/Postgres connection -- the live reproducibility proof (two full
+`fixtures world` generations -> identical WORLD_DIGEST) is a separate,
+manually-run verification against a scratch database (see the Lane 1a
+report), not something the checked-in unit suite can require infra for.
+
+Covers the four guard properties the task calls for:
+  1. seed-idempotency is a property of _row_content_key/_clickhouse_table_
+     digest being pure functions of (column_names, rows) -- same input,
+     same digest, proven directly here.
+  2. digest-drift RED: mutate one stubbed row's non-volatile field, observe
+     the digest change.
+  3. volatile columns (last_synced etc.) are excluded -- mutating ONLY a
+     volatile column must NOT change the digest (the two-real-generations-
+     apart-in-wall-clock-time reproducibility property).
+  4. missing-table tolerance mirrors runner.py's existing
+     _MISSING_TABLE_MARKERS convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.fixtures.world import (
+    _VOLATILE_COLUMNS,
+    _clickhouse_table_digest,
+    _diff_components,
+    _row_content_key,
+)
+
+
+class _StubResult:
+    def __init__(self, column_names: list[str], rows: list[tuple[Any, ...]]) -> None:
+        self.column_names = column_names
+        self.result_rows = rows
+
+
+class _StubClient:
+    def __init__(self, column_names: list[str], rows: list[tuple[Any, ...]]) -> None:
+        self.column_names = column_names
+        self.rows = rows
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def query(self, query: str, parameters: dict[str, Any]) -> _StubResult:
+        self.queries.append((query, parameters))
+        return _StubResult(self.column_names, self.rows)
+
+
+class _ExplodingMissingTableClient:
+    def query(self, query: str, parameters: dict[str, Any]) -> _StubResult:
+        raise RuntimeError("Table default.repos does not exist")
+
+
+class _ExplodingConnectivityClient:
+    def query(self, query: str, parameters: dict[str, Any]) -> _StubResult:
+        raise RuntimeError("Connection refused: clickhouse:8123")
+
+
+def test_row_content_key_excludes_volatile_columns() -> None:
+    columns = ["id", "org_id", "name", "last_synced", "updated_at"]
+    row = ("repo-1", "org-1", "web-app", "2026-08-01T00:00:00Z", "2026-08-01T00:00:00Z")
+    key = _row_content_key(columns, row)
+    assert "last_synced" not in key
+    assert "updated_at" not in key
+    assert "id='repo-1'" in key
+    assert "name='web-app'" in key
+
+
+def test_row_content_key_stable_column_order_independent() -> None:
+    """Digest content must not depend on which order the DB happens to
+    return columns in -- the key sorts its parts."""
+
+    columns_a = ["id", "name"]
+    columns_b = ["name", "id"]
+    row_a = ("repo-1", "web-app")
+    row_b = ("web-app", "repo-1")
+    assert _row_content_key(columns_a, row_a) == _row_content_key(columns_b, row_b)
+
+
+@pytest.mark.asyncio
+async def test_seed_idempotency_same_rows_same_digest() -> None:
+    """Two 'generations' that produce identical content-bearing rows (even
+    with DIFFERENT wall-clock last_synced values, simulating two runs
+    executed minutes apart) yield the SAME digest."""
+
+    columns = ["id", "org_id", "name", "last_synced"]
+    rows_run1 = [("repo-1", "org-1", "web-app", "2026-08-01T00:00:00Z")]
+    rows_run2 = [("repo-1", "org-1", "web-app", "2026-08-01T00:09:12Z")]
+
+    client1 = _StubClient(columns, rows_run1)
+    client2 = _StubClient(columns, rows_run2)
+
+    digest1 = await _clickhouse_table_digest(client1, "repos", "org-1")
+    digest2 = await _clickhouse_table_digest(client2, "repos", "org-1")
+
+    assert digest1["content_hash"] == digest2["content_hash"]
+    assert digest1["row_count"] == digest2["row_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_digest_drift_red_on_content_mutation() -> None:
+    """Mutating a NON-volatile field (status) must change the digest --
+    the RED test: plant the defect, observe the digest verify fail."""
+
+    columns = ["id", "org_id", "status"]
+    original = [("wi-1", "org-1", "done")]
+    mutated = [("wi-1", "org-1", "in_progress")]
+
+    original_digest = await _clickhouse_table_digest(
+        _StubClient(columns, original), "work_items", "org-1"
+    )
+    mutated_digest = await _clickhouse_table_digest(
+        _StubClient(columns, mutated), "work_items", "org-1"
+    )
+
+    assert original_digest["content_hash"] != mutated_digest["content_hash"], (
+        "digest must change when a real content field is mutated -- a "
+        "digest verify that stayed GREEN here would be a guard that cannot "
+        "catch drift"
+    )
+
+
+@pytest.mark.asyncio
+async def test_digest_unaffected_by_volatile_only_mutation() -> None:
+    """The inverse of the drift test: mutating ONLY a volatile column must
+    NOT trip the digest (this is what makes two real generations, run at
+    different real times, reproducible)."""
+
+    columns = ["id", "org_id", "status", "last_synced"]
+    row_a = [("wi-1", "org-1", "done", "2026-08-01T00:00:00Z")]
+    row_b = [("wi-1", "org-1", "done", "2026-08-02T12:34:56Z")]
+
+    digest_a = await _clickhouse_table_digest(
+        _StubClient(columns, row_a), "work_items", "org-1"
+    )
+    digest_b = await _clickhouse_table_digest(
+        _StubClient(columns, row_b), "work_items", "org-1"
+    )
+    assert digest_a["content_hash"] == digest_b["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_digest_drift_on_row_count_change() -> None:
+    columns = ["id", "org_id"]
+    before = [("wi-1", "org-1")]
+    after = [("wi-1", "org-1"), ("wi-2", "org-1")]
+
+    before_digest = await _clickhouse_table_digest(
+        _StubClient(columns, before), "work_items", "org-1"
+    )
+    after_digest = await _clickhouse_table_digest(
+        _StubClient(columns, after), "work_items", "org-1"
+    )
+    assert before_digest["row_count"] == 1
+    assert after_digest["row_count"] == 2
+    assert before_digest["content_hash"] != after_digest["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_missing_table_treated_as_empty_not_fatal() -> None:
+    digest = await _clickhouse_table_digest(
+        _ExplodingMissingTableClient(), "repos", "org-1"
+    )
+    assert digest["row_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_connectivity_error_fails_closed() -> None:
+    """A transient outage must not be silently treated as 'zero rows' --
+    mirrors runner.py's _detect_live_providers fail-closed contract."""
+
+    with pytest.raises(RuntimeError, match="Connection refused"):
+        await _clickhouse_table_digest(_ExplodingConnectivityClient(), "repos", "org-1")
+
+
+def test_diff_components_reports_only_drifted_tables() -> None:
+    pinned = {
+        "clickhouse": {
+            "repos": {"primary": {"row_count": 3, "content_hash": "aaa"}},
+            "teams": {"primary": {"row_count": 1, "content_hash": "bbb"}},
+        }
+    }
+    live = {
+        "clickhouse": {
+            "repos": {"primary": {"row_count": 3, "content_hash": "aaa"}},
+            "teams": {"primary": {"row_count": 1, "content_hash": "ccc"}},
+        }
+    }
+    drifted = _diff_components(pinned, live)
+    assert drifted == ["clickhouse.teams"]
+
+
+def test_diff_components_empty_when_identical() -> None:
+    doc = {"clickhouse": {"repos": {"primary": {"row_count": 1, "content_hash": "x"}}}}
+    assert _diff_components(doc, doc) == []
+
+
+def test_volatile_columns_cover_every_timestamp_this_world_writes() -> None:
+    # Documents the exact exclusion set relied on above -- a change here is
+    # a deliberate contract change, not an incidental typo.
+    assert _VOLATILE_COLUMNS == frozenset(
+        {
+            "last_synced",
+            "updated_at",
+            "created_at",
+            "computed_at",
+            "synced_at",
+            "started_at",
+            "ended_at",
+            "queued_at",
+            "finished_at",
+            "last_sync_at",
+            "feature_id",
+        }
+    )

--- a/tests/test_fixtures_world_digest.py
+++ b/tests/test_fixtures_world_digest.py
@@ -31,6 +31,7 @@ from dev_health_ops.fixtures.world import (
     _clickhouse_table_digest,
     _diff_components,
     _row_content_key,
+    _volatile_columns_for_table,
 )
 
 
@@ -64,7 +65,7 @@ class _ExplodingConnectivityClient:
 def test_row_content_key_excludes_volatile_columns() -> None:
     columns = ["id", "org_id", "name", "last_synced", "updated_at"]
     row = ("repo-1", "org-1", "web-app", "2026-08-01T00:00:00Z", "2026-08-01T00:00:00Z")
-    key = _row_content_key(columns, row)
+    key = _row_content_key(columns, row, volatile=_VOLATILE_COLUMNS)
     assert "last_synced" not in key
     assert "updated_at" not in key
     assert "id='repo-1'" in key
@@ -79,7 +80,36 @@ def test_row_content_key_stable_column_order_independent() -> None:
     columns_b = ["name", "id"]
     row_a = ("repo-1", "web-app")
     row_b = ("web-app", "repo-1")
-    assert _row_content_key(columns_a, row_a) == _row_content_key(columns_b, row_b)
+    assert _row_content_key(
+        columns_a, row_a, volatile=_VOLATILE_COLUMNS
+    ) == _row_content_key(columns_b, row_b, volatile=_VOLATILE_COLUMNS)
+
+
+def test_row_content_key_keeps_table_specific_watermark_column() -> None:
+    """Codex HIGH-3 (2026-08-05): for tables in
+    ``_WATERMARK_COLUMNS_TO_KEEP_BY_TABLE``, the listed watermark column is
+    NOT excluded -- it is exactly what a claimed source state (stale/
+    current/measured-zero) is about, so blanket-hashing it out would let a
+    regression in the aging/zeroing step go undetected forever."""
+
+    columns = ["id", "org_id", "last_synced"]
+    row = ("repo-1", "org-1", "2026-08-01T00:00:00Z")
+    key = _row_content_key(
+        columns, row, volatile=_volatile_columns_for_table("git_commits")
+    )
+    assert "last_synced='2026-08-01T00:00:00Z'" in key
+
+
+def test_volatile_columns_for_table_default_excludes_watermark() -> None:
+    """``_volatile_columns_for_table`` returns the EXCLUSION set. A table
+    with NO entry in the keep-list (e.g. plain ``repos``) still gets the
+    full blanket exclusion -- ``last_synced`` stays volatile (excluded) --
+    while a table WITH an entry (``git_commits``) has it removed from the
+    exclusion set, i.e. hashed. The per-table override is additive, not a
+    replacement of the default behavior."""
+
+    assert "last_synced" in _volatile_columns_for_table("repos")
+    assert "last_synced" not in _volatile_columns_for_table("git_commits")
 
 
 @pytest.mark.asyncio
@@ -129,7 +159,32 @@ async def test_digest_drift_red_on_content_mutation() -> None:
 async def test_digest_unaffected_by_volatile_only_mutation() -> None:
     """The inverse of the drift test: mutating ONLY a volatile column must
     NOT trip the digest (this is what makes two real generations, run at
-    different real times, reproducible)."""
+    different real times, reproducible). Uses ``teams`` -- NOT one of the
+    HIGH-3 watermark-keep tables -- deliberately: ``work_items`` (used here
+    before HIGH-3) now keeps ``last_synced`` in its digest on purpose, so it
+    would no longer demonstrate this property (see the paired test below,
+    which asserts exactly that difference for ``work_items``)."""
+
+    columns = ["id", "org_id", "status", "last_synced"]
+    row_a = [("t-1", "org-1", "done", "2026-08-01T00:00:00Z")]
+    row_b = [("t-1", "org-1", "done", "2026-08-02T12:34:56Z")]
+
+    digest_a = await _clickhouse_table_digest(
+        _StubClient(columns, row_a), "teams", "org-1"
+    )
+    digest_b = await _clickhouse_table_digest(
+        _StubClient(columns, row_b), "teams", "org-1"
+    )
+    assert digest_a["content_hash"] == digest_b["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_digest_affected_by_watermark_mutation_on_kept_table() -> None:
+    """Codex HIGH-3 (2026-08-05): the exact counterpart to the test above.
+    ``work_items`` IS one of the tables whose watermark column
+    (``last_synced``) is deliberately kept in the digest -- mutating ONLY
+    that column now DOES trip the digest, because a "stale" claim in
+    sources.json is a claim ABOUT that column."""
 
     columns = ["id", "org_id", "status", "last_synced"]
     row_a = [("wi-1", "org-1", "done", "2026-08-01T00:00:00Z")]
@@ -141,7 +196,11 @@ async def test_digest_unaffected_by_volatile_only_mutation() -> None:
     digest_b = await _clickhouse_table_digest(
         _StubClient(columns, row_b), "work_items", "org-1"
     )
-    assert digest_a["content_hash"] == digest_b["content_hash"]
+    assert digest_a["content_hash"] != digest_b["content_hash"], (
+        "work_items.last_synced must be part of the digest -- if this "
+        "passes with an unchanged hash, a regression in watermark aging "
+        "for work_items would go undetected"
+    )
 
 
 @pytest.mark.asyncio
@@ -216,5 +275,6 @@ def test_volatile_columns_cover_every_timestamp_this_world_writes() -> None:
             "finished_at",
             "last_sync_at",
             "feature_id",
+            "categorization_run_id",
         }
     )

--- a/tests/test_fixtures_world_digest_mutations_live.py
+++ b/tests/test_fixtures_world_digest_mutations_live.py
@@ -1,0 +1,409 @@
+"""CHAOS-3219 Codex adversarial review (HIGH-3, 2026-08-05): live proof that
+``compute_world_digest`` -- the actual function ``fixtures world
+--verify-digest`` calls, not a stand-in -- is sensitive to the three
+mutation shapes the finding names verbatim: "a stale watermark flip, a
+metric value change, and a work-graph row change".
+
+``tests/test_fixtures_world_digest.py`` proves ``_clickhouse_table_digest``'s
+per-table exclusion-set logic in isolation with a stub client. This file
+proves the SAME property survives through the full ``compute_world_digest``
+orchestration path (per-org iteration over the real, expanded
+``_CLICKHOUSE_DIGEST_TABLES``/``_POSTGRES_DIGEST_TABLES``, real ClickHouse
+AND Postgres engines, canonical JSON, top-level sha256) against a real
+migrated scratch database -- an orchestration-level regression (e.g. a table
+silently dropped back out of ``_CLICKHOUSE_DIGEST_TABLES``, or the wrong org
+column used) would not be caught by the stub tests alone.
+
+Each mutation is driven through the REAL production write path, not a
+hand-rolled row:
+  * stale watermark flip -- ``source_health.age_source_rows`` (the exact
+    function ``fixtures world`` itself calls to realize every "stale"
+    sources.json state) against ``git_commits``.
+  * metric value change -- ``ClickHouseMetricsSink.write_dora_metrics`` (the
+    real DORA sink) against ``dora_metrics_daily``, which HIGH-3 also newly
+    added to ``_CLICKHOUSE_DIGEST_TABLES`` -- before this fix, no digest
+    mutation test could even have been written for this table because it
+    was not covered at all.
+  * work-graph row change -- ``ClickHouseMetricsSink.write_work_graph_issue_pr``
+    against ``work_graph_issue_pr``, likewise newly covered by HIGH-3.
+
+Opt-in, mirrors ``tests/test_ask_dev_linear_project_subject_live.py``'s
+convention: skipped unless BOTH ``CLICKHOUSE_URI`` and ``POSTGRES_URI`` point
+at migrated SCRATCH databases. Never the shared dev ``default``/``devhealth``
+-- enforced here via the production ``_require_scratch_database`` guard this
+file dogfoods directly (the same CRITICAL-finding fix ``fixtures world``
+itself is gated on), not a separate ad hoc check that could drift from it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+POSTGRES_URI = os.environ.get("POSTGRES_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI or not POSTGRES_URI,
+        reason=(
+            "Requires migrated SCRATCH CLICKHOUSE_URI and POSTGRES_URI "
+            "(e.g. .../chaos3219_digest_mut_scratch) -- see module docstring."
+        ),
+    ),
+]
+
+#: A dedicated synthetic org for this file only -- never collides with
+#: ask-dev-world.v1's own "primary"/"sibling" orgs, and every row this file
+#: writes is scoped to it, so nothing here interferes with any other live
+#: suite that might share the same scratch database.
+_ORG_ALIAS = "chaos3219-high3-mutation-live"
+
+
+def _require_env_scratch() -> None:
+    from dev_health_ops.fixtures.world import _require_scratch_database
+
+    _require_scratch_database(CLICKHOUSE_URI, kind="clickhouse")
+    _require_scratch_database(POSTGRES_URI, kind="postgres")
+
+
+@pytest.fixture(scope="module")
+def manifest() -> Any:
+    from dev_health_ops.fixtures.world import WorldManifest
+
+    _require_env_scratch()
+    return WorldManifest(
+        manifest_path=Path("/dev/null"),
+        world={
+            "master_seed": 20260805,
+            "orgs": [{"alias": _ORG_ALIAS, "id_seed": f"org:{_ORG_ALIAS}"}],
+            "users": [],
+        },
+        subjects={},
+        sources={},
+    )
+
+
+@pytest.fixture(scope="module")
+def org_id(manifest: Any) -> str:
+    return str(manifest.org_id(_ORG_ALIAS))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _migrated_scratch_schemas(manifest: Any) -> None:
+    """Apply real migrations to both scratch databases once per module --
+    ``compute_world_digest`` unconditionally opens a Postgres engine and
+    queries ``users`` even when only ClickHouse tables are being asserted
+    on, so both schemas must exist."""
+
+    from dev_health_ops import migrate as migrate_mod
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    assert POSTGRES_URI is not None
+    _require_env_scratch()
+
+    sink = ClickHouseMetricsSink(dsn=CLICKHOUSE_URI)
+    try:
+        sink.ensure_schema(force=True)
+    finally:
+        sink.close()
+
+    prior = os.environ.get("POSTGRES_URI")
+    os.environ["POSTGRES_URI"] = POSTGRES_URI
+    try:
+        migrate_mod._run_upgrade(argparse.Namespace(revision="head", db=None))
+    finally:
+        if prior is None:
+            os.environ.pop("POSTGRES_URI", None)
+        else:
+            os.environ["POSTGRES_URI"] = prior
+
+
+@pytest.fixture
+def client() -> Any:
+    import clickhouse_connect
+
+    c = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+async def _digest(manifest: Any) -> dict[str, Any]:
+    from dev_health_ops.fixtures.world import compute_world_digest
+
+    assert CLICKHOUSE_URI is not None
+    assert POSTGRES_URI is not None
+    return await compute_world_digest(
+        manifest, sink=CLICKHOUSE_URI, postgres_uri=POSTGRES_URI
+    )
+
+
+def _ch_hash(doc: dict[str, Any], table: str) -> str:
+    hash_value = doc["components"]["clickhouse"][table][_ORG_ALIAS]["content_hash"]
+    assert isinstance(hash_value, str)
+    return hash_value
+
+
+@pytest.mark.asyncio
+class TestStaleWatermarkFlipLive:
+    """``git_commits.last_synced`` -- HIGH-3's own named example. Watermark
+    aging must be visible to the digest that exists to catch a regression in
+    it, driven through the real ``age_source_rows`` production path."""
+
+    async def test_flip_changes_digest(
+        self, manifest: Any, org_id: str, client: Any
+    ) -> None:
+        from dev_health_ops.fixtures.generators.source_health import (
+            age_source_rows,
+        )
+
+        repo_id = str(uuid.uuid4())
+        where = (
+            "org_id = {org_id:String} AND repo_id = {repo_id:String} "
+            "SETTINGS mutations_sync = 1"
+        )
+        client.command(
+            f"ALTER TABLE git_commits DELETE WHERE {where}",  # noqa: S608
+            parameters={"org_id": org_id, "repo_id": repo_id},
+        )
+        client.insert(
+            "git_commits",
+            [
+                [
+                    repo_id,
+                    "deadbeefcafe",
+                    "initial commit",
+                    "author-a",
+                    "author-a@example.com",
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    "author-a",
+                    "author-a@example.com",
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    0,
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    org_id,
+                ]
+            ],
+            column_names=[
+                "repo_id",
+                "hash",
+                "message",
+                "author_name",
+                "author_email",
+                "author_when",
+                "committer_name",
+                "committer_email",
+                "committer_when",
+                "parents",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        before = await _digest(manifest)
+        await age_source_rows(
+            client,
+            org_id=org_id,
+            repo_id=repo_id,
+            source="commits",
+            stale_watermark=datetime(2020, 6, 1, tzinfo=timezone.utc),
+        )
+        after = await _digest(manifest)
+
+        assert _ch_hash(before, "git_commits") != _ch_hash(after, "git_commits"), (
+            "a stale-watermark flip via the real age_source_rows path must "
+            "change compute_world_digest's git_commits hash -- an unchanged "
+            "hash here means the digest can no longer catch a regression in "
+            "watermark aging, which is exactly what HIGH-3 found"
+        )
+
+
+@pytest.mark.asyncio
+class TestMetricValueChangeLive:
+    """``dora_metrics_daily.value`` -- newly covered by HIGH-3's expanded
+    ``_CLICKHOUSE_DIGEST_TABLES`` (this table was not digested at all
+    before). Seeded and mutated via the real DORA sink write path."""
+
+    async def test_value_change_changes_digest(
+        self, manifest: Any, org_id: str, client: Any
+    ) -> None:
+        from dev_health_ops.metrics.schemas import DORAMetricsRecord
+        from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+        repo_id = uuid.uuid4()
+        day = datetime(2026, 6, 1, tzinfo=timezone.utc).date()
+        where = (
+            "org_id = {org_id:String} AND repo_id = {repo_id:String} "
+            "AND day = {day:Date} AND metric_name = {metric_name:String} "
+            "SETTINGS mutations_sync = 1"
+        )
+        params = {
+            "org_id": org_id,
+            "repo_id": str(repo_id),
+            "day": day,
+            "metric_name": "lead_time_for_changes_days",
+        }
+        # Org-wide (not key-scoped) cleanup: this file's synthetic org_id is
+        # stable across every run against the same persistent scratch
+        # database, but `repo_id` above is a fresh uuid4 each run -- a
+        # key-scoped delete would leave every PRIOR run's row behind
+        # (dora_metrics_daily has no ReplacingMergeTree dedup to paper over
+        # that), which would make the row-count assertion below flaky
+        # across reruns rather than a property of this test's own mutation.
+        client.command(
+            "ALTER TABLE dora_metrics_daily DELETE WHERE org_id = {org_id:String} "
+            "SETTINGS mutations_sync = 1",
+            parameters={"org_id": org_id},
+        )
+
+        assert CLICKHOUSE_URI is not None
+        sink = ClickHouseMetricsSink(dsn=CLICKHOUSE_URI, client=client)
+        sink.write_dora_metrics(
+            [
+                DORAMetricsRecord(
+                    repo_id=repo_id,
+                    day=day,
+                    metric_name="lead_time_for_changes_days",
+                    value=2.5,
+                    computed_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    org_id=org_id,
+                )
+            ]
+        )
+
+        before = await _digest(manifest)
+
+        # dora_metrics_daily is a plain MergeTree -- no ReplacingMergeTree
+        # dedup, so the same delete-then-reinsert discipline age_source_rows
+        # uses is required here too: an in-place ALTER ... UPDATE would work
+        # (value is not part of ORDER BY), but delete+reinsert keeps this
+        # test's mutation shape uniform with the production aging path and
+        # sidesteps ever needing to special-case which columns are safe to
+        # UPDATE in place per engine.
+        client.command(
+            f"ALTER TABLE dora_metrics_daily DELETE WHERE {where}",  # noqa: S608
+            parameters=params,
+        )
+        sink.write_dora_metrics(
+            [
+                DORAMetricsRecord(
+                    repo_id=repo_id,
+                    day=day,
+                    metric_name="lead_time_for_changes_days",
+                    value=9.75,
+                    computed_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    org_id=org_id,
+                )
+            ]
+        )
+
+        after = await _digest(manifest)
+
+        assert _ch_hash(before, "dora_metrics_daily") != _ch_hash(
+            after, "dora_metrics_daily"
+        ), (
+            "a DORA metric value change must move compute_world_digest's "
+            "dora_metrics_daily hash -- this table had NO digest coverage "
+            "at all before HIGH-3, so an unchanged hash here means the gap "
+            "is still open"
+        )
+        assert (
+            before["components"]["clickhouse"]["dora_metrics_daily"][_ORG_ALIAS][
+                "row_count"
+            ]
+            == after["components"]["clickhouse"]["dora_metrics_daily"][_ORG_ALIAS][
+                "row_count"
+            ]
+            == 1
+        ), "row count must stay 1 -- this proves a VALUE change, not a row-count change"
+
+
+@pytest.mark.asyncio
+class TestWorkGraphRowChangeLive:
+    """``work_graph_issue_pr`` -- newly covered by HIGH-3's expanded
+    ``_CLICKHOUSE_DIGEST_TABLES``. Mutated the way production sync actually
+    would: a second, later-``last_synced`` version of the same
+    (repo_id, work_item_id, pr_number) key, relying on the table's real
+    ``ReplacingMergeTree(last_synced)`` + the digest query's own ``FINAL``
+    to resolve to the latest version -- not a raw DELETE/UPDATE.
+    """
+
+    async def test_row_change_changes_digest(
+        self, manifest: Any, org_id: str, client: Any
+    ) -> None:
+        from dev_health_ops.metrics.schemas import WorkGraphIssuePRRecord
+        from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+        repo_id = uuid.uuid4()
+        work_item_id = "gh:owner/repo#42"
+        pr_number = 7
+        where = (
+            "org_id = {org_id:String} AND repo_id = {repo_id:String} "
+            "AND work_item_id = {work_item_id:String} "
+            "AND pr_number = {pr_number:UInt32} SETTINGS mutations_sync = 1"
+        )
+        params = {
+            "org_id": org_id,
+            "repo_id": str(repo_id),
+            "work_item_id": work_item_id,
+            "pr_number": pr_number,
+        }
+        client.command(
+            f"ALTER TABLE work_graph_issue_pr DELETE WHERE {where}",  # noqa: S608
+            parameters=params,
+        )
+
+        assert CLICKHOUSE_URI is not None
+        sink = ClickHouseMetricsSink(dsn=CLICKHOUSE_URI, client=client)
+        sink.write_work_graph_issue_pr(
+            [
+                WorkGraphIssuePRRecord(
+                    repo_id=repo_id,
+                    work_item_id=work_item_id,
+                    pr_number=pr_number,
+                    confidence=0.4,
+                    provenance="heuristic",
+                    evidence="branch-name-match",
+                    last_synced=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    org_id=org_id,
+                )
+            ]
+        )
+
+        before = await _digest(manifest)
+
+        sink.write_work_graph_issue_pr(
+            [
+                WorkGraphIssuePRRecord(
+                    repo_id=repo_id,
+                    work_item_id=work_item_id,
+                    pr_number=pr_number,
+                    confidence=0.95,
+                    provenance="native",
+                    evidence="api_pr_commits",
+                    last_synced=datetime(2026, 6, 2, tzinfo=timezone.utc),
+                    org_id=org_id,
+                )
+            ]
+        )
+
+        after = await _digest(manifest)
+
+        assert _ch_hash(before, "work_graph_issue_pr") != _ch_hash(
+            after, "work_graph_issue_pr"
+        ), (
+            "a work-graph row's content (confidence/provenance/evidence) "
+            "changing via a later ReplacingMergeTree version must move "
+            "compute_world_digest's work_graph_issue_pr hash -- this table "
+            "had NO digest coverage at all before HIGH-3"
+        )

--- a/tests/test_fixtures_world_generators.py
+++ b/tests/test_fixtures_world_generators.py
@@ -1,0 +1,311 @@
+"""CHAOS-3219: unit coverage for the new ask-dev-world generator modules
+(projects, source_health, conflicts, retention_conversations).
+
+Pure Python / in-memory ORM object construction -- no DB connection.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.fixtures.generators import conflicts as conflicts_gen
+from dev_health_ops.fixtures.generators import projects as projects_gen
+from dev_health_ops.fixtures.generators import retention_conversations as conv_gen
+from dev_health_ops.fixtures.generators import source_health
+
+_NOW = datetime(2026, 8, 5, tzinfo=timezone.utc)
+
+
+class TestProjects:
+    def test_project_id_equals_repo_full_name(self) -> None:
+        assert (
+            projects_gen.project_id_for_repo("meridian/web-app") == "meridian/web-app"
+        )
+
+    def test_build_project_record_defaults_name_to_repo(self) -> None:
+        record = projects_gen.build_project_record(
+            org_id="org-1", repo_full_name="meridian/web-app", as_of=_NOW
+        )
+        assert record.name == "meridian/web-app"
+        assert record.provider == "synthetic"
+        assert record.is_active is True
+
+    def test_build_project_record_display_name_override(self) -> None:
+        record = projects_gen.build_project_record(
+            org_id="org-1",
+            repo_full_name="meridian/web-app",
+            display_name="Meridian Web Application (MWA)",
+            as_of=_NOW,
+        )
+        assert record.name == "Meridian Web Application (MWA)"
+        assert record.id == "meridian/web-app"
+
+    def test_retired_version_flips_is_active_and_keeps_id(self) -> None:
+        active = projects_gen.build_project_record(
+            org_id="org-1", repo_full_name="legacy/billing", as_of=_NOW
+        )
+        retired = projects_gen.build_retired_project_version(
+            active, retired_as_of=_NOW + timedelta(hours=1)
+        )
+        assert retired.id == active.id
+        assert retired.org_id == active.org_id
+        assert retired.is_active is False
+        assert retired.updated_at is not None
+        assert active.updated_at is not None
+        assert retired.updated_at > active.updated_at
+
+    def test_retired_version_requires_strictly_later_timestamp(self) -> None:
+        active = projects_gen.build_project_record(
+            org_id="org-1", repo_full_name="legacy/billing", as_of=_NOW
+        )
+        with pytest.raises(ValueError, match="strictly after"):
+            projects_gen.build_retired_project_version(active, retired_as_of=_NOW)
+
+    @pytest.mark.asyncio
+    async def test_insert_projects_no_records_is_a_noop(self) -> None:
+        class _MustNotInsert:
+            def insert(self, *args, **kwargs):
+                raise AssertionError("insert must not be called for an empty list")
+
+        await projects_gen.insert_projects(_MustNotInsert(), [])
+
+    @pytest.mark.asyncio
+    async def test_insert_projects_calls_client_insert_with_column_names(self) -> None:
+        calls = []
+
+        class _StubClient:
+            def insert(self, table, matrix, column_names):
+                calls.append((table, matrix, column_names))
+
+        record = projects_gen.build_project_record(
+            org_id="org-1", repo_full_name="meridian/web-app", as_of=_NOW
+        )
+        await projects_gen.insert_projects(_StubClient(), [record])
+        assert len(calls) == 1
+        table, matrix, column_names = calls[0]
+        assert table == "projects"
+        assert len(matrix) == 1
+        assert column_names == list(projects_gen._PROJECT_COLUMNS)
+
+
+class TestSourceHealth:
+    def test_provider_supports_source_incidents(self) -> None:
+        assert "pagerduty" in source_health.PROVIDER_SUPPORTS_SOURCE["incidents"]
+        assert "github" not in source_health.PROVIDER_SUPPORTS_SOURCE["incidents"]
+
+    def test_provider_supports_source_commits(self) -> None:
+        assert "local" in source_health.PROVIDER_SUPPORTS_SOURCE["commits"]
+        assert "pagerduty" not in source_health.PROVIDER_SUPPORTS_SOURCE["commits"]
+
+    def test_build_sync_configuration_unconfigured_returns_none(self) -> None:
+        spec = source_health.SyncConfigurationSpec(
+            org_id="org-1", provider="pagerduty", state="unconfigured"
+        )
+        assert source_health.build_sync_configuration(spec) is None
+
+    def test_build_sync_configuration_active_success(self) -> None:
+        spec = source_health.SyncConfigurationSpec(
+            org_id="org-1", provider="local", state="active_success", last_sync_at=_NOW
+        )
+        config = source_health.build_sync_configuration(spec)
+        assert config is not None
+        assert config.is_active is True
+        assert config.last_sync_success is True
+        assert config.last_sync_error is None
+
+    def test_build_sync_configuration_active_failure(self) -> None:
+        spec = source_health.SyncConfigurationSpec(
+            org_id="org-1", provider="local", state="active_failure", last_sync_at=_NOW
+        )
+        config = source_health.build_sync_configuration(spec)
+        assert config is not None
+        assert config.last_sync_success is False
+        assert config.last_sync_error is not None
+
+    def test_build_sync_configurations_for_org_skips_unconfigured(self) -> None:
+        configs = source_health.build_sync_configurations_for_org(
+            "org-1",
+            {
+                "local": "active_success",
+                "jira": "active_success",
+                "pagerduty": "unconfigured",
+            },
+            as_of=_NOW,
+        )
+        providers = {c.provider for c in configs}
+        assert providers == {"local", "jira"}
+
+    def test_sources_configured_for_org(self) -> None:
+        configured = source_health.sources_configured_for_org(
+            {
+                "local": "active_success",
+                "jira": "active_success",
+                "pagerduty": "unconfigured",
+            }
+        )
+        assert "incidents" not in configured
+        assert "commits" in configured
+        assert "work_items" in configured
+
+    def test_sources_configured_for_org_empty_when_nothing_configured(self) -> None:
+        configured = source_health.sources_configured_for_org(
+            {
+                "local": "unconfigured",
+                "jira": "unconfigured",
+                "pagerduty": "unconfigured",
+            }
+        )
+        assert configured == set()
+
+
+class TestConflicts:
+    def test_build_conflicting_ci_runs_distinct_run_ids(self) -> None:
+        pair = conflicts_gen.build_conflicting_ci_runs(
+            repo_id=uuid.uuid4(), org_id="org-1", as_of=_NOW, seed_label="probe"
+        )
+        assert pair.run_id_success != pair.run_id_failed
+
+    def test_to_postgres_ci_pipeline_runs_opposite_status(self) -> None:
+        pair = conflicts_gen.build_conflicting_ci_runs(
+            repo_id=uuid.uuid4(), org_id="org-1", as_of=_NOW, seed_label="probe"
+        )
+        runs = conflicts_gen.to_postgres_ci_pipeline_runs(pair)
+        statuses = {r.status for r in runs}
+        assert statuses == {"success", "failed"}
+        assert all(r.repo_id == pair.repo_id for r in runs)
+
+    def test_to_clickhouse_extended_rows_shape(self) -> None:
+        pair = conflicts_gen.build_conflicting_ci_runs(
+            repo_id=uuid.uuid4(), org_id="org-1", as_of=_NOW, seed_label="probe"
+        )
+        rows = conflicts_gen.to_clickhouse_extended_rows(
+            pair, team_id="team-1", service_id="api-gateway"
+        )
+        assert len(rows) == 2
+        assert {r["status"] for r in rows} == {"success", "failed"}
+        assert all(r["org_id"] == "org-1" for r in rows)
+        assert all(r["repo_id"] == pair.repo_id for r in rows)
+
+    def test_conflicting_runs_share_repo_and_close_queued_window(self) -> None:
+        pair = conflicts_gen.build_conflicting_ci_runs(
+            repo_id=uuid.uuid4(), org_id="org-1", as_of=_NOW, seed_label="probe"
+        )
+        runs = conflicts_gen.to_postgres_ci_pipeline_runs(pair)
+        queued = sorted(r.queued_at for r in runs)
+        assert queued[1] - queued[0] <= timedelta(minutes=10)
+
+
+class TestRetentionConversations:
+    def test_retention_aged_conversation_created_at_matches_age(self) -> None:
+        bundle = conv_gen.build_retention_aged_conversation(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="probe",
+            retention_days=30,
+            age_days=40,
+            pinned_now=_NOW,
+            title="probe",
+        )
+        assert bundle.conversation.created_at == _NOW - timedelta(days=40)
+        assert (
+            bundle.conversation.expires_at
+            == bundle.conversation.created_at + timedelta(days=30)
+        )
+
+    def test_retention_zero_days_has_no_expiry(self) -> None:
+        bundle = conv_gen.build_retention_aged_conversation(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="probe",
+            retention_days=0,
+            age_days=1,
+            pinned_now=_NOW,
+            title="probe",
+        )
+        assert bundle.conversation.expires_at is None
+        assert bundle.conversation.retention_days == 0
+
+    def test_deterministic_ids_across_calls(self) -> None:
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        first = conv_gen.build_retention_aged_conversation(
+            org_id=org_id,
+            user_id=user_id,
+            id_seed="probe",
+            retention_days=30,
+            age_days=1,
+            pinned_now=_NOW,
+            title="probe",
+        )
+        second = conv_gen.build_retention_aged_conversation(
+            org_id=org_id,
+            user_id=user_id,
+            id_seed="probe",
+            retention_days=30,
+            age_days=1,
+            pinned_now=_NOW,
+            title="probe",
+        )
+        assert first.conversation.id == second.conversation.id
+
+    def test_stale_context_bundle_has_two_runs_and_one_subject_set(self) -> None:
+        bundle = conv_gen.build_stale_context_conversation(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="stale-context",
+            repo_full_name="rotated/service",
+            pinned_now=_NOW,
+        )
+        assert len(bundle.runs) == 2
+        assert len(bundle.subject_sets) == 1
+        early_run, late_run = bundle.runs
+        assert early_run.started_at < late_run.started_at
+        assert bundle.subject_sets[0].run_id == early_run.id
+        assert bundle.subject_sets[0].payload["repo_full_name"] == "rotated/service"
+
+    def test_stale_context_early_run_predates_pinned_now_by_default_window(
+        self,
+    ) -> None:
+        bundle = conv_gen.build_stale_context_conversation(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="stale-context",
+            repo_full_name="rotated/service",
+            pinned_now=_NOW,
+        )
+        early_run = bundle.runs[0]
+        assert (_NOW - early_run.started_at) >= timedelta(days=9)
+
+    def test_validation_packet_covers_every_status(self) -> None:
+        bundle = conv_gen.build_validation_packet(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="validation-packet",
+            pinned_now=_NOW,
+        )
+        statuses = {run.grounding_validation_status for run in bundle.runs}
+        assert statuses == set(conv_gen.VALIDATION_STATUSES)
+
+    def test_validation_packet_run_ids_are_unique(self) -> None:
+        bundle = conv_gen.build_validation_packet(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="validation-packet",
+            pinned_now=_NOW,
+        )
+        run_ids = [run.id for run in bundle.runs]
+        assert len(run_ids) == len(set(run_ids))
+
+    def test_insufficient_evidence_run_has_zero_citations(self) -> None:
+        bundle = conv_gen.build_validation_packet(
+            org_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            id_seed="validation-packet",
+            pinned_now=_NOW,
+        )
+        by_status = {run.grounding_validation_status: run for run in bundle.runs}
+        assert by_status["insufficient_evidence"].citation_count == 0
+        assert by_status["validated"].citation_count > 0

--- a/tests/test_fixtures_world_manifest.py
+++ b/tests/test_fixtures_world_manifest.py
@@ -1,0 +1,261 @@
+"""CHAOS-3219: shape + cross-reference guards for ask-dev-world.v1's
+world.json/subjects.json/sources.json.
+
+Pure-Python, no DB required -- runs in the standard unit tier
+(``ci/run_tests.sh``'s ``-m "not benchmark and not clickhouse"`` selection).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.fixtures.world import (
+    WORLD_SCHEMA_VERSION,
+    WorldManifest,
+    WorldManifestError,
+    collect_repo_roster,
+    derive_id,
+    derive_repo_seed,
+    load_world_manifest,
+    validate_world_manifest,
+)
+
+_WORLD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "acceptance"
+    / "world"
+    / "ask-dev-world.v1"
+)
+_MANIFEST_PATH = _WORLD_DIR / "world.json"
+
+_REQUIRED_SUBJECT_CLASSES = (
+    "exact",
+    "ambiguous",
+    "acronym-alias",
+    "no-match",
+    "deleted",
+    "stale-context",
+    "partially-resolved",
+    "bounded-set",
+)
+_REQUIRED_SOURCE_STATES = (
+    "current",
+    "stale",
+    "unavailable",
+    "unconfigured",
+    "no-data",
+    "unauthorized",
+    "truncated",
+    "conflicting",
+    "not-applicable",
+)
+
+
+@pytest.fixture(scope="module")
+def manifest() -> WorldManifest:
+    return load_world_manifest(_MANIFEST_PATH)
+
+
+def test_checked_in_manifest_loads_and_validates(manifest: WorldManifest) -> None:
+    assert manifest.world["schema_version"] == WORLD_SCHEMA_VERSION
+    assert manifest.subjects["schema_version"] == WORLD_SCHEMA_VERSION
+    assert manifest.sources["schema_version"] == WORLD_SCHEMA_VERSION
+
+
+def test_three_orgs_with_required_roles(manifest: WorldManifest) -> None:
+    roles = {org["alias"]: org["role"] for org in manifest.orgs}
+    assert roles == {
+        "primary": "primary",
+        "sibling": "sibling_tenant",
+        "disabled": "disabled_entitlement",
+    }
+
+
+class TestSubjectClassCoverage:
+    """A subject class with zero realizing rows must FAIL the guard."""
+
+    @pytest.mark.parametrize("required_class", _REQUIRED_SUBJECT_CLASSES)
+    def test_every_required_class_has_a_realizing_subject(
+        self, manifest: WorldManifest, required_class: str
+    ) -> None:
+        present = {s["class"] for s in manifest.subjects["subjects"]}
+        assert required_class in present, (
+            f"subjects.json has zero rows realizing class={required_class!r}"
+        )
+
+    def test_missing_class_fails_validation(self, tmp_path: Path) -> None:
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+
+        # Drop every subject realizing the 'deleted' class -- the guard must
+        # observe this and fail, not silently accept a thinned registry.
+        subjects["subjects"] = [
+            s for s in subjects["subjects"] if s["class"] != "deleted"
+        ]
+
+        (tmp_path / "world.json").write_text(json.dumps(world))
+        (tmp_path / "subjects.json").write_text(json.dumps(subjects))
+        (tmp_path / "sources.json").write_text(json.dumps(sources))
+
+        with pytest.raises(WorldManifestError, match="deleted"):
+            load_world_manifest(tmp_path / "world.json")
+
+
+class TestSourceStateCoverage:
+    @pytest.mark.parametrize("required_state", _REQUIRED_SOURCE_STATES)
+    def test_every_required_state_has_a_realizing_row(
+        self, manifest: WorldManifest, required_state: str
+    ) -> None:
+        present = {m["state"] for m in manifest.sources["matrix"]}
+        assert required_state in present, (
+            f"sources.json has zero rows realizing state={required_state!r}"
+        )
+
+    def test_missing_state_fails_validation(self, tmp_path: Path) -> None:
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+
+        sources["matrix"] = [m for m in sources["matrix"] if m["state"] != "stale"]
+
+        (tmp_path / "world.json").write_text(json.dumps(world))
+        (tmp_path / "subjects.json").write_text(json.dumps(subjects))
+        (tmp_path / "sources.json").write_text(json.dumps(sources))
+
+        with pytest.raises(WorldManifestError, match="stale"):
+            load_world_manifest(tmp_path / "world.json")
+
+
+def test_subject_org_alias_must_exist(tmp_path: Path) -> None:
+    world = json.loads((_WORLD_DIR / "world.json").read_text())
+    subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+    sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+
+    subjects["subjects"][0]["org_alias"] = "does-not-exist"
+
+    (tmp_path / "world.json").write_text(json.dumps(world))
+    (tmp_path / "subjects.json").write_text(json.dumps(subjects))
+    (tmp_path / "sources.json").write_text(json.dumps(sources))
+
+    with pytest.raises(WorldManifestError, match="does-not-exist"):
+        load_world_manifest(tmp_path / "world.json")
+
+
+def test_schema_version_mismatch_rejected(tmp_path: Path) -> None:
+    world = json.loads((_WORLD_DIR / "world.json").read_text())
+    subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+    sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+    world["schema_version"] = "ask_dev_world.v2"
+
+    (tmp_path / "world.json").write_text(json.dumps(world))
+    (tmp_path / "subjects.json").write_text(json.dumps(subjects))
+    (tmp_path / "sources.json").write_text(json.dumps(sources))
+
+    with pytest.raises(WorldManifestError, match="schema_version"):
+        load_world_manifest(tmp_path / "world.json")
+
+
+class TestRepoRoster:
+    """subjects.json/sources.json content actually drives what the generator
+    will seed -- collect_repo_roster is the exact function `fixtures world`
+    iterates to decide what to generate, so testing it against the real
+    checked-in manifest IS testing "subjects.json cross-checked against what
+    the generator actually seeds"."""
+
+    def test_every_named_repo_subject_is_in_the_roster(
+        self, manifest: WorldManifest
+    ) -> None:
+        roster = collect_repo_roster(manifest)
+        for subject in manifest.subjects["subjects"]:
+            alias = subject.get("org_alias")
+            repo = subject.get("repo_full_name")
+            if (
+                alias
+                and repo
+                and subject.get("entity_kind") in {"repository", "project"}
+            ):
+                assert repo in roster.get(alias, set()), (
+                    f"subject {subject['id']!r} names repo_full_name={repo!r} "
+                    f"but collect_repo_roster() would never generate it"
+                )
+
+    def test_ambiguous_candidates_are_in_the_roster(
+        self, manifest: WorldManifest
+    ) -> None:
+        for subject in manifest.subjects["subjects"]:
+            if subject["class"] != "ambiguous":
+                continue
+            roster = collect_repo_roster(manifest)
+            for candidate in subject["candidates"]:
+                assert candidate in roster[subject["org_alias"]]
+
+    def test_no_match_subject_has_no_realizing_repo(
+        self, manifest: WorldManifest
+    ) -> None:
+        roster = collect_repo_roster(manifest)
+        all_repos = {repo for repos in roster.values() for repo in repos}
+        no_match = next(
+            s for s in manifest.subjects["subjects"] if s["class"] == "no-match"
+        )
+        for mention in no_match["mentions"]:
+            assert mention not in all_repos
+
+    def test_roster_disjoint_across_orgs(self, manifest: WorldManifest) -> None:
+        roster = collect_repo_roster(manifest)
+        seen: dict[str, str] = {}
+        for alias, repos in roster.items():
+            for repo in repos:
+                assert repo not in seen, (
+                    f"repo_full_name={repo!r} claimed by both org "
+                    f"{seen.get(repo)!r} and {alias!r}"
+                )
+                seen[repo] = alias
+
+
+class TestDeterminism:
+    def test_derive_id_is_deterministic(self) -> None:
+        a = derive_id(3219000, "ask-dev-world.v1:org:primary")
+        b = derive_id(3219000, "ask-dev-world.v1:org:primary")
+        assert a == b
+
+    def test_derive_id_differs_by_seed_string(self) -> None:
+        a = derive_id(3219000, "org:primary")
+        b = derive_id(3219000, "org:sibling")
+        assert a != b
+
+    def test_derive_id_namespaced_by_master_seed(self) -> None:
+        a = derive_id(1, "org:primary")
+        b = derive_id(2, "org:primary")
+        assert a != b, "a future world version's ids must not collide with v1's"
+
+    def test_derive_repo_seed_deterministic(self) -> None:
+        a = derive_repo_seed(3219000, "primary", "meridian/web-app")
+        b = derive_repo_seed(3219000, "primary", "meridian/web-app")
+        assert a == b
+
+    def test_derive_repo_seed_differs_by_repo(self) -> None:
+        a = derive_repo_seed(3219000, "primary", "meridian/web-app")
+        b = derive_repo_seed(3219000, "primary", "meridian/atlas")
+        assert a != b
+
+    def test_manifest_org_id_matches_derive_id(self, manifest: WorldManifest) -> None:
+        primary = manifest.org("primary")
+        assert manifest.org_id("primary") == derive_id(
+            manifest.master_seed, primary["id_seed"]
+        )
+
+
+def test_validate_world_manifest_rejects_zero_orgs() -> None:
+    manifest = WorldManifest(
+        manifest_path=_MANIFEST_PATH,
+        world={"schema_version": WORLD_SCHEMA_VERSION, "orgs": []},
+        subjects={"schema_version": WORLD_SCHEMA_VERSION, "subjects": []},
+        sources={"schema_version": WORLD_SCHEMA_VERSION, "matrix": []},
+    )
+    with pytest.raises(WorldManifestError, match="zero orgs"):
+        validate_world_manifest(manifest)

--- a/tests/test_fixtures_world_manifest.py
+++ b/tests/test_fixtures_world_manifest.py
@@ -259,3 +259,64 @@ def test_validate_world_manifest_rejects_zero_orgs() -> None:
     )
     with pytest.raises(WorldManifestError, match="zero orgs"):
         validate_world_manifest(manifest)
+
+
+def _minimal_valid_world(**overrides: object) -> dict:
+    base: dict[str, object] = {
+        "schema_version": WORLD_SCHEMA_VERSION,
+        "orgs": [{"alias": "primary", "id_seed": "org:primary"}],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCrossGenerationDigestStatus:
+    """CHAOS-3432 (2026-08-05): the whole-world analogue of sources.json's
+    DECLARED_BLOCKED_STATUS / subjects.json's REALIZED_UNVERIFIED_LIVE_STATUS
+    -- typed, ticketed, schema-checked, never a silent or false claim."""
+
+    def _manifest(self, cross_gen_status: object) -> WorldManifest:
+        return WorldManifest(
+            manifest_path=_MANIFEST_PATH,
+            world=_minimal_valid_world(cross_generation_digest_status=cross_gen_status),
+            subjects={"schema_version": WORLD_SCHEMA_VERSION, "subjects": []},
+            sources={"schema_version": WORLD_SCHEMA_VERSION, "matrix": []},
+        )
+
+    def test_absent_field_is_the_default_and_passes(self) -> None:
+        manifest = WorldManifest(
+            manifest_path=_MANIFEST_PATH,
+            world=_minimal_valid_world(),
+            subjects={"schema_version": WORLD_SCHEMA_VERSION, "subjects": []},
+            sources={"schema_version": WORLD_SCHEMA_VERSION, "matrix": []},
+        )
+        validate_world_manifest(manifest)
+
+    def test_red_wrong_status_value(self) -> None:
+        with pytest.raises(WorldManifestError, match="declared-blocked"):
+            validate_world_manifest(
+                self._manifest({"status": "proven", "blocked_by": "CHAOS-3432"})
+            )
+
+    def test_red_not_a_dict(self) -> None:
+        with pytest.raises(WorldManifestError, match="declared-blocked"):
+            validate_world_manifest(self._manifest("declared-blocked"))
+
+    def test_red_declared_blocked_without_ticket_reference(self) -> None:
+        with pytest.raises(WorldManifestError, match="blocked_by"):
+            validate_world_manifest(self._manifest({"status": "declared-blocked"}))
+
+    def test_green_well_formed(self) -> None:
+        validate_world_manifest(
+            self._manifest({"status": "declared-blocked", "blocked_by": "CHAOS-3432"})
+        )
+
+    def test_checked_in_manifest_declares_chaos_3432(self) -> None:
+        """End-to-end: the actual checked-in world.json carries this
+        field, correctly typed, referencing the real ticket."""
+
+        manifest = load_world_manifest(_MANIFEST_PATH)
+        status = manifest.world.get("cross_generation_digest_status")
+        assert isinstance(status, dict)
+        assert status.get("status") == "declared-blocked"
+        assert "CHAOS-3432" in str(status.get("blocked_by"))

--- a/tests/test_fixtures_world_measured_zero.py
+++ b/tests/test_fixtures_world_measured_zero.py
@@ -1,0 +1,159 @@
+"""CHAOS-3219 Codex adversarial review (HIGH-1, 2026-08-05):
+
+``world.py``'s measured-zero write was guarded by
+``hasattr(store, "write_dora_metrics")``, where ``store`` is a
+``ClickHouseStore`` -- a type that has never had that method (it lives on
+``ClickHouseMetricsSink``). The guard was ALWAYS false, so
+``probe/source-measured-zero`` silently kept whatever random, near-certainly
+nonzero ``deployment_frequency`` value ``run_fixtures_generation``'s own
+metrics pass had already written, while ``sources.json`` claimed the repo
+reads 0.0 -- a measurement that never happened, reading as coverage.
+
+This file proves the fix two ways:
+  1. ``write_and_verify_measured_zero_metric`` against a stub client whose
+     query responses are fully controlled, covering both failure shapes
+     (wrong row count after delete+write; wrong value) and the success
+     path.
+  2. A RED/GREEN pair against the real function: temporarily skip the
+     delete step (simulating the pre-existing-row bug) and observe the
+     postcondition assertion actually fire, then restore and observe green.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.fixtures.world import (
+    MeasuredZeroWriteError,
+    write_and_verify_measured_zero_metric,
+)
+
+_REPO_ID = UUID("00000000-0000-0000-0000-000000000001")
+_ORG_ID = "org-1"
+_DAY = date(2026, 8, 4)
+_COMPUTED_AT = datetime(2026, 8, 5, tzinfo=timezone.utc)
+
+
+class _StubResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self.result_rows = rows
+
+
+class _StubClient:
+    """Controls exactly what the post-write SELECT returns, independent of
+    whether the DELETE/insert calls actually did anything -- lets the test
+    directly exercise the postcondition-assertion branch shapes."""
+
+    def __init__(self, select_rows: list[tuple[Any, ...]]) -> None:
+        self.select_rows = select_rows
+        self.commands: list[tuple[str, dict[str, Any]]] = []
+        self.inserts: list[tuple[str, list, list[str]]] = []
+
+    def command(self, query: str, parameters: dict[str, Any]) -> None:
+        self.commands.append((query, parameters))
+
+    def query(self, query: str, parameters: dict[str, Any]) -> _StubResult:
+        return _StubResult(self.select_rows)
+
+    def insert(self, table: str, matrix: list, column_names: list[str]) -> None:
+        self.inserts.append((table, matrix, column_names))
+
+
+@pytest.mark.asyncio
+class TestWriteAndVerifyMeasuredZeroMetric:
+    async def test_success_path_exactly_one_zero_row(self) -> None:
+        client = _StubClient(select_rows=[(0.0,)])
+        # Should not raise.
+        await write_and_verify_measured_zero_metric(
+            client,
+            sink_dsn="clickhouse://ch:ch@localhost:8123/scratch_db",
+            repo_id=_REPO_ID,
+            org_id=_ORG_ID,
+            metric_name="deployment_frequency",
+            day=_DAY,
+            computed_at=_COMPUTED_AT,
+        )
+        # The delete ran before the insert (defense against the plain
+        # MergeTree's lack of dedup).
+        assert len(client.commands) == 1
+        assert "DELETE" in client.commands[0][0]
+        assert len(client.inserts) == 1
+        assert client.inserts[0][0] == "dora_metrics_daily"
+
+    async def test_red_wrong_row_count_raises(self) -> None:
+        """Simulates the exact original bug's residue: the pre-existing
+        run_fixtures_generation row survives alongside the new one because
+        nothing deleted it -- two rows where exactly one is expected."""
+        client = _StubClient(select_rows=[(0.0,), (2.7,)])
+        with pytest.raises(MeasuredZeroWriteError, match="expected exactly 1 row"):
+            await write_and_verify_measured_zero_metric(
+                client,
+                sink_dsn="clickhouse://ch:ch@localhost:8123/scratch_db",
+                repo_id=_REPO_ID,
+                org_id=_ORG_ID,
+                metric_name="deployment_frequency",
+                day=_DAY,
+                computed_at=_COMPUTED_AT,
+            )
+
+    async def test_red_zero_rows_raises(self) -> None:
+        client = _StubClient(select_rows=[])
+        with pytest.raises(MeasuredZeroWriteError, match="expected exactly 1 row"):
+            await write_and_verify_measured_zero_metric(
+                client,
+                sink_dsn="clickhouse://ch:ch@localhost:8123/scratch_db",
+                repo_id=_REPO_ID,
+                org_id=_ORG_ID,
+                metric_name="deployment_frequency",
+                day=_DAY,
+                computed_at=_COMPUTED_AT,
+            )
+
+    async def test_red_nonzero_value_raises(self) -> None:
+        """The exact original failure mode: the write call 'succeeded'
+        (returned without raising) but the value read back is the
+        pre-existing random metric, not 0.0."""
+        client = _StubClient(select_rows=[(1.5,)])
+        with pytest.raises(MeasuredZeroWriteError, match="expected exactly 0.0"):
+            await write_and_verify_measured_zero_metric(
+                client,
+                sink_dsn="clickhouse://ch:ch@localhost:8123/scratch_db",
+                repo_id=_REPO_ID,
+                org_id=_ORG_ID,
+                metric_name="deployment_frequency",
+                day=_DAY,
+                computed_at=_COMPUTED_AT,
+            )
+
+
+@pytest.mark.asyncio
+async def test_hasattr_regression_guard_no_longer_used() -> None:
+    """Direct regression proof for the ORIGINAL bug shape: a
+    ClickHouseStore-like object (no write_dora_metrics attribute at all)
+    must not silently no-op the whole measured-zero realization anymore --
+    the fixed function never branches on hasattr(store, ...) in the first
+    place, it always writes via a real ClickHouseMetricsSink."""
+    client = _StubClient(select_rows=[(0.0,)])
+
+    class _StoreWithoutWriteDoraMetrics:
+        """Mirrors the real bug precisely: no write_dora_metrics method."""
+
+    assert not hasattr(_StoreWithoutWriteDoraMetrics(), "write_dora_metrics")
+
+    # The fixed call path never references `store` at all -- it is handed
+    # the raw client directly, so the absent method on a hypothetical store
+    # object is structurally irrelevant now.
+    await write_and_verify_measured_zero_metric(
+        client,
+        sink_dsn="clickhouse://ch:ch@localhost:8123/scratch_db",
+        repo_id=_REPO_ID,
+        org_id=_ORG_ID,
+        metric_name="deployment_frequency",
+        day=_DAY,
+        computed_at=_COMPUTED_AT,
+    )
+    assert len(client.inserts) == 1

--- a/tests/test_fixtures_world_runner.py
+++ b/tests/test_fixtures_world_runner.py
@@ -1,0 +1,220 @@
+"""CHAOS-3219: `dev-hops fixtures world` CLI wiring + multi-org mixed-org
+guard extension.
+
+Mirrors ``tests/test_fixtures_mixed_org_guard.py``'s style: argparse wiring
+assertions plus a monkeypatched ``run_fixtures_generation`` to prove the
+per-repo loop actually surfaces a guard refusal instead of silently
+continuing past it.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.fixtures.runner import register_commands
+from dev_health_ops.fixtures.world import (
+    WorldManifest,
+    _generate_world,
+    _generation_namespace,
+)
+
+_WORLD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "acceptance"
+    / "world"
+    / "ask-dev-world.v1"
+)
+
+
+def _world_namespace(**overrides) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    register_commands(parser.add_subparsers(dest="command"))
+    args = [
+        "fixtures",
+        "world",
+        "--manifest",
+        str(_WORLD_DIR / "world.json"),
+        "--sink",
+        "clickhouse://stub:8123/stub",
+    ]
+    ns = parser.parse_args(args)
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_world_parser_requires_manifest() -> None:
+    parser = argparse.ArgumentParser()
+    register_commands(parser.add_subparsers(dest="command"))
+    with pytest.raises(SystemExit):
+        parser.parse_args(["fixtures", "world", "--sink", "clickhouse://x/y"])
+
+
+def test_world_parser_defaults() -> None:
+    ns = _world_namespace()
+    assert ns.verify_digest is False
+    assert ns.allow_mixed_org is False
+    assert ns.postgres_uri is None
+    assert ns.digest_path is None
+    assert callable(ns.func)
+
+
+def test_world_parser_verify_digest_flag() -> None:
+    parser = argparse.ArgumentParser()
+    register_commands(parser.add_subparsers(dest="command"))
+    ns2 = parser.parse_args(
+        [
+            "fixtures",
+            "world",
+            "--manifest",
+            str(_WORLD_DIR / "world.json"),
+            "--verify-digest",
+        ]
+    )
+    assert ns2.verify_digest is True
+
+
+def test_world_func_is_a_coroutine_function() -> None:
+    """cli.py dispatches via `inspect.iscoroutinefunction(func)` ->
+    `asyncio.run(func(ns))`; a plain-def wrapper here would silently return
+    an un-awaited coroutine and crash with `int(coroutine)` (a real defect
+    caught during Lane 1a's own live verification run)."""
+
+    import inspect
+
+    ns = _world_namespace()
+    assert inspect.iscoroutinefunction(ns.func)
+
+
+class TestGenerationNamespace:
+    def test_repo_count_one_preserves_exact_repo_name(self) -> None:
+        import json
+        import uuid
+
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+        manifest = WorldManifest(
+            manifest_path=_WORLD_DIR / "world.json",
+            world=world,
+            subjects=subjects,
+            sources=sources,
+        )
+        ns = _generation_namespace(
+            manifest,
+            org_alias="primary",
+            org_id=uuid.uuid4(),
+            repo_full_name="meridian/web-app",
+            sink="clickhouse://stub/stub",
+            allow_mixed_org=False,
+        )
+        assert ns.repo_name == "meridian/web-app"
+        assert ns.repo_count == 1
+
+    def test_no_data_probe_repos_use_ordinary_generation_profile(self) -> None:
+        """generate_commits/generate_work_items raise on a zero-volume
+        profile (`random.randint(1, 0)`) -- the no-data/measured-zero probes
+        must generate normally and be zeroed POST-hoc instead (see
+        world.NO_DATA_PROBE_REPOS / _run_clickhouse_postprocess)."""
+        import json
+        import uuid
+
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+        manifest = WorldManifest(
+            manifest_path=_WORLD_DIR / "world.json",
+            world=world,
+            subjects=subjects,
+            sources=sources,
+        )
+        ns = _generation_namespace(
+            manifest,
+            org_alias="primary",
+            org_id=uuid.uuid4(),
+            repo_full_name="probe/source-no-data",
+            sink="clickhouse://stub/stub",
+            allow_mixed_org=False,
+        )
+        assert ns.commits_per_day > 0
+        assert ns.pr_count > 0
+
+    def test_truncated_probe_gets_elevated_volume(self) -> None:
+        import json
+        import uuid
+
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+        manifest = WorldManifest(
+            manifest_path=_WORLD_DIR / "world.json",
+            world=world,
+            subjects=subjects,
+            sources=sources,
+        )
+        default_ns = _generation_namespace(
+            manifest,
+            org_alias="primary",
+            org_id=uuid.uuid4(),
+            repo_full_name="meridian/web-app",
+            sink="clickhouse://stub/stub",
+            allow_mixed_org=False,
+        )
+        truncated_ns = _generation_namespace(
+            manifest,
+            org_alias="primary",
+            org_id=uuid.uuid4(),
+            repo_full_name="probe/source-truncated-workgraph",
+            sink="clickhouse://stub/stub",
+            allow_mixed_org=False,
+        )
+        assert truncated_ns.pr_count > default_ns.pr_count
+        assert truncated_ns.commits_per_day > default_ns.commits_per_day
+
+
+@pytest.mark.asyncio
+async def test_multi_org_world_stops_on_first_mixed_org_refusal(monkeypatch) -> None:
+    """Extends the CHAOS-2778 mixed-org guard to the multi-org/multi-repo
+    world loop: `run_fixtures_generation` already runs `_ensure_org_
+    unpolluted` per call (unchanged, reused verbatim -- see world.py's
+    docstring) -- this proves `_generate_world`'s per-repo loop actually
+    SURFACES that refusal (stops and returns nonzero) instead of treating a
+    guard failure as skippable and moving on to the next repo/org, which
+    would silently under-generate the world while still exiting 0."""
+
+    from dev_health_ops.fixtures import world as world_module
+
+    manifest = world_module.load_world_manifest(_WORLD_DIR / "world.json")
+
+    calls: list[str] = []
+
+    async def _fake_run_fixtures_generation(ns: argparse.Namespace) -> int:
+        calls.append(ns.repo_name)
+        # Simulate MixedOrgError surfaced as exit code 1 by the SECOND repo
+        # call (mirrors run_fixtures_generation's own MixedOrgError -> 1
+        # contract in runner.py).
+        if len(calls) == 2:
+            return 1
+        return 0
+
+    async def _fake_postgres_phase(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        world_module, "run_fixtures_generation", _fake_run_fixtures_generation
+    )
+    monkeypatch.setattr(world_module, "_run_postgres_phase", _fake_postgres_phase)
+    monkeypatch.setenv("POSTGRES_URI", "postgresql+asyncpg://stub/stub")
+
+    ns = _world_namespace()
+    rc = await _generate_world(ns, manifest)
+
+    assert rc == 1
+    assert len(calls) == 2, (
+        "the loop must stop at the first refusal, not silently continue "
+        "generating the remaining roster"
+    )

--- a/tests/test_fixtures_world_scratch_guard.py
+++ b/tests/test_fixtures_world_scratch_guard.py
@@ -1,0 +1,238 @@
+"""CHAOS-3219 Codex adversarial review (CRITICAL, 2026-08-05):
+
+``dev-hops fixtures world --sink``/``--postgres-uri`` accepted ANY
+ClickHouse/Postgres URI, including the shared dev ``default``/``devhealth``
+databases, with no check at all -- the world flow issues destructive
+mutations (``ALTER TABLE ... DELETE``, delete-and-reinsert aging,
+``DROP``/``CREATE DATABASE`` in normal operator setup) that must never
+reach a real database.
+
+This file proves the fix: :func:`_require_scratch_database` rejects every
+known-unsafe target and the missing-scratch-marker case, accepts an
+explicit scratch name, and -- the RED test that matters most -- proves
+``run_fixtures_world`` refuses BEFORE ever calling ``_generate_world`` /
+``_verify_digest`` (i.e. before any connection/migration), not merely
+somewhere downstream after damage could already have been done.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.fixtures.world import (
+    UnsafeSinkError,
+    _database_name_from_uri,
+    _require_scratch_database,
+    run_fixtures_world,
+)
+
+_WORLD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "acceptance"
+    / "world"
+    / "ask-dev-world.v1"
+)
+
+
+class TestDatabaseNameFromUri:
+    def test_extracts_path_component(self) -> None:
+        assert (
+            _database_name_from_uri("clickhouse://ch:ch@localhost:8123/my_scratch")
+            == "my_scratch"
+        )
+
+    def test_strips_query_string(self) -> None:
+        assert (
+            _database_name_from_uri(
+                "postgresql+asyncpg://u:p@host:5432/foo_scratch?sslmode=disable"
+            )
+            == "foo_scratch"
+        )
+
+    def test_missing_path_is_empty(self) -> None:
+        assert _database_name_from_uri("clickhouse://ch:ch@localhost:8123") == ""
+
+
+class TestRequireScratchDatabase:
+    def test_rejects_none(self) -> None:
+        with pytest.raises(UnsafeSinkError, match="no clickhouse URI"):
+            _require_scratch_database(None, kind="clickhouse")
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(UnsafeSinkError):
+            _require_scratch_database("", kind="clickhouse")
+
+    def test_rejects_clickhouse_default(self) -> None:
+        with pytest.raises(UnsafeSinkError, match="'default'"):
+            _require_scratch_database(
+                "clickhouse://ch:ch@localhost:8123/default", kind="clickhouse"
+            )
+
+    def test_rejects_clickhouse_missing_path_same_as_default(self) -> None:
+        """clickhouse-connect treats an omitted path as the `default`
+        database -- the guard must treat the empty name identically."""
+        with pytest.raises(UnsafeSinkError):
+            _require_scratch_database(
+                "clickhouse://ch:ch@localhost:8123", kind="clickhouse"
+            )
+
+    def test_rejects_postgres_devhealth(self) -> None:
+        with pytest.raises(UnsafeSinkError, match="'devhealth'"):
+            _require_scratch_database(
+                "postgresql+asyncpg://devhealth:devhealth@localhost:5432/devhealth",
+                kind="postgres",
+            )
+
+    def test_rejects_postgres_admin_default(self) -> None:
+        with pytest.raises(UnsafeSinkError, match="'postgres'"):
+            _require_scratch_database(
+                "postgresql+asyncpg://u:p@localhost:5432/postgres", kind="postgres"
+            )
+
+    def test_rejects_postgres_templates(self) -> None:
+        for template in ("template0", "template1"):
+            with pytest.raises(UnsafeSinkError, match=template):
+                _require_scratch_database(
+                    f"postgresql+asyncpg://u:p@localhost:5432/{template}",
+                    kind="postgres",
+                )
+
+    def test_rejects_database_missing_scratch_marker(self) -> None:
+        """A denylist alone is insufficient -- an unenumerated real
+        database name (here: a plausible future project db) must ALSO be
+        rejected because it lacks the positive scratch marker."""
+        with pytest.raises(UnsafeSinkError, match="scratch"):
+            _require_scratch_database(
+                "clickhouse://ch:ch@localhost:8123/some_other_real_project_db",
+                kind="clickhouse",
+            )
+
+    def test_accepts_explicit_scratch_name(self) -> None:
+        _require_scratch_database(
+            "clickhouse://ch:ch@localhost:8123/chaos3219_world_scratch",
+            kind="clickhouse",
+        )
+        _require_scratch_database(
+            "postgresql+asyncpg://u:p@localhost:5432/chaos3219_world_scratch_b",
+            kind="postgres",
+        )
+
+    def test_accepts_ci_local_validate_convention(self) -> None:
+        """Matches ci/local_validate.sh's own scratch naming convention."""
+        _require_scratch_database(
+            "clickhouse://ch:ch@localhost:8123/ci_local_validate_05a00cac4194",
+            kind="clickhouse",
+        )
+
+    def test_marker_check_is_case_insensitive(self) -> None:
+        _require_scratch_database(
+            "clickhouse://ch:ch@localhost:8123/MY_SCRATCH_DB", kind="clickhouse"
+        )
+
+
+def _ns_with_defaults(**overrides) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        manifest=str(_WORLD_DIR / "world.json"),
+        sink="clickhouse://ch:ch@localhost:8123/chaos3219_world_scratch",
+        postgres_uri="postgresql+asyncpg://u:p@localhost:5432/chaos3219_world_scratch",
+        digest_path=None,
+        verify_digest=False,
+        allow_mixed_org=False,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+@pytest.mark.asyncio
+class TestRunFixturesWorldRefusesBeforeAnyConnection:
+    """The RED test that matters: prove the guard fires BEFORE
+    `_generate_world`/`_verify_digest` are ever reached, not just that it
+    fires eventually. A guard bolted on somewhere downstream, after a
+    connection or a migration already ran, would not satisfy the CRITICAL
+    finding even if it happened to also return 1."""
+
+    async def test_unsafe_clickhouse_sink_blocks_generation(self, monkeypatch) -> None:
+        from dev_health_ops.fixtures import world as world_module
+
+        called = []
+
+        async def _must_not_be_called(*args, **kwargs):
+            called.append(True)
+            raise AssertionError(
+                "_generate_world must never be reached when --sink is unsafe"
+            )
+
+        monkeypatch.setattr(world_module, "_generate_world", _must_not_be_called)
+
+        ns = _ns_with_defaults(sink="clickhouse://ch:ch@localhost:8123/default")
+        rc = await run_fixtures_world(ns)
+
+        assert rc == 1
+        assert called == [], "the guard must short-circuit before generation runs"
+
+    async def test_unsafe_postgres_uri_blocks_generation(self, monkeypatch) -> None:
+        from dev_health_ops.fixtures import world as world_module
+
+        called = []
+
+        async def _must_not_be_called(*args, **kwargs):
+            called.append(True)
+            raise AssertionError(
+                "_generate_world must never be reached when --postgres-uri is unsafe"
+            )
+
+        monkeypatch.setattr(world_module, "_generate_world", _must_not_be_called)
+
+        ns = _ns_with_defaults(
+            postgres_uri="postgresql+asyncpg://devhealth:devhealth@localhost:5432/devhealth"
+        )
+        rc = await run_fixtures_world(ns)
+
+        assert rc == 1
+        assert called == [], "the guard must short-circuit before generation runs"
+
+    async def test_unsafe_sink_also_blocks_verify_digest(self, monkeypatch) -> None:
+        from dev_health_ops.fixtures import world as world_module
+
+        called = []
+
+        async def _must_not_be_called(*args, **kwargs):
+            called.append(True)
+            raise AssertionError(
+                "_verify_digest must never be reached when --sink is unsafe"
+            )
+
+        monkeypatch.setattr(world_module, "_verify_digest", _must_not_be_called)
+
+        ns = _ns_with_defaults(
+            sink="clickhouse://ch:ch@localhost:8123/default", verify_digest=True
+        )
+        rc = await run_fixtures_world(ns)
+
+        assert rc == 1
+        assert called == []
+
+    async def test_safe_uris_reach_generation(self, monkeypatch) -> None:
+        """Inverse proof: the guard is not simply always-refusing -- a
+        genuinely scratch-named pair of URIs passes through to
+        `_generate_world`."""
+        from dev_health_ops.fixtures import world as world_module
+
+        called = []
+
+        async def _fake_generate_world(ns, manifest):
+            called.append(True)
+            return 0
+
+        monkeypatch.setattr(world_module, "_generate_world", _fake_generate_world)
+
+        ns = _ns_with_defaults()  # both URIs are scratch-named despite the helper name
+        rc = await run_fixtures_world(ns)
+
+        assert rc == 0
+        assert called == [True]

--- a/tests/test_fixtures_world_source_aging.py
+++ b/tests/test_fixtures_world_source_aging.py
@@ -1,0 +1,294 @@
+"""CHAOS-3219 Codex adversarial review (HIGH-5, 2026-08-05) -- full history:
+
+1. ORIGINAL bug: ``age_source_rows`` was delete-then-reinsert. If the
+   process died between those two ClickHouse calls (crash, OOM-kill,
+   network partition), the affected table was left with ZERO rows for that
+   org/repo, which ``DataHealthService.inspect`` reads as
+   ``DataHealthState.NO_DATA``, silently corrupting a "stale" claim into a
+   "no data" one.
+
+2. FIRST fix attempt (same day): reorder to insert-then-delete, reasoning
+   that the worst a crash could do is leave both old and aged rows present,
+   which a ReplacingMergeTree resolves harmlessly via FINAL.
+
+3. That reasoning was WRONG, caught live: every affected table is a
+   ``ReplacingMergeTree(<watermark column>)``, and "aging" a row means
+   writing a LOWER version value than what's already there -- exactly the
+   case ReplacingMergeTree's "highest version wins" merge rule resolves the
+   wrong way. A live two-generation run caught this directly via
+   ``system.part_log`` forensics on a real scratch ClickHouse: the aged
+   INSERT landed (``NewPart``, 39 rows), a background merge started ~300
+   MICROSECONDS later and finished in ~2.4ms, and the merge kept the
+   pre-existing higher-version (un-aged) rows -- silently, with NO crash
+   and NO exception, under completely normal execution. Insert-then-delete
+   is strictly worse than the bug it was meant to fix: the corruption no
+   longer needs a crash to happen, and the postcondition check is the only
+   reason it was noticed at all rather than shipping as an invisible bug.
+
+4. CORRECTED fix (this file describes what's actually shipped): back to
+   delete-then-insert, which has no competing higher-version row left for a
+   merge to prefer once the delete completes, plus the postcondition check
+   from step 2 kept as a genuine improvement over the ORIGINAL code (which
+   had zero verification of any kind). The one hazard that remains -- a
+   crash strictly between the delete and the insert -- cannot be closed at
+   the ClickHouse-statement level (no cross-statement transactions for
+   MergeTree tables) and is bounded instead by the operating model:
+   ``fixtures world`` runs only against disposable SCRATCH databases that
+   are always regenerated fresh, never resumed in place after a failure.
+
+This file proves, with a *stateful* stub ClickHouse client (one that
+actually stores rows, not just records calls -- per the CLAUDE.md "assert
+the state the system exists to reach" rule):
+
+  - the happy path: delete runs before insert, ending with exactly the
+    aged rows present;
+  - a delete failure skips the insert entirely (original rows untouched);
+  - an insert that "succeeds" but isn't confirmed durable raises loudly
+    instead of being silently accepted (this table is empty at that point
+    -- the honestly-documented residual gap, now at least LOUD rather than
+    silent);
+  - the REJECTED design's failure mode reproduced directly: even with no
+    crash at all, insert-then-delete loses the aged write to a
+    ReplacingMergeTree merge that prefers the higher (un-aged) version --
+    proving this file would have caught the bug that live testing caught,
+    not just exercising the code that replaced it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from dev_health_ops.fixtures.generators import source_health
+
+_ORG = "org-1"
+_REPO = "repo-1"
+_OLD_WATERMARK = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_STALE_WATERMARK = datetime(2020, 6, 1, tzinfo=timezone.utc)
+
+_COLUMNS = ["repo_id", "hash", "org_id", "last_synced"]
+
+
+def _seed_row() -> list[Any]:
+    return [_REPO, "deadbeef", _ORG, _OLD_WATERMARK]
+
+
+class _StubResult:
+    def __init__(self, column_names: list[str], rows: list[list[Any]]) -> None:
+        self.column_names = column_names
+        self.result_rows = [tuple(row) for row in rows]
+
+
+class _StatefulStubClient:
+    """Actually stores rows -- ``insert`` appends, ``command`` (DELETE)
+    empties or filters, ``query`` reads back current state. This is what
+    makes the row-count assertions below a measurement of real state, not
+    just a check that the right methods were called."""
+
+    def __init__(self, rows: list[list[Any]]) -> None:
+        self.rows: list[list[Any]] = [list(r) for r in rows]
+        self.column_names = list(_COLUMNS)
+        self.watermark_idx = self.column_names.index("last_synced")
+        #: each entry is (table, rows_snapshot, column_names, rows_in_table_before)
+        #: -- the last element lets tests prove ORDERING structurally (e.g.
+        #: "the table was already empty when insert() ran"), not just count
+        #: how many times each method was called.
+        self.insert_calls: list[tuple[Any, ...]] = []
+        self.command_calls: list[tuple[str, int]] = []
+        self.raise_on_insert: Exception | None = None
+        self.raise_on_command: Exception | None = None
+        #: if set, the count-check query returns this instead of the true
+        #: count -- simulates a write whose durability hasn't been confirmed.
+        self.force_observed_count: int | None = None
+
+    def query(self, sql: str, parameters: dict[str, Any]) -> _StubResult:
+        if "count()" in sql:
+            if self.force_observed_count is not None:
+                return _StubResult(["count"], [[self.force_observed_count]])
+            stale = parameters["stale_watermark"]
+            count = sum(1 for r in self.rows if r[self.watermark_idx] == stale)
+            return _StubResult(["count"], [[count]])
+        return _StubResult(self.column_names, self.rows)
+
+    def insert(
+        self, table: str, rows: list[list[Any]], column_names: list[str]
+    ) -> None:
+        self.insert_calls.append(
+            (table, [list(r) for r in rows], column_names, len(self.rows))
+        )
+        if self.raise_on_insert is not None:
+            raise self.raise_on_insert
+        self.rows.extend(list(r) for r in rows)
+
+    def command(self, sql: str, parameters: dict[str, Any]) -> None:
+        self.command_calls.append((sql, len(self.rows)))
+        if self.raise_on_command is not None:
+            raise self.raise_on_command
+        if "stale_watermark" in parameters:
+            # The REJECTED insert-then-delete design's delete: exclude the
+            # already-inserted aged rows, remove only the superseded
+            # originals. Not exercised by the shipped code path, kept only
+            # so the rejected-design reference tests below can drive this
+            # stub the same way that design would have.
+            stale = parameters["stale_watermark"]
+            self.rows = [r for r in self.rows if r[self.watermark_idx] == stale]
+        else:
+            # The SHIPPED delete-then-insert design's delete: unconditional
+            # on org_id/repo_id alone (every row this stub ever holds
+            # already matches those, by construction).
+            self.rows = []
+
+
+async def _age(client: Any) -> None:
+    await source_health.age_source_rows(
+        client,
+        org_id=_ORG,
+        repo_id=_REPO,
+        source="commits",
+        stale_watermark=_STALE_WATERMARK,
+    )
+
+
+class TestAgeSourceRowsHappyPath:
+    @pytest.mark.asyncio
+    async def test_ends_with_only_aged_rows(self) -> None:
+        client = _StatefulStubClient([_seed_row()])
+        await _age(client)
+        assert len(client.rows) == 1
+        assert client.rows[0][client.watermark_idx] == _STALE_WATERMARK
+
+    @pytest.mark.asyncio
+    async def test_delete_happens_before_insert(self) -> None:
+        client = _StatefulStubClient([_seed_row()])
+        await _age(client)
+        assert len(client.command_calls) == 1
+        assert len(client.insert_calls) == 1
+        # Structural proof, not a call-count coincidence: at the moment
+        # insert() ran, the table had already been emptied by the (earlier)
+        # delete call.
+        _table, _rows, _cols, rows_in_table_before_insert = client.insert_calls[0]
+        assert rows_in_table_before_insert == 0, (
+            "insert() must run AFTER delete() -- this is the corrected "
+            "ordering: no competing higher-version row may be present when "
+            "the aged rows are written, or a ReplacingMergeTree merge can "
+            "silently prefer the wrong one (see module docstring)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_rows_is_a_noop(self) -> None:
+        client = _StatefulStubClient([])
+        await _age(client)
+        assert client.insert_calls == []
+        assert client.command_calls == []
+
+
+class TestAgeSourceRowsDeleteFailure:
+    @pytest.mark.asyncio
+    async def test_delete_exception_propagates_and_skips_insert(self) -> None:
+        client = _StatefulStubClient([_seed_row()])
+        client.raise_on_command = RuntimeError("simulated ClickHouse delete failure")
+        with pytest.raises(RuntimeError, match="simulated ClickHouse delete failure"):
+            await _age(client)
+        assert client.insert_calls == [], (
+            "insert must never run if the delete raised -- the original "
+            "row must be untouched"
+        )
+        assert len(client.rows) == 1
+        assert client.rows[0][client.watermark_idx] == _OLD_WATERMARK
+
+
+class TestAgeSourceRowsUnconfirmedInsert:
+    @pytest.mark.asyncio
+    async def test_short_observed_count_raises_loudly(self) -> None:
+        client = _StatefulStubClient([_seed_row()])
+        # The delete already ran (this design's first step) and the insert
+        # "succeeds" (appends normally), but the read-your-write count
+        # check is forced to see fewer rows than were just inserted --
+        # simulating a write whose durability hasn't been confirmed yet.
+        client.force_observed_count = 0
+        with pytest.raises(
+            source_health.SourceAgingWriteError, match="not confirmed durable"
+        ):
+            await _age(client)
+        # This IS the honestly-documented residual gap: the original row
+        # is already gone (delete ran first) and the new one is
+        # unconfirmed. Nothing can retroactively make this atomic -- what
+        # this postcondition buys is that the operation FAILS LOUDLY here
+        # instead of silently reporting success over an unverified write.
+        assert len(client.rows) == 1
+        assert client.rows[0][client.watermark_idx] == _STALE_WATERMARK
+
+
+class TestOrderingRationale:
+    """Proves the actual tradeoff ``age_source_rows``'s docstring describes,
+    for BOTH orderings, against the stateful stub -- so neither claim is
+    prose the suite doesn't verify."""
+
+    @pytest.mark.asyncio
+    async def test_shipped_ordering_crash_between_steps_reaches_zero_rows(
+        self,
+    ) -> None:
+        """The one hazard delete-then-insert cannot avoid: a process crash
+        landing strictly between the DELETE and the INSERT leaves zero
+        rows. Proven here (not hidden) so nobody mistakes this suite for
+        claiming a guarantee ClickHouse cannot actually provide -- the
+        function's docstring explains why this residual window is accepted
+        (bounded by the scratch-database, regenerate-fresh operating
+        model) rather than pretended away."""
+
+        client = _StatefulStubClient([_seed_row()])
+        client.raise_on_insert = RuntimeError(
+            "simulated crash between DELETE and INSERT"
+        )
+
+        with pytest.raises(
+            RuntimeError, match="simulated crash between DELETE and INSERT"
+        ):
+            await _age(client)
+
+        assert len(client.rows) == 0, (
+            "a crash strictly between delete and insert does leave zero "
+            "rows under the shipped ordering -- this is the known, "
+            "documented residual gap, not a claim this test disproves"
+        )
+
+    def test_rejected_insert_then_delete_loses_the_aged_write_to_a_merge(
+        self,
+    ) -> None:
+        """RED proof for the REJECTED design, reproducing what live
+        ClickHouse forensics caught: with insert-then-delete, even with NO
+        crash at all, the aged replacement can lose to a background
+        ReplacingMergeTree merge that always keeps the row with the HIGHER
+        version column -- and "aging" always writes a LOWER value. A stub
+        cannot run ClickHouse's real background merge scheduler, so this
+        models the merge's documented outcome directly: independently
+        confirmed live (see ``age_source_rows``'s docstring) via
+        ``system.part_log``, where a real merge started ~300us after the
+        insert and completed in ~2.4ms."""
+
+        client = _StatefulStubClient([_seed_row()])
+
+        # The rejected design's insert step: the aged row is written
+        # WITHOUT deleting the original first, so both versions coexist,
+        # pre-merge.
+        aged = list(_seed_row())
+        aged[client.watermark_idx] = _STALE_WATERMARK
+        client.rows.append(aged)
+        assert len(client.rows) == 2
+
+        # The merge: ReplacingMergeTree keeps the row with the MAX version
+        # per sorting key. Since aging always moves the watermark
+        # BACKWARD, the aged replacement always loses this race.
+        winner = max(client.rows, key=lambda r: r[client.watermark_idx])
+        client.rows = [winner]
+
+        assert winner[client.watermark_idx] == _OLD_WATERMARK, (
+            "the merge keeps the row with the numerically LARGER "
+            "watermark -- the aged (numerically smaller) replacement is "
+            "silently discarded, with no crash and no exception required. "
+            "This is why insert-then-delete was rejected: it is not "
+            "merely 'also has a crash window', it corrupts data on "
+            "completely normal, successful execution."
+        )

--- a/tests/test_fixtures_world_verify.py
+++ b/tests/test_fixtures_world_verify.py
@@ -1,0 +1,537 @@
+"""CHAOS-3219 Codex adversarial review (HIGH-2, 2026-08-05):
+
+Manifest validation was string-set membership only -- a bare
+``{"class": "deleted"}`` subjects.json row passed every existing check.
+This file proves the fix two ways:
+
+1. Typed per-entry schema (``validate_subject_entry_schema``/
+   ``validate_source_entry_schema``): the LITERAL codex example
+   (``{"class": "deleted"}``) is used as the RED test, plus one negative
+   case per subject class/source-state generic requirement.
+2. Live production-path verification stubs: the acronym-alias check runs
+   the REAL ``alias_matching.alias_forms`` (no DB needed -- a pure
+   function), and the DataHealthState/catalog-existence checks are proven
+   against a fully-controlled stub ClickHouse client covering both the
+   "claim matches reality" and "claim does NOT match reality" shapes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dev_health_ops.fixtures import world_verify
+from dev_health_ops.fixtures.world import load_world_manifest
+
+_WORLD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "acceptance"
+    / "world"
+    / "ask-dev-world.v1"
+)
+
+
+class TestValidateSubjectEntrySchema:
+    def test_red_bare_deleted_row_from_codex_finding(self) -> None:
+        """The EXACT example codex's finding names: {"class": "deleted"}
+        with nothing else must be rejected."""
+        with pytest.raises(world_verify.WorldSchemaError):
+            world_verify.validate_subject_entry_schema({"class": "deleted"})
+
+    def test_red_exact_missing_repo_full_name(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="repo_full_name"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    "id": "s1",
+                    "class": "exact",
+                    "org_alias": "primary",
+                    "mentions": ["x"],
+                    "expected_terminal_resolution": "EXACT",
+                }
+            )
+
+    def test_red_ambiguous_single_candidate(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="ambiguous"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    "id": "s2",
+                    "class": "ambiguous",
+                    "org_alias": "primary",
+                    "candidates": ["only-one"],
+                    "mentions": ["x"],
+                    "expected_terminal_resolution": "AMBIGUOUS",
+                }
+            )
+
+    def test_red_bounded_set_single_member(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="bounded-set"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    "id": "s3",
+                    "class": "bounded-set",
+                    "org_alias": "primary",
+                    "members": ["only-one"],
+                    "mentions": ["x"],
+                    "expected_terminal_resolution": "X",
+                }
+            )
+
+    def test_red_acronym_alias_missing_both_project_and_team(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="acronym-alias"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    "id": "s4",
+                    "class": "acronym-alias",
+                    "org_alias": "primary",
+                    "alias_form": "acronym",
+                    "mentions": ["MWA"],
+                    "expected_terminal_resolution": "X",
+                }
+            )
+
+    def test_green_well_formed_exact(self) -> None:
+        world_verify.validate_subject_entry_schema(
+            {
+                "id": "s5",
+                "class": "exact",
+                "org_alias": "primary",
+                "repo_full_name": "meridian/web-app",
+                "mentions": ["meridian/web-app"],
+                "expected_terminal_resolution": "EXACT",
+            }
+        )
+
+    def test_green_no_match_needs_no_org_alias(self) -> None:
+        world_verify.validate_subject_entry_schema(
+            {
+                "id": "s6",
+                "class": "no-match",
+                "mentions": ["the Ask Dev project"],
+                "expected_terminal_resolution": "NOT_FOUND",
+            }
+        )
+
+    def test_red_unknown_class(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="unknown class"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    "id": "s7",
+                    "class": "totally-made-up",
+                    "org_alias": "primary",
+                    "mentions": ["x"],
+                    "expected_terminal_resolution": "X",
+                }
+            )
+
+    _PARTIALLY_RESOLVED_BASE = {
+        "id": "s8",
+        "class": "partially-resolved",
+        "org_alias": "primary",
+        "team_id": "platform",
+        "mentions": ["x"],
+        "expected_terminal_resolution": "X",
+    }
+
+    def test_red_unverified_live_without_ticket_reference(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="tracked_by"):
+            world_verify.validate_subject_entry_schema(
+                {
+                    **self._PARTIALLY_RESOLVED_BASE,
+                    "verification_status": "realized-but-unverified-live",
+                }
+            )
+
+    def test_red_unknown_verification_status(self) -> None:
+        with pytest.raises(
+            world_verify.WorldSchemaError, match="unknown verification_status"
+        ):
+            world_verify.validate_subject_entry_schema(
+                {**self._PARTIALLY_RESOLVED_BASE, "verification_status": "wontfix"}
+            )
+
+    def test_green_unverified_live_with_ticket_reference(self) -> None:
+        world_verify.validate_subject_entry_schema(
+            {
+                **self._PARTIALLY_RESOLVED_BASE,
+                "verification_status": "realized-but-unverified-live",
+                "tracked_by": "CHAOS-3429 team-catalog live verification path",
+            }
+        )
+
+    def test_green_no_verification_status_is_the_default(self) -> None:
+        world_verify.validate_subject_entry_schema(self._PARTIALLY_RESOLVED_BASE)
+
+
+class TestValidateSourceEntrySchema:
+    def test_red_bare_state_only(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError):
+            world_verify.validate_source_entry_schema({"state": "stale"})
+
+    def test_red_realized_by_missing_keys(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="realized_by"):
+            world_verify.validate_source_entry_schema(
+                {
+                    "state": "stale",
+                    "data_health_state": "DataHealthState.STALE",
+                    "mechanism": "aged watermark",
+                    "realized_by": {"org_alias": "primary"},  # missing repo_full_name
+                    "source_classes": ["commits"],
+                }
+            )
+
+    def test_red_missing_source_classes(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="source_classes"):
+            world_verify.validate_source_entry_schema(
+                {
+                    "state": "stale",
+                    "data_health_state": "DataHealthState.STALE",
+                    "mechanism": "aged watermark",
+                    "realized_by": {
+                        "org_alias": "primary",
+                        "repo_full_name": "probe/source-stale",
+                    },
+                }
+            )
+
+    def test_green_null_realized_by_values_allowed(self) -> None:
+        """The documented not-applicable case: both keys present, null-valued."""
+        world_verify.validate_source_entry_schema(
+            {
+                "state": "not-applicable",
+                "data_health_state": "n/a",
+                "mechanism": "hardcoded acr special-case, no fixture needed",
+                "realized_by": {"org_alias": None, "repo_full_name": None},
+                "source_classes": ["acr"],
+            }
+        )
+
+    def test_green_well_formed(self) -> None:
+        world_verify.validate_source_entry_schema(
+            {
+                "state": "current",
+                "data_health_state": "DataHealthState.COMPLETE",
+                "mechanism": "fresh watermark",
+                "realized_by": {
+                    "org_alias": "primary",
+                    "repo_full_name": "probe/source-current",
+                },
+                "source_classes": ["commits"],
+            }
+        )
+
+
+class TestDeclaredBlockedStatus:
+    """2026-08-05: the honest third option between "realized and verified"
+    and "verified elsewhere" -- see DECLARED_BLOCKED_STATUS's own docstring
+    for the full history (the 'truncated' state's mechanism text turned out
+    to be a false 'verified empirically' claim, the first time this round's
+    new live check actually ran)."""
+
+    _BASE = {
+        "state": "truncated",
+        "data_health_state": "n/a",
+        "mechanism": "cannot currently be produced by any volume knob",
+        "realized_by": {
+            "org_alias": "primary",
+            "repo_full_name": "probe/source-truncated-workgraph",
+        },
+        "source_classes": ["work_graph"],
+    }
+
+    def test_red_declared_blocked_without_ticket_reference(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="blocked_by"):
+            world_verify.validate_source_entry_schema(
+                {**self._BASE, "status": "declared-blocked"}
+            )
+
+    def test_red_declared_blocked_with_empty_ticket_reference(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="blocked_by"):
+            world_verify.validate_source_entry_schema(
+                {**self._BASE, "status": "declared-blocked", "blocked_by": ""}
+            )
+
+    def test_red_unknown_status_value(self) -> None:
+        with pytest.raises(world_verify.WorldSchemaError, match="unknown status"):
+            world_verify.validate_source_entry_schema(
+                {**self._BASE, "status": "wontfix"}
+            )
+
+    def test_green_declared_blocked_with_ticket_reference(self) -> None:
+        world_verify.validate_source_entry_schema(
+            {
+                **self._BASE,
+                "status": "declared-blocked",
+                "blocked_by": "CHAOS-TBD generator fan-out clustering",
+            }
+        )
+
+    def test_green_no_status_is_the_default_realized_shape(self) -> None:
+        """An entry with no 'status' field at all (every OTHER sources.json
+        entry) must keep passing -- declared-blocked is additive, not a
+        new requirement on every entry."""
+        world_verify.validate_source_entry_schema(self._BASE)
+
+    def test_is_declared_blocked_true_for_blocked_entry(self) -> None:
+        entry = {
+            **self._BASE,
+            "status": "declared-blocked",
+            "blocked_by": "CHAOS-TBD generator fan-out clustering",
+        }
+        assert world_verify.is_declared_blocked(entry) is True
+
+    def test_is_declared_blocked_false_for_realized_entry(self) -> None:
+        assert world_verify.is_declared_blocked(self._BASE) is False
+
+    def test_checked_in_truncated_entry_is_declared_blocked(self) -> None:
+        """End-to-end: the actual checked-in sources.json entry this whole
+        mechanism was built for."""
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+        entry = next(e for e in sources["matrix"] if e["state"] == "truncated")
+        world_verify.validate_source_entry_schema(entry)
+        assert world_verify.is_declared_blocked(entry) is True
+        assert entry.get("blocked_by")
+
+
+class TestManifestValidationRejectsCodexExample:
+    """End-to-end: a subjects.json file containing the literal codex
+    example must fail load_world_manifest, not just the unit-level
+    validator function."""
+
+    def test_bare_deleted_row_fails_manifest_load(self, tmp_path: Path) -> None:
+        world = json.loads((_WORLD_DIR / "world.json").read_text())
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        sources = json.loads((_WORLD_DIR / "sources.json").read_text())
+
+        subjects["subjects"].append({"class": "deleted"})
+
+        (tmp_path / "world.json").write_text(json.dumps(world))
+        (tmp_path / "subjects.json").write_text(json.dumps(subjects))
+        (tmp_path / "sources.json").write_text(json.dumps(sources))
+
+        with pytest.raises(Exception, match="missing required field"):
+            load_world_manifest(tmp_path / "world.json")
+
+    def test_checked_in_manifest_still_passes(self) -> None:
+        """The real, current subjects.json/sources.json must satisfy the
+        new typed schema -- proves the stricter check isn't itself broken
+        against real content."""
+        load_world_manifest(_WORLD_DIR / "world.json")
+
+
+class TestVerifyAcronymAliasSubject:
+    """Runs the REAL alias_matching.alias_forms (pure function)."""
+
+    def test_green_acronym_matches(self) -> None:
+        world_verify.verify_acronym_alias_subject(
+            {
+                "id": "a1",
+                "project_display_name": "Meridian Web Application",
+                "mentions": ["MWA"],
+            }
+        )
+
+    def test_green_literal_parenthetical_matches(self) -> None:
+        world_verify.verify_acronym_alias_subject(
+            {
+                "id": "a2",
+                "team_display_name": "Platform Reliability (Ground Control)",
+                "mentions": ["Ground Control"],
+            }
+        )
+
+    def test_red_mention_does_not_resolve(self) -> None:
+        with pytest.raises(
+            world_verify.WorldVerificationError, match="does not resolve"
+        ):
+            world_verify.verify_acronym_alias_subject(
+                {
+                    "id": "a3",
+                    "project_display_name": "Meridian Web Application",
+                    "mentions": ["ZZZ"],
+                }
+            )
+
+    def test_red_no_display_name(self) -> None:
+        with pytest.raises(world_verify.WorldVerificationError, match="has no"):
+            world_verify.verify_acronym_alias_subject({"id": "a4", "mentions": ["MWA"]})
+
+
+class _StubResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self.result_rows = rows
+
+
+class _StubClient:
+    def __init__(
+        self, rows_by_query_substring: dict[str, list[tuple[Any, ...]]]
+    ) -> None:
+        self.rows_by_query_substring = rows_by_query_substring
+        self.queries: list[str] = []
+
+    def query(self, query: str, parameters: dict[str, Any]) -> _StubResult:
+        self.queries.append(query)
+        for substring, rows in self.rows_by_query_substring.items():
+            if substring in query:
+                return _StubResult(rows)
+        raise AssertionError(f"no stub rows configured for query: {query}")
+
+
+def _minimal_manifest() -> Any:
+    from pathlib import Path as _Path
+
+    from dev_health_ops.fixtures.world import WorldManifest
+
+    return WorldManifest(
+        manifest_path=_Path("/dev/null"),
+        world={
+            "master_seed": 1,
+            "orgs": [{"alias": "primary", "id_seed": "org:primary"}],
+            "users": [],
+        },
+        subjects={},
+        sources={},
+    )
+
+
+@pytest.mark.asyncio
+class TestVerifySubjectsAgainstProductionUnverifiedLiveGap:
+    """CHAOS-3429 (2026-08-05): the `if not repo_names: continue` gap that
+    used to silently swallow `partially-resolved` (and any future subject
+    with no repo/candidates/members) must now be loud either way -- a
+    named, ticketed skip for an explicitly marked entry, or a hard failure
+    for an unmarked one."""
+
+    async def test_red_unmarked_gap_raises(self) -> None:
+        """An entry with no repo_names and NO verification_status marker
+        must fail loudly -- this is what proves a FUTURE unverifiable
+        entry can't silently join the same blind spot the pre-3429 code
+        had for `partially-resolved`."""
+
+        manifest = _minimal_manifest()
+        manifest.subjects["subjects"] = [
+            {
+                "id": "subject.partially-resolved.example",
+                "class": "partially-resolved",
+                "org_alias": "primary",
+                "team_id": "platform",
+                "mentions": ["x"],
+                "expected_terminal_resolution": "X",
+            }
+        ]
+        client = _StubClient({})
+        with pytest.raises(
+            world_verify.WorldVerificationError, match="unmarked verification gap"
+        ):
+            await world_verify.verify_subjects_against_production(
+                client=client, manifest=manifest
+            )
+
+    async def test_green_marked_gap_logs_and_skips_without_raising(self) -> None:
+        import logging
+
+        manifest = _minimal_manifest()
+        manifest.subjects["subjects"] = [
+            {
+                "id": "subject.partially-resolved.example",
+                "class": "partially-resolved",
+                "org_alias": "primary",
+                "team_id": "platform",
+                "mentions": ["x"],
+                "expected_terminal_resolution": "X",
+                "verification_status": "realized-but-unverified-live",
+                "tracked_by": "CHAOS-3429 team-catalog live verification path",
+            }
+        ]
+        client = _StubClient({})
+        logged: list[str] = []
+
+        class _CapturingHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                logged.append(record.getMessage())
+
+        handler = _CapturingHandler(level=logging.WARNING)
+        # world_verify.py calls the module-level `logging.warning(...)`
+        # convenience function, which logs to the ROOT logger -- attach
+        # there, not to a named logger, to actually observe it.
+        logger = logging.getLogger()
+        logger.addHandler(handler)
+        try:
+            verified = await world_verify.verify_subjects_against_production(
+                client=client, manifest=manifest
+            )
+        finally:
+            logger.removeHandler(handler)
+        assert verified == [], (
+            "an unverified-live entry must NOT be reported as verified -- "
+            "that would be a false coverage claim"
+        )
+        assert any("CHAOS-3429" in message for message in logged), (
+            "the skip must be loud (a named, ticketed log line), not silent"
+        )
+
+    async def test_checked_in_partially_resolved_entry_is_marked(self) -> None:
+        """End-to-end: the actual checked-in subjects.json entry this
+        mechanism was built for skips loudly, not silently, and is not
+        falsely reported as verified."""
+
+        subjects = json.loads((_WORLD_DIR / "subjects.json").read_text())
+        manifest = _minimal_manifest()
+        manifest.subjects["subjects"] = [
+            s for s in subjects["subjects"] if s["class"] == "partially-resolved"
+        ]
+        assert len(manifest.subjects["subjects"]) == 1
+        client = _StubClient({})
+        verified = await world_verify.verify_subjects_against_production(
+            client=client, manifest=manifest
+        )
+        assert verified == []
+
+
+@pytest.mark.asyncio
+class TestVerifyConflictingCiRuns:
+    async def test_green_two_distinct_statuses(self) -> None:
+        client = _StubClient({"ci_pipeline_runs": [("success",), ("failed",)]})
+        await world_verify.verify_conflicting_ci_runs(
+            client, org_id="org-1", repo_id="repo-1"
+        )
+
+    async def test_red_only_one_status(self) -> None:
+        client = _StubClient({"ci_pipeline_runs": [("success",)]})
+        with pytest.raises(world_verify.WorldVerificationError, match="conflicting"):
+            await world_verify.verify_conflicting_ci_runs(
+                client, org_id="org-1", repo_id="repo-1"
+            )
+
+    async def test_red_no_rows(self) -> None:
+        client = _StubClient({"ci_pipeline_runs": []})
+        with pytest.raises(world_verify.WorldVerificationError):
+            await world_verify.verify_conflicting_ci_runs(
+                client, org_id="org-1", repo_id="repo-1"
+            )
+
+
+@pytest.mark.asyncio
+class TestVerifyTruncatedWorkGraph:
+    async def test_green_fanout_exceeds_max(self) -> None:
+        client = _StubClient({"work_graph_issue_pr": [(30,)]})
+        await world_verify.verify_truncated_work_graph(
+            client, org_id="org-1", max_neighbors=25
+        )
+
+    async def test_red_fanout_within_limit(self) -> None:
+        client = _StubClient({"work_graph_issue_pr": [(10,)]})
+        with pytest.raises(world_verify.WorldVerificationError, match="truncated"):
+            await world_verify.verify_truncated_work_graph(
+                client, org_id="org-1", max_neighbors=25
+            )
+
+    async def test_red_no_rows(self) -> None:
+        client = _StubClient({"work_graph_issue_pr": [(None,)]})
+        with pytest.raises(world_verify.WorldVerificationError):
+            await world_verify.verify_truncated_work_graph(
+                client, org_id="org-1", max_neighbors=25
+            )


### PR DESCRIPTION
## Summary

Codex adversarial review fixes for `ask-dev-world.v1` (CHAOS-3219 Wave 4 Phase 1 Lane 1a), plus a declared residual (CHAOS-3432) landed per explicit user disposition.

## Codex findings closed (CRITICAL + 5 HIGH), each individually live-verified

- **CRITICAL** — scratch-DB entrypoint guard: `fixtures world` now refuses any `--sink`/`--postgres-uri` that isn't an explicitly named, disposable scratch database (`UnsafeSinkError`), before any connection is opened.
- **HIGH-1** — measured-zero write bug: the previous write path silently no-op'd (wrong sink type in a `hasattr` check). Now writes through a real `ClickHouseMetricsSink` and asserts the live read-back is exactly `0.0`.
- **HIGH-2** — manifest validation vacuousness: new `world_verify.py` adds a typed per-entry schema for `subjects.json`/`sources.json` plus live production-path verification (real `alias_matching`, `DataHealthService.inspect`, catalog-row checks) after generation. Caught and fixed 3 real fixture-data bugs on first live exercise.
- **HIGH-3** — digest scope gaps: `WORLD_DIGEST` now covers 14 ClickHouse tables (was 7), with a manifest-driven per-table watermark keep-list. Live mutation tests prove stale-watermark/metric-value/work-graph-row changes move the digest.
- **HIGH-4** — sibling nondeterminism inside the pinned digest: root-caused via an enumeration-based sweep (real dynamic import closure + AST + coverage line-execution cross-reference, not a directory grep) to clock modules missing from the frozen-clock list, a postprocess handler running outside frozen-clock scope, and a random (not wall-clock) per-run identifier needing digest exclusion. One residual remains — see CHAOS-3432 below.
- **HIGH-5** — delete-then-insert aging zero-row risk: `age_source_rows` reordered to delete-then-insert with a durability postcondition. (An earlier insert-then-delete attempt was reverted after live forensics showed it introduced a worse, crash-independent corruption via a ReplacingMergeTree merge race.)

## Declared residuals (typed, ticketed, schema-validated — never a silent or false claim)

- **CHAOS-3428** — the `truncated` work-graph fan-out state was never actually achievable by the current generator; `sources.json` corrected from a false "verified empirically" claim to `declared-blocked`.
- **CHAOS-3429** — `subjects.json`'s `partially-resolved` class has no live verification path; the previously silent skip is now a loud, ticketed warning or a hard failure for any future unmarked gap.
- **CHAOS-3432** — cross-generation `WORLD_DIGEST` reproducibility (two independent `fixtures world` runs producing an identical digest) is root-caused down to a leading, unconfirmed hypothesis (concurrent ClickHouse batch insertion) but not closed. `world.json`'s new `cross_generation_digest_status` field declares this explicitly, schema-validated, with a loud runtime WARNING on every generation naming the ticket. Single-generation digest pinning (`--verify-digest`) is unaffected and proven live throughout this round.

## Validation

- 159 targeted tests green, `ruff`/`mypy` clean throughout.
- Full gate (`ci/local_validate.sh`) green except the CHAOS-3405 known-16 (verbatim id match).
