### PR TITLE
CHAOS-3412: HEAVY incremental window ratchet + watermark write-boundary invariants

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -446,7 +446,7 @@
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1999
+        "line": 2005
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2318,7 +2318,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1630
+        "line": 1636
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2342,7 +2342,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2450
+        "line": 2456
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -82,9 +82,30 @@ Consequences to expect when reading run state:
   runs do not request an upper bound and so never reach this state; only a
   manually requested past upper bound can.
 
+A stored watermark ahead of the current time is treated as corrupt. It can be
+produced by a provider record carrying a skewed timestamp, or by a version of the
+planner that predates these rules. Because watermark writes otherwise only move
+forward, such a value cannot be corrected by an ordinary run and would stop the
+dataset permanently: no unit would be planned, and the run would report "No sync
+units planned" on every attempt. The planner therefore plans a short recovery
+window instead, records a warning naming the stored value and the recovery
+window, and the next successful run replaces the corrupt watermark with a valid
+one. Records between the true last synchronized point and the recovery window are
+not re-fetched — run a bounded backfill if that span matters.
+
 These window rules — the end never in the future, and no unit for an already
 covered range — apply to full resynchronization as well as incremental
 synchronization. Both stamp the watermark at the window end on success, so both
 carry the same consequences. Bounded backfills are separate: they never stamp a
 watermark and legitimately target a historical range, so they keep their own
 chunking and bounds.
+
+Full resynchronization of a heavy record family is deliberately **not** capped.
+The cap exists so repeated incremental runs can make progress; a one-shot full
+resynchronization has no next run to continue from, so a capped window would
+cover only the cap's span and then report success — claiming a completed resync
+that did not happen. A full resync of a heavy family over a wide depth is
+therefore expected to be expensive, and where it exceeds the provider budget it
+terminalizes visibly and names the remedy rather than silently under-reading. To
+rebuild deep history for a heavy family, use bounded backfills for the period
+instead of a full resynchronization.

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -82,6 +82,14 @@ Consequences to expect when reading run state:
   runs do not request an upper bound and so never reach this state; only a
   manually requested past upper bound can.
 
+A watermark is never recorded ahead of the current time. Whatever a run reports —
+including a synchronization timestamp taken from a provider record — the recorded
+value is capped at the current time before it is stored. A record carrying a
+clock-skewed timestamp therefore cannot push a dataset's watermark into the
+future, and a watermark that has been repaired cannot be pushed back into the
+future by the next run. A cap of more than a minute is recorded as a warning and
+usually means a provider record carried a skewed timestamp.
+
 A stored watermark ahead of the current time is treated as corrupt. It can be
 produced by a provider record carrying a skewed timestamp, or by a version of the
 planner that predates these rules. Because watermark writes otherwise only move

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -43,6 +43,15 @@ window still starts at the watermark or cold-start depth, but ends no later than
 the start plus the cap. `SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS` sets the cap;
 the default is seven days, matching the proven backfill chunk size.
 
+The cap must exceed the configured watermark overlap. The window starts at the
+watermark less the overlap, so a cap at or below the overlap would end the window
+at or before the watermark it started from; because watermark writes only ever
+move forward, that write is discarded and the family re-reads the same slice on
+every run. When `SYNC_WATERMARK_OVERLAP` is greater than or equal to the cap, the
+planner widens the cap to exceed the overlap and records a warning naming both
+values. Treat that warning as a configuration defect to correct, not as a healthy
+steady state — the widened window is more expensive than the one requested.
+
 Consequences to expect when reading run state:
 
 - A capped run is a healthy partial run, not a failure. Its window end is behind
@@ -53,10 +62,22 @@ Consequences to expect when reading run state:
   overlap.
 - A ninety-day cold start at the default cap reaches the current time after
   roughly thirteen ticks. On an hourly schedule that is about half a day of
-  catch-up. Communicate the visible waiting state rather than treating the
-  interim coverage as zero.
+  catch-up.
+- A capped run finalizes as an ordinary successful run. Today there is no
+  distinct run state, badge, or freshness signal that says "caught up to here
+  only", so success alone does not mean the family has reached the current time.
+  The advancing watermark is the observable evidence of progress: read the
+  dataset's latest successful source timestamp across consecutive runs rather
+  than inferring coverage from run status. Surfacing this lag directly is
+  tracked separately as a CHAOS-3412 follow-up.
 - Catch-up is paced by the sync schedule. A heavy dataset that is far behind
   does not accelerate; to close a wide historical span faster, run a bounded
   backfill for that period instead.
 - Light and medium record families are unaffected and keep a single
   full-depth incremental window.
+- A run requested with an upper bound already covered by the dataset's watermark
+  plans no unit for that dataset. If that leaves the whole run with no units, the
+  run finalizes as failed with "No sync units planned". Read that as "the
+  requested window was already covered", not as an ingestion fault. Scheduled
+  runs do not request an upper bound and so never reach this state; only a
+  manually requested past upper bound can.

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -69,7 +69,7 @@ Consequences to expect when reading run state:
   The advancing watermark is the observable evidence of progress: read the
   dataset's latest successful source timestamp across consecutive runs rather
   than inferring coverage from run status. Surfacing this lag directly is
-  tracked separately as a CHAOS-3412 follow-up.
+  tracked separately as CHAOS-3430.
 - Catch-up is paced by the sync schedule. A heavy dataset that is far behind
   does not accelerate; to close a wide historical span faster, run a bounded
   backfill for that period instead.
@@ -81,3 +81,10 @@ Consequences to expect when reading run state:
   requested window was already covered", not as an ingestion fault. Scheduled
   runs do not request an upper bound and so never reach this state; only a
   manually requested past upper bound can.
+
+These window rules — the end never in the future, and no unit for an already
+covered range — apply to full resynchronization as well as incremental
+synchronization. Both stamp the watermark at the window end on success, so both
+carry the same consequences. Bounded backfills are separate: they never stamp a
+watermark and legitimately target a historical range, so they keep their own
+chunking and bounds.

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -18,3 +18,45 @@ lifecycle: active
 7. Record any residual gap or replay requirement.
 
 Avoid repeatedly starting overlapping backfills for the same scope and period.
+
+## Incremental windows
+
+An incremental run plans one window per source and dataset. The window starts at
+that dataset's stored watermark, less the configured watermark overlap. A
+dataset with no watermark yet cold-starts at the configured initial sync depth,
+capped by the organization's plan backfill limit. The window ends at the
+requested upper bound, or at the current time when none was requested. A
+successful unit stamps the watermark at its own window end — never at the
+current time — so a partial window advances coverage only as far as it actually
+read.
+
+### Heavy-dataset window ratchet
+
+Unit cost grows with window span. For heavy record families — commit statistics,
+file records, blame, and test results — a single window covering a wide initial
+sync depth can cost more than the provider budget allows for one unit. Such a
+unit is deferred, stamps no watermark, and every later attempt recomputes the
+same unaffordable span, so the dataset never starts.
+
+Incremental windows for heavy record families are therefore capped in span. The
+window still starts at the watermark or cold-start depth, but ends no later than
+the start plus the cap. `SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS` sets the cap;
+the default is seven days, matching the proven backfill chunk size.
+
+Consequences to expect when reading run state:
+
+- A capped run is a healthy partial run, not a failure. Its window end is behind
+  the current time by design.
+- Each successful tick stamps the watermark at its window end, so the next
+  scheduled tick resumes exactly there. Coverage ratchets forward one capped
+  window per tick with no gap and no overlap beyond the configured watermark
+  overlap.
+- A ninety-day cold start at the default cap reaches the current time after
+  roughly thirteen ticks. On an hourly schedule that is about half a day of
+  catch-up. Communicate the visible waiting state rather than treating the
+  interim coverage as zero.
+- Catch-up is paced by the sync schedule. A heavy dataset that is far behind
+  does not accelerate; to close a wide historical span faster, run a bounded
+  backfill for that period instead.
+- Light and medium record families are unaffected and keep a single
+  full-depth incremental window.

--- a/docs/operate/run/ingestion-and-backfills.md
+++ b/docs/operate/run/ingestion-and-backfills.md
@@ -82,6 +82,13 @@ Consequences to expect when reading run state:
   runs do not request an upper bound and so never reach this state; only a
   manually requested past upper bound can.
 
+A watermark is never recorded beyond what the run actually read. A synchronization
+timestamp reported by a provider is capped at the end of the unit's own window
+before it is stored, because the unit only fetched up to that point — a value
+beyond it would claim coverage of records that were never retrieved, and the next
+run would start after them. Such a value can itself be in the past, so capping at
+the current time alone does not prevent it.
+
 A watermark is never recorded ahead of the current time. Whatever a run reports —
 including a synchronization timestamp taken from a provider record — the recorded
 value is capped at the current time before it is stored. A record carrying a

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -45,14 +45,17 @@ Invariants:
     reports success. ``_effective_heavy_max_window_days`` clamps the cap above
     the overlap and logs a warning naming both values.
     See docs/operate/run/ingestion-and-backfills.md.
-  * INCREMENTAL windows never end in the future (``window_end = min(before,
-    now)``) — the success path stamps the watermark at the window END, so a
-    future end would persist a future watermark and the next run would start in
-    the future, silently skipping everything up to it. An empty or inverted
-    window (``end <= start``, i.e. the dataset is already synced past the
-    requested end) plans ZERO units rather than an inverted one: the admission
-    estimate floors a negative span to 1 day, so an inverted unit reads as cheap,
-    passes the budget guard, fetches nothing, and finalizes SUCCESS.
+  * Watermark-stamping window rules (CHAOS-3412), enforced once in
+    ``_watermark_stamping_window`` for BOTH modes whose success path stamps a
+    watermark (INCREMENTAL and FULL_RESYNC — ``sync_units`` gates on exactly
+    those two): (a) the end is clamped to ``now``, because a future ``before``
+    would persist a FUTURE watermark and the next run would start in the future
+    and silently skip everything up to it; (b) an empty or inverted window
+    (``end <= start``, i.e. already synced past the requested end) plans ZERO
+    units, because ``window_span_days`` floors a negative span to 1 day, so an
+    inverted unit is admitted at the cheapest possible cost, fetches nothing, and
+    finalizes SUCCESS — a false coverage claim. BACKFILL is deliberately excluded:
+    it never stamps a watermark (CHAOS-2514) and validates its own bounds.
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 
@@ -741,6 +744,39 @@ def _effective_heavy_max_window_days() -> int:
     return min_cap_days
 
 
+def _watermark_stamping_window(
+    window_start: datetime | None,
+    window_end: datetime,
+    now: datetime,
+) -> tuple[tuple[datetime | None, datetime | None], ...]:
+    """Normalize a window for any mode whose SUCCESS path stamps a watermark.
+
+    Both INCREMENTAL and FULL_RESYNC stamp the watermark at the unit's window END
+    (``sync_units.py`` gates on exactly those two modes), so both inherit the same
+    two failure modes. They are enforced HERE, once, rather than per branch —
+    CHAOS-3412 found the same defect in both branches, and one shared rule is also
+    one rule for any reimplementation of this contract to mirror.
+
+    1. The end is clamped to ``now``. A future ``before`` would otherwise persist
+       a FUTURE watermark, and the next run would start in the future and silently
+       skip everything up to it.
+    2. An empty or inverted window (``end <= start``) plans ZERO units. Persisting
+       ``since_at >= before_at`` is worse than useless: ``window_span_days`` floors
+       a negative span to 1 (``sync/budget_types.py``) and ``_scaled_units``
+       multiplies by that floor, so an inverted unit is admitted at the CHEAPEST
+       possible cost, fetches nothing, and finalizes SUCCESS — a false coverage
+       claim. ``set_watermark`` is monotonic, so the stamp itself is harmless; the
+       unit is the problem.
+
+    BACKFILL is deliberately NOT routed through here: it never stamps a watermark
+    (CHAOS-2514) and validates its own bounds in ``_backfill_windows``.
+    """
+    window_end = min(window_end, now)
+    if window_start is not None and window_end <= _as_utc(window_start):
+        return ()
+    return ((window_start, window_end),)
+
+
 def _is_heavy_dataset(provider: str, dataset_key: str) -> bool:
     """True when the (provider, dataset) pair is registered CostClass.HEAVY."""
     spec = get_dataset_spec(provider, dataset_key)
@@ -1068,11 +1104,7 @@ def _resolve_windows(
                 depth = resolve_initial_sync_depth(session, integration, dataset)
                 window_start = now - timedelta(days=depth)
         # WatermarkBehavior.NONE datasets keep window_start=None (registered behavior).
-        # An incremental window must never end in the future: the success path
-        # stamps the watermark at the window END, so a future ``before`` would
-        # persist a future watermark and the NEXT run would start in the future
-        # and silently skip everything up to it.
-        window_end = min(_request_before_or_now(request, now), now)
+        window_end = _request_before_or_now(request, now)
         if window_start is not None and _is_heavy_dataset(source_provider, dataset_key):
             # CHAOS-3412 ratchet: cap the span so a HEAVY unit can fit the sync
             # budget. Applies to BOTH cold-start and behind-watermark cases — a
@@ -1086,16 +1118,7 @@ def _resolve_windows(
                 days=_effective_heavy_max_window_days()
             )
             window_end = min(window_end, capped_end)
-        if window_start is not None and window_end <= _as_utc(window_start):
-            # Empty or inverted window: the dataset is already synced past the
-            # requested end. Plan NO unit rather than persisting since_at >=
-            # before_at — an inverted window's span floors to 1 day in the
-            # admission estimate and would sail through the budget guard as a
-            # cheap unit that fetches nothing and then stamps a BACKWARD-looking
-            # watermark end. ``set_watermark`` is monotonic so the stamp itself
-            # is harmless, but the unit is pure waste and reads as real coverage.
-            return ()
-        return ((window_start, window_end),)
+        return _watermark_stamping_window(window_start, window_end, now)
 
     if mode == SyncRunMode.BACKFILL.value:
         return _backfill_windows(
@@ -1106,7 +1129,9 @@ def _resolve_windows(
         # full_resync: use configured depth for all datasets (CHAOS-2569).
         depth = resolve_initial_sync_depth(session, integration, dataset)
         window_start_fr = now - timedelta(days=depth)
-        return ((window_start_fr, _request_before_or_now(request, now)),)
+        return _watermark_stamping_window(
+            window_start_fr, _request_before_or_now(request, now), now
+        )
 
     return ((None, _request_before_or_now(request, now)),)
 

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -28,6 +28,18 @@ Invariants:
     ``initial_sync_depth`` after ``before``, the residual gap
     ``[before, now - depth]`` is an accepted, tracked limitation (CHAOS-2588)
     whose fix would require such a marker. See docs/architecture/data-pipeline.md.
+  * HEAVY incremental window ratchet (CHAOS-3412): unit cost is linear in window
+    span, so a HEAVY-cost-class dataset spanning a wide ``initial_sync_depth``
+    (or a long-stale watermark) can never fit the sync budget as ONE window — it
+    is deferred forever and, having never succeeded, never stamps a watermark.
+    INCREMENTAL windows for HEAVY datasets are therefore capped at
+    ``SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS`` (default 7): the window END moves
+    in to ``window_start + cap``; depth resolution and its tier ``backfill_days``
+    cap are untouched. A capped run is a healthy PARTIAL run — the success path
+    stamps the watermark at the unit's window END (``before_at``), so the next
+    scheduled tick resumes exactly there and coverage ratchets forward one capped
+    window per tick with no gap. Catch-up is paced by the scheduler cadence.
+    See docs/operate/run/ingestion-and-backfills.md.
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 
@@ -64,6 +76,7 @@ from dev_health_ops.sync.canonical_incident_gate import (
     sync_datasets_require_canonical_incident_feature,
 )
 from dev_health_ops.sync.datasets import (
+    CostClass,
     DatasetSpec,
     WatermarkBehavior,
     get_dataset_spec,
@@ -607,6 +620,46 @@ _DEFAULT_INITIAL_SYNC_DEPTH_DAYS: int = 30
 
 
 # ---------------------------------------------------------------------------
+# HEAVY incremental window ratchet (CHAOS-3412)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS: int = 7
+
+
+def _incremental_heavy_max_window_days() -> int:
+    """Max INCREMENTAL window span (days) for a HEAVY-cost-class dataset.
+
+    Reads ``SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS``; falls back to 7 days.
+
+    CHAOS-3412: unit cost is linear in window span (see
+    ``providers/github/budget._scaled_units``). A HEAVY dataset cold-starting on
+    a wide ``initial_sync_depth`` (or resuming from a long-stale watermark) used
+    to plan ONE window covering the whole span, which could not fit the sync
+    budget — the unit was deferred, no watermark was stamped, and the next tick
+    recomputed the identical unfittable span forever. Capping the span makes
+    each tick affordable; the success path stamps the watermark at the unit's
+    window END, so successive ticks ratchet forward until the dataset is caught
+    up. 7 days matches the proven ``_backfill_windows`` chunk size.
+    """
+    raw = os.getenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS")
+    if raw is not None:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            # Non-integer env override: fall through to the default below.
+            pass
+    return _DEFAULT_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS
+
+
+def _is_heavy_dataset(provider: str, dataset_key: str) -> bool:
+    """True when the (provider, dataset) pair is registered CostClass.HEAVY."""
+    spec = get_dataset_spec(provider, dataset_key)
+    return spec is not None and spec.default_cost_class is CostClass.HEAVY
+
+
+# ---------------------------------------------------------------------------
 # Linear backfill chunk policy (CHAOS-2710, rebalanced in CHAOS-2717)
 # ---------------------------------------------------------------------------
 
@@ -914,7 +967,21 @@ def _resolve_windows(
                 depth = resolve_initial_sync_depth(session, integration, dataset)
                 window_start = now - timedelta(days=depth)
         # WatermarkBehavior.NONE datasets keep window_start=None (registered behavior).
-        return ((window_start, _request_before_or_now(request, now)),)
+        window_end = _request_before_or_now(request, now)
+        if window_start is not None and _is_heavy_dataset(source_provider, dataset_key):
+            # CHAOS-3412 ratchet: cap the span so a HEAVY unit can fit the sync
+            # budget. Applies to BOTH cold-start and behind-watermark cases — a
+            # long-idle org ratchets forward one capped window per tick. Depth
+            # resolution (and its tier backfill_days cap) is untouched; only the
+            # window END moves in.
+            # ``window_start`` may be naive when it came straight off a stored
+            # watermark row; normalize for the comparison only — the value
+            # persisted as ``since_at`` is left exactly as resolved.
+            capped_end = _as_utc(window_start) + timedelta(
+                days=_incremental_heavy_max_window_days()
+            )
+            window_end = min(window_end, capped_end)
+        return ((window_start, window_end),)
 
     if mode == SyncRunMode.BACKFILL.value:
         return _backfill_windows(

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -56,6 +56,19 @@ Invariants:
     inverted unit is admitted at the cheapest possible cost, fetches nothing, and
     finalizes SUCCESS — a false coverage claim. BACKFILL is deliberately excluded:
     it never stamps a watermark (CHAOS-2514) and validates its own bounds.
+    (c) A resolved start AHEAD of ``now`` means the stored watermark is corrupt
+    (skewed provider timestamp, or a future end persisted by pre-CHAOS-3412
+    code). Rule (b) alone would make that FATAL — zero units, FAILED forever, and
+    monotonic writes mean nothing can lower it. So the start is clamped back to a
+    bounded recovery window and warned about, and ``sync.watermarks`` permits the
+    single downward correction needed to restore a sane value.
+  * FULL_RESYNC HEAVY windows are deliberately UNCAPPED (CHAOS-3412, decided).
+    The heavy cap exists so repeated incremental ticks make progress; a one-shot
+    full resync has no next tick, so a capped window would cover the cap's span
+    and finalize SUCCESS — claiming a resync that did not happen. The wide-window
+    exposure is bounded instead by the budget exhaustion path, which terminalizes
+    visibly and names the scoped-backfill remedy. Pinned by
+    ``test_full_resync_heavy_window_is_deliberately_uncapped``.
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 
@@ -117,6 +130,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SECONDS_PER_DAY = 86_400
+
+# Recovery lookback when a stored watermark is found AHEAD of now (corrupt).
+# Small on purpose: the goal is to get ONE unit planned so the success path can
+# re-stamp a sane watermark, not to re-crawl history. See
+# _watermark_stamping_window.
+_FUTURE_WATERMARK_RECOVERY_SECONDS = 3600
 
 # (cap_days, overlap_seconds) pairs already warned about this process — see
 # _effective_heavy_max_window_days. Cleared by tests via
@@ -772,8 +791,42 @@ def _watermark_stamping_window(
     (CHAOS-2514) and validates its own bounds in ``_backfill_windows``.
     """
     window_end = min(window_end, now)
-    if window_start is not None and window_end <= _as_utc(window_start):
-        return ()
+    if window_start is not None:
+        start = _as_utc(window_start)
+        if start > now:
+            # CHAOS-3412: a resolved start AHEAD of now can only come from a
+            # corrupt watermark (a provider-supplied watermark_at derived from a
+            # source record with a skewed/bad timestamp, or a future window end
+            # persisted by pre-fix planner code). Left alone it is fatal: rule
+            # (b) below would plan ZERO units, the run finalizes FAILED, and with
+            # no unit there is nothing to re-stamp the watermark — a permanent
+            # stall, and ``set_watermark`` is monotonic so nothing else can lower
+            # it either. Clamp back far enough that a real window plans, and warn.
+            recovery_seconds = max(
+                _watermark_overlap_seconds(), _FUTURE_WATERMARK_RECOVERY_SECONDS
+            )
+            healed = now - timedelta(seconds=recovery_seconds)
+            logger.warning(
+                "sync.planner.future_watermark_clamped",
+                extra={
+                    "resolved_window_start": start.isoformat(),
+                    "now": now.isoformat(),
+                    "watermark_overlap_seconds": _watermark_overlap_seconds(),
+                    "healed_window_start": healed.isoformat(),
+                    "reason": (
+                        "resolved window start is ahead of now, which means the "
+                        "stored watermark is corrupt. Planning a bounded recovery "
+                        "window so a unit runs and re-stamps a sane watermark. "
+                        "Records between the true last-synced point and this "
+                        "recovery window are NOT re-fetched — run a bounded "
+                        "backfill if that span matters."
+                    ),
+                },
+            )
+            window_start = healed
+            start = healed
+        if window_end <= start:
+            return ()
     return ((window_start, window_end),)
 
 

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -39,12 +39,26 @@ Invariants:
     stamps the watermark at the unit's window END (``before_at``), so the next
     scheduled tick resumes exactly there and coverage ratchets forward one capped
     window per tick with no gap. Catch-up is paced by the scheduler cadence.
+    The cap must EXCEED ``SYNC_WATERMARK_OVERLAP``: the window starts at
+    ``watermark - overlap``, so a cap <= overlap ends at or before the watermark
+    and the monotonic write is discarded, stalling the ratchet while every run
+    reports success. ``_effective_heavy_max_window_days`` clamps the cap above
+    the overlap and logs a warning naming both values.
     See docs/operate/run/ingestion-and-backfills.md.
+  * INCREMENTAL windows never end in the future (``window_end = min(before,
+    now)``) — the success path stamps the watermark at the window END, so a
+    future end would persist a future watermark and the next run would start in
+    the future, silently skipping everything up to it. An empty or inverted
+    window (``end <= start``, i.e. the dataset is already synced past the
+    requested end) plans ZERO units rather than an inverted one: the admission
+    estimate floors a negative span to 1 day, so an inverted unit reads as cheap,
+    passes the budget guard, fetches nothing, and finalizes SUCCESS.
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from collections.abc import Iterable, Mapping
@@ -89,10 +103,27 @@ from dev_health_ops.sync.guard import _resolve_total_unit_cap
 from dev_health_ops.sync.pagerduty_repair import (
     repair_pagerduty_operational_integration,
 )
-from dev_health_ops.sync.watermarks import get_watermark_with_overlap
+from dev_health_ops.sync.watermarks import (
+    _watermark_overlap_seconds,
+    get_watermark_with_overlap,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_SECONDS_PER_DAY = 86_400
+
+# (cap_days, overlap_seconds) pairs already warned about this process — see
+# _effective_heavy_max_window_days. Cleared by tests via
+# reset_heavy_cap_clamp_warnings.
+_WARNED_CAP_CLAMPS: set[tuple[int, int]] = set()
+
+
+def reset_heavy_cap_clamp_warnings() -> None:
+    """Clear the once-per-process clamp-warning cache (test hook)."""
+    _WARNED_CAP_CLAMPS.clear()
 
 
 @dataclass(frozen=True)
@@ -653,6 +684,63 @@ def _incremental_heavy_max_window_days() -> int:
     return _DEFAULT_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS
 
 
+def _effective_heavy_max_window_days() -> int:
+    """The HEAVY window cap, clamped to strictly exceed the watermark overlap.
+
+    CHAOS-3412: the incremental read subtracts ``SYNC_WATERMARK_OVERLAP`` from
+    the stored watermark, so a capped HEAVY window spans
+    ``[W - overlap, W - overlap + cap]``. When ``overlap >= cap`` that end lands
+    at or before ``W`` — and ``set_watermark`` enforces a monotonic advance
+    (``max(existing, new)``, see ``sync.watermarks``), so the write is silently
+    DISCARDED. Every later tick then re-plans the identical slice, re-fetches it,
+    and reports SUCCESS while the watermark never moves: the same permanent
+    stall this ticket exists to kill, wearing a different hat.
+
+    Clamp the cap to ``floor(overlap_days) + 1``, which is strictly greater than
+    the overlap for any real overlap value, so every successful capped run
+    advances the watermark by a positive amount.
+
+    The clamp is LOUD but never fatal. Refusing to plan would reproduce the
+    do-nothing failure mode; a visibly clamped window is wider and more expensive
+    than the operator asked for, but it makes progress, and the warning names
+    both values so the misconfiguration can be corrected.
+    """
+    cap_days = _incremental_heavy_max_window_days()
+    overlap_seconds = _watermark_overlap_seconds()
+    if overlap_seconds <= 0:
+        return cap_days
+    # floor(overlap_days) + 1 > overlap_days for every real overlap.
+    min_cap_days = overlap_seconds // _SECONDS_PER_DAY + 1
+    if min_cap_days <= cap_days:
+        return cap_days
+    # Warn ONCE per distinct (cap, overlap) per process. This helper runs once
+    # per (source x heavy dataset), so an unguarded warning would emit hundreds
+    # of identical lines per plan on a large org and bury whatever else the
+    # operator needs to see. Both values are restart-loaded env settings, so a
+    # single line per process is the complete signal.
+    warn_key = (cap_days, overlap_seconds)
+    if warn_key in _WARNED_CAP_CLAMPS:
+        return min_cap_days
+    _WARNED_CAP_CLAMPS.add(warn_key)
+    logger.warning(
+        "sync.planner.heavy_window_cap_clamped_below_watermark_overlap",
+        extra={
+            "configured_cap_days": cap_days,
+            "watermark_overlap_seconds": overlap_seconds,
+            "effective_cap_days": min_cap_days,
+            "reason": (
+                "SYNC_WATERMARK_OVERLAP >= SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS "
+                "would stall the HEAVY incremental ratchet: every capped window "
+                "would end at or before its own watermark and the monotonic "
+                "watermark write would be discarded. Widening the cap so each "
+                "run makes progress. Lower SYNC_WATERMARK_OVERLAP or raise "
+                "SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS to remove this clamp."
+            ),
+        },
+    )
+    return min_cap_days
+
+
 def _is_heavy_dataset(provider: str, dataset_key: str) -> bool:
     """True when the (provider, dataset) pair is registered CostClass.HEAVY."""
     spec = get_dataset_spec(provider, dataset_key)
@@ -783,26 +871,39 @@ def _build_work_item_family_units(
     # resolve windows independently then merge index-aligned (earliest start so
     # the single crawl covers every enabled dataset; over-fetch is safe because
     # set_watermark is monotonic).
-    per_dataset_windows = [
-        _resolve_windows(
-            session=session,
-            request=request,
-            mode=mode,
-            org_id=integration.org_id,
-            source_provider=provider,
-            watermark_source_key=source.external_id,
-            dataset_key=dataset.dataset_key,
-            watermark_behavior=spec.watermark_behavior,
-            now=now,
-            integration=integration,
-            dataset=dataset,
+    resolved = [
+        (
+            dataset,
+            _resolve_windows(
+                session=session,
+                request=request,
+                mode=mode,
+                org_id=integration.org_id,
+                source_provider=provider,
+                watermark_source_key=source.external_id,
+                dataset_key=dataset.dataset_key,
+                watermark_behavior=spec.watermark_behavior,
+                now=now,
+                integration=integration,
+                dataset=dataset,
+            ),
         )
         for dataset, spec in family_specs
     ]
-    composite_windows = _merge_family_windows(per_dataset_windows)
+    # CHAOS-3412: a family dataset already synced past the requested end resolves
+    # to ZERO windows. Drop it before the index-aligned merge — otherwise its
+    # empty tuple reads as a window-count mismatch and ``_merge_family_windows``
+    # raises, taking down a plan that is merely partially caught up. The
+    # remaining datasets still collapse into one composite; the dropped dataset
+    # simply has nothing to do this tick and keeps its (later) watermark, which
+    # the monotonic ``set_watermark`` preserves.
+    contributing = [(dataset, windows) for dataset, windows in resolved if windows]
+    if not contributing:
+        return []
+    composite_windows = _merge_family_windows([windows for _, windows in contributing])
 
     processor_flags: dict[str, bool] = dict(canonical_spec.processor_flags)
-    for dataset, _spec in family_specs:
+    for dataset, _windows in contributing:
         processor_flags[_family_dataset_flag(dataset.dataset_key)] = True
     if provider == "github":
         # CHAOS-646: thread the PRS-as-work-items signal onto the composite so
@@ -967,7 +1068,11 @@ def _resolve_windows(
                 depth = resolve_initial_sync_depth(session, integration, dataset)
                 window_start = now - timedelta(days=depth)
         # WatermarkBehavior.NONE datasets keep window_start=None (registered behavior).
-        window_end = _request_before_or_now(request, now)
+        # An incremental window must never end in the future: the success path
+        # stamps the watermark at the window END, so a future ``before`` would
+        # persist a future watermark and the NEXT run would start in the future
+        # and silently skip everything up to it.
+        window_end = min(_request_before_or_now(request, now), now)
         if window_start is not None and _is_heavy_dataset(source_provider, dataset_key):
             # CHAOS-3412 ratchet: cap the span so a HEAVY unit can fit the sync
             # budget. Applies to BOTH cold-start and behind-watermark cases — a
@@ -978,9 +1083,18 @@ def _resolve_windows(
             # watermark row; normalize for the comparison only — the value
             # persisted as ``since_at`` is left exactly as resolved.
             capped_end = _as_utc(window_start) + timedelta(
-                days=_incremental_heavy_max_window_days()
+                days=_effective_heavy_max_window_days()
             )
             window_end = min(window_end, capped_end)
+        if window_start is not None and window_end <= _as_utc(window_start):
+            # Empty or inverted window: the dataset is already synced past the
+            # requested end. Plan NO unit rather than persisting since_at >=
+            # before_at — an inverted window's span floors to 1 day in the
+            # admission estimate and would sail through the budget guard as a
+            # cheap unit that fetches nothing and then stamps a BACKWARD-looking
+            # watermark end. ``set_watermark`` is monotonic so the stamp itself
+            # is harmless, but the unit is pure waste and reads as real coverage.
+            return ()
         return ((window_start, window_end),)
 
     if mode == SyncRunMode.BACKFILL.value:

--- a/src/dev_health_ops/sync/watermarks.py
+++ b/src/dev_health_ops/sync/watermarks.py
@@ -51,13 +51,17 @@ out-of-order unit result can never roll the watermark backwards.
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import func, update
+from sqlalchemy import case, func, update
+from sqlalchemy import false as sa_false
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models.settings import SyncWatermark
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Reverse map: dataset_key → frozenset[legacy_target] (INCREMENTAL only)
@@ -131,6 +135,13 @@ def apply_watermark_overlap(ts: datetime) -> datetime:
 # ---------------------------------------------------------------------------
 
 
+def _as_utc_ts(value: datetime) -> datetime:
+    """Coerce a naive timestamp to UTC for comparison."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def _monotonic_update(
     session: Session, row: SyncWatermark, timestamp: datetime
 ) -> None:
@@ -139,18 +150,47 @@ def _monotonic_update(
     On PostgreSQL uses ``GREATEST(COALESCE(last_synced_at, :ts), :ts)`` so the
     DB resolves concurrent-write races atomically.  On SQLite (tests only) falls
     back to a Python-level comparison.
+
+    ONE exception to monotonicity (CHAOS-3412): a stored ``last_synced_at`` that
+    is AHEAD of ``now`` is not a legitimate watermark — a watermark marks data
+    already synced, so it can never sit in the future. Such a value can be
+    written by a provider-supplied ``watermark_at`` derived from a source record
+    with a skewed timestamp, or by pre-CHAOS-3412 planner code that persisted a
+    future window end. Because the update is otherwise monotonic, nothing can
+    ever lower it again: the planner's window would start in the future, plan no
+    unit, and the run would finalize FAILED forever with nothing left to repair
+    it. So when the STORED value is in the future and the incoming one is not,
+    the incoming value wins and the corruption is corrected.
+
+    This preserves the CHAOS-2578 guarantee exactly where it matters — a late or
+    out-of-order result still cannot roll a LEGITIMATE (past) watermark backwards
+    — because the exception is gated on a state that is provably invalid.
     """
     dialect_name = session.bind.dialect.name if session.bind is not None else ""
+    now = datetime.now(timezone.utc)
     if dialect_name == "postgresql":
         session.execute(
             update(SyncWatermark)
             .where(SyncWatermark.id == row.id)
             .values(
-                last_synced_at=func.greatest(
-                    func.coalesce(SyncWatermark.last_synced_at, timestamp),
-                    timestamp,
+                last_synced_at=case(
+                    (
+                        # Corrupt future watermark + sane incoming value: correct
+                        # it downward. Evaluated in-database so it stays atomic
+                        # against concurrent writers.
+                        SyncWatermark.last_synced_at > now
+                        if _as_utc_ts(timestamp) <= now
+                        # An incoming FUTURE timestamp never corrects anything;
+                        # fall through to the plain monotonic path.
+                        else sa_false(),
+                        timestamp,
+                    ),
+                    else_=func.greatest(
+                        func.coalesce(SyncWatermark.last_synced_at, timestamp),
+                        timestamp,
+                    ),
                 ),
-                updated_at=datetime.now(timezone.utc),
+                updated_at=now,
             )
         )
     else:
@@ -167,10 +207,23 @@ def _monotonic_update(
                 if timestamp.tzinfo is None
                 else timestamp.astimezone(timezone.utc)
             )
-            if new_utc <= existing_utc:
+            if existing_utc > now and new_utc <= now:
+                # Corrupt future watermark: correct it downward (see docstring).
+                logger.warning(
+                    "sync.watermark.future_value_corrected",
+                    extra={
+                        "org_id": row.org_id,
+                        "source_id": row.source_id,
+                        "dataset_key": row.dataset_key,
+                        "stored_last_synced_at": existing_utc.isoformat(),
+                        "corrected_to": new_utc.isoformat(),
+                        "now": now.isoformat(),
+                    },
+                )
+            elif new_utc <= existing_utc:
                 return
         row.last_synced_at = timestamp
-        row.updated_at = datetime.now(timezone.utc)
+        row.updated_at = now
 
 
 # ---------------------------------------------------------------------------

--- a/src/dev_health_ops/sync/watermarks.py
+++ b/src/dev_health_ops/sync/watermarks.py
@@ -148,6 +148,74 @@ def _as_utc_ts(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _normalize_watermark_write(
+    timestamp: datetime,
+    *,
+    org_id: str,
+    source_id: str,
+    dataset_key: str,
+    coverage_upper_bound: datetime | None = None,
+) -> datetime:
+    """THE write-boundary normalizer. EVERY watermark writer must call this.
+
+    Two ceilings, both of which exist because a watermark is a COVERAGE CLAIM —
+    it asserts "everything up to here has been read":
+
+    1. ``now``. A watermark can never sit in the future, whatever a provider
+       reports. The unit worker prefers a provider-supplied ``watermark_at`` over
+       the planner's clamped window end, and PagerDuty derives that from source
+       record timestamps, so one skewed record would otherwise write a future
+       watermark past every planner-side clamp.
+    2. ``coverage_upper_bound`` — the unit's window END, when the caller knows
+       it. The unit only fetched up to its window end, so a stamp beyond that
+       claims data it never read. Such a value can be entirely in the PAST, so
+       the ``now`` ceiling does not catch it: the next run starts after the
+       overclaimed point and every record in between is silently skipped.
+
+    Enforcing this at each call site is what CHAOS-3412 got wrong twice — first
+    a provider stamp bypassing the planner clamp, then a second write API
+    bypassing the boundary entirely. It lives here so a writer cannot opt out;
+    ``test_every_watermark_write_api_routes_through_the_normalizer`` derives the
+    set of writers from the module AST and fails if a new one skips it.
+
+    Clamps beyond ``_FUTURE_WRITE_SKEW_TOLERANCE_SECONDS`` are warned about;
+    smaller ones are silent, because clocks routinely drift by seconds.
+    """
+    incoming = _as_utc_ts(timestamp)
+    now = datetime.now(timezone.utc)
+    ceiling = now
+    bound = "now"
+    if coverage_upper_bound is not None:
+        upper = _as_utc_ts(coverage_upper_bound)
+        if upper < ceiling:
+            ceiling, bound = upper, "window_end"
+    if incoming <= ceiling:
+        return incoming
+
+    overshoot = (incoming - ceiling).total_seconds()
+    if overshoot > _FUTURE_WRITE_SKEW_TOLERANCE_SECONDS:
+        logger.warning(
+            "sync.watermark.write_clamped",
+            extra={
+                "org_id": org_id,
+                "source_id": source_id,
+                "dataset_key": dataset_key,
+                "requested_last_synced_at": incoming.isoformat(),
+                "clamped_to": ceiling.isoformat(),
+                "ceiling": bound,
+                "overshoot_seconds": overshoot,
+                "reason": (
+                    "a watermark claims every record up to it has been read. "
+                    "Clamping to the highest point actually covered. A "
+                    "window_end clamp means a provider reported coverage beyond "
+                    "what the unit fetched; a now clamp usually means a source "
+                    "record carried a skewed timestamp."
+                ),
+            },
+        )
+    return ceiling
+
+
 def _monotonic_update(
     session: Session, row: SyncWatermark, timestamp: datetime
 ) -> None:
@@ -342,6 +410,8 @@ def set_watermark(
     source_id: str,
     dataset_key: str,
     timestamp: datetime,
+    *,
+    coverage_upper_bound: datetime | None = None,
 ) -> None:
     """Upsert the watermark. THE FULL RULE (CHAOS-2578 + CHAOS-3412):
 
@@ -355,8 +425,18 @@ def set_watermark(
        ``max(existing, new)``, so a late-arriving or out-of-order unit result can
        never roll a valid watermark backwards.
 
-    2. NEVER INTO THE FUTURE (CHAOS-3412, write boundary). The incoming value is
-       clamped to ``min(incoming, now)`` for EVERY caller, before anything else.
+    2. NEVER BEYOND WHAT WAS ACTUALLY READ (CHAOS-3412, write boundary). The
+       incoming value is clamped to ``min(incoming, coverage_upper_bound, now)``
+       for EVERY caller, before anything else, by
+       ``_normalize_watermark_write``. ``coverage_upper_bound`` is the unit's
+       window END where the caller knows it: the unit only fetched up to there,
+       so a stamp beyond it claims data it never read. That value can be wholly
+       in the PAST, so the ``now`` ceiling alone does not catch it — the next run
+       simply starts after the overclaimed point and the records in between are
+       never fetched by anyone.
+       Both write APIs route through the normalizer, and
+       ``test_every_watermark_write_api_routes_through_the_normalizer`` derives
+       the writer set from the module AST so a third one cannot quietly skip it.
        A watermark marks data already synchronized, so a future value is never
        meaningful. This is not theoretical: the unit worker prefers a
        provider-supplied ``watermark_at`` over the planner's clamped window end,
@@ -393,39 +473,13 @@ def set_watermark(
     constraint ``uq_sync_watermark_org_repo_target`` remains satisfied.
     """
     # Canonical lookup first.
-    # WRITE-BOUNDARY INVARIANT (CHAOS-3412): no future value is EVER persisted,
-    # by any caller. Clamping here rather than at each call site is deliberate —
-    # the callers are the leak. The worker prefers a provider-supplied
-    # ``watermark_at`` over the planner's clamped window end, and PagerDuty
-    # derives that from source record timestamps, so a skewed record writes a
-    # future watermark straight past every planner-side clamp. Enforcing it at
-    # the boundary covers provider stamps, worker stamps, the insert path (a
-    # first-ever row was previously written unclamped), and any future caller,
-    # and it makes the stored-future repair below durable: nothing can re-poison
-    # a watermark that has just been repaired.
-    now = datetime.now(timezone.utc)
-    incoming = _as_utc_ts(timestamp)
-    if incoming > now:
-        overshoot = (incoming - now).total_seconds()
-        if overshoot > _FUTURE_WRITE_SKEW_TOLERANCE_SECONDS:
-            logger.warning(
-                "sync.watermark.future_write_clamped",
-                extra={
-                    "org_id": org_id,
-                    "source_id": source_id,
-                    "dataset_key": dataset_key,
-                    "requested_last_synced_at": incoming.isoformat(),
-                    "clamped_to": now.isoformat(),
-                    "overshoot_seconds": overshoot,
-                    "reason": (
-                        "a watermark marks data already synchronized, so it can "
-                        "never sit in the future. Clamping to now. A large "
-                        "overshoot usually means a provider record carried a "
-                        "skewed timestamp."
-                    ),
-                },
-            )
-        timestamp = now
+    timestamp = _normalize_watermark_write(
+        timestamp,
+        org_id=org_id,
+        source_id=source_id,
+        dataset_key=dataset_key,
+        coverage_upper_bound=coverage_upper_bound,
+    )
 
     row = (
         session.query(SyncWatermark)
@@ -521,6 +575,13 @@ def set_legacy_repo_watermark(
     legacy completions cannot race and roll the watermark backwards
     (CHAOS-2578).  SQLite (tests only) falls back to Python-level comparison.
     """
+    timestamp = _normalize_watermark_write(
+        timestamp,
+        org_id=org_id,
+        source_id=repo_id,
+        dataset_key=target,
+    )
+
     # Look up the raw legacy row by (org_id, repo_id, target).
     row = (
         session.query(SyncWatermark)

--- a/src/dev_health_ops/sync/watermarks.py
+++ b/src/dev_health_ops/sync/watermarks.py
@@ -63,6 +63,12 @@ from dev_health_ops.models.settings import SyncWatermark
 
 logger = logging.getLogger(__name__)
 
+# Tolerance for benign clock skew between this process and a provider/DB clock.
+# A write beyond `now` by more than this is treated as a real defect and warned
+# about; within it, the value is still clamped but silently (clamping a few
+# seconds of skew every run would be pure log noise). See set_watermark.
+_FUTURE_WRITE_SKEW_TOLERANCE_SECONDS = 60
+
 # ---------------------------------------------------------------------------
 # Reverse map: dataset_key → frozenset[legacy_target] (INCREMENTAL only)
 # ---------------------------------------------------------------------------
@@ -337,15 +343,33 @@ def set_watermark(
     dataset_key: str,
     timestamp: datetime,
 ) -> None:
-    """Upsert the watermark, enforcing monotonic advance (CHAOS-2578).
+    """Upsert the watermark. THE FULL RULE (CHAOS-2578 + CHAOS-3412):
 
-    ``last_synced_at`` is set to ``max(existing, new)`` so that a
-    late-arriving or out-of-order unit result can never roll the watermark
-    backwards.  Both incremental and full-resync runs call this on success.
+        Watermarks advance monotonically, NEVER into the future; a stored future
+        value is corrupt state and is repaired downward once.
 
-    AMENDMENT (CHAOS-3412) — ONE exception to the rule above.
-    Gate: the STORED value is in the future AND the incoming value is not.
-    In that case the incoming value WINS and the stored value is lowered.
+    Three parts, all enforced HERE at the write boundary rather than at call
+    sites, because the call sites are what leaked:
+
+    1. MONOTONIC ADVANCE (CHAOS-2578). ``last_synced_at`` becomes
+       ``max(existing, new)``, so a late-arriving or out-of-order unit result can
+       never roll a valid watermark backwards.
+
+    2. NEVER INTO THE FUTURE (CHAOS-3412, write boundary). The incoming value is
+       clamped to ``min(incoming, now)`` for EVERY caller, before anything else.
+       A watermark marks data already synchronized, so a future value is never
+       meaningful. This is not theoretical: the unit worker prefers a
+       provider-supplied ``watermark_at`` over the planner's clamped window end,
+       and PagerDuty derives that from source record timestamps, so one skewed
+       record wrote a future watermark straight past every planner-side clamp —
+       and could re-poison an already-repaired one. Clamping at the boundary also
+       covers the insert path, which previously wrote a first-ever row unclamped.
+       Clamps beyond ``_FUTURE_WRITE_SKEW_TOLERANCE_SECONDS`` are warned about;
+       smaller ones are silent, since clocks drift by seconds routinely.
+
+    3. REPAIR ONCE (CHAOS-3412, exception to part 1). Gate: the STORED value is
+       in the future AND the incoming value is not. Then the incoming value WINS
+       and the stored value is lowered.
 
     Why this does not weaken CHAOS-2578: a watermark marks data already
     synchronized, so a value ahead of ``now`` is not a late result — it is
@@ -359,7 +383,7 @@ def set_watermark(
     cannot roll a valid watermark backwards.
 
     Narrowness is pinned by ``test_legitimate_watermark_is_still_never_rolled_backwards``
-    and ``test_future_incoming_value_does_not_lower_a_future_stored_value``;
+    and ``test_future_incoming_value_is_clamped_and_repairs_the_stored_one``;
     the correction itself by ``test_future_watermark_is_corrected_downward``
     and, against live PostgreSQL, ``test_real_postgres_future_watermark_correction``.
     See ``_monotonic_update`` for the implementation of both dialect branches.
@@ -369,6 +393,40 @@ def set_watermark(
     constraint ``uq_sync_watermark_org_repo_target`` remains satisfied.
     """
     # Canonical lookup first.
+    # WRITE-BOUNDARY INVARIANT (CHAOS-3412): no future value is EVER persisted,
+    # by any caller. Clamping here rather than at each call site is deliberate —
+    # the callers are the leak. The worker prefers a provider-supplied
+    # ``watermark_at`` over the planner's clamped window end, and PagerDuty
+    # derives that from source record timestamps, so a skewed record writes a
+    # future watermark straight past every planner-side clamp. Enforcing it at
+    # the boundary covers provider stamps, worker stamps, the insert path (a
+    # first-ever row was previously written unclamped), and any future caller,
+    # and it makes the stored-future repair below durable: nothing can re-poison
+    # a watermark that has just been repaired.
+    now = datetime.now(timezone.utc)
+    incoming = _as_utc_ts(timestamp)
+    if incoming > now:
+        overshoot = (incoming - now).total_seconds()
+        if overshoot > _FUTURE_WRITE_SKEW_TOLERANCE_SECONDS:
+            logger.warning(
+                "sync.watermark.future_write_clamped",
+                extra={
+                    "org_id": org_id,
+                    "source_id": source_id,
+                    "dataset_key": dataset_key,
+                    "requested_last_synced_at": incoming.isoformat(),
+                    "clamped_to": now.isoformat(),
+                    "overshoot_seconds": overshoot,
+                    "reason": (
+                        "a watermark marks data already synchronized, so it can "
+                        "never sit in the future. Clamping to now. A large "
+                        "overshoot usually means a provider record carried a "
+                        "skewed timestamp."
+                    ),
+                },
+            )
+        timestamp = now
+
     row = (
         session.query(SyncWatermark)
         .filter(

--- a/src/dev_health_ops/sync/watermarks.py
+++ b/src/dev_health_ops/sync/watermarks.py
@@ -343,6 +343,27 @@ def set_watermark(
     late-arriving or out-of-order unit result can never roll the watermark
     backwards.  Both incremental and full-resync runs call this on success.
 
+    AMENDMENT (CHAOS-3412) — ONE exception to the rule above.
+    Gate: the STORED value is in the future AND the incoming value is not.
+    In that case the incoming value WINS and the stored value is lowered.
+
+    Why this does not weaken CHAOS-2578: a watermark marks data already
+    synchronized, so a value ahead of ``now`` is not a late result — it is
+    provably invalid state, reachable from a provider-supplied ``watermark_at``
+    derived from a source record with a skewed timestamp, or from a future
+    window end persisted by pre-CHAOS-3412 planner code. Without the exception
+    such a value is permanent: the planner resolves a window starting in the
+    future, plans no unit, the run finalizes FAILED, and no unit exists to
+    repair it. The guarantee is therefore untouched for every value it was
+    written to protect — an out-of-order result with a PAST timestamp still
+    cannot roll a valid watermark backwards.
+
+    Narrowness is pinned by ``test_legitimate_watermark_is_still_never_rolled_backwards``
+    and ``test_future_incoming_value_does_not_lower_a_future_stored_value``;
+    the correction itself by ``test_future_watermark_is_corrected_downward``
+    and, against live PostgreSQL, ``test_real_postgres_future_watermark_correction``.
+    See ``_monotonic_update`` for the implementation of both dialect branches.
+
     The ``target`` column is set to ``dataset_key`` (preserving the existing
     convention where ``target == dataset_key``) so that the legacy unique
     constraint ``uq_sync_watermark_org_repo_target`` remains satisfied.

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1421,6 +1421,12 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                         ctx.source_external_id,
                         watermark_dataset_key,
                         watermark_at,
+                        # CHAOS-3412: a provider-supplied watermark_at may claim
+                        # coverage beyond what this unit actually fetched. The
+                        # unit only read up to its window end, so that is the
+                        # ceiling — a stamp past it silently skips every record
+                        # in between on the next run.
+                        coverage_upper_bound=ctx.window_end,
                     )
             session.flush()
             should_finalize = True

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -2680,3 +2680,282 @@ def test_backfill_windows_are_not_routed_through_the_watermark_normalizer(db_ses
         since, before = _window(unit)
         assert since < before, "backfill chunks must stay forward-ordered"
         assert before <= now
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 round 2: a FUTURE watermark must self-heal, not stall forever.
+#
+# Suppressing empty/inverted windows means a watermark ahead of `now` makes
+# every scheduled tick plan ZERO units — which finalizes FAILED, and with no
+# unit there is nothing to re-stamp the watermark, so it never recovers.
+# set_watermark is monotonic, so a future value can never be lowered by a later
+# run either. Reachable: pagerduty derives watermark_at from source record
+# timestamps (provider clock skew / bad data), and pre-fix planner code could
+# persist a future window end directly, so live DBs may already hold one.
+#
+# The planner treats a start ahead of `now` as corrupt, clamps it back so a real
+# window plans, and warns loudly. One successful run then re-stamps a sane,
+# end-clamped watermark.
+# ---------------------------------------------------------------------------
+
+
+def test_future_watermark_still_plans_a_unit(db_session, caplog):
+    """A corrupt future watermark must NOT stall the scheduled path."""
+    import logging
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+    now = datetime.now(timezone.utc)
+    corrupt = now + timedelta(days=30)
+    set_watermark(db_session, ORG_ID, source.external_id, _NON_HEAVY_DATASET, corrupt)
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.sync.planner"):
+        plan = plan_sync_run(
+            db_session,
+            SyncPlanRequest(
+                integration_id=str(integration.id),
+                org_id=ORG_ID,
+                mode=SyncRunMode.INCREMENTAL.value,
+                triggered_by="scheduled",  # scheduled path: no explicit before
+            ),
+        )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1, (
+        "a future watermark must still plan a unit; zero units finalizes FAILED "
+        "and leaves nothing to re-stamp the watermark, stalling forever"
+    )
+    since, before = _window(units[0])
+    assert since < before, "the healed window must be forward-ordered"
+    assert before <= now + timedelta(seconds=2)
+    assert since <= now
+
+    warned = [
+        r
+        for r in caplog.records
+        if "future_watermark" in r.getMessage()
+        or "watermark_ahead_of_now" in r.getMessage()
+    ]
+    assert warned, (
+        "clamping a corrupt future watermark must warn loudly; silently "
+        "rewriting a watermark is exactly the kind of invisible repair that "
+        "hides data loss"
+    )
+
+
+def test_future_watermark_recovers_after_one_success(db_session):
+    """After one successful run the watermark is sane again (self-healing)."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+    now = datetime.now(timezone.utc)
+    set_watermark(
+        db_session,
+        ORG_ID,
+        source.external_id,
+        _NON_HEAVY_DATASET,
+        now + timedelta(days=30),
+    )
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="scheduled",
+        ),
+    )
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    _, before = _window(units[0])
+
+    # Healing REQUIRES lowering the stored value, which plain monotonic
+    # semantics would discard. Go through the REAL production write path so the
+    # test proves the correction actually happens rather than assuming it.
+    set_watermark(db_session, ORG_ID, source.external_id, _NON_HEAVY_DATASET, before)
+    healed = get_watermark(db_session, ORG_ID, source.external_id, _NON_HEAVY_DATASET)
+    assert healed is not None
+    healed_aware = (
+        healed.replace(tzinfo=timezone.utc) if healed.tzinfo is None else healed
+    )
+    assert healed_aware <= now + timedelta(seconds=2), (
+        f"watermark still in the future after a successful run: {healed_aware}"
+    )
+
+    # And the next tick plans a normal forward window from the healed value.
+    plan2 = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="scheduled",
+        ),
+    )
+    units2 = _planned_units(db_session, plan2.sync_run_id)
+    assert len(units2) == 1, "the tick after healing must plan normally"
+
+
+def test_full_resync_heavy_window_is_deliberately_uncapped(db_session):
+    """POLICY PIN (CHAOS-3412, decided): full_resync does NOT get the heavy cap.
+
+    A capped one-shot full resync would cover only the cap's span and then
+    finalize SUCCESS — a false coverage claim, which is worse than the exposure
+    it would avoid. The wide-window exposure is instead bounded by the budget
+    exhaustion path: an oversized unit terminalizes visibly as
+    ``budget_deferral_exhausted`` naming the scoped-backfill remedy, which
+    satisfies "syncs or fails visibly".
+
+    This is a DECISION, not an oversight. If a future change adds the cap here,
+    it must revisit that decision rather than assume this was missed.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.FULL_RESYNC.value,
+            triggered_by="admin-api",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    since, before = _window(units[0])
+    assert abs((since - (now - timedelta(days=30))).total_seconds()) < 2
+    assert abs((before - now).total_seconds()) < 2, (
+        "full_resync of a HEAVY dataset must span the FULL configured depth. A "
+        "7-day capped window finalizing SUCCESS would misreport a 30-day resync "
+        "as complete."
+    )
+    span_days = (before - since).days
+    assert span_days >= 29, (
+        f"full_resync heavy span collapsed to {span_days} days — the heavy "
+        "incremental cap must not leak into full_resync"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 CLOSURE ARGUMENT for the window-bounds defect family.
+#
+# Six members of one family were fixed on this branch: the heavy cap itself,
+# overlap >= cap, future end, inverted end, both halves again in FULL_RESYNC,
+# and a future start from a corrupt watermark. Rather than wait for a seventh to
+# be found, this enumerates the ENTIRE sign-region state space of
+# (window_start, window_end) relative to `now` and asserts the postcondition
+# that every member of the family violated in some way.
+#
+# The postcondition, which is what "no more siblings" actually means:
+#   for every input, the result is either
+#     - zero windows, or
+#     - exactly one window (s, e) with e <= now, and s < e when s is not None.
+#   It is NEVER a window that ends in the future, is inverted, or is zero-width.
+#
+# A new sibling can only exist if it violates this postcondition or escapes the
+# helper. This test closes the first; the mutation tests that break BOTH modes
+# when the helper changes close the second.
+# ---------------------------------------------------------------------------
+
+
+def test_watermark_window_postcondition_holds_across_the_whole_state_space():
+    from datetime import timedelta
+
+    from dev_health_ops.sync.planner import _watermark_stamping_window
+
+    now = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+    offsets = [
+        ("far-past", -timedelta(days=10)),
+        ("near-past", -timedelta(hours=1)),
+        ("exactly-now", timedelta(0)),
+        ("near-future", timedelta(hours=1)),
+        ("far-future", timedelta(days=10)),
+    ]
+    starts = [(name, now + delta) for name, delta in offsets] + [("none", None)]
+    ends = [(name, now + delta) for name, delta in offsets]
+
+    checked = 0
+    for start_name, start in starts:
+        for end_name, end in ends:
+            case = f"start={start_name} end={end_name}"
+            windows = _watermark_stamping_window(start, end, now)
+            assert isinstance(windows, tuple)
+            assert len(windows) <= 1, f"{case}: helper must never split windows"
+            if not windows:
+                continue
+            s, e = windows[0]
+            assert e is not None, f"{case}: a planned window needs an end"
+            assert e <= now, f"{case}: window end {e} is in the future"
+            if s is not None:
+                assert _as_utc_for_test(s) < e, (
+                    f"{case}: window is inverted or zero-width ({s} -> {e})"
+                )
+            checked += 1
+
+    assert checked > 0, "the enumeration planned no windows at all — vacuous"
+
+
+def test_future_start_always_heals_on_the_self_healing_path():
+    """The precise anti-stall invariant, stated after analysing a near-miss.
+
+    Written first as "a future start must ALWAYS plan a window, for every end",
+    this FAILED for a future start combined with an explicitly requested PAST
+    ``before``. That looked like a seventh sibling; it is not, and the
+    distinction is the whole point:
+
+      - SCHEDULED runs send no ``before``, so the end is ``now``. This is the
+        only path that repeats unattended, so it is the only one where zero units
+        would perpetuate forever. It MUST plan a window, and does.
+      - A caller that explicitly asks for a bounded PAST range gets zero units.
+        That does not perpetuate — the next scheduled tick heals the watermark —
+        and planning a window anyway would fabricate a range the caller never
+        requested, which is how false coverage claims get made.
+
+    So the invariant is not "always plans", it is "always plans on the path that
+    would otherwise never recover". Forcing the other case would have been a
+    patch that made the system less correct.
+    """
+    from datetime import timedelta
+
+    from dev_health_ops.sync.planner import _watermark_stamping_window
+
+    now = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+    for start_delta in (timedelta(seconds=1), timedelta(hours=1), timedelta(days=90)):
+        # end == now is exactly what the scheduled path resolves to.
+        windows = _watermark_stamping_window(now + start_delta, now, now)
+        assert len(windows) == 1, (
+            f"future start (+{start_delta}) planned no unit on the scheduled "
+            "path — that is the permanent stall, not a safe no-op"
+        )
+        s, e = windows[0]
+        assert s is not None and e is not None
+        assert _as_utc_for_test(s) < _as_utc_for_test(e) <= now
+
+    # The analysed non-defect, pinned so it stays a deliberate choice.
+    assert (
+        _watermark_stamping_window(
+            now + timedelta(days=30), now - timedelta(days=10), now
+        )
+        == ()
+    ), "an explicit past `before` should still plan nothing; it self-heals later"

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -123,6 +123,10 @@ def test_enabled_sources_and_enabled_datasets_fan_out_to_units(db_session):
     _create_dataset(db_session, integration, "commits")
     _create_dataset(db_session, integration, "prs")
 
+    # NOTE: do NOT pass a hardcoded ``before`` here. These datasets cold-start at
+    # ``now - initial_sync_depth``; a fixed calendar date drifts into the past and
+    # eventually describes an INVERTED window (start > end), which now correctly
+    # plans zero units (CHAOS-3412). This test is about fan-out, not windows.
     plan = plan_sync_run(
         db_session,
         SyncPlanRequest(
@@ -130,7 +134,6 @@ def test_enabled_sources_and_enabled_datasets_fan_out_to_units(db_session):
             org_id=ORG_ID,
             mode=SyncRunMode.INCREMENTAL.value,
             triggered_by="manual",
-            before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
         ),
     )
 
@@ -181,6 +184,9 @@ def test_plan_sync_run_rejects_plan_over_unit_cap(db_session, monkeypatch):
     _create_dataset(db_session, integration, "commits")
     _create_dataset(db_session, integration, "prs")
 
+    # No hardcoded ``before`` — see the note in the fan-out test above: a fixed
+    # past date makes these cold-start windows inverted, which now plans zero
+    # units and would make this cap assertion vacuous.
     with pytest.raises(SyncPlanUnitCapExceededError) as excinfo:
         plan_sync_run(
             db_session,
@@ -189,7 +195,6 @@ def test_plan_sync_run_rejects_plan_over_unit_cap(db_session, monkeypatch):
                 org_id=ORG_ID,
                 mode=SyncRunMode.INCREMENTAL.value,
                 triggered_by="manual",
-                before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
             ),
         )
 
@@ -2319,3 +2324,226 @@ def test_heavy_ratchet_marches_watermark_forward_without_gaps(db_session, monkey
     # 30 days of depth at a 7-day cap: 5 capped ticks + a final partial tick.
     assert 4 <= len(windows) <= 7, f"unexpected tick count: {len(windows)}"
     assert windows[0][0] <= start - timedelta(days=29)
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 F2: incremental windows must never end in the future, and an
+# empty/inverted window must plan NO unit.
+#
+# The success path stamps the watermark at the window END. So a future
+# ``before`` persists a FUTURE watermark, and the next run starts in the future
+# and silently skips everything up to it. An inverted window (end <= start) is
+# worse than useless: the admission estimate floors a negative span to 1 day, so
+# it reads as a cheap unit, sails through the budget guard, fetches nothing, and
+# still finalizes as SUCCESS.
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_window_end_is_clamped_to_now(db_session):
+    """A future ``before`` must not persist a future window end."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+    set_watermark(
+        db_session,
+        ORG_ID,
+        source.external_id,
+        _NON_HEAVY_DATASET,
+        datetime.now(timezone.utc) - timedelta(days=3),
+    )
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=now + timedelta(days=45),  # far-future upper bound
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    _, before = _window(units[0])
+    assert before <= now + timedelta(seconds=2), (
+        f"window end {before} is in the future; the success path would stamp it "
+        "as the watermark and the next run would start in the future"
+    )
+
+
+def test_incremental_window_end_is_clamped_to_now_for_heavy(db_session):
+    """The future clamp applies to HEAVY datasets too, alongside the cap."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+    watermark = datetime.now(timezone.utc) - timedelta(days=2)
+    set_watermark(db_session, ORG_ID, source.external_id, _HEAVY_DATASET, watermark)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=now + timedelta(days=45),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    _, before = _window(units[0])
+    assert before <= now + timedelta(seconds=2)
+
+
+@pytest.mark.parametrize(
+    "case_id,watermark_offset_days,before_offset_days",
+    [
+        # `before` strictly older than the watermark start -> inverted window.
+        ("before-older-than-watermark", 3, 10),
+        # `before` exactly at the watermark start -> zero-width window.
+        ("before-equals-watermark", 3, 3),
+    ],
+    ids=["before-older-than-start", "before-equals-start"],
+)
+def test_empty_or_inverted_incremental_window_plans_no_unit(
+    db_session, case_id, watermark_offset_days, before_offset_days
+):
+    """end <= start must plan ZERO units, not an inverted/zero-width one."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+    anchor = datetime.now(timezone.utc)
+    set_watermark(
+        db_session,
+        ORG_ID,
+        source.external_id,
+        _NON_HEAVY_DATASET,
+        anchor - timedelta(days=watermark_offset_days),
+    )
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=anchor - timedelta(days=before_offset_days),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert units == [], (
+        f"{case_id}: an empty/inverted window must plan no unit; planned "
+        f"{[(u.since_at, u.before_at) for u in units]}"
+    )
+    assert plan.total_units == 0
+
+
+def test_cold_start_with_before_older_than_depth_plans_no_unit(db_session):
+    """The drift case that was already live in this suite.
+
+    Two pre-existing tests passed a hardcoded ``before`` of 2026-06-17 that was
+    in the future when written. Once wall-clock time passed it, their cold-start
+    windows became inverted (start = now - 30d, end = 2026-06-17) and they kept
+    passing because nothing asserted window sanity. Assert it deliberately.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=datetime.now(timezone.utc) - timedelta(days=90),
+        ),
+    )
+
+    assert _planned_units(db_session, plan.sync_run_id) == []
+
+
+def test_family_dataset_with_empty_window_does_not_break_the_merge(db_session):
+    """A partially-caught-up work-item family must still plan its composite.
+
+    ``_merge_family_windows`` raises on mismatched window counts. Once an
+    already-caught-up dataset resolves to ZERO windows, that guard would fire on
+    an ordinary partially-synced family and take the whole plan down, so empty
+    datasets are dropped before the merge.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session, provider="github")
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, "work-items")
+    _create_dataset(db_session, integration, "work-item-labels")
+
+    anchor = datetime.now(timezone.utc)
+    requested_before = anchor - timedelta(days=5)
+    # work-items is behind the requested end (contributes a window); labels is
+    # already synced past it (resolves empty).
+    set_watermark(
+        db_session, ORG_ID, source.external_id, "work-items", anchor - timedelta(days=9)
+    )
+    set_watermark(
+        db_session,
+        ORG_ID,
+        source.external_id,
+        "work-item-labels",
+        anchor - timedelta(days=2),
+    )
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=requested_before,
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    composite = units[0]
+    assert composite.dataset_key == "work-items"
+    flags = composite.processor_flags or {}
+    assert flags.get("family_dataset_work_items") is True
+    assert flags.get("family_dataset_work_item_labels") is not True, (
+        "a dataset that resolved to no window must not be marked as covered by "
+        "the composite crawl"
+    )

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -1786,3 +1786,251 @@ def test_merge_family_windows_rejects_mismatched_window_counts():
     d = datetime(2026, 6, 4, 0, 0, tzinfo=timezone.utc)
     with pytest.raises(ValueError, match="mismatched window counts"):
         _merge_family_windows([((a, b),), ((a, b), (c, d))])
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412: HEAVY incremental window ratchet
+#
+# A HEAVY dataset cold-starting on a wide ``initial_sync_depth`` used to plan
+# ONE window spanning the whole depth. Unit cost is linear in span, so that
+# single unit could never fit the sync budget; it was deferred forever, no
+# watermark was ever stamped, and every subsequent tick recomputed the same
+# unfittable span. The ratchet caps the INCREMENTAL window span for HEAVY
+# datasets so each tick plans an affordable slice and advances the watermark.
+# ---------------------------------------------------------------------------
+
+
+def _window(unit: SyncRunUnit) -> tuple[datetime, datetime]:
+    """Return a unit's (since_at, before_at) as tz-aware UTC, asserting both are set."""
+    assert unit.since_at is not None
+    assert unit.before_at is not None
+    return (
+        unit.since_at.replace(tzinfo=timezone.utc),
+        unit.before_at.replace(tzinfo=timezone.utc),
+    )
+
+
+_HEAVY_DATASET = "commit-stats"  # CostClass.HEAVY (sync/datasets.py _HEAVY_DATASETS)
+_NON_HEAVY_DATASET = "commits"  # CostClass.MEDIUM
+
+
+def test_incremental_cold_start_heavy_dataset_is_capped(db_session):
+    """CHAOS-3412: HEAVY cold-start plans ``[now - depth, now - depth + cap]``.
+
+    The window must END at ``window_start + cap``, NOT at ``now``.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    unit = units[0]
+    since, before = _window(unit)
+
+    assert abs((since - (now - timedelta(days=30))).total_seconds()) < 2
+    assert abs((before - (since + timedelta(days=7))).total_seconds()) < 2, (
+        "HEAVY cold-start window must be capped at 7 days from window_start"
+    )
+    # The decisive assertion: the window does NOT run to now.
+    assert before < now - timedelta(days=20), (
+        f"HEAVY cold-start window ended at {before} (now={now}); it must stop "
+        "at window_start + cap, not run to now"
+    )
+
+
+def test_incremental_cold_start_non_heavy_dataset_is_not_capped(db_session):
+    """Non-HEAVY datasets keep the full-depth single window (regression guard)."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    unit = units[0]
+    since, before = _window(unit)
+    assert abs((since - (now - timedelta(days=30))).total_seconds()) < 2
+    assert abs((before - now).total_seconds()) < 2, (
+        "MEDIUM dataset must keep the full-depth window ending at now"
+    )
+
+
+def test_incremental_behind_watermark_heavy_dataset_is_capped(db_session):
+    """A long-idle org whose HEAVY watermark is far behind ratchets too."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+    watermark = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    set_watermark(db_session, ORG_ID, source.external_id, _HEAVY_DATASET, watermark)
+
+    requested_before = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=requested_before,
+        ),
+    )
+
+    unit = _planned_units(db_session, plan.sync_run_id)[0]
+    since, before = _window(unit)
+    assert since == watermark
+    assert before == watermark + timedelta(days=7)
+    assert before < requested_before
+
+
+def test_incremental_watermark_within_cap_heavy_window_unchanged(db_session):
+    """A caught-up HEAVY dataset keeps its natural window ending at ``before``."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+    requested_before = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+    watermark = requested_before - timedelta(days=2)
+    set_watermark(db_session, ORG_ID, source.external_id, _HEAVY_DATASET, watermark)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=requested_before,
+        ),
+    )
+
+    unit = _planned_units(db_session, plan.sync_run_id)[0]
+    since, before = _window(unit)
+    assert since == watermark
+    assert before == requested_before, (
+        "a watermark inside the cap must not shorten the window"
+    )
+
+
+def test_heavy_max_window_days_env_override_is_respected(db_session, monkeypatch):
+    from datetime import timedelta
+
+    monkeypatch.setenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "3")
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+    watermark = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    set_watermark(db_session, ORG_ID, source.external_id, _HEAVY_DATASET, watermark)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
+        ),
+    )
+    unit = _planned_units(db_session, plan.sync_run_id)[0]
+    _, before = _window(unit)
+    assert before == watermark + timedelta(days=3)
+
+
+def test_heavy_ratchet_marches_watermark_forward_without_gaps(db_session, monkeypatch):
+    """Successive successful ticks walk the watermark to ``now``.
+
+    Each tick's window must start exactly where the previous one ended (minus
+    the configured overlap) — no gap, no overlap beyond the configured one —
+    and the sequence must terminate at ``now`` in a bounded number of ticks.
+    """
+    from datetime import timedelta
+
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", "0")
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, _HEAVY_DATASET)
+
+    start = datetime.now(timezone.utc)
+    previous_before: datetime | None = None
+    windows: list[tuple[datetime, datetime]] = []
+    for _ in range(12):
+        plan = plan_sync_run(
+            db_session,
+            SyncPlanRequest(
+                integration_id=str(integration.id),
+                org_id=ORG_ID,
+                mode=SyncRunMode.INCREMENTAL.value,
+                triggered_by="scheduled",
+            ),
+        )
+        unit = _planned_units(db_session, plan.sync_run_id)[0]
+        since, before = _window(unit)
+        windows.append((since, before))
+        if previous_before is not None:
+            assert since == previous_before, (
+                f"window must resume exactly at the previous watermark "
+                f"(gap/overlap): since={since} previous_before={previous_before}"
+            )
+        assert before - since <= timedelta(days=7) + timedelta(seconds=2)
+        # Simulate the SUCCESS path: watermark stamped at the unit's window END.
+        set_watermark(db_session, ORG_ID, source.external_id, _HEAVY_DATASET, before)
+        previous_before = before
+        if before >= start:
+            break
+
+    assert previous_before is not None
+    assert previous_before >= start, (
+        f"ratchet did not reach now within 12 ticks; last before={previous_before}"
+    )
+    # 30 days of depth at a 7-day cap: 5 capped ticks + a final partial tick.
+    assert 4 <= len(windows) <= 7, f"unexpected tick count: {len(windows)}"
+    assert windows[0][0] <= start - timedelta(days=29)

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -1814,6 +1814,291 @@ _HEAVY_DATASET = "commit-stats"  # CostClass.HEAVY (sync/datasets.py _HEAVY_DATA
 _NON_HEAVY_DATASET = "commits"  # CostClass.MEDIUM
 
 
+# ---------------------------------------------------------------------------
+# Deterministic ratchet contract table.
+#
+# These cases pin the ratchet's behavioral clauses at EXACT timestamps with no
+# wall-clock dependency and no tolerance, by driving ``_resolve_windows``
+# directly with an injected ``now``. That makes them reproducible by any other
+# implementation of the same contract (e.g. a Go-native scheduler planner), so
+# this table is the Python side of a cross-implementation differential oracle:
+# feed the same (dataset, watermark, now, requested_before, depth, cap) inputs
+# to both implementations and the (since, before) pair must match exactly.
+#
+# Every case must stay expressible as pure data — no fixture reaching into
+# Python-only internals — or it stops being portable to the other side.
+# ---------------------------------------------------------------------------
+
+_ORACLE_NOW = datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+_ORACLE_DEPTH_DAYS = 30
+_ORACLE_CAP_DAYS = 7
+# _ORACLE_NOW - 30 days, i.e. the cold-start window_start for every case below.
+_ORACLE_COLD_START = datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)
+
+
+def _dt(year: int, month: int, day: int, hour: int = 12) -> datetime:
+    return datetime(year, month, day, hour, 0, tzinfo=timezone.utc)
+
+
+# (case_id, dataset_key, watermark, requested_before, expected_since, expected_before)
+_RATCHET_CONTRACT_CASES: list[
+    tuple[str, str, datetime | None, datetime | None, datetime | None, datetime]
+] = [
+    # --- Clause: HEAVY cold-start is capped at window_start + cap ------------
+    (
+        "heavy-cold-start-is-capped",
+        "commit-stats",
+        None,
+        None,
+        _ORACLE_COLD_START,
+        _dt(2026, 5, 25),  # cold_start + 7d, NOT _ORACLE_NOW
+    ),
+    (
+        "heavy-cold-start-is-capped-for-every-heavy-key",
+        "files",
+        None,
+        None,
+        _ORACLE_COLD_START,
+        _dt(2026, 5, 25),
+    ),
+    # --- Clause: the cap is scoped to CostClass.HEAVY only -------------------
+    (
+        "medium-cold-start-is-uncapped",
+        "commits",
+        None,
+        None,
+        _ORACLE_COLD_START,
+        _ORACLE_NOW,
+    ),
+    (
+        "light-cold-start-is-uncapped",
+        "work-item-labels",
+        None,
+        None,
+        _ORACLE_COLD_START,
+        _ORACLE_NOW,
+    ),
+    (
+        "medium-behind-watermark-is-uncapped",
+        "commits",
+        _dt(2026, 3, 1),
+        None,
+        _dt(2026, 3, 1),
+        _ORACLE_NOW,
+    ),
+    # --- Clause: the cap applies to the behind-watermark case too ------------
+    (
+        "heavy-behind-watermark-is-capped",
+        "commit-stats",
+        _dt(2026, 3, 1),
+        None,
+        _dt(2026, 3, 1),
+        _dt(2026, 3, 8),  # watermark + 7d
+    ),
+    # --- Clause: the cap only ever moves the END in (it is a min, not a set) -
+    (
+        "heavy-watermark-inside-cap-keeps-natural-end",
+        "commit-stats",
+        _dt(2026, 6, 15),  # 2 days behind now
+        None,
+        _dt(2026, 6, 15),
+        _ORACLE_NOW,
+    ),
+    (
+        "heavy-watermark-exactly-at-cap-boundary-keeps-natural-end",
+        "commit-stats",
+        _dt(2026, 6, 10),  # exactly now - 7d; the tie must resolve to now
+        None,
+        _dt(2026, 6, 10),
+        _ORACLE_NOW,
+    ),
+    (
+        "heavy-requested-before-tighter-than-cap-wins",
+        "commit-stats",
+        _dt(2026, 3, 1),
+        _dt(2026, 3, 4),  # requested end is nearer than watermark + cap
+        _dt(2026, 3, 1),
+        _dt(2026, 3, 4),
+    ),
+    # --- Clause: a NONE-watermark-behavior dataset is never capped -----------
+    # NOTE: repo-metadata is the only NONE-behavior dataset and it is LIGHT, so
+    # this case exercises the NONE path end-to-end but short-circuits on the
+    # cost-class check and never reaches the ``window_start is not None`` guard.
+    # That guard is covered separately by
+    # ``test_open_start_window_is_never_capped_even_when_heavy``.
+    (
+        "none-watermark-behavior-keeps-open-start",
+        "repo-metadata",
+        None,
+        None,
+        None,  # window_start stays None; the cap must not synthesize one
+        _ORACLE_NOW,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,dataset_key,watermark,requested_before,expected_since,expected_before",
+    _RATCHET_CONTRACT_CASES,
+    ids=[case[0] for case in _RATCHET_CONTRACT_CASES],
+)
+def test_ratchet_window_contract(
+    db_session,
+    monkeypatch,
+    case_id,
+    dataset_key,
+    watermark,
+    requested_before,
+    expected_since,
+    expected_before,
+):
+    """CHAOS-3412: the exact (since, before) the ratchet must produce.
+
+    Behavioral clauses pinned by this table:
+
+    1. Cap default is 7 days, overridable via
+       ``SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS``.
+    2. The cap is scoped to ``CostClass.HEAVY`` datasets ONLY; LIGHT and MEDIUM
+       keep a single full-span window.
+    3. The cap applies to BOTH the cold-start case (no watermark, start =
+       ``now - initial_sync_depth``) and the behind-watermark case (start =
+       stored watermark less the configured overlap).
+    4. The cap only moves the window END inward: ``before = min(requested_before
+       or now, window_start + cap)``. ``window_start`` is never moved, so depth
+       resolution and the tier ``backfill_days`` cap are unaffected.
+    5. A ``WatermarkBehavior.NONE`` dataset keeps ``window_start = None`` and is
+       never capped.
+    """
+    from dev_health_ops.sync.datasets import get_dataset_spec
+
+    # Pin every input the contract depends on so the case is reproducible by
+    # another implementation: default cap, zero overlap, injected ``now``.
+    monkeypatch.delenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", raising=False)
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", "0")
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": _ORACLE_DEPTH_DAYS}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    dataset = _create_dataset(db_session, integration, dataset_key)
+    if watermark is not None:
+        set_watermark(db_session, ORG_ID, source.external_id, dataset_key, watermark)
+
+    spec = get_dataset_spec("github", dataset_key)
+    assert spec is not None and spec.supported
+
+    windows = planner._resolve_windows(
+        session=db_session,
+        request=SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="scheduled",
+            before=requested_before,
+        ),
+        mode=SyncRunMode.INCREMENTAL.value,
+        org_id=ORG_ID,
+        source_provider="github",
+        watermark_source_key=source.external_id,
+        dataset_key=dataset_key,
+        watermark_behavior=spec.watermark_behavior,
+        now=_ORACLE_NOW,
+        integration=integration,
+        dataset=dataset,
+    )
+
+    assert len(windows) == 1, (
+        f"{case_id}: the ratchet must not split a unit into multiple windows; "
+        "it caps ONE window and lets the next scheduled tick continue"
+    )
+    since, before = windows[0]
+    since = None if since is None else _as_utc_for_test(since)
+    assert since == expected_since, f"{case_id}: window_start"
+    assert before is not None
+    assert _as_utc_for_test(before) == expected_before, f"{case_id}: window_end"
+
+
+def _as_utc_for_test(value: datetime) -> datetime:
+    """SQLite hands back naive datetimes; the contract is in UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def test_open_start_window_is_never_capped_even_when_heavy(db_session, monkeypatch):
+    """The ``window_start is not None`` guard, exercised for real.
+
+    No dataset is registered HEAVY *and* ``WatermarkBehavior.NONE`` today, so
+    the contract table above can never reach this guard — every NONE dataset
+    short-circuits on the cost-class check first. The guard is still load-
+    bearing: a future HEAVY dataset registered with NONE behavior would reach
+    ``window_start + cap`` with ``window_start=None`` and raise. Force that
+    combination so the guard is covered rather than merely present.
+    """
+    from dev_health_ops.sync.datasets import WatermarkBehavior
+
+    monkeypatch.delenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", raising=False)
+    monkeypatch.setattr(planner, "_is_heavy_dataset", lambda provider, key: True)
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": _ORACLE_DEPTH_DAYS}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    dataset = _create_dataset(db_session, integration, "repo-metadata")
+
+    windows = planner._resolve_windows(
+        session=db_session,
+        request=SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="scheduled",
+        ),
+        mode=SyncRunMode.INCREMENTAL.value,
+        org_id=ORG_ID,
+        source_provider="github",
+        watermark_source_key=source.external_id,
+        dataset_key="repo-metadata",
+        watermark_behavior=WatermarkBehavior.NONE,
+        now=_ORACLE_NOW,
+        integration=integration,
+        dataset=dataset,
+    )
+
+    assert windows == ((None, _ORACLE_NOW),), (
+        "an open-start window must pass through uncapped, not raise and not "
+        "acquire a synthesized start"
+    )
+
+
+def test_ratchet_contract_table_covers_every_heavy_dataset_key(db_session):
+    """The cap is a COST-CLASS rule, not a per-key list.
+
+    If a new dataset joins ``CostClass.HEAVY``, it inherits the cap
+    automatically — assert that directly against the registry so the contract
+    table above can never drift into describing only the keys it happens to
+    name.
+    """
+    from dev_health_ops.sync.datasets import get_dataset_spec
+    from dev_health_ops.sync.planner import _is_heavy_dataset
+
+    heavy_keys = [
+        key
+        for key in ("commit-stats", "files", "blame", "tests", "commits", "prs")
+        if (spec := get_dataset_spec("github", key)) is not None
+        and spec.default_cost_class.value == "heavy"
+    ]
+    assert heavy_keys == ["commit-stats", "files", "blame", "tests"]
+    for key in heavy_keys:
+        assert _is_heavy_dataset("github", key) is True
+    for key in ("commits", "prs", "work-item-labels", "repo-metadata"):
+        assert _is_heavy_dataset("github", key) is False
+
+
 def test_incremental_cold_start_heavy_dataset_is_capped(db_session):
     """CHAOS-3412: HEAVY cold-start plans ``[now - depth, now - depth + cap]``.
 

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -2547,3 +2547,136 @@ def test_family_dataset_with_empty_window_does_not_break_the_merge(db_session):
         "a dataset that resolved to no window must not be marked as covered by "
         "the composite crawl"
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412: FULL_RESYNC inherits the same window rules as INCREMENTAL.
+#
+# sync_units.py gates watermark stamping on exactly {INCREMENTAL, FULL_RESYNC},
+# so both modes stamp the watermark at the unit's window END and both inherit
+# the future-end and inverted-window defects. Both branches now share
+# ``_watermark_stamping_window``; these tests hold FULL_RESYNC to the contract
+# independently so the shared helper cannot be bypassed for one mode later.
+# ---------------------------------------------------------------------------
+
+
+def test_full_resync_window_end_is_clamped_to_now(db_session):
+    """A future ``before`` must not persist a future full_resync window end."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.FULL_RESYNC.value,
+            triggered_by="admin-api",
+            before=now + timedelta(days=45),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    _, before = _window(units[0])
+    assert before <= now + timedelta(seconds=2), (
+        f"full_resync window end {before} is in the future; full_resync IS in "
+        "the watermark-stamping set, so this would persist a future watermark"
+    )
+
+
+def test_full_resync_inverted_window_plans_no_unit(db_session):
+    """``before`` older than ``now - depth`` must plan zero units, not an
+    inverted one whose negative span floors to 1 day in admission."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.FULL_RESYNC.value,
+            triggered_by="admin-api",
+            before=datetime.now(timezone.utc) - timedelta(days=90),  # depth is 30d
+        ),
+    )
+
+    assert _planned_units(db_session, plan.sync_run_id) == []
+    assert plan.total_units == 0
+
+
+def test_full_resync_normal_window_is_unchanged(db_session):
+    """Regression guard: the ordinary full_resync window still spans the full
+    configured depth and ends at now."""
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 14}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.FULL_RESYNC.value,
+            triggered_by="admin-api",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    since, before = _window(units[0])
+    assert abs((since - (now - timedelta(days=14))).total_seconds()) < 2
+    assert abs((before - now).total_seconds()) < 2
+
+
+def test_backfill_windows_are_not_routed_through_the_watermark_normalizer(db_session):
+    """BACKFILL must keep its own bounds handling.
+
+    Backfill never stamps a watermark (CHAOS-2514) and legitimately targets a
+    historical range that ends well before ``now``. Routing it through the
+    watermark normalizer would be harmless for the clamp but would let the
+    empty-window rule silently drop chunks, so backfill stays out of it.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.BACKFILL.value,
+            triggered_by="admin-api",
+            since=now - timedelta(days=60),
+            before=now - timedelta(days=30),  # entirely in the past
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert units, "a historical backfill must still plan units"
+    for unit in units:
+        since, before = _window(unit)
+        assert since < before, "backfill chunks must stay forward-ordered"
+        assert before <= now

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -2699,6 +2699,42 @@ def test_backfill_windows_are_not_routed_through_the_watermark_normalizer(db_ses
 # ---------------------------------------------------------------------------
 
 
+def _seed_corrupt_future_watermark(session, org_id, source_id, dataset_key, when):
+    """Write a FUTURE watermark directly, bypassing set_watermark's clamp.
+
+    CHAOS-3412 round 3 added a write-boundary invariant: ``set_watermark`` never
+    persists a future value, from any caller. That is correct, and it means the
+    corrupt state can no longer be created through the public API — so a test
+    that seeds via ``set_watermark`` silently STOPS exercising the repair path
+    while still passing. This writes the row directly, which is also how the
+    state genuinely arises: rows persisted by pre-fix code, sitting in a live
+    database.
+    """
+    row = (
+        session.query(SyncWatermark)
+        .filter(
+            SyncWatermark.org_id == org_id,
+            SyncWatermark.source_id == source_id,
+            SyncWatermark.dataset_key == dataset_key,
+        )
+        .one_or_none()
+    )
+    if row is None:
+        row = SyncWatermark(
+            repo_id=source_id,
+            target=dataset_key,
+            org_id=org_id,
+            source_id=source_id,
+            dataset_key=dataset_key,
+            last_synced_at=when,
+        )
+        session.add(row)
+    else:
+        row.last_synced_at = when
+    session.flush()
+    return row
+
+
 def test_future_watermark_still_plans_a_unit(db_session, caplog):
     """A corrupt future watermark must NOT stall the scheduled path."""
     import logging
@@ -2713,7 +2749,9 @@ def test_future_watermark_still_plans_a_unit(db_session, caplog):
     _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
     now = datetime.now(timezone.utc)
     corrupt = now + timedelta(days=30)
-    set_watermark(db_session, ORG_ID, source.external_id, _NON_HEAVY_DATASET, corrupt)
+    _seed_corrupt_future_watermark(
+        db_session, ORG_ID, source.external_id, _NON_HEAVY_DATASET, corrupt
+    )
 
     with caplog.at_level(logging.WARNING, logger="dev_health_ops.sync.planner"):
         plan = plan_sync_run(
@@ -2761,7 +2799,7 @@ def test_future_watermark_recovers_after_one_success(db_session):
     )
     _create_dataset(db_session, integration, _NON_HEAVY_DATASET)
     now = datetime.now(timezone.utc)
-    set_watermark(
+    _seed_corrupt_future_watermark(
         db_session,
         ORG_ID,
         source.external_id,

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -5447,3 +5447,103 @@ def test_fully_caught_up_plan_finalizes_failed_not_silently_successful(
         "implies coverage was refreshed"
     )
     assert run.error == "No sync units planned"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 round 3: a PROVIDER-SUPPLIED future watermark_at must not be
+# persisted, and must not re-poison a repaired watermark.
+#
+# The worker prefers result_payload["watermark_at"] over the clamped window end
+# (run_sync_unit). PagerDuty derives that value from source record timestamps,
+# so a skewed record yields a FUTURE watermark_at. Clamping the window end in
+# the planner does nothing here — this path bypasses it entirely. The write
+# boundary is the only place that closes it for every caller.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_supplied_future_watermark_is_not_persisted(db_session, monkeypatch):
+    """Composition path: provider returns a future watermark_at on success."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.sync.watermarks import get_watermark
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    unit.since_at = datetime.now(timezone.utc) - timedelta(days=2)
+    unit.before_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    skewed = datetime.now(timezone.utc) + timedelta(days=30)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {"ok": True, "watermark_at": skewed.isoformat()},
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "success"
+
+    stored = get_watermark(db_session, run.org_id, "full-chaos/dev-health", "commits")
+    assert stored is not None
+    stored_aware = _aware(stored)
+    now = datetime.now(timezone.utc)
+    assert stored_aware <= now + timedelta(seconds=60), (
+        f"a provider-supplied FUTURE watermark_at was persisted verbatim "
+        f"({stored_aware}). The planner's window-end clamp does not cover this "
+        "path — the worker prefers the provider value — so every later scheduled "
+        "tick plans a recovery slice and repeats it forever."
+    )
+
+
+def test_provider_future_watermark_cannot_repoison_a_repaired_one(
+    db_session, monkeypatch
+):
+    """The repair must not be undoable by the next provider stamp."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    # A previously REPAIRED, sane watermark.
+    set_watermark(
+        db_session,
+        run.org_id,
+        "full-chaos/dev-health",
+        "commits",
+        now - timedelta(hours=2),
+    )
+    unit.since_at = now - timedelta(days=2)
+    unit.before_at = now - timedelta(hours=1)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "watermark_at": (now + timedelta(days=30)).isoformat(),
+        },
+    )
+
+    assert getattr(run_sync_unit, "run")(str(unit.id))["status"] == "success"
+
+    stored_raw = get_watermark(
+        db_session, run.org_id, "full-chaos/dev-health", "commits"
+    )
+    assert stored_raw is not None
+    stored = _aware(stored_raw)
+    assert stored <= datetime.now(timezone.utc) + timedelta(seconds=60), (
+        f"a repaired watermark was re-poisoned to {stored} by the next "
+        "provider-supplied future value — the repair is not durable"
+    )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -5164,3 +5164,286 @@ def test_run_sync_unit_stamps_watermark_at_window_end_not_now(db_session, monkey
         "watermark was stamped near wall-clock now — a ratcheted window would "
         "silently skip everything between its window end and now"
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 F1: the HEAVY ratchet must make progress even when the configured
+# watermark overlap is >= the configured cap.
+#
+# The incremental read subtracts SYNC_WATERMARK_OVERLAP from the stored
+# watermark, so a capped window spans [W - overlap, W - overlap + cap]. With
+# overlap >= cap the end lands at or before W, and set_watermark is monotonic
+# (max(existing, new)) so the write is DISCARDED. Every tick then re-plans and
+# re-fetches the identical slice and finalizes SUCCESS while the watermark never
+# moves — the same permanent stall CHAOS-3412 exists to kill.
+#
+# These are worker-backed: they run the real run_sync_unit success path so the
+# watermark is stamped by production code, not by the test.
+# ---------------------------------------------------------------------------
+
+
+def _seed_planned_heavy_unit(session, org_id, *, dataset_key="commit-stats"):
+    """Create integration/source/dataset for a HEAVY dataset and plan one run."""
+    from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+
+    integration = session.query(Integration).filter_by(org_id=org_id).one_or_none()
+    if integration is None:
+        integration = Integration(
+            org_id=org_id,
+            provider="github",
+            name="demo",
+            config={"initial_sync_depth": 30},
+            is_active=True,
+        )
+        session.add(integration)
+        session.flush()
+        session.add(
+            IntegrationSource(
+                org_id=org_id,
+                integration_id=integration.id,
+                provider="github",
+                source_type="repo",
+                external_id="full-chaos/dev-health",
+                name="dev-health",
+                full_name="full-chaos/dev-health",
+                metadata_={},
+                is_enabled=True,
+            )
+        )
+        session.add(
+            IntegrationDataset(
+                org_id=org_id,
+                integration_id=integration.id,
+                dataset_key=dataset_key,
+                is_enabled=True,
+                options={},
+            )
+        )
+        session.flush()
+
+    plan = plan_sync_run(
+        session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=org_id,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="scheduled",
+        ),
+    )
+    units = session.query(SyncRunUnit).filter_by(sync_run_id=plan.sync_run_id).all()
+    assert len(units) == 1, f"expected exactly one planned unit, got {len(units)}"
+    return units[0]
+
+
+@pytest.mark.parametrize(
+    "overlap_days,case",
+    [(7, "overlap-equals-cap"), (14, "overlap-exceeds-cap")],
+    ids=["overlap-equals-cap", "overlap-exceeds-cap"],
+)
+def test_heavy_ratchet_advances_watermark_when_overlap_ge_cap(
+    db_session, monkeypatch, overlap_days, case
+):
+    """Two successive worker-backed ticks must STRICTLY advance the watermark."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    monkeypatch.setenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "7")
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", str(overlap_days * 86_400))
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters, "run_dataset_unit", lambda ctx, runtime: {"ok": True}
+    )
+
+    org_id = str(uuid.uuid4())
+    source_key = "full-chaos/dev-health"
+    seeded = datetime.now(timezone.utc) - timedelta(days=60)
+    set_watermark(db_session, org_id, source_key, "commit-stats", seeded)
+
+    def _current() -> datetime:
+        value = get_watermark(db_session, org_id, source_key, "commit-stats")
+        assert value is not None, "watermark row disappeared"
+        return _aware(value)
+
+    observed = [_current()]
+    for tick in range(2):
+        unit = _seed_planned_heavy_unit(db_session, org_id)
+        _mark_dispatching(db_session, unit)
+        result = getattr(run_sync_unit, "run")(str(unit.id))
+        assert result["status"] == "success", f"{case} tick {tick}: {result}"
+        current = _current()
+        assert current > observed[-1], (
+            f"{case}: tick {tick} did not advance the watermark "
+            f"({observed[-1]} -> {current}). With overlap({overlap_days}d) >= "
+            "cap(7d) the capped window ends at or before its own watermark and "
+            "the monotonic write is discarded, so the ratchet stalls forever "
+            "while every run reports success."
+        )
+        observed.append(current)
+
+    assert observed[-1] > observed[0]
+
+
+def test_heavy_cap_clamp_is_logged_when_overlap_ge_cap(caplog):
+    """The clamp must be VISIBLE — a silent widen hides the misconfiguration."""
+    import os
+
+    from dev_health_ops.sync.planner import (
+        _effective_heavy_max_window_days,
+        reset_heavy_cap_clamp_warnings,
+    )
+
+    previous = {
+        key: os.environ.get(key)
+        for key in ("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "SYNC_WATERMARK_OVERLAP")
+    }
+    os.environ["SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS"] = "7"
+    os.environ["SYNC_WATERMARK_OVERLAP"] = str(9 * 86_400)
+    # The warning is emitted once per (cap, overlap) per process; clear the
+    # cache so this test does not depend on whether another test warmed it.
+    reset_heavy_cap_clamp_warnings()
+    try:
+        with caplog.at_level(logging.WARNING, logger="dev_health_ops.sync.planner"):
+            effective = _effective_heavy_max_window_days()
+            repeats = [_effective_heavy_max_window_days() for _ in range(5)]
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    # floor(9 days) + 1 == 10, strictly greater than the 9-day overlap.
+    assert effective == 10
+    clamped = [
+        record
+        for record in caplog.records
+        if "heavy_window_cap_clamped_below_watermark_overlap" in record.getMessage()
+    ]
+    assert clamped, "clamping the cap must emit a warning naming both values"
+    record = clamped[0]
+    assert record.configured_cap_days == 7
+    assert record.watermark_overlap_seconds == 9 * 86_400
+    assert record.effective_cap_days == 10
+    # Deduped: the helper runs once per (source x heavy dataset), so repeating it
+    # must NOT re-warn — hundreds of identical lines per plan would bury the
+    # signal on a large org. The clamp itself still applies every time.
+    assert repeats == [10] * 5
+    assert len(clamped) == 1, (
+        f"expected exactly one clamp warning for 6 calls, got {len(clamped)}"
+    )
+
+
+def test_heavy_cap_is_not_clamped_when_overlap_is_below_cap():
+    """No clamp, and no widening, in the normal configuration."""
+    import os
+
+    from dev_health_ops.sync.planner import _effective_heavy_max_window_days
+
+    previous = {
+        key: os.environ.get(key)
+        for key in ("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "SYNC_WATERMARK_OVERLAP")
+    }
+    os.environ["SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS"] = "7"
+    os.environ["SYNC_WATERMARK_OVERLAP"] = "3600"
+    try:
+        assert _effective_heavy_max_window_days() == 7
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_fully_caught_up_plan_finalizes_failed_not_silently_successful(
+    db_session, monkeypatch
+):
+    """Pin the end-to-end outcome of CHAOS-3412's empty-window suppression.
+
+    Suppressing empty/inverted windows means a request whose upper bound is
+    ALREADY covered for every enabled dataset plans zero units, and a zero-unit
+    run finalizes as FAILED with "No sync units planned" (pre-existing behavior,
+    see test_finalize_zero_unit_run_does_not_report_success).
+
+    That is a deliberate trade, not an oversight: the alternative is the old
+    behavior, where an inverted window produced a unit that fetched nothing and
+    finalized SUCCESS — a false coverage claim. A loud, honest failure beats a
+    quiet, wrong success. Asserted here so the outcome is known rather than
+    discovered in production. Scheduled runs pass no explicit ``before`` and so
+    can never reach this path.
+    """
+    from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+    from dev_health_ops.sync.watermarks import set_watermark
+    from dev_health_ops.workers import sync_units
+
+    _patch_db_session(monkeypatch, db_session)
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="github",
+        name="demo",
+        config={"initial_sync_depth": 30},
+        is_active=True,
+    )
+    db_session.add(integration)
+    db_session.flush()
+    db_session.add(
+        IntegrationSource(
+            org_id=org_id,
+            integration_id=integration.id,
+            provider="github",
+            source_type="repo",
+            external_id="full-chaos/dev-health",
+            name="dev-health",
+            full_name="full-chaos/dev-health",
+            metadata_={},
+            is_enabled=True,
+        )
+    )
+    db_session.add(
+        IntegrationDataset(
+            org_id=org_id,
+            integration_id=integration.id,
+            dataset_key="commits",
+            is_enabled=True,
+            options={},
+        )
+    )
+    db_session.flush()
+
+    anchor = datetime.now(timezone.utc)
+    set_watermark(
+        db_session,
+        org_id,
+        "full-chaos/dev-health",
+        "commits",
+        anchor - timedelta(days=2),
+    )
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=org_id,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=anchor - timedelta(days=10),  # already covered
+        ),
+    )
+    assert plan.total_units == 0
+
+    sync_units.finalize_sync_run(plan.sync_run_id)
+
+    run = db_session.get(SyncRun, plan.sync_run_id)
+    assert run is not None
+    assert run.status == SyncRunStatus.FAILED.value, (
+        "an already-covered request must NOT finalize as a success that "
+        "implies coverage was refreshed"
+    )
+    assert run.error == "No sync units planned"

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -5547,3 +5547,114 @@ def test_provider_future_watermark_cannot_repoison_a_repaired_one(
         f"a repaired watermark was re-poisoned to {stored} by the next "
         "provider-supplied future value — the repair is not durable"
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 closure repair: a provider watermark_at may never exceed the
+# unit's window END.
+#
+# watermark_at is a COVERAGE CLAIM. The unit only fetched up to window_end, so a
+# stamp beyond it asserts coverage that was never read. Clamping to "now" is not
+# enough: a provider value between window_end and now is still in the past, so
+# it passes the not-future check while silently skipping every record whose
+# source time falls in (window_end, stamp]. The next plan starts after them and
+# they are never fetched.
+# ---------------------------------------------------------------------------
+
+
+def _run_unit_with_provider_watermark(
+    db_session, monkeypatch, *, since, before, provider_watermark
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    unit.since_at = since
+    unit.before_at = before
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "watermark_at": provider_watermark.isoformat(),
+        },
+    )
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "success"
+    return run
+
+
+def test_provider_watermark_cannot_exceed_the_units_window_end(db_session, monkeypatch):
+    """A past-but-beyond-window_end stamp overclaims coverage."""
+    from dev_health_ops.sync.watermarks import get_watermark
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=2)
+    before = now - timedelta(hours=6)
+    # In the PAST (so the not-future check passes) but 5h beyond what the unit
+    # actually fetched.
+    overclaim = before + timedelta(hours=5)
+
+    run = _run_unit_with_provider_watermark(
+        db_session,
+        monkeypatch,
+        since=since,
+        before=before,
+        provider_watermark=overclaim,
+    )
+
+    stored = get_watermark(db_session, run.org_id, "full-chaos/dev-health", "commits")
+    assert stored is not None
+    stored_aware = _aware(stored)
+    assert stored_aware <= _aware(before), (
+        f"watermark stamped at {stored_aware}, beyond the unit's window end "
+        f"{_aware(before)}. The unit only fetched up to window_end, so records "
+        "in between are silently skipped by the next run — a coverage claim for "
+        "data that was never read."
+    )
+
+
+@pytest.mark.parametrize("overlap_seconds", [0, 60], ids=["overlap-0", "overlap-60s"])
+def test_two_run_composition_leaves_no_gap(db_session, monkeypatch, overlap_seconds):
+    """Two successive runs must leave no unread span between them.
+
+    The second window starts at ``watermark - overlap``. If run 1 stamped beyond
+    its own window end, the span (window_end, stamp - overlap) is never fetched
+    by anyone. Uses an execution delay LARGER than the overlap so a gap would be
+    real rather than masked by the overlap.
+    """
+    from dev_health_ops.sync.watermarks import get_watermark
+
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", str(overlap_seconds))
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=2)
+    before = now - timedelta(hours=6)
+    overclaim = before + timedelta(hours=5)  # >> any overlap under test
+
+    run = _run_unit_with_provider_watermark(
+        db_session,
+        monkeypatch,
+        since=since,
+        before=before,
+        provider_watermark=overclaim,
+    )
+    stamped_raw = get_watermark(
+        db_session, run.org_id, "full-chaos/dev-health", "commits"
+    )
+    assert stamped_raw is not None
+    stamped = _aware(stamped_raw)
+
+    next_window_start = stamped - timedelta(seconds=overlap_seconds)
+    assert next_window_start <= _aware(before), (
+        f"gap of {(next_window_start - _aware(before)).total_seconds()}s between "
+        f"run 1's fetched end ({_aware(before)}) and run 2's start "
+        f"({next_window_start}) — records in that span are never fetched by "
+        "either run"
+    )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -5117,3 +5117,50 @@ def test_finalize_checkpoint_carries_family_dataset_audit_metadata(
         "work-items",
         "work-item-history",
     ]
+
+
+def test_run_sync_unit_stamps_watermark_at_window_end_not_now(db_session, monkeypatch):
+    """CHAOS-3412: the SUCCESS path stamps the watermark at the unit's
+    ``before_at`` (window END), never at wall-clock ``now``.
+
+    This is the load-bearing precondition for the HEAVY incremental window
+    ratchet (``sync/planner._resolve_windows``): a ratcheted unit deliberately
+    covers only a capped slice ending well before ``now``. If the stamp used
+    ``now``, every capped run would silently skip the data between its window
+    end and ``now`` — permanent, invisible data gaps.
+    """
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session, dataset_key="commit-stats")
+    # A ratcheted HEAVY window: 7 days ending far in the past.
+    capped_before = datetime.now(timezone.utc) - timedelta(days=23)
+    unit.since_at = capped_before - timedelta(days=7)
+    unit.before_at = capped_before
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    # The adapter returns no explicit watermark_at — the common case for every
+    # HEAVY dataset (only PagerDuty emits a data-derived watermark_at).
+    monkeypatch.setattr(
+        dataset_adapters, "run_dataset_unit", lambda ctx, runtime: {"ok": True}
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    watermark = db_session.query(SyncWatermark).one()
+    assert watermark.dataset_key == "commit-stats"
+    stamped = _aware(watermark.last_synced_at)
+    assert stamped == capped_before, (
+        f"watermark must be stamped at the unit's window end {capped_before}, "
+        f"got {stamped}"
+    )
+    assert stamped < datetime.now(timezone.utc) - timedelta(days=20), (
+        "watermark was stamped near wall-clock now — a ratcheted window would "
+        "silently skip everything between its window end and now"
+    )

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -912,6 +912,42 @@ class TestLegacyWriteMonotonicAtDBLevel:
 # ---------------------------------------------------------------------------
 
 
+def _seed_corrupt_future_watermark(session, org_id, source_id, dataset_key, when):
+    """Write a FUTURE watermark directly, bypassing set_watermark's clamp.
+
+    CHAOS-3412 round 3 added a write-boundary invariant: ``set_watermark`` never
+    persists a future value, from any caller. That is correct, and it means the
+    corrupt state can no longer be created through the public API — so a test
+    that seeds via ``set_watermark`` silently STOPS exercising the repair path
+    while still passing. This writes the row directly, which is also how the
+    state genuinely arises: rows persisted by pre-fix code, sitting in a live
+    database.
+    """
+    row = (
+        session.query(SyncWatermark)
+        .filter(
+            SyncWatermark.org_id == org_id,
+            SyncWatermark.source_id == source_id,
+            SyncWatermark.dataset_key == dataset_key,
+        )
+        .one_or_none()
+    )
+    if row is None:
+        row = SyncWatermark(
+            repo_id=source_id,
+            target=dataset_key,
+            org_id=org_id,
+            source_id=source_id,
+            dataset_key=dataset_key,
+            last_synced_at=when,
+        )
+        session.add(row)
+    else:
+        row.last_synced_at = when
+    session.flush()
+    return row
+
+
 def test_future_watermark_is_corrected_downward(db_session):
     """A stored value AHEAD of now is corrupt and must be correctable.
 
@@ -924,7 +960,9 @@ def test_future_watermark_is_corrected_downward(db_session):
 
     org, source, dataset = "wm-org", "full-chaos/dev-health", "commits"
     now = datetime.now(timezone.utc)
-    set_watermark(db_session, org, source, dataset, now + timedelta(days=30))
+    _seed_corrupt_future_watermark(
+        db_session, org, source, dataset, now + timedelta(days=30)
+    )
 
     sane = now - timedelta(hours=1)
     set_watermark(db_session, org, source, dataset, sane)
@@ -965,24 +1003,40 @@ def test_legitimate_watermark_is_still_never_rolled_backwards(db_session):
     )
 
 
-def test_future_incoming_value_does_not_lower_a_future_stored_value(db_session):
-    """Two future values: monotonic behavior still applies, no correction."""
+def test_future_incoming_value_is_clamped_and_repairs_the_stored_one(db_session):
+    """SUPERSEDED BEHAVIOR — recorded deliberately, not quietly rewritten.
+
+    This test previously asserted that an incoming FUTURE value does not lower a
+    stored future value. That pinned the leak CHAOS-3412 round 3 closed: it
+    accepted a future value being persisted at all, which is exactly how a
+    provider-supplied ``watermark_at`` re-poisoned a repaired watermark.
+
+    Under the write-boundary invariant the incoming value is clamped to ``now``
+    FIRST. The stored value is then in the future while the incoming one is sane,
+    so the repair applies and the corruption is fixed rather than preserved. The
+    new expectation is strictly stronger: a future write cannot persist, and it
+    now HEALS instead of entrenching.
+    """
     from datetime import datetime, timedelta, timezone
 
     from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
     org, source, dataset = "wm-org", "full-chaos/dev-health", "commit-stats"
     now = datetime.now(timezone.utc)
-    far_future = now + timedelta(days=30)
-    set_watermark(db_session, org, source, dataset, far_future)
+    _seed_corrupt_future_watermark(
+        db_session, org, source, dataset, now + timedelta(days=30)
+    )
+
     set_watermark(db_session, org, source, dataset, now + timedelta(days=10))
 
     stored = get_watermark(db_session, org, source, dataset)
     assert stored is not None
     stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
-    assert abs((stored - far_future).total_seconds()) < 2, (
-        "the correction is for restoring a SANE value; a still-future incoming "
-        "value must not be treated as a repair"
+    assert stored <= datetime.now(timezone.utc) + timedelta(seconds=61), (
+        f"a future write must be clamped, not persisted: {stored}"
+    )
+    assert stored < now + timedelta(days=1), (
+        "the stored future value must have been repaired, not preserved"
     )
 
 
@@ -1054,12 +1108,18 @@ def test_real_postgres_future_watermark_correction():
             now = datetime.now(timezone.utc)
 
             # --- the correction: stored future value must be lowered ---------
+            # Seed DIRECTLY: set_watermark now clamps future writes at the
+            # boundary (CHAOS-3412 round 3), so seeding through it would store
+            # `now` and this test would silently stop exercising the repair.
             corrupt = now + timedelta(days=30)
-            set_watermark(session, org, source, "commits", corrupt)
+            _seed_corrupt_future_watermark(session, org, source, "commits", corrupt)
             session.commit()
             stored = get_watermark(session, org, source, "commits")
             assert stored is not None
-            assert _aware(stored) > now, "precondition: a future value is stored"
+            assert _aware(stored) > now + timedelta(days=1), (
+                f"precondition: a MEANINGFULLY future value must be stored, got "
+                f"{_aware(stored)} — otherwise the repair below is not exercised"
+            )
 
             sane = now - timedelta(hours=1)
             set_watermark(session, org, source, "commits", sane)
@@ -1098,3 +1158,66 @@ def test_real_postgres_future_watermark_correction():
 
 def _aware(value: datetime) -> datetime:
     return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
+@pytest.mark.skipif(
+    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
+    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
+)
+def test_real_postgres_future_write_is_clamped_at_the_boundary():
+    """EXECUTE the write-boundary clamp against live PostgreSQL.
+
+    Covers both the INSERT path (first-ever row, previously written unclamped)
+    and the UPDATE path (re-poisoning a repaired value), on the dialect that
+    actually ships.
+    """
+    import os as _os
+    import uuid as _uuid
+    from datetime import timedelta
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+
+    engine = create_engine(_os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    Base.metadata.create_all(engine)
+    SyncWatermark.metadata.create_all(engine)
+
+    org = f"pg-wb-{_uuid.uuid4()}"
+    source = "full-chaos/dev-health"
+    try:
+        with Session(engine) as session:
+            now = datetime.now(timezone.utc)
+
+            # INSERT path: first-ever write carrying a future value.
+            set_watermark(session, org, source, "commits", now + timedelta(days=30))
+            session.commit()
+            session.expire_all()
+            inserted = get_watermark(session, org, source, "commits")
+            assert inserted is not None
+            assert _aware(inserted) <= datetime.now(timezone.utc) + timedelta(
+                seconds=61
+            ), (
+                f"live PostgreSQL persisted a future watermark on INSERT: "
+                f"{_aware(inserted)}"
+            )
+
+            # UPDATE path: a repaired value must not be re-poisoned.
+            set_watermark(session, org, source, "prs", now - timedelta(hours=2))
+            session.commit()
+            set_watermark(session, org, source, "prs", now + timedelta(days=30))
+            session.commit()
+            session.expire_all()
+            updated = get_watermark(session, org, source, "prs")
+            assert updated is not None
+            assert _aware(updated) <= datetime.now(timezone.utc) + timedelta(
+                seconds=61
+            ), (
+                f"live PostgreSQL re-poisoned a sane watermark on UPDATE: "
+                f"{_aware(updated)}"
+            )
+    finally:
+        with Session(engine) as cleanup:
+            cleanup.query(SyncWatermark).filter(SyncWatermark.org_id == org).delete(
+                synchronize_session=False
+            )
+            cleanup.commit()
+        engine.dispose()

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
@@ -1020,3 +1021,80 @@ def test_future_correction_sql_compiles_for_postgresql():
     sql = str(stmt.compile(dialect=postgresql.dialect()))
     assert "CASE" in sql.upper()
     assert "greatest" in sql.lower()
+
+
+@pytest.mark.skipif(
+    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
+    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
+)
+def test_real_postgres_future_watermark_correction():
+    """EXECUTE the CHAOS-3412 correction against live PostgreSQL.
+
+    The rest of the suite runs SQLite, which takes the Python branch of
+    ``_monotonic_update``. The statement a real deployment executes is the
+    ``CASE ... GREATEST`` update, and a dialect-compile check proves only that it
+    parses. This runs it: it asserts the stored row is genuinely lowered, and — on
+    the same branch — that a legitimate lower value is still discarded, so the
+    narrowness of the exception is verified where it actually runs.
+    """
+    import os as _os
+    import uuid as _uuid
+    from datetime import timedelta
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+
+    engine = create_engine(_os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    Base.metadata.create_all(engine)
+    SyncWatermark.metadata.create_all(engine)
+
+    org = f"pg-wm-{_uuid.uuid4()}"
+    source = "full-chaos/dev-health"
+    try:
+        with Session(engine) as session:
+            now = datetime.now(timezone.utc)
+
+            # --- the correction: stored future value must be lowered ---------
+            corrupt = now + timedelta(days=30)
+            set_watermark(session, org, source, "commits", corrupt)
+            session.commit()
+            stored = get_watermark(session, org, source, "commits")
+            assert stored is not None
+            assert _aware(stored) > now, "precondition: a future value is stored"
+
+            sane = now - timedelta(hours=1)
+            set_watermark(session, org, source, "commits", sane)
+            session.commit()
+            session.expire_all()
+            corrected = get_watermark(session, org, source, "commits")
+            assert corrected is not None
+            assert abs((_aware(corrected) - sane).total_seconds()) < 2, (
+                "live PostgreSQL did not lower the corrupt future watermark: "
+                f"{_aware(corrected)} (expected ~{sane}). The CASE branch is "
+                "what production executes; SQLite passing proves nothing here."
+            )
+
+            # --- narrowness, on the SAME branch ------------------------------
+            set_watermark(session, org, source, "prs", now - timedelta(hours=1))
+            session.commit()
+            set_watermark(session, org, source, "prs", now - timedelta(days=5))
+            session.commit()
+            session.expire_all()
+            kept = get_watermark(session, org, source, "prs")
+            assert kept is not None
+            assert (
+                abs((_aware(kept) - (now - timedelta(hours=1))).total_seconds()) < 2
+            ), (
+                "live PostgreSQL rolled a LEGITIMATE watermark backwards — the "
+                "GREATEST path must still win when the stored value is in the past"
+            )
+    finally:
+        with Session(engine) as cleanup:
+            cleanup.query(SyncWatermark).filter(SyncWatermark.org_id == org).delete(
+                synchronize_session=False
+            )
+            cleanup.commit()
+        engine.dispose()
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -1221,3 +1221,142 @@ def test_real_postgres_future_write_is_clamped_at_the_boundary():
             )
             cleanup.commit()
         engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412 closure repair: the write boundary must cover EVERY write API.
+#
+# set_watermark was not the only writer. set_legacy_repo_watermark writes the
+# raw legacy row directly — unclamped on insert, and handing the raw value to
+# _monotonic_update on update. That row is the D4 bridge that get_watermark's
+# reverse-legacy fallback serves to ALL of a target's sibling datasets, so one
+# poisoned legacy row poisons commits, commit-stats and files at once.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_write_api_clamps_future_on_insert(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import (
+        get_legacy_repo_watermark,
+        set_legacy_repo_watermark,
+    )
+
+    now = datetime.now(timezone.utc)
+    set_legacy_repo_watermark(
+        db_session, "lg-org", "repo-1", "git", now + timedelta(days=30)
+    )
+    stored = get_legacy_repo_watermark(db_session, "lg-org", "repo-1", "git")
+    assert stored is not None
+    stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
+    assert stored <= datetime.now(timezone.utc) + timedelta(seconds=61), (
+        f"the legacy write API persisted a future watermark on INSERT ({stored}) "
+        "— it bypasses set_watermark's boundary clamp entirely"
+    )
+
+
+def test_legacy_write_api_clamps_future_on_update(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import (
+        get_legacy_repo_watermark,
+        set_legacy_repo_watermark,
+    )
+
+    now = datetime.now(timezone.utc)
+    set_legacy_repo_watermark(
+        db_session, "lg-org", "repo-2", "git", now - timedelta(hours=2)
+    )
+    set_legacy_repo_watermark(
+        db_session, "lg-org", "repo-2", "git", now + timedelta(days=30)
+    )
+    stored = get_legacy_repo_watermark(db_session, "lg-org", "repo-2", "git")
+    assert stored is not None
+    stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
+    assert stored <= datetime.now(timezone.utc) + timedelta(seconds=61), (
+        f"the legacy write API persisted a future watermark on UPDATE ({stored})"
+    )
+
+
+def test_poisoned_legacy_row_cannot_leak_to_sibling_datasets(db_session):
+    """The amplification: one legacy row backs every sibling dataset.
+
+    get_watermark falls back to the raw legacy row for a canonical dataset with
+    no exact row of its own, so a future value written through the legacy API
+    would surface as a future watermark for commits, commit-stats AND files.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_legacy_repo_watermark
+
+    now = datetime.now(timezone.utc)
+    set_legacy_repo_watermark(
+        db_session, "lg-org", "repo-3", "git", now + timedelta(days=30)
+    )
+    for sibling in ("commits", "commit-stats", "files"):
+        seen = get_watermark(db_session, "lg-org", "repo-3", sibling)
+        if seen is None:
+            continue
+        seen = seen.replace(tzinfo=timezone.utc) if seen.tzinfo is None else seen
+        assert seen <= datetime.now(timezone.utc) + timedelta(seconds=61), (
+            f"sibling dataset {sibling!r} reads a FUTURE watermark ({seen}) via "
+            "the reverse-legacy fallback — one poisoned legacy row stalls them all"
+        )
+
+
+def test_every_watermark_write_api_routes_through_the_normalizer():
+    """DERIVED, not listed: a new write API fails this until it is wired.
+
+    The round-3 closure claimed the write boundary was closed while a second
+    write API bypassed it. Enumerating writers by hand is what let that stand,
+    so this derives them from the module's AST: any module-level function that
+    persists ``last_synced_at`` — by constructing a SyncWatermark with it, by
+    assigning to it, or by delegating to a helper that does — must call the
+    normalizer. Add a third writer and this test fails until it complies.
+    """
+    import ast
+    import inspect
+
+    from dev_health_ops.sync import watermarks as wm
+
+    NORMALIZER = "_normalize_watermark_write"
+    tree = ast.parse(inspect.getsource(wm))
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    def _persists_last_synced_at(node) -> bool:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.keyword) and sub.arg == "last_synced_at":
+                return True
+            if isinstance(sub, ast.Attribute) and sub.attr == "last_synced_at":
+                if isinstance(getattr(sub, "ctx", None), ast.Store):
+                    return True
+        return False
+
+    def _calls(node, name: str) -> bool:
+        return any(
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id == name
+            for sub in ast.walk(node)
+        )
+
+    # Writers = functions that persist last_synced_at, or delegate to one that
+    # does (_monotonic_update). Exclude the low-level helper and the normalizer.
+    writers = {
+        name
+        for name, node in functions.items()
+        if (_persists_last_synced_at(node) or _calls(node, "_monotonic_update"))
+        and name not in {"_monotonic_update", NORMALIZER}
+    }
+    assert writers, "derivation found no write APIs at all — the test is vacuous"
+
+    unnormalized = sorted(n for n in writers if not _calls(functions[n], NORMALIZER))
+    assert not unnormalized, (
+        f"these watermark write APIs bypass {NORMALIZER}(): {unnormalized}. "
+        "Every writer must route through the boundary — enforcing it at some "
+        "call sites is what CHAOS-3412 round 3 got wrong."
+    )

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -904,3 +904,119 @@ class TestLegacyWriteMonotonicAtDBLevel:
             assert stored.replace(tzinfo=timezone.utc) == t_high, (
                 f"Sibling {dataset_key!r} got wrong timestamp: {stored}, expected {t_high}"
             )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3412: the ONE exception to monotonic advance.
+# ---------------------------------------------------------------------------
+
+
+def test_future_watermark_is_corrected_downward(db_session):
+    """A stored value AHEAD of now is corrupt and must be correctable.
+
+    Nothing else can repair it: the planner would resolve a window starting in
+    the future, plan no unit, and the run would finalize FAILED forever.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+
+    org, source, dataset = "wm-org", "full-chaos/dev-health", "commits"
+    now = datetime.now(timezone.utc)
+    set_watermark(db_session, org, source, dataset, now + timedelta(days=30))
+
+    sane = now - timedelta(hours=1)
+    set_watermark(db_session, org, source, dataset, sane)
+
+    stored = get_watermark(db_session, org, source, dataset)
+    assert stored is not None
+    stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
+    assert abs((stored - sane).total_seconds()) < 2, (
+        f"a future watermark must be corrected downward; stored {stored}"
+    )
+
+
+def test_legitimate_watermark_is_still_never_rolled_backwards(db_session):
+    """The CHAOS-2578 guarantee is intact for every legitimate (past) value.
+
+    This is the guard that keeps the future-correction exception narrow: a late
+    or out-of-order unit result must still never lower a valid watermark.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+
+    org, source, dataset = "wm-org", "full-chaos/dev-health", "prs"
+    now = datetime.now(timezone.utc)
+    recent = now - timedelta(hours=1)
+    set_watermark(db_session, org, source, dataset, recent)
+
+    # A late-arriving older result — both values are in the past, so the
+    # correction exception must NOT apply.
+    set_watermark(db_session, org, source, dataset, now - timedelta(days=5))
+
+    stored = get_watermark(db_session, org, source, dataset)
+    assert stored is not None
+    stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
+    assert abs((stored - recent).total_seconds()) < 2, (
+        "an out-of-order PAST result must not roll the watermark backwards — "
+        "the future-correction exception must stay gated on a future stored value"
+    )
+
+
+def test_future_incoming_value_does_not_lower_a_future_stored_value(db_session):
+    """Two future values: monotonic behavior still applies, no correction."""
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
+
+    org, source, dataset = "wm-org", "full-chaos/dev-health", "commit-stats"
+    now = datetime.now(timezone.utc)
+    far_future = now + timedelta(days=30)
+    set_watermark(db_session, org, source, dataset, far_future)
+    set_watermark(db_session, org, source, dataset, now + timedelta(days=10))
+
+    stored = get_watermark(db_session, org, source, dataset)
+    assert stored is not None
+    stored = stored.replace(tzinfo=timezone.utc) if stored.tzinfo is None else stored
+    assert abs((stored - far_future).total_seconds()) < 2, (
+        "the correction is for restoring a SANE value; a still-future incoming "
+        "value must not be treated as a repair"
+    )
+
+
+def test_future_correction_sql_compiles_for_postgresql():
+    """The PostgreSQL branch of the correction is otherwise UNTESTED.
+
+    The unit suite runs on SQLite, which takes the Python-level branch, so the
+    ``CASE ... GREATEST`` statement the real deployment executes never runs here.
+    Compiling it against the postgresql dialect is not equivalent to executing
+    it, but it does catch the failure this construct is most likely to have —
+    an invalid/untypeable clause — instead of leaving the branch entirely
+    unmeasured. Behavior on a live PostgreSQL remains unverified by this suite.
+    """
+    from datetime import datetime, timezone
+
+    from sqlalchemy import case, func, update
+    from sqlalchemy.dialects import postgresql
+
+    from dev_health_ops.models.settings import SyncWatermark
+
+    now = datetime.now(timezone.utc)
+    ts = now
+    stmt = (
+        update(SyncWatermark)
+        .where(SyncWatermark.id == "x")
+        .values(
+            last_synced_at=case(
+                (SyncWatermark.last_synced_at > now, ts),
+                else_=func.greatest(
+                    func.coalesce(SyncWatermark.last_synced_at, ts), ts
+                ),
+            ),
+            updated_at=now,
+        )
+    )
+    sql = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "CASE" in sql.upper()
+    assert "greatest" in sql.lower()


### PR DESCRIPTION
Closes the planner half of CHAOS-3412: a HEAVY dataset could never start syncing, and the watermark write path could silently claim coverage it never read.

## The defects

**Live — these were reachable in production:**

| Defect | Effect |
| --- | --- |
| HEAVY cold-start planned one window spanning the whole `initial_sync_depth` | Unit cost is linear in span, so it never fit the sync budget, was deferred forever, never stamped a watermark, and every later tick recomputed the identical unfittable span |
| `SYNC_WATERMARK_OVERLAP >= cap` stalled the ratchet | The capped window ended at or before its own watermark; the monotonic write was discarded and every run re-fetched the same slice while reporting SUCCESS |
| Provider-supplied future `watermark_at` | The worker prefers `result_payload["watermark_at"]` over the planner's clamped window end; PagerDuty derives that from source record timestamps, so a skewed record wrote a future watermark past every planner-side clamp — and could re-poison an already-repaired one |
| `set_legacy_repo_watermark` bypassed the write boundary | A second write API, unclamped on insert and passing raw values into the monotonic update. It writes the D4 bridge row that `get_watermark`'s reverse-legacy fallback serves to every sibling dataset, so one poisoned `git` row surfaced a future watermark for commits, commit-stats and files at once |
| Watermark stamped past the unit's window end | `watermark_at` is a coverage claim, but the unit only fetched to `window_end`. A value beyond it — often still in the *past*, so a not-future check misses it — meant the next run started after records nobody ever fetched. Measured gaps of 18000s and 17940s |

**Latent — correct hardening of an internal contract, not live today:** future and inverted `before` for INCREMENTAL and FULL_RESYNC. No production caller passes `before` for either mode (`SyncTriggerRequest` has no such field; the only `before=` sites are `mode="backfill"`). Worth fixing because the Go scheduler planner is being written fresh against this contract.

## The ratchet contract

INCREMENTAL windows for `CostClass.HEAVY` datasets are capped at `SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS` (default 7, matching the proven backfill chunk size). The window END moves in to `window_start + cap`; depth resolution and its tier `backfill_days` cap are untouched. It applies to both cold-start and behind-watermark cases, is scoped by cost class read from the dataset registry rather than a hardcoded key list, and caps exactly one window — continuation is the next scheduled tick, not a bigger plan. A capped run is a healthy partial run; the success path stamps the watermark at the window END so the next tick resumes exactly there.

FULL_RESYNC HEAVY windows are deliberately **uncapped**. A one-shot resync has no next tick, so a capped window would cover the cap's span and finalize SUCCESS — claiming a resync that did not happen. The wide-window exposure is bounded instead by the budget exhaustion path (#1503), which terminalizes visibly and names the scoped-backfill remedy. Pinned by `test_full_resync_heavy_window_is_deliberately_uncapped`.

The exact contract is pinned as a **deterministic oracle table**: `tests/test_sync_planner.py::test_ratchet_window_contract` — 10 parametrized cases driving `_resolve_windows` with an injected `now`, zero tolerance, exact equality, pure data. The same inputs can be fed to any other implementation of this contract and the outputs compared.

## The CHAOS-2578 amendment

Watermark writes were monotonic (`max(existing, new)`) so a late or out-of-order result could never roll a watermark backwards. This PR adds one narrow exception plus a write-boundary rule, both stated in `set_watermark`'s own docstring so a reader arriving at the CHAOS-2578 rule finds the amendment attached to it:

- **Never beyond what was actually read.** Every incoming value is clamped to `min(incoming, coverage_upper_bound, now)` in `_normalize_watermark_write`, for every caller, before anything else. Two ceilings, both required — `now` because a watermark cannot sit in the future, and the unit's window end because a watermark cannot claim data the unit did not fetch.
- **Repair once.** When the *stored* value is in the future and the incoming one is not, the incoming value wins. The exception is gated on provably invalid state: a watermark marks data already synchronized, so a future value is not a late result. Without it, such a value is permanent — the planner resolves a window starting in the future, plans no unit, the run finalizes FAILED, and no unit exists to repair it.

Writer coverage is verified by **derivation, not a list**: `test_every_watermark_write_api_routes_through_the_normalizer` parses the module AST and asserts every function that persists `last_synced_at` routes through the normalizer, with a vacuity guard. Hand-enumeration is what let the legacy API sit outside the boundary in the first place.

## Review history

Three adversarial rounds plus a write-boundary closure. Each round's fix created the next round's defect, and the answer was never another caller-side patch — it was moving the rule somewhere it could not be bypassed:

1. **Round 1** — overlap ≥ cap stall; future/inverted windows.
2. **Round 2** — the same pair one branch down in FULL_RESYNC, closed as a class in one shared `_watermark_stamping_window`; corrupt-watermark self-heal. The prescribed self-heal was verified *insufficient* on its own: the planner clamp alone plans a unit but the monotonic write discards the sane value, so the repair had to happen at the write.
3. **Round 3** — the write boundary was not the boundary: a provider stamp bypassed it, and the insert path was entirely unclamped.
4. **Closure repair** — the second write API and the coverage overclaim.

A closure argument enumerates the whole sign-region state space of `(window_start, window_end)` against `now` and asserts the postcondition every family member violated. It immediately flagged an apparent seventh sibling — future start with an explicitly requested past `before` yielding zero units — which analysis showed is *not* a defect: that path does not perpetuate, because scheduled runs send no `before` and heal on the next tick, and forcing a window would fabricate a range the caller never requested. The invariant is therefore "always plans on the path that would otherwise never recover", and the non-defect is pinned as a deliberate choice.

Every guard was mutation-tested — eighteen mutations, each observed failing against its unfixed clause, each restored and re-verified by re-running rather than by git state.

## Evidence

- **Gate:** `ci/local_validate.sh` green — 11842 passed / 0 failed, all seven stages including the scratch-ClickHouse migration and the argMax live-execution proof.
- **Live PostgreSQL 18.4:** the dialect branch of the correction and the write-boundary clamp are *executed*, not merely compiled, on both the INSERT and UPDATE paths. Mutation-proven: reverting the `CASE` to plain `GREATEST` fails with `live PostgreSQL did not lower the corrupt future watermark`.
- **Composed live validation** against the local compose stack, on this branch merged with the exhaustion work, scratch org in a scratch database:
  - HEAVY cold-start, depth 90, no watermark, normal incremental → window `2026-07-06 → 2026-07-13`, span **7.000 days**, ending 22 days behind now.
  - Real `BudgetGuard.enforce_run` → `deferred_unit_ids` empty, `budget_deferrals` 0 → **admitted**.
  - Watermark stamped exactly at the window end.
  - Second tick resumes exactly where the first ended — no gap, no overlap — also 7.000 days.
  - Forced oversized case (`SYNC_BUDGET_DEFAULT_LIMIT=1`): deferrals 1 → 2 → `status=failed` with `sync budget deferral exhausted after 2 deferrals: dataset 'commit-stats' estimates 28 units against bucket '…:rest_core:commit_stats' whose cap is 1, over a 7-day window, so it can never be admitted and was re-deferred instead of running. Remedies: run a scoped backfill over a narrower window, or raise this bucket's cap via SYNC_BUDGET_BUCKET_LIMITS.` The "7-day window" in that text is this PR's capped window appearing in the exhaustion message — the two halves compose in operator-facing output.

## Deploy note

The merged code requires alembic `0085` (shipped by #1503). Planning a unit against an un-migrated database fails with `UndefinedColumn: column "budget_deferrals" does not exist`. Run `dev-hops migrate postgres upgrade` before workers run the new code.

## Residuals

- Live-PostgreSQL tests require `postgresql+psycopg2://` — psycopg3 is not installed — and skip loudly without `DEV_HEALTH_POSTGRES_TEST_URI`.
- A capped run finalizes as an ordinary successful run; there is no distinct state or badge saying "caught up to here only". The advancing watermark is the observable evidence of progress. Surfacing this lag directly is CHAOS-3430.
- Catch-up pacing beyond scheduler cadence is out of scope: a 90-day cold start at the default cap takes ~13 hourly ticks. Use a bounded backfill to close deep history faster.
- When every dataset is already covered, the run has zero units and finalizes FAILED with "No sync units planned". That is a deliberate trade over the old inverted-unit SUCCESS, which was a false coverage claim. Scheduled runs send no `before` and cannot reach it.

## Cross-implementation contract

Clauses C1–C11 for the Go scheduler planner mirror are recorded on CHAOS-3427, together with the oracle table above: the 7-day default cap and its env override, HEAVY-only scope resolved from the registry, application to both cold-start and behind-watermark, the cap as a `min` that only moves the END inward, open-start windows never capped, one window per unit, watermark stamped at window end, cap must exceed overlap with a visible clamp, FULL_RESYNC uncapped by design, and the write-boundary invariant with writer coverage verified by derivation.
