### PR TITLE
CHAOS-3402: make the ops unit suite CI-equivalent regardless of ambient environment

### DIFF
--- a/tests/_env_isolation.py
+++ b/tests/_env_isolation.py
@@ -1,0 +1,481 @@
+"""Ambient-environment isolation for the test suite (CHAOS-3402).
+
+Why this exists
+---------------
+CI runners start each job from a bare environment and set exactly the handful of
+variables listed in ``.github/workflows/test.yml``. A developer machine does not:
+``ops/.env`` is loaded by direnv in every ops shell, so ``pytest`` inherits ~65
+real configuration values. Tests whose intent is "this variable is ABSENT" then
+see a real-looking-but-wrong value and take a different code path. Fifteen tests
+across five files pass in CI and fail locally purely for that reason, with four
+independent root causes:
+
+* ``GITHUB_APP_PRIVATE_KEY_PATH`` (a RELATIVE path) makes the credential
+  resolver try to read a GitHub App key instead of reporting "no credentials".
+* ``AUTH_AUTO_CREATE_ORG_ON_REGISTER=false`` makes ``/auth/register`` return
+  ``org_id: null`` by design, so tests asserting auto-created orgs fail.
+* ``LOG_LEVEL=debug`` un-quiets ``aiosqlite``, which echoes raw SQL with bind
+  parameters, so log-sanitization tests that sweep every captured record
+  rediscover the secret they planted.
+* ``LICENSE_PRIVATE_KEY`` (a real 64-byte key where a 32-byte seed is required)
+  reaches a CLI subprocess through ``os.environ.copy()``.
+
+The fix is one class-level guard rather than fifteen per-test patches: before
+collection, remove every variable the application reads that no CI lane or gate
+script provides. What remains is the CI-equivalent environment, so a local run
+and a CI run see the same inputs.
+
+Deriving the list
+-----------------
+``SCRUB_ENV_NAMES`` is the union of
+
+1. every environment variable name read by ``src/dev_health_ops/**`` through
+   ``os.getenv`` / ``os.environ.get`` / ``os.environ[...]`` (string literals and
+   module-level string constants), and
+2. every name declared in the committed ``.env.example``,
+
+minus :data:`KEEP_ENV_NAMES`. The list is checked in rather than recomputed on
+every ``pytest`` start (the scan costs ~0.9s per xdist worker) and
+``tests/test_env_isolation_contract.py`` re-derives it and fails loudly on
+drift. To regenerate after adding a new ``os.getenv`` call::
+
+    python -c "import sys; sys.path.insert(0,'tests'); \
+        import _env_isolation as e; print(e.render_scrub_literal())"
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from collections.abc import Iterable, Mapping, MutableMapping
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src" / "dev_health_ops"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+#: Opt-out hatch for debugging: a comma-separated list of names to leave alone
+#: for one run (e.g. ``DEV_HEALTH_TEST_ENV_ALLOW=LOG_LEVEL pytest ...``). The
+#: exemption is echoed into the pytest header so a run that took it never reads
+#: as a clean run.
+ALLOW_ENV = "DEV_HEALTH_TEST_ENV_ALLOW"
+
+# ---------------------------------------------------------------------------
+# Keep list — every entry is a variable some CI lane, ci/ gate script, or test
+# opt-in gate SETS deliberately. Scrubbing any of these would break the lane
+# that supplies it, so ambient exposure here is accepted and CI-equivalent.
+# ---------------------------------------------------------------------------
+KEEP_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        # --- analytics / semantic DBs, supplied by CI and by ci/local_validate.sh
+        # test.yml "Run parallel unit test contract" sets all four; local_validate
+        # exports CLICKHOUSE_URI at an isolated scratch db for the clickhouse-marked
+        # tier and the live argMax proof. Scrubbing these makes the gate's live
+        # stage and 36 CH-reading test modules silently lose their target.
+        "CLICKHOUSE_URI",
+        "DATABASE_URI",
+        "DATABASE_URL",
+        "POSTGRES_URI",
+        "SECONDARY_DATABASE_URI",
+        # --- opt-in live-Postgres tiers. test.yml's second pytest step sets these;
+        # six test modules read them from the ambient environment to decide whether
+        # to run. Scrubbing would silently skip an entire tier.
+        "DEV_HEALTH_POSTGRES_TEST_URI",
+        "DEV_HEALTH_TEST_POSTGRES_ADMIN_URI",
+        "METRIC_BRIDGE_POSTGRES_TEST_URI",
+        "POSTGRES_SYNC_SCHEDULER_TEST_URL",
+        "WORKER_OUTBOX_POSTGRES_TEST_URI",
+        "EXPLAIN_CLICKHOUSE_URI",
+        # --- other opt-in tiers read from ambient by tests themselves.
+        "ASK_DEV_LIVE_OPENAI_BASE_URL",
+        "ASK_DEV_LIVE_OPENAI_MODEL",
+        "GITHUB_PRIVATE_REPO",
+        "LIVE_E2E_BASE_URL",
+        "PAGERDUTY_API_TOKEN",
+        "PAGERDUTY_LIVE_SMOKE",
+        "PAGERDUTY_REGION",
+        "SKIP_INTEGRATION_TESTS",
+        "TEST_ORG_ID",
+        # --- provider tokens exported by ci/run_tests.sh for the integration tier
+        # (GH_TOKEN -> GITHUB_TOKEN, GL_TOKEN -> GITLAB_TOKEN) and read from ambient
+        # by tests/test_connectors_integration.py and friends.
+        "GITHUB_TOKEN",
+        "GITLAB_TOKEN",
+        "GITLAB_URL",
+        # --- set by a CI lane or by ci/local_validate.sh for the process under test.
+        "DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER",
+        "DISABLE_DOTENV",
+        "ENVIRONMENT",
+        "JWT_SECRET_KEY",
+        "OPERATIONAL_ORDERING_CONTRACT",
+        "ORG_ID",
+        # OTEL off in CI and in the gate: with it on, the exporter retries to
+        # localhost:4317 on every span, flooding logs and slowing the suite.
+        "OTEL_ENABLED",
+        "REDIS_URL",
+        # --- owned by pytest itself.
+        "PYTEST_CURRENT_TEST",
+        "CI",
+        "GITHUB_ACTIONS",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Scrub list — derived; see module docstring. Regenerate with
+# ``render_scrub_literal()`` when src/ starts reading a new variable.
+# ---------------------------------------------------------------------------
+SCRUB_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "ALLOWED_CHECKOUT_DOMAINS",
+        "ALLOW_STALE_FEATURE_BUNDLES",
+        "ANTHROPIC_API_KEY",
+        "APP_BASE_URL",
+        "APP_ENV",
+        "ASK_DEV_ACCEPTANCE_OPENAI_API_KEY",
+        "ASK_DEV_ACCEPTANCE_OPENAI_BASE_URL",
+        "ASK_DEV_ACCEPTANCE_OPENAI_PORT",
+        "ASK_DEV_LIVE_ACCEPTANCE",
+        "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD",
+        "ASK_DEV_SCRIPTED_PROVIDER_ROLE",
+        "ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR",
+        "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX",
+        "ATLASSIAN_API_TOKEN",
+        "ATLASSIAN_CLIENT_ENABLED",
+        "ATLASSIAN_CLIENT_ID",
+        "ATLASSIAN_CLIENT_SECRET",
+        "ATLASSIAN_CLOUD_ID",
+        "ATLASSIAN_COOKIES_JSON",
+        "ATLASSIAN_EMAIL",
+        "ATLASSIAN_GQL_BASE_URL",
+        "ATLASSIAN_GQL_ENABLED",
+        "ATLASSIAN_GQL_EXPERIMENTAL_APIS",
+        "ATLASSIAN_JIRA_BASE_URL",
+        "ATLASSIAN_JIRA_SPRINT_IDS_FIELD",
+        "ATLASSIAN_JIRA_STORY_POINTS_FIELD",
+        "ATLASSIAN_OAUTH_ACCESS_TOKEN",
+        "ATLASSIAN_OAUTH_GQL_ENDPOINT",
+        "ATLASSIAN_OAUTH_REFRESH_TOKEN",
+        "AUTH_AUTO_CREATE_ORG_ON_REGISTER",
+        "AUTO_RUN_MIGRATIONS",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+        "BUGSINK_BASE_URL",
+        "BUGSINK_CREATE_SUPERUSER",
+        "BUGSINK_SECRET_KEY",
+        "BUSINESS_HOURS_END",
+        "BUSINESS_HOURS_START",
+        "BUSINESS_TIMEZONE",
+        "BYO_LLM_MAX_BUDGET_MICRO_USD",
+        "CELERY_BROKER_URL",
+        "CELERY_RESULT_BACKEND",
+        "COMMIT_STATS_MAX_COMMITS",
+        "CORS_ALLOWED_ORIGINS",
+        "DASHSCOPE_API_KEY",
+        "DASHSCOPE_BASE_URL",
+        "DEV_HEALTH_ALLOW_PLACEHOLDER_CLICKHOUSE_URI",
+        "DEV_HEALTH_SINK",
+        "EMAIL_API_KEY",
+        "EMAIL_FROM_ADDRESS",
+        "EMAIL_PROVIDER",
+        "ENV",
+        "EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES",
+        "EXTERNAL_INGEST_MAX_BODY_BYTES",
+        "EXTERNAL_INGEST_MAX_RECORDS",
+        "EXTERNAL_INGEST_STATUS_RETENTION_DAYS",
+        "FULLCHAOS_API_TOKEN",
+        "FULLCHAOS_API_URL",
+        "FULLCHAOS_INGEST_TOKEN",
+        "FULLCHAOS_ORG_ID",
+        "GEMINI_API_KEY",
+        "GEMINI_BASE_URL",
+        "GEMINI_MODEL",
+        "GITHUB_APP_CALLBACK_URL",
+        "GITHUB_APP_CLIENT_ID",
+        "GITHUB_APP_CLIENT_SECRET",
+        "GITHUB_APP_ID",
+        "GITHUB_APP_INSTALLATION_ID",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_APP_PRIVATE_KEY_PATH",
+        "GITHUB_APP_SLUG",
+        "GITHUB_BASE_URL",
+        "GITHUB_HTTP_BACKOFF_FACTOR",
+        "GITHUB_HTTP_BACKOFF_MAX",
+        "GITHUB_HTTP_MAX_RETRIES",
+        "GITHUB_HTTP_TIMEOUT_SECONDS",
+        "GITHUB_LINEAR_LINKBACK_BOTS",
+        "GITHUB_PROJECTS_V2",
+        "GITHUB_URL",
+        "GITHUB_WEBHOOK_SECRET",
+        "GITLAB_NOTES_LIMIT",
+        "GITLAB_WEBHOOK_TOKEN",
+        "GRAPHQL_AUTH_REQUIRED",
+        "GRAPHQL_MAX_QUERY_BYTES",
+        "HIDE_MIGRATED_CHILD_CONFIGS",
+        "IDENTITY_MAPPING_PATH",
+        "IMPERSONATION_TTL_MINUTES",
+        "INGEST_API_KEYS",
+        "INGEST_ASYNC_INSERT",
+        "INGEST_ASYNC_INSERT_TIMEOUT_MS",
+        "INGEST_SIGNING_SECRET",
+        "INSTANCE_ID",
+        "INVESTMENT_LLM_BATCH_MIN_ITEMS",
+        "INVESTMENT_LLM_BATCH_MODE",
+        "INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS",
+        "INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS",
+        "INVESTMENT_LLM_CONCURRENCY",
+        "INVESTMENT_MATERIALIZE_CHUNK_SIZE",
+        "INVESTMENT_MAX_COMPONENT_NODES",
+        "JIRA_API_TOKEN",
+        "JIRA_BASE_URL",
+        "JIRA_COMMENTS_LIMIT",
+        "JIRA_EMAIL",
+        "JIRA_EPIC_LINK_FIELD",
+        "JIRA_FETCH_ALL",
+        "JIRA_FETCH_BOARD_SPRINTS",
+        "JIRA_FETCH_COMMENTS",
+        "JIRA_FETCH_WORKLOGS",
+        "JIRA_JQL",
+        "JIRA_OPS_PROJECT_TYPES",
+        "JIRA_PROJECT_KEYS",
+        "JIRA_SPRINT_FIELD",
+        "JIRA_STORY_POINTS_FIELD",
+        "JIRA_USE_PROVIDER",
+        "JIRA_WEBHOOK_SECRET",
+        "JWT_AUDIENCE",
+        "JWT_ISSUER",
+        "LICENSE_KEY",
+        "LICENSE_PRIVATE_KEY",
+        "LICENSE_PUBLIC_KEY",
+        "LICENSE_SECRET_KEY",
+        "LINEAR_API_KEY",
+        "LINEAR_BACKFILL_MAX_WINDOW_DAYS",
+        "LINEAR_COMMENTS_LIMIT",
+        "LINEAR_TRUSTED_SCM_HOSTS",
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
+        "LLM_MODEL",
+        "LLM_PROVIDER",
+        "LMSTUDIO_BASE_URL",
+        "LMSTUDIO_MODEL",
+        "LOCAL_LLM_API_KEY",
+        "LOCAL_LLM_BASE_URL",
+        "LOCAL_LLM_MODEL",
+        "LOG_JSON",
+        "LOG_LEVEL",
+        "MIGRATION_DATABASE_URI",
+        "MIGRATION_DATABASE_URI_FILE",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_MODEL",
+        "OPENAI_API_KEY",
+        "OTEL_ENVIRONMENT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_METRIC_EXPORT_INTERVAL",
+        "OTEL_SAMPLE_RATE",
+        "OTEL_SERVICE_NAME",
+        "PAGERDUTY_SUBDOMAIN",
+        "PAGERDUTY_WEBHOOK_TRANSPORT",
+        "PAGER_DUTY_CLIENT_ID",
+        "PAGER_DUTY_REDIRECT_URI",
+        "PAGER_DUTY_SECRET",
+        "PGBOUNCER_TRANSACTION_MODE",
+        "POSTGRES_CONNECT_TIMEOUT_SECONDS",
+        "PROVIDER_SYNC_QUEUES_ENABLED",
+        "QWEN_API_KEY",
+        "QWEN_LOCAL_MODEL",
+        "QWEN_MODEL",
+        "REPO_PATH",
+        "REPO_UUID",
+        "RESEND_API_KEY",
+        "RIVER_COORDINATOR_DATABASE_PASSWORD",
+        "RIVER_COORDINATOR_DATABASE_ROLE",
+        "RIVER_DOMAIN_DATABASE_PASSWORD",
+        "RIVER_DOMAIN_DATABASE_ROLE",
+        "RIVER_QUEUE_DATABASE_PASSWORD",
+        "RIVER_QUEUE_DATABASE_ROLE",
+        "SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "SENTRY_PROFILES_RATE",
+        "SENTRY_SEND_PII",
+        "SENTRY_TRACES_RATE",
+        "SERVICE_NAME",
+        "SERVICE_VERSION",
+        "SETTINGS_ENCRYPTION_KEY",
+        "SETTINGS_ENCRYPTION_SALT",
+        "SMTP_HOST",
+        "SMTP_PASSWORD",
+        "SMTP_PORT",
+        "SMTP_USERNAME",
+        "SMTP_USE_TLS",
+        "SOCIAL_GITHUB_CLIENT_ID",
+        "SOCIAL_GITHUB_CLIENT_SECRET",
+        "SOCIAL_GITLAB_CLIENT_ID",
+        "SOCIAL_GITLAB_CLIENT_SECRET",
+        "SOCIAL_GOOGLE_CLIENT_ID",
+        "SOCIAL_GOOGLE_CLIENT_SECRET",
+        "STATUS_MAPPING_PATH",
+        "STRIPE_PRICE_ID_ENTERPRISE",
+        "STRIPE_PRICE_ID_TEAM",
+        "STRIPE_SECRET_KEY",
+        "STRIPE_WEBHOOK_SECRET",
+        "SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS",
+        "SYNC_BUDGET_BUCKET_LIMITS",
+        "SYNC_BUDGET_DEFAULT_LIMIT",
+        "SYNC_BUDGET_DEFERRAL_JITTER_SECONDS",
+        "SYNC_BUDGET_DEFERRAL_SECONDS",
+        "SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS",
+        "SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT",
+        "SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS",
+        "SYNC_COST_CLASS_QUEUES",
+        "SYNC_DISPATCH_REDISPATCH_COUNTDOWN",
+        "SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS",
+        "SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS",
+        "SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS",
+        "SYNC_REFERENCE_DISCOVERY_LEASE_SECONDS",
+        "SYNC_REFERENCE_DISCOVERY_MAX_ATTEMPTS",
+        "SYNC_REFERENCE_DISCOVERY_MAX_LIFETIME_SECONDS",
+        "SYNC_REFERENCE_DISCOVERY_READBACK_SECONDS",
+        "SYNC_RUN_AUTH_STRICT",
+        "SYNC_RUN_MAX_UNITS",
+        "SYNC_UNIT_CONCURRENCY_PER_BUCKET",
+        "SYNC_UNIT_DISPATCH_STALE_SECONDS",
+        "SYNC_UNIT_EXPIRED_LEASE_MAX_RETRIES",
+        "SYNC_UNIT_EXPIRED_LEASE_RETRY_BACKOFF_SECONDS",
+        "SYNC_UNIT_MAX_LIFETIME_SECONDS",
+        "SYNC_UNIT_RUNNING_LEASE_SECONDS",
+        "SYNC_UNIT_RUNNING_STALE_SECONDS",
+        "SYNC_WATERMARK_OVERLAP",
+        "TEAMS_API_TIMEOUT",
+        "TEAMS_USE_BETA_API",
+        "TEAM_MAPPING_PATH",
+        "TELEMETRY_ENDPOINT",
+        "TRIAL_DAYS",
+        "TRUSTED_PROXIES",
+        "VALIDATE_LOADER_OUTPUT",
+        "WORKER_GITHUB_REPO_METADATA_ENABLED",
+        "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
+        "WORKER_OPERATIONAL_BRIDGE_TOKEN",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Derivation (used by the drift guard, not on the hot path)
+# ---------------------------------------------------------------------------
+
+_ENV_READERS = {"getenv", "get", "pop"}
+_ENV_TARGETS = {"os", "os.environ", "environ"}
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "STRING"`` bindings.
+
+    ``api/auth/config.py`` reads ``os.getenv(AUTH_AUTO_CREATE_ORG_ENV)``; without
+    resolving constants the scan misses the very variable that broke eight tests.
+    """
+    consts: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                consts[target.id] = node.value.value
+    return consts
+
+
+def _literal_or_const(node: ast.expr, consts: Mapping[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return consts.get(node.id)
+    return None
+
+
+def discover_src_env_names(src_root: Path | None = None) -> set[str]:
+    """Every env var name ``src/dev_health_ops`` reads."""
+    root = src_root or SRC_ROOT
+    names: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        consts = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr in _ENV_READERS
+                    and node.args
+                    and ast.unparse(func.value) in _ENV_TARGETS
+                ):
+                    name = _literal_or_const(node.args[0], consts)
+                    if name and _ENV_NAME_RE.match(name):
+                        names.add(name)
+            elif isinstance(node, ast.Subscript) and isinstance(
+                node.value, ast.Attribute
+            ):
+                if ast.unparse(node.value) == "os.environ":
+                    name = _literal_or_const(node.slice, consts)
+                    if name and _ENV_NAME_RE.match(name):
+                        names.add(name)
+    return names
+
+
+def discover_env_example_names(path: Path | None = None) -> set[str]:
+    """Every name declared (set or commented-out) in ``.env.example``."""
+    target = path or ENV_EXAMPLE
+    pattern = re.compile(r"^\s*#?\s*([A-Z][A-Z0-9_]*)=")
+    return {
+        match.group(1)
+        for line in target.read_text(encoding="utf-8").splitlines()
+        if (match := pattern.match(line))
+    }
+
+
+def derive_scrub_names() -> set[str]:
+    """Recompute :data:`SCRUB_ENV_NAMES` from the tree."""
+    return (discover_src_env_names() | discover_env_example_names()) - KEEP_ENV_NAMES
+
+
+def render_scrub_literal() -> str:
+    """Print a paste-ready ``SCRUB_ENV_NAMES`` body (see module docstring)."""
+    return "\n".join(f'        "{name}",' for name in sorted(derive_scrub_names()))
+
+
+# ---------------------------------------------------------------------------
+# The scrub itself
+# ---------------------------------------------------------------------------
+
+
+def exempted_names(environ: Mapping[str, str] | None = None) -> frozenset[str]:
+    """Names the caller asked to keep for this run via :data:`ALLOW_ENV`."""
+    source = os.environ if environ is None else environ
+    raw = source.get(ALLOW_ENV, "")
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def scrub_ambient_env(
+    environ: MutableMapping[str, str],
+    names: Iterable[str] = SCRUB_ENV_NAMES,
+    exempt: Iterable[str] = (),
+) -> list[str]:
+    """Delete ``names`` from ``environ``; return the names actually removed.
+
+    Returning the removed names (rather than a count or nothing) is deliberate:
+    the caller reports them in the pytest header, so a run that started from a
+    polluted shell says so out loud instead of looking like a clean run.
+    """
+    exempt_set = set(exempt)
+    removed = []
+    for name in sorted(names):
+        if name in exempt_set:
+            continue
+        if environ.pop(name, None) is not None:
+            removed.append(name)
+    return removed

--- a/tests/_env_isolation.py
+++ b/tests/_env_isolation.py
@@ -73,9 +73,10 @@ KEEP_ENV_NAMES: frozenset[str] = frozenset(
         # exports CLICKHOUSE_URI at an isolated scratch db for the clickhouse-marked
         # tier and the live argMax proof. Scrubbing these makes the gate's live
         # stage and 36 CH-reading test modules silently lose their target.
+        # (DATABASE_URL, the legacy alias, is NOT here: no lane sets it, and it
+        # feeds the same resolve_credentials_sync branch DATABASE_URI does.)
         "CLICKHOUSE_URI",
         "DATABASE_URI",
-        "DATABASE_URL",
         "POSTGRES_URI",
         "SECONDARY_DATABASE_URI",
         # --- opt-in live-Postgres tiers. test.yml's second pytest step sets these;
@@ -113,13 +114,42 @@ KEEP_ENV_NAMES: frozenset[str] = frozenset(
         # OTEL off in CI and in the gate: with it on, the exporter retries to
         # localhost:4317 on every span, flooding logs and slowing the suite.
         "OTEL_ENABLED",
-        "REDIS_URL",
         # --- owned by pytest itself.
         "PYTEST_CURRENT_TEST",
         "CI",
         "GITHUB_ACTIONS",
     }
 )
+
+# ---------------------------------------------------------------------------
+# Conditional keeps — scrubbed by default, retained only when the lane that
+# needs them announces itself. Maps the variable to the sentinel that proves
+# the lane is running.
+# ---------------------------------------------------------------------------
+CONDITIONAL_KEEP_ENV_NAMES: dict[str, str] = {
+    # REDIS_URL is a *pollutant* in the unit tier and a *requirement* in exactly
+    # one CI lane, so it can be neither plainly scrubbed nor plainly kept.
+    #
+    # Pollutant: ops/.env points it at the live shared valkey container, whose
+    # rate-limit state survives between tests in an xdist worker. With it set,
+    # `pytest tests/test_linear_provider.py` fails
+    # TestLinearClientRetry::test_429_backoff_grows_exponentially (assert 5 == 4);
+    # with it unset, 65/65 pass. The whole file, not the single test -- running
+    # that test alone passes either way, which is how CHAOS-3402 came to exclude
+    # it as a "pure concurrency flake". No unit lane supplies it: `test.yml`,
+    # `ci/run_tests.sh` and `ci/local_validate.sh` mention neither REDIS_URL nor
+    # VALKEY.
+    #
+    # Requirement: ci/run_live_backend_e2e.sh:399 exports it, and :406 runs
+    # tests/test_external_ingest_customer_push_live.py -- "the only module in
+    # this repo that needs all three live services at once", which reads
+    # REDIS_URL at import (:91) and skipifs the WHOLE MODULE without it (:96).
+    # An unconditional scrub would turn that lane's coverage into a silent skip.
+    #
+    # LIVE_E2E_BASE_URL is that lane's own sentinel, exported at
+    # run_live_backend_e2e.sh:405 -- one line after REDIS_URL, same subshell.
+    "REDIS_URL": "LIVE_E2E_BASE_URL",
+}
 
 # ---------------------------------------------------------------------------
 # Scrub list — derived; see module docstring. Regenerate with
@@ -174,6 +204,7 @@ SCRUB_ENV_NAMES: frozenset[str] = frozenset(
         "CORS_ALLOWED_ORIGINS",
         "DASHSCOPE_API_KEY",
         "DASHSCOPE_BASE_URL",
+        "DATABASE_URL",
         "DEV_HEALTH_ALLOW_PLACEHOLDER_CLICKHOUSE_URI",
         "DEV_HEALTH_SINK",
         "EMAIL_API_KEY",
@@ -285,6 +316,9 @@ SCRUB_ENV_NAMES: frozenset[str] = frozenset(
         "QWEN_API_KEY",
         "QWEN_LOCAL_MODEL",
         "QWEN_MODEL",
+        # Scrubbed by default; see CONDITIONAL_KEEP_ENV_NAMES for the one lane
+        # that gets it back.
+        "REDIS_URL",
         "REPO_PATH",
         "REPO_UUID",
         "RESEND_API_KEY",
@@ -458,6 +492,23 @@ def exempted_names(environ: Mapping[str, str] | None = None) -> frozenset[str]:
     source = os.environ if environ is None else environ
     raw = source.get(ALLOW_ENV, "")
     return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def lane_conditional_keeps(
+    environ: Mapping[str, str] | None = None,
+) -> frozenset[str]:
+    """Conditional keeps whose lane sentinel is present in ``environ``.
+
+    Reported separately from :func:`exempted_names` in the pytest header: "a
+    lane needs this" and "a human asked for this" are different claims, and a
+    run that silently conflated them could not be audited afterwards.
+    """
+    source = os.environ if environ is None else environ
+    return frozenset(
+        name
+        for name, sentinel in CONDITIONAL_KEEP_ENV_NAMES.items()
+        if sentinel in source
+    )
 
 
 def scrub_ambient_env(

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -372,7 +372,14 @@ async def test_discover_integration_not_found(client):
 
 
 @pytest.mark.asyncio
-async def test_discover_integration_sanitizes_provider_error(client, caplog):
+async def test_discover_integration_sanitizes_provider_error(
+    client, caplog, quiet_aiosqlite_logger
+):
+    # `captured` below sweeps every record from every logger, so this assertion
+    # is only meaningful when the harness's own SQL driver is not echoing the
+    # planted provider string back as a bind parameter. quiet_aiosqlite_logger
+    # states that precondition rather than inheriting it from the shell's
+    # LOG_LEVEL (CHAOS-3402); application loggers keep capturing at DEBUG.
     ac, _ = client
     secret = "ghp_" + "FAKE1234567890abcdefghijklmnopqrst"
     malicious_fragments = (

--- a/tests/api/admin/test_org_deletion.py
+++ b/tests/api/admin/test_org_deletion.py
@@ -488,8 +488,13 @@ async def test_org_deletion_dry_run_returns_contract_without_deleting(session_ma
 
 @pytest.mark.asyncio
 async def test_org_deletion_deletes_only_target_org_and_sanitizes_logs(
-    session_maker, caplog
+    session_maker, caplog, quiet_aiosqlite_logger
 ):
+    # The sanitization assertions below sweep the whole captured log, so they
+    # are only meaningful when the harness's own SQL driver is not echoing the
+    # seeded secrets back as bind parameters. quiet_aiosqlite_logger states that
+    # precondition rather than inheriting it from the shell's LOG_LEVEL
+    # (CHAOS-3402); application loggers keep capturing at DEBUG.
     async with session_maker() as session:
         org1_id, org2_id = await _seed_org_pair(session)
 

--- a/tests/api/auth/test_register.py
+++ b/tests/api/auth/test_register.py
@@ -30,6 +30,21 @@ VALID_PASSWORD = "SecurePass123!"
 VALID_EMAIL = "user@example.com"
 
 
+@pytest.fixture(autouse=True)
+def _default_auto_create_org_flag(monkeypatch):
+    """Pin ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` to its unset default (on).
+
+    With the flag falsy, ``/auth/register`` correctly returns ``org_id: null``
+    and routes the user into guided onboarding instead of creating an org --
+    designed behaviour, not a bug. ``ops/.env`` carries
+    ``AUTH_AUTO_CREATE_ORG_ON_REGISTER=false``, which is what turned four of
+    these tests red on a developer machine while CI stayed green (CHAOS-3402).
+    Tests that exercise the off path set the variable themselves, after this
+    fixture has run.
+    """
+    monkeypatch.delenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", raising=False)
+
+
 @pytest_asyncio.fixture
 async def session_maker(tmp_path: Path):
     db_path = tmp_path / "register.db"

--- a/tests/api/test_new_user_journey.py
+++ b/tests/api/test_new_user_journey.py
@@ -44,6 +44,21 @@ admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 
 VALID_PASSWORD = "SecurePass123!"
 
+
+@pytest.fixture(autouse=True)
+def _default_auto_create_org_flag(monkeypatch):
+    """Pin ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` to its unset default (on).
+
+    Every journey here starts at ``/auth/register`` and then uses the returned
+    ``org_id``. With the flag falsy that field is correctly ``null`` and the
+    user is routed into guided onboarding instead -- designed behaviour, not a
+    bug. ``ops/.env`` carries ``AUTH_AUTO_CREATE_ORG_ON_REGISTER=false``, which
+    is what turned four of these tests red on a developer machine while CI
+    stayed green (CHAOS-3402).
+    """
+    monkeypatch.delenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", raising=False)
+
+
 _TABLES = tables_of(
     User,
     Organization,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for the test suite."""
 
+import logging
 import mimetypes
 import os
 import uuid
@@ -7,6 +8,14 @@ from pathlib import Path
 
 import pytest
 from git import Repo as GitRepo
+
+from tests._env_isolation import (
+    ALLOW_ENV,
+    exempted_names,
+    scrub_ambient_env,
+)
+
+_SCRUBBED_ENV_NAMES: list[str] = []
 
 
 @pytest.fixture(autouse=True)
@@ -76,6 +85,61 @@ def test_file(repo_path):
     return os.path.join(repo_path, "README.md")
 
 
+@pytest.fixture
+def quiet_aiosqlite_logger():
+    """Stop the test harness's own SQL driver from echoing bind parameters.
+
+    ``aiosqlite`` logs every operation — including INSERT statements with their
+    bind parameters — at DEBUG. Tests that assert "this secret never reaches the
+    logs" by sweeping every captured record therefore rediscover their own
+    planted secret whenever the root level is DEBUG, even though production never
+    runs on aiosqlite (it is a test-fixture-only driver, see ops/AGENTS.md) and
+    the code under test never logged it.
+
+    ``LOG_LEVEL`` is scrubbed suite-wide (CHAOS-3402), so this is the belt to
+    that braces: it states the precondition at the tests that depend on it, and
+    keeps holding if a future run configures logging some other way. It narrows
+    only the driver, so a genuine DEBUG-level leak from application code is still
+    captured and still fails the assertion.
+    """
+    driver_logger = logging.getLogger("aiosqlite")
+    previous = driver_logger.level
+    driver_logger.setLevel(logging.INFO)
+    try:
+        yield
+    finally:
+        driver_logger.setLevel(previous)
+
+
 def pytest_configure(config):
     # Ensure TypeScript files are treated as text, not video/mp2t.
     mimetypes.add_type("text/x-typescript", ".ts")
+
+    # CHAOS-3402: make the process environment CI-equivalent before any test
+    # module is imported. A developer shell carries direnv-loaded `ops/.env`,
+    # so tests whose intent is "this variable is ABSENT" would otherwise see a
+    # real-looking-but-wrong value and take a different code path. Scrubbing
+    # here rather than in an autouse fixture also covers import-time reads and
+    # subprocesses that inherit via `os.environ.copy()`. Rationale and the
+    # keep-list justification live in tests/_env_isolation.py.
+    _SCRUBBED_ENV_NAMES[:] = scrub_ambient_env(os.environ, exempt=exempted_names())
+
+
+def pytest_report_header(config):
+    """Say out loud what the shell was carrying.
+
+    A scrub that silently succeeded is indistinguishable from a clean shell, and
+    an exemption that silently applied is indistinguishable from a scrubbed run.
+    Both are reported so neither can be mistaken for the other.
+    """
+    lines = []
+    if _SCRUBBED_ENV_NAMES:
+        lines.append(
+            "ambient env scrubbed (CHAOS-3402): " + ", ".join(_SCRUBBED_ENV_NAMES)
+        )
+    exempt = exempted_names()
+    if exempt:
+        lines.append(
+            f"ambient env NOT scrubbed via {ALLOW_ENV}: " + ", ".join(sorted(exempt))
+        )
+    return lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,21 @@ from git import Repo as GitRepo
 
 from tests._env_isolation import (
     ALLOW_ENV,
+    SCRUB_ENV_NAMES,
     exempted_names,
+    lane_conditional_keeps,
     scrub_ambient_env,
 )
 
 _SCRUBBED_ENV_NAMES: list[str] = []
+_KEPT_ENV_NAMES: list[str] = []
+#: Scrub-list names still present in ``os.environ`` immediately AFTER the scrub.
+#: Must stay empty. Snapshotted at configure time rather than read live at
+#: assertion time because tests legitimately set some of these during the run
+#: (``tests/test_core_extraction.py`` writes SETTINGS_ENCRYPTION_KEY and never
+#: cleans up), and a live read would blame the scrub for another test's leftovers.
+_POST_SCRUB_RESIDUE: list[str] = []
+_SCRUB_RAN = False
 
 
 @pytest.fixture(autouse=True)
@@ -122,7 +132,15 @@ def pytest_configure(config):
     # here rather than in an autouse fixture also covers import-time reads and
     # subprocesses that inherit via `os.environ.copy()`. Rationale and the
     # keep-list justification live in tests/_env_isolation.py.
-    _SCRUBBED_ENV_NAMES[:] = scrub_ambient_env(os.environ, exempt=exempted_names())
+    global _SCRUB_RAN
+
+    kept = exempted_names() | lane_conditional_keeps()
+    _KEPT_ENV_NAMES[:] = sorted(kept)
+    _SCRUBBED_ENV_NAMES[:] = scrub_ambient_env(os.environ, exempt=kept)
+    _POST_SCRUB_RESIDUE[:] = sorted(
+        name for name in SCRUB_ENV_NAMES if name not in kept and name in os.environ
+    )
+    _SCRUB_RAN = True
 
 
 def pytest_report_header(config):
@@ -141,5 +159,10 @@ def pytest_report_header(config):
     if exempt:
         lines.append(
             f"ambient env NOT scrubbed via {ALLOW_ENV}: " + ", ".join(sorted(exempt))
+        )
+    lane_kept = lane_conditional_keeps()
+    if lane_kept:
+        lines.append(
+            "ambient env kept for an announced lane: " + ", ".join(sorted(lane_kept))
         )
     return lines

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -15,12 +15,22 @@ import sys
 import pytest
 
 # Env vars that satisfy preflight requirements; cleared for "missing" cases.
+# The child inherits os.environ, so anything the parent shell carries and this
+# list omits reaches the CLI as real configuration. `admin licenses create` is
+# asserted to report LICENSE_PRIVATE_KEY as the missing input, which only holds
+# when no signing key is configured -- a developer shell carries a real one from
+# ops/.env, and a 64-byte key where a 32-byte seed is required made the command
+# fail with "Invalid private key" instead (CHAOS-3402).
 _CONFIG_ENV = (
     "CLICKHOUSE_URI",
     "POSTGRES_URI",
     "DATABASE_URI",
     "DATABASE_URL",
     "ORG_ID",
+    "LICENSE_KEY",
+    "LICENSE_PRIVATE_KEY",
+    "LICENSE_PUBLIC_KEY",
+    "LICENSE_SECRET_KEY",
 )
 
 

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -27,6 +27,31 @@ from dev_health_ops.credentials import (
     resolve_credentials_sync,
 )
 
+_GITHUB_APP_ENV_VARS = (
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+)
+
+
+def _clear_github_app_env() -> None:
+    """State "no GitHub App is configured" instead of trusting the shell.
+
+    The env-credential path switches to App auth whenever ``GITHUB_APP_*`` is
+    present and then opens the key file directly, so a stray
+    ``GITHUB_APP_PRIVATE_KEY_PATH`` -- ``ops/.env`` carries one, as a RELATIVE
+    path that resolves against the CWD -- turns "no credentials" and "PAT only"
+    into a different code path entirely (CHAOS-3402). The suite scrubs those
+    variables process-wide; this makes the precondition local and legible.
+
+    Call inside a ``patch.dict(os.environ, ...)`` block: the pops are reverted
+    when the block exits.
+    """
+    for name in _GITHUB_APP_ENV_VARS:
+        os.environ.pop(name, None)
+
+
 # ---------------------------------------------------------------------------
 # Credential Type Validation Tests
 # ---------------------------------------------------------------------------
@@ -348,6 +373,7 @@ class TestCredentialResolver:
             mock_svc_class.return_value = mock_svc
 
             with patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_env_token"}, clear=False):
+                _clear_github_app_env()
                 result = await resolver.resolve("github")
 
                 assert isinstance(result, GitHubCredentials)
@@ -393,6 +419,7 @@ class TestCredentialResolver:
             with patch.dict(os.environ, env_patch, clear=False):
                 os.environ.pop("GITHUB_TOKEN", None)
                 os.environ.pop("GITHUB_URL", None)
+                _clear_github_app_env()
 
                 with pytest.raises(CredentialResolutionError) as exc_info:
                     await resolver.resolve("github")
@@ -445,6 +472,7 @@ class TestCredentialResolver:
             with patch.dict(
                 os.environ, {"GITHUB_TOKEN": "ghp_fallback_token"}, clear=False
             ):
+                _clear_github_app_env()
                 result = await resolver.resolve("github")
 
                 assert isinstance(result, GitHubCredentials)
@@ -537,6 +565,7 @@ class TestResolveCredentialsSync:
         with patch.dict(os.environ, env_patch, clear=False):
             os.environ.pop("DATABASE_URI", None)
             os.environ.pop("DATABASE_URL", None)
+            _clear_github_app_env()
 
             result = resolve_credentials_sync("github")
 
@@ -556,6 +585,7 @@ class TestResolveCredentialsSync:
             os.environ.pop("DATABASE_URI", None)
             os.environ.pop("DATABASE_URL", None)
             os.environ.pop("GITHUB_TOKEN", None)
+            _clear_github_app_env()
 
             with pytest.raises(CredentialResolutionError) as exc_info:
                 resolve_credentials_sync("github")

--- a/tests/test_env_isolation_contract.py
+++ b/tests/test_env_isolation_contract.py
@@ -1,0 +1,148 @@
+"""Contract tests for the ambient-environment scrub (CHAOS-3402).
+
+The scrub is a guard, and a guard that cannot fail reads as coverage while
+covering nothing. These tests pin four separate ways it could rot:
+
+* the derivation stops finding anything (a rename of ``src/`` or ``.env.example``
+  would otherwise silently produce an empty scrub list),
+* ``src/`` starts reading a variable nobody added to the checked-in list,
+* the keep-list and the scrub-list start disagreeing, or
+* ``pytest_configure`` stops running the scrub at all.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests import _env_isolation
+from tests._env_isolation import (
+    KEEP_ENV_NAMES,
+    SCRUB_ENV_NAMES,
+    derive_scrub_names,
+    discover_env_example_names,
+    discover_src_env_names,
+    exempted_names,
+    scrub_ambient_env,
+)
+
+# The four ambient variables that were observed flipping code paths in fifteen
+# tests across five files. Each is here because a run with it set was watched
+# failing and a run with it absent was watched passing -- not because it looked
+# risky.
+OBSERVED_ROOT_CAUSES = (
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "AUTH_AUTO_CREATE_ORG_ON_REGISTER",
+    "LOG_LEVEL",
+    "LICENSE_PRIVATE_KEY",
+)
+
+# Scrubbing any of these would break the lane that supplies it: ci/local_validate.sh
+# points CLICKHOUSE_URI at a per-worktree scratch database for the live stage, and
+# DEV_HEALTH_POSTGRES_TEST_URI gates the opt-in live-Postgres tier -- a scrub there
+# would turn a whole tier into silent skips rather than a visible failure.
+LANE_CRITICAL_KEEPS = (
+    "CLICKHOUSE_URI",
+    "DATABASE_URI",
+    "DEV_HEALTH_POSTGRES_TEST_URI",
+)
+
+
+def test_discovery_finds_env_reads_in_src():
+    """An empty scan must fail, not quietly produce an empty scrub list."""
+    names = discover_src_env_names()
+    assert len(names) > 100, f"src/ env-var scan found only {len(names)} names"
+    # A literal read and a module-constant read: the constant form is what
+    # AUTH_AUTO_CREATE_ORG_ON_REGISTER uses, and a scanner that only handled
+    # literals would miss the cause of eight of the fifteen failures.
+    assert "LOG_LEVEL" in names
+    assert "AUTH_AUTO_CREATE_ORG_ON_REGISTER" in names
+
+
+def test_discovery_finds_declarations_in_env_example():
+    names = discover_env_example_names()
+    assert len(names) > 50, f".env.example scan found only {len(names)} names"
+    assert "CLICKHOUSE_URI" in names
+
+
+def test_checked_in_scrub_list_matches_derivation():
+    derived = derive_scrub_names()
+    missing = sorted(derived - SCRUB_ENV_NAMES)
+    stale = sorted(SCRUB_ENV_NAMES - derived)
+    assert not missing and not stale, (
+        "SCRUB_ENV_NAMES has drifted from the tree.\n"
+        f"  add to the list:    {missing}\n"
+        f"  remove from list:   {stale}\n"
+        "Regenerate with _env_isolation.render_scrub_literal(), or add the name "
+        "to KEEP_ENV_NAMES with the CI lane or test tier that supplies it."
+    )
+
+
+def test_keep_and_scrub_lists_are_disjoint():
+    assert not (KEEP_ENV_NAMES & SCRUB_ENV_NAMES)
+
+
+@pytest.mark.parametrize("name", OBSERVED_ROOT_CAUSES)
+def test_observed_root_causes_are_scrubbed(name):
+    assert name in SCRUB_ENV_NAMES
+
+
+@pytest.mark.parametrize("name", LANE_CRITICAL_KEEPS)
+def test_lane_critical_variables_are_never_scrubbed(name):
+    assert name in KEEP_ENV_NAMES
+    assert name not in SCRUB_ENV_NAMES
+
+
+def test_scrub_removes_offenders_and_preserves_lane_variables():
+    environ = {
+        "GITHUB_APP_PRIVATE_KEY_PATH": "./github-app-local.pem",
+        "AUTH_AUTO_CREATE_ORG_ON_REGISTER": "false",
+        "LOG_LEVEL": "debug",
+        "LICENSE_PRIVATE_KEY": "x" * 88,
+        "CLICKHOUSE_URI": "clickhouse://ch:ch@localhost:8123/ci_local_validate",
+        "DEV_HEALTH_POSTGRES_TEST_URI": "postgresql+asyncpg://u:p@localhost/test",
+        "PATH": "/usr/bin",
+    }
+
+    removed = scrub_ambient_env(environ)
+
+    assert sorted(removed) == sorted(OBSERVED_ROOT_CAUSES)
+    assert environ == {
+        "CLICKHOUSE_URI": "clickhouse://ch:ch@localhost:8123/ci_local_validate",
+        "DEV_HEALTH_POSTGRES_TEST_URI": "postgresql+asyncpg://u:p@localhost/test",
+        "PATH": "/usr/bin",
+    }
+
+
+def test_scrub_honours_the_debug_exemption():
+    environ = {"LOG_LEVEL": "debug", "LICENSE_PRIVATE_KEY": "x"}
+
+    removed = scrub_ambient_env(environ, exempt={"LOG_LEVEL"})
+
+    assert removed == ["LICENSE_PRIVATE_KEY"]
+    assert environ == {"LOG_LEVEL": "debug"}
+
+
+def test_exempted_names_parses_the_allow_list():
+    assert exempted_names({_env_isolation.ALLOW_ENV: " LOG_LEVEL , LOG_JSON ,"}) == {
+        "LOG_LEVEL",
+        "LOG_JSON",
+    }
+    assert exempted_names({}) == frozenset()
+
+
+def test_scrub_actually_ran_in_this_process():
+    """The wiring, not just the data.
+
+    If ``pytest_configure`` stops calling the scrub, every other test in this
+    module still passes -- they only inspect lists. This one fails.
+    """
+    exempt = exempted_names()
+    leaked = sorted(
+        name for name in SCRUB_ENV_NAMES if name not in exempt and name in os.environ
+    )
+    assert not leaked, (
+        f"ambient environment still carries {leaked} during the test run; "
+        "the conftest scrub did not run"
+    )

--- a/tests/test_env_isolation_contract.py
+++ b/tests/test_env_isolation_contract.py
@@ -12,30 +12,35 @@ covering nothing. These tests pin four separate ways it could rot:
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
-from tests import _env_isolation
+from tests import _env_isolation, conftest
 from tests._env_isolation import (
+    CONDITIONAL_KEEP_ENV_NAMES,
     KEEP_ENV_NAMES,
     SCRUB_ENV_NAMES,
     derive_scrub_names,
     discover_env_example_names,
     discover_src_env_names,
     exempted_names,
+    lane_conditional_keeps,
     scrub_ambient_env,
 )
 
-# The four ambient variables that were observed flipping code paths in fifteen
-# tests across five files. Each is here because a run with it set was watched
-# failing and a run with it absent was watched passing -- not because it looked
-# risky.
+# The ambient variables that were observed flipping code paths, across six test
+# files. Each is here because a run with it set was watched failing and a run
+# with it absent was watched passing -- not because it looked risky.
 OBSERVED_ROOT_CAUSES = (
     "GITHUB_APP_PRIVATE_KEY_PATH",
     "AUTH_AUTO_CREATE_ORG_ON_REGISTER",
     "LOG_LEVEL",
     "LICENSE_PRIVATE_KEY",
+    # Fifth, and initially excluded by CHAOS-3402 as a "pure concurrency flake"
+    # because it passes when run alone. It does not pass alongside its siblings:
+    # ops/.env points REDIS_URL at the live shared valkey container, whose
+    # rate-limit state survives between tests. Whole file, populated shell:
+    # 1 failed (assert 5 == 4); same file with REDIS_URL unset: 65 passed.
+    "REDIS_URL",
 )
 
 # Scrubbing any of these would break the lane that supplies it: ci/local_validate.sh
@@ -100,12 +105,13 @@ def test_scrub_removes_offenders_and_preserves_lane_variables():
         "AUTH_AUTO_CREATE_ORG_ON_REGISTER": "false",
         "LOG_LEVEL": "debug",
         "LICENSE_PRIVATE_KEY": "x" * 88,
+        "REDIS_URL": "redis://localhost:6379/0",
         "CLICKHOUSE_URI": "clickhouse://ch:ch@localhost:8123/ci_local_validate",
         "DEV_HEALTH_POSTGRES_TEST_URI": "postgresql+asyncpg://u:p@localhost/test",
         "PATH": "/usr/bin",
     }
 
-    removed = scrub_ambient_env(environ)
+    removed = scrub_ambient_env(environ, exempt=lane_conditional_keeps(environ))
 
     assert sorted(removed) == sorted(OBSERVED_ROOT_CAUSES)
     assert environ == {
@@ -113,6 +119,29 @@ def test_scrub_removes_offenders_and_preserves_lane_variables():
         "DEV_HEALTH_POSTGRES_TEST_URI": "postgresql+asyncpg://u:p@localhost/test",
         "PATH": "/usr/bin",
     }
+
+
+def test_conditional_keep_returns_redis_url_to_the_live_e2e_lane():
+    """Both directions, because only the pair proves the condition does anything.
+
+    ci/run_live_backend_e2e.sh exports REDIS_URL and LIVE_E2E_BASE_URL together,
+    then runs the one module that skipifs itself without REDIS_URL. Scrubbing it
+    there would convert that lane's coverage into a silent skip.
+    """
+    assert CONDITIONAL_KEEP_ENV_NAMES["REDIS_URL"] == "LIVE_E2E_BASE_URL"
+
+    unit_tier = {"REDIS_URL": "redis://localhost:6379/0"}
+    assert scrub_ambient_env(unit_tier, exempt=lane_conditional_keeps(unit_tier)) == [
+        "REDIS_URL"
+    ]
+    assert unit_tier == {}
+
+    live_lane = {
+        "REDIS_URL": "redis://localhost:6379/0",
+        "LIVE_E2E_BASE_URL": "http://127.0.0.1:8000",
+    }
+    assert scrub_ambient_env(live_lane, exempt=lane_conditional_keeps(live_lane)) == []
+    assert live_lane["REDIS_URL"] == "redis://localhost:6379/0"
 
 
 def test_scrub_honours_the_debug_exemption():
@@ -137,12 +166,15 @@ def test_scrub_actually_ran_in_this_process():
 
     If ``pytest_configure`` stops calling the scrub, every other test in this
     module still passes -- they only inspect lists. This one fails.
+
+    It asserts the residue snapshotted immediately after the scrub rather than a
+    live read of ``os.environ``: tests legitimately write scrub-listed names
+    during a run and do not always clean up (``tests/test_core_extraction.py:19``
+    sets SETTINGS_ENCRYPTION_KEY unconditionally), and under ``--dist loadscope``
+    such a leftover lands on this worker. A live read blamed the scrub for
+    another test's leftover and failed the whole-suite run.
     """
-    exempt = exempted_names()
-    leaked = sorted(
-        name for name in SCRUB_ENV_NAMES if name not in exempt and name in os.environ
-    )
-    assert not leaked, (
-        f"ambient environment still carries {leaked} during the test run; "
-        "the conftest scrub did not run"
+    assert conftest._SCRUB_RAN, "conftest.pytest_configure did not run the scrub"
+    assert not conftest._POST_SCRUB_RESIDUE, (
+        f"scrub-listed names survived the scrub: {conftest._POST_SCRUB_RESIDUE}"
     )


### PR DESCRIPTION
## CHAOS-3402 — ops unit tests couple to ambient environment

15 tests across 6 files passed in CI and failed on any developer machine with direnv-loaded `ops/.env`. CI runners start bare and set 7 variables; an ops shell carries ~65. Tests whose intent is "this variable is ABSENT" saw a real-looking-but-wrong value and took a different code path.

### Acceptance evidence

```
set -a; . ops/.env; set +a
pytest tests -m "not benchmark and not clickhouse" \
  --ignore=tests/test_connectors_integration.py --ignore=tests/test_private_repo_access.py \
  --ignore=tests/test_0066_celery_river_cutover_postgres.py \
  --ignore=tests/test_chaos_3337_source_class_postgres_migration.py \
  --ignore=tests/api/admin/test_add_member_visibility.py \
  -n 4 --dist loadscope
```
**`12097 passed, 90 skipped, 1 xfailed, 0 failed` in 158.57s.**

Direct pytest from a **fully populated `ops/.env` shell** — no `env -u`, no gate, no known-fail allowance list. That is what CHAOS-3402 asks for, and it is the run that distinguishes this change from the gate-level shell neutralization landing separately: a gate that unsets the same variables would go green with this change entirely absent.

### Root causes — each observed alone, from an `env -i` base

| Variable | Tests it fails, alone |
| --- | --- |
| `GITHUB_APP_PRIVATE_KEY_PATH` (relative path) | 4 × `test_credential_resolver.py` |
| `AUTH_AUTO_CREATE_ORG_ON_REGISTER=false` | 4 × `test_register.py` + 4 × `test_new_user_journey.py` |
| `LOG_LEVEL=debug` | `test_org_deletion.py::…sanitizes_logs`, `test_integrations.py::…sanitizes_provider_error` |
| `LICENSE_PRIVATE_KEY` (64-byte key, 32-byte seed required) | `test_cli_preflight.py::test_admin_license_create_is_not_a_postgres_preflight_false_positive` |
| `REDIS_URL` (live shared valkey) | `test_linear_provider.py::TestLinearClientRetry::test_429_backoff_grows_exponentially` |

Each attributed by adding **one** variable to a clean base, never by subtracting one from a populated shell — a subtractive result cannot distinguish "this variable causes it" from "this variable plus everything else still present causes it".

### The fix

`tests/_env_isolation.py` derives `SCRUB_ENV_NAMES` mechanically rather than by hand:

> (every env var name read by `src/dev_health_ops/**` via `os.getenv` / `os.environ.get` / `os.environ[...]`) ∪ (every name declared in `.env.example`) − `KEEP_ENV_NAMES`

The AST scan resolves **module-level string constants**, not just literals: `api/auth/config.py:20` reads `os.getenv(AUTH_AUTO_CREATE_ORG_ENV)`, and a literal-only scanner would have missed the cause of 8 of the 15 failures. It also handles `os.environ["X"]` subscript access, the form most likely to raise rather than default.

`tests/conftest.py` applies it in `pytest_configure` — before any test module is imported, so import-time reads and subprocesses inheriting via `os.environ.copy()` are covered too. Scrubbed and exempted names are reported in the pytest header, so a run that started from a polluted shell says so rather than looking clean.

**Never scrubbed**, because scrubbing them breaks the lane that supplies them:
- **`CLICKHOUSE_URI`** — `ci/local_validate.sh` exports it at a per-worktree scratch database for the live stage and the argMax proof; `test.yml:116` sets it; 36 test modules read it.
- **`DATABASE_URI`** — `test.yml:115`.
- **`DEV_HEALTH_POSTGRES_TEST_URI`** — `test.yml:153`, gates the opt-in live-Postgres tier. Scrubbing it would convert a whole tier into silent skips rather than a visible failure.

Every other keep-list entry is justified in-file against the same test: which CI lane, `ci/` script, or test opt-in gate actually sets it. `DATABASE_URL` failed that test and was moved to the scrub list — no lane sets it, and it feeds the same `resolve_credentials_sync` branch (`resolver.py:460`) that `DATABASE_URI` does.

**`REDIS_URL` is a conditional keep.** It is a pollutant in the unit tier and a requirement in exactly one lane, so it can be neither plainly scrubbed nor plainly kept:
- Pollutant: `ops/.env` points it at the live shared valkey container, whose rate-limit state survives between tests in an xdist worker. Whole file: `pytest tests/test_linear_provider.py` → 1 failed; `env -u REDIS_URL` → 65 passed. Running that test *alone* passes either way, which is how it came to be excluded as a "pure concurrency flake".
- Requirement: `ci/run_live_backend_e2e.sh:399` exports it and `:406` runs `tests/test_external_ingest_customer_push_live.py`, the only module needing all three live services at once, which reads `REDIS_URL` at import (`:91`) and `skipif`s the **whole module** without it (`:96`). An unconditional scrub converts that lane's coverage into a silent skip.

So it is scrubbed by default and returned only when `LIVE_E2E_BASE_URL` is present — that lane's own sentinel, exported one line later in the same subshell (`:405`). Both directions are pinned by a test.

Per-test preconditions are stated locally as well, so each affected test declares its own "this variable is absent" instead of trusting the shell. **Both layers were observed closing the gap independently**: with the class scrub exempted for all four original offenders via `DEV_HEALTH_TEST_ENV_ALLOW`, the 15 tests still pass from a fully populated shell.

### Regression evidence

Full CI unit tier run twice from the same populated shell, `HEAD` vs `tests/` reverted to `origin/main`:

| | result |
| --- | --- |
| BEFORE | **18 failed**, 12062 passed |
| AFTER | **3 failed**, 12092 passed |

Exactly **one regression**, and it was this PR's own new guard test (over-strict; since rewritten). **No pre-existing test regressed, so no scrub-list entry is wrong.** The three AFTER failures were that guard, the `REDIS_URL` backoff test, and a missing `mkdocs-material` in the local venv — all three since resolved.

### Guard cannot rot

`tests/test_env_isolation_contract.py` pins four failure modes: an empty derivation fails loudly; checked-in-vs-derived drift fails with the exact diff and the regeneration command; the lane-critical keeps are asserted un-scrubbed; and one test asserts the scrub **actually ran in this process**, not merely that the list looks right.

That last one was re-proved able to fail: replacing the scrub call with a no-op makes it report 43 surviving names and go red. Restore verified by content digest and `grep -c MUTATION` → 0, not by a build and not by `git status`.

### Two corrections to the ticket

**1. The `uuid.UUID()` TypeError is in test code, not a production defect.** The ticket flagged it as possibly "a leaked or empty-string env var feeding an org/user id", reachable in production from a misconfigured deployment. It is not.

- `api/auth/config.py:11-28` — `auth_auto_create_org_on_register(default=True)`; `_FALSY` includes `"false"`.
- `api/auth/routers/register.py:117` sets `org_id = None`; `:118` gates org creation on the flag; `:152-156` logs "registered without organization for first-run onboarding". HTTP 201 with `org_id: null` is **designed behaviour** (CHAOS-2670/2671/2682) — the verified user is routed into guided onboarding.
- The `TypeError` is at `tests/api/auth/test_register.py:149`, `uuid.UUID(response.json()["org_id"])` on a legitimately-null field. Application code never does this: every id crossing that boundary goes through `_require_uuid` (`api/auth/routers/common.py:61-64`, called at `register.py:115` and `:131`), which type-guards. `grep -rn "UUID(.*getenv\|UUID(.*environ" src/` returns nothing.

No follow-up ticket needed; ambient env exposed a configuration path, not a defect.

**2. `test_429_backoff_grows_exponentially` was excluded on wrong reasoning.** The ticket ruled it "not env-related… passes serially with ambient env still present, which is what rules env out." The serial pass was an artifact of running it too narrowly — it is deterministic and env-caused, evidence above.

### CHAOS-3405

**Subsumed — all 14 explained.** 3405's 14 are these 15 minus `test_cli_preflight.py`; each is attributed to exactly one ambient variable, and all 14 pass from a fully populated `.env` shell with this change. Its standing instruction to treat those 14 as known-machine-local **must be retired** — it currently tells every local gate run to ignore 14 real signals.

### Not claimed

`tests/test_budget_guard_cooldown.py::test_budget_wall_clock_cap_exhausts_below_the_count_cap` failed BEFORE and passed AFTER, but **is not claimed as fixed by this change**. It does not reproduce in isolation with or without the ambient `SYNC_BUDGET_*` values (52 passed either way), and it does wall-clock arithmetic with `datetime.now()`. Most likely load-sensitive under 4-worker contention. Unattributed.

### Related, not fixed here

Chasing the credential-resolver mechanism surfaced a real production defect, filed as **CHAOS-3442**. When `GITHUB_APP_PRIVATE_KEY_PATH` points at an unreadable file, `resolver.py:234` opens it unguarded and the caller at `:213` catches only `(ValueError, TypeError)`, so `FileNotFoundError` escapes `CredentialResolver.resolve()` as a non-domain exception carrying the filesystem path; the sync twin at `:558` catches `OSError` and returns `None`, silently discarding a valid `GITHUB_TOKEN` behind a misleading "no github environment credentials found". Both paths prefer App auth whenever a path is merely present, even when a token is configured. Reproduced standalone; out of scope for this PR.

### Validation

- **Direct pytest, populated `ops/.env` shell** (the acceptance run): 12097 passed, 0 failed.
- **`ci/local_validate.sh`**: lint, `ruff check`, `mypy`, CH scratch provisioning, CH migrate, and the FULL unit suite (12097 passed, 102 skipped, 1 xfailed) all green. The final `argMax live-exec proof` stage **did not return a verdict** — it wedged on a quiet, single-instance box with no ClickHouse query in flight and no Python child (CHAOS-3362). Recorded as *not obtained*, not as a pass and not as a failure. That stage is a direct Python script with no pytest entry point, so a `pytest_configure` scrub cannot reach it, and this diff touches only `tests/`.

SCREENSHOT-WAIVER: backend test-infrastructure change, no rendered surface.
