### PR TITLE
CHAOS-3412: give budget deferrals an exhaustion path

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -441,12 +441,12 @@
       "notes": "only launchdarkly/feature-flags route-ready in Go"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1974",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1999",
       "surface": "finalize_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1974
+        "line": 1999
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2313,12 +2313,12 @@
       "notes": "grep-evading form; internal to dispatch_sync_run fan-out"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1609",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1630",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1609
+        "line": 1630
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2337,12 +2337,12 @@
       "notes": "grep-evading form; internal to unit completion"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2425",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2450",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2425
+        "line": 2450
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",
@@ -2361,12 +2361,12 @@
       "notes": "grep-evading form"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:843",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:849",
       "surface": "getattr(run_sync_reference_discovery,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 843
+        "line": 849
       },
       "queue_or_cadence": "n/a",
       "dispatches": "run_sync_reference_discovery",
@@ -2385,12 +2385,12 @@
       "notes": "grep-evading form; reconciler repair redrive"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:861",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:867",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 861
+        "line": 867
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2409,12 +2409,12 @@
       "notes": "grep-evading form; reconciler repair redrive"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:869",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_reconciler.py:875",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_reconciler.py",
-        "line": 869
+        "line": 875
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2481,12 +2481,12 @@
       "notes": "grep-evading form; POST /webhooks/pagerduty/{binding_id}"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:475",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:476",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 475
+        "line": 476
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2505,12 +2505,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/sync"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:547",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:548",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 547
+        "line": 548
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2602,12 +2602,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:424",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:425",
       "surface": "POST /integrations/{integration_id}/sync",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 424
+        "line": 425
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2627,12 +2627,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:496",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:497",
       "surface": "POST /integrations/{integration_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 496
+        "line": 497
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/docs/admin/sync-and-coverage/status-and-freshness.md
+++ b/docs/admin/sync-and-coverage/status-and-freshness.md
@@ -41,6 +41,32 @@ Read the administrative activity and execution records together:
 
 Manual, scheduled, and backfill synchronization share the same canonical run model. The timing trigger differs; the execution truth should still identify the planned units and final outcome.
 
+### Budget-deferred and budget-exhausted units
+
+A unit whose estimated provider cost does not fit its budget bucket is
+*deferred*, not failed: it returns to `retrying` with a later availability
+time and the reason `budget_deferred`. This is normal when a bucket is
+temporarily full. It is **not** normal for the same unit to stay there.
+
+Read the two states separately:
+
+- **Blocked.** The run's unit rollup reports a budget-blocked count, and each
+  unit reports how many times it has been deferred. A dataset that is enabled,
+  shows as enabled, and produces nothing is visible here rather than looking
+  idle.
+- **Exhausted.** A unit that cannot ever fit its bucket — typically the first
+  incremental synchronization of a high-cost dataset over a wide initial
+  depth — stops being deferred once its deferral count or its elapsed
+  deferral time passes the configured caps. It then fails with the reason
+  `budget_deferral_exhausted`, and the failure text names the bucket, the
+  estimate, the cap it could not fit, and the window span that produced the
+  estimate.
+
+An exhausted unit is a configuration outcome, not a provider fault. The two
+remedies are to synchronize a narrower window with a bounded backfill, or to
+raise that bucket's cap. Raising per-synchronization ingest caps is not a
+remedy — it changes what is fetched, not whether the unit is admitted.
+
 ## Check freshness against the product question
 
 Compare:

--- a/docs/contribute/architecture/contracts.md
+++ b/docs/contribute/architecture/contracts.md
@@ -170,6 +170,56 @@ Do not infer route ownership from deployed replicas, health endpoints, queue nam
 - Outbox and replay identifiers preserve tenant and source scope.
 - An ambiguous commit outcome is not safe to retry without inspection.
 
+## Deferral-episode contracts
+
+A synchronization unit carries per-episode deferral bookkeeping — a count and
+a first-seen timestamp — for each independent reason it can be held back:
+provider rate limiting, and provider-budget admission. Each pair is the sole
+input to that episode's exhaustion decision, which turns an endless deferral
+loop into a visible, terminal failure.
+
+The contract is **keep or clear**, and it is symmetric:
+
+- A stamp that ends an episode clears that episode's pair. Success ends every
+  episode.
+- A stamp that begins or continues an episode writes that episode's pair and
+  clears every other episode's pair. A budget deferral is not a rate-limit
+  event, and a rate-limit deferral is not a budget event.
+- A non-terminal stamp never leaves an episode pair untouched. Leaving stale
+  counters behind is what allows an exhaustion decision to fail a healthy unit
+  against an episode that already ended.
+- An exhaustion decision reads only its own episode's columns, and also
+  requires the unit's own last recorded error category to belong to that
+  episode. The second check is defence in depth against a missed clear site.
+
+Per-episode bookkeeping alone is not sufficient, and treating it as sufficient
+is a recurring trap. Because each episode resets the others, a unit whose
+blocking *reason* keeps changing is never measured by any of them, and sits
+blocked indefinitely — the same outcome the exhaustion decisions exist to
+prevent, reached by a different route. A separate aggregate clock therefore
+records when a unit first became blocked for any reason at all. It survives
+every episode change and is cleared only when the unit is actually dispatched
+or succeeds, and it bounds the total blocked time independently of cause.
+
+Two further rules apply to every exhaustion decision:
+
+- It is evaluated only for a unit confirmed to be blocked on the current pass,
+  under the same locks and from the same evaluation that established the block.
+  History alone never terminates a unit: one that has become admissible is
+  admitted, however long it was previously held back.
+- The failure it records is built from that same current evaluation, so the
+  reason an operator reads is the reason the decision was made on — not
+  whatever an earlier pass happened to persist.
+
+Deferral admission itself is currently implemented only in the Python
+dispatcher, but the stamps that end an episode exist in both runtimes. Where a
+runtime writes a non-terminal stamp without resetting an episode pair it does
+not know about, the exhaustion decision's error-category check is what keeps a
+stale counter from being acted on: a stamp written for an unrelated reason
+records that reason, and an exhaustion decision only accepts its own. That
+check is a backstop, not the contract. A new episode pair is not complete until
+every non-terminal stamp in every runtime accounts for it.
+
 ## Metric and taxonomy contracts
 
 Metrics and taxonomies have one registry or computation source. Units, scope, time, weighting, aggregation, evidence quality, and missing-state semantics are part of the public contract.

--- a/docs/reference/configuration/environment.md
+++ b/docs/reference/configuration/environment.md
@@ -63,6 +63,26 @@ Generate current entries for:
 - scheduler ownership;
 - Go job registry, migration state, deployment profiles, health, operator token, River schema, retention, and pool limits.
 
+Deferral exhaustion on the dispatcher uses three non-secret, restart-loaded
+caps. Two bound a single budget-deferral episode: `SYNC_BUDGET_MAX_DEFERRALS`
+(default 10) and `SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS` (default 21,600),
+whichever is reached first. Both are deliberately generous relative to the
+deferral interval, so a bucket that frees up admits the unit rather than
+terminalizing it.
+
+The third, `SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS` (default 86,400), bounds
+how long a unit may remain blocked in total, regardless of how many times the
+*reason* changes. The per-episode caps cannot cover that case: each blocking
+reason resets the other's counters, so a unit alternating between a budget
+block and a rate-limit cooldown would otherwise never reach either cap while
+never running. This aggregate clock starts when a unit first becomes blocked
+for any reason and stops only when the unit is dispatched or succeeds.
+
+No cap changes what is admitted — to change that, adjust the bucket limits
+themselves. A unit is only ever failed by one of these caps on a pass where it
+is confirmed to still be blocked; one that has become admissible is dispatched
+instead, however long it was previously held back.
+
 A setting that enables a route is not sufficient evidence that the corresponding worker owns production work. The checked-in route, handler coverage, profile, and migration state must agree.
 
 ## External services and telemetry

--- a/src/dev_health_ops/alembic/versions/0085_add_sync_unit_budget_deferrals.py
+++ b/src/dev_health_ops/alembic/versions/0085_add_sync_unit_budget_deferrals.py
@@ -1,0 +1,125 @@
+"""Add sync run unit deferral-exhaustion columns (CHAOS-3412).
+
+``sync/budget_guard.py`` defers a unit whose estimate does not fit its bucket
+by re-stamping it ``retrying`` with a fresh ``available_at``. That deferral
+does NOT increment ``attempts``, and until CHAOS-3412 no counter tracked the
+budget episode at all -- so a permanently oversized unit (a HEAVY dataset on
+a wide ``initial_sync_depth``) looped forever: never run, never failed, never
+visible.
+
+Three columns, two different lifecycles:
+
+* ``budget_deferrals`` / ``budget_first_deferred_at`` give the BUDGET episode
+  the same count-plus-wall-clock exhaustion state the rate-limit episode
+  already has in ``rate_limit_deferrals`` / ``rate_limit_first_seen_at``
+  (revision 0022). Per-episode columns are reset whenever a DIFFERENT episode
+  begins, so they measure one continuous episode.
+* ``first_blocked_at`` is the AGGREGATE clock and is deliberately NOT
+  per-episode. Each episode kind clears the other's counters, so a unit that
+  alternates between budget deferral and rate-limit cooldown keeps both
+  per-episode caps permanently out of reach while never running -- the same
+  invisible-forever outcome by a different route. ``first_blocked_at`` is set
+  once when a unit first becomes blocked for ANY reason and survives episode
+  changes; it is cleared only when the unit is actually dispatched or
+  succeeds.
+
+Lock safety: each ``ADD COLUMN`` takes a brief ACCESS EXCLUSIVE lock on
+``sync_run_units``, which is hot. On PostgreSQL 11+ a constant (non-volatile)
+``DEFAULT`` does not rewrite the table, so the lock is held only for the
+catalog update -- the real risk is queueing behind a long-running transaction
+and blocking every reader behind it. A 5s ``lock_timeout`` bounds that: the
+migration fails fast instead of stalling production. If it fails with
+``canceling statement due to lock timeout``, find and end the long
+transaction (``pg_stat_activity`` / ``pg_locks``) and re-run -- the column
+adds are individually guarded, so a retry resumes rather than failing on a
+duplicate column.
+
+Retry safety: each column is guarded individually so a rerun after a partial
+failure resumes instead of failing on a duplicate column. The downgrade
+mirrors that by dropping columns only when present.
+
+Revision ID: 0085
+Revises: 0084
+Create Date: 2026-08-05 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0085"
+down_revision: str | None = "0084"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    _set_lock_timeout()
+    _add_column_if_missing(
+        "sync_run_units",
+        sa.Column(
+            "budget_deferrals",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    _add_column_if_missing(
+        "sync_run_units",
+        sa.Column(
+            "budget_first_deferred_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    _add_column_if_missing(
+        "sync_run_units",
+        sa.Column("first_blocked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    _set_lock_timeout()
+    _drop_column_if_present("sync_run_units", "first_blocked_at")
+    _drop_column_if_present("sync_run_units", "budget_first_deferred_at")
+    _drop_column_if_present("sync_run_units", "budget_deferrals")
+
+
+def _set_lock_timeout() -> None:
+    """Bound how long this migration waits for a table lock, to 5 seconds.
+
+    ``SET LOCAL`` scopes it to the migration's own transaction, so it cannot
+    leak into any other session. Skipped on non-PostgreSQL backends (the unit
+    suite runs migrations against SQLite, which has no such setting).
+
+    The statement is a literal rather than an interpolated string: there is no
+    caller-supplied value here, and building even a constant timeout through
+    ``sa.text(f"...")`` trips
+    ``python.sqlalchemy.security.audit.avoid-sqlalchemy-text`` and reads like
+    the SQL-injection shape that rule exists to catch. Every other migration
+    in this tree issues raw DDL as a plain ``op.execute("...")`` string; this
+    now matches.
+    """
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name not in _column_names(table_name):
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    if column_name in _column_names(table_name):
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -165,6 +165,7 @@ def _unit_to_response(unit: object) -> SyncRunUnitResponse:
             "attempts": int(getattr(unit, "attempts")),
             "available_at": getattr(unit, "available_at"),
             "rate_limit_deferrals": int(getattr(unit, "rate_limit_deferrals")),
+            "budget_deferrals": int(getattr(unit, "budget_deferrals", 0) or 0),
             "duration_seconds": getattr(unit, "duration_seconds"),
             "error": getattr(unit, "error"),
             "error_category": error_category,
@@ -613,6 +614,17 @@ async def get_sync_run_units(
         )
     )
 
+    # CHAOS-3412: a unit the budget guard is holding back is 'retrying'
+    # with the guard's own error_category -- derived here rather than
+    # stored, so it stays true the moment the unit is admitted or fails.
+    budget_blocked_unit_count = sum(
+        1
+        for unit in units
+        if unit.status == "retrying"
+        and isinstance(unit.result, dict)
+        and unit.result.get("error_category") == "budget_deferred"
+    )
+
     return SyncRunUnitSummary(
         by_status=rollups["by_status"],
         by_source=rollups["by_source"],
@@ -625,6 +637,7 @@ async def get_sync_run_units(
         unit_count=total_units,
         next_retry_at=min(retry_times) if retry_times else None,
         retry_exhausted_unit_count=retry_exhausted_unit_count,
+        budget_blocked_unit_count=budget_blocked_unit_count,
         units=[
             _unit_to_response(u) for u in (units if limit is None else units[:limit])
         ],

--- a/src/dev_health_ops/api/admin/schemas/integrations.py
+++ b/src/dev_health_ops/api/admin/schemas/integrations.py
@@ -175,6 +175,11 @@ class SyncRunUnitSummary(BaseModel):
     partial_failure_summary: dict[str, Any] | None = None
     next_retry_at: datetime | None = None
     retry_exhausted_unit_count: int = 0
+    # CHAOS-3412: units the sync budget guard is currently holding back
+    # (status 'retrying' AND error_category 'budget_deferred'). Distinct
+    # from failed_unit_count: these have not failed, they are BLOCKED --
+    # the state that used to be invisible because nothing counted it.
+    budget_blocked_unit_count: int = 0
     units: list[SyncRunUnitResponse]
 
 
@@ -196,6 +201,7 @@ class SyncRunUnitResponse(BaseModel):
     attempts: int
     available_at: datetime | None
     rate_limit_deferrals: int
+    budget_deferrals: int = 0
     duration_seconds: int | None
     error: str | None
     error_category: str | None

--- a/src/dev_health_ops/models/integrations.py
+++ b/src/dev_health_ops/models/integrations.py
@@ -262,6 +262,28 @@ class SyncRunUnit(Base):
     rate_limit_first_seen_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Budget-deferral episode bookkeeping (CHAOS-3412) -- the same
+    # count-plus-wall-clock pair shape as the rate-limit episode above, but a
+    # SEPARATE episode: a budget deferral is not a rate limit, and each kind
+    # clears the other's pair at its own episode boundaries (see
+    # docs/contribute/architecture/contracts.md "Deferral-episode contracts").
+    budget_deferrals: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    budget_first_deferred_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # AGGREGATE blocked clock (CHAOS-3412 review round 2). Deliberately NOT a
+    # per-episode column: because each episode kind clears the other's pair, a
+    # unit alternating between budget deferral and rate-limit cooldown keeps
+    # BOTH per-episode caps permanently out of reach while never running. This
+    # is set once when a unit first becomes blocked for ANY reason, SURVIVES
+    # episode changes, and is cleared only on a successful dispatch claim or
+    # SUCCESS -- so it measures "how long has this unit been going nowhere",
+    # which no per-episode counter can.
+    first_blocked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     expired_lease_retry_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -9,9 +9,10 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Any
 
-from sqlalchemy import or_, text, update
+from sqlalchemy import func, or_, text, update
 
 from dev_health_ops.models import (
     ProviderRateLimitObservation,
@@ -51,6 +52,68 @@ _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY = "rate_limit_cooldown_exhausted"
 _RATE_LIMIT_EPISODE_ERROR_CATEGORIES = frozenset(
     {"rate_limit", _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY}
 )
+
+# --- Budget-deferral episode (CHAOS-3412) ---------------------------------
+# A unit whose estimate can never fit its bucket (a HEAVY dataset planned
+# over a wide initial_sync_depth) was re-deferred forever: _defer_unit_for_
+# budget re-stamps RETRYING with a fresh available_at, does NOT increment
+# ``attempts``, and nothing tracked the budget episode, so no exhaustion
+# predicate could ever become true. That is a CONFIGURATION error, and
+# configuration errors must be visible -- these caps give the budget episode
+# the same count-plus-wall-clock exit the rate-limit episode has.
+_BUDGET_DEFERRED_CATEGORY = "budget_deferred"
+_BUDGET_DEFERRAL_EXHAUSTED_CATEGORY = "budget_deferral_exhausted"
+
+#: Count cap: how many consecutive budget deferrals a unit may accumulate
+#: before it fails loudly (``SYNC_BUDGET_MAX_DEFERRALS``).
+BUDGET_MAX_DEFERRALS_DEFAULT = 10
+#: Wall-clock cap measured from ``budget_first_deferred_at``
+#: (``SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS``). Deliberately longer than
+#: the count cap times the default 60s deferral: a run whose budget frees up
+#: (a sibling finishing, an hourly bucket rolling over) should be admitted,
+#: not terminalized, so only a unit that is STILL blocked after hours of
+#: real elapsed time is judged permanently oversized.
+BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT = 6 * 60 * 60  # 6 hours
+
+# Defence in depth for _budget_deferral_exhausted, mirroring
+# _RATE_LIMIT_EPISODE_ERROR_CATEGORIES: the unit's own last-recorded
+# result.error_category must ALSO show a budget-deferral cause before the
+# exhaustion check can fire, so a row surviving a missed clear site (whose
+# last real cause was 'rate_limit', 'worker_lost', 'soft_timeout', ...) is
+# refused here regardless of what the counters say.
+_BUDGET_EPISODE_ERROR_CATEGORIES = frozenset({_BUDGET_DEFERRED_CATEGORY})
+
+# --- Aggregate blocked clock (CHAOS-3412 review round 2, F2) --------------
+# Both per-episode budgets are, by design, reset when the OTHER episode kind
+# begins. That makes them unreachable for a unit whose blocking reason keeps
+# alternating -- an oversized estimate (this ticket's configuration error)
+# plus recurring sibling 429 cooldowns ping-pongs the category forever, each
+# stamp clearing the other's counters, and the unit sits in RETRYING exactly
+# as this ticket's acceptance forbids. ``first_blocked_at`` is the outer
+# bound that no episode reset can move: set once when a unit first becomes
+# blocked for ANY reason, cleared only when it actually gets dispatched or
+# succeeds.
+_DEFERRAL_TOTAL_EXHAUSTED_CATEGORY = "deferral_exhausted"
+
+#: Sentinel: the verdict was refused, so THIS pass still owns the unit.
+_CARRY_ON = object()
+
+#: Aggregate wall-clock cap measured from ``first_blocked_at``
+#: (``SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS``). Deliberately much larger
+#: than either per-episode cap: this is the backstop for "blocked for a
+#: reason that keeps changing", not the primary diagnosis, so a unit with a
+#: single identifiable cause still fails with that cause's specific category
+#: and error text long before this fires.
+DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT = 24 * 60 * 60  # 24 hours
+
+#: Human-readable names for the episode a unit was LAST blocked by, used in
+#: the aggregate-exhaustion error text so an operator is not left guessing
+#: which of the two causes was most recent.
+_EPISODE_KIND_BY_ERROR_CATEGORY = {
+    _BUDGET_DEFERRED_CATEGORY: "sync budget admission",
+    _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY: "provider rate-limit cooldown",
+    "rate_limit": "provider rate limit (in-worker 429)",
+}
 
 
 @dataclass(frozen=True)
@@ -220,7 +283,7 @@ class BudgetGuard:
                 )
             log_ctx = _unit_log_context(sync_run_id, unit)
             if cooldown_expiry is not None:
-                outcome = _apply_cooldown_deferral(
+                outcome = _resolve_cooldown_blocked_unit(
                     session,
                     unit,
                     cooldown_expiry=cooldown_expiry,
@@ -237,8 +300,14 @@ class BudgetGuard:
                 # persisted rate_limit_deferrals/rate_limit_first_seen_at
                 # state instead of letting it dispatch and burn a worker
                 # slot only to rediscover the same exhaustion in-worker.
-                outcome = _terminalize_rate_limit_exhausted(
-                    session, unit, now=enforced_at, log_ctx=log_ctx
+                # No cooldown gates this unit, so a REFUSED verdict simply
+                # means "not terminalizable on this evidence" -- it falls
+                # through to normal budget admission, not to a claim into an
+                # active cooldown.
+                outcome = _settle_or_skip(
+                    _terminalize_rate_limit_exhausted(
+                        session, unit, now=enforced_at, log_ctx=log_ctx
+                    )
                 )
             else:
                 continue
@@ -260,6 +329,13 @@ class BudgetGuard:
             now=enforced_at,
             budget_keys=budget_keys,
         )
+        # The DURABLE baseline (review round 2, R2-F1): consumption from work
+        # already dispatching/running, captured BEFORE the admission loop
+        # starts adding this pass's own admissions to consumed_by_bucket. Any
+        # terminal verdict below is measured against this snapshot, so it is
+        # a fact about the unit and the world rather than about the order the
+        # candidate loop happened to visit siblings in.
+        baseline_consumption: dict[str, int] = dict(consumed_by_bucket)
 
         for unit in units:
             if str(unit.id) in cooldown_handled_unit_ids:
@@ -286,6 +362,59 @@ class BudgetGuard:
                     would_defer = True
 
             if would_defer:
+                # Exhaustion is evaluated HERE, not before admission (review
+                # round 2, F1): the question is never "has this unit been
+                # deferred a lot", it is "has this unit been deferred a lot
+                # AND does it still not fit RIGHT NOW". A sibling finishing or
+                # a bucket rolling over between passes frees capacity, and a
+                # unit that would be admitted on this pass must be admitted,
+                # not killed on last pass's evidence. Every observation above
+                # was computed under the advisory locks this pass holds, so
+                # ``would_defer`` is the current, authoritative answer.
+                terminal_outcome: tuple[datetime, bool] | None = None
+                unfitness = _baseline_unfitness(
+                    estimates,
+                    baseline_consumption=baseline_consumption,
+                    limits=limits,
+                    default_limit=default_limit,
+                )
+                if unfitness is not None and _budget_deferral_exhausted(
+                    unit, now=enforced_at
+                ):
+                    # The episode cap may only end a unit whose misfit is
+                    # real independent of this pass's optional admissions
+                    # (R2-F1). A unit deferred purely because a sibling was
+                    # admitted first keeps deferring -- its counter still
+                    # advances, and if the contention genuinely never clears
+                    # the aggregate clock below is the loud backstop.
+                    terminal_outcome = _settle_or_skip(
+                        _terminalize_budget_exhausted(
+                            session,
+                            unit,
+                            now=enforced_at,
+                            log_ctx=log_ctx,
+                            observations=unit_observations,
+                            unfitness=unfitness,
+                        )
+                    )
+                elif _deferral_total_exhausted(unit, now=enforced_at):
+                    # Checked second: a unit with one identifiable cause fails
+                    # with that cause's specific category and error text; the
+                    # aggregate clock is the backstop for the alternating case
+                    # no single-cause cap can reach.
+                    terminal_outcome = _settle_or_skip(
+                        _terminalize_deferral_total_exhausted(
+                            session, unit, now=enforced_at, log_ctx=log_ctx
+                        )
+                    )
+                if terminal_outcome is not None:
+                    for observation in unit_observations:
+                        observation["decision"] = "exhausted"
+                    observations.extend(unit_observations)
+                    continue
+                # Either not exhausted, or the CAS lost the race (the unit
+                # moved on concurrently) — fall through and defer normally,
+                # exactly as a lost _defer_unit_for_budget race does.
                 available_at = enforced_at + timedelta(
                     seconds=deferral_seconds + random.uniform(0, float(jitter_seconds))  # noqa: S311
                 )
@@ -372,10 +501,9 @@ class BudgetGuard:
         same exclusion indefinitely without ever accumulating enough
         deferrals to terminalize). Every match here goes through the exact
         same write path ``enforce_run``'s own cooldown loop uses
-        (``_apply_cooldown_deferral`` / ``_terminalize_rate_limit_exhausted``
-        for the wall-clock-exhausted-without-a-visible-observation case) --
-        one deferral semantics, reused by both call sites, not a second,
-        weaker one.
+        (``_resolve_cooldown_blocked_unit``, which owns cap ordering and the
+        deferral write for both call sites) -- one deferral semantics,
+        reused, not a second, weaker one.
 
         Returns the unit ids to additionally exclude from this pass's claim
         (deferred AND terminalized -- terminalized units are already
@@ -424,7 +552,11 @@ class BudgetGuard:
                 )
             log_ctx = _unit_log_context(sync_run_id, unit)
             if cooldown_expiry is not None:
-                outcome = _apply_cooldown_deferral(
+                # Same helper enforce_run uses (review round 2, R2-F2): this
+                # path previously had its own copy of the ordering that also
+                # omitted the aggregate check entirely, so a unit past the
+                # aggregate cap could be deferred here indefinitely.
+                outcome = _resolve_cooldown_blocked_unit(
                     session,
                     unit,
                     cooldown_expiry=cooldown_expiry,
@@ -433,8 +565,10 @@ class BudgetGuard:
                     log_ctx=log_ctx,
                 )
             elif _rate_limit_deferral_exhausted(unit, now=checked_at):
-                outcome = _terminalize_rate_limit_exhausted(
-                    session, unit, now=checked_at, log_ctx=log_ctx
+                outcome = _settle_or_skip(
+                    _terminalize_rate_limit_exhausted(
+                        session, unit, now=checked_at, log_ctx=log_ctx
+                    )
                 )
             else:
                 continue
@@ -581,10 +715,25 @@ def _defer_unit_for_budget(
             available_at=available_at,
             error="deferred by sync budget guard",
             result={
-                "error_category": "budget_deferred",
+                "error_category": _BUDGET_DEFERRED_CATEGORY,
                 "not_before": available_at.isoformat(),
                 "budget_guard": observations,
             },
+            # CHAOS-3412: the budget episode's own bookkeeping. Incremented
+            # in SQL (not from the stale in-memory value) so concurrent
+            # dispatch passes cannot both write the same count; first-seen
+            # is COALESCEd so it keeps the FIRST deferral of the episode and
+            # the wall-clock cap measures the whole episode, not the last lap.
+            budget_deferrals=SyncRunUnit.budget_deferrals + 1,
+            budget_first_deferred_at=func.coalesce(
+                SyncRunUnit.budget_first_deferred_at, now
+            ),
+            # AGGREGATE blocked clock (F2): set-if-null, so it marks when this
+            # unit FIRST went nowhere and survives every episode change after
+            # that. COALESCE, not an overwrite -- an overwrite here would let
+            # the alternation reset the outer bound too, which is the whole
+            # defect.
+            first_blocked_at=func.coalesce(SyncRunUnit.first_blocked_at, now),
             # Review finding (round 3): a budget deferral is NOT a rate-limit
             # episode -- clear any stale rate_limit_deferrals/first_seen_at
             # this unit is carrying from an EARLIER, since-resolved
@@ -605,6 +754,14 @@ def _defer_unit_for_budget(
         unit.available_at = available_at
         unit.rate_limit_deferrals = 0
         unit.rate_limit_first_seen_at = None
+        # Mirror the SQL-side increment/coalesce onto the in-memory row so a
+        # caller reading the ORM object in the same pass sees the same state
+        # the database now holds (the other columns above do this already).
+        unit.budget_deferrals = int(unit.budget_deferrals or 0) + 1
+        if unit.budget_first_deferred_at is None:
+            unit.budget_first_deferred_at = now
+        if unit.first_blocked_at is None:
+            unit.first_blocked_at = now
         return True
     return False
 
@@ -808,6 +965,256 @@ def _cooldown_claim_predicate(now: datetime) -> Any:
     )
 
 
+# ---------------------------------------------------------------------------
+# Terminalization chokepoint (CHAOS-3412 closure)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TerminalVerdict:
+    """A proposal to terminally fail a unit, carrying the evidence it rests on.
+
+    ``episode`` names the episode the verdict ASSERTS as the cause, or
+    ``None`` for the aggregate backstop which asserts no single cause.
+    ``evidence`` becomes the persisted ``result`` payload, so what an operator
+    reads and what the decision was made on are the same object.
+    ``fitness`` is required for fitness-based categories.
+    """
+
+    error_category: str
+    error_text: str
+    evidence: Mapping[str, Any]
+    episode: str | None = None
+    fitness: BudgetUnfitness | None = None
+
+
+#: Episode name -> the ``result.error_category`` values that evidence it. A
+#: verdict asserting an episode may only be issued for a unit whose OWN last
+#: recorded cause is in that episode's set.
+_EPISODE_EVIDENCE: dict[str, frozenset[str]] = {
+    "rate_limit": _RATE_LIMIT_EPISODE_ERROR_CATEGORIES,
+    "budget": _BUDGET_EPISODE_ERROR_CATEGORIES,
+}
+
+#: Categories whose claim is about FITNESS, and therefore may only be issued
+#: with a durable-world verdict attached.
+_FITNESS_BASED_CATEGORIES = frozenset({_BUDGET_DEFERRAL_EXHAUSTED_CATEGORY})
+
+#: Phrases an error text may use only when its own evidence licenses them.
+#: This is what "the text may only assert what the evidence supports" means
+#: mechanically -- instances 3 and 5 below were both this failure.
+_CLAIM_LICENCES: dict[str, str] = {
+    "can never be admitted": "permanently_oversized",
+    "alternated": "episodes_alternated",
+    "kept changing": "episodes_alternated",
+}
+
+
+class TerminalOutcome(str, Enum):
+    """What a terminalization attempt actually did.
+
+    REFUSED and CAS_LOST were previously both ``None``, and callers read that
+    single value as "lost a race, skip this unit" -- so an evidence refusal
+    left a cooldown-blocked unit unstamped, ``_claim_units`` dispatched it
+    despite the active cooldown, and the claim cleared ``first_blocked_at``.
+    A refusal silently resetting the aggregate clock is a direct violation of
+    the invariant this module exists to enforce, so the two outcomes are now
+    distinct in the type, not merely in intent.
+    """
+
+    TERMINALIZED = "terminalized"
+    REFUSED = "refused"
+    CAS_LOST = "cas_lost"
+
+
+@dataclass(frozen=True)
+class TerminalDecision:
+    outcome: TerminalOutcome
+    at: datetime | None = None
+
+
+class TerminalVerdictError(AssertionError):
+    """A malformed verdict -- a defect in this module, not in the data."""
+
+
+def _unit_last_error_category(unit: SyncRunUnit) -> str | None:
+    result = unit.result
+    if not isinstance(result, Mapping):
+        return None
+    category = result.get("error_category")
+    return str(category) if category is not None else None
+
+
+def _terminalize_unit(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    verdict: TerminalVerdict,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> TerminalDecision:
+    """THE single place a sync unit is terminally failed by a deferral
+    exhaustion decision, and the closure of a five-instance defect class.
+
+    THE INVARIANT
+    -------------
+    A unit may only be terminalized on a fact that is true of the unit and the
+    DURABLE world, and its error text may only assert what its own recorded
+    evidence supports.
+
+    Three checks enforce it, and every terminal deferral stamp routes through
+    them:
+
+    (a) EPISODE-VALIDATED EVIDENCE. A verdict naming an episode is refused
+        unless the unit's own last recorded cause belongs to that episode.
+        Counters alone are not evidence: they outlive the episode that wrote
+        them. A refusal is NOT an error -- it means "this unit's state does
+        not support this claim", and the caller defers instead.
+    (b) DURABLE-WORLD FITNESS. A fitness-based category must carry a
+        ``BudgetUnfitness`` measured against durable consumption only, never
+        against capacity taken by this pass's own optional admissions.
+    (c) LICENSED CLAIMS. An error text may contain a claim phrase only when
+        the evidence licenses it. Asserting "can never be admitted" about a
+        unit that fits, or "the reason kept changing" about a unit with one
+        cause, is a false diagnosis that costs an operator the true one.
+
+    (b) and (c) are invariants over code this module writes, so violating them
+    raises: it is a bug here, and a silent one would be indistinguishable from
+    a correct verdict. (a) is a statement about run-time data and so refuses.
+
+    THE FIVE INSTANCES THIS SUBSUMES
+    --------------------------------
+    Every finding across three review rounds was the same shape -- a terminal
+    verdict resting on evidence weaker than the claim it made:
+
+    1. R1-F1: exhaustion decided from deferral HISTORY before checking whether
+       the unit still failed to fit, killing units on a pass where freed
+       capacity would have admitted them. -> (b).
+    2. R1-F2: a per-episode counter treated as evidence of "stuck", when each
+       episode resets the others, so an alternating unit was never measured at
+       all. -> the aggregate clock, whose verdict carries no episode and
+       therefore asserts none.
+    3. R1-F1 (second order): the failure text rebuilt from the PREVIOUS pass's
+       persisted observation, so it named a bucket state that no longer
+       existed. -> (c), plus evidence and text now coming from one object.
+    4. R2-F1: fitness measured against capacity consumed by this pass's own
+       earlier admissions, making a terminal verdict depend on candidate
+       ORDER. -> (b).
+    5. R2-F2 / R3: an episode's counters re-read WITHOUT the category guard,
+       so stale capped counters from a resolved episode produced a
+       wrong-category irreversible failure; and a generic explanation asserted
+       over specific evidence. -> (a) and (c).
+
+    WHY A SIXTH CANNOT SLIP IN QUIETLY
+    ----------------------------------
+    ``test_every_terminal_deferral_stamp_routes_through_the_chokepoint``
+    derives, by AST over this module and the two worker modules, every
+    ``status=FAILED`` stamp whose recorded category is a registered deferral
+    exhaustion, and asserts each one is lexically inside this function. A new
+    terminal path either routes through here -- and is checked -- or fails
+    that test. It cannot be added quietly, which is the only property that
+    makes "the class is closed" a claim rather than a hope.
+    """
+    _assert_verdict_wellformed(verdict)
+    if verdict.episode is not None:
+        licensed = _EPISODE_EVIDENCE[verdict.episode]
+        last_category = _unit_last_error_category(unit)
+        if last_category not in licensed:
+            # (a) Refusal, not an error: the unit's own state does not
+            # evidence the episode this verdict names.
+            logger.warning(
+                "dispatch_sync_run.terminal_verdict_refused",
+                extra={
+                    **log_ctx,
+                    "error_category": verdict.error_category,
+                    "asserted_episode": verdict.episode,
+                    "unit_last_error_category": last_category,
+                },
+            )
+            return TerminalDecision(TerminalOutcome.REFUSED)
+    result: Any = session.execute(
+        update(SyncRunUnit)
+        .where(SyncRunUnit.id == unit.id, _cooldown_claim_predicate(now))
+        .values(
+            status=SyncRunUnitStatus.FAILED.value,
+            error=verdict.error_text,
+            result={**verdict.evidence, "error_category": verdict.error_category},
+            lease_owner=None,
+            lease_expires_at=None,
+            last_heartbeat_at=now,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    if int(result.rowcount or 0) == 0:
+        return TerminalDecision(TerminalOutcome.CAS_LOST)
+    unit.status = SyncRunUnitStatus.FAILED.value
+    logger.warning(
+        "dispatch_sync_run.unit_terminalized",
+        extra={
+            **log_ctx,
+            "error_category": verdict.error_category,
+            "error": verdict.error_text,
+            **{f"evidence_{k}": v for k, v in verdict.evidence.items()},
+        },
+    )
+    return TerminalDecision(TerminalOutcome.TERMINALIZED, now)
+
+
+def _assert_verdict_wellformed(verdict: TerminalVerdict) -> None:
+    """Checks (b) and (c) -- invariants over verdicts this module builds."""
+    if verdict.episode is not None and verdict.episode not in _EPISODE_EVIDENCE:
+        raise TerminalVerdictError(
+            f"verdict {verdict.error_category!r} names unknown episode "
+            f"{verdict.episode!r}; register it in _EPISODE_EVIDENCE so the "
+            "evidence check can be applied to it"
+        )
+    if verdict.error_category in _FITNESS_BASED_CATEGORIES and verdict.fitness is None:
+        raise TerminalVerdictError(
+            f"verdict {verdict.error_category!r} makes a fitness claim but "
+            "carries no BudgetUnfitness measured against the durable baseline"
+        )
+    if not verdict.error_text.strip():
+        raise TerminalVerdictError(
+            f"verdict {verdict.error_category!r} has no error text; an "
+            "unexplained terminal failure is the state this ticket exists to "
+            "remove"
+        )
+    for phrase, evidence_key in _CLAIM_LICENCES.items():
+        if (
+            phrase in verdict.error_text
+            and verdict.evidence.get(evidence_key) is not True
+        ):
+            raise TerminalVerdictError(
+                f"verdict {verdict.error_category!r} claims {phrase!r} but its "
+                f"evidence does not license it ({evidence_key}="
+                f"{verdict.evidence.get(evidence_key)!r}). An error text may "
+                "only assert what its own evidence supports."
+            )
+
+
+def _live_rate_limit_episode(unit: SyncRunUnit) -> tuple[int, datetime | None]:
+    """This unit's rate-limit episode counters IF its own last recorded cause
+    evidences that the episode is live -- otherwise ``(0, None)``, a FRESH
+    episode.
+
+    THE single place that decides whether persisted rate-limit counters are
+    evidence (CHAOS-3412 closure, instance 5). Counters outlive the episode
+    that wrote them: every production stamp that sets a non-zero
+    ``rate_limit_deferrals`` co-writes a rate-limit ``error_category``, so a
+    unit whose last cause is ``worker_lost`` or ``budget_deferred`` is
+    carrying bookkeeping from an episode that already resolved. Reading those
+    numbers as if they described the present is what let a stale capped
+    counter produce an irreversible wrong-category failure.
+
+    Every reader goes through here, so there is no second interpretation of
+    the same columns to drift from this one.
+    """
+    if _unit_last_error_category(unit) in _RATE_LIMIT_EPISODE_ERROR_CATEGORIES:
+        return int(unit.rate_limit_deferrals or 0), unit.rate_limit_first_seen_at
+    return 0, None
+
+
 def _rate_limit_deferral_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
     """True when this unit's SHARED rate-limit-deferral budget
     (``RATE_LIMIT_MAX_DEFERRALS`` / ``RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS``) is
@@ -837,21 +1244,14 @@ def _rate_limit_deferral_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
     still show its last real cause (``budget_deferred``, ``worker_lost``,
     ``soft_timeout``, ...) and be refused here regardless.
     """
-    if unit.rate_limit_deferrals <= 0 and unit.rate_limit_first_seen_at is None:
-        return False
-    result = unit.result
-    error_category = (
-        result.get("error_category") if isinstance(result, Mapping) else None
-    )
-    if error_category not in _RATE_LIMIT_EPISODE_ERROR_CATEGORIES:
+    attempts, first_seen_at = _live_rate_limit_episode(unit)
+    if attempts <= 0 and first_seen_at is None:
         return False
     return (
         plan_rate_limit_deferral(
             retry_after_seconds=None,
-            attempts=unit.rate_limit_deferrals,
-            first_seen_at=unit.rate_limit_first_seen_at.isoformat()
-            if unit.rate_limit_first_seen_at
-            else None,
+            attempts=attempts,
+            first_seen_at=first_seen_at.isoformat() if first_seen_at else None,
             now=now,
         )
         is None
@@ -864,48 +1264,484 @@ def _terminalize_rate_limit_exhausted(
     *,
     now: datetime,
     log_ctx: dict[str, Any],
-) -> tuple[datetime, bool] | None:
-    """Terminally fail a unit whose shared rate-limit-deferral budget is
-    spent (CHAOS-2742 binding decision: run-liveness beats optimism).
+) -> TerminalDecision:
+    """Propose terminal failure for a spent RATE-LIMIT episode (CHAOS-2742).
 
-    Shared by :func:`_apply_cooldown_deferral` (when
-    ``plan_rate_limit_deferral`` returns ``None`` for a unit matched by a
-    currently-visible cooldown) and the wall-clock-exhaustion-without-a-
-    visible-observation path in ``enforce_run`` / ``reconfirm_cooldowns``
-    (review finding) -- one CAS, one code path, for both triggers.
-
-    Returns ``(now, True)`` on a successful CAS transition, or ``None`` if
-    the CAS lost the race (the unit moved on concurrently).
+    Builds the verdict; :func:`_terminalize_unit` decides. Because the verdict
+    names the ``rate_limit`` episode, the chokepoint refuses it for a unit
+    whose own last cause is something else -- which is what closes instance 5,
+    where this function was reachable from a counter re-read that skipped the
+    category guard. Returns ``None`` on refusal or a lost CAS; the caller
+    defers instead.
     """
-    claim_predicate = _cooldown_claim_predicate(now)
-    result: Any = session.execute(
-        update(SyncRunUnit)
-        .where(SyncRunUnit.id == unit.id, claim_predicate)
-        .values(
-            status=SyncRunUnitStatus.FAILED.value,
-            error="rate limit cooldown deferral budget exhausted",
-            result={
-                "error_category": _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY,
-                "rate_limit_deferrals": unit.rate_limit_deferrals,
-            },
-            lease_owner=None,
-            lease_expires_at=None,
-            last_heartbeat_at=now,
-            updated_at=now,
+    deferrals = int(unit.rate_limit_deferrals or 0)
+    return _terminalize_unit(
+        session,
+        unit,
+        verdict=TerminalVerdict(
+            error_category=_RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY,
+            error_text="rate limit cooldown deferral budget exhausted",
+            evidence={"rate_limit_deferrals": deferrals},
+            episode="rate_limit",
+        ),
+        now=now,
+        log_ctx=log_ctx,
+    )
+
+
+@dataclass(frozen=True)
+class BudgetUnfitness:
+    """Why a unit does not fit its bucket, measured against a STABLE
+    baseline (review round 2, R2-F1).
+
+    ``durable_units`` is consumption from work already DISPATCHING/RUNNING --
+    it exists whether or not this dispatch pass admits anything. It
+    deliberately EXCLUDES capacity taken by siblings admitted earlier in this
+    same pass, because that is an artefact of candidate ordering: the same
+    unit, in the same world, is fit or unfit depending on which sibling the
+    loop happened to reach first. A terminal verdict may not rest on that.
+
+    ``permanent`` is the strong case -- the unit's own estimate exceeds the
+    whole bucket limit, so no amount of other work finishing can ever make
+    room. Only that case may claim "can never be admitted".
+    """
+
+    budget_key: str
+    estimated_units: int
+    budget_limit: int
+    durable_units: int
+    permanent: bool
+
+
+def _baseline_unfitness(
+    estimates: Iterable[BudgetEstimate],
+    *,
+    baseline_consumption: Mapping[str, int],
+    limits: Mapping[str, int],
+    default_limit: int,
+) -> BudgetUnfitness | None:
+    """The worst way this unit fails to fit against the durable baseline, or
+    ``None`` if it fits -- meaning any deferral it just took was caused by
+    contention with THIS pass's own optional admissions and must never be
+    grounds for terminalizing it.
+
+    Worst = a permanent misfit ahead of a contention misfit, then the largest
+    estimate, so the reported cause is the one an operator most needs.
+    """
+    worst: BudgetUnfitness | None = None
+    for estimate in estimates:
+        bucket = estimate.bucket.to_dict()
+        budget_key = _budget_key(bucket, route_family=estimate.route_family)
+        limit = _limit_for_bucket(
+            bucket,
+            route_family=estimate.route_family,
+            limits=limits,
+            default_limit=default_limit,
         )
-        .execution_options(synchronize_session=False)
+        durable = int(baseline_consumption.get(budget_key, 0))
+        if durable + estimate.estimated_units <= limit:
+            continue
+        candidate = BudgetUnfitness(
+            budget_key=budget_key,
+            estimated_units=estimate.estimated_units,
+            budget_limit=limit,
+            durable_units=durable,
+            permanent=estimate.estimated_units > limit,
+        )
+        rank = (candidate.permanent, candidate.estimated_units)
+        if worst is None or rank > (worst.permanent, worst.estimated_units):
+            worst = candidate
+    return worst
+
+
+def _budget_deferral_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
+    """True when this unit's BUDGET-deferral episode is spent -- it has been
+    deferred by the budget guard more than ``SYNC_BUDGET_MAX_DEFERRALS``
+    times, or has been stuck in one continuous budget episode for longer
+    than ``SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS`` (CHAOS-3412).
+
+    Structured exactly like :func:`_rate_limit_deferral_exhausted`, but it
+    reads ONLY the budget columns (``budget_deferrals`` /
+    ``budget_first_deferred_at``). That separation is load-bearing: the
+    invariants pinned in ``tests/test_budget_guard_cooldown.py`` require a
+    budget-deferred unit NOT to be terminalized off stale rate-limit
+    columns, and the converse holds here too.
+
+    A fresh unit (``budget_deferrals == 0`` and
+    ``budget_first_deferred_at is None``) is never "exhausted" -- this only
+    fires for a unit with genuine prior budget-deferral history.
+
+    Defence in depth (mirroring the rate-limit predicate's round-3 finding):
+    the budget pair is cleared at every SUCCESS stamp and every
+    non-budget RETRYING stamp -- see the "keep or clear" contract in
+    ``docs/contribute/architecture/contracts.md`` -- so an unrelated retry reason
+    should never reach here with stale nonzero columns. This is a SECOND,
+    independent check in case a clear site is ever missed: the unit's own
+    MOST RECENTLY recorded ``result.error_category`` must also be the budget
+    guard's own deferral category.
+
+    Go-side gap this check currently covers (CHAOS-3412 landed Python-only):
+    the Go sync runtime writes non-terminal stamps of its own --
+    ``lease_repair.go``'s expired-lease retry and ``repository_postgres.go``'s
+    release-for-retry -- and neither resets the budget pair, because Go does
+    not do budget admission and did not know the pair existed. A unit that was
+    budget-deferred here and then re-stamped by Go therefore comes back with
+    stale nonzero columns. It is refused anyway: both Go stamps OVERWRITE
+    ``result.error_category`` with their own cause (``worker_lost``,
+    ``provider_unit_retryable``), so the check above rejects it. That is this
+    defence-in-depth gate doing exactly the job it was added for, not a reason
+    to consider the contract complete -- the Go clears are still owed, and are
+    tracked with the rest of the Go parity work.
+
+    Known, accepted consequence of that symmetry: a unit that ALTERNATES
+    between a budget deferral and a rate-limit deferral resets each episode
+    as the other begins, so neither episode's caps accumulate. That is the
+    correct reading of the state (the reason it is being held back genuinely
+    keeps changing, and neither cause is by itself permanent), and it is the
+    same property the rate-limit predicate already has. The loop CHAOS-3412
+    closes is the one this ticket observed and the one that is reachable by
+    configuration: an estimate that can never fit, re-deferred for the same
+    reason every pass.
+    """
+    deferrals = int(unit.budget_deferrals or 0)
+    first_deferred_at = unit.budget_first_deferred_at
+    if deferrals <= 0 and first_deferred_at is None:
+        return False
+    result = unit.result
+    error_category = (
+        result.get("error_category") if isinstance(result, Mapping) else None
     )
-    if int(result.rowcount or 0) == 0:
+    if error_category not in _BUDGET_EPISODE_ERROR_CATEGORIES:
+        return False
+    if deferrals >= _budget_max_deferrals():
+        return True
+    if first_deferred_at is None:
+        return False
+    elapsed = (now - _as_aware(first_deferred_at)).total_seconds()
+    return elapsed >= _budget_deferral_wall_clock_seconds()
+
+
+def _deferral_total_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
+    """True when this unit has been continuously blocked -- for ANY mix of
+    reasons -- for longer than ``SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS``
+    (CHAOS-3412 review round 2, F2).
+
+    Reads ONLY ``first_blocked_at``. It deliberately does not look at any
+    per-episode column, and does not gate on ``result.error_category``: the
+    whole point is that the category KEEPS CHANGING, so cross-reading episode
+    state is exactly what makes the alternating case unreachable. The pinned
+    invariants in ``tests/test_budget_guard_cooldown.py`` (a budget-deferred
+    unit must not be terminalized off stale rate-limit columns, and the
+    converse) are unaffected, because this predicate reads neither pair.
+
+    What replaces the error-category gate is WHERE this is evaluated: only at
+    the moment the guard is about to defer the unit AGAIN, on this pass, for a
+    reason it has just re-established. A unit that would be admitted now is
+    never asked this question (F1), so a stale timestamp cannot terminalize a
+    unit that is no longer blocked.
+
+    A unit that has never been blocked (``first_blocked_at is None``) is never
+    exhausted.
+    """
+    first_blocked_at = unit.first_blocked_at
+    if first_blocked_at is None:
+        return False
+    elapsed = (now - _as_aware(first_blocked_at)).total_seconds()
+    return elapsed >= _deferral_total_wall_clock_seconds()
+
+
+def _deferral_total_wall_clock_seconds() -> int:
+    return max(
+        1,
+        _env_int(
+            "SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS",
+            DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT,
+        ),
+    )
+
+
+def _last_episode_kind(unit: SyncRunUnit) -> str:
+    result = unit.result
+    error_category = (
+        result.get("error_category") if isinstance(result, Mapping) else None
+    )
+    return _EPISODE_KIND_BY_ERROR_CATEGORY.get(
+        str(error_category), f"unknown ({error_category!r})"
+    )
+
+
+def _terminalize_deferral_total_exhausted(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> TerminalDecision:
+    """Propose terminal failure for a unit past the AGGREGATE clock, whatever
+    mix of reasons kept it there (CHAOS-3412 F2).
+
+    The verdict names NO episode: this decision deliberately asserts that no
+    single cause explains the block, so it must not be validated against one.
+    Its text is built from the counters it carries -- it claims alternation
+    only when both are non-zero, which the chokepoint's licence check then
+    enforces independently.
+    """
+    budget_deferrals = int(unit.budget_deferrals or 0)
+    rate_limit_deferrals = int(unit.rate_limit_deferrals or 0)
+    first_blocked_at = unit.first_blocked_at
+    blocked_seconds = (
+        int((now - _as_aware(first_blocked_at)).total_seconds())
+        if first_blocked_at is not None
+        else 0
+    )
+    alternated = budget_deferrals > 0 and rate_limit_deferrals > 0
+    cause = (
+        "The blocking reason alternated between sync budget admission and "
+        "provider rate limiting, so no single-cause cap applied"
+        if alternated
+        else "It stayed blocked without any single-cause cap being reached"
+    )
+    error_text = (
+        f"sync unit blocked for {blocked_seconds // 3600}h without ever "
+        f"running; last blocked by {_last_episode_kind(unit)} "
+        f"(budget deferrals: {budget_deferrals}, rate-limit deferrals: "
+        f"{rate_limit_deferrals}). {cause}. Remedies: run a scoped backfill "
+        "over a narrower window, raise this bucket's cap via "
+        "SYNC_BUDGET_BUCKET_LIMITS, or reduce concurrent load on the provider "
+        "so cooldowns stop recurring."
+    )
+    return _terminalize_unit(
+        session,
+        unit,
+        verdict=TerminalVerdict(
+            error_category=_DEFERRAL_TOTAL_EXHAUSTED_CATEGORY,
+            error_text=error_text,
+            evidence={
+                "budget_deferrals": budget_deferrals,
+                "rate_limit_deferrals": rate_limit_deferrals,
+                "first_blocked_at": (
+                    _as_aware(first_blocked_at).isoformat()
+                    if first_blocked_at is not None
+                    else None
+                ),
+                "blocked_seconds": blocked_seconds,
+                "last_episode": _last_episode_kind(unit),
+                "episodes_alternated": alternated,
+            },
+            episode=None,
+        ),
+        now=now,
+        log_ctx=log_ctx,
+    )
+
+
+def _budget_max_deferrals() -> int:
+    return max(1, _env_int("SYNC_BUDGET_MAX_DEFERRALS", BUDGET_MAX_DEFERRALS_DEFAULT))
+
+
+def _budget_deferral_wall_clock_seconds() -> int:
+    return max(
+        1,
+        _env_int(
+            "SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS",
+            BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT,
+        ),
+    )
+
+
+def _blocking_budget_observation(
+    observations: Iterable[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    """The observation from THIS pass that actually blocked the unit -- the
+    one whose projected units exceeded its bucket limit.
+
+    Takes the current pass's observations rather than reading the unit's
+    persisted ``result['budget_guard']`` (review round 2, F1): now that
+    exhaustion is decided after the live fit check, the explanation must come
+    from the same evaluation that made the decision, not from whatever the
+    previous pass happened to record. Falls back to the largest estimate when
+    no entry carries an explicit would-defer decision.
+    """
+    entries = [entry for entry in observations if isinstance(entry, Mapping)]
+    if not entries:
         return None
-    unit.status = SyncRunUnitStatus.FAILED.value
-    logger.warning(
-        "dispatch_sync_run.rate_limit_cooldown_exhausted",
-        extra={**log_ctx, "rate_limit_deferrals": unit.rate_limit_deferrals},
+    blocking = [
+        entry
+        for entry in entries
+        if entry.get("decision") in {"would_defer", "deferred", "exhausted"}
+    ]
+    candidates = blocking or entries
+    return max(candidates, key=lambda entry: int(entry.get("estimated_units") or 0))
+
+
+def _budget_exhaustion_error_text(
+    unit: SyncRunUnit,
+    *,
+    deferrals: int,
+    unfitness: BudgetUnfitness,
+) -> str:
+    """Operator-actionable failure text: WHAT could not fit, BY HOW MUCH,
+    over WHAT window, and what an operator can actually do.
+
+    The "can never be admitted" claim is emitted ONLY when it is literally
+    true -- the estimate alone exceeds the whole bucket cap (review round 2,
+    R2-F1). When the unit is instead blocked by sustained consumption from
+    work already running, the text says exactly that, because telling an
+    operator a unit can never run when raising nothing and waiting would let
+    it run is a false diagnosis that costs them the real one.
+    """
+    span_days = _window_span_days(unit)
+    head = (
+        f"sync budget deferral exhausted after {deferrals} deferrals: dataset "
+        f"'{unit.dataset_key}' estimates {unfitness.estimated_units} units "
+        f"against bucket '{unfitness.budget_key}' whose cap is "
+        f"{unfitness.budget_limit}, over a {span_days}-day window"
     )
-    return now, True
+    if unfitness.permanent:
+        middle = ", so it can never be admitted and was re-deferred instead of running"
+    else:
+        middle = (
+            f", and {unfitness.durable_units} units of that cap are held by sync "
+            "work already running. The contention has not cleared for the whole "
+            "deferral budget, so the unit was re-deferred instead of running"
+        )
+    return (
+        f"{head}{middle}. Remedies: run a scoped backfill over a narrower "
+        "window, or raise this bucket's cap via SYNC_BUDGET_BUCKET_LIMITS."
+    )
 
 
-def _apply_cooldown_deferral(
+def _window_span_days(unit: SyncRunUnit) -> int:
+    since_at = unit.since_at
+    before_at = unit.before_at
+    if since_at is None or before_at is None:
+        return 0
+    return max(0, (_as_aware(before_at) - _as_aware(since_at)).days)
+
+
+def _terminalize_budget_exhausted(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    now: datetime,
+    log_ctx: dict[str, Any],
+    observations: Iterable[Mapping[str, Any]],
+    unfitness: BudgetUnfitness,
+) -> TerminalDecision:
+    """Propose terminal failure for a spent BUDGET episode whose misfit holds
+    against the durable baseline (CHAOS-3412).
+
+    Names the ``budget`` episode, so the chokepoint refuses it for a unit
+    whose own last cause is not a budget deferral; and carries ``unfitness``,
+    without which the chokepoint rejects the fitness claim outright.
+    """
+    unit_observations = list(observations)
+    deferrals = int(unit.budget_deferrals or 0)
+    return _terminalize_unit(
+        session,
+        unit,
+        verdict=TerminalVerdict(
+            error_category=_BUDGET_DEFERRAL_EXHAUSTED_CATEGORY,
+            error_text=_budget_exhaustion_error_text(
+                unit, deferrals=deferrals, unfitness=unfitness
+            ),
+            evidence={
+                "budget_deferrals": deferrals,
+                "budget_key": unfitness.budget_key,
+                "estimated_units": unfitness.estimated_units,
+                "budget_limit": unfitness.budget_limit,
+                "durable_units": unfitness.durable_units,
+                "permanently_oversized": unfitness.permanent,
+                "budget_first_deferred_at": (
+                    _as_aware(unit.budget_first_deferred_at).isoformat()
+                    if unit.budget_first_deferred_at is not None
+                    else None
+                ),
+                "budget_guard": [
+                    dict(observation)
+                    for observation in [_blocking_budget_observation(unit_observations)]
+                    if observation
+                ],
+            },
+            episode="budget",
+            fitness=unfitness,
+        ),
+        now=now,
+        log_ctx=log_ctx,
+    )
+
+
+def _plan_cooldown_deferral(
+    unit: SyncRunUnit, *, cooldown_expiry: datetime, now: datetime
+) -> Any:
+    """The rate-limit deferral plan for a cooldown-gated unit, or ``None``
+    when the shared rate-limit deferral budget is spent.
+
+    Extracted from :func:`_apply_cooldown_deferral` (review round 2, R2-F2)
+    so that exactly ONE place computes it and
+    :func:`_resolve_cooldown_blocked_unit` can consult the episode-specific
+    verdict BEFORE the aggregate backstop, without a second copy of the
+    planning call drifting from this one.
+
+    Reads the counters through :func:`_live_rate_limit_episode` (closure,
+    instance 5): this function previously re-read them raw, so stale capped
+    counters from a RESOLVED episode made it return ``None`` and terminalize
+    the unit under a category its own state did not evidence. With the
+    normalizer, an unevidenced episode plans as a FRESH one and the unit
+    defers instead -- counters restarting from this genuine block.
+    """
+    attempts, first_seen_at = _live_rate_limit_episode(unit)
+    return plan_rate_limit_deferral(
+        retry_after_seconds=max(0.0, (cooldown_expiry - now).total_seconds()),
+        attempts=attempts,
+        first_seen_at=first_seen_at.isoformat() if first_seen_at else None,
+        now=now,
+    )
+
+
+def _settle_or_skip(decision: TerminalDecision) -> tuple[datetime, bool] | None:
+    """For call sites where the unit is NOT held by an active cooldown, so a
+    refusal and a lost race have the same safe consequence: leave the unit to
+    the pass's normal handling (budget admission / the claim), which stamps it
+    either way. Distinct from :func:`_settle_terminal_decision`, which the
+    cooldown path needs because there a refusal must NOT fall through to a
+    claim."""
+    if decision.outcome is TerminalOutcome.TERMINALIZED:
+        return _terminalized_at(decision), True
+    return None
+
+
+def _terminalized_at(decision: TerminalDecision) -> datetime:
+    """The timestamp a TERMINALIZED decision must carry. Missing it means the
+    chokepoint wrote a row without recording when -- fail loudly rather than
+    coercing, since a silently-None stamp reads as a successful write."""
+    if decision.at is None:
+        raise TerminalVerdictError(
+            "TERMINALIZED decision carries no timestamp; the write happened "
+            "but the caller cannot report when"
+        )
+    return decision.at
+
+
+def _settle_terminal_decision(
+    decision: TerminalDecision,
+) -> tuple[datetime, bool] | None | object:
+    """Map a chokepoint decision onto the caller contract, keeping REFUSED
+    distinct from CAS_LOST.
+
+    Returns ``(at, True)`` when written, ``None`` on a genuine lost race (the
+    unit moved on, so another pass owns it), or :data:`_CARRY_ON` when the
+    verdict was refused -- meaning THIS pass still owns the unit and must
+    stamp it some other way rather than leaving it for ``_claim_units``.
+    """
+    if decision.outcome is TerminalOutcome.TERMINALIZED:
+        return _terminalized_at(decision), True
+    if decision.outcome is TerminalOutcome.CAS_LOST:
+        return None
+    return _CARRY_ON
+
+
+def _resolve_cooldown_blocked_unit(
     session: Any,
     unit: SyncRunUnit,
     *,
@@ -914,8 +1750,105 @@ def _apply_cooldown_deferral(
     now: datetime,
     log_ctx: dict[str, Any],
 ) -> tuple[datetime, bool] | None:
-    """Defer (or, on rate-limit-deferral-budget exhaustion, terminally fail)
-    a unit gated by an active shared cooldown (CHAOS-2760).
+    """THE decision for a unit gated by an active shared cooldown -- one
+    implementation, called by BOTH ``enforce_run`` and
+    ``reconfirm_cooldowns`` (review round 2, R2-F2).
+
+    Those two paths previously each carried their own hand-kept copy of this
+    ordering, and had already drifted in both directions: ``enforce_run``
+    checked the aggregate cap before the episode cap, and
+    ``reconfirm_cooldowns`` did not check the aggregate cap at all. Two copies
+    of an ordering rule is the same disease as any other duplicated invariant.
+
+    The ordering, which is the actual contract:
+
+    1. EPISODE-SPECIFIC caps first, always. A unit with one identifiable cause
+       must fail with THAT cause's category and error text.
+    2. The AGGREGATE clock second, as the backstop for the case no
+       single-cause cap can see.
+    3. Otherwise defer.
+
+    A REFUSED verdict never falls out of this function as ``None``. The unit
+    is blocked by a live cooldown right now, so it must leave here stamped:
+    refusal drops through to a FRESH deferral, which is what the closure
+    promises for unevidenced counters and what keeps ``first_blocked_at``
+    intact. Returning ``None`` would let ``_claim_units`` dispatch it straight
+    into the cooldown and reset the aggregate clock on the way.
+    """
+    refused = False
+
+    # 1a. Episode cap from the unit's own persisted state.
+    if _rate_limit_deferral_exhausted(unit, now=now):
+        settled = _settle_terminal_decision(
+            _terminalize_rate_limit_exhausted(session, unit, now=now, log_ctx=log_ctx)
+        )
+        if settled is not _CARRY_ON:
+            return settled  # type: ignore[return-value]
+        refused = True
+
+    # 1b. Episode cap as the shared planner sees it. Skipped after a refusal:
+    # the planner reads the same counters the refusal just rejected.
+    deferral = (
+        None
+        if refused
+        else _plan_cooldown_deferral(unit, cooldown_expiry=cooldown_expiry, now=now)
+    )
+    if not refused and deferral is None:
+        settled = _settle_terminal_decision(
+            _terminalize_rate_limit_exhausted(session, unit, now=now, log_ctx=log_ctx)
+        )
+        if settled is not _CARRY_ON:
+            return settled  # type: ignore[return-value]
+        refused = True
+
+    # 2. Aggregate backstop.
+    if _deferral_total_exhausted(unit, now=now):
+        settled = _settle_terminal_decision(
+            _terminalize_deferral_total_exhausted(
+                session, unit, now=now, log_ctx=log_ctx
+            )
+        )
+        if settled is not _CARRY_ON:
+            return settled  # type: ignore[return-value]
+
+    # 3. Defer. After a refusal this is a FRESH episode: the counters that
+    # were refused as evidence are not reused as a starting point either.
+    if deferral is None:
+        deferral = plan_rate_limit_deferral(
+            retry_after_seconds=max(0.0, (cooldown_expiry - now).total_seconds()),
+            attempts=0,
+            first_seen_at=None,
+            now=now,
+        )
+    if deferral is None:
+        # A fresh plan is never exhausted; if that ever changes, fail loudly
+        # rather than silently leaving a cooldown-blocked unit claimable.
+        raise TerminalVerdictError(
+            "fresh rate-limit deferral plan came back exhausted; a "
+            "cooldown-blocked unit would be left unstamped"
+        )
+    return _apply_cooldown_deferral(
+        session,
+        unit,
+        deferral=deferral,
+        jitter_seconds=jitter_seconds,
+        now=now,
+        log_ctx=log_ctx,
+    )
+
+
+def _apply_cooldown_deferral(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    deferral: Any,
+    jitter_seconds: int,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> tuple[datetime, bool] | None:
+    """Write the cooldown deferral stamp for a unit whose plan is already
+    known to be live (CHAOS-2760). Callers reach this only through
+    :func:`_resolve_cooldown_blocked_unit`, which owns the cap ordering.
 
     Cooldown deferrals COUNT against the SAME
     ``rate_limit_deferrals`` / ``rate_limit_first_seen_at`` budget the
@@ -930,21 +1863,6 @@ def _apply_cooldown_deferral(
     e.g. another dispatcher pass claimed/reconciled it first -- the caller
     simply skips it, mirroring ``_defer_unit_for_budget``).
     """
-    retry_after_seconds = max(0.0, (cooldown_expiry - now).total_seconds())
-    deferral = plan_rate_limit_deferral(
-        retry_after_seconds=retry_after_seconds,
-        attempts=unit.rate_limit_deferrals,
-        first_seen_at=unit.rate_limit_first_seen_at.isoformat()
-        if unit.rate_limit_first_seen_at
-        else None,
-        now=now,
-    )
-
-    if deferral is None:
-        return _terminalize_rate_limit_exhausted(
-            session, unit, now=now, log_ctx=log_ctx
-        )
-
     claim_predicate = _cooldown_claim_predicate(now)
     # Use plan_rate_limit_deferral's OWN not_before, not cooldown_expiry
     # directly: not_before already clamps to the remaining
@@ -972,6 +1890,17 @@ def _apply_cooldown_deferral(
             available_at=available_at,
             rate_limit_deferrals=deferral.attempts,
             rate_limit_first_seen_at=first_seen_at,
+            # CHAOS-3412 episode symmetry: a cooldown deferral is a
+            # RATE-LIMIT episode, not a budget one -- clear the budget pair,
+            # exactly as _defer_unit_for_budget clears this pair.
+            budget_deferrals=0,
+            budget_first_deferred_at=None,
+            # AGGREGATE blocked clock (F2): set-if-null, so it marks when this
+            # unit FIRST went nowhere and survives every episode change after
+            # that. COALESCE, not an overwrite -- an overwrite here would let
+            # the alternation reset the outer bound too, which is the whole
+            # defect.
+            first_blocked_at=func.coalesce(SyncRunUnit.first_blocked_at, now),
             error="deferred by sync cooldown guard",
             result={
                 "error_category": _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY,
@@ -991,6 +1920,10 @@ def _apply_cooldown_deferral(
     unit.available_at = available_at
     unit.rate_limit_deferrals = deferral.attempts
     unit.rate_limit_first_seen_at = first_seen_at
+    unit.budget_deferrals = 0
+    unit.budget_first_deferred_at = None
+    if unit.first_blocked_at is None:
+        unit.first_blocked_at = now
     logger.info(
         "dispatch_sync_run.rate_limit_cooldown_deferred",
         extra={

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -237,6 +237,12 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
                         # an ongoing one.
                         rate_limit_deferrals=0,
                         rate_limit_first_seen_at=None,
+                        # CHAOS-3412 episode symmetry: an expired-lease
+                        # retry is not a budget episode either -- clear the
+                        # budget pair so BudgetGuard's budget-exhaustion
+                        # check never mistakes it for an ongoing one.
+                        budget_deferrals=0,
+                        budget_first_deferred_at=None,
                         updated_at=now,
                         lease_owner=None,
                         lease_expires_at=None,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -51,7 +51,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, TypedDict
 
 from billiard.exceptions import SoftTimeLimitExceeded
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, SessionTransactionOrigin
 
@@ -1379,6 +1379,16 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     # (sync/budget_guard.py _rate_limit_deferral_exhausted).
                     rate_limit_deferrals=0,
                     rate_limit_first_seen_at=None,
+                    # CHAOS-3412, same reasoning for the BUDGET episode:
+                    # SUCCESS ends it too. A unit that got through is by
+                    # definition not permanently oversized, so its next
+                    # budget deferral must start a fresh count and a fresh
+                    # wall clock rather than inheriting a resolved episode's.
+                    budget_deferrals=0,
+                    budget_first_deferred_at=None,
+                    # The aggregate blocked clock stops here too: the unit
+                    # got through, so it is not "going nowhere" any more.
+                    first_blocked_at=None,
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=completed_at,
@@ -1496,6 +1506,17 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     available_at=not_before,
                     rate_limit_deferrals=deferral.attempts,
                     rate_limit_first_seen_at=first_seen_at,
+                    # CHAOS-3412 episode symmetry: a rate-limit deferral is
+                    # NOT a budget episode -- clear the budget pair, exactly
+                    # as _defer_unit_for_budget clears the rate-limit pair.
+                    budget_deferrals=0,
+                    budget_first_deferred_at=None,
+                    # AGGREGATE blocked clock (CHAOS-3412 review round 2):
+                    # set-if-null. A 429 deferral is still "this unit went
+                    # nowhere", so it starts the outer clock if nothing else
+                    # has -- but never restarts one already running, or the
+                    # budget/rate-limit alternation would reset it too.
+                    first_blocked_at=func.coalesce(SyncRunUnit.first_blocked_at, now),
                     error=sanitize_error_text(exc),
                     result=deferral_result_payload,
                     lease_owner=None,
@@ -1782,6 +1803,10 @@ def _stamp_sync_unit_soft_timeout(
                     # the budget-guard deferral clear).
                     rate_limit_deferrals=0,
                     rate_limit_first_seen_at=None,
+                    # CHAOS-3412 episode symmetry: nor is it a budget
+                    # episode -- clear that pair for the same reason.
+                    budget_deferrals=0,
+                    budget_first_deferred_at=None,
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=completed_at,
@@ -2601,7 +2626,16 @@ def _claim_units(
         session.execute(
             update(SyncRunUnit)
             .where(*planned_where)
-            .values(status=SyncRunUnitStatus.DISPATCHING.value, updated_at=now)
+            .values(
+                status=SyncRunUnitStatus.DISPATCHING.value,
+                updated_at=now,
+                # CHAOS-3412 (review round 2): a successful claim is the
+                # moment the unit stops being blocked, so the aggregate
+                # blocked clock stops with it. Set on PLANNED too (where it
+                # is already NULL) so the claim path has ONE rule rather than
+                # two that could drift.
+                first_blocked_at=None,
+            )
             .returning(SyncRunUnit.id)
             .execution_options(synchronize_session=False)
         )
@@ -2627,6 +2661,10 @@ def _claim_units(
                 status=SyncRunUnitStatus.DISPATCHING.value,
                 updated_at=now,
                 available_at=None,
+                # The claim that actually matters for CHAOS-3412: a
+                # previously-deferred unit is being dispatched, so it is no
+                # longer going nowhere and the aggregate clock resets.
+                first_blocked_at=None,
             )
             .returning(SyncRunUnit.id)
             .execution_options(synchronize_session=False)

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -1230,6 +1230,94 @@ async def test_get_sync_run_units_exposes_error_category(
 
 
 @pytest.mark.asyncio
+async def test_get_sync_run_units_surfaces_budget_blocked_units(
+    client, session_maker, seeded_state
+):
+    """CHAOS-3412: budget-blocked units must be COUNTED, not just present.
+
+    Before this, a run whose units were all deferred by the budget guard
+    reported zero failures, zero exhausted retries, and nothing else an
+    operator could act on -- the run simply looked idle. The rollup now
+    carries budget_blocked_unit_count, and each unit carries how many times
+    it has been deferred, so "enabled but producing nothing" is visible.
+    """
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    source_id = await _seed_source(
+        session_maker, seeded_state["org_id"], integration_id
+    )
+    run_id = await _seed_sync_run(session_maker, seeded_state["org_id"], integration_id)
+
+    async with session_maker() as session:
+        session.add_all(
+            [
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="tests",
+                    cost_class="heavy",
+                    mode="incremental",
+                    status="retrying",
+                    attempts=0,
+                    budget_deferrals=6,
+                    result={"error_category": "budget_deferred"},
+                ),
+                # Retrying for an UNRELATED reason -- must not be counted.
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="prs",
+                    cost_class="standard",
+                    mode="incremental",
+                    status="retrying",
+                    attempts=1,
+                    result={"error_category": "rate_limit"},
+                ),
+                # Already terminalized by the exhaustion path -- it is a
+                # FAILURE now, not a block, so it must not be counted either.
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="commit-stats",
+                    cost_class="heavy",
+                    mode="incremental",
+                    status="failed",
+                    attempts=0,
+                    budget_deferrals=10,
+                    result={"error_category": "budget_deferral_exhausted"},
+                ),
+            ]
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["budget_blocked_unit_count"] == 1
+    blocked = next(unit for unit in data["units"] if unit["dataset_key"] == "tests")
+    assert blocked["budget_deferrals"] == 6
+    assert blocked["error_category"] == "budget_deferred"
+    exhausted = next(
+        unit for unit in data["units"] if unit["dataset_key"] == "commit-stats"
+    )
+    assert exhausted["budget_deferrals"] == 10
+    assert exhausted["error_category"] == "budget_deferral_exhausted"
+    # A unit that never met the budget guard reports a zero, not a null.
+    unrelated = next(unit for unit in data["units"] if unit["dataset_key"] == "prs")
+    assert unrelated["budget_deferrals"] == 0
+
+
+@pytest.mark.asyncio
 async def test_get_sync_run_units_non_dict_result_has_no_error_category(
     client, session_maker, seeded_state
 ):

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0084"}
+    assert _revisions(migrated_to_0065.engine) == {"0085"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0084"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0084"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0084"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0084",)
+    assert heads == ("0085",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -66,6 +66,11 @@ from dev_health_ops.models import (
     SyncRunUnit,
     SyncRunUnitStatus,
 )
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
 from dev_health_ops.sync.dispatch_outbox import OUTBOX_KIND_DISPATCH
 from tests._helpers import seed_sync_dispatch_transport_routes
 from tests.test_sync_units import (
@@ -565,6 +570,13 @@ def test_cooldown_deferral_consumes_rate_limit_budget_and_terminalizes(
         processor_flags={"sync_git": True},
         rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
         rate_limit_first_seen_at=now - timedelta(minutes=5),
+        # Producible state (CHAOS-3412 closure): every production stamp that
+        # sets a non-zero rate_limit_deferrals co-writes a rate-limit
+        # error_category, so counters without one is a state the producer
+        # cannot emit. The guard now treats unevidenced counters as a fresh
+        # episode, so a fixture that omitted the cause was asserting against
+        # an impossible row.
+        result={"error_category": "rate_limit_cooldown_deferred"},
     )
     run.total_units = 2
     db_session.add(second)
@@ -875,6 +887,13 @@ def test_cooldown_wall_clock_budget_exhausted_terminalizes_rather_than_sleeping_
         rate_limit_deferrals=1,
         rate_limit_first_seen_at=now
         - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 60),
+        # Producible state (CHAOS-3412 closure): every production stamp that
+        # sets a non-zero rate_limit_deferrals co-writes a rate-limit
+        # error_category, so counters without one is a state the producer
+        # cannot emit. The guard now treats unevidenced counters as a fresh
+        # episode, so a fixture that omitted the cause was asserting against
+        # an impossible row.
+        result={"error_category": "rate_limit_cooldown_deferred"},
     )
     run.total_units = 2
     db_session.add(second)
@@ -1131,6 +1150,13 @@ def test_reconfirm_cooldowns_terminalizes_exhausted_match_directly(
         processor_flags={"sync_git": True},
         rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
         rate_limit_first_seen_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        # Producible state (CHAOS-3412 closure): every production stamp that
+        # sets a non-zero rate_limit_deferrals co-writes a rate-limit
+        # error_category, so counters without one is a state the producer
+        # cannot emit. The guard now treats unevidenced counters as a fresh
+        # episode, so a fixture that omitted the cause was asserting against
+        # an impossible row.
+        result={"error_category": "rate_limit_cooldown_deferred"},
     )
     run.total_units = 2
     db_session.add(second)
@@ -1467,3 +1493,1551 @@ def test_rate_limit_state_cleared_on_success_starts_fresh_episode_later(
     assert deferral is not None
     fresh_first_seen = datetime.fromisoformat(deferral.first_seen_at)
     assert abs((fresh_first_seen - much_later).total_seconds()) < 1
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412: budget-deferral episode exhaustion
+# ---------------------------------------------------------------------------
+
+
+def _lap_budget_deferrals(db_session, run, unit, *, laps: int) -> list[dict]:
+    """Run ``dispatch_sync_run`` ``laps`` times, making the unit due again
+    between laps so every lap re-evaluates the SAME budget-deferred unit --
+    the loop an operator actually observes (``updated_at`` advancing while
+    the unit never leaves ``retrying``)."""
+    from dev_health_ops.workers import sync_units
+
+    results = []
+    for _ in range(laps):
+        results.append(sync_units.dispatch_sync_run(str(run.id)))
+        db_session.refresh(unit)
+        if unit.status != SyncRunUnitStatus.RETRYING.value:
+            break
+        unit.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        db_session.flush()
+    return results
+
+
+def test_budget_deferral_exhausts_instead_of_looping_forever(db_session, monkeypatch):
+    """NEGATIVE CONTROL (CHAOS-3412), kept as the regression test.
+
+    Before the fix this test's loop ran forever: ``_defer_unit_for_budget``
+    re-stamped ``retrying`` with a fresh ``available_at`` every lap while
+    ``attempts`` stayed pinned at 0 and no exhaustion predicate existed for
+    the budget episode, so the unit never failed, never ran, and never
+    surfaced an error to the operator. Run against unmodified code, the
+    final assertions below fail with ``'retrying' != 'failed'`` -- that is
+    the defect. After the fix the count cap (``SYNC_BUDGET_MAX_DEFERRALS``)
+    terminalizes the unit with an actionable error.
+    """
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    # An estimate this unit can never fit: the guard is doing its job, the
+    # unit is permanently oversized for its bucket (the CHAOS-3412 shape).
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    results = _lap_budget_deferrals(
+        db_session, run, unit, laps=BUDGET_MAX_DEFERRALS_DEFAULT + 1
+    )
+
+    # Every lap up to the cap deferred; none of them dispatched the unit.
+    assert all(result["status"] == "deferred" for result in results[:-1])
+    assert all(result["queued_units"] == 0 for result in results)
+
+    db_session.refresh(unit)
+    # The loop now has an exit: the unit fails LOUDLY instead of sitting in
+    # retrying forever.
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "budget_deferral_exhausted"
+    assert unit.budget_deferrals == BUDGET_MAX_DEFERRALS_DEFAULT
+    assert unit.budget_first_deferred_at is not None
+    # It never ran: the exhaustion is a configuration error surfaced before
+    # a worker slot is burned, so attempts stays 0 (the ticket's observation).
+    assert unit.attempts == 0
+    # The error text has to be actionable on its own -- it names the bucket,
+    # the estimate, the cap it could never fit, the window span that drove
+    # the estimate, and the two operator remedies.
+    assert unit.error is not None
+    assert "github:" in unit.error and "rest_core" in unit.error
+    assert "backfill" in unit.error.lower()
+    assert "SYNC_BUDGET_BUCKET_LIMITS" in unit.error
+
+
+def test_budget_deferral_exhaustion_finalizes_the_run_as_failed(
+    db_session, monkeypatch
+):
+    """Reached-state assertion, not just the unit's own row: terminalizing
+    the last blocked unit has to move the RUN to a terminal, failed state
+    too. A unit that fails while its run stays open forever would swap one
+    invisible-nothing-happening for another.
+    """
+    from dev_health_ops.models import SyncRunStatus
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    _lap_budget_deferrals(db_session, run, unit, laps=BUDGET_MAX_DEFERRALS_DEFAULT + 1)
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert run.status in {
+        SyncRunStatus.FAILED.value,
+        SyncRunStatus.PARTIAL_FAILED.value,
+    }
+
+
+def test_budget_wall_clock_cap_exhausts_below_the_count_cap(db_session, monkeypatch):
+    """The second cap: a unit stuck in ONE continuous budget episode for
+    longer than SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS terminalizes even
+    though its deferral COUNT is nowhere near the cap (a long deferral
+    interval would otherwise let it loop for weeks).
+
+    The bucket limit is set deliberately (review round 2, F1): exhaustion is
+    only ever decided for a unit that STILL does not fit on this pass, so a
+    test that left the bucket wide open would assert the unit is killed while
+    it is actually admissible -- which is the defect F1 fixed, not the cap
+    this test is about.
+    """
+    from dev_health_ops.sync.budget_guard import (
+        BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT,
+        BUDGET_MAX_DEFERRALS_DEFAULT,
+    )
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = now - timedelta(seconds=1)
+    unit.budget_deferrals = 2
+    assert unit.budget_deferrals < BUDGET_MAX_DEFERRALS_DEFAULT
+    unit.budget_first_deferred_at = now - timedelta(
+        seconds=BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT + 60
+    )
+    unit.result = {
+        "error_category": "budget_deferred",
+        "not_before": (now - timedelta(seconds=1)).isoformat(),
+        "budget_guard": [
+            {
+                "decision": "deferred",
+                "budget_key": "github:org:api.github.com:fp:rest_core:git",
+                "estimated_units": 360,
+                "budget_limit": 100,
+            }
+        ],
+    }
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    # Still oversized on THIS pass -- the wall clock is what ends it, but the
+    # unit must genuinely not fit for exhaustion to be considered at all.
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "budget_deferral_exhausted"
+    assert unit.result["budget_deferrals"] == 2
+    # The error text is built from THIS pass's live observation, not from the
+    # stale result['budget_guard'] payload seeded above (which claims 360
+    # units against a cap of 100). Review round 2, F1: the explanation has to
+    # come from the same evaluation that made the decision, or an operator is
+    # handed numbers from a bucket state that no longer exists.
+    assert unit.error is not None
+    assert "360" not in unit.error, unit.error
+    assert "estimates 2 units" in unit.error
+    assert "cap is 0" in unit.error
+    assert "rest_core" in unit.error
+    assert "SYNC_BUDGET_BUCKET_LIMITS" in unit.error
+
+
+def test_fresh_unit_with_no_budget_history_is_never_exhausted(db_session, monkeypatch):
+    """Guard-failing control: exhaustion must require GENUINE prior
+    budget-deferral history. A unit with a clean budget pair dispatches
+    normally, even on a pass where the guard is evaluated.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    assert unit.budget_deferrals == 0
+    assert unit.budget_first_deferred_at is None
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_stale_budget_state_does_not_terminalize_unrelated_retry(
+    db_session, monkeypatch
+):
+    """Defence in depth (mirrors the rate-limit predicate's round-3 gate):
+    a unit carrying budget-exhausted-LOOKING budget columns whose own last
+    recorded cause is something else entirely (here a rate-limit deferral)
+    must NOT be terminalized off them. Only a unit whose last cause is the
+    budget guard's own deferral category is eligible.
+    """
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = now - timedelta(seconds=1)
+    # Well past BOTH caps -- and still not eligible.
+    unit.budget_deferrals = BUDGET_MAX_DEFERRALS_DEFAULT + 5
+    unit.budget_first_deferred_at = now - timedelta(days=7)
+    unit.result = {"error_category": "rate_limit", "rate_limit_deferrals": 1}
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert unit.status != SyncRunUnitStatus.FAILED.value
+    assert result == {"status": "dispatched", "queued_units": 1}
+
+
+def test_rate_limit_deferral_clears_the_budget_episode_pair(db_session, monkeypatch):
+    """Episode symmetry (the converse of the existing budget-deferral-clears-
+    the-rate-limit-pair invariant): a rate-limit cooldown deferral is NOT a
+    budget episode, so it clears budget_deferrals/budget_first_deferred_at.
+    Without this, a unit that budget-deferred a few times and then hit a
+    genuine 429 would keep counting toward budget exhaustion off a cause
+    that has nothing to do with its budget.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    second.budget_deferrals = 4
+    second.budget_first_deferred_at = now - timedelta(minutes=30)
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=120),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.budget_deferrals == 0
+    assert second.budget_first_deferred_at is None
+
+
+def test_budget_episode_pair_cleared_on_success_starts_fresh_later(
+    db_session, monkeypatch
+):
+    """A unit that resolves its budget episode by SUCCEEDING gets a fresh
+    count and a fresh wall clock for any later episode -- it is not
+    immediately exhausted against a resolved one. This is what makes the
+    Lane 2 window ratchet safe: each narrowed window that succeeds resets
+    the episode instead of inheriting the cold-start block's history.
+    """
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+    from tests.test_sync_units import (
+        _mark_dispatching,
+        _patch_finalize_apply,
+        _patch_runtime,
+    )
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.budget_deferrals = 7
+    unit.budget_first_deferred_at = now - timedelta(hours=4)
+    db_session.flush()
+
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", lambda ctx, rt: {"ok": 1})
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "success"
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.budget_deferrals == 0
+    assert unit.budget_first_deferred_at is None
+
+
+def _stamp_values_calls(source: str):
+    """Every ``update(SyncRunUnit).values(...)`` call in a module, as
+    {keyword: unparsed value} dicts."""
+    import ast
+
+    calls = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "values":
+            continue
+        calls.append(
+            {
+                keyword.arg: ast.unparse(keyword.value)
+                for keyword in node.keywords
+                if keyword.arg is not None
+            }
+        )
+    return calls
+
+
+#: Columns every stamp writes regardless of WHY it fired -- status plumbing,
+#: not deferral lifecycle. Listed so that any OTHER column a deferral stamp
+#: touches is treated as lifecycle state and must be classified below.
+_GENERIC_STAMP_COLUMNS = frozenset(
+    {
+        "status",
+        "available_at",
+        "attempts",
+        "duration_seconds",
+        "error",
+        "result",
+        "processor_flags",
+        "lease_owner",
+        "lease_expires_at",
+        "last_heartbeat_at",
+        "updated_at",
+        "expired_lease_retry_count",
+        "last_retry_reason",
+        "retry_exhausted_at",
+    }
+)
+
+
+def test_deferral_lifecycle_columns_are_classified_and_stamped_correctly():
+    """CHAOS-3412 closure guard for the defect CLASS, not just this instance.
+
+    Two distinct lifecycles have to stay straight, and getting either wrong
+    reintroduces an invisible-forever unit:
+
+    * PER-EPISODE (``rate_limit_*`` / ``budget_*``) -- reset by every
+      non-terminal stamp, so each pair measures ONE continuous episode. A
+      stamp that forgets a pair lets an exhaustion decision read a resolved
+      episode's counters.
+    * AGGREGATE (``first_blocked_at``) -- deliberately NOT in the per-episode
+      set. It is set-if-null by every DEFERRAL stamp and cleared ONLY by a
+      successful dispatch claim or SUCCESS. If a non-terminal stamp reset it
+      the way it resets the per-episode pairs, the budget/rate-limit
+      alternation would clear the outer bound too and the F2 oscillation
+      would be unbounded again.
+
+    The column set is DERIVED from the live model and from what the real
+    deferral stamps actually assign -- never listed here -- so a THIRD
+    lifecycle column added later fails this test until someone classifies it.
+    """
+    import ast
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    read = lambda rel: (repo_root / rel).read_text()  # noqa: E731
+
+    model_columns = {
+        statement.target.id
+        for node in ast.walk(
+            ast.parse(read("src/dev_health_ops/models/integrations.py"))
+        )
+        if isinstance(node, ast.ClassDef) and node.name == "SyncRunUnit"
+        for statement in node.body
+        if isinstance(statement, ast.AnnAssign)
+        and isinstance(statement.target, ast.Name)
+    }
+    per_episode = {
+        name
+        for name in model_columns
+        if name.startswith("rate_limit_") or name.startswith("budget_")
+    }
+    # A derivation that finds nothing must FAIL, not read as "all clean".
+    assert len(per_episode) >= 4, per_episode
+    assert {"budget_deferrals", "budget_first_deferred_at"} <= per_episode
+    # The aggregate column is deliberately outside the per-episode set --
+    # pinned so a rename into the prefix space cannot silently enrol it into
+    # the "reset at every stamp" rule that would defeat it.
+    assert "first_blocked_at" in model_columns
+    assert "first_blocked_at" not in per_episode
+
+    # (module, marker keyword, marker value) for the three real DEFERRAL
+    # stamps -- the ones that hold a unit back without it ever running.
+    deferral_stamps = [
+        (
+            "src/dev_health_ops/sync/budget_guard.py",
+            "error",
+            "'deferred by sync budget guard'",
+        ),
+        (
+            "src/dev_health_ops/sync/budget_guard.py",
+            "error",
+            "'deferred by sync cooldown guard'",
+        ),
+        (
+            "src/dev_health_ops/workers/sync_units.py",
+            "rate_limit_first_seen_at",
+            "first_seen_at",
+        ),
+    ]
+    lifecycle_columns: set[str] = set()
+    for relative_path, marker_key, marker_value in deferral_stamps:
+        matches = [
+            assigned
+            for assigned in _stamp_values_calls(read(relative_path))
+            if assigned.get(marker_key) == marker_value
+        ]
+        assert len(matches) == 1, (
+            f"{relative_path}: expected exactly one deferral stamp with "
+            f"{marker_key}={marker_value}, found {len(matches)} -- the stamp "
+            "this guard measures moved or changed meaning."
+        )
+        assigned = matches[0]
+        lifecycle_columns |= (set(assigned) & model_columns) - _GENERIC_STAMP_COLUMNS
+        # Every deferral stamp must START the aggregate clock, set-if-null.
+        assert "first_blocked_at" in assigned, (
+            f"{relative_path} deferral stamp does not set first_blocked_at; "
+            "a blocking reason that never starts the aggregate clock is "
+            "invisible to the outer bound."
+        )
+        assert "coalesce" in assigned["first_blocked_at"].lower(), (
+            f"{relative_path} overwrites first_blocked_at instead of "
+            "COALESCEing it. An overwrite lets an episode change restart the "
+            "outer bound, which is exactly the F2 defect."
+        )
+
+    # The classification is exhaustive: every lifecycle column a deferral
+    # stamp writes is either per-episode or the aggregate clock.
+    assert lifecycle_columns == per_episode | {"first_blocked_at"}, (
+        f"unclassified deferral-lifecycle column(s): "
+        f"{sorted(lifecycle_columns - (per_episode | {'first_blocked_at'}))}. "
+        "Decide whether it resets per episode or tracks the aggregate block, "
+        "and extend this guard accordingly."
+    )
+
+    # Per-episode rule: every non-terminal stamp assigns EVERY per-episode
+    # column. Terminal (failed) stamps are excluded -- a failed unit is never
+    # a dispatch candidate, so no predicate reads it.
+    sites = [
+        ("src/dev_health_ops/workers/sync_units.py", "SUCCESS"),
+        ("src/dev_health_ops/workers/sync_units.py", "RETRYING"),
+        ("src/dev_health_ops/workers/sync_reconciler.py", "RETRYING"),
+        ("src/dev_health_ops/sync/budget_guard.py", "RETRYING"),
+    ]
+    checked = 0
+    for relative_path, status_name in sites:
+        marker = f"SyncRunUnitStatus.{status_name}.value"
+        for assigned in _stamp_values_calls(read(relative_path)):
+            if assigned.get("status") != marker:
+                continue
+            checked += 1
+            missing = per_episode - set(assigned)
+            assert not missing, (
+                f"{relative_path} {status_name} stamp does not assign "
+                f"{sorted(missing)}. Every non-terminal stamp must either "
+                "clear an episode pair or set it deliberately; leaving it "
+                "untouched is what let CHAOS-3412's budget columns (and, "
+                "before it, CHAOS-2760's rate-limit columns) be read from a "
+                "resolved episode."
+            )
+    # An unmeasured path must fail loudly rather than read as covered.
+    assert checked >= len(sites), f"only located {checked} stamp sites"
+
+    # Aggregate rule: SUCCESS and the dispatch claim are the ONLY places that
+    # clear it, and they clear it outright rather than COALESCEing.
+    claim_and_success = [
+        assigned
+        for assigned in _stamp_values_calls(
+            read("src/dev_health_ops/workers/sync_units.py")
+        )
+        if assigned.get("first_blocked_at") == "None"
+    ]
+    assert len(claim_and_success) == 3, (
+        "expected exactly 3 first_blocked_at clear sites (SUCCESS plus the "
+        f"two dispatch-claim UPDATEs), found {len(claim_and_success)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 review round 2: F1 (fit-before-kill) and F2 (aggregate clock)
+# ---------------------------------------------------------------------------
+
+
+def test_unit_at_count_cap_is_admitted_when_capacity_frees_up(db_session, monkeypatch):
+    """F1 (HIGH): exhaustion is a statement about NOW, not about history.
+
+    A unit can reach the deferral cap and then have its bucket free up --
+    a sibling finishes, an hourly window rolls over. Evaluating exhaustion
+    before admission killed it on last pass's evidence, discarding work that
+    would have succeeded on this one. Before the fix this test failed with
+    'failed' != 'dispatching'.
+    """
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    _lap_budget_deferrals(db_session, run, unit, laps=BUDGET_MAX_DEFERRALS_DEFAULT)
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.budget_deferrals == BUDGET_MAX_DEFERRALS_DEFAULT
+
+    # Capacity is now available. The unit is AT the cap, so under the old
+    # ordering this pass would have killed it without ever asking whether it
+    # still fits.
+    monkeypatch.delenv("SYNC_BUDGET_BUCKET_LIMITS", raising=False)
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.result is None or (
+        unit.result.get("error_category") != "budget_deferral_exhausted"
+    )
+    # The successful claim also stops the aggregate blocked clock: the unit
+    # is no longer going nowhere.
+    assert unit.first_blocked_at is None
+
+
+def test_unit_at_count_cap_still_oversized_is_terminalized(db_session, monkeypatch):
+    """F1's other half -- the guard must still fail a unit that reached the
+    cap AND genuinely still does not fit. Without this, 'check fit first'
+    could be satisfied by never terminalizing at all.
+    """
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    _lap_budget_deferrals(db_session, run, unit, laps=BUDGET_MAX_DEFERRALS_DEFAULT)
+    db_session.refresh(unit)
+    assert unit.budget_deferrals == BUDGET_MAX_DEFERRALS_DEFAULT
+
+    # Bucket is STILL full on this pass.
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "budget_deferral_exhausted"
+
+
+def _alternate_blocking_laps(db_session, run, unit, monkeypatch, *, laps: int):
+    """Alternate the unit between a budget block and a rate-limit cooldown
+    block, so each stamp clears the OTHER episode's counters. This is the F2
+    oscillation: genuine, continuous blocking that no per-episode cap can
+    ever measure."""
+    from dev_health_ops.workers import sync_units
+
+    observation = None
+    for lap in range(laps):
+        now = datetime.now(timezone.utc)
+        if lap % 2 == 0:
+            if observation is not None:
+                db_session.delete(observation)
+                observation = None
+            monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+        else:
+            monkeypatch.delenv("SYNC_BUDGET_BUCKET_LIMITS", raising=False)
+            observation = _observation(
+                run,
+                unit,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=now + timedelta(seconds=90),
+                observed_at=now - timedelta(seconds=5),
+            )
+            db_session.add(observation)
+        db_session.flush()
+
+        sync_units.dispatch_sync_run(str(run.id))
+        db_session.refresh(unit)
+        if unit.status == SyncRunUnitStatus.FAILED.value:
+            return lap
+        unit.available_at = now - timedelta(seconds=1)
+        db_session.flush()
+    return None
+
+
+def test_alternating_episodes_preserve_the_aggregate_blocked_clock(
+    db_session, monkeypatch
+):
+    """F2 (HIGH), first half -- the mechanism that makes the cap reachable.
+
+    Each episode kind clears the other's counters by design, so neither
+    per-episode cap can ever accumulate under alternation. first_blocked_at
+    is the one thing an episode change must NOT reset; if it did, the
+    aggregate cap would be as unreachable as the per-episode ones.
+    """
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    terminalized_at = _alternate_blocking_laps(
+        db_session, run, unit, monkeypatch, laps=8
+    )
+    assert terminalized_at is None, "aggregate cap is 24h; 8 same-second laps"
+
+    db_session.refresh(unit)
+    first_blocked_at = unit.first_blocked_at
+    # Neither per-episode counter can accumulate -- this is why the
+    # per-episode caps are structurally unreachable here.
+    assert unit.budget_deferrals <= 1
+    assert unit.rate_limit_deferrals <= 1
+    # But the aggregate clock survived every episode change.
+    assert first_blocked_at is not None
+
+    _alternate_blocking_laps(db_session, run, unit, monkeypatch, laps=4)
+    db_session.refresh(unit)
+    assert _aware(unit.first_blocked_at) == _aware(first_blocked_at)
+
+
+def test_alternating_episodes_terminalize_at_the_aggregate_cap(db_session, monkeypatch):
+    """F2 (HIGH), second half -- the loop actually ends.
+
+    Once the aggregate clock passes SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS,
+    a unit that is STILL blocked fails with its own category, naming the last
+    episode kind and both counters so an operator can read "alternating"
+    straight off the error.
+    """
+    from dev_health_ops.sync.budget_guard import (
+        DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT,
+    )
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    # Odd lap count so the LAST completed lap is a budget lap -- the error
+    # text names whichever episode most recently blocked the unit, and the
+    # assertion below is only meaningful if that is deterministic.
+    assert _alternate_blocking_laps(db_session, run, unit, monkeypatch, laps=7) is None
+    db_session.refresh(unit)
+    assert unit.first_blocked_at is not None
+    assert unit.result["error_category"] == "budget_deferred"
+
+    # Simulate the elapsed time the laps above cannot: the unit has now been
+    # blocked, continuously and for shifting reasons, past the outer bound.
+    unit.first_blocked_at = datetime.now(timezone.utc) - timedelta(
+        seconds=DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT + 60
+    )
+    db_session.flush()
+
+    assert _alternate_blocking_laps(db_session, run, unit, monkeypatch, laps=2) == 0
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "deferral_exhausted"
+    assert unit.result["blocked_seconds"] >= DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT
+    # Both counters are reported: neither is a usable CAP under alternation,
+    # but together they are the diagnosis.
+    assert "budget deferrals" in unit.error
+    assert "rate-limit deferrals" in unit.error
+    # Names the episode that most recently blocked it, resolved from the
+    # unit's own persisted category -- never the "unknown" fallback.
+    assert "sync budget admission" in unit.error
+    assert "unknown" not in unit.error
+
+
+def test_aggregate_cap_does_not_kill_a_unit_that_now_fits(db_session, monkeypatch):
+    """F1's rule applied to the aggregate cap too: a unit blocked for longer
+    than the outer bound but ADMISSIBLE on this pass is dispatched, not
+    failed. The aggregate predicate is only ever asked of a unit the guard
+    has just re-established is blocked.
+    """
+    from dev_health_ops.sync.budget_guard import (
+        DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT,
+    )
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = now - timedelta(seconds=1)
+    unit.first_blocked_at = now - timedelta(
+        seconds=DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT * 3
+    )
+    unit.result = {"error_category": "budget_deferred"}
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    # No bucket limit and no cooldown: the unit fits now.
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.first_blocked_at is None
+
+
+def test_aggregate_blocked_clock_cleared_on_success(db_session, monkeypatch):
+    """A unit that gets through is not going nowhere: SUCCESS stops the
+    aggregate clock, so a later, unrelated blocking episode starts its own
+    24h rather than inheriting a resolved one's.
+    """
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+    from tests.test_sync_units import (
+        _mark_dispatching,
+        _patch_finalize_apply,
+        _patch_runtime,
+    )
+
+    run, unit = _seed_run(db_session)
+    unit.first_blocked_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    db_session.flush()
+
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", lambda ctx, rt: {"ok": 1})
+
+    assert getattr(run_sync_unit, "run")(str(unit.id))["status"] == "success"
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.first_blocked_at is None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 review round 2: R2-F1 (order-independent terminalization) and
+# R2-F2 (episode-specific caps first, on every path)
+# ---------------------------------------------------------------------------
+
+
+def _estimate(unit, units_cost: int) -> tuple[BudgetEstimate, ...]:
+    return (
+        BudgetEstimate(
+            bucket=BudgetBucketKey(
+                provider="github",
+                org_id=str(unit.org_id),
+                host="api.github.com",
+                credential_fingerprint="fp",
+                dimension=BudgetDimension.REST_CORE,
+            ),
+            estimated_units=units_cost,
+            confidence="high",
+            route_family="git",
+        ),
+    )
+
+
+def _run_with_order(db_session, monkeypatch, *, order, costs, at_cap_dataset):
+    """Two siblings in one bucket with controlled estimates and a controlled
+    candidate ORDER (review round 2, R2-F1). `at_cap_dataset` starts at the
+    budget deferral cap. Estimates and order are injected because the defect
+    IS about ordering: it cannot be exercised without controlling both."""
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.dataset_key = "alpha"
+    second = _sibling_unit(
+        run, first, dataset_key="beta", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    by_key = {"alpha": first, "beta": second}
+    for name, unit in by_key.items():
+        if name == at_cap_dataset:
+            unit.status = SyncRunUnitStatus.RETRYING.value
+            unit.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            unit.budget_deferrals = BUDGET_MAX_DEFERRALS_DEFAULT
+            unit.budget_first_deferred_at = datetime.now(timezone.utc) - timedelta(
+                minutes=5
+            )
+            unit.result = {"error_category": "budget_deferred"}
+    db_session.flush()
+
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate(by_key[ctx.dataset_key], costs[ctx.dataset_key]),
+    )
+    ordered = [by_key[name] for name in order]
+    monkeypatch.setattr(
+        budget_guard,
+        "_dispatch_candidate_units",
+        lambda *a, **k: [
+            u
+            for u in ordered
+            if u.status
+            in {SyncRunUnitStatus.PLANNED.value, SyncRunUnitStatus.RETRYING.value}
+        ],
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+    db_session.refresh(by_key[at_cap_dataset])
+    return by_key[at_cap_dataset]
+
+
+@pytest.mark.parametrize("order", [["alpha", "beta"], ["beta", "alpha"]])
+def test_at_cap_unit_that_fits_the_baseline_is_never_killed_in_either_order(
+    db_session, monkeypatch, order
+):
+    """R2-F1 (HIGH): a terminal verdict may not depend on candidate order.
+
+    beta costs 2 against a bucket cap of 10 and sits at its deferral cap;
+    alpha costs 9. Visiting alpha first consumed 9 of the cap, so beta's live
+    estimate became would_defer and beta was terminalized -- with an error
+    that literally read "estimates 2 units ... whose cap is 10 ... so it can
+    never be admitted". Visiting beta first admitted it. Same unit, same
+    world, opposite verdicts.
+
+    Terminalization is now measured against the DURABLE baseline (work
+    already dispatching/running), which no candidate ordering can change.
+    """
+    at_cap = _run_with_order(
+        db_session,
+        monkeypatch,
+        order=order,
+        costs={"alpha": 9, "beta": 2},
+        at_cap_dataset="beta",
+    )
+    assert at_cap.status != SyncRunUnitStatus.FAILED.value, (
+        f"order {order} terminalized a unit whose own estimate (2) fits the "
+        f"bucket cap (10): {at_cap.error}"
+    )
+    if at_cap.status == SyncRunUnitStatus.RETRYING.value:
+        assert at_cap.result is not None
+        # Deferred rather than killed -- and the counter still advances, so
+        # the aggregate clock remains the backstop if contention never clears.
+        assert at_cap.result["error_category"] == "budget_deferred"
+        assert at_cap.first_blocked_at is not None
+
+
+def test_permanently_oversized_unit_at_cap_is_still_terminalized(
+    db_session, monkeypatch
+):
+    """R2-F1's other half: "measure against the baseline" must not degrade
+    into "never terminalize". A unit whose OWN estimate exceeds the whole
+    bucket cap is unfit no matter what else is running or admitted, and must
+    still fail -- with the "can never be admitted" claim, which is true here.
+    """
+    at_cap = _run_with_order(
+        db_session,
+        monkeypatch,
+        order=["alpha", "beta"],
+        costs={"alpha": 1, "beta": 40},
+        at_cap_dataset="beta",
+    )
+    assert at_cap.status == SyncRunUnitStatus.FAILED.value
+    assert at_cap.result is not None
+    assert at_cap.error is not None
+    assert at_cap.result["error_category"] == "budget_deferral_exhausted"
+    assert at_cap.result["permanently_oversized"] is True
+    assert "can never be admitted" in at_cap.error
+
+
+def test_contention_blocked_unit_error_never_claims_it_can_never_be_admitted(
+    db_session, monkeypatch
+):
+    """The claim has to be literally true when made. A unit blocked only by
+    DURABLE contention (work already running) is genuinely at its cap and is
+    terminalized, but it is not permanently oversized -- waiting would let it
+    run. The text must say contention, not "never".
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.dataset_key = "alpha"
+    # alpha is RUNNING with a live lease: durable consumption, not an
+    # optional admission this pass makes.
+    first.status = SyncRunUnitStatus.RUNNING.value
+    first.lease_owner = "worker-a"
+    first.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    second = _sibling_unit(
+        run, first, dataset_key="beta", processor_flags={"sync_git": True}
+    )
+    second.status = SyncRunUnitStatus.RETRYING.value
+    second.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    second.budget_deferrals = BUDGET_MAX_DEFERRALS_DEFAULT
+    second.budget_first_deferred_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    second.result = {"error_category": "budget_deferred"}
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    by_key = {"alpha": first, "beta": second}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate(
+            by_key[ctx.dataset_key], {"alpha": 9, "beta": 2}[ctx.dataset_key]
+        ),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+    db_session.refresh(second)
+
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.error is not None
+    assert second.result["permanently_oversized"] is False
+    assert second.result["durable_units"] == 9
+    assert "can never be admitted" not in second.error
+    assert "already running" in second.error
+
+
+def test_sibling_completion_lets_a_previously_contended_unit_run(
+    db_session, monkeypatch
+):
+    """The race codex named: the durable holder finishes between passes, so
+    the contention that was blocking the unit is gone and it must run. Under
+    the old ordering the unit could already have been killed by then.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.dataset_key = "alpha"
+    first.status = SyncRunUnitStatus.RUNNING.value
+    first.lease_owner = "worker-a"
+    first.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    second = _sibling_unit(
+        run, first, dataset_key="beta", processor_flags={"sync_git": True}
+    )
+    second.status = SyncRunUnitStatus.RETRYING.value
+    second.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    second.budget_deferrals = BUDGET_MAX_DEFERRALS_DEFAULT - 1
+    second.budget_first_deferred_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    second.result = {"error_category": "budget_deferred"}
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    by_key = {"alpha": first, "beta": second}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate(
+            by_key[ctx.dataset_key], {"alpha": 9, "beta": 2}[ctx.dataset_key]
+        ),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    # Pass 1: alpha still running -> beta contends, defers, hits its cap.
+    sync_units.dispatch_sync_run(str(run.id))
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.budget_deferrals == BUDGET_MAX_DEFERRALS_DEFAULT
+
+    # Pass 2: alpha finished. The cap is spent, but the unit now fits.
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    first.lease_owner = None
+    first.lease_expires_at = None
+    second.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    db_session.flush()
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value, second.error
+    assert result["queued_units"] == 1
+
+
+def test_single_cause_rate_limit_unit_gets_the_specific_category(
+    db_session, monkeypatch
+):
+    """R2-F2 (MEDIUM): episode-specific caps are evaluated before the
+    aggregate backstop on EVERY path. A unit whose only cause was rate
+    limiting used to fail as the generic 'deferral_exhausted' carrying "the
+    blocking reason kept changing" -- false for a unit that only ever had one
+    reason, and it hides the actionable diagnosis.
+    """
+    from dev_health_ops.sync.budget_guard import (
+        DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT,
+    )
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import RATE_LIMIT_MAX_DEFERRALS
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        status=SyncRunUnitStatus.RETRYING.value,
+        rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
+        rate_limit_first_seen_at=now - timedelta(hours=3),
+        result={"error_category": "rate_limit_cooldown_deferred"},
+    )
+    second.available_at = now - timedelta(seconds=1)
+    second.budget_deferrals = 0  # never had a budget episode
+    second.first_blocked_at = now - timedelta(
+        seconds=DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT + 60
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    # Both caps were spent; the SPECIFIC one wins.
+    assert second.result["error_category"] == "rate_limit_cooldown_exhausted"
+
+
+def test_generic_exhaustion_text_only_claims_alternation_when_it_happened(
+    db_session, monkeypatch
+):
+    """The generic category is also reachable for a SINGLE-cause unit (one
+    held back purely by durable budget contention, which the episode cap
+    deliberately does not terminalize). Its text must match its own evidence:
+    both counters non-zero means alternation, otherwise it must not claim it.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import (
+        DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT,
+    )
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.dataset_key = "alpha"
+    first.status = SyncRunUnitStatus.RUNNING.value
+    first.lease_owner = "worker-a"
+    first.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    second = _sibling_unit(
+        run, first, dataset_key="beta", processor_flags={"sync_git": True}
+    )
+    second.status = SyncRunUnitStatus.RETRYING.value
+    second.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    # Budget-only history, and past the aggregate bound.
+    second.budget_deferrals = 3
+    second.budget_first_deferred_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    second.rate_limit_deferrals = 0
+    second.first_blocked_at = datetime.now(timezone.utc) - timedelta(
+        seconds=DEFERRAL_TOTAL_WALL_CLOCK_SECONDS_DEFAULT + 60
+    )
+    second.result = {"error_category": "budget_deferred"}
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    by_key = {"alpha": first, "beta": second}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate(
+            by_key[ctx.dataset_key], {"alpha": 9, "beta": 2}[ctx.dataset_key]
+        ),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+    db_session.refresh(second)
+
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.error is not None
+    assert second.result["error_category"] == "deferral_exhausted"
+    # The evidence says one cause only -- the text must agree with it.
+    assert second.result["episodes_alternated"] is False
+    assert second.result["rate_limit_deferrals"] == 0
+    assert "alternated" not in second.error
+    assert "kept changing" not in second.error
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 closure: the terminalization chokepoint
+# ---------------------------------------------------------------------------
+
+
+def test_stale_capped_counters_with_cooldown_defer_as_a_fresh_episode(
+    db_session, monkeypatch
+):
+    """Closure instance 5 (codex round 3).
+
+    A unit carrying CAPPED rate-limit counters from an episode that already
+    resolved -- its own last cause is 'worker_lost' -- meets an active
+    cooldown. ``_plan_cooldown_deferral`` re-read those counters raw, returned
+    None, and terminalized the unit as rate_limit_cooldown_exhausted:
+    irreversible, and under a category the unit's own state contradicts. The
+    pre-existing regression only covered the no-visible-cooldown path.
+
+    Counters are evidence only when the unit's last cause says the episode is
+    live, so this is a FRESH episode: the unit defers and its counters restart
+    from this genuine block.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import RATE_LIMIT_MAX_DEFERRALS
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        status=SyncRunUnitStatus.RETRYING.value,
+        rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
+        rate_limit_first_seen_at=now - timedelta(hours=3),
+        result={"error_category": "worker_lost", "retry_reason": "expired_lease"},
+    )
+    second.available_at = now - timedelta(seconds=1)
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value, second.error
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    # Restarted, not continued: the resolved episode's 10 is not inherited.
+    assert second.rate_limit_deferrals == 1
+
+
+def test_chokepoint_refuses_a_verdict_the_unit_state_does_not_evidence():
+    """The chokepoint's own check (a), tested directly rather than only
+    through a caller: a verdict naming an episode the unit's last cause does
+    not evidence is REFUSED (returns None), not written."""
+    from dev_health_ops.sync.budget_guard import (
+        TerminalOutcome,
+        TerminalVerdict,
+        _terminalize_unit,
+    )
+
+    class _Session:
+        def __init__(self):
+            self.executed = []
+
+        def execute(self, statement):
+            self.executed.append(statement)
+            raise AssertionError("refused verdict must never reach the database")
+
+    unit = SyncRunUnit(
+        org_id="org",
+        sync_run_id=uuid.uuid4(),
+        integration_id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RETRYING.value,
+        rate_limit_deferrals=10,
+        result={"error_category": "worker_lost"},
+    )
+    session = _Session()
+    decision = _terminalize_unit(
+        session,
+        unit,
+        verdict=TerminalVerdict(
+            error_category="rate_limit_cooldown_exhausted",
+            error_text="rate limit cooldown deferral budget exhausted",
+            evidence={"rate_limit_deferrals": 10},
+            episode="rate_limit",
+        ),
+        now=datetime.now(timezone.utc),
+        log_ctx={},
+    )
+    # A refusal is its OWN outcome, never conflated with a lost CAS race.
+    assert decision.outcome is TerminalOutcome.REFUSED
+    assert decision.at is None
+    assert session.executed == []
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+
+
+def test_chokepoint_rejects_unlicensed_claims_and_missing_fitness():
+    """Checks (b) and (c) are invariants over code this module writes, so they
+    raise rather than silently producing a false diagnosis."""
+    from dev_health_ops.sync.budget_guard import (
+        TerminalVerdict,
+        TerminalVerdictError,
+        _assert_verdict_wellformed,
+    )
+
+    # (c) an unlicensed "can never be admitted"
+    with pytest.raises(TerminalVerdictError, match="can never be admitted"):
+        _assert_verdict_wellformed(
+            TerminalVerdict(
+                error_category="deferral_exhausted",
+                error_text="... so it can never be admitted ...",
+                evidence={"permanently_oversized": False},
+            )
+        )
+    # (c) an unlicensed alternation claim
+    with pytest.raises(TerminalVerdictError, match="alternated"):
+        _assert_verdict_wellformed(
+            TerminalVerdict(
+                error_category="deferral_exhausted",
+                error_text="the reason alternated between causes",
+                evidence={"episodes_alternated": False},
+            )
+        )
+    # (b) a fitness claim with no durable-world verdict attached
+    with pytest.raises(TerminalVerdictError, match="fitness claim"):
+        _assert_verdict_wellformed(
+            TerminalVerdict(
+                error_category="budget_deferral_exhausted",
+                error_text="exhausted",
+                evidence={},
+                episode="budget",
+            )
+        )
+    # An unexplained terminal failure is the state this ticket removes.
+    with pytest.raises(TerminalVerdictError, match="no error text"):
+        _assert_verdict_wellformed(
+            TerminalVerdict(
+                error_category="deferral_exhausted", error_text="  ", evidence={}
+            )
+        )
+
+
+def test_every_terminal_deferral_stamp_routes_through_the_chokepoint():
+    """The property that makes "the class is closed" a claim and not a hope.
+
+    Derives every ``status=FAILED`` stamp in the deferral subsystem and
+    asserts each one is lexically inside ``_terminalize_unit``. A sixth
+    terminal path either routes through the chokepoint -- and is therefore
+    subject to checks (a), (b) and (c) -- or fails here. It cannot be added
+    quietly.
+
+    Scope is stated rather than assumed: the deferral-exhaustion categories
+    this closure owns. ``worker_lost_retry_exhausted`` (lease-retry
+    exhaustion, workers/sync_reconciler.py) is a different subsystem with its
+    own decision path and is deliberately NOT claimed here -- claiming it
+    without routing it would be exactly the kind of coverage assertion this
+    ticket exists to stop making.
+    """
+    import ast
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    guard_path = "src/dev_health_ops/sync/budget_guard.py"
+    other_paths = [
+        "src/dev_health_ops/workers/sync_units.py",
+        "src/dev_health_ops/workers/sync_reconciler.py",
+    ]
+
+    guard_source = (repo_root / guard_path).read_text()
+    guard_tree = ast.parse(guard_source)
+
+    # The registered categories, derived from the module rather than listed.
+    owned_categories = {
+        node.targets[0].id: ast.literal_eval(node.value)
+        for node in ast.walk(guard_tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id.endswith("_EXHAUSTED_CATEGORY")
+        and isinstance(node.value, ast.Constant)
+    }
+    assert len(owned_categories) >= 3, owned_categories
+    owned = set(owned_categories.values())
+
+    def enclosing_functions(tree):
+        """{node -> nearest enclosing function name} for every node."""
+        owner: dict[ast.AST, str] = {}
+        for func in ast.walk(tree):
+            if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for child in ast.walk(func):
+                    owner.setdefault(child, func.name)
+        return owner
+
+    def failed_stamps(tree):
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute) or func.attr != "values":
+                continue
+            assigned = {
+                keyword.arg: ast.unparse(keyword.value)
+                for keyword in node.keywords
+                if keyword.arg is not None
+            }
+            if assigned.get("status") == "SyncRunUnitStatus.FAILED.value":
+                yield node, assigned
+
+    owner = enclosing_functions(guard_tree)
+    guard_stamps = list(failed_stamps(guard_tree))
+    # A derivation that finds nothing must FAIL, not read as "all routed".
+    assert guard_stamps, "no FAILED stamps found in budget_guard.py"
+    for node, _assigned in guard_stamps:
+        assert owner.get(node) == "_terminalize_unit", (
+            f"{guard_path}: a status=FAILED stamp lives in "
+            f"{owner.get(node)!r}, outside the terminalization chokepoint. "
+            "Every terminal deferral verdict must route through "
+            "_terminalize_unit so its evidence, fitness and claims are "
+            "checked; adding a second terminal path reopens the defect class "
+            "this closure exists to shut."
+        )
+
+    # No module outside the guard may stamp one of the owned categories.
+    for relative_path in other_paths:
+        tree = ast.parse((repo_root / relative_path).read_text())
+        for _node, assigned in failed_stamps(tree):
+            rendered = assigned.get("result", "")
+            leaked = [category for category in owned if category in rendered]
+            assert not leaked, (
+                f"{relative_path} stamps deferral-exhaustion category "
+                f"{leaked!r} outside the chokepoint in budget_guard.py"
+            )
+
+    # And every terminalize helper actually delegates to it.
+    delegating = {
+        func.name
+        for func in ast.walk(guard_tree)
+        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and func.name.startswith("_terminalize_")
+        and func.name != "_terminalize_unit"
+        and "_terminalize_unit(" in ast.unparse(func)
+    }
+    declared = {
+        func.name
+        for func in ast.walk(guard_tree)
+        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and func.name.startswith("_terminalize_")
+        and func.name != "_terminalize_unit"
+    }
+    assert declared, "no _terminalize_* helpers found"
+    assert declared == delegating, (
+        f"terminalize helper(s) {sorted(declared - delegating)} do not "
+        "delegate to _terminalize_unit"
+    )
+
+
+def _cooldown_blocked_stale_counter_unit(db_session, monkeypatch):
+    """A unit carrying CAPPED rate-limit counters from a RESOLVED episode
+    (last cause 'worker_lost'), due, and gated by an ACTIVE cooldown."""
+    from dev_health_ops.workers.rate_limit_defer import RATE_LIMIT_MAX_DEFERRALS
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        status=SyncRunUnitStatus.RETRYING.value,
+        rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
+        rate_limit_first_seen_at=now - timedelta(hours=3),
+        result={"error_category": "worker_lost", "retry_reason": "expired_lease"},
+    )
+    second.available_at = now - timedelta(seconds=1)
+    second.first_blocked_at = now - timedelta(hours=2)
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    return run, second
+
+
+def test_stale_counters_under_cooldown_defer_fresh_through_the_outer_caller(
+    db_session, monkeypatch
+):
+    """Driven through the OUTER dispatch path, not the resolver directly.
+
+    Pins the promise end to end: unevidenced counters + an active cooldown
+    defer as a FRESH episode, the aggregate clock is untouched, and the unit
+    is not claimable while the cooldown holds.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _cooldown_blocked_stale_counter_unit(db_session, monkeypatch)
+    before = _aware(unit.first_blocked_at)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.rate_limit_deferrals == 1
+    assert _aware(unit.first_blocked_at) == before
+    # Not claimable: it carries a future availability under the live cooldown.
+    assert unit.available_at is not None
+    assert _aware(unit.available_at) > datetime.now(timezone.utc)
+
+
+def test_refused_verdict_defers_rather_than_leaving_the_unit_claimable(
+    db_session, monkeypatch
+):
+    """A REFUSED verdict must never read as a lost CAS race.
+
+    Both used to be ``None``, and callers treated ``None`` as "another pass
+    owns this unit, skip it" -- so a refusal left a cooldown-blocked unit
+    unstamped, ``_claim_units`` dispatched it into the live cooldown, and the
+    claim cleared ``first_blocked_at``. A refusal silently resetting the
+    aggregate clock violates the invariant this module enforces.
+
+    The refusal path is not reachable through normal state (the episode
+    normalizer settles those counters before any verdict is proposed), so the
+    condition is injected: an episode whose evidence set licenses nothing.
+    Before the fix this test failed with 'dispatching' != 'retrying' and a
+    wiped first_blocked_at.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _cooldown_blocked_stale_counter_unit(db_session, monkeypatch)
+    before = _aware(unit.first_blocked_at)
+
+    monkeypatch.setattr(
+        budget_guard,
+        "_EPISODE_EVIDENCE",
+        {**budget_guard._EPISODE_EVIDENCE, "rate_limit": frozenset()},
+    )
+    monkeypatch.setattr(
+        budget_guard, "_rate_limit_deferral_exhausted", lambda unit, *, now: True
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result["queued_units"] == 0
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "rate_limit_cooldown_deferred"
+    # Fresh episode: the refused counters are not reused as a starting point.
+    assert unit.rate_limit_deferrals == 1
+    # The aggregate clock survives a refusal.
+    assert _aware(unit.first_blocked_at) == before
+
+
+def test_terminal_decision_distinguishes_refusal_from_a_lost_race():
+    """The type-level half: REFUSED and CAS_LOST are distinct outcomes, and
+    only the cooldown path's settler treats them differently. One value with
+    two meanings is what let the bug exist."""
+    from dev_health_ops.sync.budget_guard import (
+        _CARRY_ON,
+        TerminalDecision,
+        TerminalOutcome,
+        _settle_or_skip,
+        _settle_terminal_decision,
+    )
+
+    now = datetime.now(timezone.utc)
+    written = TerminalDecision(TerminalOutcome.TERMINALIZED, now)
+    refused = TerminalDecision(TerminalOutcome.REFUSED)
+    lost = TerminalDecision(TerminalOutcome.CAS_LOST)
+
+    assert TerminalOutcome.REFUSED is not TerminalOutcome.CAS_LOST
+    # Cooldown path: a refusal must be carried on (stamped by the caller),
+    # a lost race must not.
+    assert _settle_terminal_decision(written) == (now, True)
+    assert _settle_terminal_decision(refused) is _CARRY_ON
+    assert _settle_terminal_decision(lost) is None
+    # Non-cooldown path: both are safely "leave to normal handling".
+    assert _settle_or_skip(written) == (now, True)
+    assert _settle_or_skip(refused) is None
+    assert _settle_or_skip(lost) is None

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0084"}
+    assert set(heads) == {"0066", "0085"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0084"}
+        assert set(heads) == {"0066", "0085"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0084"
+        assert script.get_revision("application_schema@head").revision == "0085"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0084"}
-        assert scripts.get_revision("application_schema@head").revision == "0084"
-        assert _database_has_revision(cfg, ("0084",), "0065")
-        assert not _database_has_revision(cfg, ("0084",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0085"}
+        assert scripts.get_revision("application_schema@head").revision == "0085"
+        assert _database_has_revision(cfg, ("0085",), "0065")
+        assert not _database_has_revision(cfg, ("0085",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## The defect

Enabling a HEAVY dataset on an org with a wide `initial_sync_depth` produced units that were **deferred forever**. They never ran, never failed, and never exhausted — they sat in `retrying` indefinitely while the operator saw no data and no error.

`_defer_unit_for_budget` re-stamped `retrying` with a fresh `available_at`, did **not** increment `attempts`, and nothing tracked the budget episode at all — so no exhaustion predicate could ever become true. The window never narrowed and the counter never advanced: a closed loop by construction.

The loop is now closed at both ends, and every terminal outcome is actionable.

## RED negative control (pre-fix, on unmodified code)

A probe asserting the **broken** behaviour was written first and **passed** on unmodified code — 25 consecutive dispatch laps:

```
status=retrying, attempts=0, error_category=budget_deferred   (every lap)
updated_at advancing, never terminalized
25 laps, no exit
```

The kept regression test — the same scenario asserting the **new** behaviour — then failed on that same unmodified code:

```
>       assert unit.status == SyncRunUnitStatus.FAILED.value
E       AssertionError: assert 'retrying' == 'failed'
```

After the fix the probe fails at lap 11 (`'noop' != 'deferred'`): the loop is gone. Every subsequent guard in this PR was added the same way — defect reproduced first, fix second.

## What closes it

**Migration 0085** adds three columns to `sync_run_units`, with two deliberately different lifecycles:

- `budget_deferrals` / `budget_first_deferred_at` — the BUDGET episode, mirroring the rate-limit pair from 0022. `_budget_deferral_exhausted` fires on `SYNC_BUDGET_MAX_DEFERRALS` (10) or `SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS` (21600).
- `first_blocked_at` — the AGGREGATE clock. Because each episode kind resets the other's counters, a unit alternating between a budget block and a rate-limit cooldown keeps **both** per-episode caps permanently out of reach while never running. This is set-if-null by every deferral stamp, survives episode changes, and is cleared only on a successful dispatch claim or SUCCESS. Bounded by `SYNC_DEFERRAL_TOTAL_WALL_CLOCK_SECONDS` (86400).

**Exhaustion is evaluated after the live fit check, never before it**, and against a durable baseline (work already dispatching/running) — never against capacity taken by the same pass's own earlier admissions, which would make a terminal verdict depend on candidate ordering. A unit that has become admissible is admitted, however long it was previously held back.

**Terminal failures are actionable and honest.** `budget_deferral_exhausted` names the bucket, estimate, cap and window span; `deferral_exhausted` names the last episode kind and both counters. The claim "can never be admitted" is emitted only when the estimate alone exceeds the whole cap, and the alternation claim only when both counters evidence it.

**Surfacing:** `budget_deferrals` per unit and a derived `budget_blocked_unit_count` on the run rollup, so a blocked run stops looking idle.

## Episode-symmetry clear sites

Five non-terminal Python stamps, each clearing the episode pairs it does not own:

1. `workers/sync_units.py` — SUCCESS
2. `workers/sync_units.py` — rate-limit deferral (RETRYING)
3. `workers/sync_units.py` — soft-timeout retry (RETRYING)
4. `workers/sync_reconciler.py` — expired-lease retry (RETRYING)
5. `sync/budget_guard.py` — cooldown deferral (RETRYING)

Plus the aggregate clock's own clear sites: SUCCESS and both dispatch-claim UPDATEs.

`_RATE_LIMIT_EPISODE_ERROR_CATEGORIES` is untouched. A test derives the episode column set from the **live model** and asserts every non-terminal stamp assigns all of them, so a future third episode pair cannot be half-wired.

## Review history

Three Codex rounds, then a structural closure rather than a fifth patch.

Every finding across the rounds was one shape — *a terminal verdict resting on evidence weaker than the claim it made*: exhaustion decided from history without current fitness; a per-episode counter standing in for "stuck"; failure text rebuilt from a previous pass's state; fitness contaminated by the same pass's ordering; and an episode's counters re-read without their category guard.

Rather than patch the fifth instance, all terminal stamps now route through **one chokepoint** (`_terminalize_unit`) that enforces the invariant directly: (a) a verdict naming an episode is refused unless the unit's own last recorded cause evidences it; (b) a fitness claim must carry a durable-world verdict; (c) an error text may assert a claim phrase only when its evidence licenses it. An AST derivation test enumerates every `status=FAILED` stamp in the subsystem and asserts each is inside the chokepoint, so a sixth terminal path fails the build rather than being added quietly. The closure argument — the invariant, all five instances, and why a sixth cannot slip in — is the chokepoint's docstring.

The last reviewed fix made **refusal distinct from CAS-loss** in the return contract; both were previously `None`, and callers read that as "another pass owns this unit", which would have left a cooldown-blocked unit claimable and reset the aggregate clock. This was **latent, not live** — the episode normalizer already blocked the reachable route — and is fixed so it cannot become live.

## Migration 0085 — claim

`origin/main` head was **0084**, and `0085*` was free there. **This PR claims 0085.** The Go worker program holds an unlanded `0085_add_sync_unit_effect_snapshots.py` in an uncommitted worktree; that lane renumbers at transplant. Verified live: upgrade creates all three columns with correct types and default, downgrade drops them, re-upgrade is idempotent.

Each `ADD COLUMN` runs under a bounded `SET LOCAL lock_timeout` so the migration fails fast rather than queueing behind a long transaction and blocking every reader of a hot table. Rehearsed rather than assumed: with an ACCESS EXCLUSIVE lock held from another session, the migration failed in 5s with `LockNotAvailableError` (not a hang), added no column, and applied cleanly on retry once the lock cleared.

## Scope: Python-only

Budget admission and deferral are Python-only on every ref. Go's stamps do not yet clear these columns — they overwrite `result.error_category` with their own cause (`worker_lost`, `provider_unit_retryable`), so the chokepoint's evidence check refuses them and the gap is closed for now by a backstop rather than by the contract.

**Go parity is bucketed to CHAOS-3427, and is blocking for that program's scheduler activation.** This PR touches no `internal/` file.

## Gate evidence

- `bash ci/local_validate.sh` on this tip: **11819 passed, 100 skipped, 1 xfailed, 0 failed** in 2m23s. All seven stages green, including the argMax live-exec proof against a real engine.
- Full unit suite run as CI runs it (not a hand-picked subset), plus `tests/workers/` (407 passed) and `ci/check_transitional_inventory.py`.
- Live PostgreSQL 18 (matching the deployed image): migration up / down / idempotent re-up, and the lock-timeout rehearsal above.
- Postgres-gated migration and head-pin suites run with a real database so they executed rather than skipping: **115 passed, 0 skipped**.

`contracts/jobs/v1/transitional-inventory.json` re-anchored for 10 line shifts. Verified a pure shift, not a content change: each anchored line is byte-identical between base and tip with only its number moved, phantom/unowned counts balance per file, and ordering is preserved. The JSON diff changes only `id` and `line` fields.

## Residuals

- The aggregate `deferral_exhausted` category is legitimately reachable for a **single-cause** unit — one held back purely by durable budget contention, which the episode cap deliberately does not terminalize. Its error text is evidence-driven and does not claim alternation in that case.
- A unit alternating between episodes resets each per-episode counter by design; the aggregate clock is what bounds it. Documented in the predicate.
- New knobs default to 10 deferrals / 6h per budget episode and 24h aggregate. All three are restart-loaded and non-secret; none changes what is admitted — bucket limits do that.

## Deploy note

This PR adds columns to `sync_run_units` (migration 0085). Run `dev-hops migrate postgres upgrade` **before** workers run the new code — planning a unit against an un-migrated database fails with `UndefinedColumn: budget_deferrals`.

Verified live: composed acceptance validation passed on a scratch DB (ratchet + exhaustion both green; operator error text names dataset / estimate / bucket / cap / window plus the two remedies).

## Follow-on

PR-2 (cold-start window ratchet) follows after this merges. The shared-file rebase order is deliberate.

Refs CHAOS-3412.

