### PR TITLE
fix(ask-dev): stop update_run from nulling provider_source

### DIFF
--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -2126,7 +2126,21 @@ class DevPersistenceService:
         run.state = state
         run.answer_id = answer_id
         run.terminal_reason = safe_terminal_reason
-        run.provider_source = provider_source
+        # Leave-unchanged, NOT clobber-to-None -- matching tool_call_count /
+        # citation_count / metric_count below. provider_source is set once at
+        # admission (append_user_message_and_run) and is then read back by
+        # _enforce_platform_allowance, which filters on
+        # `provider_source == "platform"`. Assigning it unconditionally from a
+        # parameter defaulting to None meant every caller that did not re-pass
+        # it nulled the column and dropped the run out of the allowance query
+        # -- silently disabling the monthly request and cost limits. Two real
+        # callers send a bare state update: OrchestratorPersistence.mark_state
+        # (state only, every non-terminal transition) and router.py's
+        # provider-unavailable 503 path (terminal, so the loss is permanent).
+        # No caller ever needs to clear this back to NULL; a run's provider is
+        # a fact about how it was admitted, not mutable per-update state.
+        if provider_source is not None:
+            run.provider_source = provider_source
         run.provider_fingerprint = safe_provider_fingerprint
         run.model_fingerprint = safe_model_fingerprint
         run.prompt_version = safe_prompt_version

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -52,9 +52,12 @@ from dev_health_ops.api.dev.contracts_v2.narrative import (
     DevNarrative as DevNarrativeContract,
 )
 from dev_health_ops.api.dev.persistence import (
+    DevAdmissionLimits,
+    DevMonthlyRequestLimitExceeded,
     DevPersistenceNotFound,
     DevPersistenceService,
     DevPersistenceValidationError,
+    DevPlatformAllowance,
 )
 from dev_health_ops.api.dev.persistence import service as dev_persistence_service
 from dev_health_ops.api.dev.persistence.service import (
@@ -302,6 +305,95 @@ async def _accepted_run(
         scope_snapshot={},
     )
     return conversation.id, accepted.run.id
+
+
+# -- dev_runs.provider_source durability --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_run_without_provider_source_leaves_the_column_intact(
+    persistence,
+) -> None:
+    """``update_run`` assigned ``run.provider_source = provider_source``
+    unconditionally from a parameter defaulting to ``None``, so every
+    caller that did not re-pass it silently nulled the column.
+
+    That is not cosmetic. ``_enforce_platform_allowance`` filters on
+    ``provider_source == "platform"``, so a nulled column does not merely
+    lose a label -- it makes the run invisible to the allowance query, and
+    the monthly request and cost limits stop applying altogether. Two real
+    call sites send a bare state update: ``OrchestratorPersistence
+    .mark_state`` (state only, on every non-terminal transition) and
+    router.py's provider-unavailable 503 path (state + error fields only,
+    and that one is terminal, so the loss is permanent).
+
+    This is exercised on SQLite deliberately: the defect is a plain ORM
+    attribute assignment with no backend-specific behaviour, and the
+    Postgres-gated module that also covers it does not run in the PR
+    gate.
+    """
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    allowance = DevPlatformAllowance(
+        monthly_request_limit=1,
+        monthly_cost_limit_microusd=6_000_000,
+    )
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        conversation_id = conversation.id
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            client_message_id=uuid.uuid4(),
+            question="First platform request",
+            scope_snapshot={},
+            admission_limits=DevAdmissionLimits(),
+            provider_source="platform",
+            platform_allowance=allowance,
+        )
+        run_id = accepted.run.id
+        # Exactly the shape router.py sends on the provider-unavailable
+        # path: a terminal state plus the error fields, and nothing else.
+        await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="completed",
+            estimated_cost_microusd=1_000_000,
+        )
+        await session.commit()
+
+    # Read back on a fresh session: the claim is about what is DURABLE, not
+    # about an identity-mapped in-memory object that never round-tripped.
+    async with maker() as session:
+        persisted = await session.get(DevRun, run_id)
+        assert persisted is not None
+        assert persisted.provider_source == "platform"
+
+    # ...and the state the column exists to reach. One platform run is
+    # already on record against a monthly limit of one, so the next
+    # admission must be refused. With the column nulled the allowance query
+    # matches zero rows and this admission is wrongly accepted -- which is
+    # what makes the bug a silently unenforced billing limit rather than a
+    # cosmetic data loss.
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        with pytest.raises(DevMonthlyRequestLimitExceeded):
+            await service.append_user_message_and_run(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                client_message_id=uuid.uuid4(),
+                question="Second platform request",
+                scope_snapshot={},
+                admission_limits=DevAdmissionLimits(),
+                provider_source="platform",
+                platform_allowance=allowance,
+            )
 
 
 # -- dev_run_intents ----------------------------------------------------


### PR DESCRIPTION
## Impact

**Platform monthly request and cost allowances have not been enforced.**

`DevPersistenceService.update_run` assigned:

```python
run.provider_source = provider_source
```

unconditionally, from a keyword parameter defaulting to `None`. Every caller that didn't re-pass `provider_source` therefore **nulled the column**.

`_enforce_platform_allowance` (`service.py:3034`) counts a month's runs with `DevRun.provider_source == "platform"`. A nulled column doesn't merely lose a label — it drops the run out of the allowance query entirely, `request_count` and `charged_microusd` come back zero, and neither `DevMonthlyRequestLimitExceeded` nor `DevMonthlyCostLimitExceeded` can ever fire.

Two real call sites send a bare state update:

| site | passes | effect |
|---|---|---|
| `OrchestratorPersistence.mark_state` (`orchestrator_persistence.py:59`) | `state` only, on every non-terminal transition | in-flight runs invisible to the allowance count for their whole life |
| `router.py:1486`, provider-unavailable 503 path | `state` + 2 error fields | **terminal — loss is permanent**; the run never counts against the org's monthly budget |

## Fix

Guard the assignment with `if provider_source is not None:`, matching the **leave-unchanged idiom this same mutation block already uses** for `tool_call_count`, `citation_count` and `metric_count`. No caller ever needs to clear the column back to NULL — a run's provider is a fact about how it was admitted, not mutable per-update state. `append_user_message_and_run` (`service.py:1719`) is the sole other writer and sets it once, at creation.

## Scope — checked, not assumed

`update_run` is the **only** `update_*` method on the service. Inside its mutation block, 19 fields are assigned unconditionally and 3 are already guarded.

`provider_source` is the only one of the 19 that is **also set at admission**, so it's the only member of the class currently reachable. The other 18 are written solely by `update_run`'s own terminal writer (`orchestrator_persistence.py:362`), which supplies the full set, and `mark_state` returns early for terminal states so it can never run after it.

Those 18 are therefore **safe by accident of the present call graph, not by construction** — any new partial-update caller re-opens the class. Reported here rather than changed, because making terminal-write fields leave-unchanged would mask genuinely missing writes. Worth a follow-up decision, not a silent widening of this PR.

## Verification

**RED first.** `tests/api/dev/test_persistence_v2.py::test_update_run_without_provider_source_leaves_the_column_intact` drives the real router-shaped call (terminal state + cost, no `provider_source`), reads the row back **on a fresh session** so the claim is about durable state rather than an identity-mapped object, and then asserts **the state the column exists to reach** — that a second admission against a monthly limit of one is actually *refused*, not merely that a string is present.

Observed failing on unmodified code:
```
tests/api/dev/test_persistence_v2.py:375: in test_update_run_without_provider_source_leaves_the_column_intact
    assert persisted.provider_source == "platform"
E   AssertionError: assert None == 'platform'
```
Passing with the fix. It lives in the SQLite module deliberately: the defect is a plain ORM assignment with no backend-specific behaviour, and the Postgres-gated module that also covers it doesn't run in the PR gate.

**The two Postgres allowance proofs now pass** — `test_platform_monthly_allowance_charges_unique_runs_and_replay_is_free` and `test_platform_monthly_allowance_reserves_unknown_cost_fail_closed`. Worth stating plainly: these had **never once executed in CI**, having sat behind the fixture-teardown deadlock fixed in #1511. They are the only coverage of this path anywhere in the suite, which is why a fully unenforced billing limit went unnoticed.

- Full `tests/api/dev` suite: **2076 passed, 1 xfailed**, no regressions from the semantics change.
- `ruff check`, `ruff format --check`, `mypy` (2083 files) clean.

## Relationship to #1511

Independent, but #1511 is what makes this one *provable* — until the deadlock is fixed, the Postgres allowance tests can't run at all. Either order merges cleanly; #1511 first gives the better signal.
