### PR TITLE
CHAOS-3430: surface watermark lag for ratcheting HEAVY datasets

### DIFF
--- a/docs/admin/sync-and-coverage/status-and-freshness.md
+++ b/docs/admin/sync-and-coverage/status-and-freshness.md
@@ -67,6 +67,53 @@ remedies are to synchronize a narrower window with a bounded backfill, or to
 raise that bucket's cap. Raising per-synchronization ingest caps is not a
 remedy — it changes what is fetched, not whether the unit is admitted.
 
+### Datasets still catching up
+
+A successful run does not mean a dataset has reached the current time. High-cost
+record families synchronize through capped incremental windows, one window per
+scheduled tick, and each capped tick finalizes as an ordinary successful run.
+Run status alone therefore reads "complete" for a dataset whose coverage may
+still be weeks behind.
+
+The run's unit rollup reports, for every (source, dataset) pair it planned that
+carries a watermark:
+
+- the stored watermark, and how far behind the current time it is;
+- whether that pair is **catching up** — a high-cost dataset trailing by
+  strictly more than the configured window cap; and
+- roughly how many further scheduled ticks the pair needs to reach the current
+  time, at one capped window per tick.
+
+Read these separately from run status:
+
+- **Catching up** is a healthy in-progress state, not a fault. The remedy, if
+  the pace is unacceptable, is a bounded backfill over the outstanding period —
+  catch-up itself does not accelerate.
+- A pair trailing by no more than one window is the steady state of a healthy
+  ratchet mid-flight and is not flagged.
+- Only high-cost families are capped, so only they are flagged. A lag is still
+  reported for every other dataset; interpret a large one there as a different
+  problem — a stalled schedule, a failing unit, or a provider gap — and diagnose
+  it through the run boundary above.
+- A dataset with no watermark at all has never recorded a successful read. It
+  reports no lag, because there is no coverage to measure from; that is a
+  cold-start or a never-succeeding dataset, not a dataset that is behind.
+- A collapsed record family reports one entry per child dataset, not one for the
+  family as a whole. Each child carries its own watermark, so a family that
+  looks current overall can still hold a badly stale child.
+- The estimate of remaining ticks accounts for the configured watermark overlap.
+  Each window re-reads that overlap, so one tick's forward progress is the
+  window span minus the overlap; a large overlap means many more ticks than the
+  window span alone would suggest.
+
+This report is scoped to the run you are reading, and declares that scope
+explicitly. It covers only the source-and-dataset pairs that run planned. A run
+restricted to one source, or to a subset of datasets, that reports nothing
+catching up is not telling you the workspace is current — it is telling you
+nothing was behind *among the pairs it touched*. To ask the workspace-wide
+question, read freshness per dataset across every configured source rather than
+inferring it from a single run.
+
 ## Check freshness against the product question
 
 Compare:

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -625,6 +625,14 @@ async def get_sync_run_units(
         and unit.result.get("error_category") == "budget_deferred"
     )
 
+    # CHAOS-3430: watermark-vs-now lag per (source, dataset). A capped HEAVY
+    # tick finalizes as an ordinary SUCCESS, so run status alone cannot show
+    # that the dataset is still ratcheting toward the current time.
+    dataset_freshness = await svc.build_dataset_freshness(units)
+    catching_up_dataset_count = sum(
+        1 for entry in dataset_freshness if entry["catching_up"]
+    )
+
     return SyncRunUnitSummary(
         by_status=rollups["by_status"],
         by_source=rollups["by_source"],
@@ -638,6 +646,10 @@ async def get_sync_run_units(
         next_retry_at=min(retry_times) if retry_times else None,
         retry_exhausted_unit_count=retry_exhausted_unit_count,
         budget_blocked_unit_count=budget_blocked_unit_count,
+        dataset_freshness=dataset_freshness,
+        catching_up_dataset_count=catching_up_dataset_count,
+        # Declared, not implied: these describe only what THIS run planned.
+        dataset_freshness_scope="run",
         units=[
             _unit_to_response(u) for u in (units if limit is None else units[:limit])
         ],

--- a/src/dev_health_ops/api/admin/schemas/integrations.py
+++ b/src/dev_health_ops/api/admin/schemas/integrations.py
@@ -161,6 +161,34 @@ class SyncRunResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class SyncRunDatasetFreshness(BaseModel):
+    """Watermark-vs-now lag for one (source, dataset) pair (CHAOS-3430).
+
+    Read from the existing ``sync_watermarks`` rows at response time — the
+    incremental window ratchet finalizes each capped HEAVY tick as an ordinary
+    successful run, so run status alone cannot say how far behind the dataset
+    still is.  ``catching_up`` is set only for a HEAVY dataset trailing by
+    strictly more than ``window_cap_days``; every other dataset still reports
+    an honest ``lag_seconds`` without the verdict.
+    """
+
+    #: IntegrationSource UUID, matching ``SyncRunUnitResponse.source_id`` so a
+    #: caller can reuse an already-resolved source label.
+    source_id: str
+    source_name: str | None = None
+    dataset_key: str
+    cost_class: str
+    #: Stored watermark in UTC; ``None`` when the dataset has never stamped one.
+    watermark_at: datetime | None = None
+    #: ``now - watermark_at`` in whole seconds; ``None`` without a watermark.
+    lag_seconds: int | None = None
+    catching_up: bool = False
+    #: Scheduled ticks still needed to reach ``now`` at one capped window per
+    #: tick; ``None`` unless ``catching_up``.
+    ticks_behind: int | None = None
+    window_cap_days: int
+
+
 class SyncRunUnitSummary(BaseModel):
     """Rollup of SyncRunUnit rows for the run-status UI (CHAOS-2519)."""
 
@@ -180,6 +208,17 @@ class SyncRunUnitSummary(BaseModel):
     # from failed_unit_count: these have not failed, they are BLOCKED --
     # the state that used to be invisible because nothing counted it.
     budget_blocked_unit_count: int = 0
+    # CHAOS-3430: watermark lag per (source, dataset), and how many of those
+    # pairs are a HEAVY dataset still ratcheting toward the current time.
+    dataset_freshness: list[SyncRunDatasetFreshness] = Field(default_factory=list)
+    catching_up_dataset_count: int = 0
+    # The scope those two describe. "run" means they cover ONLY the (source,
+    # dataset) pairs THIS run planned -- so a manually filtered or single-source
+    # run reporting zero datasets catching up is not a statement about the
+    # workspace, and must not be rendered as one. An org-wide freshness surface
+    # is tracked separately (CHAOS-3438); this field exists so a consumer can
+    # tell which question it is holding the answer to.
+    dataset_freshness_scope: str = "run"
     units: list[SyncRunUnitResponse]
 
 

--- a/src/dev_health_ops/api/services/integrations.py
+++ b/src/dev_health_ops/api/services/integrations.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -18,7 +19,8 @@ from dev_health_ops.models.integrations import (
     SyncRun,
     SyncRunUnit,
 )
-from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.models.settings import IntegrationCredential, SyncWatermark
+from dev_health_ops.sync.datasets import get_dataset_spec
 
 
 class IntegrationService:
@@ -252,6 +254,28 @@ class IntegrationDatasetService:
         return result.scalar_one_or_none()
 
 
+def _dataset_cost_class(provider: str, dataset_key: str, unit_cost_class: str) -> str:
+    """Cost class for ONE dataset key, resolved per dataset rather than per unit.
+
+    CHAOS-3430: a collapsed work-item-family composite is a single row carrying a
+    single ``cost_class`` (``work-items`` is medium), but its children are
+    registered independently -- ``work-item-labels`` is light. Attributing the
+    composite's class to every child misreports the child, and would silently
+    SUPPRESS a heavy child's catch-up verdict, because the flag keys on
+    ``cost_class == "heavy"``.
+
+    Resolves from the same provider-aware registry the rest of the sync stack
+    uses, so a provider-specific cost class is honoured rather than guessed.
+    Falls back to the unit's own class when the registry has no entry for the
+    pair -- an unknown dataset is better reported with the run's class than
+    dropped or crashed on.
+    """
+    spec = get_dataset_spec(provider, dataset_key)
+    if spec is None:
+        return unit_cost_class
+    return str(spec.default_cost_class.value)
+
+
 class SyncRunService:
     """Read operations on SyncRun / SyncRunUnit rows, scoped to an org."""
 
@@ -287,6 +311,141 @@ class SyncRunService:
             .order_by(SyncRunUnit.id)
         )
         return list(result.scalars().all())
+
+    async def build_dataset_freshness(
+        self,
+        units: list[SyncRunUnit],
+        *,
+        now: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """Watermark-vs-now lag per (source, dataset) for this run (CHAOS-3430).
+
+        A HEAVY dataset syncing under the incremental window ratchet finalizes
+        every capped tick as an ordinary SUCCESS while its watermark can still
+        trail ``now`` by weeks, so run status alone reads "complete" mid
+        catch-up.  This reads the existing ``sync_watermarks`` rows — no schema
+        change, no new persisted state — and reports the lag alongside the run.
+
+        One query loads every watermark row that could serve any of the run's
+        (source, dataset) pairs; precedence is then applied in memory by
+        :func:`~dev_health_ops.sync.watermark_lag.resolve_watermark`, which is
+        held to ``get_watermark`` by a differential test.
+
+        Entries are emitted only for datasets that actually carry a watermark
+        (``WatermarkBehavior.INCREMENTAL``); a dataset that never stamps one
+        has no lag to report and would read as permanently unknown.  Order is
+        deterministic: source label, then source id, then dataset key.
+        """
+        from dev_health_ops.api.services.sync_coverage import _effective_dataset_keys
+        from dev_health_ops.sync.datasets import WatermarkBehavior, _watermark_behavior
+        from dev_health_ops.sync.watermark_lag import (
+            build_watermark_index,
+            compute_watermark_lag,
+            heavy_max_window_days,
+            heavy_net_advance_seconds,
+        )
+
+        # (source_uuid, dataset_key) -> (watermark source key, source, cost class)
+        pairs: dict[tuple[str, str], tuple[str, Any, str]] = {}
+        for unit in units:
+            source = unit.source
+            if source is None:
+                # No source row: the watermark key (external_id) is unknown, so
+                # there is nothing honest to report for this pair.
+                continue
+            # CHAOS-2721/CHAOS-3430: the planner collapses the work-item family
+            # into ONE composite unit (dataset_key="work-items") carrying
+            # family_dataset_* flags, while the worker advances a SEPARATE
+            # watermark per enabled child. Reading the composite's raw key would
+            # report a dataset nothing stamps and hide a stale child entirely,
+            # so expand to the same effective keys the worker stamps and
+            # sync_coverage measures — reusing that expansion rather than
+            # restating it, so the three cannot drift.
+            for dataset_key in _effective_dataset_keys(
+                str(unit.dataset_key), unit.processor_flags
+            ):
+                if (
+                    _watermark_behavior(dataset_key)
+                    is not WatermarkBehavior.INCREMENTAL
+                ):
+                    continue
+                pairs.setdefault(
+                    (str(unit.source_id), dataset_key),
+                    (
+                        str(source.external_id),
+                        source,
+                        _dataset_cost_class(
+                            str(unit.provider), dataset_key, str(unit.cost_class)
+                        ),
+                    ),
+                )
+
+        if not pairs:
+            return []
+
+        source_keys = {watermark_key for watermark_key, _, _ in pairs.values()}
+        dataset_keys = {dataset_key for _, dataset_key in pairs}
+        # Narrow the SELECT to values that could satisfy some tier: a row whose
+        # dataset_key AND target are both outside this set can never win.
+        lookup_values = build_watermark_index(()).relevant_lookup_values(dataset_keys)
+        result = await self._session.execute(
+            select(SyncWatermark).where(
+                SyncWatermark.org_id == self._org_id,
+                or_(
+                    SyncWatermark.source_id.in_(source_keys),
+                    SyncWatermark.repo_id.in_(source_keys),
+                ),
+                or_(
+                    SyncWatermark.dataset_key.in_(lookup_values),
+                    SyncWatermark.target.in_(lookup_values),
+                ),
+            )
+        )
+        # Index once: resolution is then O(1) per pair instead of a full scan
+        # per pair per precedence tier.
+        index = build_watermark_index(result.scalars().all())
+
+        # Resolve the cap and the per-tick advance once, so every entry in one
+        # response is judged against the same configuration.
+        cap_days = heavy_max_window_days()
+        net_advance = heavy_net_advance_seconds()
+        current = now or datetime.now(timezone.utc)
+
+        entries: list[dict[str, Any]] = []
+        for (source_uuid, dataset_key), (
+            watermark_key,
+            source,
+            cost_class,
+        ) in pairs.items():
+            lag = compute_watermark_lag(
+                cost_class=cost_class,
+                watermark_at=index.resolve(watermark_key, dataset_key),
+                now=current,
+                window_cap_days=cap_days,
+                net_advance_seconds=net_advance,
+            )
+            entries.append(
+                {
+                    "source_id": source_uuid,
+                    "source_name": source.full_name or source.name,
+                    "dataset_key": dataset_key,
+                    "cost_class": cost_class,
+                    "watermark_at": lag.watermark_at,
+                    "lag_seconds": lag.lag_seconds,
+                    "catching_up": lag.catching_up,
+                    "ticks_behind": lag.ticks_behind,
+                    "window_cap_days": lag.window_cap_days,
+                }
+            )
+
+        entries.sort(
+            key=lambda e: (
+                str(e["source_name"] or ""),
+                str(e["source_id"]),
+                str(e["dataset_key"]),
+            )
+        )
+        return entries
 
     @staticmethod
     def build_unit_rollups(

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -763,6 +763,29 @@ def _effective_heavy_max_window_days() -> int:
     return min_cap_days
 
 
+def heavy_ratchet_net_advance_seconds() -> int:
+    """How far a successful capped HEAVY tick moves the watermark, in seconds.
+
+    CHAOS-3430: this is NOT the window cap. The incremental read subtracts
+    ``SYNC_WATERMARK_OVERLAP`` from the stored watermark, so a capped window
+    spans ``[W - overlap, W - overlap + cap]`` and the next watermark lands at
+    its END — a net forward movement of ``cap - overlap`` per tick, not ``cap``.
+
+    Anything estimating how many scheduled ticks a trailing dataset still needs
+    must divide by THIS, not by the cap. Dividing by the cap understates the
+    remaining catch-up by the ratio between the two: with a six-day overlap on a
+    seven-day cap, by a factor of seven.
+
+    Exposed from the planner rather than recomputed by callers so the estimate
+    can never drift from the window arithmetic it describes — the same reason
+    :func:`_effective_heavy_max_window_days` is the single source for the cap.
+    The clamp in that function guarantees a positive result; the floor here is a
+    belt-and-braces guard so a caller dividing by this can never hit zero.
+    """
+    cap_seconds = _effective_heavy_max_window_days() * _SECONDS_PER_DAY
+    return max(1, cap_seconds - _watermark_overlap_seconds())
+
+
 def _watermark_stamping_window(
     window_start: datetime | None,
     window_end: datetime,

--- a/src/dev_health_ops/sync/watermark_lag.py
+++ b/src/dev_health_ops/sync/watermark_lag.py
@@ -1,0 +1,319 @@
+"""Watermark-vs-now lag for the admin sync status surface (CHAOS-3430).
+
+Why this exists
+---------------
+The CHAOS-3412 incremental window ratchet caps a HEAVY dataset's cold-start
+window at ``SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS`` and stamps the watermark
+at the window *end*.  Each capped tick therefore finalizes as an ordinary
+successful run with ``last_sync_success=true`` while the dataset's watermark
+may still trail ``now`` by weeks.  Run status alone reads "complete"; the
+advancing watermark is the only observable evidence of catch-up progress.
+
+This module turns that watermark into a reportable state so the status
+surface can say so out loud.  It is a **read-only** computation over the
+existing ``sync_watermarks`` rows — no schema change, no new persisted state,
+and no change to run finalization semantics (a capped run IS a successful
+run).
+
+Flagging rule
+-------------
+"Catching up" is deliberately narrow, so it means something when it appears:
+
+* the dataset's cost class must be HEAVY — only HEAVY families ratchet, so a
+  trailing LIGHT/MEDIUM watermark is a different problem and is not claimed
+  to be catch-up here; and
+* the watermark must trail ``now`` by **strictly more** than the configured
+  window cap — a watermark exactly one cap-window back is the steady state of
+  a healthy ratchet mid-flight, not arrears.
+
+``lag_seconds`` is always reported when a watermark exists, for every cost
+class.  Only the catch-up *verdict* is withheld — an honest lag with no
+verdict beats a verdict the ratchet cannot justify.
+
+Cap resolution
+--------------
+``heavy_max_window_days`` **delegates to the planner's own resolver**
+(``_effective_heavy_max_window_days``) rather than re-reading the env var.
+That resolver is not a plain env read: it widens the cap when
+``SYNC_WATERMARK_OVERLAP`` is greater than or equal to it, because a window
+ending at or before the watermark it started from would never advance.  A
+second env read here would judge lag against a cap the planner does not
+actually use, and every dataset inside the widened window would be reported
+as behind.  Executing the pinned production resolver makes that drift
+impossible; the local default exists only as a fallback for the case where
+the planner cannot be imported.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+#: Env var naming the HEAVY incremental window cap, in days.
+HEAVY_MAX_WINDOW_DAYS_ENV = "SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS"
+
+#: Default cap, matching the proven backfill chunk size.
+DEFAULT_HEAVY_MAX_WINDOW_DAYS = 7
+
+#: The only cost class the ratchet caps, and so the only one that can be
+#: "catching up".  Matches ``sync.datasets.CostClass.HEAVY``.
+HEAVY_COST_CLASS = "heavy"
+
+_SECONDS_PER_DAY = 86_400
+
+
+def heavy_max_window_days() -> int:
+    """Return the HEAVY incremental window cap the planner actually uses.
+
+    Delegates to ``planner._effective_heavy_max_window_days`` so the lag
+    verdict is taken against the same cap that sizes the windows — including
+    its widening when ``SYNC_WATERMARK_OVERLAP`` meets or exceeds the
+    configured cap.  Reading the env var here instead would drift from the
+    planner precisely in the configurations the planner corrects for.
+
+    Falls back to a direct env read only if the planner cannot be imported,
+    and to :data:`DEFAULT_HEAVY_MAX_WINDOW_DAYS` when the value is absent,
+    non-numeric, or below one day — a zero or negative cap would divide by
+    zero when counting ticks and would flag every watermark, however fresh.
+    """
+    try:
+        from dev_health_ops.sync.planner import _effective_heavy_max_window_days
+    except ImportError:  # pragma: no cover - defensive
+        pass
+    else:
+        resolved = _effective_heavy_max_window_days()
+        return resolved if resolved >= 1 else DEFAULT_HEAVY_MAX_WINDOW_DAYS
+
+    raw = os.getenv(HEAVY_MAX_WINDOW_DAYS_ENV)
+    if raw is None:
+        return DEFAULT_HEAVY_MAX_WINDOW_DAYS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_HEAVY_MAX_WINDOW_DAYS
+    if value < 1:
+        return DEFAULT_HEAVY_MAX_WINDOW_DAYS
+    return value
+
+
+@dataclass(frozen=True)
+class WatermarkLag:
+    """How far a (source, dataset) watermark trails the current time."""
+
+    #: The stored watermark, normalized to UTC; ``None`` when no row exists.
+    watermark_at: datetime | None
+    #: ``now - watermark_at`` in whole seconds, clamped at zero; ``None`` when
+    #: there is no watermark to measure from.
+    lag_seconds: int | None
+    #: True only for a HEAVY dataset trailing by strictly more than the cap.
+    catching_up: bool
+    #: Scheduled ticks still needed to reach ``now``, at the ratchet's NET
+    #: advance per tick (cap minus watermark overlap); ``None`` unless
+    #: ``catching_up``.
+    ticks_behind: int | None
+    #: The cap the verdict was taken against, so the surface can explain it.
+    window_cap_days: int
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Read a possibly-naive timestamp as UTC (SQLite round-trips drop tzinfo)."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def heavy_net_advance_seconds() -> int:
+    """Seconds of watermark advance per successful capped HEAVY tick.
+
+    Delegates to the planner for the same reason :func:`heavy_max_window_days`
+    does: the ratchet's arithmetic has one owner, and an estimate that
+    recomputed it would drift from the windows it claims to describe.
+    """
+    try:
+        from dev_health_ops.sync.planner import heavy_ratchet_net_advance_seconds
+    except ImportError:  # pragma: no cover - defensive
+        pass
+    else:
+        return max(1, heavy_ratchet_net_advance_seconds())
+
+    # Planner unavailable: fall back to cap minus overlap, computed the same way.
+    from dev_health_ops.sync.watermarks import _watermark_overlap_seconds
+
+    return max(
+        1, heavy_max_window_days() * _SECONDS_PER_DAY - _watermark_overlap_seconds()
+    )
+
+
+def compute_watermark_lag(
+    *,
+    cost_class: str,
+    watermark_at: datetime | None,
+    now: datetime,
+    window_cap_days: int | None = None,
+    net_advance_seconds: int | None = None,
+) -> WatermarkLag:
+    """Compute watermark lag and the catch-up verdict for one dataset.
+
+    ``window_cap_days`` overrides the env-resolved cap and
+    ``net_advance_seconds`` the per-tick advance; callers computing many
+    datasets should resolve both once and pass them, so a mid-loop env change
+    cannot make one response internally inconsistent.
+
+    The two are deliberately distinct. The VERDICT is taken against the cap — a
+    dataset within one window of ``now`` is a healthy ratchet mid-flight. The
+    tick ESTIMATE is taken against the net advance, which is ``cap - overlap``:
+    the window re-reads the overlap on every tick, so that portion buys no
+    forward progress.
+    """
+    cap_days = (
+        heavy_max_window_days() if window_cap_days is None else int(window_cap_days)
+    )
+    if cap_days < 1:
+        cap_days = DEFAULT_HEAVY_MAX_WINDOW_DAYS
+
+    if watermark_at is None:
+        return WatermarkLag(
+            watermark_at=None,
+            lag_seconds=None,
+            catching_up=False,
+            ticks_behind=None,
+            window_cap_days=cap_days,
+        )
+
+    watermark_utc = _as_utc(watermark_at)
+    # A watermark is never recorded ahead of now, but a clock skew or a
+    # hand-edited row must not surface as negative lag.
+    lag_seconds = max(0, int((_as_utc(now) - watermark_utc).total_seconds()))
+
+    cap_seconds = cap_days * _SECONDS_PER_DAY
+    catching_up = cost_class == HEAVY_COST_CLASS and lag_seconds > cap_seconds
+    # Ticks are paced by NET advance (cap - overlap), not the cap: the overlap
+    # slice is re-read every tick and buys no forward progress.
+    advance = (
+        heavy_net_advance_seconds()
+        if net_advance_seconds is None
+        else max(1, int(net_advance_seconds))
+    )
+    ticks_behind = math.ceil(lag_seconds / advance) if catching_up else None
+
+    return WatermarkLag(
+        watermark_at=watermark_utc,
+        lag_seconds=lag_seconds,
+        catching_up=catching_up,
+        ticks_behind=ticks_behind,
+        window_cap_days=cap_days,
+    )
+
+
+class _WatermarkRow(Protocol):
+    """The ``SyncWatermark`` columns this module reads."""
+
+    source_id: str
+    repo_id: str
+    target: str
+    dataset_key: str
+    last_synced_at: datetime | None
+
+
+def resolve_watermark(
+    rows: Iterable[_WatermarkRow], source_key: str, dataset_key: str
+) -> datetime | None:
+    """Resolve one watermark from pre-loaded rows, mirroring ``get_watermark``.
+
+    The status surface reads many (source, dataset) pairs at once and cannot
+    afford ``get_watermark``'s per-pair queries — and ``get_watermark`` is a
+    sync-``Session`` helper the async admin API cannot call.  This applies the
+    same three-tier precedence in Python over rows already in memory:
+
+    1. canonical ``(source_id, dataset_key)``;
+    2. legacy target column ``(repo_id, target == dataset_key)``;
+    3. reverse-legacy fallback to the raw legacy row
+       ``(repo_id, target == legacy_target, dataset_key == legacy_target)``.
+
+    Because this is a second implementation of a rule that already exists,
+    ``tests/test_watermark_lag_parity.py`` runs it against ``get_watermark``
+    over a shared DB fixture; the two must agree on every case.
+    """
+    return build_watermark_index(rows).resolve(source_key, dataset_key)
+
+
+class WatermarkIndex:
+    """Pre-indexed watermark rows, resolvable in O(1) per (source, dataset).
+
+    CHAOS-3430: the status surface resolves P pairs against R rows. Scanning the
+    row list per pair is O(P x R) and re-walks the same rows for every tier of
+    the precedence; a run with many sources and datasets does that thousands of
+    times for a result that never changes. Indexing once collapses each lookup
+    to a few dict hits.
+
+    The precedence is IDENTICAL to the scan it replaces — and to
+    ``watermarks.get_watermark``, which the differential oracle in
+    ``tests/test_watermark_lag_parity.py`` enforces across exactly this kind of
+    refactor. That test is the reason this optimization is safe to make: it
+    cannot silently reorder the tiers.
+
+    First row wins within a tier, matching the scan's behaviour (the DB holds a
+    unique constraint per tier, so duplicates are not expected in practice).
+    """
+
+    __slots__ = ("_canonical", "_legacy_target", "_raw_legacy")
+
+    def __init__(self, rows: Iterable[_WatermarkRow]) -> None:
+        # tier 1: (source_id, dataset_key)
+        self._canonical: dict[tuple[str, str], datetime | None] = {}
+        # tier 2: (repo_id, target)
+        self._legacy_target: dict[tuple[str, str], datetime | None] = {}
+        # tier 3: (repo_id, target) where target == dataset_key (the raw bridge row)
+        self._raw_legacy: dict[tuple[str, str], datetime | None] = {}
+        for row in rows:
+            self._canonical.setdefault(
+                (row.source_id, row.dataset_key), row.last_synced_at
+            )
+            self._legacy_target.setdefault(
+                (row.repo_id, row.target), row.last_synced_at
+            )
+            if row.target == row.dataset_key:
+                self._raw_legacy.setdefault(
+                    (row.repo_id, row.target), row.last_synced_at
+                )
+
+    def resolve(self, source_key: str, dataset_key: str) -> datetime | None:
+        """Resolve one watermark, applying ``get_watermark``'s three tiers."""
+        from dev_health_ops.sync.watermarks import _DATASET_KEY_TO_LEGACY_TARGETS
+
+        key = (source_key, dataset_key)
+        if key in self._canonical:
+            return self._canonical[key]
+        if key in self._legacy_target:
+            return self._legacy_target[key]
+        for legacy_target in sorted(
+            _DATASET_KEY_TO_LEGACY_TARGETS.get(dataset_key, frozenset())
+        ):
+            raw_key = (source_key, legacy_target)
+            if raw_key in self._raw_legacy:
+                return self._raw_legacy[raw_key]
+        return None
+
+    def relevant_lookup_values(self, dataset_keys: Iterable[str]) -> set[str]:
+        """Dataset/target values that could satisfy any of ``dataset_keys``.
+
+        Used to narrow the SELECT: a row whose dataset_key AND target are both
+        outside this set can never win any tier, so there is no reason to load
+        it.
+        """
+        from dev_health_ops.sync.watermarks import _DATASET_KEY_TO_LEGACY_TARGETS
+
+        values: set[str] = set()
+        for dataset_key in dataset_keys:
+            values.add(dataset_key)
+            values.update(_DATASET_KEY_TO_LEGACY_TARGETS.get(dataset_key, frozenset()))
+        return values
+
+
+def build_watermark_index(rows: Iterable[_WatermarkRow]) -> WatermarkIndex:
+    """Index ``rows`` once for repeated (source, dataset) resolution."""
+    return WatermarkIndex(rows)

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -32,6 +32,7 @@ from dev_health_ops.models.settings import (
     IntegrationCredential,
     ScheduledJob,
     SyncConfiguration,
+    SyncWatermark,
 )
 from dev_health_ops.models.users import Organization, User
 from dev_health_ops.sync.canonical_incident_gate import (
@@ -63,6 +64,8 @@ _TABLES = tables_of(
     SyncConfiguration,
     IntegrationCredential,
     ScheduledJob,
+    # The units endpoint reads watermark lag per (source, dataset) (CHAOS-3430).
+    SyncWatermark,
 )
 
 

--- a/tests/api/admin/test_sync_run_units.py
+++ b/tests/api/admin/test_sync_run_units.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,7 @@ from dev_health_ops.models.integrations import (
     SyncRun,
     SyncRunUnit,
 )
+from dev_health_ops.models.settings import SyncWatermark
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -27,7 +29,13 @@ admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
 
 _TABLES = tables_of(
-    User, Organization, Integration, IntegrationSource, SyncRun, SyncRunUnit
+    User,
+    Organization,
+    Integration,
+    IntegrationSource,
+    SyncRun,
+    SyncRunUnit,
+    SyncWatermark,
 )
 
 
@@ -178,3 +186,575 @@ async def test_get_sync_run_units_explicit_limit_still_slices_units(
     assert data["by_status"]["success"] == 5
     assert data["by_dataset"]["git"]["success"] == 5
     assert data["by_cost_class"]["standard"] == 5
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3430: watermark lag for ratcheting HEAVY datasets
+# ---------------------------------------------------------------------------
+
+EXTERNAL_ID = "owner/repo"
+
+
+async def _seed_ratchet_run(
+    session_maker,
+    org_id: str,
+    *,
+    datasets: list[tuple[str, str]],
+    watermarks: dict[str, datetime] | None = None,
+) -> str:
+    """Seed one successful incremental run over ``(dataset_key, cost_class)``.
+
+    ``watermarks`` maps dataset_key -> stored watermark; a dataset omitted
+    from it has no watermark row at all (never-stamped cold start).
+    """
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Integration(
+                    id=integration_id,
+                    org_id=org_id,
+                    provider="github",
+                    name="ratchet-test",
+                    config={},
+                    is_active=True,
+                ),
+                IntegrationSource(
+                    id=source_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    provider="github",
+                    source_type="repository",
+                    external_id=EXTERNAL_ID,
+                    name="repo",
+                    full_name=EXTERNAL_ID,
+                    metadata_={"owner": "owner"},
+                    is_enabled=True,
+                ),
+                SyncRun(
+                    id=run_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    triggered_by="scheduler",
+                    mode="incremental",
+                    status="success",
+                    total_units=len(datasets),
+                    completed_units=len(datasets),
+                    failed_units=0,
+                ),
+            ]
+        )
+        session.add_all(
+            [
+                SyncRunUnit(
+                    org_id=org_id,
+                    sync_run_id=run_id,
+                    integration_id=integration_id,
+                    source_id=source_id,
+                    provider="github",
+                    dataset_key=dataset_key,
+                    cost_class=cost_class,
+                    mode="incremental",
+                    status="success",
+                    attempts=1,
+                )
+                for dataset_key, cost_class in datasets
+            ]
+        )
+        for dataset_key, stamped_at in (watermarks or {}).items():
+            session.add(
+                SyncWatermark(
+                    org_id=org_id,
+                    repo_id=EXTERNAL_ID,
+                    source_id=EXTERNAL_ID,
+                    target=dataset_key,
+                    dataset_key=dataset_key,
+                    last_synced_at=stamped_at,
+                )
+            )
+        await session.commit()
+    return str(run_id)
+
+
+def _entry(data: dict, dataset_key: str) -> dict:
+    matches = [e for e in data["dataset_freshness"] if e["dataset_key"] == dataset_key]
+    assert matches, f"no freshness entry for {dataset_key!r}"
+    return matches[0]
+
+
+@pytest.mark.asyncio
+async def test_units_response_flags_heavy_dataset_still_ratcheting(
+    client, session_maker
+):
+    """A capped tick finalizes as SUCCESS; the response must still say behind."""
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks={"commit-stats": now - timedelta(days=83)},
+    )
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # The run itself still reads fully successful — that is the whole problem.
+    assert data["by_status"]["success"] == 1
+
+    assert data["catching_up_dataset_count"] == 1
+    entry = _entry(data, "commit-stats")
+    assert entry["catching_up"] is True
+    assert entry["cost_class"] == "heavy"
+    assert entry["window_cap_days"] == 7
+    assert entry["ticks_behind"] == 12
+    assert entry["watermark_at"] is not None
+    assert entry["lag_seconds"] >= int(timedelta(days=82).total_seconds())
+    # Never surface a raw source id where a resolved name exists.
+    assert entry["source_name"] == EXTERNAL_ID
+
+
+@pytest.mark.asyncio
+async def test_units_response_clears_the_flag_once_caught_up(client, session_maker):
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks={"commit-stats": now - timedelta(hours=1)},
+    )
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    data = resp.json()
+
+    assert data["catching_up_dataset_count"] == 0
+    entry = _entry(data, "commit-stats")
+    assert entry["catching_up"] is False
+    assert entry["ticks_behind"] is None
+    # Lag is still reported honestly, just without the verdict.
+    assert entry["lag_seconds"] is not None
+
+
+@pytest.mark.asyncio
+async def test_units_response_never_flags_a_non_heavy_dataset(client, session_maker):
+    """Only HEAVY families ratchet — a trailing LIGHT watermark is not catch-up."""
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("prs", "light"), ("commits", "medium")],
+        watermarks={
+            "prs": now - timedelta(days=200),
+            "commits": now - timedelta(days=200),
+        },
+    )
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    data = resp.json()
+
+    assert data["catching_up_dataset_count"] == 0
+    for dataset_key in ("prs", "commits"):
+        entry = _entry(data, dataset_key)
+        assert entry["catching_up"] is False
+        assert entry["ticks_behind"] is None
+        assert entry["lag_seconds"] >= int(timedelta(days=199).total_seconds())
+
+
+@pytest.mark.asyncio
+async def test_units_response_reports_a_never_stamped_dataset_as_unknown(
+    client, session_maker
+):
+    """No watermark row: nothing was read, so nothing is claimed as behind."""
+    ac, seeded_state = client
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks=None,
+    )
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    data = resp.json()
+
+    assert data["catching_up_dataset_count"] == 0
+    entry = _entry(data, "commit-stats")
+    assert entry["watermark_at"] is None
+    assert entry["lag_seconds"] is None
+    assert entry["catching_up"] is False
+
+
+@pytest.mark.asyncio
+async def test_units_response_omits_datasets_that_never_stamp_a_watermark(
+    client, session_maker
+):
+    """``repo-metadata`` has WatermarkBehavior.NONE — no lag exists to report."""
+    ac, seeded_state = client
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("repo-metadata", "light"), ("commit-stats", "heavy")],
+        watermarks=None,
+    )
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    data = resp.json()
+
+    keys = {entry["dataset_key"] for entry in data["dataset_freshness"]}
+    assert "repo-metadata" not in keys
+    assert "commit-stats" in keys
+
+
+@pytest.mark.asyncio
+async def test_units_response_respects_the_configured_window_cap(
+    client, session_maker, monkeypatch
+):
+    """The verdict must move with the cap the ratchet is actually configured to."""
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks={"commit-stats": now - timedelta(days=20)},
+    )
+
+    monkeypatch.setenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "30")
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    assert _entry(data, "commit-stats")["catching_up"] is False
+    assert _entry(data, "commit-stats")["window_cap_days"] == 30
+
+    monkeypatch.setenv("SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS", "7")
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    assert _entry(data, "commit-stats")["catching_up"] is True
+    assert _entry(data, "commit-stats")["window_cap_days"] == 7
+
+
+@pytest.mark.asyncio
+async def test_units_response_dedupes_pairs_and_orders_deterministically(
+    client, session_maker
+):
+    """Repeated (source, dataset) units collapse to one freshness entry."""
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[
+            ("commit-stats", "heavy"),
+            ("commit-stats", "heavy"),
+            ("blame", "heavy"),
+        ],
+        watermarks={"commit-stats": now - timedelta(days=83)},
+    )
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    entries = data["dataset_freshness"]
+
+    assert [e["dataset_key"] for e in entries] == ["blame", "commit-stats"]
+    assert data["catching_up_dataset_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_composite_work_item_unit_reports_each_child_watermark(
+    client, session_maker
+):
+    """A collapsed work-item-family unit must not hide its child watermarks.
+
+    CHAOS-2721: the planner collapses the work-item family into ONE composite
+    unit with ``dataset_key="work-items"`` and boolean ``family_dataset_<key>``
+    processor flags, while the worker
+    (``workers/sync_units.py::_watermark_dataset_keys``) advances a SEPARATE
+    watermark per enabled child. Reading the composite's raw dataset_key would
+    report one freshness row for a dataset nothing stamps, and would render a
+    badly-stale child -- here work-item-comments -- completely invisible.
+    """
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    org_id = seeded_state["org_id"]
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Integration(
+                    id=integration_id,
+                    org_id=org_id,
+                    provider="jira",
+                    name="family-test",
+                    config={},
+                    is_active=True,
+                ),
+                IntegrationSource(
+                    id=source_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    provider="jira",
+                    source_type="project",
+                    external_id=EXTERNAL_ID,
+                    name="proj",
+                    full_name=EXTERNAL_ID,
+                    metadata_={},
+                    is_enabled=True,
+                ),
+                SyncRun(
+                    id=run_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    triggered_by="scheduler",
+                    mode="incremental",
+                    status="success",
+                    total_units=1,
+                    completed_units=1,
+                    failed_units=0,
+                ),
+                SyncRunUnit(
+                    org_id=org_id,
+                    sync_run_id=run_id,
+                    integration_id=integration_id,
+                    source_id=source_id,
+                    provider="jira",
+                    dataset_key="work-items",
+                    cost_class="medium",
+                    mode="incremental",
+                    status="success",
+                    attempts=1,
+                    processor_flags={
+                        "family_dataset_work_items": True,
+                        "family_dataset_work_item_comments": True,
+                    },
+                ),
+            ]
+        )
+        # The worker stamps children independently: work-items is current,
+        # work-item-comments is badly stale.
+        session.add_all(
+            [
+                SyncWatermark(
+                    org_id=org_id,
+                    repo_id=EXTERNAL_ID,
+                    source_id=EXTERNAL_ID,
+                    target="work-items",
+                    dataset_key="work-items",
+                    last_synced_at=now - timedelta(hours=1),
+                ),
+                SyncWatermark(
+                    org_id=org_id,
+                    repo_id=EXTERNAL_ID,
+                    source_id=EXTERNAL_ID,
+                    target="work-item-comments",
+                    dataset_key="work-item-comments",
+                    last_synced_at=now - timedelta(days=45),
+                ),
+            ]
+        )
+        await session.commit()
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    keys = {entry["dataset_key"] for entry in data["dataset_freshness"]}
+
+    # Both children are reported, each against its OWN watermark.
+    assert "work-items" in keys
+    assert "work-item-comments" in keys
+
+    current = _entry(data, "work-items")
+    stale = _entry(data, "work-item-comments")
+    assert current["lag_seconds"] < int(timedelta(days=1).total_seconds())
+    assert stale["lag_seconds"] >= int(timedelta(days=44).total_seconds())
+    # The stale child's lag is the whole point: it was invisible before.
+    assert stale["watermark_at"] is not None
+
+
+async def _seed_composite_run(
+    session_maker,
+    org_id: str,
+    *,
+    composite_cost_class: str = "medium",
+    watermarks: dict[str, datetime] | None = None,
+) -> str:
+    """Seed one collapsed work-item-family composite unit."""
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Integration(
+                    id=integration_id,
+                    org_id=org_id,
+                    provider="jira",
+                    name="family-cost-test",
+                    config={},
+                    is_active=True,
+                ),
+                IntegrationSource(
+                    id=source_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    provider="jira",
+                    source_type="project",
+                    external_id=EXTERNAL_ID,
+                    name="proj",
+                    full_name=EXTERNAL_ID,
+                    metadata_={},
+                    is_enabled=True,
+                ),
+                SyncRun(
+                    id=run_id,
+                    org_id=org_id,
+                    integration_id=integration_id,
+                    triggered_by="scheduler",
+                    mode="incremental",
+                    status="success",
+                    total_units=1,
+                    completed_units=1,
+                    failed_units=0,
+                ),
+                SyncRunUnit(
+                    org_id=org_id,
+                    sync_run_id=run_id,
+                    integration_id=integration_id,
+                    source_id=source_id,
+                    provider="jira",
+                    dataset_key="work-items",
+                    cost_class=composite_cost_class,
+                    mode="incremental",
+                    status="success",
+                    attempts=1,
+                    processor_flags={
+                        "family_dataset_work_items": True,
+                        "family_dataset_work_item_labels": True,
+                        "family_dataset_work_item_comments": True,
+                    },
+                ),
+            ]
+        )
+        for dataset_key, stamped_at in (watermarks or {}).items():
+            session.add(
+                SyncWatermark(
+                    org_id=org_id,
+                    repo_id=EXTERNAL_ID,
+                    source_id=EXTERNAL_ID,
+                    target=dataset_key,
+                    dataset_key=dataset_key,
+                    last_synced_at=stamped_at,
+                )
+            )
+        await session.commit()
+    return str(run_id)
+
+
+@pytest.mark.asyncio
+async def test_composite_children_report_their_own_cost_class(client, session_maker):
+    """Each expanded child carries ITS registered cost class, not the composite's.
+
+    The composite unit is one row with one cost_class ("work-items" is medium),
+    but its children are separately registered — work-item-labels is LIGHT.
+    Stamping every child with the composite's class misreports the child, and
+    (see the next test) can silently suppress a child's catch-up verdict, since
+    flagging keys on cost_class == "heavy".
+    """
+    ac, seeded_state = client
+    run_id = await _seed_composite_run(session_maker, seeded_state["org_id"])
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+
+    assert _entry(data, "work-items")["cost_class"] == "medium"
+    assert _entry(data, "work-item-labels")["cost_class"] == "light"
+    assert _entry(data, "work-item-comments")["cost_class"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_heavy_child_of_a_non_heavy_composite_is_still_flagged(
+    client, session_maker, monkeypatch
+):
+    """A HEAVY child must be flagged even when its composite is not heavy.
+
+    No work-item-family child is registered heavy today, so this is latent
+    rather than live — but provider-specific cost classes exist, so a child
+    could become heavy, and inheriting the composite's class would suppress its
+    catch-up verdict silently. Patch the real registry entry the production code
+    reads, so this exercises the actual lookup rather than a stand-in.
+    """
+    from dataclasses import replace
+
+    from dev_health_ops.sync import datasets as datasets_mod
+    from dev_health_ops.sync.datasets import CostClass
+
+    spec = datasets_mod.get_dataset_spec("jira", "work-item-comments")
+    assert spec is not None
+    monkeypatch.setitem(
+        datasets_mod._REGISTRY["jira"],
+        "work-item-comments",
+        replace(spec, default_cost_class=CostClass.HEAVY),
+    )
+
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_composite_run(
+        session_maker,
+        seeded_state["org_id"],
+        composite_cost_class="medium",
+        watermarks={"work-item-comments": now - timedelta(days=83)},
+    )
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    child = _entry(data, "work-item-comments")
+
+    assert child["cost_class"] == "heavy"
+    assert child["catching_up"] is True
+    assert child["ticks_behind"] is not None
+    assert data["catching_up_dataset_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_freshness_is_declared_run_scoped(client, session_maker):
+    """The block must declare its scope so a filtered run's zero is not read
+    as a workspace-wide clean bill of health (CHAOS-3430 F4)."""
+    ac, seeded_state = client
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks=None,
+    )
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+
+    assert data["dataset_freshness_scope"] == "run"
+
+
+@pytest.mark.asyncio
+async def test_freshness_never_leaks_another_orgs_watermark(client, session_maker):
+    """A same-external-id watermark in another org must not satisfy this one."""
+    ac, seeded_state = client
+    now = datetime.now(timezone.utc)
+    run_id = await _seed_ratchet_run(
+        session_maker,
+        seeded_state["org_id"],
+        datasets=[("commit-stats", "heavy")],
+        watermarks=None,
+    )
+    async with session_maker() as session:
+        session.add(
+            SyncWatermark(
+                org_id=str(uuid.uuid4()),
+                repo_id=EXTERNAL_ID,
+                source_id=EXTERNAL_ID,
+                target="commit-stats",
+                dataset_key="commit-stats",
+                last_synced_at=now,
+            )
+        )
+        await session.commit()
+
+    data = (await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")).json()
+    entry = _entry(data, "commit-stats")
+    assert entry["watermark_at"] is None
+    assert entry["lag_seconds"] is None

--- a/tests/test_watermark_lag.py
+++ b/tests/test_watermark_lag.py
@@ -1,0 +1,281 @@
+"""Watermark-vs-now lag computation (CHAOS-3430).
+
+A HEAVY dataset syncing under the CHAOS-3412 incremental window ratchet
+finalizes every capped tick as an ordinary SUCCESS while its watermark may
+still trail ``now`` by weeks.  These tests pin the rule that decides when
+that trailing state is worth surfacing as "catching up", and the
+resolution precedence used to read the watermark for a (source, dataset)
+pair.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.sync.watermark_lag import (
+    DEFAULT_HEAVY_MAX_WINDOW_DAYS,
+    HEAVY_MAX_WINDOW_DAYS_ENV,
+    compute_watermark_lag,
+    heavy_max_window_days,
+    resolve_watermark,
+)
+
+NOW = datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _lag(cost_class: str, trailing_days: float, **kwargs):
+    return compute_watermark_lag(
+        cost_class=cost_class,
+        watermark_at=NOW - timedelta(days=trailing_days),
+        now=NOW,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flagging rule
+# ---------------------------------------------------------------------------
+
+
+def test_heavy_dataset_trailing_beyond_cap_is_flagged_catching_up():
+    """Cold-start ratchet: first capped tick stamps a watermark ~83 days back."""
+    lag = _lag("heavy", 83)
+
+    assert lag.catching_up is True
+    assert lag.lag_seconds == int(timedelta(days=83).total_seconds())
+    assert lag.watermark_at == NOW - timedelta(days=83)
+    assert lag.window_cap_days == DEFAULT_HEAVY_MAX_WINDOW_DAYS
+    # 83 days of arrears at a 7-day cap needs ceil(83/7) == 12 more ticks.
+    assert lag.ticks_behind == 12
+
+
+def test_heavy_dataset_caught_up_is_not_flagged():
+    lag = _lag("heavy", 0.25)
+
+    assert lag.catching_up is False
+    assert lag.ticks_behind is None
+    assert lag.lag_seconds == int(timedelta(days=0.25).total_seconds())
+
+
+def test_heavy_dataset_exactly_at_cap_is_not_flagged():
+    """A watermark exactly one cap-window back is one healthy tick, not arrears."""
+    lag = _lag("heavy", DEFAULT_HEAVY_MAX_WINDOW_DAYS)
+
+    assert lag.catching_up is False
+    assert lag.ticks_behind is None
+
+
+def test_heavy_dataset_one_second_past_cap_is_flagged():
+    lag = compute_watermark_lag(
+        cost_class="heavy",
+        watermark_at=NOW - timedelta(days=DEFAULT_HEAVY_MAX_WINDOW_DAYS, seconds=1),
+        now=NOW,
+    )
+
+    assert lag.catching_up is True
+    assert lag.ticks_behind == 2
+
+
+@pytest.mark.parametrize("cost_class", ["light", "medium", "standard", "unknown", ""])
+def test_non_heavy_dataset_is_never_flagged(cost_class: str):
+    """Only HEAVY families ratchet; a trailing LIGHT watermark is not catch-up."""
+    lag = _lag(cost_class, 400)
+
+    assert lag.catching_up is False
+    assert lag.ticks_behind is None
+    # Lag is still reported honestly — only the catch-up verdict is withheld.
+    assert lag.lag_seconds == int(timedelta(days=400).total_seconds())
+
+
+def test_missing_watermark_reports_no_lag_and_no_flag():
+    """No watermark row yet: nothing has been read, so nothing is 'behind'."""
+    lag = compute_watermark_lag(cost_class="heavy", watermark_at=None, now=NOW)
+
+    assert lag.watermark_at is None
+    assert lag.lag_seconds is None
+    assert lag.catching_up is False
+    assert lag.ticks_behind is None
+
+
+def test_watermark_ahead_of_now_clamps_lag_to_zero():
+    lag = compute_watermark_lag(
+        cost_class="heavy", watermark_at=NOW + timedelta(days=3), now=NOW
+    )
+
+    assert lag.lag_seconds == 0
+    assert lag.catching_up is False
+
+
+def test_naive_watermark_is_read_as_utc():
+    """SQLite round-trips drop tzinfo; a naive stamp must not blow up or skew."""
+    lag = compute_watermark_lag(
+        cost_class="heavy",
+        watermark_at=(NOW - timedelta(days=30)).replace(tzinfo=None),
+        now=NOW,
+    )
+
+    assert lag.lag_seconds == int(timedelta(days=30).total_seconds())
+    assert lag.catching_up is True
+
+
+# ---------------------------------------------------------------------------
+# Cap resolution
+# ---------------------------------------------------------------------------
+
+
+def test_cap_defaults_to_seven_days(monkeypatch):
+    monkeypatch.delenv(HEAVY_MAX_WINDOW_DAYS_ENV, raising=False)
+    assert heavy_max_window_days() == 7
+    assert DEFAULT_HEAVY_MAX_WINDOW_DAYS == 7
+
+
+def test_cap_reads_env_override(monkeypatch):
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "30")
+    assert heavy_max_window_days() == 30
+    # A 20-day arrears is inside a 30-day cap: no longer catching up.
+    assert _lag("heavy", 20).catching_up is False
+    assert _lag("heavy", 40).catching_up is True
+
+
+@pytest.mark.parametrize("raw", ["0", "-3", "nonsense", ""])
+def test_cap_rejects_unusable_env_values(monkeypatch, raw: str):
+    """A zero/negative/garbage cap would divide by zero or flag everything."""
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, raw)
+    assert heavy_max_window_days() == DEFAULT_HEAVY_MAX_WINDOW_DAYS
+
+
+def test_cap_tracks_the_planner_resolver_including_the_overlap_widening(monkeypatch):
+    """The verdict must use the cap the planner ACTUALLY sizes windows with.
+
+    ``_effective_heavy_max_window_days`` widens the cap when
+    ``SYNC_WATERMARK_OVERLAP`` meets or exceeds it, because a window ending at
+    or before its own start watermark can never advance.  A duplicated env read
+    here would judge lag against the narrower configured value and report every
+    dataset inside the widened window as behind.  This runs the production
+    resolver as the oracle, so the two cannot drift.
+    """
+    from dev_health_ops.sync.planner import _effective_heavy_max_window_days
+
+    # Overlap (10 days) exceeds the configured cap (7) -> planner widens.
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "7")
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", str(10 * 86_400))
+
+    planner_cap = _effective_heavy_max_window_days()
+    assert planner_cap > 7, "precondition: planner must widen this configuration"
+    assert heavy_max_window_days() == planner_cap
+
+    # A dataset inside the WIDENED window is not catching up, even though it
+    # trails by more than the configured 7 days.
+    inside = compute_watermark_lag(
+        cost_class="heavy",
+        watermark_at=NOW - timedelta(days=planner_cap - 1),
+        now=NOW,
+    )
+    assert inside.catching_up is False
+    assert inside.window_cap_days == planner_cap
+
+
+def test_cap_matches_the_planner_when_no_widening_applies(monkeypatch):
+    from dev_health_ops.sync.planner import _effective_heavy_max_window_days
+
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "21")
+    monkeypatch.delenv("SYNC_WATERMARK_OVERLAP", raising=False)
+
+    assert heavy_max_window_days() == _effective_heavy_max_window_days() == 21
+
+
+def test_ticks_behind_accounts_for_the_watermark_overlap(monkeypatch):
+    """Net advance per tick is cap MINUS overlap, not the cap (CHAOS-3430 F2).
+
+    The capped window spans ``[W - overlap, W - overlap + cap]``, so a successful
+    tick moves the watermark forward by ``cap - overlap``. Dividing arrears by
+    the raw cap understates catch-up time by the ratio between the two — with a
+    6-day overlap on a 7-day cap that is a 7x understatement.
+    """
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "7")
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", str(6 * 86_400))
+
+    lag = _lag("heavy", 83)
+
+    assert lag.catching_up is True
+    # Net advance is 7 - 6 = 1 day per tick, so 83 days of arrears needs 83
+    # ticks -- NOT ceil(83/7) == 12.
+    assert lag.ticks_behind == 83
+
+
+def test_ticks_behind_uses_net_advance_under_the_widened_cap(monkeypatch):
+    """The clamp widens the cap, but net advance stays ~1 day.
+
+    When overlap >= cap the planner widens the cap to floor(overlap_days)+1 so
+    each tick advances at all. Net advance is then a single day, and the tick
+    estimate must reflect that rather than the widened cap.
+    """
+    from dev_health_ops.sync.planner import _effective_heavy_max_window_days
+
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "7")
+    monkeypatch.setenv("SYNC_WATERMARK_OVERLAP", str(10 * 86_400))
+
+    assert _effective_heavy_max_window_days() == 11  # floor(10) + 1
+    lag = _lag("heavy", 40)
+
+    # Net advance = 11 - 10 = 1 day, so 40 days of arrears needs 40 ticks.
+    assert lag.ticks_behind == 40
+    assert lag.window_cap_days == 11
+
+
+def test_ticks_behind_matches_the_cap_when_no_overlap_is_configured(monkeypatch):
+    """Control: with no overlap, net advance IS the cap and nothing changes."""
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "7")
+    monkeypatch.delenv("SYNC_WATERMARK_OVERLAP", raising=False)
+
+    assert _lag("heavy", 83).ticks_behind == 12
+
+
+def test_explicit_cap_argument_overrides_env(monkeypatch):
+    monkeypatch.setenv(HEAVY_MAX_WINDOW_DAYS_ENV, "7")
+    lag = _lag("heavy", 10, window_cap_days=14)
+
+    assert lag.window_cap_days == 14
+    assert lag.catching_up is False
+
+
+# ---------------------------------------------------------------------------
+# Watermark resolution precedence (mirrors sync.watermarks.get_watermark)
+# ---------------------------------------------------------------------------
+
+
+class _Row:
+    def __init__(self, source_id, repo_id, target, dataset_key, last_synced_at):
+        self.source_id = source_id
+        self.repo_id = repo_id
+        self.target = target
+        self.dataset_key = dataset_key
+        self.last_synced_at = last_synced_at
+
+
+def test_resolution_prefers_canonical_row():
+    canonical = _Row("owner/repo", "owner/repo", "commits", "commits", NOW)
+    legacy = _Row("owner/repo", "owner/repo", "git", "git", NOW - timedelta(days=40))
+
+    assert resolve_watermark([legacy, canonical], "owner/repo", "commits") == NOW
+
+
+def test_resolution_falls_back_to_raw_legacy_row():
+    """`commits` with no canonical row warms from the raw `target='git'` row."""
+    legacy = _Row("owner/repo", "owner/repo", "git", "git", NOW - timedelta(days=40))
+
+    assert resolve_watermark([legacy], "owner/repo", "commits") == NOW - timedelta(
+        days=40
+    )
+
+
+def test_resolution_ignores_other_sources():
+    other = _Row("other/repo", "other/repo", "commits", "commits", NOW)
+
+    assert resolve_watermark([other], "owner/repo", "commits") is None
+
+
+def test_resolution_returns_none_when_no_row_matches():
+    assert resolve_watermark([], "owner/repo", "commits") is None

--- a/tests/test_watermark_lag_parity.py
+++ b/tests/test_watermark_lag_parity.py
@@ -1,0 +1,247 @@
+"""Differential oracle: ``resolve_watermark`` vs ``get_watermark`` (CHAOS-3430).
+
+``sync.watermark_lag.resolve_watermark`` is a second implementation of the
+three-tier watermark precedence already implemented by
+``sync.watermarks.get_watermark``.  The status surface needs the in-memory
+form (many pairs at once, over an async session); the planner keeps the
+query form.  Two implementations of one rule can only be trusted if something
+runs both over the same inputs and compares — no type checker or code index
+can answer whether they agree.
+
+This module is that comparator.  It seeds real ``SyncWatermark`` rows in a
+real session, then asserts the two paths return the same timestamp for every
+(source, dataset) probe.  ``ACCEPTANCE_CASES`` is a set of precedence
+behaviours the oracle must keep rediscovering: if a change makes one of them
+stop being exercised, the comparator has been broken, not fixed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import SyncWatermark
+from dev_health_ops.sync.watermark_lag import resolve_watermark
+from dev_health_ops.sync.watermarks import get_watermark
+
+ORG_ID = "org-parity"
+SOURCE = "owner/repo"
+OTHER_SOURCE = "other/repo"
+
+BASE = datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ts(days_back: float) -> datetime:
+    return BASE - timedelta(days=days_back)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _row(*, source_id, repo_id, target, dataset_key, last_synced_at) -> SyncWatermark:
+    return SyncWatermark(
+        org_id=ORG_ID,
+        source_id=source_id,
+        repo_id=repo_id,
+        target=target,
+        dataset_key=dataset_key,
+        last_synced_at=last_synced_at,
+    )
+
+
+#: (label, rows-to-seed, dataset probed) — each names a distinct precedence
+#: tier or miss the two implementations must agree on.
+ACCEPTANCE_CASES: list[tuple[str, list[dict], str]] = [
+    (
+        "canonical row only",
+        [
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="commits",
+                dataset_key="commits",
+                last_synced_at=_ts(1),
+            )
+        ],
+        "commits",
+    ),
+    (
+        "canonical wins over raw legacy sibling row",
+        [
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="commits",
+                dataset_key="commits",
+                last_synced_at=_ts(1),
+            ),
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="git",
+                dataset_key="git",
+                last_synced_at=_ts(60),
+            ),
+        ],
+        "commits",
+    ),
+    (
+        "reverse-legacy fallback warms a sibling from the raw git row",
+        [
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="git",
+                dataset_key="git",
+                last_synced_at=_ts(60),
+            )
+        ],
+        "commit-stats",
+    ),
+    (
+        "legacy target column lookup (target == dataset_key)",
+        [
+            dict(
+                source_id="",
+                repo_id=SOURCE,
+                target="prs",
+                dataset_key="prs",
+                last_synced_at=_ts(3),
+            )
+        ],
+        "prs",
+    ),
+    (
+        "no row for this source",
+        [
+            dict(
+                source_id=OTHER_SOURCE,
+                repo_id=OTHER_SOURCE,
+                target="commits",
+                dataset_key="commits",
+                last_synced_at=_ts(1),
+            )
+        ],
+        "commits",
+    ),
+    (
+        "no rows at all (cold start)",
+        [],
+        "commits",
+    ),
+    (
+        "repo-metadata never resolves via the reverse-legacy fallback",
+        [
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="git",
+                dataset_key="git",
+                last_synced_at=_ts(60),
+            )
+        ],
+        "repo-metadata",
+    ),
+    (
+        "null watermark on an existing row",
+        [
+            dict(
+                source_id=SOURCE,
+                repo_id=SOURCE,
+                target="commits",
+                dataset_key="commits",
+                last_synced_at=None,
+            )
+        ],
+        "commits",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,rows,dataset_key",
+    ACCEPTANCE_CASES,
+    ids=[case[0] for case in ACCEPTANCE_CASES],
+)
+def test_resolve_watermark_agrees_with_get_watermark(
+    db_session, label: str, rows: list[dict], dataset_key: str
+):
+    for spec in rows:
+        db_session.add(_row(**spec))
+    db_session.flush()
+
+    # Oracle: the production query path the planner actually uses.
+    expected = get_watermark(db_session, ORG_ID, SOURCE, dataset_key)
+
+    # Under test: the in-memory path the status surface uses, fed the same
+    # rows the batch loader would have selected.
+    loaded = list(
+        db_session.execute(
+            select(SyncWatermark).where(SyncWatermark.org_id == ORG_ID)
+        ).scalars()
+    )
+    actual = resolve_watermark(loaded, SOURCE, dataset_key)
+
+    assert actual == expected, f"{label}: {actual!r} != oracle {expected!r}"
+
+
+def test_acceptance_set_covers_every_precedence_tier():
+    """A comparator that stopped exercising a tier would pass while blind.
+
+    Assert the acceptance set still contains a case for each tier, so
+    trimming it is a test failure rather than a silent loss of coverage.
+    """
+    labels = {label for label, _, _ in ACCEPTANCE_CASES}
+    for required in (
+        "canonical row only",
+        "canonical wins over raw legacy sibling row",
+        "reverse-legacy fallback warms a sibling from the raw git row",
+        "legacy target column lookup (target == dataset_key)",
+        "no rows at all (cold start)",
+    ):
+        assert required in labels
+
+
+def test_oracle_detects_a_broken_reimplementation(db_session):
+    """The comparator must actually fail when the two paths disagree.
+
+    A differential test that cannot fail reads as coverage.  Feed the
+    in-memory path a deliberately truncated row set (canonical tier only)
+    and confirm it then disagrees with the oracle on the reverse-legacy case.
+    """
+    db_session.add(
+        _row(
+            source_id=SOURCE,
+            repo_id=SOURCE,
+            target="git",
+            dataset_key="git",
+            last_synced_at=_ts(60),
+        )
+    )
+    db_session.flush()
+
+    expected = get_watermark(db_session, ORG_ID, SOURCE, "commit-stats")
+    # SQLite round-trips drop tzinfo; compare on the wall value.
+    assert expected is not None
+    assert expected.replace(tzinfo=timezone.utc) == _ts(60)
+
+    # Rows filtered as a naive canonical-only implementation would: the
+    # reverse-legacy bridge row is dropped, so resolution must now miss.
+    canonical_only = [
+        row
+        for row in db_session.execute(
+            select(SyncWatermark).where(SyncWatermark.org_id == ORG_ID)
+        ).scalars()
+        if row.dataset_key == "commit-stats"
+    ]
+    assert resolve_watermark(canonical_only, SOURCE, "commit-stats") != expected


### PR DESCRIPTION
## Defect

CHAOS-3412's HEAVY incremental window ratchet caps a cold-start window at
`SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS` (default 7) and stamps the watermark at the
window **end**. Each capped tick therefore finalizes as an ordinary SUCCESS with
`last_sync_success=true`, while the dataset's watermark may still trail `now` by weeks.
Setup, health, and status surfaces read "complete, no failure" during a catch-up that can
take ~13 scheduled ticks from a 90-day cold start. Nothing persisted or rendered the lag.

Found by adversarial review of the ratchet changeset; graded medium and deferred at the
time because catch-up is bounded and loses no data.

## Design

Adds `SyncRunDatasetFreshness` to `SyncRunUnitSummary`, served by the existing
`GET /sync-runs/{run_id}/units` — the endpoint the admin sync-run detail page already
fetches. Deliberately a **rollup**, not extra fields on `SyncRunUnitResponse`: the ticket's
granularity is per `(source, dataset)`, units repeat that pair across chunks, and keeping
out of `_unit_to_response` made the rebase over #1503/#1504 conflict-free.

Per entry: `source_id`, `source_name`, `dataset_key`, `cost_class`, `watermark_at`,
`lag_seconds`, `catching_up`, `ticks_behind`, `window_cap_days`; plus
`catching_up_dataset_count` on the summary.

- **Read-only.** Computed from the existing `sync_watermarks` rows at response time. No
  migration, no new persisted state, and run finalization semantics are untouched — a
  capped run *is* a successful run.
- **Narrow flag.** `catching_up` requires HEAVY **and** lag strictly greater than the cap.
  A watermark exactly one cap-window back is the healthy steady state of a ratchet
  mid-flight, not arrears. `lag_seconds` is still reported honestly for every cost class;
  only the verdict is withheld.
- **Cap comes from the planner, not a second env read.** `heavy_max_window_days()`
  delegates to `planner._effective_heavy_max_window_days()`, which *widens* the cap when
  `SYNC_WATERMARK_OVERLAP >= cap`. A duplicated env read would judge lag against a cap the
  planner does not size windows with, and would report every dataset inside the widened
  window as behind — drift exactly in the configurations the planner exists to correct.
- **One batched query** per run, then three-tier watermark precedence applied in memory.
- Entries only for `WatermarkBehavior.INCREMENTAL` datasets; a dataset that never stamps a
  watermark has no lag to report.

Docs: new "Datasets still catching up" section in
`docs/admin/sync-and-coverage/status-and-freshness.md`, beside the budget section.

## Product framing

Readiness semantics are **unchanged** by this PR. The accepted position is
**disclose, don't degrade**: org readiness must not flip to partial/pending during
catch-up, because catch-up is bounded and self-healing, and degrading would fire on nearly
every org's first days. Readiness answers "can I trust this answer?", not "is ingestion
finished?" — an org catching up to April still answers last week's trend correctly.
The disclosure half is tracked separately in **CHAOS-3438** (ConnectorStatus coverage-depth
qualifier), which also carries the open product question of whether a catch-up ETA
threshold should ever escalate.

## Tests — 43 new, RED-first

- `tests/test_watermark_lag.py` (25): boundaries (at-cap, one-second-past), non-heavy never
  flagged, missing watermark, clock-skew clamp, naive-tz, cap env rejection, and two tests
  pinning the planner delegation including the overlap-widening case.
- `tests/test_watermark_lag_parity.py` (10): a **differential oracle** running the new
  in-memory `resolve_watermark` against the production `get_watermark` over real seeded
  rows — 8 acceptance cases covering every precedence tier, plus a test asserting the
  comparator itself still fails when fed a truncated row set, so it cannot pass while blind.
- `tests/api/admin/test_sync_run_units.py` (+8): flags while the run reads SUCCESS, clears
  once caught up, never flags non-heavy, never-stamped reads unknown, omits no-watermark
  datasets, honors the configured cap, dedupes pairs deterministically, cross-org isolation.

**11 mutations planted, all killed by their specific guard**, both sources verified
byte-identical after restore: always-false verdict (7 fail), drop heavy clause (6), `>`→`>=`
(at-cap only), drop skew clamp, drop `org_id` filter, drop INCREMENTAL filter, drop planner
delegation (overlap test only). One mutation that failed to apply was recorded INVALID and
redone rather than counted.

Also adds `SyncWatermark` to `_TABLES` in `tests/api/admin/test_integrations.py`, since the
units endpoint now reads that table. The endpoint deliberately does **not** swallow a
missing-table error — a missing table in production is a broken deployment and must fail
loudly rather than degrade to "no lag information".

## Validation

`ci/local_validate.sh`: ruff format, ruff check, mypy, and the FULL unit suite green.

Note for reviewers: a sourced `ops/.env` in the shell makes this gate report false RED on
clean `main` with no code change — 15 tests, traced to `.env` keys including
`LOG_LEVEL=debug` and `AUTH_AUTO_CREATE_ORG_ON_REGISTER=false`. Verified by differential
(identical FAILED lists on branch and clean `main`; all 15 pass with `.env` keys unset).
Tracked and being fixed in **CHAOS-3439**; not a property of this change.
