### PR TITLE
CHAOS-3389: QUA shadow mode — bounded structured-output resolution shadow, flag-gated, zero live-path effect

### DIFF
--- a/src/dev_health_ops/alembic/versions/0086_add_dev_run_qua_shadow.py
+++ b/src/dev_health_ops/alembic/versions/0086_add_dev_run_qua_shadow.py
@@ -1,0 +1,106 @@
+"""Add dev_run_qua_shadow (CHAOS-3389 Question Understanding Agent shadow mode).
+
+Revision ID: 0086
+Revises: 0085
+Create Date: 2026-08-05 00:00:00
+
+Additive only: one new table, FK'd to ``dev_runs`` exactly like every other
+Wave 3.1 per-run audit table (0074). Audit-only -- nothing in ``api/dev``
+reads this table back to affect a live run; see
+``dev_health_ops.api.dev.qua_shadow`` and
+``dev_health_ops.models.dev_persistence.DevRunQuaShadow`` for the shape and
+the non-influence guarantee.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0086"
+down_revision: str | None = "0085"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_UUID = postgresql.UUID(as_uuid=True)
+_JSON = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+_STATUS_VALUES = (
+    "'evaluated', 'skipped_disabled', 'skipped_no_provider', "
+    "'skipped_no_mentions', 'skipped_budget_exhausted', "
+    "'skipped_catalog_unavailable', 'skipped_timeout', "
+    "'skipped_provider_error', 'skipped_unexpected_decision', "
+    "'skipped_invalid_output'"
+)
+
+
+def _owner_fk() -> sa.ForeignKeyConstraint:
+    return sa.ForeignKeyConstraint(
+        ["run_id", "org_id", "user_id"],
+        ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+        name="fk_dev_run_qua_shadow_run_owner",
+        ondelete="CASCADE",
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dev_run_qua_shadow",
+        sa.Column("id", _UUID, nullable=False),
+        sa.Column("run_id", _UUID, nullable=False),
+        sa.Column("org_id", _UUID, nullable=False),
+        sa.Column("user_id", _UUID, nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("deterministic_decision", sa.String(length=16), nullable=False),
+        sa.Column("cardinality_corroborated", sa.Boolean(), nullable=True),
+        sa.Column("latency_ms", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("model_fingerprint", sa.String(length=64), nullable=True),
+        sa.Column("payload", _JSON, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.CheckConstraint(
+            f"status IN ({_STATUS_VALUES})", name="ck_dev_run_qua_shadow_status"
+        ),
+        sa.CheckConstraint(
+            "deterministic_decision IN ('proceed', 'terminate')",
+            name="ck_dev_run_qua_shadow_deterministic_decision",
+        ),
+        _owner_fk(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_dev_run_qua_shadow_run"),
+    )
+    op.create_index(
+        "ix_dev_run_qua_shadow_owner_run",
+        "dev_run_qua_shadow",
+        ["org_id", "user_id", "run_id"],
+    )
+
+
+def downgrade() -> None:
+    # Codex adversarial review round 1 (HIGH, confirmed): an unconditional
+    # drop here would silently erase real, already-persisted QUA shadow
+    # evidence on a routine downgrade -- exactly the failure mode 0074's own
+    # downgrade already refuses to allow for its Wave 3.1 tables. Same
+    # guard, same posture: refuse (raise) rather than discard data. This
+    # migration adds no other schema, so -- unlike 0074, which had to check
+    # both a tagging column and several sibling tables -- one row-count
+    # check on this table alone is the whole guard.
+    bind = op.get_bind()
+    if bind.dialect.has_table(bind, "dev_run_qua_shadow"):
+        row_count = bind.execute(
+            sa.select(sa.func.count()).select_from(sa.table("dev_run_qua_shadow"))
+        ).scalar()
+        if row_count:
+            raise RuntimeError(
+                f"refusing to downgrade 0086: dev_run_qua_shadow has "
+                f"{row_count} row(s); this downgrade is for pre-release "
+                "rehearsal only"
+            )
+    op.drop_table("dev_run_qua_shadow")

--- a/src/dev_health_ops/api/dev/contracts_v2/__init__.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/__init__.py
@@ -91,6 +91,12 @@ from .plan import (
     DevSourceRequirement,
     PlanRegistryID,
 )
+from .question_understanding import (
+    QUESTION_UNDERSTANDING_SCHEMA_VERSION,
+    DevQuestionUnderstanding,
+    DevQuestionUnderstandingMention,
+    QUAOutcome,
+)
 from .result import (
     DevInvestigationResult,
     DevObservedChangeV2,
@@ -157,6 +163,14 @@ from .validators import (
 #: -- the frame only ever carries them as opaque ``OpaqueID`` pointers
 #: (``finding_refs``/``deficiency_refs``, ``frame.py``), so they do not
 #: belong in this dict.
+#:
+#: ``dev_question_understanding.v1`` (CHAOS-3389, ``question_understanding``
+#: module) is excluded for the same reason, one layer stronger: it never
+#: reaches the frame or any API surface at all, only a Postgres shadow-audit
+#: row (``qua_shadow.QUAShadowRecord``), and its models subclass plain
+#: ``BaseModel`` rather than ``ContractModelV2`` specifically so the
+#: ``ContractModelV2.__subclasses__()`` reflection sweep this dict backs
+#: (``test_round4_every_v2_identifier_is_classified``) never sees it either.
 #:
 #: They ARE imported directly above (mirroring the ``health_rules`` import
 #: a few lines up), which is the load-bearing half of "registered": the
@@ -257,6 +271,8 @@ __all__ = [
     "NO_ANSWER_ANSWER_FIELD_POLICY",
     "NO_ANSWER_FRAME_FIELD_POLICY",
     "NO_ANSWER_OUTCOMES",
+    "QUESTION_UNDERSTANDING_SCHEMA_VERSION",
+    "QUAOutcome",
     "NarrativeFailureCode",
     "NoAnswerFieldPolicy",
     "OperationalDeficiencyInventory",
@@ -264,6 +280,8 @@ __all__ = [
     "ProgressStateV2",
     "PublicOutcome",
     "QuestionIntentID",
+    "DevQuestionUnderstanding",
+    "DevQuestionUnderstandingMention",
     "ResolutionOutcome",
     "RuleApplicability",
     "RuleDirection",

--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -1,0 +1,131 @@
+"""``dev_question_understanding.v1`` -- the Question Understanding Agent's
+structured-output contract (CHAOS-3389 shadow phase).
+
+This is deliberately NOT one of the frontend-facing v2 contracts (it never
+reaches ``dev_answer_frame.v1`` or any API response): it is the shape one
+QUA shadow call's model output is validated against before being folded into
+a ``qua_shadow.QUAShadowRecord`` and persisted as a Postgres audit row. It
+lives in ``contracts_v2`` anyway, alongside ``dev_resolution_ledger.v1`` and
+``dev_subject_mention.v1``, because the platform spec (CHAOS-3389 comment
+6fa38d88) treats it as a first-class pinned schema id and the closed
+vocabularies it reuses (``QuestionIntentID``, ``Cardinality``) are defined
+here.
+
+**The never-widen invariant is NOT enforced by this static model.** This
+class only checks *shape*: is ``selected_candidate_index`` an int or null,
+is ``confidence`` a probability, is ``outcome`` one of three closed values.
+Whether a given index actually falls within the specific shortlist shown for
+that mention is a **per-call** fact this static schema cannot know (two
+different questions show different candidate counts) -- that bound is
+enforced two other ways, both in ``qua_shadow.py``:
+
+1. The wire-level JSON Schema handed to the provider (``_response_schema``)
+   bounds every index field to ``[0, total_candidates - 1]`` for THIS call,
+   built fresh per call. A provider honoring the schema cannot even
+   *generate* an out-of-range integer, and when there are zero authorized
+   candidates the bound is ``[0, -1]`` -- empty, so no integer satisfies it.
+2. ``_verify`` re-checks every index against the exact per-mention slice
+   after parsing, in case a provider does not honor the schema strictly.
+   A violation there marks that one mention's proposal ``rejected``, never
+   the whole record, and it is never a live-path decision either way --
+   shadow mode never acts on any of this.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
+
+from .base import Cardinality, QuestionIntentID, ShortText
+
+__all__ = [
+    "QUESTION_UNDERSTANDING_SCHEMA_VERSION",
+    "DevQuestionUnderstanding",
+    "DevQuestionUnderstandingMention",
+    "QUAOutcome",
+]
+
+QUESTION_UNDERSTANDING_SCHEMA_VERSION = "dev_question_understanding.v1"
+
+#: Bound applied to every candidate-index field regardless of shortlist size
+#: (belt: the wire schema's own per-call bound is tighter; this is the
+#: absolute ceiling a hand-authored ``max_length``/``le`` must never exceed).
+_MAX_MENTIONS = 25
+_MAX_CANDIDATE_INDICES = 25
+
+
+class QUAOutcome(StrEnum):
+    """What the model proposes for one mention, over the shortlist it was
+    shown -- mirrors ``ResolutionOutcome``'s three-way shape
+    (committed / ambiguous / unresolved) without reusing that enum: this is
+    a MODEL proposal, never a live resolution outcome, and keeping the
+    vocabularies distinct is what keeps "closed vocabularies stay closed on
+    the live path" true by construction -- there is no shared enum a shadow
+    bug could accidentally widen.
+    """
+
+    RESOLVED = "resolved"
+    AMBIGUOUS = "ambiguous"
+    NO_MATCH = "no_match"
+
+
+class _QUAStrictModel(BaseModel):
+    """Shared strict posture for this schema only.
+
+    Not ``ContractModelV2``: that base is for frozen, wire-stable objects
+    the frontend or another service depends on. This schema is parsed once
+    per shadow call, immediately projected into ``QUAShadowRecord``, and
+    never handed to a client -- freezing it buys nothing. ``extra="forbid"``
+    is what matters: a field this build does not recognize must fail
+    validation, not silently pass through as an unvalidated proposal.
+
+    Model-wide ``strict=True`` was tried and reverted: pydantic's strict
+    mode also rejects the ordinary JSON-string spelling of an ``Enum``
+    field in *Python*-mode validation (``model_validate`` on an
+    already-parsed dict, which is what ``qua_shadow.py`` calls) -- every
+    real provider response would then fail ``intent_id``/``cardinality``
+    validation outright, which is worse than the coercion bug it would
+    have fixed. Strictness is applied per-field instead, only to the
+    numeric fields actually at risk (see ``_StrictIndex``/``_StrictScore``
+    below); ``QUAOutcome``/``QuestionIntentID``/``Cardinality`` stay in the
+    default lax mode that accepts their own string values.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+#: Codex adversarial review round 2 (MEDIUM, confirmed): pydantic's default
+#: LAX mode coerces cross-type input -- a provider response with
+#: ``selected_candidate_index: true`` or ``candidate_indices: ["0"]`` would
+#: otherwise validate cleanly (``bool`` is an ``int`` subclass in Python;
+#: numeric strings coerce silently) instead of failing as
+#: SKIPPED_INVALID_OUTPUT, contaminating shadow-vs-deterministic analytics
+#: with a malformed provider response the schema was supposed to catch.
+_StrictIndex = Annotated[StrictInt, Field(ge=0)]
+_StrictScore = Annotated[StrictFloat, Field(ge=0.0, le=1.0)]
+
+
+class DevQuestionUnderstandingMention(_QUAStrictModel):
+    #: Not re-validated as a literal substring here (question_interpreter's
+    #: deterministic ``_validate_proposal`` does that for its own
+    #: classifier). Shadow mode never acts on this text either way; it is
+    #: recorded for shadow-vs-deterministic analytics only.
+    text_span: ShortText
+    outcome: QUAOutcome
+    selected_candidate_index: _StrictIndex | None = None
+    candidate_indices: tuple[_StrictIndex, ...] = Field(
+        default_factory=tuple, max_length=_MAX_CANDIDATE_INDICES
+    )
+    confidence: _StrictScore
+
+
+class DevQuestionUnderstanding(_QUAStrictModel):
+    schema_version: Literal["dev_question_understanding.v1"]
+    intent_id: QuestionIntentID
+    cardinality: Cardinality
+    mentions: tuple[DevQuestionUnderstandingMention, ...] = Field(
+        max_length=_MAX_MENTIONS
+    )
+    requires_clarification: bool

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -43,6 +43,9 @@ from dev_health_ops.llm.budget import budget_idempotency_scope
 from dev_health_ops.metrics.prometheus import (
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL,
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL,
+    ASK_DEV_QUA_SHADOW_FAULT_TOTAL,
+    ASK_DEV_QUA_SHADOW_LATENCY_SECONDS,
+    ASK_DEV_QUA_SHADOW_TOTAL,
     ASK_DEV_TOOL_EXECUTOR_FAULT_TOTAL,
     ASK_DEV_UNHANDLED_RUN_FAULT_TOTAL,
     ASK_DEV_UNREGISTERED_TERMINAL_CODE_TOTAL,
@@ -114,6 +117,7 @@ from .preflight_outcomes import (
     project_preflight_error,
 )
 from .prompts import PromptComposer, PromptConversationTurn
+from .qua_shadow import QUAShadowRecord, QuestionUnderstandingShadow
 from .status_answer_render import (
     build_deterministic_status_claims,
     deterministic_answer_status,
@@ -504,6 +508,18 @@ class RunRecorder(Protocol):
         """
         ...
 
+    async def record_qua_shadow(self, record: QUAShadowRecord) -> None:
+        """Persist one CHAOS-3389 QUA shadow evaluation.
+
+        Called at most once per run, only when a ``QuestionUnderstandingShadow``
+        is configured -- never affects any live decision; see this module's
+        own call site for the full non-influence argument. Best-effort:
+        callers must tolerate this raising (mirrors ``record_frame``'s own
+        failure-recovery posture) since a shadow-record write is strictly
+        secondary to the run it shadows.
+        """
+        ...
+
     async def record_narrative(self, narrative: DevNarrative) -> None:
         """Persist one ``dev_narrative.v1`` (CHAOS-3297 stack #4).
 
@@ -578,6 +594,9 @@ class NullRunRecorder:
 
     async def record_investigation_result(self, result: DevInvestigationResult) -> None:
         del result
+
+    async def record_qua_shadow(self, record: QUAShadowRecord) -> None:
+        del record
 
     async def record_narrative(self, narrative: DevNarrative) -> None:
         del narrative
@@ -725,6 +744,7 @@ class DevOrchestrator:
         plan_registry: Mapping[QuestionIntentID, DevInvestigationPlan] | None = None,
         plan_executor: PlanExecutor | None = None,
         narrative_provider: narrative_fallback.NarrativeProvider | None = None,
+        qua_shadow: QuestionUnderstandingShadow | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -754,6 +774,12 @@ class DevOrchestrator:
         # the seam C3/C4 live-endpoint controls inject a scripted provider
         # through.
         self._narrative_provider = narrative_provider
+        # CHAOS-3389 shadow phase: ``None`` is the flag-off path -- no
+        # shadow call, no shadow record, byte-identical to this seam not
+        # existing. See the ``qua_shadow`` call site in ``run()`` for the
+        # structural argument that even when set, this can never affect any
+        # live decision.
+        self._qua_shadow = qua_shadow
         self._composer = PromptComposer(registry)
 
     async def run(
@@ -1512,6 +1538,142 @@ class DevOrchestrator:
                             await self._recorder.record_subject_set(
                                 preflight_result.subject_set
                             )
+
+                if self._qua_shadow is not None:
+                    # CHAOS-3389 shadow phase: runs strictly AFTER the
+                    # deterministic decision above is fully computed and
+                    # persisted, and its result (`shadow_record`) is a local
+                    # variable nothing below this block ever reads -- that is
+                    # the structural half of "flipping the flag changes zero
+                    # live-path behavior" (the RED test in
+                    # test_chaos_3389_qua_shadow.py proves the other half:
+                    # OrchestratorResult is byte-identical with the shadow on
+                    # vs off, even against a provider that always raises).
+                    # Every exception from either the evaluation or the
+                    # persistence write is caught here -- a shadow-mode bug
+                    # must never fail or roll back the run it shadows.
+                    try:
+                        shadow_record = await self._qua_shadow.evaluate(
+                            question=request.question,
+                            interpretation=preflight_result.interpretation,
+                            org_id=org_id,
+                            permission_fingerprint=permission_fingerprint,
+                            deterministic_decision=preflight_result.decision,
+                            remaining_seconds=remaining(),
+                        )
+                    except Exception as shadow_fault:
+                        logger.exception(
+                            "ask_dev.orchestrator.qua_shadow_evaluation_fault",
+                            extra={
+                                "run_id": run_id,
+                                "exception_type": type(shadow_fault).__name__,
+                            },
+                        )
+                        ASK_DEV_QUA_SHADOW_FAULT_TOTAL.labels(
+                            exception_type=type(shadow_fault).__name__
+                        ).inc()
+                        shadow_record = None
+                    if shadow_record is not None:
+                        ASK_DEV_QUA_SHADOW_TOTAL.labels(
+                            status=shadow_record.status.value,
+                            deterministic_decision=preflight_result.decision.value,
+                        ).inc()
+                        if shadow_record.latency_ms > 0:
+                            ASK_DEV_QUA_SHADOW_LATENCY_SECONDS.labels(
+                                status=shadow_record.status.value
+                            ).observe(shadow_record.latency_ms / 1000.0)
+                        try:
+                            await self._recorder.record_qua_shadow(shadow_record)
+                        except Exception as shadow_write_fault:
+                            logger.exception(
+                                "ask_dev.orchestrator.qua_shadow_write_fault",
+                                extra={
+                                    "run_id": run_id,
+                                    "exception_type": type(shadow_write_fault).__name__,
+                                },
+                            )
+                            ASK_DEV_QUA_SHADOW_FAULT_TOTAL.labels(
+                                exception_type=type(shadow_write_fault).__name__
+                            ).inc()
+                            # Mirrors CHAOS-3424's own ledger-write-fault
+                            # recovery immediately above: a failed write can
+                            # mark the session rollback-only, so every later
+                            # write in finish() (record_answer/terminal/etc.)
+                            # must not inherit that state.
+                            #
+                            # Codex adversarial review round 1 (HIGH,
+                            # confirmed): unlike the CHAOS-3424 handler above
+                            # -- where the failure IS the ledger write, so
+                            # there is nothing valid to replay -- THIS
+                            # rollback fires strictly after a PROCEED
+                            # decision's resolution ledger already flushed
+                            # successfully earlier in this same transaction.
+                            # Re-persisting only preflight diagnostics/
+                            # subject set (as originally written) would
+                            # silently discard those already-good ledger
+                            # rows on the rollback below -- the exact
+                            # forensic data CHAOS-3424 exists to make
+                            # durable, lost by an unrelated OPTIONAL
+                            # shadow-record write failing. Replayed here
+                            # alongside the other two, in the ledger's own
+                            # ordinal order, exactly as the PROCEED block
+                            # above first wrote them.
+                            # Codex adversarial review round 2 (HIGH,
+                            # confirmed): the replay sequence itself used to
+                            # be unguarded -- if the underlying fault is a
+                            # genuinely dead connection (not just a
+                            # constraint violation on the shadow row alone),
+                            # `rollback()` or any one of the three replay
+                            # calls below can ALSO raise, and that second
+                            # exception was not caught here at all. It would
+                            # propagate out of this whole block to the
+                            # orchestrator's own top-level catch-all
+                            # (`unhandled_run_fault`, this module's last
+                            # resort), degrading what must stay a routine,
+                            # graceful terminal into a generic internal_error
+                            # -- turning an OPTIONAL telemetry failure into a
+                            # live-outcome change, exactly what this seam
+                            # must never do. Wrapped so a second, worse
+                            # failure here is recorded distinctly and
+                            # swallowed rather than escalated: if recovery
+                            # itself cannot succeed, this run's diagnostics
+                            # may be incomplete, but its OUTCOME is still
+                            # never sacrificed for optional shadow telemetry.
+                            try:
+                                await self._recorder.rollback()
+                                await self._recorder.record_preflight(
+                                    preflight_outcome=preflight_result.diagnostic,
+                                    legacy_guard_reason=None,
+                                )
+                                if (
+                                    preflight_result.decision
+                                    is PreflightDecision.PROCEED
+                                    and preflight_result.ledger is not None
+                                ):
+                                    for (
+                                        resolution_entry
+                                    ) in preflight_result.ledger.entries:
+                                        await self._recorder.append_resolution(
+                                            resolution_entry
+                                        )
+                                if preflight_result.subject_set is not None:
+                                    await self._recorder.record_subject_set(
+                                        preflight_result.subject_set
+                                    )
+                            except Exception as shadow_recovery_fault:
+                                logger.exception(
+                                    "ask_dev.orchestrator.qua_shadow_recovery_fault",
+                                    extra={
+                                        "run_id": run_id,
+                                        "exception_type": type(
+                                            shadow_recovery_fault
+                                        ).__name__,
+                                    },
+                                )
+                                ASK_DEV_QUA_SHADOW_FAULT_TOTAL.labels(
+                                    exception_type=type(shadow_recovery_fault).__name__
+                                ).inc()
+
                 if preflight_result.decision is PreflightDecision.TERMINATE:
                     assert preflight_result.answer is not None
                     assert preflight_result.outcome is not None

--- a/src/dev_health_ops/api/dev/orchestrator_persistence.py
+++ b/src/dev_health_ops/api/dev/orchestrator_persistence.py
@@ -18,7 +18,51 @@ from .contracts_v2.subject import DevResolutionEntry, DevSubjectSet
 from .orchestrator import RunState
 from .persistence.service import DevPersistenceService
 from .prompts import PROMPT_VERSION
+from .qua_shadow import QUAShadowMentionAssessment, QUAShadowRecord
+from .scope_service import AuthorizedEntity
 from .tool_registry import TOOL_CONTRACT_VERSION, ToolExecution
+
+
+def _entity_json(entity: AuthorizedEntity) -> dict[str, Any]:
+    return {
+        "kind": entity.kind.value,
+        "canonical_id": entity.canonical_id,
+        "label": entity.label,
+        "repository_id": entity.repository_id,
+    }
+
+
+def _mention_assessment_json(assessment: QUAShadowMentionAssessment) -> dict[str, Any]:
+    return {
+        "mention_id": assessment.mention_id,
+        "text_span": assessment.text_span,
+        "outcome": assessment.outcome.value,
+        "selected_entity": (
+            _entity_json(assessment.selected_entity)
+            if assessment.selected_entity is not None
+            else None
+        ),
+        "candidate_entities": [
+            _entity_json(entity) for entity in assessment.candidate_entities
+        ],
+        "confidence": assessment.confidence,
+        "rejected_reason": assessment.rejected_reason,
+    }
+
+
+def _qua_shadow_payload(record: QUAShadowRecord) -> dict[str, Any]:
+    return {
+        "schema_version": record.schema_version,
+        "intent_id": record.intent_id.value if record.intent_id is not None else None,
+        "cardinality": (
+            record.cardinality.value if record.cardinality is not None else None
+        ),
+        "requires_clarification": record.requires_clarification,
+        "mentions": [
+            _mention_assessment_json(assessment) for assessment in record.mentions
+        ],
+        "error_class": record.error_class,
+    }
 
 
 def _digest(value: str) -> str:
@@ -219,6 +263,36 @@ class PersistenceRunRecorder:
             frame_id=uuid.UUID(frame.frame_id),
             public_outcome=frame.public_outcome.value,
             payload=frame.model_dump(mode="json"),
+        )
+
+    async def record_qua_shadow(self, record: QUAShadowRecord) -> None:
+        """Persist one CHAOS-3389 QUA shadow evaluation.
+
+        Best-effort by design: the orchestrator's own call site wraps this
+        in a defensive ``try/except`` (mirroring CHAOS-3424's ledger-write
+        handling) precisely because a shadow-record write must never strand
+        the live run it shadows.
+        """
+
+        if record.deterministic_decision is None:
+            # Every real evaluate() call sets this unconditionally (it is
+            # the FIRST thing threaded through every branch); a caller that
+            # somehow reaches persistence without it is a programming error,
+            # not a state this table's CHECK constraint should quietly
+            # coerce into a fabricated "proceed".
+            raise ValueError(
+                "qua_shadow record has no deterministic_decision to persist"
+            )
+        await self._service.record_qua_shadow(
+            org_id=self._org_id,
+            user_id=self._user_id,
+            run_id=self._run_id,
+            status=record.status.value,
+            deterministic_decision=record.deterministic_decision.value,
+            cardinality_corroborated=record.cardinality_corroborated,
+            latency_ms=record.latency_ms,
+            model_fingerprint=record.model_fingerprint,
+            payload=_qua_shadow_payload(record),
         )
 
     async def rollback(self) -> None:

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -46,6 +46,7 @@ from dev_health_ops.models.dev_persistence import (
     DevRun,
     DevRunIntent,
     DevRunNarrative,
+    DevRunQuaShadow,
     DevRunResolution,
     DevRunSourceObservation,
     DevRunStageDiagnostic,
@@ -272,6 +273,25 @@ _STAGE_IDS = frozenset(
     }
 )
 _STAGE_STATUSES = frozenset({"started", "completed", "failed", "skipped"})
+# CHAOS-3389: mirrors qua_shadow.QUAShadowStatus / subject_preflight.
+# PreflightDecision -- hand-maintained the same way every other closed
+# vocabulary above is (this table has no Python-side reflection over those
+# enums), reconciled by ``migrations/0086``'s identical CHECK constraint.
+_QUA_SHADOW_STATUSES = frozenset(
+    {
+        "evaluated",
+        "skipped_disabled",
+        "skipped_no_provider",
+        "skipped_no_mentions",
+        "skipped_budget_exhausted",
+        "skipped_catalog_unavailable",
+        "skipped_timeout",
+        "skipped_provider_error",
+        "skipped_unexpected_decision",
+        "skipped_invalid_output",
+    }
+)
+_PREFLIGHT_DECISIONS = frozenset({"proceed", "terminate"})
 
 # Bounds on the opaque JSONB payload each Wave 3.1 artifact carries. These are
 # defense-in-depth (SQLite test targets have no DB-level byte-length CHECK);
@@ -279,6 +299,9 @@ _STAGE_STATUSES = frozenset({"started", "completed", "failed", "skipped"})
 _INTENT_PAYLOAD_MAX_BYTES = 16 * 1024
 _RESOLUTION_PAYLOAD_MAX_BYTES = 8 * 1024
 _SUBJECT_SET_PAYLOAD_MAX_BYTES = 16 * 1024
+#: CHAOS-3389: up to 25 mentions x 25 candidate indices each, plus
+#: intent/cardinality/error bookkeeping -- generously bounded, still small.
+_QUA_SHADOW_PAYLOAD_MAX_BYTES = 32 * 1024
 # Codex finding (HIGH, 2026-08-01): a dense-but-valid `status.entity.v2`
 # observation (status_facts + up to 100 required_children + pull_requests +
 # ci_checks + deployments + incidents, each fact carrying its own
@@ -753,6 +776,11 @@ _PAYLOAD_MODEL_VALIDATORS: dict[type, Any] = {
     DevRunResolution: _KNOWN_UNVALIDATED_PAYLOAD_GAP,
     DevRunSubjectSet: _KNOWN_UNVALIDATED_PAYLOAD_GAP,
     DevRunSourceObservation: _KNOWN_UNVALIDATED_PAYLOAD_GAP,
+    # CHAOS-3389: same posture as the three Wave 3.1 rows above -- audit-only,
+    # server-internal, never a frontend-facing wire contract (qua_shadow.py's
+    # own module docstring), so it is not a candidate for full ORM-boundary
+    # contract validation the way dev_answer_frames/dev_run_narratives are.
+    DevRunQuaShadow: _KNOWN_UNVALIDATED_PAYLOAD_GAP,
 }
 
 
@@ -2496,6 +2524,57 @@ class DevPersistenceService:
                 payload,
                 field="subject_set_payload",
                 max_bytes=_SUBJECT_SET_PAYLOAD_MAX_BYTES,
+            ),
+            created_at=self._now(),
+        )
+        self.session.add(record)
+        await self.session.flush()
+        return record
+
+    async def record_qua_shadow(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        run_id: uuid.UUID,
+        status: str,
+        deterministic_decision: str,
+        cardinality_corroborated: bool | None,
+        latency_ms: float,
+        model_fingerprint: str | None,
+        payload: Mapping[str, Any],
+    ) -> DevRunQuaShadow:
+        """Persist one CHAOS-3389 QUA shadow evaluation.
+
+        Audit-only, exactly like ``append_resolution``'s posture: at most
+        one row per run (``uq_dev_run_qua_shadow_run``), never read back by
+        any live-path code to affect a run.
+        """
+
+        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+        if run is None:
+            raise DevPersistenceNotFound("run not found")
+        if status not in _QUA_SHADOW_STATUSES:
+            raise DevPersistenceValidationError("invalid qua_shadow status")
+        if deterministic_decision not in _PREFLIGHT_DECISIONS:
+            raise DevPersistenceValidationError(
+                "invalid qua_shadow deterministic_decision"
+            )
+        record = DevRunQuaShadow(
+            run_id=run.id,
+            org_id=org_id,
+            user_id=user_id,
+            status=status,
+            deterministic_decision=deterministic_decision,
+            cardinality_corroborated=cardinality_corroborated,
+            latency_ms=latency_ms,
+            model_fingerprint=_safe_token(
+                model_fingerprint, field="model_fingerprint", max_bytes=64
+            ),
+            payload=_bounded_json(
+                payload,
+                field="qua_shadow_payload",
+                max_bytes=_QUA_SHADOW_PAYLOAD_MAX_BYTES,
             ),
             created_at=self._now(),
         )

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -121,6 +121,7 @@ from .org_policy import load_ask_dev_org_policy
 from .portfolio_status_service import PortfolioStatusService
 from .project_health_service import ProjectHealthService
 from .prompts import LEGACY_PROMPT_VERSION, PROMPT_VERSION
+from .qua_shadow import QUAShadowConfig, QuestionUnderstandingShadow
 from .question_interpreter import QuestionInterpreter
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
@@ -2391,6 +2392,41 @@ async def _assemble_production_runtime(
         if wave_3_1_enabled
         else None
     )
+    # CHAOS-3389 shadow phase: a single env flag flip, gated on wave_3_1
+    # (the shadow seam runs alongside the deterministic preflight and is
+    # meaningless without it). Off by default -- ``QUAShadowConfig.enabled``
+    # defaults to ``False``, so an unset env var is byte-identical to this
+    # whole seam not existing (see qua_shadow.py's own module docstring and
+    # the RED test proving it).
+    #
+    # ``provider=None`` deliberately, even when the flag is on (Codex
+    # adversarial review round 1, HIGH, confirmed): ``provider.provider``
+    # here is the SAME instance ``attach_agent_budget_guard``
+    # (llm/budget.py) already wrapped for the live investigation call --
+    # `decide()` is monkeypatched in place, not copied, so a shadow call
+    # against it would consume the SAME org BYO budget/quota the live call
+    # needs, and could make the live call fail with budget_exhausted. That
+    # is a genuine live-outcome effect, exactly what shadow mode must never
+    # have. No isolated shadow quota exists yet, and no separate
+    # ``question_understanding`` role certification exists yet either (both
+    # explicitly follow-on work per the platform spec, comment 6fa38d88) --
+    # until one of those lands, `evaluate()` always resolves to
+    # SKIPPED_NO_PROVIDER in production, which is the correct, safe
+    # "unavailable" outcome this seam is built to degrade to. The QUA logic
+    # itself is fully implemented and exercised end-to-end by
+    # tests/api/dev/test_chaos_3389_qua_shadow.py's scripted (never
+    # budget-shared) providers.
+    qua_shadow = (
+        QuestionUnderstandingShadow(
+            provider=None,
+            scope_service=scope_service,
+            config=QUAShadowConfig(
+                enabled=os.getenv("ASK_DEV_QUA_SHADOW_ENABLED") == "1"
+            ),
+        )
+        if wave_3_1_enabled
+        else None
+    )
     # CHAOS-3295: the plan-governed investigation seam rides the same
     # organization gate as preflight -- a plan can only run once a subject
     # is committed, and only the preflight commits one.
@@ -2456,6 +2492,7 @@ async def _assemble_production_runtime(
         versions=versions,
         platform_certification_stale=provider.platform_certification_stale,
         preflight=preflight,
+        qua_shadow=qua_shadow,
         # CHAOS-3297 stack #3: the combined ten-plan lookup -- orchestrator.py's
         # own plan_registry.get(intent.intent_id) is intent-generic and needs
         # no change to reach the four new plans.

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -1,0 +1,668 @@
+"""CHAOS-3389 shadow phase: the Question Understanding Agent (QUA) shadow seam.
+
+Runs a bounded, no-tool, structured-output LLM call **alongside** the
+deterministic ``SubjectPreflight`` resolver, over a candidate shortlist the
+caller is already authorized to see (the same ``ScopeResolutionService``
+catalog boundary the deterministic path itself uses, never a new subject
+directory). The proposal is recorded as a ``QUAShadowRecord`` and **never**
+fed back into any live decision -- see ``orchestrator.py``'s call site for
+the structural half of that guarantee (nothing downstream reads the record
+this module returns).
+
+Hardening conditions this module builds in from the start (CHAOS-3389
+adversarial critique, comment 7d1368d9):
+
+* **Permission fingerprint in any cache key.** This module introduces no new
+  cache. It calls ``ScopeResolutionService.search()`` directly, which is
+  already keyed by ``(org_id, permission_fingerprint, payload, watermark)``
+  (``scope_service.py:716-719``) -- reusing that boundary is what makes "the
+  shadow shortlist is exactly what the caller is authorized to see" true
+  without inventing a second cache to get wrong.
+* **Org-wide-cardinality widening needs deterministic corroboration.** See
+  ``_cardinality_corroborated``: a model-proposed ``organization_wide``
+  cardinality is trusted (for shadow analytics -- again, never for a live
+  decision) only when the deterministic interpreter independently reached
+  the same cardinality. This is what stops "how is the Contxt Fabric doing?"
+  from reading as a corroborated org-wide proposal just because the model
+  found no candidate id to name.
+* **Never-widen holds structurally.** ``_response_schema`` bounds every
+  candidate-index field to ``[0, len(combined) - 1]`` for the exact
+  authorized shortlist THIS call built -- when that shortlist is empty the
+  bound is ``[0, -1]``, which no integer satisfies, so the wire schema
+  itself cannot express a candidate when none were authorized. ``_verify``
+  re-checks every accepted index against its OWN mention's slice (not just
+  the call-wide bound) after parsing, independent of whether the provider
+  honored the schema.
+* **LLM unavailable degrades to silent skip, never a block.** Every branch
+  of ``evaluate()`` returns a ``QUAShadowRecord`` (never raises); the
+  orchestrator's own call site additionally wraps the call and the
+  recorder write in defensive ``try/except`` so a bug in either can never
+  roll back or fail the run it is shadowing.
+* **Latency instrumented, never gated.** ``latency_ms`` is captured on
+  every branch that reaches the provider call (success, timeout, and
+  provider error alike), for the future probe-certification's budget
+  evidence -- nothing in this module or its caller conditions the live run
+  on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import ValidationError
+
+from dev_health_ops.llm.agent.contracts import (
+    AgentFinalAnswer,
+    AgentLLMProvider,
+    AgentMessage,
+    AgentMessageRole,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.metrics.prometheus import (
+    ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL,
+)
+
+from .contracts_v2.base import Cardinality, QuestionIntentID
+from .contracts_v2.question_understanding import (
+    QUESTION_UNDERSTANDING_SCHEMA_VERSION,
+    DevQuestionUnderstanding,
+    QUAOutcome,
+)
+from .contracts_v2.subject import DevSubjectMention
+from .question_interpreter import InterpretedQuestion
+from .scope_service import (
+    SEARCHABLE_ENTITY_KINDS,
+    AuthorizedEntity,
+    EntityKind,
+    ScopeResolutionService,
+    ScopeSearchRequest,
+)
+from .subject_preflight import PreflightDecision
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "QUA_SHADOW_RESOLUTION_PATH",
+    "QUAShadowConfig",
+    "QUAShadowMentionAssessment",
+    "QUAShadowRecord",
+    "QUAShadowStatus",
+    "QuestionUnderstandingShadow",
+]
+
+#: The exact ``resolution_path`` value lane 2a's ``wave4_case_result.v1``
+#: corpus receipt reserves for a case this shadow seam evaluated (team-lead
+#: coordination ruling, 2026-08-05: fixed by decree as kebab-case
+#: ``"qua-shadow"``, with ``"qua-committed"`` reserved for the future rank/
+#: commit modes, so no reconciliation is needed once 2a's receipt type
+#: lands). This module does not write that receipt itself -- 2a's runner
+#: does not exist on any branch yet as of this writing -- but the string is
+#: pinned here, in one place, so 2a's runner can import it instead of
+#: hand-typing a literal that could drift from this module's own vocabulary.
+QUA_SHADOW_RESOLUTION_PATH = "qua-shadow"
+
+_SYSTEM_PROMPT = (
+    "You are the Ask Dev Question Understanding Agent, running in SHADOW "
+    "MODE. Your output is recorded for offline comparison only and NEVER "
+    "affects any live answer, tool call, or scope decision. You are given "
+    "the user's question and, for each named mention, a closed list of "
+    "already-authorized candidate entities identified only by an integer "
+    'index. For each mention, propose an outcome ("resolved" if exactly '
+    'one candidate is clearly the one named, "ambiguous" if more than one '
+    'plausibly is, "no_match" if none is) and, only for "resolved", the '
+    "single candidate index. You must never propose an index that was not "
+    "listed for that exact mention, and you must never invent an entity "
+    "name, id, or index. Also propose the overall intent_id and cardinality "
+    "for the question as a whole."
+)
+
+
+class QUAShadowStatus(StrEnum):
+    """How one shadow evaluation went.
+
+    Entirely internal to the shadow audit trail -- distinct from, and never
+    merged with, ``ResolutionOutcome`` or ``PreflightDecision`` (the live,
+    closed vocabularies the deterministic resolver owns). Adding a member
+    here can never widen what the live resolution path can express.
+    """
+
+    EVALUATED = "evaluated"
+    SKIPPED_DISABLED = "skipped_disabled"
+    SKIPPED_NO_PROVIDER = "skipped_no_provider"
+    SKIPPED_NO_MENTIONS = "skipped_no_mentions"
+    SKIPPED_BUDGET_EXHAUSTED = "skipped_budget_exhausted"
+    SKIPPED_CATALOG_UNAVAILABLE = "skipped_catalog_unavailable"
+    SKIPPED_TIMEOUT = "skipped_timeout"
+    SKIPPED_PROVIDER_ERROR = "skipped_provider_error"
+    SKIPPED_UNEXPECTED_DECISION = "skipped_unexpected_decision"
+    SKIPPED_INVALID_OUTPUT = "skipped_invalid_output"
+
+
+@dataclass(frozen=True, slots=True)
+class QUAShadowConfig:
+    #: The single flag flip CHAOS-3389 requires: off is byte-identical to
+    #: the seam not existing at all (see ``evaluate``'s first branch).
+    enabled: bool = False
+    #: Platform-spec hard cap (comment 6fa38d88, "Performance and budgets").
+    #: Also bounded by the run's own remaining wall-clock budget at the call
+    #: site -- whichever is smaller governs.
+    hard_timeout_seconds: float = 2.5
+    max_candidates_per_mention: int = 25
+    max_total_candidates: int = 50
+    max_output_tokens: int = 1024
+
+
+@dataclass(frozen=True, slots=True)
+class QUAShadowMentionAssessment:
+    """One mention's shadow proposal, verified against its OWN authorized
+    shortlist slice -- never the call's combined shortlist.
+
+    ``rejected_reason`` is set (and ``selected_entity`` forced ``None``)
+    whenever the model's claimed index fell outside this mention's own
+    slice, however schema-valid the integer was for the call as a whole
+    (e.g. it named a candidate that was only ever shown for a DIFFERENT
+    mention). The rest of the assessment is still recorded -- a rejection
+    is shadow-analytics signal, not a reason to discard the row.
+    """
+
+    mention_id: str
+    text_span: str
+    outcome: QUAOutcome
+    selected_entity: AuthorizedEntity | None
+    candidate_entities: tuple[AuthorizedEntity, ...]
+    confidence: float
+    rejected_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class QUAShadowRecord:
+    schema_version: str = "qua_shadow_record.v1"
+    status: QUAShadowStatus = QUAShadowStatus.SKIPPED_DISABLED
+    deterministic_decision: PreflightDecision | None = None
+    #: Captured whenever a provider call was actually attempted (success,
+    #: timeout, or provider error) -- zero on every branch that skipped
+    #: before reaching the provider.
+    latency_ms: float = 0.0
+    model_fingerprint: str | None = None
+    intent_id: QuestionIntentID | None = None
+    cardinality: Cardinality | None = None
+    cardinality_corroborated: bool | None = None
+    requires_clarification: bool | None = None
+    mentions: tuple[QUAShadowMentionAssessment, ...] = ()
+    error_class: str | None = None
+
+    @property
+    def evaluated(self) -> bool:
+        return self.status is QUAShadowStatus.EVALUATED
+
+
+class QuestionUnderstandingShadow:
+    """Runs the QUA shadow call alongside the deterministic resolver.
+
+    Structural non-influence: ``evaluate()`` returns a ``QUAShadowRecord``
+    and has no other effect -- no argument is mutated, nothing is written
+    anywhere, no exception escapes. The caller decides what (if anything)
+    to do with the record; production only ever persists it.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: AgentLLMProvider | None,
+        scope_service: ScopeResolutionService,
+        config: QUAShadowConfig,
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._provider = provider
+        self._scope_service = scope_service
+        self._config = config
+        self._now = now
+        self._monotonic = monotonic
+
+    async def evaluate(
+        self,
+        *,
+        question: str,
+        interpretation: InterpretedQuestion,
+        org_id: str,
+        permission_fingerprint: str,
+        deterministic_decision: PreflightDecision,
+        remaining_seconds: float,
+    ) -> QUAShadowRecord:
+        if not self._config.enabled:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_DISABLED,
+                deterministic_decision=deterministic_decision,
+            )
+        if self._provider is None:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_NO_PROVIDER,
+                deterministic_decision=deterministic_decision,
+            )
+        mentions = interpretation.mentions
+        if not mentions:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_NO_MENTIONS,
+                deterministic_decision=deterministic_decision,
+            )
+        budget = min(self._config.hard_timeout_seconds, max(0.0, remaining_seconds))
+        if budget <= 0:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED,
+                deterministic_decision=deterministic_decision,
+            )
+
+        # Codex adversarial review round 1 (HIGH, confirmed): `budget` above
+        # is the deadline for the WHOLE call, not just the provider request
+        # -- catalog search runs first and was previously uncapped, so a
+        # slow (or hanging) catalog could blow through `hard_timeout_seconds`
+        # entirely before the provider call even starts, directly
+        # contradicting "never blocks or degrades the run" (this whole
+        # method is awaited synchronously in the orchestrator's critical
+        # path). Bounded here, and the provider call below gets what's
+        # actually left, not the stale up-front `budget`.
+        shortlist_started = self._monotonic()
+        try:
+            per_mention_candidates = await asyncio.wait_for(
+                self._shortlist(
+                    interpretation=interpretation,
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                ),
+                timeout=budget,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_CATALOG_UNAVAILABLE,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - shortlist_started) * 1000.0,
+            )
+        except Exception:
+            logger.exception(
+                "ask_dev.qua_shadow.catalog_fault", extra={"org_id": org_id}
+            )
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_CATALOG_UNAVAILABLE,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - shortlist_started) * 1000.0,
+            )
+
+        remaining_budget = budget - (self._monotonic() - shortlist_started)
+        if remaining_budget <= 0:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - shortlist_started) * 1000.0,
+            )
+
+        combined, mention_ranges = self._combine_shortlists(
+            mentions=mentions, per_mention_candidates=per_mention_candidates
+        )
+        messages = self._build_messages(
+            question=question,
+            mentions=mentions,
+            combined=combined,
+            mention_ranges=mention_ranges,
+        )
+        response_schema = self._response_schema(
+            mention_count=len(mentions), candidate_count=len(combined)
+        )
+
+        started = self._monotonic()
+        try:
+            result = await asyncio.wait_for(
+                self._provider.decide(
+                    messages=messages,
+                    tools=(),
+                    response_schema=response_schema,
+                    timeout_seconds=remaining_budget,
+                    max_output_tokens=self._config.max_output_tokens,
+                    signal=None,
+                ),
+                timeout=remaining_budget,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_TIMEOUT,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - started) * 1000.0,
+            )
+        except AgentProviderError as exc:
+            # Codex round 1 (MEDIUM, confirmed): every AgentProviderError
+            # used to collapse onto SKIPPED_PROVIDER_ERROR, so the
+            # provider's OWN internal timeout (raised as
+            # AgentProviderErrorCode.TIMEOUT -- e.g.
+            # ScriptedAgentProvider's/the real OpenAI-compatible adapter's
+            # internal wait racing this call's own timeout_seconds) was
+            # indistinguishable from a genuine provider failure. Mapped to
+            # the SAME closed status this method's own asyncio.wait_for
+            # timeout already uses -- both really are "the call did not
+            # finish in time", just raised from two different layers.
+            # `error_class` carries the specific code (budget_exhausted,
+            # rate_limited, ...) for every OTHER AgentProviderError kind,
+            # so those stay distinguishable in the persisted record/logs
+            # without growing the closed status vocabulary itself.
+            status = (
+                QUAShadowStatus.SKIPPED_TIMEOUT
+                if exc.code is AgentProviderErrorCode.TIMEOUT
+                else QUAShadowStatus.SKIPPED_PROVIDER_ERROR
+            )
+            logger.warning(
+                "ask_dev.qua_shadow.provider_error",
+                extra={"provider_error_code": exc.code.value},
+            )
+            return QUAShadowRecord(
+                status=status,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - started) * 1000.0,
+                error_class=exc.code.value,
+            )
+        except Exception as exc:  # defense in depth: never propagate
+            logger.exception("ask_dev.qua_shadow.provider_fault")
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_PROVIDER_ERROR,
+                deterministic_decision=deterministic_decision,
+                latency_ms=(self._monotonic() - started) * 1000.0,
+                error_class=type(exc).__name__,
+            )
+        latency_ms = (self._monotonic() - started) * 1000.0
+
+        if not isinstance(result.decision, AgentFinalAnswer):
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_UNEXPECTED_DECISION,
+                deterministic_decision=deterministic_decision,
+                latency_ms=latency_ms,
+                model_fingerprint=result.model_fingerprint,
+            )
+        try:
+            parsed = DevQuestionUnderstanding.model_validate(result.decision.value)
+        except ValidationError:
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_INVALID_OUTPUT,
+                deterministic_decision=deterministic_decision,
+                latency_ms=latency_ms,
+                model_fingerprint=result.model_fingerprint,
+            )
+        if len(parsed.mentions) != len(mentions):
+            # Totality: the model must account for every mention it was
+            # shown, in order -- a short or padded ``mentions`` list cannot
+            # be zipped against the real mentions without silently
+            # mismatching which proposal belongs to which named subject.
+            return QUAShadowRecord(
+                status=QUAShadowStatus.SKIPPED_INVALID_OUTPUT,
+                deterministic_decision=deterministic_decision,
+                latency_ms=latency_ms,
+                model_fingerprint=result.model_fingerprint,
+            )
+
+        assessments = self._verify(
+            mentions=mentions,
+            proposal=parsed,
+            combined=combined,
+            mention_ranges=mention_ranges,
+        )
+        cardinality_corroborated = self._cardinality_corroborated(
+            interpretation=interpretation, proposed=parsed.cardinality
+        )
+        if not cardinality_corroborated:
+            ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL.labels(
+                intent=parsed.intent_id.value
+            ).inc()
+
+        return QUAShadowRecord(
+            status=QUAShadowStatus.EVALUATED,
+            deterministic_decision=deterministic_decision,
+            latency_ms=latency_ms,
+            model_fingerprint=result.model_fingerprint,
+            intent_id=parsed.intent_id,
+            cardinality=parsed.cardinality,
+            cardinality_corroborated=cardinality_corroborated,
+            requires_clarification=parsed.requires_clarification,
+            mentions=assessments,
+        )
+
+    async def _shortlist(
+        self,
+        *,
+        interpretation: InterpretedQuestion,
+        org_id: str,
+        permission_fingerprint: str,
+    ) -> dict[str, tuple[AuthorizedEntity, ...]]:
+        """Per-mention authorized candidates, via the SAME
+        ``ScopeResolutionService.search`` boundary (and therefore the same
+        ``permission_fingerprint``-keyed cache, CHAOS-3389 hardening
+        condition #1) the deterministic resolver itself uses. No new
+        subject directory, no new cache, no RapidFuzz prefilter -- all
+        explicitly deferred per the adversarial critique.
+        """
+
+        untyped_ids = interpretation.untyped_mention_ids
+        all_kinds = tuple(sorted(SEARCHABLE_ENTITY_KINDS, key=lambda kind: kind.value))
+
+        async def one(
+            mention: DevSubjectMention,
+        ) -> tuple[str, tuple[AuthorizedEntity, ...]]:
+            kinds = (
+                all_kinds
+                if mention.mention_id in untyped_ids
+                else (EntityKind(mention.requested_entity_kind.value),)
+            )
+            result = await self._scope_service.search(
+                org_id,
+                permission_fingerprint,
+                ScopeSearchRequest(
+                    query=mention.normalized_lookup_text,
+                    kinds=kinds,
+                    limit=self._config.max_candidates_per_mention,
+                    allowed_kinds=SEARCHABLE_ENTITY_KINDS,
+                    include_alias_matches=True,
+                ),
+            )
+            return mention.mention_id, result.candidates
+
+        pairs = await asyncio.gather(
+            *(one(mention) for mention in interpretation.mentions)
+        )
+        return dict(pairs)
+
+    def _combine_shortlists(
+        self,
+        *,
+        mentions: Sequence[DevSubjectMention],
+        per_mention_candidates: dict[str, tuple[AuthorizedEntity, ...]],
+    ) -> tuple[tuple[AuthorizedEntity, ...], dict[str, tuple[int, int]]]:
+        """One combined, globally-indexed candidate list plus each mention's
+        own half-open ``[start, end)`` slice into it.
+
+        Bounded by ``max_total_candidates`` across the WHOLE call, not per
+        mention -- a mention beyond the bound gets an empty slice (never a
+        partial one straddling the truncation point, which would let an
+        in-range index silently resolve to a candidate that belonged to a
+        different, already-truncated mention).
+        """
+
+        combined: list[AuthorizedEntity] = []
+        ranges: dict[str, tuple[int, int]] = {}
+        max_total = self._config.max_total_candidates
+        for mention in mentions:
+            if len(combined) >= max_total:
+                ranges[mention.mention_id] = (len(combined), len(combined))
+                continue
+            start = len(combined)
+            candidates = per_mention_candidates.get(mention.mention_id, ())
+            room = max_total - start
+            combined.extend(candidates[:room])
+            ranges[mention.mention_id] = (start, len(combined))
+        return tuple(combined), ranges
+
+    def _build_messages(
+        self,
+        *,
+        question: str,
+        mentions: Sequence[DevSubjectMention],
+        combined: Sequence[AuthorizedEntity],
+        mention_ranges: dict[str, tuple[int, int]],
+    ) -> tuple[AgentMessage, ...]:
+        lines = [f'Question: "{question}"', "", "Named mentions:"]
+        for mention in mentions:
+            start, end = mention_ranges.get(mention.mention_id, (0, 0))
+            lines.append(
+                f'- "{mention.original_text_span}" '
+                f"(requested kind: {mention.requested_entity_kind.value}):"
+            )
+            if start == end:
+                lines.append("    (no authorized candidates)")
+            for index in range(start, end):
+                entity = combined[index]
+                lines.append(f"    [{index}] {entity.kind.value}: {entity.label}")
+        return (
+            AgentMessage(role=AgentMessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+            AgentMessage(role=AgentMessageRole.USER, content="\n".join(lines)),
+        )
+
+    def _response_schema(
+        self, *, mention_count: int, candidate_count: int
+    ) -> dict[str, Any]:
+        """A JSON Schema whose index bounds make an out-of-authorization
+        candidate literally inexpressible for THIS call. When
+        ``candidate_count`` is zero the bound is ``[0, -1]`` -- an empty
+        range no integer satisfies, so a provider honoring the schema
+        cannot select any candidate at all when none were authorized.
+        """
+
+        max_index = candidate_count - 1
+        index_schema = {"type": ["integer", "null"], "minimum": 0, "maximum": max_index}
+        mention_schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["text_span", "outcome", "confidence"],
+            "properties": {
+                "text_span": {"type": "string", "maxLength": 512},
+                "outcome": {
+                    "type": "string",
+                    "enum": [outcome.value for outcome in QUAOutcome],
+                },
+                "selected_candidate_index": index_schema,
+                "candidate_indices": {
+                    "type": "array",
+                    "maxItems": 25,
+                    "items": {"type": "integer", "minimum": 0, "maximum": max_index},
+                },
+                "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            },
+        }
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "schema_version",
+                "intent_id",
+                "cardinality",
+                "mentions",
+                "requires_clarification",
+            ],
+            "properties": {
+                "schema_version": {"const": QUESTION_UNDERSTANDING_SCHEMA_VERSION},
+                "intent_id": {
+                    "type": "string",
+                    "enum": [intent.value for intent in QuestionIntentID],
+                },
+                "cardinality": {
+                    "type": "string",
+                    "enum": [card.value for card in Cardinality],
+                },
+                "requires_clarification": {"type": "boolean"},
+                "mentions": {
+                    "type": "array",
+                    "minItems": mention_count,
+                    "maxItems": mention_count,
+                    "items": mention_schema,
+                },
+            },
+        }
+
+    def _verify(
+        self,
+        *,
+        mentions: Sequence[DevSubjectMention],
+        proposal: DevQuestionUnderstanding,
+        combined: Sequence[AuthorizedEntity],
+        mention_ranges: dict[str, tuple[int, int]],
+    ) -> tuple[QUAShadowMentionAssessment, ...]:
+        assessments: list[QUAShadowMentionAssessment] = []
+        for mention, proposed in zip(mentions, proposal.mentions, strict=True):
+            start, end = mention_ranges.get(mention.mention_id, (0, 0))
+            rejected_reason: str | None = None
+            selected_entity: AuthorizedEntity | None = None
+            if proposed.selected_candidate_index is not None:
+                if start <= proposed.selected_candidate_index < end:
+                    selected_entity = combined[proposed.selected_candidate_index]
+                else:
+                    rejected_reason = "index_outside_mention_shortlist"
+            candidate_entities = tuple(
+                combined[index]
+                for index in proposed.candidate_indices
+                if start <= index < end
+            )
+            if len(candidate_entities) != len(proposed.candidate_indices):
+                rejected_reason = (
+                    rejected_reason or "candidate_index_outside_mention_shortlist"
+                )
+            # Codex round 1 (MEDIUM, confirmed): outcome and
+            # selected_candidate_index are independently-typed fields on the
+            # wire, so a provider can propose a self-contradictory pair --
+            # "resolved" with no index, or "ambiguous"/"no_match" WITH one --
+            # and nothing above catches it; both would otherwise persist as
+            # EVALUATED with inconsistent shadow evidence. Cross-checked
+            # here rather than in the pydantic model itself: whether an
+            # index is "present" depends on it ALSO passing the shortlist
+            # bounds check above, which the model has no way to know.
+            if (
+                proposed.outcome is QUAOutcome.RESOLVED
+                and selected_entity is None
+                and rejected_reason is None
+            ):
+                rejected_reason = "resolved_outcome_missing_index"
+            elif (
+                proposed.outcome is not QUAOutcome.RESOLVED
+                and selected_entity is not None
+            ):
+                rejected_reason = "non_resolved_outcome_has_index"
+                selected_entity = None
+            assessments.append(
+                QUAShadowMentionAssessment(
+                    mention_id=mention.mention_id,
+                    text_span=mention.original_text_span,
+                    outcome=proposed.outcome,
+                    selected_entity=selected_entity,
+                    candidate_entities=candidate_entities,
+                    confidence=proposed.confidence,
+                    rejected_reason=rejected_reason,
+                )
+            )
+        return tuple(assessments)
+
+    def _cardinality_corroborated(
+        self, *, interpretation: InterpretedQuestion, proposed: Cardinality
+    ) -> bool:
+        """CHAOS-3389 critique §2 hardening condition: an org-wide
+        cardinality proposal is only trusted when the DETERMINISTIC
+        interpreter independently reached the same cardinality. This is
+        what makes "how is the Contxt Fabric doing?" -- a named subject the
+        model failed to match to any candidate id -- read as uncorroborated
+        rather than silently equivalent to a genuine organization-wide
+        question. Shadow mode never acts on this either way; it is recorded
+        so the eventual verified-commit phase can enforce it as a real gate.
+        """
+
+        if proposed is not Cardinality.ORGANIZATION_WIDE:
+            return True
+        return interpretation.intent.cardinality is Cardinality.ORGANIZATION_WIDE

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -22,6 +22,7 @@ from .orchestrator import (
     ScopeResolver,
 )
 from .prompts import PromptConversationTurn
+from .qua_shadow import QuestionUnderstandingShadow
 from .subject_preflight import SubjectPreflight
 from .tool_registry import AskDevToolRegistry
 
@@ -60,6 +61,11 @@ class BoundedDevRuntime:
     #: same seam to drive the live C3/C4 provider-failure-matrix controls
     #: through the real endpoint.
     narrative_provider: narrative_fallback.NarrativeProvider | None = None
+    #: CHAOS-3389 shadow phase. ``None`` is the flag-off path -- identical to
+    #: today whether or not ``preflight`` is set. Production only sets this
+    #: once ``preflight`` is also set (the shadow seam runs alongside the
+    #: deterministic resolver, so it is meaningless without it).
+    qua_shadow: QuestionUnderstandingShadow | None = None
 
     async def run(
         self,
@@ -88,6 +94,7 @@ class BoundedDevRuntime:
             plan_registry=self.plan_registry,
             plan_executor=self.plan_executor,
             narrative_provider=self.narrative_provider,
+            qua_shadow=self.qua_shadow,
         )
         return await orchestrator.run(
             request=request,

--- a/src/dev_health_ops/llm/agent/roles.py
+++ b/src/dev_health_ops/llm/agent/roles.py
@@ -48,11 +48,23 @@ class AgentRole(str, Enum):
     members and store slots only -- their probes are CHAOS-3285 PR4, gated
     on CHAOS-3294's ``dev_question_intent.v1`` / ``dev_narrative.v1``
     schemas landing on main.
+
+    ``QUESTION_UNDERSTANDING`` (CHAOS-3389 shadow phase) is the same kind of
+    reserved, probe-less member: the Question Understanding Agent shadow
+    seam (``dev_health_ops.api.dev.qua_shadow``) calls the SAME
+    already-certified ``LEGACY_AGENT`` provider today rather than gating on
+    a certification this role has never earned -- a separate
+    ``question_understanding`` probe/certification key is explicitly
+    follow-on work (platform spec comment 6fa38d88, follow-on issue #2), not
+    part of shadow mode. The member exists now so the role identity is
+    stable from the start and admin/readiness surfaces can adopt it without
+    a wire-vocabulary change later.
     """
 
     LEGACY_AGENT = "legacy_agent"
     INTENT_CLASSIFICATION = "intent_classification"
     ANSWER_FRAME_NARRATIVE = "answer_frame_narrative"
+    QUESTION_UNDERSTANDING = "question_understanding"
 
 
 class RoleCertificationState(str, Enum):

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -224,6 +224,50 @@ if _PROMETHEUS_AVAILABLE:
         ["failure_code"],
     )
 
+    # ---------------------------------------------------------------------------
+    # Ask Dev Question Understanding Agent shadow mode (CHAOS-3389)
+    # ---------------------------------------------------------------------------
+    ASK_DEV_QUA_SHADOW_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_qua_shadow_total",
+        "Ask Dev QUA shadow evaluations by outcome status (qua_shadow."
+        "QUAShadowStatus, content-free) and the deterministic preflight "
+        "decision (proceed/terminate) it ran alongside. Every increment is "
+        "shadow-only telemetry -- it never affects any live run.",
+        ["status", "deterministic_decision"],
+    )
+
+    ASK_DEV_QUA_SHADOW_LATENCY_SECONDS = _prometheus_client_module.Histogram(
+        "devhealth_ask_dev_qua_shadow_latency_seconds",
+        "Ask Dev QUA shadow provider-call latency, by outcome status. Feeds "
+        "the future probe-certification's latency budget evidence -- "
+        "recorded, never gated on.",
+        ["status"],
+        buckets=(0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 2.5, 5.0),
+    )
+
+    ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_qua_shadow_fault_total",
+        "Ask Dev QUA shadow evaluations or shadow-record writes that raised "
+        "outside qua_shadow.py's own defensive handling, caught at the "
+        "orchestrator call site so a shadow-mode bug can never fail or roll "
+        "back the live run it shadows. Every increment is a shadow-path "
+        "defect, not a live-path one.",
+        ["exception_type"],
+    )
+
+    ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL = (
+        _prometheus_client_module.Counter(
+            "devhealth_ask_dev_qua_shadow_cardinality_uncorroborated_total",
+            "Ask Dev QUA shadow proposals with cardinality=organization_wide "
+            "that the deterministic interpreter did NOT independently reach "
+            "the same cardinality for (CHAOS-3389 adversarial critique "
+            "hardening condition: an org-wide proposal is a model-proposed "
+            "widening channel and must never be trusted without deterministic "
+            "corroboration -- shadow mode records this but never acts on it).",
+            ["intent"],
+        )
+    )
+
 else:
     # Graceful no-ops when prometheus_client is unavailable
     CELERY_TASKS_TOTAL = _noop_counter()
@@ -245,6 +289,10 @@ else:
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL = _noop_counter()
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL = _noop_counter()
     ASK_DEV_NARRATIVE_FALLBACK_TOTAL = _noop_counter()
+    ASK_DEV_QUA_SHADOW_TOTAL = _noop_counter()
+    ASK_DEV_QUA_SHADOW_LATENCY_SECONDS = _noop_histogram()
+    ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _noop_counter()
+    ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL = _noop_counter()
 
 
 # ---------------------------------------------------------------------------

--- a/src/dev_health_ops/models/dev_persistence.py
+++ b/src/dev_health_ops/models/dev_persistence.py
@@ -588,6 +588,60 @@ class DevRunSubjectSet(Base):
     )
 
 
+class DevRunQuaShadow(Base):
+    """CHAOS-3389 shadow phase: one Question Understanding Agent shadow
+    evaluation per run (``qua_shadow.QUAShadowRecord``).
+
+    Audit-only, exactly like ``DevRunResolution``'s posture but for the
+    shadow path -- persisted so shadow-vs-deterministic comparisons are
+    possible from data, never read back to influence any live decision (no
+    code anywhere in ``api/dev`` queries this table to affect a run;
+    querying it is a future analytics/replay concern only). ``status`` and
+    ``deterministic_decision`` are closed, server-owned vocabularies
+    (``qua_shadow.QUAShadowStatus`` / ``subject_preflight.PreflightDecision``)
+    -- distinct from, and never merged with, ``dev_run_resolutions.outcome``.
+    """
+
+    __tablename__ = "dev_run_qua_shadow"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    deterministic_decision: Mapped[str] = mapped_column(String(16), nullable=False)
+    cardinality_corroborated: Mapped[bool | None] = mapped_column(nullable=True)
+    latency_ms: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    model_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('evaluated', 'skipped_disabled', 'skipped_no_provider', "
+            "'skipped_no_mentions', 'skipped_budget_exhausted', "
+            "'skipped_catalog_unavailable', 'skipped_timeout', "
+            "'skipped_provider_error', 'skipped_unexpected_decision', "
+            "'skipped_invalid_output')",
+            name="ck_dev_run_qua_shadow_status",
+        ),
+        CheckConstraint(
+            "deterministic_decision IN ('proceed', 'terminate')",
+            name="ck_dev_run_qua_shadow_deterministic_decision",
+        ),
+        UniqueConstraint("run_id", name="uq_dev_run_qua_shadow_run"),
+        ForeignKeyConstraint(
+            ["run_id", "org_id", "user_id"],
+            ["dev_runs.id", "dev_runs.org_id", "dev_runs.user_id"],
+            name="fk_dev_run_qua_shadow_run_owner",
+            ondelete="CASCADE",
+        ),
+        Index("ix_dev_run_qua_shadow_owner_run", "org_id", "user_id", "run_id"),
+    )
+
+
 class DevRunSourceObservation(Base):
     """Wave 3.1: one ``dev_source_observation.v1`` deterministic-plan-step row.
 

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -378,6 +378,10 @@ class Recorder:
         self.preflight_diagnostics: list[tuple[str | None, str | None]] = []
         self.frames: list[Any] = []
         self.resolutions: list[Any] = []
+        #: CHAOS-3389: every QUA shadow record this recorder was asked to
+        #: persist. Empty whenever the shadow seam is unwired/disabled --
+        #: exactly the RED test's own assertion surface.
+        self.qua_shadow_records: list[Any] = []
         #: CHAOS-3325: the recorder-method call sequence, by name -- proves
         #: append_resolution lands before record_frame, not just that both
         #: were called (two same-length lists alone prove nothing about
@@ -425,6 +429,9 @@ class Recorder:
     async def record_investigation_result(self, result: DevInvestigationResult) -> None:
         """No-op here; CHAOS-3295's InvestigationRecorder subclass captures this."""
         del result
+
+    async def record_qua_shadow(self, record: Any) -> None:
+        self.qua_shadow_records.append(record)
 
     async def record_narrative(self, narrative: Any) -> None:
         """No-op here; CHAOS-3297 stack #4's narrative synthesis is not
@@ -558,6 +565,7 @@ async def run_preflight_orchestrator(
     registry_factory: Callable[[list[DevToolRequest]], AskDevToolRegistry] = (
         recording_registry
     ),
+    qua_shadow: Any = None,
 ) -> RunOutput:
     """One full orchestrator run with the preflight wired the way production wires it.
 
@@ -623,6 +631,7 @@ async def run_preflight_orchestrator(
         preflight=preflight,
         plan_registry=plan_registry,
         plan_executor=plan_executor,
+        qua_shadow=qua_shadow,
     )
     result = await orchestrator.run(
         request=request,

--- a/tests/api/dev/test_chaos_3389_qua_shadow.py
+++ b/tests/api/dev/test_chaos_3389_qua_shadow.py
@@ -1,0 +1,1123 @@
+"""CHAOS-3389 shadow phase: the Question Understanding Agent (QUA) shadow seam.
+
+RED-first coverage for the greenlit shadow-mode-only scope: (1) the seam is
+flag-gated and, when the flag is off OR the shadow provider is unavailable,
+the live ``OrchestratorResult`` is byte-identical to the seam not existing
+at all; (2) the never-widen invariant holds even against a provider that
+proposes an out-of-shortlist candidate; (3) an org-wide cardinality
+proposal is recorded as uncorroborated unless the deterministic interpreter
+independently agrees; (4) the shortlist fetch is authorized through the
+SAME ``permission_fingerprint``-keyed boundary the deterministic resolver
+uses, never a new one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality
+from dev_health_ops.api.dev.qua_shadow import (
+    QUAShadowConfig,
+    QUAShadowStatus,
+    QuestionUnderstandingShadow,
+)
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_service import (
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import PreflightDecision
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentMessage,
+    AgentProviderCapabilities,
+    AgentToolDefinition,
+    CancellationSignal,
+    StreamingMode,
+    StructuredOutputMode,
+    ToolDecisionMode,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.agent.scripted import ScriptedAgentProvider, ScriptedStep
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
+    NIGHTFALL_PROJECT,
+    ORG_ID,
+    PERMISSION_FINGERPRINT,
+    SeededCatalog,
+    request_for,
+    run_preflight_orchestrator,
+)
+
+pytestmark = pytest.mark.asyncio
+
+#: A structurally-valid (if unused) capabilities value -- every fake
+#: provider below only ever raises from `decide()`, but must still satisfy
+#: the real `AgentLLMProvider` Protocol's `capabilities` property type for
+#: mypy, not just duck-type it for pytest.
+_FAKE_CAPABILITIES = AgentProviderCapabilities(
+    structured_output=StructuredOutputMode.JSON_SCHEMA,
+    tool_decisions=ToolDecisionMode.NATIVE,
+    streaming=StreamingMode.BUFFERED,
+    supports_cancellation=True,
+    context_window_tokens=100_000,
+    max_output_tokens=10_000,
+    readiness_version="test-fake",
+    disclosure_key="test-fake",
+)
+
+
+class _RaisingProvider:
+    """A shadow provider whose `decide()` always raises a fixed error --
+    parametrized rather than duplicated per error kind, and structurally
+    typed to satisfy `AgentLLMProvider` for both pytest and mypy."""
+
+    def __init__(self, error: AgentProviderError) -> None:
+        self._error = error
+
+    @property
+    def capabilities(self) -> AgentProviderCapabilities:
+        return _FAKE_CAPABILITIES
+
+    async def decide(
+        self,
+        messages: Sequence[AgentMessage],
+        tools: Sequence[AgentToolDefinition],
+        response_schema: Mapping[str, Any],
+        timeout_seconds: float,
+        max_output_tokens: int,
+        signal: CancellationSignal | None = None,
+    ) -> AgentDecisionResult:
+        raise self._error
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _catalog(entities) -> SeededCatalog:
+    return SeededCatalog(entities)
+
+
+async def _interpretation(question: str):
+    interpreter = QuestionInterpreter()
+    return await interpreter.interpret(request_for(question))
+
+
+def _qua_response(
+    *,
+    intent_id: str = "entity_status",
+    cardinality: str = "singular",
+    mentions: list[dict],
+    requires_clarification: bool = False,
+) -> dict:
+    return {
+        "schema_version": "dev_question_understanding.v1",
+        "intent_id": intent_id,
+        "cardinality": cardinality,
+        "mentions": mentions,
+        "requires_clarification": requires_clarification,
+    }
+
+
+# ---------------------------------------------------------------------------
+# RED: flipping the flag changes zero live-path behavior
+# ---------------------------------------------------------------------------
+
+
+def _always_failing_provider() -> _RaisingProvider:
+    """A shadow provider that always raises -- proves the live path survives
+    a fully broken QUA call, not merely an absent one."""
+
+    return _RaisingProvider(
+        AgentProviderError(AgentProviderErrorCode.PROVIDER_UNAVAILABLE)
+    )
+
+
+def _shadow_records(output) -> list:
+    """``RunOutput.recorder`` is typed ``Recorder | None`` (a generic
+    harness field other callers legitimately never set); every call site in
+    this module DOES set it via ``recorder_factory``, so this is a real
+    invariant of how this module's tests are built, not an unchecked
+    assumption -- asserted here once instead of at each of the several call
+    sites below."""
+
+    assert output.recorder is not None
+    return output.recorder.qua_shadow_records
+
+
+async def _shadow(*, enabled: bool, provider) -> QuestionUnderstandingShadow:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    return QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=enabled),
+    )
+
+
+async def test_shadow_unwired_matches_shadow_wired_but_disabled() -> None:
+    """Two different ways to be "off": the seam not constructed at all
+    (``qua_shadow=None``, production's own flag-off shape) vs constructed
+    with ``config.enabled=False`` (a deployed-but-toggled-off shape). Both
+    must leave the live outcome identical; only the disabled-but-wired shape
+    additionally records a SKIPPED_DISABLED audit row -- which is itself
+    proof the seam ran and chose to do nothing, not proof of a live effect.
+    """
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-off-baseline",
+    )
+    shadow_unset = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-off-unset",
+        qua_shadow=None,
+    )
+    shadow_disabled = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-off-disabled",
+        qua_shadow=await _shadow(enabled=False, provider=_always_failing_provider()),
+    )
+    assert shadow_unset.outcome_tuple() == baseline.outcome_tuple()
+    assert shadow_disabled.outcome_tuple() == baseline.outcome_tuple()
+    assert _shadow_records(shadow_unset) == []
+    [record] = _shadow_records(shadow_disabled)
+    assert record.status is QUAShadowStatus.SKIPPED_DISABLED
+    assert record.latency_ms == 0.0
+
+
+async def test_shadow_enabled_but_provider_always_fails_is_byte_identical_for_a_proceed_run() -> (
+    None
+):
+    """The stronger claim: even a WORKING, ENABLED shadow seam whose provider
+    always raises must never change the live outcome -- only its own record."""
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-fail-baseline",
+    )
+    shadow_failing = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-fail-shadow",
+        qua_shadow=await _shadow(enabled=True, provider=_always_failing_provider()),
+    )
+    assert shadow_failing.outcome_tuple() == baseline.outcome_tuple()
+    # The shadow record itself IS observable -- proving the seam ran -- it
+    # just never touched the live outcome above.
+    assert len(_shadow_records(shadow_failing)) == 1
+    assert (
+        _shadow_records(shadow_failing)[0].status
+        is QUAShadowStatus.SKIPPED_PROVIDER_ERROR
+    )
+
+
+async def test_shadow_enabled_but_provider_always_fails_is_byte_identical_for_a_terminate_run() -> (
+    None
+):
+    """Same proof on the OTHER decision branch (TERMINATE): an unresolved
+    named subject's clarification terminal is unaffected by a failing
+    shadow seam."""
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-terminate-baseline",
+    )
+    shadow_failing = await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-terminate-shadow",
+        qua_shadow=await _shadow(enabled=True, provider=_always_failing_provider()),
+    )
+    assert shadow_failing.outcome_tuple() == baseline.outcome_tuple()
+    assert baseline.result.state is not None
+    assert (
+        shadow_failing.result.answer is None
+    )  # sanity: this really is a TERMINATE run
+
+
+async def test_shadow_enabled_with_a_successful_proposal_still_does_not_change_the_answer() -> (
+    None
+):
+    """The strongest version of the RED proof: the shadow provider not only
+    runs, it returns a VALID, high-confidence, correct-looking proposal --
+    and the live answer is still byte-identical to the flag being off."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    mention = interpretation.mentions[0]
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": mention.original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": 0,
+                                "candidate_indices": [0],
+                                "confidence": 0.99,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-success",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-success-baseline",
+    )
+    shadowed = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-success-live",
+        qua_shadow=shadow,
+    )
+    assert shadowed.outcome_tuple() == baseline.outcome_tuple()
+    [record] = _shadow_records(shadowed)
+    assert record.status is QUAShadowStatus.EVALUATED
+    assert record.mentions[0].selected_entity == ASK_DEV_PROJECT
+    assert record.mentions[0].rejected_reason is None
+
+
+class _RaisingShadow:
+    """Not a real ``QuestionUnderstandingShadow`` -- duck-typed to bypass
+    its own internal exception handling entirely and raise straight out of
+    ``evaluate()``, the way a genuine bug in qua_shadow.py itself would.
+    Proves the ORCHESTRATOR's own defensive try/except (orchestrator.py's
+    call site, distinct from qua_shadow.py's internal one every other test
+    in this module exercises) is load-bearing, not merely decorative."""
+
+    async def evaluate(self, **_kwargs):
+        raise RuntimeError("qua_shadow.py has a real bug")
+
+
+async def test_a_shadow_component_that_raises_outright_still_never_affects_the_run() -> (
+    None
+):
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-raising-baseline",
+    )
+    with_raising_shadow = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-raising-live",
+        qua_shadow=_RaisingShadow(),
+    )
+    assert with_raising_shadow.outcome_tuple() == baseline.outcome_tuple()
+    # evaluate() raised before ever returning a record -- nothing to persist.
+    assert _shadow_records(with_raising_shadow) == []
+
+
+# ---------------------------------------------------------------------------
+# Never-widen holds structurally, even against a malicious/buggy provider
+# ---------------------------------------------------------------------------
+
+
+async def test_an_index_outside_the_mentions_own_shortlist_is_rejected_not_trusted() -> (
+    None
+):
+    """Two mentions, each with its own disjoint shortlist. A provider that
+    (however schema-valid the integer is for the call as a whole) selects
+    an index that belonged to the OTHER mention's shortlist must never have
+    that candidate recorded as selected."""
+
+    catalog = _catalog(
+        [
+            (ORG_ID, ATLAS_PROJECT_ONE),
+            (ORG_ID, ATLAS_PROJECT_TWO),
+            (ORG_ID, NIGHTFALL_PROJECT),
+        ]
+    )
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation(
+        "What's the status of the Atlas project and the Nightfall project?"
+    )
+    assert len(interpretation.mentions) == 2
+
+    # Atlas resolves ambiguous (two entities) -> occupies indices [0, 1];
+    # Nightfall resolves exact -> occupies index [2]. A provider claiming
+    # index 2 for the FIRST (Atlas) mention is claiming a candidate that was
+    # only ever authorized for the second mention.
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        cardinality="plural_cohort",
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": 2,
+                                "candidate_indices": [],
+                                "confidence": 0.9,
+                            },
+                            {
+                                "text_span": interpretation.mentions[
+                                    1
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": 2,
+                                "candidate_indices": [],
+                                "confidence": 0.9,
+                            },
+                        ],
+                    )
+                )
+            )
+        ],
+        script_id="qua-cross-mention",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Atlas project and the Nightfall project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.TERMINATE,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+    first, second = record.mentions
+    assert first.selected_entity is None
+    assert first.rejected_reason == "index_outside_mention_shortlist"
+    # The second mention legitimately owns index 2 -- its own proposal is
+    # unaffected by the first mention's rejection.
+    assert second.selected_entity == NIGHTFALL_PROJECT
+    assert second.rejected_reason is None
+
+
+async def test_zero_authorized_candidates_makes_every_index_structurally_inexpressible() -> (
+    None
+):
+    """When a mention has no authorized candidates at all, the wire schema's
+    own bound is [0, -1] -- no integer satisfies it. A provider that ignores
+    the schema and returns index 0 anyway is still caught by the runtime
+    verifier."""
+
+    catalog = _catalog([])  # nothing authorized in this org at all
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": 0,
+                                "candidate_indices": [0],
+                                "confidence": 0.9,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-empty-shortlist",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.TERMINATE,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+    [assessment] = record.mentions
+    assert assessment.selected_entity is None
+    assert assessment.rejected_reason == "index_outside_mention_shortlist"
+
+
+# ---------------------------------------------------------------------------
+# Org-wide cardinality requires deterministic corroboration
+# ---------------------------------------------------------------------------
+
+
+async def test_org_wide_proposal_uncorroborated_when_deterministic_named_a_subject() -> (
+    None
+):
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    assert interpretation.intent.cardinality is not Cardinality.ORGANIZATION_WIDE
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        cardinality="organization_wide",
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "no_match",
+                                "selected_candidate_index": None,
+                                "candidate_indices": [],
+                                "confidence": 0.4,
+                            }
+                        ],
+                    )
+                )
+            )
+        ],
+        script_id="qua-org-wide-uncorroborated",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.TERMINATE,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+    assert record.cardinality is Cardinality.ORGANIZATION_WIDE
+    assert record.cardinality_corroborated is False
+
+
+async def test_org_wide_proposal_corroborated_when_deterministic_also_computed_org_wide() -> (
+    None
+):
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    # A genuinely org-wide question, per CHAOS-3393's own portfolio case:
+    # no named mentions at all.
+    interpreter = QuestionInterpreter()
+    interpretation = await interpreter.interpret(
+        request_for("How is the whole portfolio doing?")
+    )
+    assert interpretation.intent.cardinality is Cardinality.ORGANIZATION_WIDE
+    assert not interpretation.mentions
+
+    async def one() -> None:
+        # evaluate() itself skips when there are no mentions -- the
+        # cardinality-corroboration helper is exercised directly here since
+        # a mentionless call never reaches the model at all (correctly: an
+        # org-wide question is not a resolution question).
+        shadow = QuestionUnderstandingShadow(
+            provider=ScriptedAgentProvider([], script_id="unused"),
+            scope_service=scope_service,
+            config=QUAShadowConfig(enabled=True),
+        )
+        assert shadow._cardinality_corroborated(  # noqa: SLF001 - internal, tested directly
+            interpretation=interpretation, proposed=Cardinality.ORGANIZATION_WIDE
+        )
+
+    await one()
+
+
+# ---------------------------------------------------------------------------
+# Silent-skip on every "not available" condition -- never a block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("config", "provider", "expected"),
+    [
+        (
+            QUAShadowConfig(enabled=False),
+            "present",
+            QUAShadowStatus.SKIPPED_DISABLED,
+        ),
+        (
+            QUAShadowConfig(enabled=True),
+            None,
+            QUAShadowStatus.SKIPPED_NO_PROVIDER,
+        ),
+    ],
+)
+async def test_unavailable_conditions_skip_silently_with_a_typed_status(
+    config, provider, expected
+) -> None:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    resolved_provider = (
+        ScriptedAgentProvider([], script_id="unused") if provider == "present" else None
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=resolved_provider, scope_service=scope_service, config=config
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is expected
+    assert record.latency_ms == 0.0
+
+
+async def test_no_mentions_skips_silently() -> None:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await QuestionInterpreter().interpret(
+        request_for("How is the whole portfolio doing?")
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=ScriptedAgentProvider([], script_id="unused"),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="How is the whole portfolio doing?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_NO_MENTIONS
+
+
+async def test_zero_remaining_budget_skips_without_calling_the_provider() -> None:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=_always_failing_provider(),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=0.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED
+    assert record.latency_ms == 0.0
+
+
+async def test_malformed_output_is_recorded_as_invalid_not_raised() -> None:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [ScriptedStep(decision=AgentFinalAnswer({"not": "the right shape"}))],
+        script_id="qua-malformed",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_INVALID_OUTPUT
+
+
+# ---------------------------------------------------------------------------
+# permission_fingerprint hardening: reuses the existing authorized-catalog
+# cache boundary, never a new one.
+# ---------------------------------------------------------------------------
+
+
+async def test_shortlist_fetch_is_authorized_through_the_permission_fingerprint_boundary() -> (
+    None
+):
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=ScriptedAgentProvider([], script_id="unused"),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    per_mention = await shadow._shortlist(  # noqa: SLF001 - internal, tested directly
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+    )
+    assert per_mention[interpretation.mentions[0].mention_id] == (ASK_DEV_PROJECT,)
+    # The search actually went through scope_service.search -> the seeded
+    # catalog's own search(), which is the SAME call the deterministic
+    # resolver makes -- proven by the catalog's own recorded call.
+    assert any(org == ORG_ID for org, _query in catalog.search_calls)
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial review round 1 findings, each with a RED test proving
+# the fix -- these fail against the pre-fix code (verified by hand before
+# landing the fix, per this repo's RED-first convention).
+# ---------------------------------------------------------------------------
+
+
+async def test_a_provider_internal_timeout_maps_to_skipped_timeout_not_generic_error() -> (
+    None
+):
+    """Codex round 1 (MEDIUM, confirmed): every AgentProviderError used to
+    collapse onto SKIPPED_PROVIDER_ERROR, hiding the provider's own
+    TIMEOUT code behind the same generic bucket the RED test in this module
+    already uses for a genuine provider failure -- corrupting shadow
+    telemetry the eventual probe-certification needs to be trustworthy.
+
+    Simulates the real OpenAI-compatible adapter's OWN internal timeout
+    race: raises ``AgentProviderError(TIMEOUT)`` directly, the way a
+    provider that lost its own wait_for race against ``timeout_seconds``
+    does -- never via this method's outer ``asyncio.wait_for`` at all.
+    """
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=_RaisingProvider(
+            AgentProviderError(AgentProviderErrorCode.TIMEOUT, retryable=True)
+        ),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_TIMEOUT
+    assert record.latency_ms > 0.0
+
+
+async def test_a_non_timeout_provider_error_keeps_its_own_code_as_error_class() -> None:
+    """The companion case: a RATE_LIMITED (or any other non-timeout)
+    AgentProviderError stays under SKIPPED_PROVIDER_ERROR, but now with the
+    specific code as `error_class` instead of the uninformative literal
+    "AgentProviderError" every kind used to share."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=_RaisingProvider(
+            AgentProviderError(AgentProviderErrorCode.RATE_LIMITED, retryable=True)
+        ),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_PROVIDER_ERROR
+    assert record.error_class == "rate_limited"
+
+
+async def test_resolved_outcome_without_an_index_is_rejected_not_evaluated_clean() -> (
+    None
+):
+    """Codex round 1 (MEDIUM, confirmed): outcome and
+    selected_candidate_index are independently-typed on the wire -- a
+    provider proposing "resolved" with no index (or with one rejected by
+    the shortlist-bounds check) must not persist as clean EVALUATED
+    evidence with a None selection and no explanation."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": None,
+                                "candidate_indices": [],
+                                "confidence": 0.8,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-resolved-no-index",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+    [assessment] = record.mentions
+    assert assessment.rejected_reason == "resolved_outcome_missing_index"
+
+
+async def test_no_match_outcome_with_an_index_is_rejected_and_the_index_dropped() -> (
+    None
+):
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "no_match",
+                                "selected_candidate_index": 0,
+                                "candidate_indices": [],
+                                "confidence": 0.2,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-no-match-with-index",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+    [assessment] = record.mentions
+    assert assessment.rejected_reason == "non_resolved_outcome_has_index"
+    assert assessment.selected_entity is None
+
+
+class _SlowSearchCatalog(SeededCatalog):
+    """Same seeded data, but ``search`` never returns within any
+    real-world shadow budget -- simulates a hanging/very slow catalog."""
+
+    def __init__(self, *args, delay_seconds: float, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._delay_seconds = delay_seconds
+
+    async def search(self, *args, **kwargs):
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(self._delay_seconds)
+        return await super().search(*args, **kwargs)
+
+
+async def test_a_hanging_catalog_search_is_bounded_by_the_shadow_budget_not_uncapped() -> (
+    None
+):
+    """Codex round 1 (HIGH, confirmed): the shadow budget used to be
+    computed once, up front, and only ever enforced on the provider call --
+    catalog search itself was a bare, uncapped `asyncio.gather`. Because
+    `evaluate()` is awaited synchronously in the orchestrator's own
+    critical path, an unbounded catalog call would delay or hang the live
+    run it is supposed to never affect. Proven here with a catalog that
+    sleeps for far longer than the configured hard timeout -- the WHOLE
+    call must still return within roughly that budget, not the sleep
+    duration."""
+
+    import time
+
+    catalog = _SlowSearchCatalog([(ORG_ID, ASK_DEV_PROJECT)], delay_seconds=5.0)
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=_always_failing_provider(),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True, hard_timeout_seconds=0.2),
+    )
+    started = time.monotonic()
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    elapsed = time.monotonic() - started
+    assert elapsed < 1.0, (
+        f"evaluate() took {elapsed:.2f}s against a 0.2s hard timeout and a "
+        "5s catalog delay -- the catalog call is not actually bounded"
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_CATALOG_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial review round 2 findings.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_bool_masquerading_as_an_index_is_rejected_not_silently_coerced() -> (
+    None
+):
+    """Codex round 2 (MEDIUM, confirmed): pydantic's default lax mode
+    coerces ``True`` to ``1`` for an ``int`` field (``bool`` is an ``int``
+    subclass in Python) -- a provider response with
+    ``selected_candidate_index: true`` would otherwise validate as a clean,
+    confident selection of candidate 1 instead of being rejected as
+    malformed output."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": True,
+                                "candidate_indices": [],
+                                "confidence": 0.9,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-bool-as-index",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_INVALID_OUTPUT
+
+
+async def test_a_numeric_string_confidence_is_rejected_not_silently_coerced() -> None:
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "no_match",
+                                "selected_candidate_index": None,
+                                "candidate_indices": [],
+                                "confidence": "0.9",
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-string-confidence",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_INVALID_OUTPUT
+
+
+async def test_the_real_wire_shape_still_validates_cleanly_under_strict_fields() -> (
+    None
+):
+    """Guard against over-correction: `intent_id`/`cardinality` (enums) and
+    ordinary well-typed ints/floats must still validate normally -- strict
+    mode is scoped to the specific coercion-prone fields only, not the
+    whole model (see the contract module's own docstring for why a
+    model-wide `strict=True` was tried and reverted)."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    provider = ScriptedAgentProvider(
+        [
+            ScriptedStep(
+                decision=AgentFinalAnswer(
+                    _qua_response(
+                        mentions=[
+                            {
+                                "text_span": interpretation.mentions[
+                                    0
+                                ].original_text_span,
+                                "outcome": "resolved",
+                                "selected_candidate_index": 0,
+                                "candidate_indices": [0],
+                                "confidence": 0.9,
+                            }
+                        ]
+                    )
+                )
+            )
+        ],
+        script_id="qua-well-typed",
+    )
+    shadow = QuestionUnderstandingShadow(
+        provider=provider,
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.EVALUATED
+
+
+async def test_a_broken_recorder_during_shadow_write_recovery_never_degrades_the_run() -> (
+    None
+):
+    """Codex round 2 (HIGH, confirmed): the shadow-write-failure recovery
+    sequence (rollback + replay) was itself unguarded -- if THAT also
+    raises (a genuinely dead connection, not just a constraint violation on
+    the shadow row alone), the exception used to propagate out of this
+    whole block to the orchestrator's own top-level catch-all, degrading a
+    routine graceful terminal into a generic internal_error. Drives that
+    exact double-failure through the real orchestrator via a recorder whose
+    `record_qua_shadow` AND `rollback` both raise, and asserts the run
+    still reaches its normal terminal -- never internal_error."""
+
+    class _DoublyBrokenRecorder:
+        """Wraps a real Recorder-shaped fake; record_qua_shadow AND
+        rollback both raise, simulating a connection that is truly gone."""
+
+        def __init__(self, inner) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        async def record_qua_shadow(self, record) -> None:
+            raise RuntimeError("shadow write: connection gone")
+
+        async def rollback(self) -> None:
+            raise RuntimeError("rollback: connection gone too")
+
+    from tests._chaos_3292_preflight import Recorder as _FakeRecorder
+
+    def recorder_factory():
+        return _DoublyBrokenRecorder(_FakeRecorder())
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-recovery-fault-baseline",
+    )
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-recovery-fault-live",
+        qua_shadow=await _shadow(enabled=True, provider=_always_failing_provider()),
+        recorder_factory=recorder_factory,
+    )
+    # The double failure must never surface as the orchestrator's generic
+    # catch-all terminal -- the run reaches the SAME outcome the baseline
+    # (no shadow seam at all) does.
+    assert output.result.state == baseline.result.state
+    assert (output.result.error.code if output.result.error else None) != (
+        "internal_error"
+    )

--- a/tests/api/dev/test_chaos_3423_3424_persistence_prerequisites.py
+++ b/tests/api/dev/test_chaos_3423_3424_persistence_prerequisites.py
@@ -46,6 +46,14 @@ from dev_health_ops.api.dev.persistence import (
     DevPersistenceNotFound,
     DevPersistenceService,
 )
+from dev_health_ops.api.dev.qua_shadow import (
+    QUAShadowConfig,
+    QuestionUnderstandingShadow,
+)
+from dev_health_ops.api.dev.scope_service import (
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.llm.agent.contracts import AgentFinalAnswer
 from dev_health_ops.llm.agent.scripted import ScriptedStep
@@ -59,6 +67,7 @@ from dev_health_ops.models.dev_persistence import (
     DevRun,
     DevRunIntent,
     DevRunNarrative,
+    DevRunQuaShadow,
     DevRunResolution,
     DevRunSourceObservation,
     DevRunStageDiagnostic,
@@ -72,6 +81,7 @@ from tests._chaos_3292_preflight import (
     ATLAS_PROJECT_ONE,
     ATLAS_PROJECT_TWO,
     Recorder,
+    SeededCatalog,
     grounded_answer_payload,
     run_preflight_orchestrator,
     scope_dict,
@@ -96,6 +106,7 @@ _TABLES = tables_of(
     DevRunIntent,
     DevRunSourceObservation,
     DevRunStageDiagnostic,
+    DevRunQuaShadow,
 )
 
 #: The exact real member of ``ScopeResolutionOutcome`` the CHAOS-3421 live
@@ -811,6 +822,137 @@ async def test_chaos_3424_ledger_write_failure_never_strands_the_run(
         # The CHAOS-3423 transcript row still landed -- proof the session
         # recovered cleanly enough for finish()'s own later writes to
         # succeed on it.
+        assistant_rows = (
+            await session.scalars(
+                select(DevMessage).where(
+                    DevMessage.conversation_id == conversation_id,
+                    DevMessage.role == "assistant",
+                )
+            )
+        ).all()
+        assert len(assistant_rows) == 1
+        assert assistant_rows[0].content == output.result.error.safe_message
+
+
+@pytest.mark.asyncio
+async def test_chaos_3389_shadow_write_failure_preserves_the_already_flushed_ledger(
+    seeded, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Codex adversarial review round 1 on CHAOS-3389 (HIGH, confirmed): the
+    QUA shadow-write recovery originally mirrored CHAOS-3424's OWN ledger-
+    write-fault handler byte-for-byte -- but the two failures are not
+    symmetric. CHAOS-3424's handler fires when the ledger write ITSELF
+    fails, so there is nothing valid to replay. This shadow-write failure
+    fires AFTER the SAME PROCEED decision's resolution ledger already
+    flushed successfully in this transaction -- rolling back and
+    re-persisting only preflight diagnostics/subject set (as the recovery
+    originally did) would silently discard those already-good ledger rows,
+    the exact CHAOS-3424 forensic data this scenario is built to prove
+    survives. Drives a REAL ``DevPersistenceService.record_qua_shadow``
+    failure on the identical PROCEED widening scenario CHAOS-3424's own
+    sibling test above uses, and asserts the ledger rows are still there
+    after recovery -- not merely that the run reaches a terminal state.
+    """
+
+    maker, org_id, user_id = seeded
+    question = "How is Nightfall doing?"
+    conversation_id, run_id = await _seed_run(maker, org_id, user_id, question=question)
+
+    class ShadowWriteBoom(Exception):
+        pass
+
+    async def _always_failing(self, *args, **kwargs):
+        raise ShadowWriteBoom("simulated qua_shadow storage failure")
+
+    monkeypatch.setattr(DevPersistenceService, "record_qua_shadow", _always_failing)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        def recorder_factory() -> Recorder:
+            return cast(
+                Recorder,
+                PersistenceRunRecorder(
+                    service,
+                    org_id=org_id,
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                    run_id=run_id,
+                    provider_source="platform",
+                ),
+            )
+
+        # provider=None -> evaluate() always resolves to a real (non-None)
+        # SKIPPED_NO_PROVIDER record without ever touching the network --
+        # exactly production's own posture today (Codex round 1 finding on
+        # budget isolation) -- which is enough to reach record_qua_shadow
+        # and exercise the failure this test is about. The catalog is real
+        # but never consulted (evaluate() returns before the shortlist
+        # fetch when the provider is absent).
+        qua_shadow = QuestionUnderstandingShadow(
+            provider=None,
+            scope_service=ScopeResolutionService(
+                SeededCatalog([]), cache=ScopeRequestCache()
+            ),
+            config=QUAShadowConfig(enabled=True),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            output = await run_preflight_orchestrator(
+                question=question,
+                entities=[(str(org_id), ASK_DEV_PROJECT)],
+                org_id=str(org_id),
+                user_id=str(user_id),
+                conversation_id=str(conversation_id),
+                run_id=str(run_id),
+                answer_id=str(uuid.uuid4()),
+                script=_leaking_but_not_narrating(str(org_id)),
+                script_id="chaos-3389-shadow-write-failure",
+                recorder_factory=recorder_factory,
+                qua_shadow=qua_shadow,
+            )
+        await session.commit()
+
+        shadow_faults = _log_records(
+            caplog, "ask_dev.orchestrator.qua_shadow_write_fault"
+        )
+        assert len(shadow_faults) == 1
+        assert _log_extra(shadow_faults[0], "exception_type") == "ShadowWriteBoom"
+
+        # Setup control: the same PROCEED widening shape CHAOS-3424's own
+        # sibling test exercises.
+        assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+        assert output.result.error is not None
+        assert output.result.error.code == "scope_not_found"
+
+        # The real assertion: the resolution ledger entries that flushed
+        # successfully BEFORE the shadow write ever ran must still be there
+        # after the shadow-write-failure recovery rolled back and replayed.
+        ledger_rows = (
+            await session.scalars(
+                select(DevRunResolution).where(DevRunResolution.run_id == run_id)
+            )
+        ).all()
+        assert len(ledger_rows) >= 1, (
+            "a failed OPTIONAL shadow-record write must never discard the "
+            f"already-flushed resolution ledger -- got {len(ledger_rows)} rows."
+        )
+        assert all(row.outcome != "exact_match" for row in ledger_rows)
+
+        # No shadow row landed (the write genuinely failed) -- but nothing
+        # ELSE the run wrote is missing either.
+        shadow_rows = (
+            await session.scalars(
+                select(DevRunQuaShadow).where(DevRunQuaShadow.run_id == run_id)
+            )
+        ).all()
+        assert shadow_rows == []
+
+        run_row = await session.get(DevRun, run_id)
+        assert run_row is not None
+        assert run_row.state == "insufficient_evidence"
+        assert run_row.preflight_outcome == "proceeded_unresolved_bare_name"
+
         assistant_rows = (
             await session.scalars(
                 select(DevMessage).where(

--- a/tests/api/dev/test_orchestrator.py
+++ b/tests/api/dev/test_orchestrator.py
@@ -106,6 +106,9 @@ class Recorder:
     async def record_investigation_result(self, result: DevInvestigationResult) -> None:
         del result
 
+    async def record_qua_shadow(self, record: Any) -> None:
+        del record
+
     async def record_narrative(self, narrative: Any) -> None:
         if self.fail_narrative_write:
             raise RuntimeError("narrative storage unavailable")

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -2842,18 +2842,22 @@ async def test_zero_day_immediate_purge_covers_every_new_artifact_and_orphan_wri
 #: against that contract (``record_intent`` -> ``dev_question_intent.v1``,
 #: ``append_resolution`` -> a ``dev_resolution_ledger.v1`` entry,
 #: ``record_subject_set`` -> ``dev_subject_set.v1``,
-#: ``append_source_observation`` -> ``dev_source_observation.v1``) -- the
-#: same open-boundary shape ``record_frame``/``record_narrative`` had.
-#: Enumerated here deliberately, not silently ignored: closing these is out
-#: of this round's scope, but touching any of these four names is now a
-#: conscious edit to this set, not a silent pass through the totality
-#: assertion below.
+#: ``append_source_observation`` -> ``dev_source_observation.v1``,
+#: ``record_qua_shadow`` (CHAOS-3389) -> a ``qua_shadow.QUAShadowRecord``
+#: projection, which is not a frontend-facing wire contract at all -- see
+#: ``qua_shadow.py``'s own module docstring) -- the same open-boundary
+#: shape ``record_frame``/``record_narrative`` had. Enumerated here
+#: deliberately, not silently ignored: closing these is out of this
+#: round's scope, but touching any of these five names is now a conscious
+#: edit to this set, not a silent pass through the totality assertion
+#: below.
 _KNOWN_UNVALIDATED_PAYLOAD_SINKS = frozenset(
     {
         "record_intent",
         "append_resolution",
         "record_subject_set",
         "append_source_observation",
+        "record_qua_shadow",
     }
 )
 
@@ -2953,6 +2957,7 @@ def test_payload_bearing_orm_model_names_matches_the_live_schema() -> None:
         "DevRunSourceObservation",
         "DevAnswerFrame",
         "DevRunNarrative",
+        "DevRunQuaShadow",
     }
 
 

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -297,6 +297,111 @@ def test_0074_downgrade_refuses_with_folded_column_only_data() -> None:
         engine.dispose()
 
 
+def test_0086_downgrade_refuses_with_populated_shadow_data() -> None:
+    """CHAOS-3389 Codex adversarial review round 1 (HIGH, confirmed): the
+    original 0086 downgrade unconditionally dropped ``dev_run_qua_shadow``,
+    unlike every other Wave 3.1 audit table's downgrade guard (0074's own
+    pattern, proven above) -- a routine pre-release downgrade rehearsal
+    would have silently erased real QUA shadow evidence. Fail-before/
+    pass-after, mirroring ``test_0074_downgrade_refuses_with_folded_column_only_data``:
+    the guard must raise while a row exists, and the same downgrade must
+    then succeed once the table is empty.
+
+    Only ``m68``/``m74`` (for ``dev_runs``) and ``m86`` itself are loaded --
+    ``dev_run_qua_shadow`` FKs to ``dev_runs`` alone, so every migration
+    between them is irrelevant to this table's own creation, exactly as the
+    0074 tests above already establish for 0069/0074.
+    """
+
+    m68 = _load("0068_add_ask_dev_persistence")
+    m74 = _load("0074_add_ask_dev_v2_persistence")
+    m86 = _load("0086_add_dev_run_qua_shadow")
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _parent_and_v1_tables(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                m68.upgrade()
+                m74.upgrade()
+                m86.upgrade()
+
+            tables = set(sa.inspect(connection).get_table_names())
+            assert "dev_run_qua_shadow" in tables
+
+            org_id, user_id, conv_id, run_id = (str(uuid.uuid4()) for _ in range(4))
+            connection.execute(
+                sa.text("INSERT INTO organizations (id, name) VALUES (:id, 'o')"),
+                {"id": org_id},
+            )
+            connection.execute(
+                sa.text("INSERT INTO users (id, email) VALUES (:id, 'u@example.com')"),
+                {"id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_conversations "
+                    "(id, org_id, user_id, current_scope, retention_days, "
+                    "created_at, updated_at) VALUES "
+                    "(:id, :org_id, :user_id, '{}', 30, CURRENT_TIMESTAMP, "
+                    "CURRENT_TIMESTAMP)"
+                ),
+                {"id": conv_id, "org_id": org_id, "user_id": user_id},
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_runs "
+                    "(id, request_id, conversation_id, org_id, user_id, state, "
+                    "started_at, created_at) VALUES "
+                    "(:id, :req, :conv, :org_id, :user_id, 'accepted', "
+                    "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                {
+                    "id": run_id,
+                    "req": str(uuid.uuid4()),
+                    "conv": conv_id,
+                    "org_id": org_id,
+                    "user_id": user_id,
+                },
+            )
+            connection.commit()
+
+            shadow_row_id = str(uuid.uuid4())
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_run_qua_shadow "
+                    "(id, run_id, org_id, user_id, status, "
+                    "deterministic_decision, payload, created_at) VALUES "
+                    "(:id, :run_id, :org_id, :user_id, 'skipped_no_provider', "
+                    "'proceed', '{}', CURRENT_TIMESTAMP)"
+                ),
+                {
+                    "id": shadow_row_id,
+                    "run_id": run_id,
+                    "org_id": org_id,
+                    "user_id": user_id,
+                },
+            )
+            connection.commit()
+
+            with Operations.context(context):
+                with pytest.raises(RuntimeError, match="dev_run_qua_shadow"):
+                    m86.downgrade()
+
+            connection.execute(
+                sa.text("DELETE FROM dev_run_qua_shadow WHERE id = :id"),
+                {"id": shadow_row_id},
+            )
+            connection.commit()
+            with Operations.context(context):
+                m86.downgrade()  # now succeeds
+            tables = set(sa.inspect(connection).get_table_names())
+            assert "dev_run_qua_shadow" not in tables
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.skipif(
     not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
 )

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0085",)
+    assert heads == ("0086",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0085"}
+    assert set(heads) == {"0066", "0086"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0085"}
+        assert set(heads) == {"0066", "0086"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0085"
+        assert script.get_revision("application_schema@head").revision == "0086"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0085"}
-        assert scripts.get_revision("application_schema@head").revision == "0085"
-        assert _database_has_revision(cfg, ("0085",), "0065")
-        assert not _database_has_revision(cfg, ("0085",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0086"}
+        assert scripts.get_revision("application_schema@head").revision == "0086"
+        assert _database_has_revision(cfg, ("0086",), "0065")
+        assert not _database_has_revision(cfg, ("0086",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## CHAOS-3389: Question Understanding Agent (QUA) shadow mode

Shadow phase only — per the greenlight ([comment](https://linear.app/fullchaos/issue/CHAOS-3389#comment-92a19e5e)) bounded by the platform spec ([6fa38d88](https://linear.app/fullchaos/issue/CHAOS-3389#comment-6fa38d88)) and the Fable-5 adversarial critique ([7d1368d9](https://linear.app/fullchaos/issue/CHAOS-3389#comment-7d1368d9)). Directory tables/projector, RapidFuzz, and auto-commit/rank modes are explicitly **not** built here. Full design writeup: [CHAOS-3389 comment](https://linear.app/fullchaos/issue/CHAOS-3389#comment-16bd8fed).

### ⚠️ Production currently collects ZERO real QUA evidence — by design

`ASK_DEV_QUA_SHADOW_ENABLED=1` wires the whole seam, but `production_runtime.py` constructs it with `provider=None`, so every production call resolves to `SKIPPED_NO_PROVIDER` before touching a model. This is intentional, not an oversight (Codex round 1, HIGH, confirmed): `provider.provider` in production is the same instance `attach_agent_budget_guard` already monkeypatches for the live investigation call — a shadow call against it would consume the org's real BYO budget/quota, risking the *live* call failing with `budget_exhausted`. No isolated shadow quota exists yet. The QUA logic itself is fully implemented and exercised end-to-end by scripted (never budget-shared) providers in `tests/api/dev/test_chaos_3389_qua_shadow.py`. Wiring a real provider is a one-line follow-up once budget isolation lands.

### What shipped

- **QUA role**: `AgentRole.QUESTION_UNDERSTANDING` (reserved/probe-less, same posture as `INTENT_CLASSIFICATION`/`ANSWER_FRAME_NARRATIVE`).
- **`api/dev/qua_shadow.py`** — `QuestionUnderstandingShadow.evaluate()`: bounded, no-tool, structured-output call over a per-mention candidate shortlist fetched through `ScopeResolutionService.search()` — the **same** authorization boundary (and `permission_fingerprint`-keyed cache) the deterministic resolver already uses. No new subject directory, no new cache, no RapidFuzz.
- **Never-widen enforced two ways**: a per-call JSON Schema bounding every candidate-index field to `[0, total_candidates-1]` (empty/`[0,-1]` when nothing was authorized — structurally inexpressible), plus a runtime verifier that re-checks every accepted index against that *specific* mention's own slice (catches a provider naming an index authorized for a different mention in the same call).
- **Org-wide-cardinality corroboration**: a `cardinality=organization_wide` proposal is recorded `cardinality_corroborated=False` unless the deterministic interpreter independently reached the same cardinality (closes the critique's named failure mode).
- **LLM-unavailable degrades to silent skip, never a block**: every branch of `evaluate()` returns a typed `QUAShadowRecord`; the orchestrator wraps the evaluation, the persistence write, *and* (after round 2) the write-failure recovery sequence itself in defensive `try/except`.
- **Orchestrator hook** sits after the deterministic decision is fully computed and persisted, before the branch that acts on it — its result is a local variable nothing downstream reads. RED-proven: `OrchestratorResult` is byte-identical across shadow unset/disabled/failing/succeeding, on both PROCEED and TERMINATE.
- **Persistence**: new table `dev_run_qua_shadow` (migration 0086), closed-vocab CHECK constraints, audit-only, guarded downgrade (refuses when populated). `dev_question_understanding.v1` lives in `contracts_v2` on plain `BaseModel` (not `ContractModelV2`) so it's excluded from the answer-frame reflection sweep.
- **Feature flag**: `ASK_DEV_QUA_SHADOW_ENABLED`, gated on `wave_3_1_enabled`. Off by default.
- Also fixes the migration-head pin (`0085`→`0086`) across the five files that track it, and closes two persistence totality-check registries for the new table/method.

### Codex adversarial review — 2 rounds, 10 findings, all confirmed and addressed

**Round 1** (6 findings, all fixed + RED-tested + mutation-verified):
1. **[HIGH]** Shadow call not isolated from live provider budgets — fixed via `provider=None` in production (see caveat above).
2. **[HIGH]** Shadow-write-failure recovery discarded the just-flushed PROCEED resolution ledger on rollback — fixed to replay all three (preflight/ledger/subject_set); real-persistence integration test added.
3. **[HIGH]** Catalog search was uncapped, able to block the run's own critical path indefinitely — fixed, one deadline spans catalog + provider work.
4. **[HIGH]** Migration downgrade dropped the table unconditionally — fixed with a row-count guard matching every sibling Wave-3.1 table.
5. **[MED]** Outcome/index contradictions (`resolved` + no index, `ambiguous` + an index) persisted as clean evidence — fixed with a cross-field check.
6. **[MED]** Every `AgentProviderError` collapsed onto one generic status, hiding the provider's own TIMEOUT code — fixed, TIMEOUT now maps correctly; `error_class` carries the specific code for every other kind.

**Round 2** (4 findings — 2 fixed+tested, 2 validated-and-explicitly-deferred):
1. **[HIGH]** Recovery sequence itself (rollback + replay) was unguarded — fixed, wrapped so a double failure is recorded and swallowed rather than escalating to a generic `internal_error`. Mutation-verified.
2. **[MED]** Type coercion (`true`→`1`, `"0.9"`→`0.9`) could silently contaminate shadow evidence — fixed with per-field `StrictInt`/`StrictFloat` (model-wide `strict=True` was tried first and reverted — it broke enum fields under Python-mode validation).
3. **[HIGH]** "Production flag always produces no-provider skips" — confirms finding #1 above is working as designed, not a new bug. Documented, not silently fixed further.
4. **[MED]** A later, unrelated write failure can roll back and lose an already-successful shadow row — verified as a **pre-existing** gap (the TERMINATE branch's own `record_frame`-failure handler already drops the terminating ledger entry the same way, pre-dating this change). Tracked on **CHAOS-3441** rather than fixed here (needs a shared replay-registry pattern across multiple existing recovery sites).

Every fix that changes behavior is paired with a test that fails on the pre-fix code and passes after (mutation-verified by hand for the highest-severity ones: removed the fix, confirmed the paired test goes red, restored, confirmed green).

### Verification

- `ci/local_validate.sh`: **GATE PASSED**, fully green — 12117 passed, 102 skipped (env-gated), 1 pre-registered xfail, **0 failed**. Did not hit the CHAOS-3405 known-16 this run.
- `ruff check` / `ruff format --check` / `mypy`: clean on every touched file.

Closes/relates: CHAOS-3389. Prerequisite work: CHAOS-3423/3424. Follow-on: CHAOS-3441 (cross-handler replay gap), isolated shadow-provider budget (CHAOS-3452).

