### PR TITLE
fix(providersync): isolate live-oracle imports from unavailable go-quality deps

### DIFF
--- a/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_items_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.machinery
 import pathlib
 import sys
 import types
@@ -9,32 +10,153 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SRC_ROOT = _REPO_ROOT / "src/dev_health_ops"
 
-def install_minimal_oracle_imports() -> None:
-    """Load the normalizer without unrelated API/client runtime dependencies.
+
+def _install_namespace_package_stub(module_name: str, source_dir: pathlib.Path) -> None:
+    """Install a namespace package that skips ``<package>/__init__.py``.
+
+    Several ``dev_health_ops`` packages have an aggregator ``__init__.py``
+    that eagerly imports every sibling submodule (Celery tasks, PyGithub /
+    python-gitlab connectors, ClickHouse sinks, ...), pulling in third-party
+    dependencies the Go quality image never installs even though the one
+    submodule an oracle actually needs has no such dependency itself.
+    Registering a plain namespace package under ``module_name`` -- pointing
+    ``__path__`` at the real package directory -- lets Python's import
+    machinery resolve `module_name.submodule` straight to the real,
+    unmodified submodule source without ever executing the aggregator
+    ``__init__.py``. Nothing about the submodules themselves is replaced.
+    """
+    if module_name in sys.modules:
+        return
+    package = types.ModuleType(module_name)
+    package.__path__ = [str(source_dir)]
+    package.__package__ = module_name
+    # A bare types.ModuleType defaults __spec__ to None. Left unset, any
+    # later importlib.util.find_spec(module_name) call -- dev_health_ops
+    # legacy code makes exactly this call to probe optional-package
+    # availability -- raises ValueError("<module>.__spec__ is None") for an
+    # already-imported module with no spec, instead of returning one. A real
+    # namespace-package ModuleSpec keeps that probe (and anything else that
+    # inspects __spec__) working the same as it would against the genuine
+    # package.
+    spec = importlib.machinery.ModuleSpec(module_name, loader=None, is_package=True)
+    spec.submodule_search_locations = package.__path__
+    package.__spec__ = spec
+    sys.modules[module_name] = package
+
+
+def _install_attribute_stub(module_name: str, **attributes: Any) -> None:
+    """Install a bare module exposing only the given dummy attributes.
+
+    Used for a heavy sibling import that the target function never calls
+    (``dev_health_ops.metrics.dependencies.get_metrics_dependencies`` is
+    referenced by other functions in the same file, never by
+    ``parse_github_projects_v2_env``) or whose concrete class is only ever
+    used as an assignment/``setattr`` target (``ClickHouseStore`` in
+    ``dev_health_ops.storage``), never constructed or executed, by the
+    production code paths these oracles exercise.
+    """
+    if module_name in sys.modules:
+        return
+    stub = types.ModuleType(module_name)
+    for name, value in attributes.items():
+        setattr(stub, name, value)
+    sys.modules[module_name] = stub
+
+
+def _install_bare_leaf_stub(module_name: str) -> None:
+    """Install an empty placeholder for a leaf third-party dependency.
+
+    ``urllib3``/``requests``/``jwt``/``clickhouse_connect`` are real runtime
+    dependencies of production provider and metrics-sink code, but every
+    reference to them in the import chains these oracles execute is either a
+    deferred (in-function) call or a type annotation left unevaluated by
+    ``from __future__ import annotations`` -- never a module-level call. An
+    empty module therefore satisfies `import` without ever standing in for
+    real HTTP/JWT/ClickHouse behavior; if a future change adds a
+    module-level use, import fails loudly instead of silently returning
+    fake data.
+    """
+    if module_name in sys.modules:
+        return
+    sys.modules[module_name] = types.ModuleType(module_name)
+
+
+def install_minimal_oracle_imports(*, real_client: bool = False) -> None:
+    """Load provider/model code without unrelated runtime dependencies.
 
     The Go quality image intentionally contains only the Python standard
-    library plus the few dependencies used directly by provider code.  The
-    aggregate ``dev_health_ops.models`` initializer imports API licensing,
-    which in turn imports FastAPI even though these row oracles only need the
-    standalone work-item and AI-attribution dataclasses.  The normalizer also
-    imports five client Protocols for annotations; importing their concrete
-    module would pull transport/auth dependencies into a row-only oracle.
+    library plus the few dependencies used directly by provider code (see
+    ``ci/requirements-live-python-oracles.txt``). Several aggregator
+    ``__init__.py`` modules and a handful of leaf third-party libraries pull
+    in FastAPI, ClickHouse, Redis/Valkey, Celery, PyGithub/python-gitlab,
+    ``requests``, and JWT machinery that these row/decision oracles never
+    exercise. Installing namespace packages, attribute-only stand-ins, and
+    empty leaf placeholders for exactly those unreached branches preserves
+    every real production module and function the oracles DO call --
+    nothing involved in producing a compared value is replaced.
 
-    Installing a normal namespace package for the model directory and a typed
-    annotation-only client module preserves the real production model and
-    normalizer modules/functions.  Nothing involved in producing row values is
-    replaced.
+    ``real_client=True`` skips the ``dev_health_ops.providers.github.client``
+    Protocol-only stub below so callers that subclass or call the real
+    ``GitHubWorkClient`` (pagination, REST selection, the GraphQL
+    comment/event adapters) get the genuine module instead of the
+    annotation-only stand-in used by pairs that only need it as a type.
     """
-    if "dev_health_ops.models" in sys.modules:
-        return
-    models_dir = (
-        pathlib.Path(__file__).resolve().parents[4] / "src/dev_health_ops/models"
+    _install_namespace_package_stub("dev_health_ops.models", _SRC_ROOT / "models")
+    _install_namespace_package_stub(
+        "dev_health_ops.connectors", _SRC_ROOT / "connectors"
     )
-    package = types.ModuleType("dev_health_ops.models")
-    package.__path__ = [str(models_dir)]
-    package.__package__ = "dev_health_ops.models"
-    sys.modules[package.__name__] = package
+    _install_namespace_package_stub(
+        "dev_health_ops.connectors.utils", _SRC_ROOT / "connectors/utils"
+    )
+    _install_namespace_package_stub(
+        "dev_health_ops.metrics.sinks", _SRC_ROOT / "metrics/sinks"
+    )
+    _install_namespace_package_stub("dev_health_ops.workers", _SRC_ROOT / "workers")
+
+    def _metrics_dependencies_unavailable(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError(
+            "get_metrics_dependencies is unavailable in the minimal oracle "
+            "import environment -- only parse_github_projects_v2_env-style "
+            "helpers that never call it are expected to run here"
+        )
+
+    _install_attribute_stub(
+        "dev_health_ops.metrics.dependencies",
+        get_metrics_dependencies=_metrics_dependencies_unavailable,
+    )
+    _install_attribute_stub(
+        "dev_health_ops.storage.clickhouse",
+        ClickHouseStore=type("ClickHouseStore", (), {}),
+    )
+
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        # dev_health_ops.connectors.utils.graphql has no
+        # `from __future__ import annotations`, so its
+        # `response: requests.Response` parameter annotation is evaluated
+        # at function-definition time (import time), not deferred like
+        # every other annotation these oracles load -- it needs a real
+        # attribute, not just an importable module.
+        setattr(requests_stub, "Response", type("Response", (), {}))
+        sys.modules["requests"] = requests_stub
+    _install_bare_leaf_stub("jwt")
+    _install_bare_leaf_stub("clickhouse_connect")
+    if "urllib3" not in sys.modules:
+        urllib3_stub = types.ModuleType("urllib3")
+        urllib3_util_stub = types.ModuleType("urllib3.util")
+        urllib3_retry_stub = types.ModuleType("urllib3.util.retry")
+        setattr(urllib3_retry_stub, "Retry", type("Retry", (), {}))
+        setattr(urllib3_util_stub, "retry", urllib3_retry_stub)
+        setattr(urllib3_stub, "util", urllib3_util_stub)
+        sys.modules["urllib3"] = urllib3_stub
+        sys.modules["urllib3.util"] = urllib3_util_stub
+        sys.modules["urllib3.util.retry"] = urllib3_retry_stub
+
+    if real_client:
+        return
 
     client_name = "dev_health_ops.providers.github.client"
     if client_name not in sys.modules:

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_composition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_composition.py
@@ -12,6 +12,11 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pagination.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pagination.py
@@ -12,6 +12,11 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports(real_client=True)
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pr-skip.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_pr-skip.py
@@ -12,6 +12,11 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_row.py
@@ -10,6 +10,11 @@ from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_target-parser.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_target-parser.py
@@ -14,6 +14,11 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_transition.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items-project-v2_transition.py
@@ -10,6 +10,11 @@ from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-comment.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-comment.py
@@ -10,6 +10,11 @@ from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports(real_client=True)
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-event.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_pr-social-event.py
@@ -10,6 +10,11 @@ from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports(real_client=True)
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_rest-selection.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_rest-selection.py
@@ -16,6 +16,11 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports(real_client=True)
 
 with (
     contextlib.redirect_stdout(io.StringIO()),


### PR DESCRIPTION
## Problem

The hosted `go-quality` check installs a minimal oracle Python env via
`python -m pip install --no-deps -r ci/requirements-live-python-oracles.txt`
(no `fastapi`/`urllib3`/`requests`/PyJWT/`valkey`/`clickhouse_connect`). Ten
checked-in live-oracle pairs under
`internal/providersync/testdata/oracle_pairs/` did not call
`install_minimal_oracle_imports()` before their first `dev_health_ops.*`
import, so their transitive import chains reached one of those unavailable
packages and the pairs failed with `ModuleNotFoundError` in that
environment (they pass fine against a normal dev venv, which has every real
dependency).

Failing pairs (10 Go subtests; `row.py` covers both the `WorkItem` and
`DraftIssue` cases under one pair id):
- `github/work-items-project-v2/{composition,pagination,pr-skip,row,target-parser,transition}`
- `github/work-items/{pr-social-comment,pr-social-event,rest-selection}`

## Fix

Extend `install_minimal_oracle_imports()` in `_github_work_items_helpers.py`
with the same technique it already uses for `dev_health_ops.models` (a
namespace package pointed at the real source directory, so Python's import
machinery resolves needed submodules without ever running an aggregator
`__init__.py`):

- **Namespace-package stubs** for `dev_health_ops.connectors`,
  `dev_health_ops.connectors.utils`, `dev_health_ops.metrics.sinks`, and
  `dev_health_ops.workers` — each has an aggregator `__init__.py` that
  eagerly imports every sibling submodule (PyGithub/python-gitlab
  connectors, Redis/Valkey, ClickHouse sink mixins, Celery tasks) even
  though the oracle only needs one dependency-light submodule underneath.
  These stubs also carry a real `importlib.machinery.ModuleSpec` — a bare
  `types.ModuleType` leaves `__spec__` as `None`, which broke an
  **already-passing** pair (`github/work-items/issue`, etc.) via
  `dev_health_ops/utils.py`'s `importlib.util.find_spec("dev_health_ops.connectors")`
  legacy-availability probe (`ValueError: dev_health_ops.connectors.__spec__ is None`).
  Caught this by re-running the full 17-pair suite after the first pass and
  fixing it before it could ship.
- **Attribute-only stubs** for `dev_health_ops.metrics.dependencies` (its
  real `get_metrics_dependencies` is called by four other functions in that
  file, never by `parse_github_projects_v2_env`) and
  `dev_health_ops.storage.clickhouse` (`ClickHouseStore` there is only ever
  a `setattr` target in `storage/__init__.py`, never constructed by these
  oracles).
- **Bare leaf stubs** for `requests`, `jwt`, `urllib3`, `clickhouse_connect`
  — real production dependencies whose only touches in these import chains
  are lazy (inside a function body) or an unevaluated type annotation,
  never a module-level call. `requests` additionally needs a real
  `Response` attribute because `connectors/utils/graphql.py` is one of the
  few files in this chain without `from __future__ import annotations`, so
  its `response: requests.Response` parameter annotation is evaluated
  eagerly at import time.
- A new `real_client: bool` kwarg skips the existing Protocol-only
  `dev_health_ops.providers.github.client` stub for the four pairs that
  subclass or call the **genuine** `GitHubWorkClient`
  (pagination, REST selection, the GraphQL comment/event adapters).

Wired the guard call as the first `dev_health_ops`-touching statement in
each of the 9 affected pair files, matching the existing `github_work-items_issue.py`
template.

## Proof

Reproduced the CI environment locally: a scratch `python3.13.14` venv with
`pip install --no-deps -r ci/requirements-live-python-oracles.txt` (the exact
CI install line).

- **Before**: `PYTHON=<scratch venv> bash ci/check_go.sh live-python-oracles`
  → `FAIL`, exactly the 10 subtests above red with `ModuleNotFoundError`
  for `fastapi`/`valkey`/`clickhouse_connect`/`urllib3` per chain.
- **After**: same command → `ok internal/providersync`, `ok
  internal/scheduler/sync`. Ran twice for stability. Also re-ran against a
  normal fully-populated dev venv to confirm the stubs are inert when the
  real dependencies are present.
- `ruff format`/`check` and `mypy` clean on the changed files.

## Gate

`ci/local_validate.sh` (mypy 2115 files, full `go test`, `check_go.sh fast`
— including `live-python-oracles` — ClickHouse scratch-db migrate, full
pytest unit suite) all green **except** two pre-existing, unrelated
failures in `tests/api/dev/test_project_scope_status_snapshot_repositories.py`
(`test_committed_project_scope_status_snapshot_reads_its_work_items`,
`test_derived_repository_set_is_exactly_the_projects_own_work`). Verified
these are unrelated to this change: the file is untouched by this diff,
fails deterministically and identically with this branch's changes
`git stash`ed away (i.e. against unmodified `feat/go-worker-runtime-migration`
tip), and fails in complete isolation outside the gate too. `go-quality`
itself (`ci/check_go.sh all`) never runs the Python unit suite at all, so
this pre-existing defect is outside this PR's and this check's scope.

## Scope guardrails

No dependencies were added to `ci/requirements-live-python-oracles.txt` —
that file's own header says it enforces the isolation this PR is closing a
gap in. All stubs are namespace/attribute-only placeholders installed at
oracle-subprocess runtime; nothing here is reachable from a real deployment
import path.
