### PR TITLE
fix(tests): unwedge the DROP SCHEMA deadlock in test_persistence_postgres

### DIFF
--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -39,23 +39,46 @@ from dev_health_ops.api.dev.persistence import service as dev_persistence_servic
 from dev_health_ops.models.dev_persistence import (
     DevAnswerFrame,
     DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
     DevMessage,
     DevRun,
+    DevRunIntent,
     DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
 _POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+# Must stay in step with test_persistence_v2.py's `_TABLES`: the service
+# under test writes and reads the whole Ask Dev persistence family, so a
+# table missing here is not a narrower fixture, it is an UndefinedTableError
+# the moment a test reaches that code path. This list had drifted 8 models
+# behind its SQLite sibling, which went unnoticed only because every test
+# past the first one in this module was unreachable (the fixture-teardown
+# deadlock fixed alongside this).
 _TABLES = tables_of(
     Organization,
     User,
     DevConversation,
     DevMessage,
     DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevRunIntent,
+    DevRunResolution,
+    DevRunSubjectSet,
+    DevRunSourceObservation,
     DevAnswerFrame,
     DevRunNarrative,
+    DevRunStageDiagnostic,
 )
 
 _ERROR_CODE_BY_OUTCOME: dict[str, str] = {
@@ -201,6 +224,18 @@ async def postgres_persistence() -> AsyncIterator[
             await engine.dispose()
         if schema_created:
             async with admin_engine.begin() as connection:
+                # DROP SCHEMA ... CASCADE needs ACCESS EXCLUSIVE on every table
+                # in the schema, so a session this test leaked still-open (a
+                # query issued outside its `async with`, leaving the backend
+                # `idle in transaction` holding ACCESS SHARE) makes this
+                # statement wait forever. There is no server-side timeout by
+                # default, so that hang is unbounded: under pytest-xdist it
+                # silently wedges one worker inside fixture teardown, the
+                # controller then blocks forever waiting for a report that
+                # never comes, and the whole CI job burns its 6-hour limit
+                # with no failure ever attributed to this file. Bound the wait
+                # so the leak fails loudly and points here instead.
+                await connection.execute(text("SET LOCAL lock_timeout = '30s'"))
                 await connection.execute(
                     text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
                 )
@@ -379,7 +414,13 @@ async def test_postgres_serializes_concurrent_user_admission_and_replay_is_free(
 
     async with maker() as verify_session:
         assert await verify_session.scalar(select(func.count(DevRun.id))) == 2
-    assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2
+        # Both counts must stay INSIDE the `async with`. Querying
+        # verify_session after the block exits silently opens a brand-new
+        # transaction on a session nothing will ever close or roll back,
+        # leaving the Postgres backend `idle in transaction` with an ACCESS
+        # SHARE lock on dev_messages -- which then blocks this fixture's
+        # teardown DROP SCHEMA ... CASCADE indefinitely.
+        assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Urgency

**main's `coverage` job has not completed a single time in at least two days.** 17+ consecutive runs, zero successes, several burning the full 6-hour ceiling:

| run | coverage | duration |
|---|---|---|
| 30955513702 | cancelled | 22:13 → 04:13 = **6h00** |
| 30981580636 | cancelled | 06:30 → 12:31 = **6h01** |
| 31037703374 | cancelled | 19:04 → 21:19 = 2h15 (superseded) |
| …14 more | **all cancelled, zero successes** | |

It isn't flaky infrastructure. It's this file. Job `92227067726` stalls on gw2 immediately after one specific test, then terminates orphan `pytest`/`python` workers at the ceiling.

## Root cause

`tests/api/dev/test_persistence_postgres.py::test_postgres_serializes_concurrent_user_admission_and_replay_is_free` ends with:

```python
async with maker() as verify_session:
    assert await verify_session.scalar(select(func.count(DevRun.id))) == 2
assert await verify_session.scalar(select(func.count(DevMessage.id))) == 2   # <-- outside
```

The second assert was dedented out of the `async with` by 41340e9ae (#1328). Querying the session after the block exits opens a **fresh transaction on a session nothing will ever close or roll back**, leaving the Postgres backend `idle in transaction` holding `ACCESS SHARE` on `dev_messages`. The fixture's teardown then runs `DROP SCHEMA … CASCADE`, which needs `ACCESS EXCLUSIVE` on that table — and with no `lock_timeout`, waits forever.

Under pytest-xdist this is invisible: the worker reports the test `PASSED` (call phase) and *then* wedges in fixture teardown. The other workers drain to 99%, the controller blocks forever on a report that never arrives, and the job dies at the 6h ceiling with **no failure attributed to any file**.

## Evidence

Reproduced deterministically **on this tree** (main `0829610ee`) against a throwaway `postgres:17.4`:

```
test_postgres_serializes_concurrent_user_admission_and_replay_is_free PASSED [7%]
Fatal Python error: Aborted
  File ".../asyncio/base_events.py", line 683 in run_forever
  File ".../_pytest/runner.py", line 194 in pytest_runtest_teardown
exit=124   (hard timeout — never finished)
```

Postgres names the blocker outright, live, while wedged:

```
74 | 77 | idle in transaction | DROP SCHEMA IF EXISTS "ask_dev_admission_…" | SELECT count(dev_messages.id) FROM dev_messages
pg_blocking_pids(DROP SCHEMA backend) = {74}
```

## Changes

1. **Move the second assert back inside the `async with`.** Hang gone — the module completes in ~9s (previously: never).
2. **`SET LOCAL lock_timeout = '30s'` before the teardown `DROP`,** so a future leak of this shape fails loudly and points at this file instead of silently costing a 6-hour job. Verified as a real guard, not decoration: with the leak deliberately reintroduced the run ends in **32.2s with a teardown ERROR** rather than hanging.
3. **Complete `_TABLES`,** which had drifted 8 models behind its SQLite sibling in `test_persistence_v2.py` (`DevToolCall`, `DevFeedback`, `DevConversationTombstone`, `DevRunIntent`, `DevRunResolution`, `DevRunSubjectSet`, `DevRunSourceObservation`, `DevRunStageDiagnostic`). Undetectable while every test after the first was unreachable; with the deadlock fixed they surface immediately as `relation "dev_run_resolutions" does not exist`. Clears 8 of the 10 tests in this module that had **never once executed in CI**.

## Also unblocks the feature stack

The same defect hangs the PR-gated `test-matrix` on the `feat/go-worker-runtime-migration` stack, which additionally sets `DEV_HEALTH_POSTGRES_TEST_URI` in the parallel unit step (5/5 runs that actually executed the suite hung; the "green" ones were `skipped` by the paths filter). That stack picks this up through its main-sync rather than a separate copy — a feature-only duplicate would just conflict at sync time.

## Known residual — fixed separately

Two tests in this module still fail, and they are **correct**; the product is wrong. `DevPersistenceService.update_run` nulls `provider_source`, which disables platform allowance enforcement entirely. That's a production-semantics change and doesn't belong in a CI fix — separate PR follows.

## Verification

- 15 passed / 2 failed (those two) across **2 consecutive `-n 4 --dist loadscope` runs**, alongside `test_health_rule_persistence_postgres.py`.
- Negative control: leak reintroduced → 32.2s teardown ERROR, not a hang. Restore verified **by execution**, not by `git diff`.
- `ruff check`, `ruff format --check`, `mypy` (2083 files) clean.
