### PR TITLE
CHAOS-3413: bound the coverage job with a timeout so a hang fails instead of masking as cancelled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,25 @@ jobs:
       github.event_name != 'pull_request' &&
       (github.event_name == 'merge_group' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-26.04-arm
+    # CHAOS-3413: this job has hung indefinitely (1h45m-6h, then auto-cancelled
+    # by the next push's `cancel-in-progress` group) instead of failing, for
+    # days -- `cancelled` isn't a red check, so it merged silently as routine
+    # supersession while the COVERAGE_THRESHOLD=70 gate went unenforced. The
+    # hang starts precisely at #1335 (2026-07-30T19:40:46Z), which first gave
+    # this job DEV_HEALTH_POSTGRES_TEST_URI and so first let its live-Postgres
+    # tests actually execute -- concurrently, under xdist -n4, against the one
+    # shared Postgres service container, unlike `test-matrix` which serializes
+    # them. Before that regression, this job completed successfully in a
+    # consistent ~9m20s-11m30s (e.g. runs 30230488894, 30203314534,
+    # 30098888467) every time back through at least 07-09; it has not
+    # completed even once since. 25m is a deliberately generous multiple of
+    # that real historical baseline, not a guess -- comfortable room for
+    # coverage-instrumentation overhead plus whatever normal variance, while
+    # still bounding an indefinite hang into a `failure` well inside a
+    # workday. Tighten once the root fix (serializing the live-Postgres tests
+    # the way test-matrix already does) restores a real completion to compare
+    # against.
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## What

Adds `timeout-minutes: 25` to the `coverage` job in `.github/workflows/test.yml`.

## ⚠️ This PR's own CI cannot verify this change

`coverage` is `SKIPPED` on every `pull_request`-triggered run (confirmed via `gh pr checks` on #1506/#1507 — job-level `SKIPPED`, not inferred from the YAML). **This PR will show all-green regardless of whether `timeout-minutes: 25` is correct or even syntactically effective** — a passing check here says nothing about the change. It only takes effect on the post-merge `push`-to-`main` run, where `coverage` actually executes. Do not read a green PR as "tested." The timeout's actual behavior was validated separately via `workflow_dispatch` on a scratch branch, not through this PR.

## Why

The `coverage` job hung indefinitely (1h45m–6h) and was auto-cancelled by the next push's `cancel-in-progress` concurrency group on every run from PR #1335 (2026-07-30T19:40:46Z) through today — it did not complete once in that window. `cancelled` isn't a red check, so the `COVERAGE_THRESHOLD=70` gate went unenforced on `main` for days with no visible signal.

## Root cause (CHAOS-3413) — corrected from this PR's original diagnosis

**The actual root cause is fixed in #1511, not here.** `tests/api/dev/test_persistence_postgres.py:382` had an `assert` dedented outside its `async with` block, opening a fresh transaction on a session nothing ever closed — the Postgres backend was left `idle in transaction` holding a lock, and the fixture's own `DROP SCHEMA ... CASCADE` teardown then queued behind it forever (no `lock_timeout` anywhere to bound the wait). #1511 fixes the dedent and adds `SET LOCAL lock_timeout = '30s'` as a guard, verified red-first (leak reintroduced → a 32s teardown `ERROR`, not a hang).

This PR's original body attributed the hang to a broader concurrency hazard — several live-Postgres test files running together under `coverage`'s single `xdist -n4` pass — and proposed serializing them to fix it. That hypothesis was tested directly: `workflow_dispatch` on `fix/test-persistence-postgres-deadlock` (unmodified, no serialization) completed `coverage` in **9m0s**, inside the historical healthy band, with no hang. The broader concurrency hypothesis did not hold up; it was one file, one dedented line. The serialization work was withdrawn.

## What this PR is for, now

Purely prospective. `#1511` is what closes CHAOS-3413. This PR converts any *future* hang — this class or a new one — from a silent 6-hour `cancelled` into a bounded `failed`, so it can't go unnoticed the way this one did for days.

`25m` is a generous multiple of the job's real historical runtime: every healthy run completed in a consistent ~9m20s–11m30s (e.g. `30230488894`, `30203314534`, `30098888467`, back through at least 2026-07-09), and the `fix/test-persistence-postgres-deadlock` dispatch above confirms a normal run lands at 9m0s.

## Blast radius

This job never runs on `pull_request` (`github.event_name != 'pull_request'` unconditionally — always `skipped` there), and the repo's required-status-check ruleset names only `test` and `lint`, both satisfied on every PR regardless of `coverage`'s outcome. There is no active merge-queue path either (no `merge_queue` ruleset entry, zero `merge_group`-triggered runs in history). So this change cannot block any PR merge — it only makes an already-non-gating `cancelled` into an already-non-gating `failed` on the post-merge push run, where it's actually visible.
