### PR TITLE
fix(tests): unwedge the test-matrix hang in test_persistence_postgres

### DIFF
--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -39,23 +39,46 @@ from dev_health_ops.api.dev.persistence import service as dev_persistence_servic
 from dev_health_ops.models.dev_persistence import (
     DevAnswerFrame,
     DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
     DevMessage,
     DevRun,
+    DevRunIntent,
     DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
 _POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+# Must stay in step with test_persistence_v2.py's `_TABLES`: the service
+# under test writes and reads the whole Ask Dev persistence family, so a
+# table missing here is not a narrower fixture, it is an UndefinedTableError
+# the moment a test reaches that code path. This list had drifted 8 models
+# behind its SQLite sibling, which went unnoticed only because every test
+# past the first one in this module was unreachable (the fixture-teardown
+# deadlock fixed alongside this).
 _TABLES = tables_of(
     Organization,
     User,
     DevConversation,
     DevMessage,
     DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
     DevAnswerFrame,
     DevRunNarrative,
+    DevRunStageDiagnostic,
 )
 
 _ERROR_CODE_BY_OUTCOME: dict[str, str] = {
@@ -201,6 +224,18 @@ async def postgres_persistence() -> AsyncIterator[
             await engine.dispose()
         if schema_created:
             async with admin_engine.begin() as connection:
+                # DROP SCHEMA ... CASCADE needs ACCESS EXCLUSIVE on every table
+                # in the schema, so a session this test leaked still-open (a
+                # query issued outside its `async with`, leaving the backend
+                # `idle in transaction` holding ACCESS SHARE) makes this
+                # statement wait forever. There is no server-side timeout by
+                # default, so that hang is unbounded: under pytest-xdist it
+                # silently wedges one worker inside fixture teardown, the
+                # controller then blocks forever waiting for a report that
+                # never comes, and the whole CI job burns its 6-hour limit
+                # with no failure ever attributed to this file. Bound the wait
+                # so the leak fails loudly and points here instead.
+                await connection.execute(text("SET LOCAL lock_timeout = '30s'"))
                 await connection.execute(
                     text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
                 )
@@ -379,7 +414,13 @@ async def test_postgres_serializes_concurrent_user_admission_and_replay_is_free(
 
     async with maker() as verify_session:
         assert await verify_session.scalar(select(func.count(DevRun.id))) == 2
-    assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2
+        # Both counts must stay INSIDE the `async with`. Querying
+        # verify_session after the block exits silently opens a brand-new
+        # transaction on a session nothing will ever close or roll back,
+        # leaving the Postgres backend `idle in transaction` with an ACCESS
+        # SHARE lock on dev_messages -- which then blocks this fixture's
+        # teardown DROP SCHEMA ... CASCADE indefinitely.
+        assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes the `test-matrix` job hanging at 99% and burning its 6-hour limit on the `feat/go-worker-runtime-migration` stack. The same defect is also wedging **main's post-merge `coverage` job** (job `92227067726`: 06:30 → 12:31, identical signature) — it just doesn't block PRs there because `coverage` is skipped on `pull_request`.

## Root cause

`tests/api/dev/test_persistence_postgres.py::test_postgres_serializes_concurrent_user_admission_and_replay_is_free` ended with:

```python
async with maker() as verify_session:
    assert await verify_session.scalar(select(func.count(DevRun.id))) == 2
assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2   # <-- outside
```

The second assert was dedented out of the `async with` by 41340e9ae (#1328). Querying the session after the block exits opens a **fresh transaction on a session nothing will ever close or roll back**, leaving the Postgres backend `idle in transaction` holding `ACCESS SHARE` on `dev_messages`. The fixture's teardown then runs `DROP SCHEMA … CASCADE`, which needs `ACCESS EXCLUSIVE` on that table — and with no `lock_timeout`, waits forever.

Under pytest-xdist this is invisible: the worker reports the test `PASSED` (call phase) and *then* wedges in fixture teardown. The other workers drain to 99%, the controller blocks forever on a report that never arrives, and the job dies at the 6h ceiling with **no failure attributed to any file**.

## Evidence

Every hung leg across every run stalls at exactly the same place — the last test each stalled worker completed:

| run / job | leg | last completed on the stalled worker |
|---|---|---|
| #1484 `92199718468` | 3.14 gw1 | `test_persistence_postgres.py::test_postgres_serializes_concurrent_user_admission…` (51%) |
| #1484 `92199718466` | 3.13 gw3 | same (50%) |
| #1484 `92199718470` | 3.12 gw3 | same (51%) |
| #1447 `91834854028` | 3.14 gw1 | same (50%) |
| main `coverage` `92227067726` | gw2 | same (51%) |

Every "green" `test-matrix` on this stack was in fact **`skipped`** by the paths filter (`#1474`, `#1470`, `#1461`, `#1457`) — so *every* run that actually executed the suite hung. Not intermittent.

Reproduced locally against a throwaway `postgres:17.4`. faulthandler pins the hang inside fixture teardown:

```
Current thread (most recent call first):
  File ".../asyncio/base_events.py", line 683 in run_forever
  File ".../pytest_asyncio/plugin.py", line 330 in finalizer
  File ".../_pytest/runner.py", line 194 in pytest_runtest_teardown
```

and Postgres names the culprit outright:

```
85|active|Lock|relation|DROP SCHEMA IF EXISTS "ask_dev_admission_…" CASCADE
88|idle in transaction|SELECT count(dev_messages.id) AS count_1 FROM dev_messages
pg_blocking_pids(85) = {88}
```

## Changes

1. **Move the second assert back inside the `async with`.** Hang gone — the module completes in ~6s (previously: never).
2. **`SET LOCAL lock_timeout = '30s'` before the teardown `DROP SCHEMA`,** so a future leak of this shape fails loudly and points at this file instead of silently costing a 6-hour CI job. Verified as a real guard, not decoration: with the leak deliberately reintroduced, the run ends in **32.2s with a teardown ERROR** instead of hanging.
3. **Complete `_TABLES`,** which had drifted 8 models behind its SQLite sibling in `test_persistence_v2.py` (`DevToolCall`, `DevFeedback`, `DevConversationTombstone`, `DevRunIntent`, `DevRunResolution`, `DevRunSubjectSet`, `DevRunSourceObservation`, `DevRunStageDiagnostic`). Undetectable while every test after the first was unreachable; with the deadlock fixed they surface immediately as `relation "dev_run_resolutions" does not exist`. Clears 8 of the 10 tests in this module that had **never once executed in CI**.

## Known residual — NOT fixed here

Two tests still fail, and they are **right**; the product is wrong:

```
FAILED test_platform_monthly_allowance_charges_unique_runs_and_replay_is_free
FAILED test_platform_monthly_allowance_reserves_unknown_cost_fail_closed
      Failed: DID NOT RAISE DevMonthlyRequestLimitExceeded / DevMonthlyCostLimitExceeded
```

`DevPersistenceService.update_run` (`service.py:1905`) assigns `run.provider_source = provider_source` **unconditionally** from a parameter that defaults to `None`. Any `update_run()` call that doesn't re-pass it nulls the column. `_enforce_platform_allowance` (`service.py:3034`) filters on `provider_source == "platform"`, so the monthly request and cost allowances match zero rows and **are never enforced**. Confirmed by dumping the rows the allowance query sees — `provider_source` is `None` on every run after an `update_run`.

These two tests are the **only** coverage of that path anywhere in the suite, and the deadlock meant they had never run. Fixing it is a production-semantics change (does `provider_source=None` mean "leave unchanged" or "clear"?) with its own blast radius, so it belongs in a separate ticket rather than riding along here.

**So: this PR takes the gate from "hangs for 6 hours with nothing attributed" to "fails in ~7 minutes with two named, actionable failures."** Strictly better and actionable, but the `test` gate will not be green until the `provider_source` defect is fixed.

## Verification

- Module green except the two above across **2 consecutive `-n 4 --dist loadscope` runs** (6.3s, 10.1s), run alongside `test_health_rule_persistence_postgres.py`.
- Negative control: leak reintroduced → 32.2s teardown ERROR, not a hang. Restore verified **by execution** (test passes in 2.2s), not by `git diff`.
- `ruff check`, `ruff format --check`, and `mypy` (2045 files) clean.
