### PR TITLE
CHAOS-3219 Phase 2: wave4 corpus runner — receipts, resolution-path derivation, invariant checkers, docker-exec verification plane

### DIFF
--- a/scripts/acceptance/corpus/_inner_ledger_query.py
+++ b/scripts/acceptance/corpus/_inner_ledger_query.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Runs INSIDE the ``ask-dev-acceptance-api`` container, never on the host.
+
+Invoked by ``db_verify.query_resolution_ledger_via_exec`` as
+``docker compose ... exec -T api python -m
+scripts.acceptance.corpus._inner_ledger_query --run-id <uuid>`` (team-lead
+ruling 2026-08-06: the resolution-ledger read is one of exactly two harness
+concerns allowed through the container boundary -- see
+``compose_context.py``'s module docstring).
+
+Queries ``dev_run_resolutions`` directly via SQLAlchemy against
+``DATABASE_URI`` (already present in the container's own environment --
+``compose.yml``'s ``api`` service sets it to this project's own pgbouncer,
+the SAME value ``dev-hops`` itself uses) and prints exactly ONE JSON line to
+stdout: ``{"entries": [{"outcome": ..., "mention_id": ..., "committed_label":
+..., "committed_canonical_id": ...}, ...]}``. All diagnostics go to stderr --
+stdout is a strict machine contract the host-side ``db_verify`` parses
+verbatim.
+
+Deliberately extracts only the fields ``resolution_path.py`` needs
+(``ResolutionLedgerEntry``'s shape) rather than dumping the full row/payload
+-- this is a narrow, purpose-built verification-plane reader, not a general
+database export tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.dev_persistence import DevRunResolution
+
+
+async def _fetch_entries(run_id: uuid.UUID, database_uri: str) -> list[dict[str, Any]]:
+    engine = create_async_engine(database_uri)
+    try:
+        maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with maker() as session:
+            rows = (
+                await session.scalars(
+                    select(DevRunResolution)
+                    .where(DevRunResolution.run_id == run_id)
+                    .order_by(DevRunResolution.entry_ordinal)
+                )
+            ).all()
+            entries: list[dict[str, Any]] = []
+            for row in rows:
+                payload = row.payload if isinstance(row.payload, dict) else {}
+                committed_raw = payload.get("committed_entity_ref")
+                committed: dict[str, Any] = (
+                    committed_raw if isinstance(committed_raw, dict) else {}
+                )
+                entries.append(
+                    {
+                        "outcome": row.outcome,
+                        "mention_id": str(row.mention_id),
+                        "committed_label": committed.get("display_label"),
+                        "committed_canonical_id": committed.get("entity_id"),
+                    }
+                )
+            return entries
+    finally:
+        await engine.dispose()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--database-uri", default=os.getenv("DATABASE_URI"))
+    args = parser.parse_args(argv)
+
+    if not args.database_uri:
+        print(
+            "DATABASE_URI is not set in this container's environment and "
+            "--database-uri was not provided",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        run_id = uuid.UUID(args.run_id)
+    except ValueError as exc:
+        print(f"--run-id {args.run_id!r} is not a valid UUID: {exc}", file=sys.stderr)
+        return 1
+
+    entries = asyncio.run(_fetch_entries(run_id, args.database_uri))
+    print(json.dumps({"entries": entries}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acceptance/corpus/_inner_transcript_query.py
+++ b/scripts/acceptance/corpus/_inner_transcript_query.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Runs INSIDE the ``ask-dev-acceptance-api`` container, never on the host.
+
+Invoked by ``db_verify.query_transcript_assistant_schema_versions_via_exec``
+as ``docker compose ... exec -T api python -m
+scripts.acceptance.corpus._inner_transcript_query --conversation-id <uuid>``
+(team-lead ruling 2026-08-06: exactly two -- now three, per the
+``terminal_persists_assistant_row`` invariant checker -- harness concerns are
+allowed through the container boundary; see ``compose_context.py``'s module
+docstring).
+
+Queries ``dev_messages`` directly via SQLAlchemy against ``DATABASE_URI``
+for every ``role="assistant"`` row on one conversation, and prints exactly
+ONE JSON line to stdout: ``{"assistant_schema_versions": [<schema_version
+or null>, ...]}``, in row-creation order. Deliberately extracts only the
+``answer_payload.schema_version`` field (never the payload body, never
+``content``) -- this is a narrow, purpose-built verification-plane reader
+proving CHAOS-3423's own "every terminal persists a real transcript row"
+guarantee from the corpus side, not a general transcript export tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.dev_persistence import DevMessage
+
+
+async def _fetch_assistant_schema_versions(
+    conversation_id: uuid.UUID, database_uri: str
+) -> list[Any]:
+    engine = create_async_engine(database_uri)
+    try:
+        maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with maker() as session:
+            rows = (
+                await session.scalars(
+                    select(DevMessage)
+                    .where(
+                        DevMessage.conversation_id == conversation_id,
+                        DevMessage.role == "assistant",
+                    )
+                    .order_by(DevMessage.created_at, DevMessage.id)
+                )
+            ).all()
+            versions: list[Any] = []
+            for row in rows:
+                payload = (
+                    row.answer_payload if isinstance(row.answer_payload, dict) else {}
+                )
+                versions.append(payload.get("schema_version"))
+            return versions
+    finally:
+        await engine.dispose()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--conversation-id", required=True)
+    parser.add_argument("--database-uri", default=os.getenv("DATABASE_URI"))
+    args = parser.parse_args(argv)
+
+    if not args.database_uri:
+        print(
+            "DATABASE_URI is not set in this container's environment and "
+            "--database-uri was not provided",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        conversation_id = uuid.UUID(args.conversation_id)
+    except ValueError as exc:
+        print(
+            f"--conversation-id {args.conversation_id!r} is not a valid UUID: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    versions = asyncio.run(
+        _fetch_assistant_schema_versions(conversation_id, args.database_uri)
+    )
+    print(json.dumps({"assistant_schema_versions": versions}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acceptance/corpus/_inner_world_digest.py
+++ b/scripts/acceptance/corpus/_inner_world_digest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Runs INSIDE the ``ask-dev-acceptance-api`` container, never on the host.
+
+Invoked by ``db_verify.verify_world_digest_via_exec`` as ``docker compose
+... exec -T api python -m scripts.acceptance.corpus._inner_world_digest
+--manifest ... --sink ... --postgres-uri ...`` (team-lead ruling
+2026-08-06: WORLD_DIGEST verification, ruling D2, is one of exactly two
+harness concerns allowed through the container boundary -- see
+``compose_context.py``'s module docstring).
+
+Thin CLI wrapper over ``scripts.acceptance.corpus.world_digest_guard.
+verify_world_digest`` (which is itself a thin wrapper over
+``dev_health_ops.fixtures.world``) -- reused rather than reimplemented, so
+this script and the pure-Python unit-tested comparison logic
+(``require_world_digest_match``) can never quietly diverge. Prints exactly
+ONE JSON line to stdout; all diagnostics go to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from scripts.acceptance.corpus.world_digest_guard import verify_world_digest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--sink", required=True)
+    parser.add_argument("--postgres-uri", required=True)
+    parser.add_argument("--digest-path", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        verification = asyncio.run(
+            verify_world_digest(
+                args.manifest,
+                sink=args.sink,
+                postgres_uri=args.postgres_uri,
+                digest_path=args.digest_path,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 -- reported as structured JSON, not a traceback the host must scrape
+        print(f"world digest verification raised: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "pinned_digest": verification.pinned_digest,
+                "live_digest": verification.live_digest,
+                "matched": verification.matched,
+                "drifted_components": list(verification.drifted_components),
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acceptance/corpus/arming.py
+++ b/scripts/acceptance/corpus/arming.py
@@ -1,0 +1,37 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the armed-or-throw check, factored out
+as a pure function so it is unit-testable without invoking pytest's own
+fixture/collection machinery.
+
+Generalizes the existing smoke-script convention
+(``os.getenv("ASK_DEV_LIVE_ACCEPTANCE") != "1"`` -> exit 64, see
+``smoke_ask_dev_exact_commit.py``'s ``main()``) for a pytest-native runner:
+there is no meaningful "exit code" inside a pytest test, so the live corpus
+runner's session fixture converts :class:`NotArmedError` into
+``pytest.fail(..., pytrace=False)`` -- a definite, red FAILED outcome, never
+a ``pytest.skip`` (a skip is not unconditionally treated as non-passing by
+every consumer of a pytest report the way it is inside this repo's own
+``wave31_manifest.py`` execution checker; failing is unambiguous everywhere).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+__all__ = ["ARM_ENV_VAR", "NotArmedError", "require_armed"]
+
+ARM_ENV_VAR = "ASK_DEV_LIVE_ACCEPTANCE"
+
+
+class NotArmedError(Exception):
+    """The live-acceptance arming env var is not set to ``"1"``."""
+
+
+def require_armed(env: Mapping[str, str] | None = None) -> None:
+    source = env if env is not None else os.environ
+    if source.get(ARM_ENV_VAR) != "1":
+        raise NotArmedError(
+            f"{ARM_ENV_VAR}=1 is required before the Wave 4 corpus runner "
+            "touches the network -- this must fail loud, never silently "
+            "skip or proceed unarmed"
+        )

--- a/scripts/acceptance/corpus/case_schema.py
+++ b/scripts/acceptance/corpus/case_schema.py
@@ -1,0 +1,342 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: corpus case + resolution-profile
+loading and validation.
+
+Case JSON schema is Lane 2b's authoritative spec (``case-schema.md``,
+authored alongside ``tests/acceptance/world/ask-dev-world.v1/corpus/*.json``);
+the interface decision fixed with the team-lead (2026-08-05) is: ``id`` /
+``question`` / ``subject_class`` / invariant-first ``invariants`` +
+``resolution_profile_ref``. This loader validates defensively -- it rejects
+a case MISSING one of those fields (Lane 2a's runner cannot execute or
+classify a case without them), but never rejects an unknown EXTRA field, so
+it does not have to change in lockstep with every schema addition Lane 2b's
+case authoring needs for its own bookkeeping.
+
+Matcher-specific expected outcomes never live on the case itself -- they
+live in a versioned ``resolution-profile`` file
+(``tests/acceptance/world/ask-dev-world.v1/resolution-profiles/<ref>.json``),
+keyed by case id. This is the pluggable seam CHAOS-3389's fold-in requires:
+when the Question Understanding Agent flips a case's actual resolution
+behavior (e.g. from clarification to a direct resolved answer), only the
+profile changes -- a new ``resolution-profiles/qua-v1.json`` -- never the
+case file, never this loader, never the runner.
+
+``status: "declared-blocked"`` (team-lead direction, 2026-08-06, folding in
+2b's codex round-1 finding): a corpus case blocked on an external ticket
+(e.g. a `[BLOCKED on CHAOS-3393]` registry entry) loads successfully with
+ZERO invariants -- the world-manifest discipline already established
+elsewhere in this project (``world.json``'s own ``declared-blocked``/
+``blocked_by`` fields for ``cross_generation_digest_status``; ``sources.json``
+truncated-workgraph's identical status/blocked_by pair) applied here so a
+legitimately-blocked case can be loaded and LOUDLY, COUNTABLY reported as
+blocked (never silently dropped, never crashing the whole corpus load,
+never mistaken for a passing case) instead of forcing placeholder invariants
+that would assert nothing real. See :func:`load_corpus_case`'s docstring for
+the exact field contract.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "ACTIVE_STATUS",
+    "DECLARED_BLOCKED_STATUS",
+    "CaseSchemaError",
+    "CorpusCase",
+    "ResolutionProfile",
+    "load_corpus_case",
+    "load_corpus_cases",
+    "load_resolution_profile",
+    "resolve_case_expectations",
+]
+
+_CASE_REQUIRED_FIELDS = ("id", "question", "subject_class")
+_PROFILE_SCHEMA_VERSION_PREFIX = "resolution-profile."
+
+#: The only two case statuses this loader understands. Mirrors the
+#: ``declared-blocked``/``blocked_by`` convention already established in
+#: ``world.json``/``sources.json`` (CHAOS-3428/CHAOS-3432's own status
+#: fields) -- one discipline, applied consistently across the fixture world
+#: and the corpus case layer.
+ACTIVE_STATUS = "active"
+DECLARED_BLOCKED_STATUS = "declared-blocked"
+_KNOWN_STATUSES = frozenset({ACTIVE_STATUS, DECLARED_BLOCKED_STATUS})
+
+#: Codex round-3 finding (MEDIUM, confirmed): a non-empty string like
+#: "not-a-ticket" satisfied the earlier ``blocked_by`` check, letting a
+#: case suppress its own coverage with no traceable blocker despite the
+#: documented ticket-reference contract. Matches this repo's own real
+#: convention (``world.json``'s ``"CHAOS-3432 concurrent ClickHouse ..."``
+#: -- a leading ``CHAOS-<number>`` token, optionally followed by free-text
+#: description) rather than requiring an exact bare ``CHAOS-<number>`` --
+#: anchored at the start only, so descriptive suffixes stay allowed.
+_BLOCKED_BY_TICKET_PATTERN = re.compile(r"^CHAOS-\d+\b")
+
+
+class CaseSchemaError(Exception):
+    """A corpus case or resolution-profile file fails structural validation.
+
+    Raised at load time, never at assertion time -- a malformed case must
+    fail loud before any HTTP call is made, not surface as a confusing
+    downstream assertion failure that looks like a product defect.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusCase:
+    id: str
+    question: str
+    subject_class: str
+    invariants: tuple[Mapping[str, Any], ...]
+    resolution_profile_ref: str | None
+    status: str
+    blocked_by: str | None
+    source_path: Path
+    raw: Mapping[str, Any] = field(repr=False)
+
+    @property
+    def is_declared_blocked(self) -> bool:
+        return self.status == DECLARED_BLOCKED_STATUS
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionProfile:
+    profile_id: str
+    schema_version: str
+    cases: Mapping[str, Mapping[str, Any]]
+    source_path: Path
+
+
+def _require_str(payload: Mapping[str, Any], field_name: str, *, where: Path) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise CaseSchemaError(
+            f"{where}: required field {field_name!r} must be a non-empty string, "
+            f"got {value!r}"
+        )
+    return value
+
+
+def load_corpus_case(path: Path) -> CorpusCase:
+    """Load and structurally validate one corpus case file.
+
+    Missing/mistyped required fields raise :class:`CaseSchemaError`
+    immediately -- this function never returns a partially-valid case for a
+    caller to trip over later.
+    """
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CaseSchemaError(f"{path}: not valid JSON ({exc})") from exc
+    if not isinstance(raw, Mapping):
+        raise CaseSchemaError(f"{path}: top-level JSON value must be an object")
+
+    missing = [f for f in _CASE_REQUIRED_FIELDS if f not in raw]
+    if missing:
+        raise CaseSchemaError(
+            f"{path}: missing required field(s) {missing} -- Lane 2a's runner "
+            "cannot execute or classify a case without every one of "
+            f"{_CASE_REQUIRED_FIELDS}"
+        )
+
+    case_id = _require_str(raw, "id", where=path)
+    question = _require_str(raw, "question", where=path)
+    subject_class = _require_str(raw, "subject_class", where=path)
+
+    status = raw.get("status", ACTIVE_STATUS)
+    if not isinstance(status, str) or status not in _KNOWN_STATUSES:
+        raise CaseSchemaError(
+            f"{path}: {case_id!r} 'status' must be one of {sorted(_KNOWN_STATUSES)!r} "
+            f"(or absent, defaulting to {ACTIVE_STATUS!r}), got {status!r}"
+        )
+    is_blocked = status == DECLARED_BLOCKED_STATUS
+
+    blocked_by = raw.get("blocked_by")
+    if is_blocked:
+        if not isinstance(blocked_by, str) or not blocked_by.strip():
+            raise CaseSchemaError(
+                f"{path}: {case_id!r} status={DECLARED_BLOCKED_STATUS!r} requires "
+                "a non-empty 'blocked_by' ticket reference (e.g. 'CHAOS-3393') -- "
+                "a blocked case must be loudly, traceably blocked, never a bare "
+                "status flag with no way to know what unblocks it"
+            )
+        if not _BLOCKED_BY_TICKET_PATTERN.match(blocked_by.strip()):
+            raise CaseSchemaError(
+                f"{path}: {case_id!r} 'blocked_by' {blocked_by!r} does not start "
+                "with a real ticket reference (e.g. 'CHAOS-3393' or 'CHAOS-3393 "
+                "some description') -- a value like 'not-a-ticket' would let "
+                "coverage be suppressed with no traceable, actionable blocker"
+            )
+    elif blocked_by is not None:
+        raise CaseSchemaError(
+            f"{path}: {case_id!r} 'blocked_by' is only valid when "
+            f"status={DECLARED_BLOCKED_STATUS!r}, got status={status!r} with "
+            f"blocked_by={blocked_by!r}"
+        )
+
+    invariants_raw = raw.get("invariants", [])
+    if not isinstance(invariants_raw, list):
+        raise CaseSchemaError(f"{path}: {case_id!r} 'invariants' must be a list")
+    if not is_blocked and not invariants_raw:
+        raise CaseSchemaError(
+            f"{path}: {case_id!r} 'invariants' must be a non-empty list -- a "
+            "case with zero invariant assertions would let the "
+            "assertion_count>0 false-green guard silently pass on a case "
+            "that never asserted anything (a case with nothing to assert "
+            f"yet belongs under status={DECLARED_BLOCKED_STATUS!r}, not an "
+            "empty invariants list on an 'active' case)"
+        )
+    for index, entry in enumerate(invariants_raw):
+        if (
+            not isinstance(entry, Mapping)
+            or "category" not in entry
+            or "check" not in entry
+        ):
+            raise CaseSchemaError(
+                f"{path}: {case_id!r} invariants[{index}] must be an object "
+                "with at least 'category' and 'check' fields, got "
+                f"{entry!r}"
+            )
+
+    resolution_profile_ref = raw.get("resolution_profile_ref")
+    if resolution_profile_ref is not None and (
+        not isinstance(resolution_profile_ref, str)
+        or not resolution_profile_ref.strip()
+    ):
+        raise CaseSchemaError(
+            f"{path}: {case_id!r} 'resolution_profile_ref' must be a "
+            f"non-empty string or absent/null, got {resolution_profile_ref!r}"
+        )
+
+    if case_id != path.stem and not path.stem.endswith(case_id):
+        # Not fatal on its own -- the id inside the file is authoritative,
+        # matching the frozen-registry convention where filenames are a
+        # human convenience, not the identity. Surfaced only as part of the
+        # duplicate-id check in load_corpus_cases, which is where a real
+        # naming collision would actually cause silent data loss.
+        pass
+
+    return CorpusCase(
+        id=case_id,
+        question=question,
+        subject_class=subject_class,
+        invariants=tuple(invariants_raw),
+        resolution_profile_ref=resolution_profile_ref,
+        status=status,
+        blocked_by=blocked_by,
+        source_path=path,
+        raw=raw,
+    )
+
+
+def load_corpus_cases(
+    directory: Path, *, pattern: str = "case-*.json"
+) -> list[CorpusCase]:
+    """Load every corpus case file under ``directory`` matching ``pattern``.
+
+    Returns an empty list for a directory that does not exist or has no
+    matching files -- this is a deliberate, documented non-failure: Lane 2b
+    lands case content on its own schedule (merge order is 2a before 2b),
+    and a live-armed test session is what enforces "zero cases collected is
+    a failure", not this loader (see
+    ``tests/acceptance/test_wave4_corpus_runner_live.py``'s session guard).
+    A loader that raised on an absent directory would make Lane 2a's own
+    merge fail before Lane 2b exists at all.
+
+    Raises :class:`CaseSchemaError` on any malformed file (fail loud, don't
+    skip) or on a duplicate case id across files (silently keeping "the
+    last one glob happened to return" would make corpus content nondeterministic).
+    """
+
+    if not directory.is_dir():
+        return []
+    cases: dict[str, CorpusCase] = {}
+    duplicates: dict[str, list[Path]] = {}
+    for path in sorted(directory.glob(pattern)):
+        case = load_corpus_case(path)
+        if case.id in cases:
+            duplicates.setdefault(case.id, [cases[case.id].source_path]).append(path)
+        else:
+            cases[case.id] = case
+    if duplicates:
+        raise CaseSchemaError(
+            f"{directory}: duplicate case id(s) across files: {duplicates!r}"
+        )
+    return sorted(cases.values(), key=lambda case: case.id)
+
+
+def load_resolution_profile(path: Path) -> ResolutionProfile:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CaseSchemaError(f"{path}: not valid JSON ({exc})") from exc
+    if not isinstance(raw, Mapping):
+        raise CaseSchemaError(f"{path}: top-level JSON value must be an object")
+
+    schema_version = _require_str(raw, "schema_version", where=path)
+    if not schema_version.startswith(_PROFILE_SCHEMA_VERSION_PREFIX):
+        raise CaseSchemaError(
+            f"{path}: schema_version {schema_version!r} does not start with "
+            f"{_PROFILE_SCHEMA_VERSION_PREFIX!r} -- refusing to load a file "
+            "that may not actually be a resolution-profile document"
+        )
+    profile_id = _require_str(raw, "profile_id", where=path)
+    cases_raw = raw.get("cases")
+    if not isinstance(cases_raw, Mapping):
+        raise CaseSchemaError(f"{path}: 'cases' must be an object keyed by case id")
+    for case_id, expectations in cases_raw.items():
+        if not isinstance(expectations, Mapping):
+            raise CaseSchemaError(
+                f"{path}: cases[{case_id!r}] must be an object of expected "
+                f"values, got {expectations!r}"
+            )
+
+    return ResolutionProfile(
+        profile_id=profile_id,
+        schema_version=schema_version,
+        cases=dict(cases_raw),
+        source_path=path,
+    )
+
+
+def resolve_case_expectations(
+    case: CorpusCase, profiles: Mapping[str, ResolutionProfile]
+) -> Mapping[str, Any]:
+    """The matcher-specific expected-outcome block for one case.
+
+    A case with no ``resolution_profile_ref`` gets an empty block -- it
+    asserts invariants only, by design (e.g. an adversarial or
+    non-subject-shaped case with nothing matcher-specific to pin). A case
+    that DOES cite a profile ref, but whose id has no entry in that
+    profile's ``cases`` map, fails loud here -- exactly the same
+    "cites-but-missing" contract as the script-inventory preflight, and for
+    the identical reason: silently treating it as "no matcher-specific
+    expectations" would let a profile-authoring gap masquerade as an
+    intentionally invariant-only case.
+    """
+
+    if case.resolution_profile_ref is None:
+        return {}
+    profile = profiles.get(case.resolution_profile_ref)
+    if profile is None:
+        raise CaseSchemaError(
+            f"case {case.id!r} cites resolution_profile_ref "
+            f"{case.resolution_profile_ref!r}, which was not loaded (known "
+            f"profiles: {sorted(profiles)!r})"
+        )
+    expectations = profile.cases.get(case.id)
+    if expectations is None:
+        raise CaseSchemaError(
+            f"case {case.id!r} cites resolution profile "
+            f"{case.resolution_profile_ref!r}, but that profile has no "
+            f"'cases[{case.id!r}]' entry -- a case cannot cite a profile and "
+            "then run with no matcher-specific expectations silently "
+            "assumed"
+        )
+    return expectations

--- a/scripts/acceptance/corpus/compose_context.py
+++ b/scripts/acceptance/corpus/compose_context.py
@@ -1,0 +1,90 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the docker-compose invocation context
+shared by the corpus runner's verification plane (``db_verify.py``).
+
+Team-lead ruling (2026-08-06), binding: the runner's VERIFICATION plane
+(WORLD_DIGEST guard, resolution-ledger read) reaches the acceptance
+Compose project's database through the CONTAINER boundary
+(``docker compose exec -T``) -- never by exposing a host port on
+postgres/clickhouse, never by adding a test-only product API endpoint.
+Product-facing case execution stays wire-only against the public API; only
+these two harness concerns get exec-based DB access.
+
+Every field here duplicates a literal already hardcoded in
+``run_ask_dev_compose.sh`` (``project_name``, the two compose file paths,
+the ``ask-dev-acceptance`` profile) -- MUST NOT drift from that launcher.
+Duplicated rather than imported because the launcher is bash and this is
+Python; ``test_compose_context_matches_the_launcher_literals`` (this
+package's static-wiring-guard companion) greps both files for the same
+literal strings so a future rename in one is caught in the unit tier, not
+discovered live.
+
+The "duplicate project-name trap" this repo's own history warns about
+(``ops/compose.yml`` project ``dev-health-ops`` vs the parent repo's
+``compose.yml`` project ``dev-health`` destroying each other's postgres
+pre-CHAOS-3142): every compose invocation here ALWAYS passes an explicit
+``--project-name``/``--project-directory``, never relies on Compose's
+directory-name-derived default.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = ["ComposeContext"]
+
+#: Must match run_ask_dev_compose.sh's `project_name=` literal exactly.
+DEFAULT_PROJECT_NAME = "dev-health-ask-dev-acceptance"
+
+#: Must match run_ask_dev_compose.sh's `--profile ask-dev-acceptance` literal.
+DEFAULT_PROFILE = "ask-dev-acceptance"
+
+#: This file lives at <ops_root>/scripts/acceptance/corpus/compose_context.py.
+_OPS_ROOT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeContext:
+    project_name: str
+    project_directory: Path
+    compose_files: tuple[Path, ...]
+    profile: str | None = None
+    api_service: str = field(default="api")
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ComposeContext:
+        """Build the context the launcher itself would use, honoring the
+        SAME override env vars ``run_ask_dev_compose.sh`` reads (e.g. a
+        developer running two acceptance-shaped stacks side by side)."""
+
+        source = env if env is not None else os.environ
+        project_name = source.get(
+            "ASK_DEV_ACCEPTANCE_PROJECT_NAME", DEFAULT_PROJECT_NAME
+        )
+        ops_root = Path(source.get("ASK_DEV_ACCEPTANCE_OPS_ROOT", str(_OPS_ROOT)))
+        return cls(
+            project_name=project_name,
+            project_directory=ops_root,
+            compose_files=(
+                ops_root / "compose.yml",
+                ops_root / "tests" / "acceptance" / "compose.ask-dev.yml",
+            ),
+            profile=DEFAULT_PROFILE,
+        )
+
+    def base_args(self) -> list[str]:
+        args = [
+            "docker",
+            "compose",
+            "--project-name",
+            self.project_name,
+            "--project-directory",
+            str(self.project_directory),
+        ]
+        for compose_file in self.compose_files:
+            args += ["-f", str(compose_file)]
+        if self.profile is not None:
+            args += ["--profile", self.profile]
+        return args

--- a/scripts/acceptance/corpus/db_verify.py
+++ b/scripts/acceptance/corpus/db_verify.py
@@ -1,0 +1,303 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the corpus runner's DB verification
+plane -- ``docker compose exec -T``, never a host port, never a new product
+API endpoint (team-lead ruling, 2026-08-06).
+
+Exactly three harness concerns get this: :func:`verify_world_digest_via_exec`
+(ruling D2), :func:`query_resolution_ledger_via_exec` (the CHAOS-3424
+resolution ledger, for ``resolution_path`` derivation), and
+:func:`query_transcript_assistant_schema_versions_via_exec` (the CHAOS-3423
+transcript row, for ``terminal_persists_assistant_row``). Product-facing
+case execution (the SSE HTTP round-trip in
+``test_wave4_corpus_runner_live.py``) stays wire-only against the public
+API -- this module is not, and must never become, a general-purpose
+database client for case assertions.
+
+The exec boundary itself FAILS LOUD on any failure -- ``docker``/``compose``
+missing, the ``api`` container not running, a non-zero exit, or output this
+module cannot parse -- via :class:`DbVerifyUnavailableError`. This is
+distinct from :func:`scripts.acceptance.corpus.resolution_path.
+derive_resolution_path`'s own honest ``None`` for a ledger with genuinely
+zero rows: that "no data" reading only applies once the exec plane has
+actually reached the database and found nothing -- an exec that could not
+even be attempted must never be silently treated the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from scripts.acceptance.corpus.compose_context import ComposeContext
+from scripts.acceptance.corpus.resolution_path import ResolutionLedgerEntry
+from scripts.acceptance.corpus.world_digest_guard import WorldDigestVerification
+
+__all__ = [
+    "DbVerifyUnavailableError",
+    "ExecRunner",
+    "exec_in_api",
+    "query_resolution_ledger_via_exec",
+    "query_transcript_assistant_schema_versions_via_exec",
+    "verify_world_digest_via_exec",
+]
+
+#: Injectable for tests -- must behave like ``subprocess.run`` (accepting
+#: ``capture_output``/``text``/``timeout`` keywords and returning something
+#: with ``.returncode``/``.stdout``/``.stderr``).
+ExecRunner = Callable[..., Any]
+
+
+class DbVerifyUnavailableError(Exception):
+    """The exec verification plane could not be reached at all.
+
+    Never caught internally and downgraded to "no data" -- see the module
+    docstring. A caller that wants "the corpus run cannot proceed without
+    this measurement" behavior should let this propagate; the CHAOS-3219
+    Phase 2 mandate ("a measurement that did not happen must FAIL, loudly")
+    applies directly here.
+    """
+
+
+def exec_in_api(
+    context: ComposeContext,
+    command: Sequence[str],
+    *,
+    runner: ExecRunner = subprocess.run,
+    timeout: float = 60.0,
+) -> str:
+    """Run ``command`` inside the acceptance stack's ``api`` container via
+    ``docker compose exec -T`` and return its stdout.
+
+    ``-T`` (no pseudo-TTY) is non-negotiable -- allocating one would corrupt
+    the machine-parseable stdout contract both inner scripts rely on.
+    """
+
+    args = [*context.base_args(), "exec", "-T", context.api_service, *command]
+    try:
+        result = runner(args, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError as exc:
+        raise DbVerifyUnavailableError(
+            f"docker compose is not available on this host: {exc}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise DbVerifyUnavailableError(
+            f"docker compose exec -T {context.api_service} {' '.join(command)} "
+            f"timed out after {timeout}s"
+        ) from exc
+    if result.returncode != 0:
+        raise DbVerifyUnavailableError(
+            f"docker compose exec -T {context.api_service} {' '.join(command)} "
+            f"exited {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _parse_json_line(stdout: str, *, command: Sequence[str]) -> Mapping[str, Any]:
+    stripped = stdout.strip()
+    if not stripped:
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} produced no stdout -- expected one JSON line"
+        )
+    try:
+        payload = json.loads(stripped.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} produced output this module cannot parse "
+            f"as JSON: {stripped!r} ({exc})"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} produced a JSON value that is not an object: "
+            f"{payload!r}"
+        )
+    return payload
+
+
+def _require_str_field(
+    payload: Mapping[str, Any], key: str, *, command: Sequence[str]
+) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output field {key!r} must be a string, "
+            f"got {value!r} ({payload!r})"
+        )
+    return value
+
+
+#: `fixtures/world.py`'s `compute_world_digest` always produces
+#: `hashlib.sha256(...).hexdigest()` -- exactly 64 lowercase hex characters.
+#: Codex round-3 finding (HIGH, confirmed): requiring only `isinstance(str)`
+#: let two EMPTY strings ("" == "") report `matched=True` for a
+#: WORLD_DIGEST verification that never actually computed a real digest at
+#: all -- an empty-string false-green, not merely a formatting nitpick.
+_SHA256_HEXDIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require_digest_field(
+    payload: Mapping[str, Any], key: str, *, command: Sequence[str]
+) -> str:
+    value = _require_str_field(payload, key, command=command)
+    if not _SHA256_HEXDIGEST.match(value):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output field {key!r} is not a "
+            f"64-character lowercase hex sha256 digest: {value!r}"
+        )
+    return value
+
+
+def verify_world_digest_via_exec(
+    context: ComposeContext,
+    *,
+    manifest_path_in_container: str,
+    sink: str,
+    postgres_uri: str,
+    digest_path_in_container: str | None = None,
+    runner: ExecRunner = subprocess.run,
+) -> WorldDigestVerification:
+    command = [
+        "python",
+        "-m",
+        "scripts.acceptance.corpus._inner_world_digest",
+        "--manifest",
+        manifest_path_in_container,
+        "--sink",
+        sink,
+        "--postgres-uri",
+        postgres_uri,
+    ]
+    if digest_path_in_container is not None:
+        command += ["--digest-path", digest_path_in_container]
+    stdout = exec_in_api(context, command, runner=runner)
+    payload = _parse_json_line(stdout, command=command)
+
+    # Codex round-2 finding (HIGH, confirmed): the original version trusted
+    # `payload["matched"]` verbatim -- a non-bool truthy value (e.g. the
+    # STRING "false", which Python's `bool("false")` evaluates True) could
+    # slip a mismatched digest pair past `require_world_digest_match`
+    # entirely. Every field is now type-checked, and `matched` is
+    # RECOMPUTED from the two digest strings rather than trusted from the
+    # inner script's own claim -- the inner script's `matched` value is
+    # never consulted at all, closing the class of bug rather than one
+    # instance of it.
+    pinned_digest = _require_digest_field(payload, "pinned_digest", command=command)
+    live_digest = _require_digest_field(payload, "live_digest", command=command)
+    drifted_raw = payload.get("drifted_components")
+    if not isinstance(drifted_raw, list) or not all(
+        isinstance(item, str) for item in drifted_raw
+    ):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output field 'drifted_components' must "
+            f"be a list of strings, got {drifted_raw!r}"
+        )
+    return WorldDigestVerification(
+        pinned_digest=pinned_digest,
+        live_digest=live_digest,
+        matched=(pinned_digest == live_digest),
+        drifted_components=tuple(drifted_raw),
+    )
+
+
+def _ledger_entry_from_json(
+    entry: Any, *, command: Sequence[str]
+) -> ResolutionLedgerEntry:
+    # Codex round-2 finding (HIGH, confirmed): indexing `entry["outcome"]`
+    # directly let a malformed row leak a raw KeyError/TypeError instead of
+    # DbVerifyUnavailableError -- every caller of this module expects
+    # exactly one exception type for "the verification plane misbehaved".
+    if not isinstance(entry, Mapping):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output 'entries' contains a non-object "
+            f"entry: {entry!r}"
+        )
+    outcome = entry.get("outcome")
+    mention_id = entry.get("mention_id")
+    if not isinstance(outcome, str) or not isinstance(mention_id, str):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output entry is missing a string "
+            f"'outcome'/'mention_id': {entry!r}"
+        )
+    committed_label = entry.get("committed_label")
+    committed_canonical_id = entry.get("committed_canonical_id")
+    if committed_label is not None and not isinstance(committed_label, str):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output entry 'committed_label' must be "
+            f"a string or null: {entry!r}"
+        )
+    if committed_canonical_id is not None and not isinstance(
+        committed_canonical_id, str
+    ):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output entry 'committed_canonical_id' "
+            f"must be a string or null: {entry!r}"
+        )
+    return ResolutionLedgerEntry(
+        outcome=outcome,
+        mention_id=mention_id,
+        committed_label=committed_label,
+        committed_canonical_id=committed_canonical_id,
+    )
+
+
+def query_resolution_ledger_via_exec(
+    context: ComposeContext,
+    *,
+    run_id: str | uuid.UUID,
+    database_uri: str | None = None,
+    runner: ExecRunner = subprocess.run,
+) -> list[ResolutionLedgerEntry]:
+    command = [
+        "python",
+        "-m",
+        "scripts.acceptance.corpus._inner_ledger_query",
+        "--run-id",
+        str(run_id),
+    ]
+    if database_uri is not None:
+        command += ["--database-uri", database_uri]
+    stdout = exec_in_api(context, command, runner=runner)
+    payload = _parse_json_line(stdout, command=command)
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output has no 'entries' list: {payload!r}"
+        )
+    return [_ledger_entry_from_json(entry, command=command) for entry in entries]
+
+
+def query_transcript_assistant_schema_versions_via_exec(
+    context: ComposeContext,
+    *,
+    conversation_id: str | uuid.UUID,
+    database_uri: str | None = None,
+    runner: ExecRunner = subprocess.run,
+) -> list[str | None]:
+    """The ``dev_messages.answer_payload.schema_version`` of every assistant
+    row on one conversation -- for ``invariants.terminal_persists_
+    assistant_row`` (CHAOS-3423's own guarantee, verified from the corpus
+    side, per team-lead direction 2026-08-06 folding this in as the third
+    harness concern allowed through the exec verification plane)."""
+
+    command = [
+        "python",
+        "-m",
+        "scripts.acceptance.corpus._inner_transcript_query",
+        "--conversation-id",
+        str(conversation_id),
+    ]
+    if database_uri is not None:
+        command += ["--database-uri", database_uri]
+    stdout = exec_in_api(context, command, runner=runner)
+    payload = _parse_json_line(stdout, command=command)
+    versions = payload.get("assistant_schema_versions")
+    if not isinstance(versions, list) or not all(
+        item is None or isinstance(item, str) for item in versions
+    ):
+        raise DbVerifyUnavailableError(
+            f"{' '.join(command)} JSON output 'assistant_schema_versions' "
+            f"must be a list of strings/nulls, got {versions!r}"
+        )
+    return versions

--- a/scripts/acceptance/corpus/invariants.py
+++ b/scripts/acceptance/corpus/invariants.py
@@ -1,0 +1,460 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the pluggable invariant-check registry.
+
+This is the seam the CHAOS-3389 fold-in requires (invariant-first case
+assertions; matcher-specific expectations come from a versioned
+``resolution-profile``): a case's ``invariants[].check`` names a checker
+here; the checker's ``args`` may pull an exact expected value out of the
+case's resolved resolution-profile block (``from_profile``) instead of a
+literal, so the SAME case file works unmodified across profiles -- when a
+future QUA profile flips a case's expected resolution behavior, only that
+profile's JSON changes, never the case file or this registry.
+
+Six checkers are implemented today (``resolution_path_in``,
+``no_internal_error``, ``public_outcome_in``, ``scope_resolution_outcome_in``,
+``no_unauthorized_candidate_surfaces``, ``terminal_persists_assistant_row``)
+-- the first three prove the runner's own wiring end-to-end; the latter
+three graduated from :data:`NOT_YET_IMPLEMENTED_CATEGORIES` on Lane 2b's
+explicit request once its authored cases started declaring them (2026-08-06:
+57/57 of 2b's cases load against this module's schema today). The full "for
+every case assert" matrix (issue Group 1: intent/cardinality, plan
+id/version, per-source applicability, fact counts, metric ids/values/units,
+health dimensions, evidence/citation precision, persistence/replay, etc.) is
+still NOT implemented here -- each remaining one is a real checker this
+registry can grow, one at a time, as Lane 2b's case authoring needs it.
+Listed explicitly in :data:`NOT_YET_IMPLEMENTED_CATEGORIES` so this is a
+documented gap, not a silent one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "NOT_YET_IMPLEMENTED_CATEGORIES",
+    "CHECKS",
+    "InvariantCheckError",
+    "InvariantContext",
+    "InvariantResult",
+    "evaluate_invariant",
+    "register_check",
+]
+
+#: The issue's Group 1 "For every case assert" bullets this registry does
+#: NOT yet have a checker for -- see the module docstring. Not consulted by
+#: any code path; exists purely as an honest, grep-able residual-coverage
+#: note.
+NOT_YET_IMPLEMENTED_CATEGORIES: tuple[str, ...] = (
+    "intent-cardinality-version",
+    "plan-id-version-bounds",
+    "source-applicability-observation-state",
+    "fact-sample-counts-coverage-attribution",
+    "required-prohibited-facts",
+    "completion-numerator-denominator",
+    "metric-ids-values-units-versions",
+    "health-dimensions-rule-versions",
+    "workload-denominator-baseline",
+    "deficiency-category-severity-evidence",
+    "evidence-citation-precision-freshness-conflicts",
+    "ordered-sections-narrative-mode-fallback",
+    "provider-source-time-token-cost-limits",
+    "persistence-replay-retention-deletion",
+)
+
+
+class InvariantCheckError(Exception):
+    """A checker is misconfigured (unknown name, missing/bad args) -- this
+    is a case/profile-authoring defect, distinct from an assertion that ran
+    and failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantContext:
+    """Everything one invariant check can inspect about a completed case run."""
+
+    resolution_path: str | None
+    public_outcome: str | None
+    #: Raw, already-validated SSE event dicts, in stream order.
+    events: Sequence[Mapping[str, Any]]
+    #: The case's resolved matcher-specific expectations block
+    #: (``case_schema.resolve_case_expectations``'s return value) -- empty
+    #: for a case with no ``resolution_profile_ref``.
+    expectations: Mapping[str, Any]
+    #: ``dev_messages.answer_payload.schema_version`` for every assistant
+    #: row this run's conversation has, in creation order -- via the
+    #: docker-exec verification plane
+    #: (``db_verify.query_transcript_assistant_schema_versions_via_exec``).
+    #: Empty by default: only populated by a caller that actually ran that
+    #: query; a case with no ``terminal_persists_assistant_row`` invariant
+    #: never needs it, and the wire alone cannot answer this question (see
+    #: ``resolution_path``'s identical "public API cannot see this" story).
+    assistant_schema_versions: Sequence[str | None] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantResult:
+    passed: bool
+    detail: str
+
+
+CheckFn = Callable[[Mapping[str, Any], InvariantContext], InvariantResult]
+
+CHECKS: dict[str, CheckFn] = {}
+
+
+def register_check(name: str) -> Callable[[CheckFn], CheckFn]:
+    """Decorator registering a checker under ``name``. Raises if ``name`` is
+    already registered -- a silent overwrite would let two checkers with the
+    same name shadow each other with no signal about which one actually
+    runs."""
+
+    def decorator(fn: CheckFn) -> CheckFn:
+        if name in CHECKS:
+            raise InvariantCheckError(f"a check named {name!r} is already registered")
+        CHECKS[name] = fn
+        return fn
+
+    return decorator
+
+
+def _resolve_allowed(
+    args: Mapping[str, Any], context: InvariantContext, *, check_name: str
+) -> list[Any]:
+    allowed = list(args.get("allowed", []))
+    profile_key = args.get("from_profile")
+    if profile_key is not None:
+        if profile_key not in context.expectations:
+            raise InvariantCheckError(
+                f"{check_name}: profile key {profile_key!r} not found in "
+                f"resolved expectations {dict(context.expectations)!r}"
+            )
+        allowed.append(context.expectations[profile_key])
+    if not allowed:
+        raise InvariantCheckError(
+            f"{check_name} requires a non-empty 'allowed' list and/or a "
+            "'from_profile' key resolvable in the case's resolution profile"
+        )
+    return allowed
+
+
+@register_check("resolution_path_in")
+def _resolution_path_in(
+    args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    allowed = _resolve_allowed(args, context, check_name="resolution_path_in")
+    if context.resolution_path is None:
+        # Codex round-1 finding (HIGH, confirmed): `None` means "not
+        # observed" (see resolution_path.py's own honest-absence contract)
+        # -- it must NEVER satisfy this check, even if a case/profile
+        # authoring mistake put a literal `null` into `allowed`. A case
+        # that declares this check is asserting it OBSERVED a specific
+        # resolution path; an unobserved run has not met that bar by
+        # definition.
+        return InvariantResult(
+            passed=False,
+            detail=(
+                "resolution_path was not observed (None) -- a case that "
+                "declares resolution_path_in requires an observed path, "
+                f"never an absence; allowed={allowed!r}"
+            ),
+        )
+    passed = context.resolution_path in allowed
+    return InvariantResult(
+        passed=passed,
+        detail=f"resolution_path={context.resolution_path!r}, allowed={allowed!r}",
+    )
+
+
+@register_check("no_internal_error")
+def _no_internal_error(
+    _args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    offending = [
+        event
+        for event in context.events
+        if event.get("event") == "error"
+        and isinstance(event.get("data"), Mapping)
+        and isinstance(event["data"].get("error"), Mapping)
+        and event["data"]["error"].get("code") == "internal_error"
+    ]
+    return InvariantResult(
+        passed=not offending,
+        detail=(
+            "no internal_error event"
+            if not offending
+            else f"{len(offending)} internal_error event(s) present"
+        ),
+    )
+
+
+@register_check("public_outcome_in")
+def _public_outcome_in(
+    args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    """Assert the run's terminal ``PublicOutcome`` -- added per Codex
+    round-1 (HIGH, confirmed): before this checker existed, no implemented
+    invariant asserted the terminal outcome at all, so a case whose only
+    check was ``no_internal_error`` would pass identically whether it
+    actually answered or silently terminated in ``scope_ambiguous``, a
+    missing answer frame, or any other non-``internal_error`` shape. Same
+    ``allowed``/``from_profile`` seam as ``resolution_path_in``.
+    """
+
+    allowed = _resolve_allowed(args, context, check_name="public_outcome_in")
+    if context.public_outcome is None:
+        return InvariantResult(
+            passed=False,
+            detail=(
+                "public_outcome was not observed (None) -- no "
+                "answer.completed event was found, or the run did not "
+                f"reach a terminal answer; allowed={allowed!r}"
+            ),
+        )
+    passed = context.public_outcome in allowed
+    return InvariantResult(
+        passed=passed,
+        detail=f"public_outcome={context.public_outcome!r}, allowed={allowed!r}",
+    )
+
+
+def _all_scope_resolutions_from_events(
+    events: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Every ``scope_resolution`` block off every ``scope.resolved`` event
+    in stream order -- the only event type that carries one
+    (``contracts.py``'s per-event allowed-payload mapping).
+
+    Codex round-3 finding (HIGH, confirmed): production's own
+    ``validate_stream`` does not forbid more than one ``scope.resolved``
+    event in a single run's stream (e.g. a re-resolution mid-investigation)
+    -- an earlier version of this helper returned only the FIRST match, so
+    an unauthorized candidate surfaced on a SECOND ``scope.resolved`` event
+    was invisible to ``no_unauthorized_candidate_surfaces`` even though the
+    overall stream passed ``validate_stream`` cleanly. Every caller that
+    cares about "the current/final resolution" (e.g.
+    ``scope_resolution_outcome_in``) uses the LAST element; every caller
+    that cares about "was anything unauthorized EVER surfaced" (e.g.
+    ``no_unauthorized_candidate_surfaces``) must scan ALL elements.
+    """
+
+    resolutions: list[Mapping[str, Any]] = []
+    for event in events:
+        if event.get("event") != "scope.resolved":
+            continue
+        data = event.get("data")
+        if isinstance(data, Mapping):
+            resolution = data.get("scope_resolution")
+            if isinstance(resolution, Mapping):
+                resolutions.append(resolution)
+    return resolutions
+
+
+@register_check("scope_resolution_outcome_in")
+def _scope_resolution_outcome_in(
+    args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    """Assert the wire ``scope.resolved`` event's own
+    ``ScopeResolutionOutcome`` (exact/filtered/inherited/
+    organization_fallback/ambiguous/unresolved/forbidden_or_not_found) --
+    the SCOPE-level enum, distinct from ``resolution_path``'s per-mention
+    ``ResolutionOutcome`` classification (see resolution_path.py's module
+    docstring for why the two are different vocabularies). Same
+    ``allowed``/``from_profile`` seam as the other ``*_in`` checks.
+
+    Uses the LAST ``scope.resolved`` event when a stream carries more than
+    one (e.g. a re-resolution mid-investigation) -- the current/final
+    resolution is what "the outcome of this run" means.
+    """
+
+    allowed = _resolve_allowed(args, context, check_name="scope_resolution_outcome_in")
+    resolutions = _all_scope_resolutions_from_events(context.events)
+    outcome = resolutions[-1].get("outcome") if resolutions else None
+    if outcome is None:
+        return InvariantResult(
+            passed=False,
+            detail=(
+                "no scope.resolved event with a scope_resolution.outcome "
+                f"was found in the stream; allowed={allowed!r}"
+            ),
+        )
+    passed = outcome in allowed
+    return InvariantResult(
+        passed=passed,
+        detail=f"scope_resolution_outcome={outcome!r}, allowed={allowed!r}",
+    )
+
+
+def _candidate_entity_ids(resolution: Mapping[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for candidate in resolution.get("candidates") or []:
+        if not isinstance(candidate, Mapping):
+            continue
+        entity_ref = candidate.get("entity_ref")
+        if isinstance(entity_ref, Mapping):
+            entity_id = entity_ref.get("entity_id")
+            if isinstance(entity_id, str):
+                ids.append(entity_id)
+    return ids
+
+
+@register_check("no_unauthorized_candidate_surfaces")
+def _no_unauthorized_candidate_surfaces(
+    args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    """Assert every disambiguation candidate the run surfaced belongs to
+    the case's own authorized world-entity set -- the launch threshold
+    "zero cross-tenant leakage" / "zero unresolved-subject fabrication",
+    applied per case. ``authorized_entity_ids`` (literal list, and/or
+    ``from_profile`` pulling it out of the resolved resolution-profile
+    block) is REQUIRED -- unlike the ``*_in`` checks' ``allowed``, there is
+    no sensible default "everything is authorized" fallback a security
+    invariant should ever silently assume.
+
+    Scans EVERY ``scope.resolved`` event in the stream, not only the first
+    (Codex round-3, HIGH, confirmed: a stream can legally carry more than
+    one, and an earlier version of this check only ever inspected the
+    first one -- see :func:`_all_scope_resolutions_from_events`).
+
+    KNOWN TRUST BOUNDARY (Codex round-3, HIGH, evaluated and NOT changed
+    here -- reported, not silently accepted): ``authorized_entity_ids`` is
+    a value the CASE/PROFILE declares, exactly like every other ``*_in``
+    checker's ``allowed`` list -- this function has no independent access
+    to the pinned world manifest to verify that declaration is itself
+    correct. A case that mis-declares an overly broad authorized set can
+    make this check vacuous for that case, same as a case that mis-declares
+    an overly broad ``resolution_path_in``/``public_outcome_in`` allowed
+    set would. Closing this would mean threading the pinned world/subjects
+    registry into every invariant evaluation as an independent oracle --
+    a real, larger design change (cross-referencing case-declared
+    expectations against the frozen registry), not a bug in this specific
+    checker; correctness of the DECLARED authorized set is Lane 2b's case-
+    authoring/review responsibility today, not something this generic
+    registry enforces at runtime.
+    """
+
+    authorized = list(args.get("authorized_entity_ids", []))
+    profile_key = args.get("from_profile")
+    if profile_key is not None:
+        if profile_key not in context.expectations:
+            raise InvariantCheckError(
+                "no_unauthorized_candidate_surfaces: profile key "
+                f"{profile_key!r} not found in resolved expectations "
+                f"{dict(context.expectations)!r}"
+            )
+        authorized.extend(context.expectations[profile_key])
+    if not authorized:
+        raise InvariantCheckError(
+            "no_unauthorized_candidate_surfaces requires a non-empty "
+            "'authorized_entity_ids' list and/or a 'from_profile' key "
+            "resolvable in the case's resolution profile"
+        )
+    authorized_set = set(authorized)
+
+    resolutions = _all_scope_resolutions_from_events(context.events)
+    candidate_ids = [
+        entity_id
+        for resolution in resolutions
+        for entity_id in _candidate_entity_ids(resolution)
+    ]
+    offending = [
+        entity_id for entity_id in candidate_ids if entity_id not in authorized_set
+    ]
+    return InvariantResult(
+        passed=not offending,
+        detail=(
+            "no unauthorized candidates surfaced"
+            if not offending
+            else f"unauthorized candidate id(s) surfaced: {offending!r} "
+            f"(authorized: {sorted(authorized_set)!r})"
+        ),
+    )
+
+
+#: The closed set of schema versions that mean "a real terminal transcript
+#: row exists" -- mirrors ``persistence/service.py``'s own
+#: ``_REAL_ANSWER_SCHEMA_VERSIONS`` plus ``dev_error.v1`` (CHAOS-3423's
+#: no-answer-terminal row), since ``terminal_persists_assistant_row`` must
+#: accept EITHER a genuine answer or a genuine no-answer-terminal error row
+#: -- both are "the terminal persisted a transcript row", which is exactly
+#: what CHAOS-3423 exists to guarantee.
+_REAL_TERMINAL_SCHEMA_VERSIONS = frozenset(
+    {"dev_answer.v1", "dev_answer.v2", "dev_error.v1"}
+)
+
+
+@register_check("terminal_persists_assistant_row")
+def _terminal_persists_assistant_row(
+    _args: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    """Assert CHAOS-3423's own guarantee from the corpus side: every
+    terminal run leaves EXACTLY ONE real ``dev_messages`` assistant row
+    (``dev_answer.v1``/``dev_answer.v2``/``dev_error.v1``) for its
+    conversation. Needs ``assistant_schema_versions`` populated via the
+    docker-exec verification plane (``db_verify.
+    query_transcript_assistant_schema_versions_via_exec``) -- the public
+    wire alone cannot answer "did persistence actually happen".
+
+    Codex round-3 finding (MEDIUM, confirmed): the original version only
+    checked "at least one recognized row exists", which would also pass for
+    a DUPLICATE or stale extra assistant row left over from a retry/replay
+    bug -- exactly the kind of persistence defect CHAOS-3423/replay-safety
+    exists to prevent. Tightened to require the conversation's assistant
+    rows be EXACTLY one, and that one recognized.
+
+    ASSUMPTION, explicit: the corpus runner creates a FRESH conversation
+    per case (one turn each) -- see ``test_wave4_corpus_runner_live.py``'s
+    ``test_corpus_case``. "Exactly one assistant row in the whole
+    conversation" is therefore equivalent to "exactly one for this run"
+    today. A future MULTI-TURN corpus case (e.g. the two-turn acronym-alias
+    disambiguation flow ``resolution_path.py``'s module docstring
+    describes) would need this checker to scope by the run/message
+    boundary instead of the whole conversation -- not built here since no
+    such case exists yet; noted so it isn't rediscovered as a surprise.
+    """
+
+    matching = [
+        version
+        for version in context.assistant_schema_versions
+        if version in _REAL_TERMINAL_SCHEMA_VERSIONS
+    ]
+    total = len(context.assistant_schema_versions)
+    passed = total == 1 and len(matching) == 1
+    if passed:
+        detail = f"exactly one real terminal transcript row found: {matching!r}"
+    elif total == 0:
+        detail = "no assistant row found at all for this conversation"
+    elif total > 1:
+        detail = (
+            f"expected exactly one assistant row, found {total}: "
+            f"{list(context.assistant_schema_versions)!r}"
+        )
+    else:
+        detail = (
+            "the conversation's one assistant row is not a recognized "
+            f"dev_answer.v1/dev_answer.v2/dev_error.v1 schema_version: "
+            f"{list(context.assistant_schema_versions)!r}"
+        )
+    return InvariantResult(passed=passed, detail=detail)
+
+
+def evaluate_invariant(
+    entry: Mapping[str, Any], context: InvariantContext
+) -> InvariantResult:
+    """Dispatch one case ``invariants[]`` entry to its registered checker."""
+
+    check_name = entry.get("check")
+    if not isinstance(check_name, str):
+        raise InvariantCheckError(f"invariant entry has no string 'check': {entry!r}")
+    fn = CHECKS.get(check_name)
+    if fn is None:
+        raise InvariantCheckError(
+            f"unknown invariant check {check_name!r} -- known checks: "
+            f"{sorted(CHECKS)!r}"
+        )
+    args = entry.get("args", {})
+    if not isinstance(args, Mapping):
+        raise InvariantCheckError(
+            f"invariant entry 'args' must be an object: {entry!r}"
+        )
+    return fn(args, context)

--- a/scripts/acceptance/corpus/quota.py
+++ b/scripts/acceptance/corpus/quota.py
@@ -1,0 +1,198 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: scripted-provider quota coordination.
+
+Recon finding this exists to close: the compose-configured platform ceiling
+(``tests/acceptance/compose.ask-dev.yml``: ``ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX=1000``,
+``ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD=200_000_000``) is enforced ONLY
+by the real admission path at request time
+(``DevPersistenceService._enforce_platform_allowance`` ->
+``DevMonthlyCostLimitExceeded``) -- there is no in-band coordinator. Phase
+1c's ``test_ask_dev_quota_headroom.py`` proves the ceiling *should* clear
+134 cases x 3 runs with margin, at an offline allowance-accounting level;
+it does not track or bound spend *during* a real corpus run.
+
+Without this module, a corpus run that overruns the ceiling (a case
+retried more than planned, a future larger corpus, a lower ceiling in some
+other environment) would see its N-th case fail with a raw
+``DevMonthlyCostLimitExceeded``/429 that looks exactly like a per-case
+product defect. ``QuotaBudget`` tracks the SAME estimate
+``test_ask_dev_quota_headroom.py`` already validates has headroom, locally,
+case by case, and fails loud with an actionable message (how many
+requests/cost remain, which case tripped it) BEFORE the real admission path
+would 429 -- turning an opaque per-case failure into a diagnosable
+quota-coordination one.
+
+This is advisory bookkeeping, not enforcement: the real ceiling lives
+server-side and is what actually protects the platform. A caller that never
+calls :meth:`QuotaBudget.reserve` is not blocked from anything -- this
+module only helps the runner behave well against a shared, real limit.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_ROUNDS_PER_RUN",
+    "QuotaBudget",
+    "QuotaConfigurationError",
+    "QuotaExhaustedError",
+    "estimate_run_cost_microusd",
+]
+
+#: The scripted acceptance model id (scripted_openai_service.py). Pricing is
+#: looked up by this exact string in ``openai_compatible._PLATFORM_MODEL_PRICES``.
+DEFAULT_MODEL = "ask-dev-scripted-v1"
+
+#: orchestrator.py's ``DevRunLimits`` default model-round cap -- the
+#: worst-case number of provider round-trips one run can make. Mirrors
+#: ``test_ask_dev_quota_headroom.py``'s identical constant so both proofs
+#: use the same worst-case assumption.
+DEFAULT_ROUNDS_PER_RUN = 4
+
+_REQUEST_MAX_ENV = "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX"
+_COST_MAX_ENV = "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD"
+
+
+class QuotaConfigurationError(Exception):
+    """The environment does not declare a usable quota ceiling.
+
+    Raised rather than defaulting to "unlimited": a corpus run against a
+    stack that forgot to set these (compose misconfiguration, or a
+    developer running against a different environment entirely) must not
+    silently proceed un-budgeted.
+    """
+
+
+class QuotaExhaustedError(Exception):
+    """A reservation would exceed the tracked request or cost ceiling."""
+
+
+def estimate_run_cost_microusd(
+    *,
+    model: str = DEFAULT_MODEL,
+    input_tokens: int,
+    output_tokens: int,
+    rounds: int = DEFAULT_ROUNDS_PER_RUN,
+) -> int:
+    """The real production pricing function, applied to a per-round token
+    estimate and summed over the worst-case round count one run can reach.
+
+    Raises ``ValueError`` (not a silent 0) if ``model`` has no priced entry
+    -- an unpriced model falling back to "free" would make every reservation
+    against it vacuous.
+    """
+
+    per_round = _estimated_cost_microusd(
+        model=model, input_tokens=input_tokens, output_tokens=output_tokens
+    )
+    if per_round is None:
+        raise ValueError(
+            f"{model!r} has no priced entry in _PLATFORM_MODEL_PRICES -- "
+            "refusing to silently treat this reservation as free"
+        )
+    return per_round * rounds
+
+
+@dataclass(slots=True)
+class QuotaBudget:
+    """Tracks estimated request/cost spend against a fixed monthly ceiling.
+
+    Not thread-safe and not process-shared -- one instance per corpus-runner
+    pytest session, mirroring the single-process, sequential-by-default
+    nature of the acceptance run itself.
+    """
+
+    max_requests: int
+    max_cost_microusd: int
+    spent_requests: int = 0
+    spent_cost_microusd: int = 0
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> QuotaBudget:
+        """Build a budget from the same env vars the compose stack sets.
+
+        Raises :class:`QuotaConfigurationError` if either is missing,
+        non-numeric, or non-positive -- an un-set or zero ceiling is
+        treated as a configuration error, never as "no limit".
+        """
+
+        source = env if env is not None else os.environ
+        max_requests = _positive_int(source, _REQUEST_MAX_ENV)
+        max_cost_microusd = _positive_int(source, _COST_MAX_ENV)
+        return cls(max_requests=max_requests, max_cost_microusd=max_cost_microusd)
+
+    def remaining_requests(self) -> int:
+        return self.max_requests - self.spent_requests
+
+    def remaining_cost_microusd(self) -> int:
+        return self.max_cost_microusd - self.spent_cost_microusd
+
+    def reserve(self, *, case_id: str, requests: int, cost_microusd: int) -> None:
+        """Record spend for one case, or raise before recording anything.
+
+        A failed reservation leaves the budget untouched (no partial
+        spend) -- a caller that catches :class:`QuotaExhaustedError` and
+        aborts the run gets an accurate "spent so far" figure for its
+        failure report.
+        """
+
+        if self.spent_requests + requests > self.max_requests:
+            raise QuotaExhaustedError(
+                f"case {case_id!r} needs {requests} request(s) but only "
+                f"{self.remaining_requests()} remain of the "
+                f"{self.max_requests}-request monthly ceiling "
+                f"({self.spent_requests} already spent this run)"
+            )
+        if self.spent_cost_microusd + cost_microusd > self.max_cost_microusd:
+            raise QuotaExhaustedError(
+                f"case {case_id!r} needs {cost_microusd} microUSD but only "
+                f"{self.remaining_cost_microusd()} remain of the "
+                f"{self.max_cost_microusd}-microUSD monthly ceiling "
+                f"({self.spent_cost_microusd} already spent this run)"
+            )
+        self.spent_requests += requests
+        self.spent_cost_microusd += cost_microusd
+
+    def release(self, *, requests: int, cost_microusd: int) -> None:
+        """Credit back a reservation that turned out not to be used.
+
+        Codex round-1 finding (MEDIUM, confirmed): ``reserve`` is called
+        BEFORE the case's HTTP request is even attempted (a worst-case
+        pre-charge, so a case that trips the ceiling never touches the
+        network at all). Without a release path, a pre-admission failure
+        (the conversation-creation call itself failing, a network error
+        before any real server-side usage occurred) leaves that spend
+        charged locally with no corresponding real usage -- silently
+        eating into budget later cases could have legitimately used. A
+        caller should call this from a ``finally``/exception handler around
+        the request it guarded, crediting back exactly what it reserved.
+
+        Never raises on over-release (clamped at zero) -- a caller
+        reporting a slightly-wrong credit-back is far preferable to a
+        second exception masking the original failure that triggered the
+        release in the first place.
+        """
+
+        self.spent_requests = max(0, self.spent_requests - requests)
+        self.spent_cost_microusd = max(0, self.spent_cost_microusd - cost_microusd)
+
+
+def _positive_int(source: Mapping[str, str], env_name: str) -> int:
+    raw = source.get(env_name)
+    if raw is None:
+        raise QuotaConfigurationError(
+            f"{env_name} is not set -- a corpus run must not proceed "
+            "un-budgeted against an unknown platform quota ceiling"
+        )
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise QuotaConfigurationError(f"{env_name}={raw!r} is not an integer") from exc
+    if value <= 0:
+        raise QuotaConfigurationError(f"{env_name}={value} must be positive")
+    return value

--- a/scripts/acceptance/corpus/receipt.py
+++ b/scripts/acceptance/corpus/receipt.py
@@ -1,0 +1,366 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the ``wave4_case_result.v1`` receipt
+writer, and a session-level closed-registry summary.
+
+Ad-hoc schema, like ``scripts/acceptance/acceptance_artifact.py``'s
+``ask_dev_acceptance_artifact.v1`` (confirmed via recon: acceptance-runner
+receipts live entirely outside ``export_contracts.py``/
+``export_contracts_v2.py``, which are reserved for wire contracts served to
+real clients with fixture-coverage totality enforcement) -- a plain dict
+with a hand-picked ``schema_version`` string, written as JSON under
+``tests/acceptance/``.
+
+This receipt doubles as the CHAOS-3389 QUA shadow-replay harness (fold-in
+design, 2026-08-05): its ``resolution_path`` field is exactly what a future
+shadow-mode replay diffs case-by-case against the deterministic baseline,
+so its shape is fixed now rather than treated as an implementation detail
+free to change later.
+
+False-green prevention (team-lead mandate): ``write`` refuses to produce a
+receipt with zero assertions (a case that asserted nothing proves nothing,
+regardless of whether every one of its zero checks "passed"), and
+:func:`write_session_summary` refuses to claim a session covered anything
+if it collected zero case receipts, and reports an expected-vs-received set
+difference against the corpus registry rather than silently aggregating
+"whatever showed up".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.acceptance.acceptance_artifact import redact_secrets
+
+__all__ = [
+    "DECLARED_BLOCKED_RECEIPT_STATUS",
+    "RECEIPT_SCHEMA_VERSION",
+    "RESOLUTION_PATHS",
+    "ReceiptValidationError",
+    "SessionSummaryError",
+    "Wave4Assertion",
+    "Wave4CaseRecorder",
+    "write_declared_blocked_receipt",
+    "write_session_summary",
+]
+
+RECEIPT_SCHEMA_VERSION = "wave4_case_result.v1"
+
+#: A THIRD status value, distinct from "passed"/"failed" -- world-manifest
+#: discipline (team-lead direction, 2026-08-06): a declared-blocked case
+#: never ran, so it must never look like a pass OR a same-shape failure; it
+#: gets its own explicit, loud, ticket-linked status.
+DECLARED_BLOCKED_RECEIPT_STATUS = "declared-blocked"
+
+#: Codex round-3 finding (MEDIUM, confirmed) -- mirrors
+#: ``case_schema.py``'s identical pattern (this module stays deliberately
+#: un-import-coupled to that one, so the check is duplicated rather than
+#: shared, matching this module's existing "backend-agnostic" philosophy).
+_BLOCKED_BY_TICKET_PATTERN = re.compile(r"^CHAOS-\d+\b")
+
+#: Team-lead decree, binding, kebab-case. ``qua-shadow``/``qua-committed``
+#: are reserved for the future QUA shadow-replay mode and are never set by
+#: this repo's own resolution_path derivation today -- they exist in this
+#: set so a future caller CAN set them without this module rejecting a
+#: valid value it merely doesn't produce itself yet.
+RESOLUTION_PATHS = frozenset(
+    {
+        "deterministic-exact",
+        "deterministic-alias",
+        "miss-clarification",
+        "qua-shadow",
+        "qua-committed",
+    }
+)
+
+
+class ReceiptValidationError(Exception):
+    """A receipt would be written in a state that reads as false coverage."""
+
+
+#: Every key ``write()`` itself computes and guards. Codex round-1 finding
+#: (HIGH, confirmed): ``set_extra`` had no reserved-key check and its
+#: ``**self._extra`` was merged LAST into the artifact dict, so
+#: ``set_extra("status", "passed")`` (or ``resolution_path``/``world_digest``/
+#: ``assertion_count``/...) silently overwrote the guarded value -- a
+#: caller could record a failed assertion, then paper over it with one
+#: extra-field call. Closed two ways, redundantly: :meth:`set_extra` now
+#: refuses any of these keys outright, AND ``write()`` spreads ``_extra``
+#: FIRST so even a hypothetical future bypass of the first guard could only
+#: ever be overwritten by the real computed value, never the reverse.
+_RESERVED_RECEIPT_KEYS = frozenset(
+    {
+        "schema_version",
+        "case_id",
+        "question",
+        "subject_class",
+        "resolution_profile_ref",
+        "resolution_path",
+        "world_digest",
+        "started_at",
+        "finished_at",
+        "status",
+        "assertion_count",
+        "assertions",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Wave4Assertion:
+    category: str
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(slots=True)
+class Wave4CaseRecorder:
+    """Collects one corpus case's assertions and writes its
+    ``wave4_case_result.v1`` receipt.
+
+    ``resolution_path`` and ``world_digest`` are tracked as explicitly-set
+    fields (via :meth:`set_resolution_path`/:meth:`set_world_digest`), not
+    constructor defaults, so a caller that forgets to set either gets a
+    loud error at :meth:`write` time rather than a receipt silently
+    claiming ``resolution_path: null`` for a case that actually had one, or
+    an un-pinned world digest.
+    """
+
+    case_id: str
+    question: str
+    subject_class: str
+    resolution_profile_ref: str | None
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    assertions: list[Wave4Assertion] = field(default_factory=list)
+    _resolution_path: str | None = field(default=None, repr=False)
+    _resolution_path_set: bool = field(default=False, repr=False)
+    _world_digest: str | None = field(default=None, repr=False)
+    _world_digest_set: bool = field(default=False, repr=False)
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def check(self, *, category: str, name: str, condition: bool, detail: str) -> None:
+        """Record one assertion. Never raises on a failed condition --
+        unlike ``ScenarioRecorder.check`` (acceptance_artifact.py), a
+        corpus case's remaining invariants still matter for diagnosis even
+        after one fails, so this records every assertion for the case and
+        lets :meth:`write` compute the overall verdict from the full list.
+        """
+
+        self.assertions.append(
+            Wave4Assertion(
+                category=category,
+                name=name,
+                passed=bool(condition),
+                detail=redact_secrets(detail),
+            )
+        )
+
+    def set_resolution_path(self, value: str | None) -> None:
+        if value is not None and value not in RESOLUTION_PATHS:
+            raise ReceiptValidationError(
+                f"resolution_path {value!r} is not one of {sorted(RESOLUTION_PATHS)!r}"
+            )
+        self._resolution_path = value
+        self._resolution_path_set = True
+
+    def set_world_digest(self, value: str) -> None:
+        if not value:
+            raise ReceiptValidationError("world_digest must be a non-empty string")
+        self._world_digest = value
+        self._world_digest_set = True
+
+    def set_extra(self, key: str, value: Any) -> None:
+        """Escape hatch for fields specific to one case/family (e.g. a
+        quota snapshot, a provider-script id used) that do not warrant a
+        dedicated constructor parameter every other case must also thread
+        through.
+
+        Raises on any of :data:`_RESERVED_RECEIPT_KEYS` -- see that
+        constant's docstring for why (Codex round-1, HIGH).
+        """
+
+        if key in _RESERVED_RECEIPT_KEYS:
+            raise ReceiptValidationError(
+                f"{key!r} is a reserved receipt field computed by write() -- "
+                "set_extra cannot be used to set or override it"
+            )
+        self._extra[key] = value
+
+    def write(self, path: Path) -> dict[str, Any]:
+        if not self.assertions:
+            raise ReceiptValidationError(
+                f"case {self.case_id!r}: refusing to write a receipt with "
+                "zero assertions -- a case that asserted nothing proves "
+                "nothing about its own claim, regardless of the case's "
+                "'invariants' declaration (see case_schema.py's own "
+                "non-empty-invariants guard, which should make this "
+                "unreachable in practice; this is the defense-in-depth "
+                "backstop at write time)"
+            )
+        if not self._resolution_path_set:
+            raise ReceiptValidationError(
+                f"case {self.case_id!r}: resolution_path was never set -- "
+                "call set_resolution_path(None) explicitly for a "
+                "non-subject-shaped case, so the receipt records an honest, "
+                "deliberate absence rather than a value that was simply "
+                "never assigned"
+            )
+        if not self._world_digest_set:
+            raise ReceiptValidationError(
+                f"case {self.case_id!r}: world_digest was never set -- "
+                "every receipt must be pinned to the WORLD_DIGEST it ran "
+                "against (ruling D2), even a matched one"
+            )
+
+        finished_at = datetime.now(UTC)
+        all_passed = all(a.passed for a in self.assertions)
+        # `_extra` spreads FIRST -- defense in depth alongside set_extra's own
+        # reserved-key rejection (Codex round-1, HIGH): even if a reserved
+        # key somehow reached `_extra`, the computed fields below always win.
+        artifact: dict[str, Any] = {
+            **self._extra,
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "case_id": self.case_id,
+            "question": self.question,
+            "subject_class": self.subject_class,
+            "resolution_profile_ref": self.resolution_profile_ref,
+            "resolution_path": self._resolution_path,
+            "world_digest": self._world_digest,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "status": "passed" if all_passed else "failed",
+            "assertion_count": len(self.assertions),
+            "assertions": [
+                {
+                    "category": a.category,
+                    "name": a.name,
+                    "passed": a.passed,
+                    "detail": a.detail,
+                }
+                for a in self.assertions
+            ],
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(artifact, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+        )
+        return artifact
+
+
+def write_declared_blocked_receipt(
+    *,
+    case_id: str,
+    question: str,
+    subject_class: str,
+    resolution_profile_ref: str | None,
+    blocked_by: str,
+    path: Path,
+) -> dict[str, Any]:
+    """Write a ``wave4_case_result.v1`` receipt for a case that never ran.
+
+    Takes plain values rather than a ``CorpusCase`` object (case_schema.py's
+    type) so this module stays decoupled from that one -- the same
+    "backend-agnostic" philosophy ``resolution_path.py`` already applies to
+    its own inputs. ``blocked_by`` is REQUIRED and non-empty: a
+    declared-blocked receipt with no ticket reference would be exactly the
+    silent, untraceable "blocked" this whole mechanism exists to prevent
+    (mirrors ``case_schema.py``'s own load-time requirement).
+    """
+
+    if not blocked_by.strip():
+        raise ReceiptValidationError(
+            f"case {case_id!r}: declared-blocked receipt requires a "
+            "non-empty 'blocked_by' ticket reference"
+        )
+    if not _BLOCKED_BY_TICKET_PATTERN.match(blocked_by.strip()):
+        raise ReceiptValidationError(
+            f"case {case_id!r}: declared-blocked receipt 'blocked_by' "
+            f"{blocked_by!r} does not start with a real ticket reference "
+            "(e.g. 'CHAOS-3393')"
+        )
+    now = datetime.now(UTC).isoformat()
+    artifact: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "case_id": case_id,
+        "question": question,
+        "subject_class": subject_class,
+        "resolution_profile_ref": resolution_profile_ref,
+        "resolution_path": None,
+        "world_digest": None,
+        "started_at": now,
+        "finished_at": now,
+        "status": DECLARED_BLOCKED_RECEIPT_STATUS,
+        "blocked_by": blocked_by,
+        "assertion_count": 0,
+        "assertions": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    return artifact
+
+
+class SessionSummaryError(Exception):
+    """A corpus-run session's receipts do not support a trustworthy summary."""
+
+
+def write_session_summary(
+    receipts: list[dict[str, Any]],
+    path: Path,
+    *,
+    expected_case_ids: frozenset[str],
+) -> dict[str, Any]:
+    """Aggregate a corpus run's per-case receipts into one session summary.
+
+    False-green guards, per the team-lead mandate:
+
+    * ``case_count > 0`` -- a session that collected zero receipts raises
+      rather than writing a summary that would otherwise report "0/0 cases
+      passed", which reads as vacuously green.
+    * expected-vs-received set difference against ``expected_case_ids`` --
+      reported, never silently absorbed. A case in ``expected_case_ids``
+      with no receipt is ``missing``; a receipt whose case id is not in
+      ``expected_case_ids`` is ``unexpected`` (e.g. a misrouted or stale
+      artifact). Neither condition raises here -- Phase 5a's aggregator
+      owns the launch-threshold gating decision over this summary; this
+      function's job is to make both conditions visible in the artifact,
+      not to itself decide pass/fail policy on them.
+    """
+
+    if not receipts:
+        raise SessionSummaryError(
+            "refusing to write a session summary for zero case receipts -- "
+            "a corpus run that collected no cases at all must fail loud, "
+            "never report a vacuous, technically-zero-failures green"
+        )
+    received_ids = {receipt["case_id"] for receipt in receipts}
+    missing = sorted(expected_case_ids - received_ids)
+    unexpected = sorted(received_ids - expected_case_ids)
+    passed = sum(1 for receipt in receipts if receipt.get("status") == "passed")
+    declared_blocked = sorted(
+        receipt["case_id"]
+        for receipt in receipts
+        if receipt.get("status") == DECLARED_BLOCKED_RECEIPT_STATUS
+    )
+    summary = {
+        "schema_version": "wave4_session_summary.v1",
+        "case_count": len(receipts),
+        "passed_count": passed,
+        "failed_count": len(receipts) - passed - len(declared_blocked),
+        "declared_blocked_count": len(declared_blocked),
+        "declared_blocked_case_ids": declared_blocked,
+        "expected_case_count": len(expected_case_ids),
+        "missing_case_ids": missing,
+        "unexpected_case_ids": unexpected,
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(summary, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    return summary

--- a/scripts/acceptance/corpus/resolution_path.py
+++ b/scripts/acceptance/corpus/resolution_path.py
@@ -1,0 +1,327 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: derive a ``wave4_case_result.v1``
+receipt's ``resolution_path`` field from persisted CHAOS-3423/3424 state.
+
+Enum (team-lead decree, binding, also fixed with the CHAOS-3389 QUA shadow
+fold-in): exactly ``deterministic-exact | deterministic-alias |
+miss-clarification | qua-shadow | qua-committed``, kebab-case. Only the
+first three are ever produced by this module today -- ``qua-shadow`` and
+``qua-committed`` are reserved for the future Question Understanding Agent
+shadow-replay mode (CHAOS-3389) and are never emitted here; a caller wiring
+that mode in later assigns them directly, this module has no opinion on it.
+
+WHY THIS MUST BE RE-DERIVED, NOT READ OFF A COLUMN (recon finding,
+2026-08-05): ``dev_run_resolutions.outcome`` is the closed
+``ResolutionOutcome`` vocabulary (``exact_match`` / ``ambiguous_candidates``
+/ ``no_authorized_match`` / ``catalog_unavailable`` / ``unsupported_kind``)
+-- it does not distinguish "matched the mention text directly" from "matched
+via a CHAOS-3388 derived alias/acronym form". Worse, ``alias_matching.py``'s
+own contract (see its module docstring) is that an alias/acronym hit is
+*never* auto-commit eligible -- it must always be offered as a candidate
+first (``ambiguous_candidates``), never silently picked. So a single ledger
+entry's ``exact_match`` outcome, on its own, actually already tells you the
+match was NOT an alias/acronym hit (those can't produce ``exact_match``
+directly) -- UNLESS a *later* entry for the same mention commits an entity
+that an *earlier* entry for that mention had offered as a candidate, which
+is exactly what a real acronym-alias corpus case's two-turn disambiguation
+flow (ask -> get candidates -> user selects one -> commits) looks like on
+the wire. That "did this mention's own history include a candidate offer
+before it committed" check is therefore the PRIMARY signal; a label-based
+fallback (recomputing ``alias_matching.alias_forms`` against the case's own
+known mention text) exists only to positively confirm a single-entry
+``exact_match`` really is a direct match, not silently assume it.
+
+Only ``ambiguous_candidates`` is ever "a candidate was genuinely offered"
+evidence (Codex round-1 finding, HIGH, confirmed against
+``DevResolutionEntry.validate_outcome_payload``: ``no_authorized_match`` /
+``catalog_unavailable`` / ``unsupported_kind`` are structurally forbidden
+from carrying ``candidates`` at all). Treating any of those three as
+candidate-evidence would mislabel "transient failure, then a genuine direct
+match on retry" as alias-assisted convergence -- fixed here to check
+``ambiguous_candidates`` specifically, never the whole unresolved set.
+
+``classify_match_kind`` (Codex round-1 finding, HIGH, confirmed by executing
+it against this repo's real ``subjects.json`` fixture data): the original
+implementation accepted ANY bidirectional substring as "exact" -- both a
+false positive ("meridian/web-app extra" against "meridian/web-app") and,
+separately, too narrow for a real canonical-ID-keyed exact match (production
+``ClickHouseAuthorizedEntityCatalog.exact`` matches ``ref.value.casefold() in
+{canonical_id.casefold(), label.casefold()}`` -- literal equality against
+EITHER the id or the raw label, never a substring). Rewritten to mirror that
+exact contract: equality against the committed canonical id (when supplied),
+the raw committed label, or its parenthetical-stripped primary form: never a
+substring test. A mention that only substring-matches was never a
+production ``exact_match`` in the first place (it would have gone through
+``search``/candidates instead) -- so a caller handing this function such a
+pair has a data problem this function is right to reject loudly, not paper
+over.
+
+RESIDUAL, DOCUMENTED HONESTLY: whether a follow-up disambiguation turn's
+``dev_run_resolutions`` entry reuses the ORIGINAL mention's ``mention_id`` or
+mints a fresh one (a new mention extracted from the follow-up text) has not
+yet been observed against a real multi-turn acronym-alias corpus case (Lane
+2b has not authored one yet). Both branches are handled here: the
+mention-id-history check covers a reused id; the label-based fallback covers
+a fresh id whose committed label is still only alias-reachable from the
+case's declared mention text. If a live run surfaces a THIRD shape neither
+branch covers, that is a defect in this module to fix once observed --
+not something this docstring should overclaim proof of today.
+
+CALLER CONTRACT for ``mention_text`` (tightened after Codex round-1):
+callers MUST supply the exact, already-normalized span that reached the
+resolver -- e.g. ``DevSubjectMention.normalized_lookup_text`` or a case's own
+explicitly pinned lookup string -- NEVER a full natural-language utterance
+lifted verbatim from ``subjects.json``'s human-readable ``mentions`` array
+(several of those, e.g. "the web-app repo", are descriptive phrases, not
+resolver input; only the acronym-alias subject class's ``mentions`` entries
+are documented as literal spans). Passing the wrong string here does not
+silently misclassify -- it raises, per the equality-only contract above --
+but choosing the right string is the caller's responsibility, not
+something this module can infer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from dev_health_ops.api.dev.alias_matching import alias_forms, strip_parentheticals
+
+__all__ = [
+    "ResolutionPath",
+    "ResolutionPathError",
+    "ResolutionLedgerEntry",
+    "classify_match_kind",
+    "derive_resolution_path",
+]
+
+ResolutionPath = Literal[
+    "deterministic-exact",
+    "deterministic-alias",
+    "miss-clarification",
+    "qua-shadow",
+    "qua-committed",
+]
+
+#: Mirrors ``dev_health_ops.api.dev.contracts_v2.subject.UNRESOLVED_OUTCOMES``
+#: as plain strings -- this module deliberately never imports the ORM/session
+#: layer or the contracts_v2 pydantic models, only the pure alias-scoring
+#: helper, so it has no opinion on how a caller obtained these values (a real
+#: ``DevRunResolution`` row's ``.outcome`` column, or a fabricated string in a
+#: unit test).
+_UNRESOLVED_OUTCOMES = frozenset(
+    {
+        "ambiguous_candidates",
+        "no_authorized_match",
+        "catalog_unavailable",
+        "unsupported_kind",
+    }
+)
+_KNOWN_OUTCOMES = _UNRESOLVED_OUTCOMES | {"exact_match"}
+
+#: The ONLY outcome that can ever carry candidates
+#: (``DevResolutionEntry.validate_outcome_payload``'s own contract) -- the
+#: sole legitimate evidence that "a candidate was offered before this
+#: mention committed". ``no_authorized_match``/``catalog_unavailable``/
+#: ``unsupported_kind`` are structurally forbidden from carrying candidates
+#: and must never be treated as alias-assisted-convergence evidence.
+_CANDIDATE_BEARING_OUTCOME = "ambiguous_candidates"
+
+
+class ResolutionPathError(Exception):
+    """The ledger cannot be classified as any known resolution path.
+
+    Raised rather than defaulted to a guess: a receipt that silently
+    reported ``deterministic-exact`` for a row this module could not
+    actually explain would be exactly the false-confidence this lane exists
+    to prevent (an outcome value outside the CHECK-constrained vocabulary,
+    or an ``exact_match`` entry whose committed label matches neither
+    directly nor via any alias form of the case's own declared mention
+    text).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionLedgerEntry:
+    """The minimal, backend-agnostic shape this module needs off one
+    resolution-ledger entry.
+
+    Callers build this from either a real ``DevRunResolution`` ORM row (an
+    integration/live test) or a fabricated one (a fast unit test) -- this
+    module never imports SQLAlchemy so it cannot itself be the reason a live
+    run needs a database.
+
+    ``mention_text`` is NOT read off the persisted row -- ``DevResolutionEntry``
+    (contracts_v2/subject.py) carries only an opaque ``mention_id``, never the
+    original text span (that lives on a separate, not-independently-persisted
+    ``DevSubjectMention``). Callers supply it out-of-band -- see the module
+    docstring's "CALLER CONTRACT" section for exactly what string that must
+    be. Required for ``exact_match`` entries with no prior candidate offer
+    (needed to classify exact-vs-alias); may be ``None`` for an unresolved
+    entry, which never needs that classification.
+
+    ``committed_canonical_id`` is the committed entity's own id (e.g.
+    ``DevEntityRefV2.entity_id``) -- optional, but when supplied lets a
+    mention that names the id directly (rather than any display label)
+    classify as ``exact`` too, matching production's own
+    ``ClickHouseAuthorizedEntityCatalog.exact`` contract (id-or-label
+    equality).
+    """
+
+    outcome: str
+    mention_id: str
+    committed_label: str | None = None
+    committed_canonical_id: str | None = None
+    mention_text: str | None = None
+
+
+def classify_match_kind(
+    mention_text: str,
+    committed_label: str,
+    *,
+    committed_canonical_id: str | None = None,
+) -> Literal["exact", "alias"]:
+    """Whether ``committed_label``/``committed_canonical_id`` matches
+    ``mention_text`` directly or only through a CHAOS-3388 derived
+    alias/acronym form.
+
+    "Directly" mirrors production's own
+    ``ClickHouseAuthorizedEntityCatalog.exact`` contract exactly: casefolded
+    EQUALITY (never a substring test) against the committed canonical id (if
+    supplied), the raw committed label, or the label's parenthetical-stripped
+    primary form. Anything that only lines up through
+    ``alias_matching.alias_forms`` (a parenthetical literal alias or a
+    derived acronym of the label) is "alias".
+
+    Raises :class:`ResolutionPathError` if none of those match -- this can
+    happen if the caller passed the wrong mention text (see the module
+    docstring's "CALLER CONTRACT"), or the catalog label changed between
+    resolution time and this later recomputation. A mention that only
+    substring-matches the label was never a production ``exact_match`` in
+    the first place (production's own ``exact()`` never accepts a
+    substring) -- so silently accepting one here would misclassify by
+    definition, not merely by bad luck.
+    """
+
+    needle = mention_text.strip().casefold()
+    if not needle or not committed_label.strip():
+        raise ResolutionPathError(
+            "cannot classify an empty mention_text or committed_label "
+            f"(mention_text={mention_text!r}, committed_label={committed_label!r})"
+        )
+    if (
+        committed_canonical_id is not None
+        and needle == committed_canonical_id.strip().casefold()
+    ):
+        return "exact"
+    raw_label = committed_label.strip().casefold()
+    if needle == raw_label:
+        return "exact"
+    primary, _aliases = strip_parentheticals(committed_label)
+    if primary.strip() and needle == primary.strip().casefold():
+        return "exact"
+    forms = alias_forms(committed_label)
+    if needle in forms.literal_aliases or needle in forms.acronyms:
+        return "alias"
+    raise ResolutionPathError(
+        f"committed label {committed_label!r} (canonical id "
+        f"{committed_canonical_id!r}) matches neither directly (equality) "
+        f"nor via any alias/acronym form of mention text {mention_text!r} -- "
+        "cannot classify exact vs alias. If this mention text is a natural-"
+        "language utterance rather than the normalized resolver-input span, "
+        "that is the likely cause -- see this module's CALLER CONTRACT."
+    )
+
+
+def derive_resolution_path(
+    entries: Sequence[ResolutionLedgerEntry],
+) -> ResolutionPath | None:
+    """The ``wave4_case_result.v1`` ``resolution_path`` for one case's full
+    resolution history.
+
+    ``entries`` must already be reduced to the caller's intended scope, in
+    chronological order (ascending ``entry_ordinal`` within a run; runs in
+    the order they occurred within the same conversation for a multi-turn
+    case) -- this module does not itself know how many runs a case's
+    conversation spans, only classifies whatever sequence it is handed.
+
+    Returns ``None`` for an empty sequence -- a case whose subject class is
+    ``n/a`` (no subject mention at all: ``portfolio.*``, ``investment.*``,
+    etc.) never appends to ``dev_run_resolutions``, and reporting a
+    resolution path for a run that resolved no subject would be a
+    fabricated field, not an honest absence. Callers must not coerce
+    ``None`` to a default path value -- and note ``invariants.py``'s
+    ``resolution_path_in`` checker independently refuses to ever match
+    ``None`` against ANY allowed list, precisely to close that path at the
+    assertion layer too.
+
+    Classification, per distinct ``mention_id`` (in first-seen order, since
+    that is the order the case's own subject mentions were made in):
+
+    * If any entry for that mention has an unresolved outcome, AND NO later
+      entry for the SAME mention_id ever commits it (``exact_match``), that
+      mention counts as unresolved.
+    * Otherwise the mention resolves, via its LAST entry (which must be
+      ``exact_match`` given the above) -- classified ``alias`` if any
+      EARLIER entry for that same mention_id was specifically
+      ``ambiguous_candidates`` (the only outcome that can carry a candidate
+      offer -- the two-turn disambiguation shape), else via
+      :func:`classify_match_kind` against the mention's own declared text
+      and the committed label/id (the single-shot fallback).
+
+    The whole case is ``miss-clarification`` if ANY mention never resolves.
+    Otherwise it is ``deterministic-alias`` if ANY resolved mention
+    classified as ``alias``, else ``deterministic-exact``.
+    """
+
+    if not entries:
+        return None
+
+    unknown = {entry.outcome for entry in entries} - _KNOWN_OUTCOMES
+    if unknown:
+        raise ResolutionPathError(
+            f"resolution ledger entry outcome(s) outside the known "
+            f"ResolutionOutcome vocabulary: {sorted(unknown)!r}"
+        )
+
+    by_mention: dict[str, list[ResolutionLedgerEntry]] = {}
+    order: list[str] = []
+    for entry in entries:
+        if entry.mention_id not in by_mention:
+            by_mention[entry.mention_id] = []
+            order.append(entry.mention_id)
+        by_mention[entry.mention_id].append(entry)
+
+    saw_alias = False
+    for mention_id in order:
+        history = by_mention[mention_id]
+        final = history[-1]
+        if final.outcome != "exact_match":
+            # The mention's own last word is still unresolved -- the whole
+            # case never converged on a committed subject for it.
+            return "miss-clarification"
+        candidate_previously_offered = any(
+            entry.outcome == _CANDIDATE_BEARING_OUTCOME for entry in history[:-1]
+        )
+        if candidate_previously_offered:
+            saw_alias = True
+            continue
+        if final.mention_text is None or final.committed_label is None:
+            raise ResolutionPathError(
+                f"mention {mention_id!r} resolved to exact_match on its first "
+                "entry with no prior candidate offer, but no mention_text/"
+                "committed_label was supplied -- cannot confirm this is a "
+                "direct match rather than an (impossible-by-contract, but "
+                "unverifiable without the text) single-shot alias commit"
+            )
+        if (
+            classify_match_kind(
+                final.mention_text,
+                final.committed_label,
+                committed_canonical_id=final.committed_canonical_id,
+            )
+            == "alias"
+        ):
+            saw_alias = True
+
+    return "deterministic-alias" if saw_alias else "deterministic-exact"

--- a/scripts/acceptance/corpus/script_inventory.py
+++ b/scripts/acceptance/corpus/script_inventory.py
@@ -1,0 +1,79 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: script-inventory startup preflight.
+
+Requirement (team-lead mandate, item 1): a corpus case citing a missing
+scripted-provider script must FAIL LOUDLY at startup, never silently skip
+or fall through.
+
+Recon finding this exists to close: production's own
+``provider_scripts.py`` has NO such check. A registry case id absent from
+``role-<role>.json``'s ``cases`` map is, by that module's own README,
+"not an error by itself -- it simply means no question routes to it yet",
+and at request time an unmapped question is *indistinguishable on the wire*
+from an ordinary one -- it silently falls through to the generic default
+heuristic (see ``provider_scripts.ScriptEngine.resolve`` returning
+``None``). That is exactly correct production behavior (it keeps every
+pre-CHAOS-3219 smoke/probe/oracle working unconditionally), but it is the
+WRONG behavior for a corpus runner: a case whose scripted decisions were
+never authored would silently get an unscripted, nondeterministic-shaped
+answer from the default heuristic and could pass or fail its assertions for
+reasons having nothing to do with what the case claims to prove. This
+module is the runner-side check production deliberately does not make.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+__all__ = [
+    "ScriptInventoryError",
+    "missing_scripted_cases",
+    "check_script_inventory",
+]
+
+
+class ScriptInventoryError(Exception):
+    """One or more corpus cases have no matching scripted-provider entry."""
+
+
+def missing_scripted_cases(
+    case_ids: Iterable[str], scripted_case_ids: Iterable[str]
+) -> list[str]:
+    """Corpus case ids with no entry in the active role's script file.
+
+    ``scripted_case_ids`` is the raw ``role_script.cases`` key set (a
+    ``RoleScript`` from ``dev_health_ops.llm.agent.provider_scripts`` has
+    exactly this shape) -- this function takes plain string iterables, not
+    the ``RoleScript`` type itself, so it has no import-time dependency on
+    the scripted-provider module and can be unit tested with fabricated
+    data.
+    """
+
+    return sorted(set(case_ids) - set(scripted_case_ids))
+
+
+def check_script_inventory(
+    case_ids: Iterable[str],
+    scripted_case_ids: Iterable[str],
+    *,
+    role: str,
+) -> None:
+    """Raise :class:`ScriptInventoryError` if any case id lacks a script.
+
+    Call this once, at session start, before any corpus case executes a
+    single HTTP request -- not per-case, and never downgraded to a skip.
+    A run that "skipped" the missing cases would still exit non-negative
+    for the cases it did run, reading as partial coverage rather than the
+    authoring gap it actually is.
+    """
+
+    missing = missing_scripted_cases(case_ids, scripted_case_ids)
+    if missing:
+        raise ScriptInventoryError(
+            f"{len(missing)} corpus case(s) have no entry in role-{role}.json's "
+            f"scripted-provider decisions -- a corpus run must never execute "
+            "these against the unscripted default heuristic (nondeterministic, "
+            "proves nothing about the case's own claim): "
+            f"{missing!r}. Author their provider-scripts/role-{role}.json "
+            "entries before this case can run in the corpus, or remove the "
+            "case file if it is not yet ready."
+        )

--- a/scripts/acceptance/corpus/sse_client.py
+++ b/scripts/acceptance/corpus/sse_client.py
@@ -1,0 +1,78 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: pure SSE-frame parsing for the corpus
+runner's live HTTP driver.
+
+Deliberately decoupled from ``dev_health_ops.api.dev.contracts.DevStreamEvent``
+-- this module returns plain ``dict`` frames (``{"event": str, "data": dict}``)
+so its parsing logic (frame splitting, ``event:``/``data:`` line handling,
+JSON decoding) is unit-testable without constructing real contract payloads.
+The live corpus runner validates each returned frame's ``data`` through
+``DevStreamEvent.model_validate`` itself, exactly like every existing smoke
+script (``smoke_ask_dev_exact_commit.py``'s ``_sse_request``, which this
+module's parsing mirrors) -- that validation belongs at the call site, which
+knows it is talking to the real Ask Dev wire contract, not in a
+contract-agnostic parser.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = ["SseFrame", "SseParseError", "parse_sse_events"]
+
+
+class SseParseError(Exception):
+    """A frame is missing its event name or its data payload.
+
+    Raised rather than silently dropping the malformed frame: a corpus
+    case's assertions read the event sequence positionally and by kind
+    (e.g. "the scope.resolved event", "the last event"); a silently-dropped
+    frame would shift or hide exactly the evidence an assertion depends on.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class SseFrame:
+    event: str
+    data: dict[str, Any]
+
+
+def parse_sse_events(body: str) -> list[SseFrame]:
+    """Split a full SSE response body into its ``event``/``data`` frames.
+
+    Frames are separated by a blank line (``\\n\\n``); a frame may carry
+    multiple ``data: `` lines, which are joined before JSON-decoding (the
+    SSE spec's own multi-line data convention). Trailing/leading blank
+    frames (a body ending in a stray ``\\n\\n``) are skipped, not reported
+    as malformed.
+    """
+
+    frames: list[SseFrame] = []
+    for raw_frame in body.split("\n\n"):
+        if not raw_frame.strip():
+            continue
+        event_name: str | None = None
+        data_lines: list[str] = []
+        for line in raw_frame.splitlines():
+            if line.startswith("event: "):
+                event_name = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                data_lines.append(line.removeprefix("data: "))
+        if event_name is None:
+            raise SseParseError(f"SSE frame omitted an event name: {raw_frame!r}")
+        if not data_lines:
+            raise SseParseError(f"SSE {event_name!r} frame omitted data: {raw_frame!r}")
+        try:
+            data = json.loads("\n".join(data_lines))
+        except json.JSONDecodeError as exc:
+            raise SseParseError(
+                f"SSE {event_name!r} frame data is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise SseParseError(
+                f"SSE {event_name!r} frame data must decode to an object, "
+                f"got {type(data).__name__}"
+            )
+        frames.append(SseFrame(event=event_name, data=data))
+    return frames

--- a/scripts/acceptance/corpus/world_digest_guard.py
+++ b/scripts/acceptance/corpus/world_digest_guard.py
@@ -1,0 +1,110 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: WORLD_DIGEST-pinned oracle guard
+(ruling D2 -- expected values are computed from the world generator and
+pinned by digest; a receipt whose world digest does not match the pinned
+one must FAIL, never silently be trusted).
+
+Thin wrapper over ``dev_health_ops.fixtures.world`` rather than a
+reimplementation: ``compute_world_digest``/``read_pinned_digest``/
+``_diff_components`` are the exact functions ``fixtures world
+--verify-digest`` itself uses (see ``world.py``'s own ``_verify_digest``,
+which this module's :func:`verify_world_digest` mirrors) -- importing them
+means Lane 2a's guard and the CLI's own verification can never quietly
+diverge on what "drift" means. This module only adds a plain,
+``argparse``-free function signature a pytest fixture can call, and splits
+the async compute-and-compare step from a pure, synchronously-testable
+assertion step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from dev_health_ops.fixtures.world import (
+    _diff_components,
+    compute_world_digest,
+    default_digest_path,
+    load_world_manifest,
+    read_pinned_digest,
+)
+
+__all__ = [
+    "WorldDigestMismatchError",
+    "WorldDigestVerification",
+    "require_world_digest_match",
+    "verify_world_digest",
+]
+
+
+class WorldDigestMismatchError(Exception):
+    """The live WORLD_DIGEST does not match the pinned one."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorldDigestVerification:
+    pinned_digest: str
+    live_digest: str
+    matched: bool
+    drifted_components: tuple[str, ...]
+
+
+async def verify_world_digest(
+    manifest_path: str | Path,
+    *,
+    sink: str,
+    postgres_uri: str,
+    digest_path: str | Path | None = None,
+) -> WorldDigestVerification:
+    """Compute the live digest and compare it to the pinned one.
+
+    Needs a live, reachable ClickHouse/Postgres scratch database -- this is
+    the one function in this module that cannot be unit tested without
+    infra. :func:`require_world_digest_match` (pure) is what a unit test
+    exercises against a fabricated :class:`WorldDigestVerification`.
+    """
+
+    manifest = load_world_manifest(manifest_path)
+    path = (
+        Path(digest_path) if digest_path is not None else default_digest_path(manifest)
+    )
+    pinned = read_pinned_digest(path)
+    live = await compute_world_digest(manifest, sink=sink, postgres_uri=postgres_uri)
+    matched = live["digest"] == pinned["digest"]
+    drifted = (
+        ()
+        if matched
+        else tuple(
+            _diff_components(pinned.get("components", {}), live.get("components", {}))
+        )
+    )
+    return WorldDigestVerification(
+        pinned_digest=pinned["digest"],
+        live_digest=live["digest"],
+        matched=matched,
+        drifted_components=drifted,
+    )
+
+
+def require_world_digest_match(
+    verification: WorldDigestVerification, *, digest_path: str | Path
+) -> None:
+    """Raise :class:`WorldDigestMismatchError` on a mismatch; no-op on a match.
+
+    Call this once, at corpus-run session start, before any case executes:
+    a receipt minted against a world state that has drifted from the pinned
+    fixture (ruling D2) must never be trusted, regardless of whether the
+    individual case assertions happen to still pass by coincidence.
+    """
+
+    if verification.matched:
+        return
+    raise WorldDigestMismatchError(
+        "WORLD_DIGEST verification FAILED against "
+        f"{digest_path}: pinned={verification.pinned_digest} "
+        f"live={verification.live_digest}. Drifted component(s): "
+        f"{list(verification.drifted_components)}. A wave4_case_result.v1 "
+        "receipt computed against a world state that does not match the "
+        "frozen fixture must never be trusted (ruling D2) -- regenerate and "
+        "re-pin WORLD_DIGEST (or fix what drifted), never suppress this "
+        "check."
+    )

--- a/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.basic-exact.json
+++ b/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.basic-exact.json
@@ -1,0 +1,12 @@
+{
+  "id": "runner-selftest.basic-exact",
+  "question": "What's the status of the Ask Dev project?",
+  "subject_class": "exact",
+  "invariants": [
+    {
+      "category": "subject-resolution",
+      "check": "resolution_path_in",
+      "args": {"allowed": ["deterministic-exact"]}
+    }
+  ]
+}

--- a/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.declared-blocked.json
+++ b/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.declared-blocked.json
@@ -1,0 +1,8 @@
+{
+  "id": "runner-selftest.declared-blocked",
+  "question": "How are the meridian and atlas projects doing together?",
+  "subject_class": "bounded-set",
+  "status": "declared-blocked",
+  "blocked_by": "CHAOS-3393",
+  "invariants": []
+}

--- a/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.needs-profile.json
+++ b/tests/acceptance/corpus/fixtures/cases/case-runner-selftest.needs-profile.json
@@ -1,0 +1,12 @@
+{
+  "id": "runner-selftest.needs-profile",
+  "question": "What's the status of MWA?",
+  "subject_class": "acronym-alias",
+  "resolution_profile_ref": "runner-selftest-v1",
+  "invariants": [
+    {
+      "category": "public-outcome",
+      "check": "no_internal_error"
+    }
+  ]
+}

--- a/tests/acceptance/corpus/fixtures/profiles/runner-selftest-v1.json
+++ b/tests/acceptance/corpus/fixtures/profiles/runner-selftest-v1.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "resolution-profile.v1",
+  "profile_id": "runner-selftest-v1",
+  "cases": {
+    "runner-selftest.needs-profile": {
+      "expected_resolution_path": "deterministic-alias",
+      "expected_public_outcome": "answered"
+    }
+  }
+}

--- a/tests/acceptance/corpus/test_arming.py
+++ b/tests/acceptance/corpus/test_arming.py
@@ -1,0 +1,24 @@
+"""Unit coverage for ``scripts.acceptance.corpus.arming``."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.arming import NotArmedError, require_armed
+
+
+class TestRequireArmed:
+    def test_armed_is_a_silent_no_op(self) -> None:
+        require_armed({"ASK_DEV_LIVE_ACCEPTANCE": "1"})
+
+    def test_missing_raises(self) -> None:
+        with pytest.raises(NotArmedError, match="ASK_DEV_LIVE_ACCEPTANCE=1"):
+            require_armed({})
+
+    def test_wrong_value_raises(self) -> None:
+        with pytest.raises(NotArmedError):
+            require_armed({"ASK_DEV_LIVE_ACCEPTANCE": "true"})
+
+    def test_zero_raises(self) -> None:
+        with pytest.raises(NotArmedError):
+            require_armed({"ASK_DEV_LIVE_ACCEPTANCE": "0"})

--- a/tests/acceptance/corpus/test_case_schema.py
+++ b/tests/acceptance/corpus/test_case_schema.py
@@ -1,0 +1,284 @@
+"""Unit coverage for ``scripts.acceptance.corpus.case_schema``.
+
+Fixtures live under ``tests/acceptance/corpus/fixtures/`` -- deliberately
+NOT under ``tests/acceptance/world/ask-dev-world.v1/corpus/`` (Lane 2b's
+landing zone for the real 134-case registry content) or
+``resolution-profiles/`` (the real profile directory), so this suite has
+zero merge-collision surface with Lane 2b's concurrent authoring regardless
+of landing order. Case ids here are prefixed ``runner-selftest.`` per the
+team-lead's directive so they can never collide with a frozen registry id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.acceptance.corpus.case_schema import (
+    ACTIVE_STATUS,
+    DECLARED_BLOCKED_STATUS,
+    CaseSchemaError,
+    load_corpus_case,
+    load_corpus_cases,
+    load_resolution_profile,
+    resolve_case_expectations,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+_CASES_DIR = _FIXTURES / "cases"
+_PROFILES_DIR = _FIXTURES / "profiles"
+
+
+class TestLoadCorpusCase:
+    def test_loads_a_minimal_valid_case(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.basic-exact.json")
+        assert case.id == "runner-selftest.basic-exact"
+        assert case.question == "What's the status of the Ask Dev project?"
+        assert case.subject_class == "exact"
+        assert case.resolution_profile_ref is None
+        assert len(case.invariants) == 1
+        assert case.invariants[0]["category"] == "subject-resolution"
+        assert case.status == ACTIVE_STATUS
+        assert case.blocked_by is None
+        assert case.is_declared_blocked is False
+
+    def test_loads_a_case_with_resolution_profile_ref(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.needs-profile.json")
+        assert case.resolution_profile_ref == "runner-selftest-v1"
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text('{"id": "x", "question": "q", "subject_class": "exact"}')
+        with pytest.raises(CaseSchemaError, match="invariants"):
+            load_corpus_case(path)
+
+    def test_empty_invariants_list_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", "invariants": []}'
+        )
+        with pytest.raises(CaseSchemaError, match="non-empty"):
+            load_corpus_case(path)
+
+    def test_invariant_missing_category_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"invariants": [{"check": "no_internal_error"}]}'
+        )
+        with pytest.raises(CaseSchemaError, match="category"):
+            load_corpus_case(path)
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text("{not json")
+        with pytest.raises(CaseSchemaError, match="not valid JSON"):
+            load_corpus_case(path)
+
+    def test_unknown_extra_field_is_accepted(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-extra.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"invariants": [{"category": "c", "check": "k"}], '
+            '"lane_2b_bookkeeping_field": "whatever"}'
+        )
+        case = load_corpus_case(path)
+        assert case.raw["lane_2b_bookkeeping_field"] == "whatever"
+
+
+class TestDeclaredBlockedCases:
+    """Team-lead direction 2026-08-06, folding in 2b's codex round-1
+    finding: a declared-blocked case must load with zero invariants (never
+    crash the whole corpus load, never need placeholder invariants) but
+    still be loudly, traceably blocked."""
+
+    def test_loads_with_zero_invariants(self) -> None:
+        case = load_corpus_case(
+            _CASES_DIR / "case-runner-selftest.declared-blocked.json"
+        )
+        assert case.status == DECLARED_BLOCKED_STATUS
+        assert case.blocked_by == "CHAOS-3393"
+        assert case.invariants == ()
+        assert case.is_declared_blocked is True
+
+    def test_active_case_with_empty_invariants_still_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """An 'active' (the default) case with zero invariants is still
+        rejected -- declared-blocked is an explicit opt-in, never inferred
+        from an empty list."""
+
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", "invariants": []}'
+        )
+        with pytest.raises(CaseSchemaError, match="non-empty"):
+            load_corpus_case(path)
+
+    def test_declared_blocked_without_blocked_by_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"status": "declared-blocked", "invariants": []}'
+        )
+        with pytest.raises(CaseSchemaError, match="blocked_by"):
+            load_corpus_case(path)
+
+    def test_declared_blocked_with_malformed_ticket_reference_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex round-3, MEDIUM, confirmed: a bare non-empty string like
+        'not-a-ticket' used to satisfy the check, letting coverage be
+        suppressed with no traceable, actionable blocker."""
+
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"status": "declared-blocked", "blocked_by": "not-a-ticket", '
+            '"invariants": []}'
+        )
+        with pytest.raises(CaseSchemaError, match="ticket reference"):
+            load_corpus_case(path)
+
+    def test_declared_blocked_ticket_reference_may_carry_a_description(
+        self, tmp_path: Path
+    ) -> None:
+        """Matches this repo's own real convention (world.json's
+        'CHAOS-3432 concurrent ClickHouse ...') -- a leading CHAOS-<number>
+        token followed by free text is accepted, not just a bare id."""
+
+        path = tmp_path / "case-ok.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"status": "declared-blocked", '
+            '"blocked_by": "CHAOS-3432 concurrent ClickHouse nondeterminism", '
+            '"invariants": []}'
+        )
+        case = load_corpus_case(path)
+        assert case.blocked_by == "CHAOS-3432 concurrent ClickHouse nondeterminism"
+
+    def test_blocked_by_on_an_active_case_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"blocked_by": "CHAOS-1", "invariants": [{"category": "c", "check": "k"}]}'
+        )
+        with pytest.raises(CaseSchemaError, match="only valid when"):
+            load_corpus_case(path)
+
+    def test_unknown_status_value_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "case-bad.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"status": "made-up-status", "invariants": [{"category": "c", "check": "k"}]}'
+        )
+        with pytest.raises(CaseSchemaError, match="status"):
+            load_corpus_case(path)
+
+    def test_declared_blocked_can_still_carry_real_invariants(
+        self, tmp_path: Path
+    ) -> None:
+        """Declared-blocked relaxes the non-empty requirement -- it does not
+        forbid invariants for a case that has some but not all of what it
+        needs."""
+
+        path = tmp_path / "case-partial.json"
+        path.write_text(
+            '{"id": "x", "question": "q", "subject_class": "exact", '
+            '"status": "declared-blocked", "blocked_by": "CHAOS-1", '
+            '"invariants": [{"category": "c", "check": "k"}]}'
+        )
+        case = load_corpus_case(path)
+        assert len(case.invariants) == 1
+
+    def test_loading_the_whole_corpus_directory_does_not_crash_on_a_blocked_case(
+        self,
+    ) -> None:
+        """The regression this whole feature exists to fix: before this
+        change, a declared-blocked case's empty invariants list crashed
+        load_corpus_cases for the ENTIRE directory, not just that one case."""
+
+        cases = load_corpus_cases(_CASES_DIR)
+        ids = [case.id for case in cases]
+        assert "runner-selftest.declared-blocked" in ids
+        assert "runner-selftest.basic-exact" in ids  # sibling cases still load
+
+
+class TestLoadCorpusCases:
+    def test_loads_every_matching_case_sorted_by_id(self) -> None:
+        cases = load_corpus_cases(_CASES_DIR)
+        ids = [case.id for case in cases]
+        assert ids == sorted(ids)
+        assert "runner-selftest.basic-exact" in ids
+        assert "runner-selftest.needs-profile" in ids
+
+    def test_missing_directory_returns_empty_list_not_an_error(
+        self, tmp_path: Path
+    ) -> None:
+        assert load_corpus_cases(tmp_path / "does-not-exist") == []
+
+    def test_duplicate_case_id_across_files_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "case-a.json").write_text(
+            '{"id": "dup", "question": "q1", "subject_class": "exact", '
+            '"invariants": [{"category": "c", "check": "k"}]}'
+        )
+        (tmp_path / "case-b.json").write_text(
+            '{"id": "dup", "question": "q2", "subject_class": "exact", '
+            '"invariants": [{"category": "c", "check": "k"}]}'
+        )
+        with pytest.raises(CaseSchemaError, match="duplicate case id"):
+            load_corpus_cases(tmp_path)
+
+
+class TestLoadResolutionProfile:
+    def test_loads_a_valid_profile(self) -> None:
+        profile = load_resolution_profile(_PROFILES_DIR / "runner-selftest-v1.json")
+        assert profile.profile_id == "runner-selftest-v1"
+        assert "runner-selftest.needs-profile" in profile.cases
+
+    def test_wrong_schema_version_prefix_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "profile-bad.json"
+        path.write_text(
+            '{"schema_version": "something_else.v1", "profile_id": "x", "cases": {}}'
+        )
+        with pytest.raises(CaseSchemaError, match="schema_version"):
+            load_resolution_profile(path)
+
+    def test_non_object_case_entry_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "profile-bad.json"
+        path.write_text(
+            '{"schema_version": "resolution-profile.v1", "profile_id": "x", '
+            '"cases": {"a": "not-an-object"}}'
+        )
+        with pytest.raises(CaseSchemaError, match="must be an object"):
+            load_resolution_profile(path)
+
+
+class TestResolveCaseExpectations:
+    def test_case_with_no_profile_ref_gets_empty_block(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.basic-exact.json")
+        assert resolve_case_expectations(case, {}) == {}
+
+    def test_case_with_profile_ref_resolves_its_block(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.needs-profile.json")
+        profile = load_resolution_profile(_PROFILES_DIR / "runner-selftest-v1.json")
+        expectations = resolve_case_expectations(case, {profile.profile_id: profile})
+        assert expectations["expected_resolution_path"] == "deterministic-alias"
+
+    def test_case_citing_unloaded_profile_raises(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.needs-profile.json")
+        with pytest.raises(CaseSchemaError, match="not loaded"):
+            resolve_case_expectations(case, {})
+
+    def test_case_citing_profile_with_no_entry_for_it_raises(self) -> None:
+        case = load_corpus_case(_CASES_DIR / "case-runner-selftest.needs-profile.json")
+        profile = load_resolution_profile(_PROFILES_DIR / "runner-selftest-v1.json")
+        empty_profile = type(profile)(
+            profile_id=profile.profile_id,
+            schema_version=profile.schema_version,
+            cases={},
+            source_path=profile.source_path,
+        )
+        with pytest.raises(CaseSchemaError, match="no 'cases"):
+            resolve_case_expectations(case, {empty_profile.profile_id: empty_profile})

--- a/tests/acceptance/corpus/test_compose_context.py
+++ b/tests/acceptance/corpus/test_compose_context.py
@@ -1,0 +1,110 @@
+"""Unit coverage for ``scripts.acceptance.corpus.compose_context``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.acceptance.corpus.compose_context import (
+    DEFAULT_PROFILE,
+    DEFAULT_PROJECT_NAME,
+    ComposeContext,
+)
+
+
+class TestComposeContextFromEnv:
+    def test_defaults_match_the_launcher_literals(self) -> None:
+        context = ComposeContext.from_env({})
+        assert (
+            context.project_name
+            == DEFAULT_PROJECT_NAME
+            == "dev-health-ask-dev-acceptance"
+        )
+        assert context.profile == DEFAULT_PROFILE == "ask-dev-acceptance"
+        assert context.compose_files[0].name == "compose.yml"
+        assert context.compose_files[1] == (
+            context.project_directory / "tests" / "acceptance" / "compose.ask-dev.yml"
+        )
+
+    def test_project_name_override(self) -> None:
+        context = ComposeContext.from_env(
+            {"ASK_DEV_ACCEPTANCE_PROJECT_NAME": "custom-project"}
+        )
+        assert context.project_name == "custom-project"
+
+    def test_ops_root_override(self, tmp_path: Path) -> None:
+        context = ComposeContext.from_env(
+            {"ASK_DEV_ACCEPTANCE_OPS_ROOT": str(tmp_path)}
+        )
+        assert context.project_directory == tmp_path
+        assert context.compose_files[0] == tmp_path / "compose.yml"
+
+
+class TestBaseArgs:
+    def test_includes_project_name_and_directory_explicitly(self) -> None:
+        context = ComposeContext(
+            project_name="p",
+            project_directory=Path("/ops"),
+            compose_files=(Path("/ops/compose.yml"),),
+        )
+        args = context.base_args()
+        assert args[:4] == ["docker", "compose", "--project-name", "p"]
+        assert "--project-directory" in args
+        assert "/ops" in args
+
+    def test_includes_every_compose_file_with_its_own_flag(self) -> None:
+        context = ComposeContext(
+            project_name="p",
+            project_directory=Path("/ops"),
+            compose_files=(Path("/ops/a.yml"), Path("/ops/b.yml")),
+        )
+        args = context.base_args()
+        assert args.count("-f") == 2
+        assert "/ops/a.yml" in args
+        assert "/ops/b.yml" in args
+
+    def test_includes_profile_when_set(self) -> None:
+        context = ComposeContext(
+            project_name="p",
+            project_directory=Path("/ops"),
+            compose_files=(),
+            profile="my-profile",
+        )
+        args = context.base_args()
+        assert "--profile" in args
+        assert "my-profile" in args
+
+    def test_omits_profile_flag_when_none(self) -> None:
+        context = ComposeContext(
+            project_name="p",
+            project_directory=Path("/ops"),
+            compose_files=(),
+            profile=None,
+        )
+        args = context.base_args()
+        assert "--profile" not in args
+
+
+class TestStaysInSyncWithTheLauncher:
+    """Static wiring guard (repo convention, ``test_ask_dev_compose.py``'s
+    pattern): a future rename of the project name/profile/compose paths in
+    ``run_ask_dev_compose.sh`` without updating ``compose_context.py``'s
+    defaults must fail in the unit tier, not be discovered against a live
+    stack."""
+
+    def test_project_name_literal_matches_the_launcher(self) -> None:
+        launcher = (
+            Path(__file__).resolve().parents[3]
+            / "scripts"
+            / "acceptance"
+            / "run_ask_dev_compose.sh"
+        ).read_text(encoding="utf-8")
+        assert f'project_name="{DEFAULT_PROJECT_NAME}"' in launcher
+
+    def test_profile_literal_matches_the_launcher(self) -> None:
+        launcher = (
+            Path(__file__).resolve().parents[3]
+            / "scripts"
+            / "acceptance"
+            / "run_ask_dev_compose.sh"
+        ).read_text(encoding="utf-8")
+        assert f"--profile {DEFAULT_PROFILE}" in launcher

--- a/tests/acceptance/corpus/test_db_verify.py
+++ b/tests/acceptance/corpus/test_db_verify.py
@@ -1,0 +1,432 @@
+"""Unit coverage for ``scripts.acceptance.corpus.db_verify``.
+
+All tests inject a fake ``runner`` (dependency injection, matching
+``subprocess.run``'s call shape) -- none of this needs a real Docker
+daemon. The actual live ``docker compose exec`` path is exercised only by a
+genuinely booted acceptance stack, out of the unit tier's reach by design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from scripts.acceptance.corpus.compose_context import ComposeContext
+from scripts.acceptance.corpus.db_verify import (
+    DbVerifyUnavailableError,
+    exec_in_api,
+    query_resolution_ledger_via_exec,
+    query_transcript_assistant_schema_versions_via_exec,
+    verify_world_digest_via_exec,
+)
+
+
+@dataclass(slots=True)
+class _FakeResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _context() -> ComposeContext:
+    return ComposeContext(
+        project_name="dev-health-ask-dev-acceptance",
+        project_directory=Path("/ops"),
+        compose_files=(Path("/ops/compose.yml"),),
+        profile="ask-dev-acceptance",
+    )
+
+
+class TestExecInApi:
+    def test_success_returns_stdout(self) -> None:
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append(args)
+            return _FakeResult(returncode=0, stdout="hello\n")
+
+        out = exec_in_api(_context(), ["echo", "hi"], runner=runner)
+        assert out == "hello\n"
+        assert calls[0][:2] == ["docker", "compose"]
+        assert "exec" in calls[0]
+        assert "-T" in calls[0]
+        assert "api" in calls[0]
+        assert calls[0][-2:] == ["echo", "hi"]
+
+    def test_nonzero_exit_raises_with_stderr(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=1, stderr="boom")
+
+        with pytest.raises(DbVerifyUnavailableError, match="boom"):
+            exec_in_api(_context(), ["false"], runner=runner)
+
+    def test_missing_docker_binary_raises(self) -> None:
+        def runner(args, **kwargs):
+            raise FileNotFoundError("no docker")
+
+        with pytest.raises(DbVerifyUnavailableError, match="not available"):
+            exec_in_api(_context(), ["true"], runner=runner)
+
+    def test_timeout_raises(self) -> None:
+        import subprocess
+
+        def runner(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs.get("timeout", 60))
+
+        with pytest.raises(DbVerifyUnavailableError, match="timed out"):
+            exec_in_api(_context(), ["sleep", "999"], runner=runner)
+
+    def test_custom_api_service_name_is_used(self) -> None:
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append(args)
+            return _FakeResult(returncode=0, stdout="ok")
+
+        context = ComposeContext(
+            project_name="p",
+            project_directory=Path("/ops"),
+            compose_files=(),
+            api_service="custom-api",
+        )
+        exec_in_api(context, ["true"], runner=runner)
+        # The service argument immediately follows "-T" -- must be the
+        # custom name, never the default "api" literal.
+        service_index = calls[0].index("-T") + 1
+        assert calls[0][service_index] == "custom-api"
+
+
+#: Real-shaped (64 lowercase hex char) sha256 hexdigests -- matches what
+#: `fixtures/world.py`'s `compute_world_digest` actually produces. Using
+#: single-character placeholders here previously masked a real bug (Codex
+#: round-3, HIGH): "" == "" also "matches", but is not a validation any
+#: strict-format check should accept as a real digest.
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+
+
+class TestVerifyWorldDigestViaExec:
+    def test_parses_a_matched_result(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    f'{{"pinned_digest": "{_DIGEST_A}", "live_digest": "{_DIGEST_A}", '
+                    '"matched": true, "drifted_components": []}\n'
+                ),
+            )
+
+        result = verify_world_digest_via_exec(
+            _context(),
+            manifest_path_in_container="/app/tests/acceptance/world/ask-dev-world.v1/world.json",
+            sink="clickhouse://ch:ch@clickhouse:8123/default",
+            postgres_uri="postgresql+asyncpg://postgres:postgres@pgbouncer:6432/postgres",
+            runner=runner,
+        )
+        assert result.matched is True
+        assert result.pinned_digest == _DIGEST_A
+
+    def test_nonzero_exit_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=1, stderr="world digest verification raised: boom"
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="boom"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_missing_expected_key_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0, stdout=f'{{"pinned_digest": "{_DIGEST_A}"}}\n'
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="must be a string"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_empty_digest_strings_are_rejected_not_treated_as_a_match(self) -> None:
+        """Codex round-3, HIGH, confirmed: two empty strings are equal, so
+        the previous (type-only) validation let a genuinely empty,
+        never-computed pair of digests report `matched=True` -- an
+        unverified world silently passing WORLD_DIGEST verification."""
+
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout='{"pinned_digest": "", "live_digest": "", "matched": true, '
+                '"drifted_components": []}\n',
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="sha256 digest"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_non_hex_digest_is_rejected(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout='{"pinned_digest": "not-a-real-digest", '
+                f'"live_digest": "{_DIGEST_A}", "matched": true, '
+                '"drifted_components": []}\n',
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="sha256 digest"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_matched_is_recomputed_never_trusted_from_the_inner_script(self) -> None:
+        """Codex round-2, HIGH, confirmed: a non-bool truthy `matched` value
+        (e.g. the STRING "false") used to slip a real digest mismatch past
+        this function entirely. `matched` is now always recomputed from the
+        two digest strings; the inner script's own claim is never read."""
+
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    f'{{"pinned_digest": "{_DIGEST_A}", "live_digest": "{_DIGEST_B}", '
+                    '"matched": "false", "drifted_components": ["x.y"]}\n'
+                ),
+            )
+
+        result = verify_world_digest_via_exec(
+            _context(),
+            manifest_path_in_container="/app/x/world.json",
+            sink="clickhouse://x",
+            postgres_uri="postgresql://x",
+            runner=runner,
+        )
+        assert result.matched is False
+
+    def test_non_bool_matched_true_string_still_recomputed_correctly(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    f'{{"pinned_digest": "{_DIGEST_A}", "live_digest": "{_DIGEST_A}", '
+                    '"matched": "false", "drifted_components": []}\n'
+                ),
+            )
+
+        result = verify_world_digest_via_exec(
+            _context(),
+            manifest_path_in_container="/app/x/world.json",
+            sink="clickhouse://x",
+            postgres_uri="postgresql://x",
+            runner=runner,
+        )
+        # Even though the inner script's own (bogus) "matched" claim was the
+        # string "false", the digests are equal -- the recomputed value
+        # must be the real True, never influenced by the untrusted claim.
+        assert result.matched is True
+
+    def test_non_string_drifted_components_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    f'{{"pinned_digest": "{_DIGEST_A}", "live_digest": "{_DIGEST_B}", '
+                    '"matched": true, "drifted_components": [1, 2]}\n'
+                ),
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="drifted_components"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_unparseable_stdout_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout="not json at all")
+
+        with pytest.raises(DbVerifyUnavailableError, match="cannot parse"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+    def test_empty_stdout_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout="")
+
+        with pytest.raises(DbVerifyUnavailableError, match="no stdout"):
+            verify_world_digest_via_exec(
+                _context(),
+                manifest_path_in_container="/app/x/world.json",
+                sink="clickhouse://x",
+                postgres_uri="postgresql://x",
+                runner=runner,
+            )
+
+
+class TestQueryResolutionLedgerViaExec:
+    def test_parses_entries(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    '{"entries": [{"outcome": "exact_match", "mention_id": "m1", '
+                    '"committed_label": "meridian/web-app", '
+                    '"committed_canonical_id": "repo-01"}]}\n'
+                ),
+            )
+
+        entries = query_resolution_ledger_via_exec(
+            _context(), run_id="run-1", runner=runner
+        )
+        assert len(entries) == 1
+        assert entries[0].outcome == "exact_match"
+        assert entries[0].mention_id == "m1"
+        assert entries[0].committed_label == "meridian/web-app"
+        assert entries[0].committed_canonical_id == "repo-01"
+
+    def test_empty_ledger_returns_empty_list(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout='{"entries": []}\n')
+
+        assert (
+            query_resolution_ledger_via_exec(_context(), run_id="run-1", runner=runner)
+            == []
+        )
+
+    def test_missing_entries_key_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout="{}\n")
+
+        with pytest.raises(DbVerifyUnavailableError, match="no 'entries'"):
+            query_resolution_ledger_via_exec(_context(), run_id="run-1", runner=runner)
+
+    def test_run_id_is_passed_through_as_a_string(self) -> None:
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append(args)
+            return _FakeResult(returncode=0, stdout='{"entries": []}\n')
+
+        import uuid
+
+        run_id = uuid.uuid4()
+        query_resolution_ledger_via_exec(_context(), run_id=run_id, runner=runner)
+        assert str(run_id) in calls[0]
+
+    def test_non_object_entry_raises_db_verify_unavailable_not_a_bare_type_error(
+        self,
+    ) -> None:
+        """Codex round-2, HIGH, confirmed: indexing a malformed entry used
+        to leak a raw KeyError/TypeError instead of the one exception type
+        every caller of this module expects."""
+
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout='{"entries": ["not-an-object"]}\n')
+
+        with pytest.raises(DbVerifyUnavailableError, match="non-object"):
+            query_resolution_ledger_via_exec(_context(), run_id="run-1", runner=runner)
+
+    def test_entry_missing_outcome_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0, stdout='{"entries": [{"mention_id": "m1"}]}\n'
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="outcome"):
+            query_resolution_ledger_via_exec(_context(), run_id="run-1", runner=runner)
+
+    def test_non_string_committed_label_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout=(
+                    '{"entries": [{"outcome": "exact_match", "mention_id": "m1", '
+                    '"committed_label": 123}]}\n'
+                ),
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="committed_label"):
+            query_resolution_ledger_via_exec(_context(), run_id="run-1", runner=runner)
+
+
+class TestQueryTranscriptAssistantSchemaVersionsViaExec:
+    def test_parses_versions(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0,
+                stdout='{"assistant_schema_versions": ["dev_answer.v2", null]}\n',
+            )
+
+        versions = query_transcript_assistant_schema_versions_via_exec(
+            _context(), conversation_id="conv-1", runner=runner
+        )
+        assert versions == ["dev_answer.v2", None]
+
+    def test_empty_result_returns_empty_list(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0, stdout='{"assistant_schema_versions": []}\n'
+            )
+
+        assert (
+            query_transcript_assistant_schema_versions_via_exec(
+                _context(), conversation_id="conv-1", runner=runner
+            )
+            == []
+        )
+
+    def test_missing_key_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=0, stdout="{}\n")
+
+        with pytest.raises(DbVerifyUnavailableError, match="list of strings/nulls"):
+            query_transcript_assistant_schema_versions_via_exec(
+                _context(), conversation_id="conv-1", runner=runner
+            )
+
+    def test_nonzero_exit_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(returncode=1, stderr="boom")
+
+        with pytest.raises(DbVerifyUnavailableError, match="boom"):
+            query_transcript_assistant_schema_versions_via_exec(
+                _context(), conversation_id="conv-1", runner=runner
+            )
+
+    def test_non_string_non_null_version_raises(self) -> None:
+        def runner(args, **kwargs):
+            return _FakeResult(
+                returncode=0, stdout='{"assistant_schema_versions": [123]}\n'
+            )
+
+        with pytest.raises(DbVerifyUnavailableError, match="list of strings/nulls"):
+            query_transcript_assistant_schema_versions_via_exec(
+                _context(), conversation_id="conv-1", runner=runner
+            )

--- a/tests/acceptance/corpus/test_inner_ledger_query.py
+++ b/tests/acceptance/corpus/test_inner_ledger_query.py
@@ -1,0 +1,188 @@
+"""Integration coverage for ``scripts.acceptance.corpus._inner_ledger_query``'s
+query logic against a real (ephemeral, sqlite-backed) database.
+
+``_fetch_entries`` is plain, DB-agnostic SQLAlchemy -- exercising it via
+aiosqlite here (rather than requiring a live Postgres) mirrors this repo's
+own established pattern for testing otherwise-Postgres-oriented production
+code (``test_ask_dev_quota_headroom.py``'s "aiosqlite in-memory DB" comment
+makes the same tradeoff explicitly). What is NOT covered here: the actual
+``docker compose exec`` invocation and the container's real ``DATABASE_URI``
+(asyncpg/Postgres) -- those need a genuinely booted acceptance stack, see
+``db_verify.py``'s own docstring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.dev_persistence import (
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevRunResolution,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from scripts.acceptance.corpus._inner_ledger_query import _fetch_entries
+from tests._helpers import tables_of
+
+_TABLES = tables_of(
+    User, Organization, DevConversation, DevMessage, DevRun, DevRunResolution
+)
+
+
+@pytest_asyncio.fixture
+async def seeded_run(tmp_path: Path):
+    database = tmp_path / "inner-ledger-query.db"
+    database_uri = f"sqlite+aiosqlite:///{database}"
+    engine = create_async_engine(database_uri)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync: Base.metadata.create_all(sync, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id, conversation_id, run_id = (
+        uuid.uuid4(),
+        uuid.uuid4(),
+        uuid.uuid4(),
+        uuid.uuid4(),
+    )
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ledger-query", name="Ledger Query"),
+                User(id=user_id, email="ledger-query@example.com"),
+            ]
+        )
+        await session.flush()
+        session.add(
+            DevConversation(
+                id=conversation_id,
+                org_id=org_id,
+                user_id=user_id,
+                current_scope={},
+                retention_days=30,
+            )
+        )
+        await session.flush()
+        session.add(
+            DevRun(
+                id=run_id,
+                request_id=uuid.uuid4(),
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                state="completed",
+            )
+        )
+        await session.commit()
+    try:
+        yield maker, database_uri, run_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_returns_ordered_shaped_rows(seeded_run) -> None:
+    maker, database_uri, run_id = seeded_run
+    async with maker() as session:
+        session.add_all(
+            [
+                DevRunResolution(
+                    run_id=run_id,
+                    org_id=(await session.get(DevRun, run_id)).org_id,
+                    user_id=(await session.get(DevRun, run_id)).user_id,
+                    entry_ordinal=1,
+                    mention_id=uuid.uuid4(),
+                    outcome="ambiguous_candidates",
+                    payload={"outcome": "ambiguous_candidates"},
+                    resolved_at=datetime.now(UTC),
+                ),
+                DevRunResolution(
+                    run_id=run_id,
+                    org_id=(await session.get(DevRun, run_id)).org_id,
+                    user_id=(await session.get(DevRun, run_id)).user_id,
+                    entry_ordinal=0,
+                    mention_id=uuid.uuid4(),
+                    outcome="exact_match",
+                    payload={
+                        "outcome": "exact_match",
+                        "committed_entity_ref": {
+                            "display_label": "meridian/web-app",
+                            "entity_id": "repo-01",
+                        },
+                    },
+                    resolved_at=datetime.now(UTC),
+                ),
+            ]
+        )
+        await session.commit()
+
+    entries = await _fetch_entries(run_id, database_uri)
+    assert len(entries) == 2
+    # Ordered by entry_ordinal (0 before 1), regardless of insertion order.
+    assert entries[0]["outcome"] == "exact_match"
+    assert entries[0]["committed_label"] == "meridian/web-app"
+    assert entries[0]["committed_canonical_id"] == "repo-01"
+    assert entries[1]["outcome"] == "ambiguous_candidates"
+    assert entries[1]["committed_label"] is None
+    assert entries[1]["committed_canonical_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_empty_ledger_returns_empty_list(seeded_run) -> None:
+    _maker, database_uri, run_id = seeded_run
+    entries = await _fetch_entries(run_id, database_uri)
+    assert entries == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_entries_only_returns_rows_for_the_requested_run(
+    seeded_run,
+) -> None:
+    maker, database_uri, run_id = seeded_run
+    other_run_id = uuid.uuid4()
+    async with maker() as session:
+        run = await session.get(DevRun, run_id)
+        session.add(
+            DevRun(
+                id=other_run_id,
+                request_id=uuid.uuid4(),
+                org_id=run.org_id,
+                user_id=run.user_id,
+                conversation_id=run.conversation_id,
+                state="completed",
+            )
+        )
+        await session.flush()
+        session.add(
+            DevRunResolution(
+                run_id=other_run_id,
+                org_id=run.org_id,
+                user_id=run.user_id,
+                entry_ordinal=0,
+                mention_id=uuid.uuid4(),
+                outcome="no_authorized_match",
+                payload={"outcome": "no_authorized_match"},
+                resolved_at=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+
+    entries = await _fetch_entries(run_id, database_uri)
+    assert entries == []

--- a/tests/acceptance/corpus/test_inner_transcript_query.py
+++ b/tests/acceptance/corpus/test_inner_transcript_query.py
@@ -1,0 +1,138 @@
+"""Integration coverage for
+``scripts.acceptance.corpus._inner_transcript_query``'s query logic against
+a real (ephemeral, sqlite-backed) database -- same tradeoff as
+``test_inner_ledger_query.py``: aiosqlite here stands in for the container's
+real asyncpg/Postgres connection, proving the query/shape logic without
+needing a live Postgres. The actual ``docker compose exec`` invocation is
+exercised only against a genuinely booted acceptance stack.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.dev_persistence import DevConversation, DevMessage
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from scripts.acceptance.corpus._inner_transcript_query import (
+    _fetch_assistant_schema_versions,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(User, Organization, DevConversation, DevMessage)
+
+
+@pytest_asyncio.fixture
+async def seeded_conversation(tmp_path: Path):
+    database = tmp_path / "inner-transcript-query.db"
+    database_uri = f"sqlite+aiosqlite:///{database}"
+    engine = create_async_engine(database_uri)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync: Base.metadata.create_all(sync, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id, conversation_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(
+                    id=org_id, slug="transcript-query", name="Transcript Query"
+                ),
+                User(id=user_id, email="transcript-query@example.com"),
+            ]
+        )
+        await session.flush()
+        session.add(
+            DevConversation(
+                id=conversation_id, org_id=org_id, user_id=user_id, current_scope={}
+            )
+        )
+        await session.commit()
+    try:
+        yield maker, database_uri, org_id, user_id, conversation_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_no_assistant_rows_returns_empty_list(seeded_conversation) -> None:
+    _maker, database_uri, _org_id, _user_id, conversation_id = seeded_conversation
+    versions = await _fetch_assistant_schema_versions(conversation_id, database_uri)
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_returns_schema_versions_in_creation_order(seeded_conversation) -> None:
+    maker, database_uri, org_id, user_id, conversation_id = seeded_conversation
+    async with maker() as session:
+        session.add_all(
+            [
+                DevMessage(
+                    conversation_id=conversation_id,
+                    org_id=org_id,
+                    user_id=user_id,
+                    role="user",
+                    content="what's the status?",
+                    client_message_id=uuid.uuid4(),
+                ),
+                DevMessage(
+                    conversation_id=conversation_id,
+                    org_id=org_id,
+                    user_id=user_id,
+                    role="assistant",
+                    answer_id=uuid.uuid4(),
+                    answer_payload={"schema_version": "dev_answer.v2"},
+                ),
+            ]
+        )
+        await session.commit()
+
+    versions = await _fetch_assistant_schema_versions(conversation_id, database_uri)
+    assert versions == ["dev_answer.v2"]
+
+
+@pytest.mark.asyncio
+async def test_only_returns_rows_for_the_requested_conversation(
+    seeded_conversation,
+) -> None:
+    maker, database_uri, org_id, user_id, conversation_id = seeded_conversation
+    other_conversation_id = uuid.uuid4()
+    async with maker() as session:
+        session.add(
+            DevConversation(
+                id=other_conversation_id,
+                org_id=org_id,
+                user_id=user_id,
+                current_scope={},
+            )
+        )
+        await session.flush()
+        session.add(
+            DevMessage(
+                conversation_id=other_conversation_id,
+                org_id=org_id,
+                user_id=user_id,
+                role="assistant",
+                answer_id=uuid.uuid4(),
+                answer_payload={"schema_version": "dev_error.v1"},
+            )
+        )
+        await session.commit()
+
+    versions = await _fetch_assistant_schema_versions(conversation_id, database_uri)
+    assert versions == []

--- a/tests/acceptance/corpus/test_invariants.py
+++ b/tests/acceptance/corpus/test_invariants.py
@@ -1,0 +1,424 @@
+"""Unit coverage for ``scripts.acceptance.corpus.invariants``."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.invariants import (
+    CHECKS,
+    InvariantCheckError,
+    InvariantContext,
+    evaluate_invariant,
+    register_check,
+)
+
+
+def _context(
+    *,
+    resolution_path: str | None = "deterministic-exact",
+    public_outcome: str | None = "answered",
+    events: tuple = (),
+    expectations: dict | None = None,
+    assistant_schema_versions: tuple = (),
+) -> InvariantContext:
+    return InvariantContext(
+        resolution_path=resolution_path,
+        public_outcome=public_outcome,
+        events=events,
+        expectations=expectations or {},
+        assistant_schema_versions=assistant_schema_versions,
+    )
+
+
+def _scope_resolved_event(*, outcome: str, candidates: list | None = None) -> dict:
+    return {
+        "event": "scope.resolved",
+        "data": {
+            "scope_resolution": {
+                "outcome": outcome,
+                "candidates": candidates or [],
+            }
+        },
+    }
+
+
+def _candidate(entity_id: str) -> dict:
+    return {"entity_ref": {"entity_id": entity_id}, "reason": "close match"}
+
+
+class TestResolutionPathIn:
+    def test_passes_when_the_actual_path_is_in_the_literal_allowed_list(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {"allowed": ["deterministic-exact"]},
+            },
+            _context(resolution_path="deterministic-exact"),
+        )
+        assert result.passed
+
+    def test_fails_when_the_actual_path_is_not_in_the_allowed_list(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {"allowed": ["deterministic-alias"]},
+            },
+            _context(resolution_path="deterministic-exact"),
+        )
+        assert not result.passed
+        assert "deterministic-exact" in result.detail
+
+    def test_pulls_the_expected_value_from_the_profile(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {"from_profile": "expected_resolution_path"},
+            },
+            _context(
+                resolution_path="deterministic-alias",
+                expectations={"expected_resolution_path": "deterministic-alias"},
+            ),
+        )
+        assert result.passed
+
+    def test_missing_profile_key_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="not found"):
+            evaluate_invariant(
+                {"check": "resolution_path_in", "args": {"from_profile": "nope"}},
+                _context(expectations={}),
+            )
+
+    def test_no_allowed_and_no_from_profile_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="requires"):
+            evaluate_invariant({"check": "resolution_path_in", "args": {}}, _context())
+
+    def test_literal_and_from_profile_combine(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {
+                    "allowed": ["deterministic-exact"],
+                    "from_profile": "expected_resolution_path",
+                },
+            },
+            _context(
+                resolution_path="deterministic-alias",
+                expectations={"expected_resolution_path": "deterministic-alias"},
+            ),
+        )
+        assert result.passed
+
+    def test_unobserved_none_never_matches_even_if_literally_allowed(self) -> None:
+        """Codex round-1, HIGH, confirmed: `None` (unobserved) must never
+        satisfy this check, even if a case/profile authoring mistake put a
+        literal `None` into the allowed list."""
+
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {"allowed": [None, "deterministic-exact"]},
+            },
+            _context(resolution_path=None),
+        )
+        assert not result.passed
+        assert "not observed" in result.detail
+
+    def test_unobserved_none_fails_even_from_profile(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "resolution_path_in",
+                "args": {"from_profile": "expected_resolution_path"},
+            },
+            _context(
+                resolution_path=None,
+                expectations={"expected_resolution_path": None},
+            ),
+        )
+        assert not result.passed
+
+
+class TestPublicOutcomeIn:
+    def test_passes_when_actual_outcome_is_allowed(self) -> None:
+        result = evaluate_invariant(
+            {"check": "public_outcome_in", "args": {"allowed": ["answered"]}},
+            _context(public_outcome="answered"),
+        )
+        assert result.passed
+
+    def test_fails_when_actual_outcome_is_not_allowed(self) -> None:
+        result = evaluate_invariant(
+            {"check": "public_outcome_in", "args": {"allowed": ["answered"]}},
+            _context(public_outcome="needs_clarification"),
+        )
+        assert not result.passed
+
+    def test_pulls_expected_value_from_profile(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "public_outcome_in",
+                "args": {"from_profile": "expected_public_outcome"},
+            },
+            _context(
+                public_outcome="answered",
+                expectations={"expected_public_outcome": "answered"},
+            ),
+        )
+        assert result.passed
+
+    def test_unobserved_none_never_passes(self) -> None:
+        result = evaluate_invariant(
+            {"check": "public_outcome_in", "args": {"allowed": ["answered"]}},
+            _context(public_outcome=None),
+        )
+        assert not result.passed
+        assert "not observed" in result.detail
+
+
+class TestNoInternalError:
+    def test_passes_with_no_error_events(self) -> None:
+        result = evaluate_invariant(
+            {"check": "no_internal_error"},
+            _context(events=({"event": "answer.completed", "data": {}},)),
+        )
+        assert result.passed
+
+    def test_passes_with_a_non_internal_error(self) -> None:
+        events = ({"event": "error", "data": {"error": {"code": "scope_ambiguous"}}},)
+        result = evaluate_invariant(
+            {"check": "no_internal_error"}, _context(events=events)
+        )
+        assert result.passed
+
+    def test_fails_on_an_internal_error_event(self) -> None:
+        events = ({"event": "error", "data": {"error": {"code": "internal_error"}}},)
+        result = evaluate_invariant(
+            {"check": "no_internal_error"}, _context(events=events)
+        )
+        assert not result.passed
+
+
+class TestScopeResolutionOutcomeIn:
+    def test_passes_when_actual_outcome_is_allowed(self) -> None:
+        events = (_scope_resolved_event(outcome="exact"),)
+        result = evaluate_invariant(
+            {"check": "scope_resolution_outcome_in", "args": {"allowed": ["exact"]}},
+            _context(events=events),
+        )
+        assert result.passed
+
+    def test_fails_when_actual_outcome_is_not_allowed(self) -> None:
+        events = (_scope_resolved_event(outcome="ambiguous"),)
+        result = evaluate_invariant(
+            {"check": "scope_resolution_outcome_in", "args": {"allowed": ["exact"]}},
+            _context(events=events),
+        )
+        assert not result.passed
+
+    def test_no_scope_resolved_event_fails(self) -> None:
+        result = evaluate_invariant(
+            {"check": "scope_resolution_outcome_in", "args": {"allowed": ["exact"]}},
+            _context(events=()),
+        )
+        assert not result.passed
+        assert "no scope.resolved event" in result.detail
+
+    def test_pulls_expected_value_from_profile(self) -> None:
+        events = (_scope_resolved_event(outcome="organization_fallback"),)
+        result = evaluate_invariant(
+            {
+                "check": "scope_resolution_outcome_in",
+                "args": {"from_profile": "expected_scope_resolution_outcome"},
+            },
+            _context(
+                events=events,
+                expectations={
+                    "expected_scope_resolution_outcome": "organization_fallback"
+                },
+            ),
+        )
+        assert result.passed
+
+    def test_uses_the_last_of_multiple_scope_resolved_events(self) -> None:
+        """Codex round-3, HIGH, confirmed: production's validate_stream does
+        not forbid more than one scope.resolved event (e.g. a
+        re-resolution mid-investigation) -- the FINAL one is the outcome of
+        record for this check."""
+
+        events = (
+            _scope_resolved_event(outcome="ambiguous"),
+            _scope_resolved_event(outcome="exact"),
+        )
+        result = evaluate_invariant(
+            {"check": "scope_resolution_outcome_in", "args": {"allowed": ["exact"]}},
+            _context(events=events),
+        )
+        assert result.passed
+
+
+class TestNoUnauthorizedCandidateSurfaces:
+    def test_unauthorized_candidate_on_a_second_scope_resolved_event_is_caught(
+        self,
+    ) -> None:
+        """Codex round-3, HIGH, confirmed: an earlier version of this check
+        only ever inspected the FIRST scope.resolved event, so an
+        unauthorized candidate surfaced on a SECOND one was invisible even
+        though the overall stream passes validate_stream cleanly."""
+
+        events = (
+            _scope_resolved_event(
+                outcome="ambiguous", candidates=[_candidate("repo-1")]
+            ),
+            _scope_resolved_event(
+                outcome="ambiguous", candidates=[_candidate("sibling-org-repo")]
+            ),
+        )
+        result = evaluate_invariant(
+            {
+                "check": "no_unauthorized_candidate_surfaces",
+                "args": {"authorized_entity_ids": ["repo-1"]},
+            },
+            _context(events=events),
+        )
+        assert not result.passed
+        assert "sibling-org-repo" in result.detail
+
+    def test_passes_when_every_candidate_is_authorized(self) -> None:
+        events = (
+            _scope_resolved_event(
+                outcome="ambiguous",
+                candidates=[_candidate("repo-1"), _candidate("repo-2")],
+            ),
+        )
+        result = evaluate_invariant(
+            {
+                "check": "no_unauthorized_candidate_surfaces",
+                "args": {"authorized_entity_ids": ["repo-1", "repo-2"]},
+            },
+            _context(events=events),
+        )
+        assert result.passed
+
+    def test_fails_when_an_unauthorized_candidate_surfaces(self) -> None:
+        events = (
+            _scope_resolved_event(
+                outcome="ambiguous",
+                candidates=[_candidate("repo-1"), _candidate("sibling-org-repo")],
+            ),
+        )
+        result = evaluate_invariant(
+            {
+                "check": "no_unauthorized_candidate_surfaces",
+                "args": {"authorized_entity_ids": ["repo-1"]},
+            },
+            _context(events=events),
+        )
+        assert not result.passed
+        assert "sibling-org-repo" in result.detail
+
+    def test_no_candidates_at_all_passes(self) -> None:
+        result = evaluate_invariant(
+            {
+                "check": "no_unauthorized_candidate_surfaces",
+                "args": {"authorized_entity_ids": ["repo-1"]},
+            },
+            _context(events=()),
+        )
+        assert result.passed
+
+    def test_pulls_authorized_set_from_profile(self) -> None:
+        events = (
+            _scope_resolved_event(
+                outcome="ambiguous", candidates=[_candidate("repo-1")]
+            ),
+        )
+        result = evaluate_invariant(
+            {
+                "check": "no_unauthorized_candidate_surfaces",
+                "args": {"from_profile": "authorized_entity_ids"},
+            },
+            _context(events=events, expectations={"authorized_entity_ids": ["repo-1"]}),
+        )
+        assert result.passed
+
+    def test_missing_authorized_set_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="requires a non-empty"):
+            evaluate_invariant(
+                {"check": "no_unauthorized_candidate_surfaces", "args": {}},
+                _context(),
+            )
+
+
+class TestTerminalPersistsAssistantRow:
+    def test_passes_with_a_real_answer_schema_version(self) -> None:
+        result = evaluate_invariant(
+            {"check": "terminal_persists_assistant_row"},
+            _context(assistant_schema_versions=("dev_answer.v2",)),
+        )
+        assert result.passed
+
+    def test_passes_with_a_dev_error_v1_row(self) -> None:
+        result = evaluate_invariant(
+            {"check": "terminal_persists_assistant_row"},
+            _context(assistant_schema_versions=("dev_error.v1",)),
+        )
+        assert result.passed
+
+    def test_fails_with_no_rows_at_all(self) -> None:
+        result = evaluate_invariant(
+            {"check": "terminal_persists_assistant_row"},
+            _context(assistant_schema_versions=()),
+        )
+        assert not result.passed
+
+    def test_fails_with_only_unrecognized_schema_versions(self) -> None:
+        result = evaluate_invariant(
+            {"check": "terminal_persists_assistant_row"},
+            _context(assistant_schema_versions=("something_else.v1",)),
+        )
+        assert not result.passed
+
+    def test_fails_with_a_duplicate_real_row(self) -> None:
+        """Codex round-3, MEDIUM, confirmed: 'at least one recognized row'
+        also passed for a DUPLICATE/stale extra assistant row -- exactly
+        the persistence defect CHAOS-3423/replay-safety exists to prevent.
+        """
+
+        result = evaluate_invariant(
+            {"check": "terminal_persists_assistant_row"},
+            _context(assistant_schema_versions=("dev_answer.v2", "dev_answer.v2")),
+        )
+        assert not result.passed
+        assert "expected exactly one" in result.detail
+
+
+class TestEvaluateInvariantDispatch:
+    def test_unknown_check_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="unknown invariant check"):
+            evaluate_invariant({"check": "not_a_real_check"}, _context())
+
+    def test_missing_check_name_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="no string 'check'"):
+            evaluate_invariant({}, _context())
+
+    def test_non_object_args_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="must be an object"):
+            evaluate_invariant(
+                {"check": "no_internal_error", "args": "nope"}, _context()
+            )
+
+
+class TestRegisterCheck:
+    def test_duplicate_registration_raises(self) -> None:
+        with pytest.raises(InvariantCheckError, match="already registered"):
+
+            @register_check("no_internal_error")
+            def _dup(args, context):  # noqa: ANN001, ARG001
+                raise AssertionError("should never run")
+
+    def test_the_documented_checks_are_registered(self) -> None:
+        assert "resolution_path_in" in CHECKS
+        assert "no_internal_error" in CHECKS
+        assert "public_outcome_in" in CHECKS
+        assert "scope_resolution_outcome_in" in CHECKS
+        assert "no_unauthorized_candidate_surfaces" in CHECKS
+        assert "terminal_persists_assistant_row" in CHECKS

--- a/tests/acceptance/corpus/test_quota.py
+++ b/tests/acceptance/corpus/test_quota.py
@@ -1,0 +1,177 @@
+"""Unit coverage for ``scripts.acceptance.corpus.quota``."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.quota import (
+    QuotaBudget,
+    QuotaConfigurationError,
+    QuotaExhaustedError,
+    estimate_run_cost_microusd,
+)
+
+
+class TestEstimateRunCostMicrousd:
+    def test_prices_the_real_scripted_model(self) -> None:
+        cost = estimate_run_cost_microusd(
+            input_tokens=8_000, output_tokens=3_000, rounds=4
+        )
+        assert cost > 0
+
+    def test_unpriced_model_raises_rather_than_being_free(self) -> None:
+        with pytest.raises(ValueError, match="no priced entry"):
+            estimate_run_cost_microusd(
+                model="definitely-not-a-priced-model",
+                input_tokens=100,
+                output_tokens=100,
+            )
+
+    def test_more_rounds_costs_more(self) -> None:
+        one_round = estimate_run_cost_microusd(
+            input_tokens=100, output_tokens=100, rounds=1
+        )
+        four_rounds = estimate_run_cost_microusd(
+            input_tokens=100, output_tokens=100, rounds=4
+        )
+        assert four_rounds == one_round * 4
+
+
+class TestQuotaBudgetFromEnv:
+    def test_builds_from_the_compose_configured_values(self) -> None:
+        budget = QuotaBudget.from_env(
+            {
+                "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "1000",
+                "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "200000000",
+            }
+        )
+        assert budget.max_requests == 1000
+        assert budget.max_cost_microusd == 200_000_000
+        assert budget.remaining_requests() == 1000
+
+    def test_missing_request_max_raises(self) -> None:
+        with pytest.raises(
+            QuotaConfigurationError, match="ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX"
+        ):
+            QuotaBudget.from_env({"ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "1"})
+
+    def test_missing_cost_max_raises(self) -> None:
+        with pytest.raises(
+            QuotaConfigurationError, match="ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD"
+        ):
+            QuotaBudget.from_env({"ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "1"})
+
+    def test_non_integer_value_raises(self) -> None:
+        with pytest.raises(QuotaConfigurationError, match="not an integer"):
+            QuotaBudget.from_env(
+                {
+                    "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "lots",
+                    "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "1",
+                }
+            )
+
+    def test_zero_or_negative_value_raises(self) -> None:
+        with pytest.raises(QuotaConfigurationError, match="must be positive"):
+            QuotaBudget.from_env(
+                {
+                    "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "0",
+                    "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "1",
+                }
+            )
+
+
+class TestQuotaBudgetReserve:
+    def test_reserve_accumulates_spend(self) -> None:
+        budget = QuotaBudget(max_requests=10, max_cost_microusd=1000)
+        budget.reserve(case_id="a", requests=2, cost_microusd=100)
+        budget.reserve(case_id="b", requests=3, cost_microusd=200)
+        assert budget.spent_requests == 5
+        assert budget.spent_cost_microusd == 300
+        assert budget.remaining_requests() == 5
+        assert budget.remaining_cost_microusd() == 700
+
+    def test_exceeding_request_ceiling_raises_and_names_the_case(self) -> None:
+        budget = QuotaBudget(max_requests=5, max_cost_microusd=1_000_000)
+        budget.reserve(case_id="a", requests=4, cost_microusd=1)
+        with pytest.raises(QuotaExhaustedError, match="case 'b'"):
+            budget.reserve(case_id="b", requests=2, cost_microusd=1)
+
+    def test_exceeding_cost_ceiling_raises_and_names_the_case(self) -> None:
+        budget = QuotaBudget(max_requests=1_000_000, max_cost_microusd=100)
+        budget.reserve(case_id="a", requests=1, cost_microusd=90)
+        with pytest.raises(QuotaExhaustedError, match="case 'b'"):
+            budget.reserve(case_id="b", requests=1, cost_microusd=20)
+
+    def test_a_failed_reservation_leaves_the_budget_unchanged(self) -> None:
+        budget = QuotaBudget(max_requests=5, max_cost_microusd=100)
+        budget.reserve(case_id="a", requests=4, cost_microusd=10)
+        with pytest.raises(QuotaExhaustedError):
+            budget.reserve(case_id="b", requests=2, cost_microusd=10)
+        assert budget.spent_requests == 4
+        assert budget.spent_cost_microusd == 10
+
+    def test_exact_fit_is_allowed(self) -> None:
+        budget = QuotaBudget(max_requests=5, max_cost_microusd=100)
+        budget.reserve(case_id="a", requests=5, cost_microusd=100)
+        assert budget.remaining_requests() == 0
+        assert budget.remaining_cost_microusd() == 0
+
+
+class TestQuotaBudgetRelease:
+    def test_release_credits_back_a_reservation(self) -> None:
+        budget = QuotaBudget(max_requests=10, max_cost_microusd=1000)
+        budget.reserve(case_id="a", requests=3, cost_microusd=300)
+        budget.release(requests=3, cost_microusd=300)
+        assert budget.spent_requests == 0
+        assert budget.spent_cost_microusd == 0
+
+    def test_release_only_credits_the_released_amount(self) -> None:
+        budget = QuotaBudget(max_requests=10, max_cost_microusd=1000)
+        budget.reserve(case_id="a", requests=5, cost_microusd=500)
+        budget.reserve(case_id="b", requests=2, cost_microusd=200)
+        budget.release(requests=2, cost_microusd=200)  # case b's pre-admission failure
+        assert budget.spent_requests == 5
+        assert budget.spent_cost_microusd == 500
+
+    def test_a_released_reservation_frees_room_for_a_later_case(self) -> None:
+        budget = QuotaBudget(max_requests=5, max_cost_microusd=1_000_000)
+        budget.reserve(case_id="a", requests=5, cost_microusd=1)
+        budget.release(requests=5, cost_microusd=1)
+        # Would have raised QuotaExhaustedError before the release.
+        budget.reserve(case_id="b", requests=5, cost_microusd=1)
+        assert budget.spent_requests == 5
+
+    def test_over_release_clamps_at_zero_rather_than_raising(self) -> None:
+        budget = QuotaBudget(max_requests=10, max_cost_microusd=1000)
+        budget.reserve(case_id="a", requests=1, cost_microusd=10)
+        budget.release(requests=100, cost_microusd=10_000)
+        assert budget.spent_requests == 0
+        assert budget.spent_cost_microusd == 0
+
+
+class TestQuotaHeadroomAtPlannedCorpusScale:
+    """The same 134-case x 3-run headroom claim
+    ``test_ask_dev_quota_headroom.py`` proves at the allowance-accounting
+    level, re-proven here through THIS module's own budget tracker --
+    proving the coordination layer agrees with the admission-path proof,
+    not a second, silently-diverging estimate."""
+
+    def test_134_cases_times_3_runs_clears_the_compose_ceiling_with_margin(
+        self,
+    ) -> None:
+        budget = QuotaBudget.from_env(
+            {
+                "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "1000",
+                "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "200000000",
+            }
+        )
+        per_run_cost = estimate_run_cost_microusd(
+            input_tokens=8_000, output_tokens=3_000, rounds=4
+        )
+        planned_runs = 134 * 3
+        for index in range(planned_runs):
+            budget.reserve(
+                case_id=f"case-{index}", requests=1, cost_microusd=per_run_cost
+            )
+        assert budget.remaining_requests() >= 0
+        assert budget.remaining_cost_microusd() >= 0

--- a/tests/acceptance/corpus/test_receipt.py
+++ b/tests/acceptance/corpus/test_receipt.py
@@ -1,0 +1,292 @@
+"""Unit coverage for ``scripts.acceptance.corpus.receipt``."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.acceptance.corpus.receipt import (
+    DECLARED_BLOCKED_RECEIPT_STATUS,
+    RECEIPT_SCHEMA_VERSION,
+    ReceiptValidationError,
+    SessionSummaryError,
+    Wave4CaseRecorder,
+    write_declared_blocked_receipt,
+    write_session_summary,
+)
+
+
+def _recorder(**overrides: object) -> Wave4CaseRecorder:
+    defaults: dict[str, object] = dict(
+        case_id="runner-selftest.basic-exact",
+        question="What's the status of the Ask Dev project?",
+        subject_class="exact",
+        resolution_profile_ref=None,
+    )
+    defaults.update(overrides)
+    return Wave4CaseRecorder(**defaults)  # type: ignore[arg-type]
+
+
+class TestWave4CaseRecorderWrite:
+    def test_zero_assertions_raises(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        with pytest.raises(ReceiptValidationError, match="zero assertions"):
+            recorder.write(tmp_path / "receipt.json")
+
+    def test_unset_resolution_path_raises(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.check(category="c", name="n", condition=True, detail="d")
+        recorder.set_world_digest("digest-abc")
+        with pytest.raises(ReceiptValidationError, match="resolution_path"):
+            recorder.write(tmp_path / "receipt.json")
+
+    def test_unset_world_digest_raises(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.check(category="c", name="n", condition=True, detail="d")
+        recorder.set_resolution_path("deterministic-exact")
+        with pytest.raises(ReceiptValidationError, match="world_digest"):
+            recorder.write(tmp_path / "receipt.json")
+
+    def test_invalid_resolution_path_value_raises(self) -> None:
+        recorder = _recorder()
+        with pytest.raises(ReceiptValidationError, match="not one of"):
+            recorder.set_resolution_path("something-invented")
+
+    def test_explicit_none_resolution_path_is_allowed(self, tmp_path: Path) -> None:
+        recorder = _recorder(subject_class="n/a")
+        recorder.check(category="c", name="n", condition=True, detail="d")
+        recorder.set_resolution_path(None)
+        recorder.set_world_digest("digest-abc")
+        artifact = recorder.write(tmp_path / "receipt.json")
+        assert artifact["resolution_path"] is None
+
+    def test_writes_the_expected_schema_shape(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.check(
+            category="subject-resolution",
+            name="exact_match",
+            condition=True,
+            detail="ok",
+        )
+        recorder.check(
+            category="public-outcome", name="answered", condition=True, detail="ok"
+        )
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        path = tmp_path / "receipt.json"
+        artifact = recorder.write(path)
+
+        assert artifact["schema_version"] == RECEIPT_SCHEMA_VERSION
+        assert artifact["case_id"] == "runner-selftest.basic-exact"
+        assert artifact["resolution_path"] == "deterministic-exact"
+        assert artifact["world_digest"] == "digest-abc"
+        assert artifact["assertion_count"] == 2
+        assert artifact["status"] == "passed"
+        assert len(artifact["assertions"]) == 2
+
+        on_disk = json.loads(path.read_text())
+        assert on_disk == artifact
+
+    def test_any_failed_assertion_makes_status_failed(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.check(category="c", name="ok", condition=True, detail="fine")
+        recorder.check(category="c", name="bad", condition=False, detail="broke")
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        artifact = recorder.write(tmp_path / "receipt.json")
+        assert artifact["status"] == "failed"
+        assert artifact["assertion_count"] == 2
+
+    def test_check_does_not_raise_on_a_failed_condition(self) -> None:
+        """Unlike ScenarioRecorder.check -- a corpus case's remaining
+        invariants still matter for diagnosis after one fails."""
+
+        recorder = _recorder()
+        recorder.check(category="c", name="bad", condition=False, detail="broke")
+        assert len(recorder.assertions) == 1
+        assert recorder.assertions[0].passed is False
+
+    def test_secrets_are_redacted_in_assertion_detail(self, tmp_path: Path) -> None:
+        # Runtime-constructed so no commit ever contains a JWT-shaped literal
+        # (gitleaks scans the full PR commit range).
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+        payload = (
+            base64.urlsafe_b64encode(b'{"sub":"1234567890"}').rstrip(b"=").decode()
+        )
+        jwt = f"{header}.{payload}.abcdefghij1234567890"
+        recorder = _recorder()
+        recorder.check(category="c", name="n", condition=True, detail=f"token={jwt}")
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        artifact = recorder.write(tmp_path / "receipt.json")
+        assert jwt not in artifact["assertions"][0]["detail"]
+        assert "REDACTED_JWT" in artifact["assertions"][0]["detail"]
+
+    def test_extra_fields_are_included(self, tmp_path: Path) -> None:
+        recorder = _recorder()
+        recorder.check(category="c", name="n", condition=True, detail="d")
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        recorder.set_extra("provider_script_id_used", "runner-selftest.basic-exact")
+        artifact = recorder.write(tmp_path / "receipt.json")
+        assert artifact["provider_script_id_used"] == "runner-selftest.basic-exact"
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "schema_version",
+            "case_id",
+            "question",
+            "subject_class",
+            "resolution_profile_ref",
+            "resolution_path",
+            "world_digest",
+            "started_at",
+            "finished_at",
+            "status",
+            "assertion_count",
+            "assertions",
+        ],
+    )
+    def test_set_extra_rejects_every_reserved_field(self, key: str) -> None:
+        """Codex round-1, HIGH, confirmed: set_extra had no reserved-key
+        check, so `set_extra("status", "passed")` (or resolution_path/
+        world_digest/assertion_count/...) silently overwrote a guarded,
+        already-computed field -- a caller could record a failed assertion
+        then paper over it with one extra-field call."""
+
+        recorder = _recorder()
+        with pytest.raises(ReceiptValidationError, match="reserved"):
+            recorder.set_extra(key, "attempted-override")
+
+    def test_a_forged_status_override_cannot_survive_write(
+        self, tmp_path: Path
+    ) -> None:
+        """Defense-in-depth proof: even bypassing the public set_extra guard
+        by writing directly into the recorder's internal _extra dict cannot
+        flip a failed receipt to "passed" -- write() spreads _extra FIRST,
+        so the real computed status always wins."""
+
+        recorder = _recorder()
+        recorder.check(category="c", name="bad", condition=False, detail="broke")
+        recorder.set_resolution_path("deterministic-exact")
+        recorder.set_world_digest("digest-abc")
+        recorder._extra["status"] = "passed"  # bypassing the public API on purpose
+        artifact = recorder.write(tmp_path / "receipt.json")
+        assert artifact["status"] == "failed"
+
+
+class TestWriteDeclaredBlockedReceipt:
+    def test_writes_the_expected_shape(self, tmp_path: Path) -> None:
+        path = tmp_path / "receipt.json"
+        artifact = write_declared_blocked_receipt(
+            case_id="portfolio.multi-project.status",
+            question="How are the meridian and atlas projects doing together?",
+            subject_class="bounded-set",
+            resolution_profile_ref=None,
+            blocked_by="CHAOS-3393",
+            path=path,
+        )
+        assert artifact["schema_version"] == RECEIPT_SCHEMA_VERSION
+        assert artifact["status"] == DECLARED_BLOCKED_RECEIPT_STATUS
+        assert artifact["blocked_by"] == "CHAOS-3393"
+        assert artifact["resolution_path"] is None
+        assert artifact["world_digest"] is None
+        assert artifact["assertion_count"] == 0
+        assert artifact["assertions"] == []
+
+        on_disk = json.loads(path.read_text())
+        assert on_disk == artifact
+
+    def test_empty_blocked_by_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ReceiptValidationError, match="blocked_by"):
+            write_declared_blocked_receipt(
+                case_id="x",
+                question="q",
+                subject_class="exact",
+                resolution_profile_ref=None,
+                blocked_by="",
+                path=tmp_path / "receipt.json",
+            )
+
+    def test_malformed_ticket_reference_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ReceiptValidationError, match="ticket reference"):
+            write_declared_blocked_receipt(
+                case_id="x",
+                question="q",
+                subject_class="exact",
+                resolution_profile_ref=None,
+                blocked_by="not-a-ticket",
+                path=tmp_path / "receipt.json",
+            )
+
+
+class TestWriteSessionSummary:
+    def _receipt(self, case_id: str, *, status: str = "passed") -> dict:
+        return {"case_id": case_id, "status": status}
+
+    def test_zero_receipts_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(SessionSummaryError, match="zero case receipts"):
+            write_session_summary(
+                [], tmp_path / "summary.json", expected_case_ids=frozenset()
+            )
+
+    def test_reports_case_and_pass_counts(self, tmp_path: Path) -> None:
+        receipts = [self._receipt("a"), self._receipt("b", status="failed")]
+        summary = write_session_summary(
+            receipts, tmp_path / "summary.json", expected_case_ids=frozenset({"a", "b"})
+        )
+        assert summary["case_count"] == 2
+        assert summary["passed_count"] == 1
+        assert summary["failed_count"] == 1
+        assert summary["missing_case_ids"] == []
+        assert summary["unexpected_case_ids"] == []
+
+    def test_declared_blocked_receipts_counted_separately_from_pass_and_fail(
+        self, tmp_path: Path
+    ) -> None:
+        receipts = [
+            self._receipt("a", status="passed"),
+            self._receipt("b", status="failed"),
+            self._receipt("c", status=DECLARED_BLOCKED_RECEIPT_STATUS),
+        ]
+        summary = write_session_summary(
+            receipts,
+            tmp_path / "summary.json",
+            expected_case_ids=frozenset({"a", "b", "c"}),
+        )
+        assert summary["case_count"] == 3
+        assert summary["passed_count"] == 1
+        assert summary["failed_count"] == 1
+        assert summary["declared_blocked_count"] == 1
+        assert summary["declared_blocked_case_ids"] == ["c"]
+        # A declared-blocked case IS received, not missing.
+        assert summary["missing_case_ids"] == []
+
+    def test_reports_missing_expected_cases(self, tmp_path: Path) -> None:
+        receipts = [self._receipt("a")]
+        summary = write_session_summary(
+            receipts,
+            tmp_path / "summary.json",
+            expected_case_ids=frozenset({"a", "b", "c"}),
+        )
+        assert summary["missing_case_ids"] == ["b", "c"]
+
+    def test_reports_unexpected_received_cases(self, tmp_path: Path) -> None:
+        receipts = [self._receipt("a"), self._receipt("runner-selftest.extra")]
+        summary = write_session_summary(
+            receipts, tmp_path / "summary.json", expected_case_ids=frozenset({"a"})
+        )
+        assert summary["unexpected_case_ids"] == ["runner-selftest.extra"]
+
+    def test_writes_to_disk(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "summary.json"
+        write_session_summary(
+            [self._receipt("a")], path, expected_case_ids=frozenset({"a"})
+        )
+        assert json.loads(path.read_text())["case_count"] == 1

--- a/tests/acceptance/corpus/test_resolution_path.py
+++ b/tests/acceptance/corpus/test_resolution_path.py
@@ -1,0 +1,250 @@
+"""Unit coverage for ``scripts.acceptance.corpus.resolution_path``.
+
+Pure-logic module (no DB, no live infra) -- these are fast unit-tier tests.
+A companion live/integration suite
+(``tests/api/dev/test_wave4_resolution_path_live.py``) drives the REAL
+``DevOrchestrator`` + a real (ephemeral) sqlite-backed ``PersistenceRunRecorder``
+to prove this module classifies genuinely persisted ``dev_run_resolutions``
+rows correctly, not just hand-built dataclass fixtures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.resolution_path import (
+    ResolutionLedgerEntry,
+    ResolutionPathError,
+    classify_match_kind,
+    derive_resolution_path,
+)
+
+
+def _entry(
+    outcome: str,
+    *,
+    mention_id: str = "m1",
+    committed_label: str | None = None,
+    committed_canonical_id: str | None = None,
+    mention_text: str | None = None,
+) -> ResolutionLedgerEntry:
+    return ResolutionLedgerEntry(
+        outcome=outcome,
+        mention_id=mention_id,
+        committed_label=committed_label,
+        committed_canonical_id=committed_canonical_id,
+        mention_text=mention_text,
+    )
+
+
+class TestClassifyMatchKind:
+    def test_identical_text_is_exact(self) -> None:
+        assert classify_match_kind("meridian/web-app", "meridian/web-app") == "exact"
+
+    def test_case_insensitive(self) -> None:
+        assert classify_match_kind("MERIDIAN/WEB-APP", "meridian/web-app") == "exact"
+
+    def test_matches_canonical_id_directly(self) -> None:
+        # Codex round-1, HIGH: production's exact() matches EITHER the
+        # canonical id or the label -- a mention naming the id must classify
+        # exact even though it shares no text with the label at all.
+        assert (
+            classify_match_kind(
+                "project-ask-dev-uuid",
+                "Meridian Web Application (MWA)",
+                committed_canonical_id="project-ask-dev-uuid",
+            )
+            == "exact"
+        )
+
+    def test_canonical_id_match_is_case_insensitive(self) -> None:
+        assert (
+            classify_match_kind(
+                "PROJECT-ASK-DEV-UUID",
+                "Some Label",
+                committed_canonical_id="project-ask-dev-uuid",
+            )
+            == "exact"
+        )
+
+    def test_a_mere_substring_is_never_exact(self) -> None:
+        # Codex round-1, HIGH, confirmed by executing the old implementation:
+        # bidirectional substring matching accepted "meridian/web-app extra"
+        # as exact against "meridian/web-app" -- production's own exact()
+        # never accepts a substring, only equality. A pure substring here is
+        # not alias-reachable either, so it must raise.
+        with pytest.raises(ResolutionPathError):
+            classify_match_kind("meridian/web-app extra", "meridian/web-app")
+
+    def test_a_shortened_substring_is_never_exact(self) -> None:
+        with pytest.raises(ResolutionPathError):
+            classify_match_kind("web-app", "meridian/web-app")
+
+    def test_parenthetical_literal_alias_is_alias(self) -> None:
+        assert classify_match_kind("MWA", "Meridian Web Application (MWA)") == "alias"
+
+    def test_derived_acronym_is_alias(self) -> None:
+        assert (
+            classify_match_kind(
+                "ACR", "Dev Health Agent Context Runtime (Context Fabric)"
+            )
+            == "alias"
+        )
+
+    def test_unrelated_text_raises(self) -> None:
+        with pytest.raises(ResolutionPathError):
+            classify_match_kind("Nightfall", "meridian/web-app")
+
+    def test_empty_mention_text_raises(self) -> None:
+        with pytest.raises(ResolutionPathError):
+            classify_match_kind("", "meridian/web-app")
+
+
+class TestDeriveResolutionPath:
+    def test_empty_ledger_is_none(self) -> None:
+        assert derive_resolution_path([]) is None
+
+    def test_single_shot_direct_exact_match_is_deterministic_exact(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            )
+        ]
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+    def test_single_shot_canonical_id_match_is_deterministic_exact(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                committed_label="Meridian Web Application (MWA)",
+                committed_canonical_id="project-01",
+                mention_text="project-01",
+            )
+        ]
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+    def test_single_shot_alias_reachable_label_is_deterministic_alias(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                committed_label="Meridian Web Application (MWA)",
+                mention_text="MWA",
+            )
+        ]
+        assert derive_resolution_path(entries) == "deterministic-alias"
+
+    def test_final_entry_still_unresolved_is_miss_clarification(self) -> None:
+        entries = [_entry("ambiguous_candidates")]
+        assert derive_resolution_path(entries) == "miss-clarification"
+
+    def test_no_authorized_match_is_miss_clarification(self) -> None:
+        entries = [_entry("no_authorized_match")]
+        assert derive_resolution_path(entries) == "miss-clarification"
+
+    def test_mention_resolved_after_earlier_candidate_offer_is_deterministic_alias(
+        self,
+    ) -> None:
+        """Two-turn disambiguation shape: the same mention_id first surfaces
+        candidates (nothing committed), then a follow-up commits it exactly
+        -- this is the alias-assisted convergence path, never a direct
+        match, regardless of what the eventual committed label looks like.
+        """
+
+        entries = [
+            _entry("ambiguous_candidates", mention_id="m1"),
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="Meridian Web Application",
+                mention_text="Meridian Web Application",
+            ),
+        ]
+        assert derive_resolution_path(entries) == "deterministic-alias"
+
+    def test_transient_failure_then_exact_is_not_alias(self) -> None:
+        """Codex round-1, MEDIUM, confirmed: `catalog_unavailable` and
+        `no_authorized_match` are structurally forbidden from carrying
+        candidates (``DevResolutionEntry.validate_outcome_payload``) -- a
+        transient failure followed by a genuine direct match on retry must
+        NEVER be mislabeled as alias-assisted convergence."""
+
+        entries = [
+            _entry("catalog_unavailable", mention_id="m1"),
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            ),
+        ]
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+    def test_no_authorized_match_then_exact_is_not_alias(self) -> None:
+        entries = [
+            _entry("no_authorized_match", mention_id="m1"),
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            ),
+        ]
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+    def test_multiple_mentions_any_alias_makes_the_whole_case_alias(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            ),
+            _entry(
+                "exact_match",
+                mention_id="m2",
+                committed_label="Meridian Web Application (MWA)",
+                mention_text="MWA",
+            ),
+        ]
+        assert derive_resolution_path(entries) == "deterministic-alias"
+
+    def test_multiple_mentions_all_exact_is_deterministic_exact(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            ),
+            _entry(
+                "exact_match",
+                mention_id="m2",
+                committed_label="meridian/api-gateway",
+                mention_text="meridian/api-gateway",
+            ),
+        ]
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+    def test_one_mention_unresolved_dominates_even_if_another_resolves(self) -> None:
+        entries = [
+            _entry(
+                "exact_match",
+                mention_id="m1",
+                committed_label="meridian/web-app",
+                mention_text="meridian/web-app",
+            ),
+            _entry("no_authorized_match", mention_id="m2"),
+        ]
+        assert derive_resolution_path(entries) == "miss-clarification"
+
+    def test_single_shot_exact_match_missing_mention_text_raises(self) -> None:
+        entries = [_entry("exact_match", committed_label="meridian/web-app")]
+        with pytest.raises(ResolutionPathError):
+            derive_resolution_path(entries)
+
+    def test_unknown_outcome_value_raises(self) -> None:
+        entries = [_entry("something_new")]
+        with pytest.raises(ResolutionPathError):
+            derive_resolution_path(entries)

--- a/tests/acceptance/corpus/test_script_inventory.py
+++ b/tests/acceptance/corpus/test_script_inventory.py
@@ -1,0 +1,79 @@
+"""Unit + real-file coverage for ``scripts.acceptance.corpus.script_inventory``."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.llm.agent.provider_scripts import (
+    load_registry_ids,
+    load_role_script,
+)
+from scripts.acceptance.corpus.script_inventory import (
+    ScriptInventoryError,
+    check_script_inventory,
+    missing_scripted_cases,
+)
+
+
+class TestMissingScriptedCases:
+    def test_no_missing_when_every_case_id_is_scripted(self) -> None:
+        assert missing_scripted_cases(["a", "b"], ["a", "b", "c"]) == []
+
+    def test_reports_every_missing_id_sorted(self) -> None:
+        assert missing_scripted_cases(["b", "a", "c"], ["a"]) == ["b", "c"]
+
+
+class TestCheckScriptInventory:
+    def test_passes_silently_when_nothing_is_missing(self) -> None:
+        check_script_inventory(["a"], ["a", "b"], role="legacy_agent")
+
+    def test_raises_loud_when_a_case_has_no_script(self) -> None:
+        with pytest.raises(ScriptInventoryError, match="scripted.provider"):
+            check_script_inventory(["a", "missing-one"], ["a"], role="legacy_agent")
+
+    def test_error_names_every_missing_case_id(self) -> None:
+        with pytest.raises(ScriptInventoryError) as excinfo:
+            check_script_inventory(
+                ["missing-one", "missing-two"], [], role="legacy_agent"
+            )
+        assert "missing-one" in str(excinfo.value)
+        assert "missing-two" in str(excinfo.value)
+
+
+class TestAgainstTheRealCheckedInRoleFile:
+    """The exact regression this module exists to catch: prove it against
+    the REAL ``registry-ids.v1.json`` and ``role-legacy_agent.json`` this
+    repo ships, not just fabricated id lists."""
+
+    def test_the_real_registry_has_cases_with_no_script_yet(self) -> None:
+        """Setup control: as of this writing, Lane 2b has authored zero
+        corpus case files, so ``role-legacy_agent.json`` scripts only a
+        handful of the 134 registry ids -- proving the real files really do
+        exercise the missing-script branch, not an artificial fixture that
+        happens to always pass.
+        """
+
+        registry_ids = load_registry_ids()
+        role_script = load_role_script("legacy_agent")
+        missing = missing_scripted_cases(registry_ids, role_script.cases)
+        assert missing, (
+            "expected the checked-in role-legacy_agent.json to leave at "
+            "least one registry id unscripted today"
+        )
+
+    def test_a_scripted_registry_id_is_never_reported_missing(self) -> None:
+        role_script = load_role_script("legacy_agent")
+        scripted_ids = list(role_script.cases)
+        assert scripted_ids, "role-legacy_agent.json should script at least one case"
+        assert missing_scripted_cases(scripted_ids, role_script.cases) == []
+
+    def test_check_raises_for_a_corpus_case_id_the_real_role_file_never_scripted(
+        self,
+    ) -> None:
+        role_script = load_role_script("legacy_agent")
+        with pytest.raises(ScriptInventoryError):
+            check_script_inventory(
+                ["runner-selftest.definitely-unscripted"],
+                role_script.cases,
+                role="legacy_agent",
+            )

--- a/tests/acceptance/corpus/test_sse_client.py
+++ b/tests/acceptance/corpus/test_sse_client.py
@@ -1,0 +1,59 @@
+"""Unit coverage for ``scripts.acceptance.corpus.sse_client``."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.sse_client import SseParseError, parse_sse_events
+
+
+class TestParseSseEvents:
+    def test_parses_a_single_frame(self) -> None:
+        body = 'event: run.started\ndata: {"run_id": "abc"}\n\n'
+        frames = parse_sse_events(body)
+        assert len(frames) == 1
+        assert frames[0].event == "run.started"
+        assert frames[0].data == {"run_id": "abc"}
+
+    def test_parses_multiple_frames_in_order(self) -> None:
+        body = (
+            'event: run.started\ndata: {"a": 1}\n\n'
+            'event: progress\ndata: {"a": 2}\n\n'
+            'event: done\ndata: {"a": 3}\n\n'
+        )
+        frames = parse_sse_events(body)
+        assert [frame.event for frame in frames] == ["run.started", "progress", "done"]
+        assert [frame.data["a"] for frame in frames] == [1, 2, 3]
+
+    def test_joins_multi_line_data(self) -> None:
+        body = 'event: answer.completed\ndata: {"a": 1,\ndata: "b": 2}\n\n'
+        frames = parse_sse_events(body)
+        assert frames[0].data == {"a": 1, "b": 2}
+
+    def test_skips_leading_and_trailing_blank_frames(self) -> None:
+        body = "\n\nevent: done\ndata: {}\n\n\n\n"
+        frames = parse_sse_events(body)
+        assert len(frames) == 1
+
+    def test_missing_event_name_raises(self) -> None:
+        body = 'data: {"a": 1}\n\n'
+        with pytest.raises(SseParseError, match="omitted an event name"):
+            parse_sse_events(body)
+
+    def test_missing_data_raises(self) -> None:
+        body = "event: done\n\n"
+        with pytest.raises(SseParseError, match="omitted data"):
+            parse_sse_events(body)
+
+    def test_invalid_json_data_raises(self) -> None:
+        body = "event: done\ndata: {not json}\n\n"
+        with pytest.raises(SseParseError, match="not valid JSON"):
+            parse_sse_events(body)
+
+    def test_non_object_json_data_raises(self) -> None:
+        body = "event: done\ndata: [1, 2, 3]\n\n"
+        with pytest.raises(SseParseError, match="must decode to an object"):
+            parse_sse_events(body)
+
+    def test_empty_body_returns_no_frames(self) -> None:
+        assert parse_sse_events("") == []

--- a/tests/acceptance/corpus/test_world_digest_guard.py
+++ b/tests/acceptance/corpus/test_world_digest_guard.py
@@ -1,0 +1,62 @@
+"""Unit coverage for ``scripts.acceptance.corpus.world_digest_guard``.
+
+``verify_world_digest`` (the async compute-and-compare half) needs a live,
+reachable ClickHouse/Postgres scratch database and is NOT exercised here --
+doing so would mean either standing up real infra in a unit test (wrong
+tier) or mocking ``compute_world_digest`` so thoroughly the test would only
+prove the mock behaves as scripted. It is exercised by the live corpus
+runner's own armed-or-throw session setup instead. This suite covers the
+pure comparison/assertion half (``require_world_digest_match``), which is
+where the actual pass/fail decision logic worth unit-testing lives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.acceptance.corpus.world_digest_guard import (
+    WorldDigestMismatchError,
+    WorldDigestVerification,
+    require_world_digest_match,
+)
+
+
+def _verification(
+    *, matched: bool, drifted: tuple[str, ...] = ()
+) -> WorldDigestVerification:
+    return WorldDigestVerification(
+        pinned_digest="pinned-abc",
+        live_digest="live-abc" if matched else "live-xyz",
+        matched=matched,
+        drifted_components=drifted,
+    )
+
+
+class TestRequireWorldDigestMatch:
+    def test_a_match_is_a_silent_no_op(self) -> None:
+        require_world_digest_match(
+            _verification(matched=True), digest_path="WORLD_DIGEST"
+        )
+
+    def test_a_mismatch_raises(self) -> None:
+        with pytest.raises(WorldDigestMismatchError):
+            require_world_digest_match(
+                _verification(matched=False, drifted=("clickhouse.commits",)),
+                digest_path="WORLD_DIGEST",
+            )
+
+    def test_mismatch_error_names_the_drifted_components(self) -> None:
+        with pytest.raises(WorldDigestMismatchError, match="clickhouse.commits"):
+            require_world_digest_match(
+                _verification(
+                    matched=False, drifted=("clickhouse.commits", "postgres.users")
+                ),
+                digest_path="WORLD_DIGEST",
+            )
+
+    def test_mismatch_error_names_both_digests(self) -> None:
+        with pytest.raises(WorldDigestMismatchError, match="pinned-abc") as excinfo:
+            require_world_digest_match(
+                _verification(matched=False), digest_path="WORLD_DIGEST"
+            )
+        assert "live-xyz" in str(excinfo.value)

--- a/tests/acceptance/test_wave4_corpus_runner_live.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live.py
@@ -1,0 +1,581 @@
+"""CHAOS-3219 Wave 4 Phase 2 Lane 2a: the pytest-based corpus runner (D5).
+
+Drives real corpus cases from
+``tests/acceptance/world/ask-dev-world.v1/corpus/*.json`` (Lane 2b) through
+the real Ask Dev acceptance stack over `/api/v1/dev/**` HTTP/SSE, evaluates
+each case's ``invariants`` via ``scripts.acceptance.corpus.invariants``, and
+writes one ``wave4_case_result.v1`` receipt per case
+(``scripts.acceptance.corpus.receipt``). ``write_session_summary``
+(receipt.py) aggregates the per-case receipts this run writes into
+``tests/acceptance/artifacts/wave4/session-summary.json`` -- invoked as a
+separate CI step after this file's own pytest run completes (Phase 5c's
+wiring), not from inside this module.
+
+Session-start guards, in order:
+
+1. armed-or-throw (``ASK_DEV_LIVE_ACCEPTANCE=1``) -- the ONE guard that
+   legitimately SKIPS rather than fails when absent. This module is
+   collected by the standard, always-on unit-tier gate (the whole
+   ``tests/`` directory, unconditionally -- see ops/AGENTS.md), unlike the
+   pre-CHAOS-3219 smoke-script convention where only the launcher ever
+   invoked the live script directly. Failing loud merely because nobody
+   booted the acceptance stack would break that gate for every ordinary
+   local/CI run; ``test_live_openai_smoke.py`` documents the identical
+   reasoning for its own opt-in live suite. See the ``_armed_or_throw``
+   fixture docstring.
+2. script-inventory preflight -- every collected case id must have a
+   scripted-provider entry for the active role. Fails loud, never skips,
+   once armed.
+3. WORLD_DIGEST verification -- the live fixture database must match the
+   pinned digest (ruling D2). Fails loud, never skips, once armed.
+4. quota budget construction from the compose-configured ceiling.
+
+KNOWN OPERATIONAL RISK (Codex round-1, MEDIUM, deliberately NOT fixed here
+-- Phase 5c's territory, not Lane 2a's): because guard 1 skips rather than
+fails, a CI acceptance JOB that forgets to export
+``ASK_DEV_LIVE_ACCEPTANCE=1`` reports a green, entirely-skipped run --
+indistinguishable at a glance from a real pass. This module cannot fix its
+own invocation from the inside; Phase 5c's launcher/workflow wiring must
+positively assert non-zero collected+executed tests for this file specifically
+(e.g. parse the pytest summary, or run it with ``--no-cov -p no:cacheprovider
+-rs`` and grep for an unexpected "skipped" line), the same way
+``test_live_openai_smoke.py``'s own ``ASK_DEV_LIVE_GATE`` two-tier pattern
+lets ITS caller distinguish "opted out" from "the gate forgot to opt in".
+
+"Armed-or-THROW" describes guards 2-4: once armed, nothing downstream of
+the arming check may skip -- only guard 1 itself is a legitimate skip.
+
+VERIFICATION PLANE (team-lead ruling, 2026-08-06): product-facing case
+execution (the SSE HTTP round-trip below) stays wire-only against the
+public API, matching the existing smoke-script convention
+(``prepare_ask_dev_acceptance.py``'s "public-API-only seeding" philosophy)
+-- the acceptance Compose overlay (``compose.ask-dev.yml``) deliberately
+exposes NO host port for postgres/clickhouse (``ports: !reset []``,
+isolation-by-design), and that stays intact. Exactly three harness concerns
+that genuinely need database access reach it through the CONTAINER boundary
+instead, via ``docker compose exec -T`` (``scripts.acceptance.corpus.
+db_verify``) -- never a host port, never a new product API endpoint:
+
+* WORLD_DIGEST verification (guard 3, ruling D2) --
+  ``db_verify.verify_world_digest_via_exec``.
+* The CHAOS-3424 resolution ledger read for ``resolution_path`` derivation
+  -- ``db_verify.query_resolution_ledger_via_exec``, keyed by the ``run_id``
+  every ``DevStreamEvent`` carries.
+* The CHAOS-3423 transcript read for ``terminal_persists_assistant_row``
+  (2b codex round-1 addition, team-lead direction 2026-08-06) --
+  ``db_verify.query_transcript_assistant_schema_versions_via_exec``, keyed
+  by ``conversation_id``.
+
+Both fail loud (``DbVerifyUnavailableError``) if the exec plane itself
+cannot be reached at all (docker/compose missing, non-zero exit, unparseable
+output) -- distinct from :func:`derive_resolution_path`'s own honest
+``None``, which applies only once the exec plane genuinely reached the
+ledger and found it empty (a non-subject-shaped case). A residual, honestly
+documented limitation: entries the exec plane returns carry no
+``mention_text`` (``DevResolutionEntry`` never persists the original mention
+span -- see ``resolution_path.py``'s module docstring); a single-shot
+``exact_match`` entry with no prior candidate offer therefore cannot be
+classified exact-vs-alias without it, and ``test_corpus_case`` records that
+as a named, failed assertion (never a silent guess) rather than crashing --
+closeable once a corpus case declares its own expected mention text (Lane
+2b schema addition, not decided here).
+
+Merge-order note: this repo's Lane 2a merges before Lane 2b, so
+``tests/acceptance/world/ask-dev-world.v1/corpus/`` may not exist, or may be
+empty, in this checkout. Case loading (``load_corpus_cases``) returns an
+empty list for that -- not an error, matching ``case_schema.py``'s own
+documented contract -- so the parametrized ``test_corpus_case`` below simply
+collects zero cases in that state, while
+``test_at_least_one_corpus_case_is_collected`` fails loud IF the run is
+armed but still finds nothing (the actual false-green guard; it does not
+fire merely from importing this module unarmed).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pytest
+from pydantic import ValidationError
+
+from dev_health_ops.api.dev.contracts import (
+    DevStreamEvent,
+    StreamEventType,
+    validate_stream,
+)
+from dev_health_ops.api.dev.terminal_frames import PUBLIC_OUTCOME_BY_ERROR_CODE
+from dev_health_ops.llm.agent.provider_scripts import current_role, load_role_script
+from scripts.acceptance.corpus.arming import NotArmedError, require_armed
+from scripts.acceptance.corpus.case_schema import (
+    CorpusCase,
+    load_corpus_cases,
+    load_resolution_profile,
+    resolve_case_expectations,
+)
+from scripts.acceptance.corpus.compose_context import ComposeContext
+from scripts.acceptance.corpus.db_verify import (
+    DbVerifyUnavailableError,
+    query_resolution_ledger_via_exec,
+    query_transcript_assistant_schema_versions_via_exec,
+    verify_world_digest_via_exec,
+)
+from scripts.acceptance.corpus.invariants import InvariantContext, evaluate_invariant
+from scripts.acceptance.corpus.quota import QuotaBudget, estimate_run_cost_microusd
+from scripts.acceptance.corpus.receipt import (
+    Wave4CaseRecorder,
+    write_declared_blocked_receipt,
+)
+from scripts.acceptance.corpus.resolution_path import (
+    ResolutionPathError,
+    derive_resolution_path,
+)
+from scripts.acceptance.corpus.script_inventory import check_script_inventory
+from scripts.acceptance.corpus.sse_client import SseFrame, parse_sse_events
+from scripts.acceptance.corpus.world_digest_guard import (
+    WorldDigestMismatchError,
+    require_world_digest_match,
+)
+from scripts.acceptance.prepare_ask_dev_acceptance import (
+    AcceptanceApi,
+    AcceptanceFailure,
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WORLD_DIR = _ROOT / "tests" / "acceptance" / "world" / "ask-dev-world.v1"
+_CORPUS_DIR = _WORLD_DIR / "corpus"
+_PROFILES_DIR = _WORLD_DIR / "resolution-profiles"
+_RECEIPTS_DIR = _ROOT / "tests" / "acceptance" / "artifacts" / "wave4"
+
+#: Internal-network connection strings -- meaningful only from INSIDE the
+#: ask-dev-acceptance Compose network (docker compose exec), never from the
+#: host. Match compose.yml's own `api` service DATABASE_URI/CLICKHOUSE_URI
+#: exactly (direct to `postgres`, bypassing pgbouncer, for the same caution
+#: compose.yml's own migration comment gives: a verification read should not
+#: depend on pgbouncer's transaction-mode pooling behavior).
+_CONTAINER_CLICKHOUSE_SINK = "clickhouse://ch:ch@clickhouse:8123/default"
+_CONTAINER_POSTGRES_URI = (
+    "postgresql+asyncpg://postgres:postgres@postgres:5432/postgres"
+)
+_CONTAINER_WORLD_MANIFEST = "/app/tests/acceptance/world/ask-dev-world.v1/world.json"
+
+#: Computed at collection time -- pure JSON loading, no live infra, safe to
+#: run unarmed (this is exactly what lets `pytest --collect-only` work
+#: without touching the network, and what makes a malformed case file a
+#: COLLECTION error rather than a runtime one).
+_ALL_CASES: list[CorpusCase] = load_corpus_cases(_CORPUS_DIR)
+#: Declared-blocked cases (team-lead direction 2026-08-06) never execute --
+#: they get their own receipt via `test_declared_blocked_case` below,
+#: entirely without touching the network/quota/script-inventory machinery
+#: the executable cases need.
+_CASES: list[CorpusCase] = [case for case in _ALL_CASES if not case.is_declared_blocked]
+_BLOCKED_CASES: list[CorpusCase] = [
+    case for case in _ALL_CASES if case.is_declared_blocked
+]
+
+
+def _load_resolution_profiles() -> dict[str, Any]:
+    profiles: dict[str, Any] = {}
+    if _PROFILES_DIR.is_dir():
+        for path in sorted(_PROFILES_DIR.glob("*.json")):
+            profile = load_resolution_profile(path)
+            profiles[profile.profile_id] = profile
+    return profiles
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _armed_or_throw() -> None:
+    """Skip (never fail) when nobody asked for this run at all.
+
+    This module IS collected by the standard, always-on unit-tier gate
+    (``ci/local_validate.sh`` runs the whole ``tests/`` directory
+    unconditionally -- see ops/AGENTS.md) -- unlike the pre-CHAOS-3219
+    smoke-script convention (a standalone ``.py`` script only the launcher
+    ever invokes), this is a real pytest module every contributor's ordinary
+    local/CI run collects. Failing loud here merely because
+    ``ASK_DEV_LIVE_ACCEPTANCE`` is unset would break that gate for every
+    contributor who has not booted the acceptance Compose stack -- exactly
+    the same reasoning ``test_live_openai_smoke.py`` already documents for
+    its own opt-in live suite ("nobody asked for the live gate to run
+    here"). "Armed-or-THROW" still holds for everything downstream of this
+    check: once armed, the script-inventory/world-digest/quota guards below
+    never skip, only fail loud.
+    """
+
+    try:
+        require_armed()
+    except NotArmedError as exc:
+        pytest.skip(str(exc))
+
+
+@pytest.fixture(scope="session")
+def role_script():
+    role = current_role()
+    return role, load_role_script(role)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _script_inventory_preflight(role_script) -> None:
+    role, script = role_script
+    check_script_inventory([case.id for case in _CASES], script.cases, role=role)
+
+
+@pytest.fixture(scope="session")
+def compose_context() -> ComposeContext:
+    return ComposeContext.from_env()
+
+
+def _resolve_world_digest_pin(context: ComposeContext) -> str:
+    """Verify the live world matches WORLD_DIGEST via the exec verification
+    plane, or let :class:`DbVerifyUnavailableError`/
+    ``WorldDigestMismatchError`` propagate. Returns the verified live digest
+    string for receipts to pin against.
+    """
+
+    verification = verify_world_digest_via_exec(
+        context,
+        manifest_path_in_container=_CONTAINER_WORLD_MANIFEST,
+        sink=_CONTAINER_CLICKHOUSE_SINK,
+        postgres_uri=_CONTAINER_POSTGRES_URI,
+    )
+    require_world_digest_match(verification, digest_path=_WORLD_DIR / "WORLD_DIGEST")
+    return verification.live_digest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _world_digest_pin(compose_context: ComposeContext) -> str:
+    try:
+        return _resolve_world_digest_pin(compose_context)
+    except (DbVerifyUnavailableError, WorldDigestMismatchError) as exc:
+        pytest.fail(str(exc), pytrace=False)
+
+
+@pytest.fixture(scope="session")
+def resolution_profiles() -> dict[str, Any]:
+    return _load_resolution_profiles()
+
+
+@pytest.fixture(scope="session")
+def quota_budget() -> QuotaBudget:
+    return QuotaBudget.from_env()
+
+
+@pytest.fixture(scope="session")
+def acceptance_api() -> tuple[AcceptanceApi, str]:
+    api = AcceptanceApi(
+        os.getenv("ASK_DEV_ACCEPTANCE_API_URL", "http://127.0.0.1:18080")
+    )
+    email = os.getenv("TEST_SUPERUSER_EMAIL", "admin@devhealth.example")
+    password = os.getenv("TEST_SUPERUSER_PASSWORD", "devhealth123")
+    login = api.request(
+        "POST", "/api/v1/auth/login", {"email": email, "password": password}
+    )
+    token = login.get("access_token") if isinstance(login, dict) else None
+    if not token:
+        raise AcceptanceFailure("login returned no access_token")
+    api.token = token
+    user = login.get("user") if isinstance(login, dict) else None
+    org_id = user.get("org_id") if isinstance(user, dict) else None
+    if not org_id:
+        raise AcceptanceFailure("login returned no user.org_id")
+    return api, org_id
+
+
+def _scope(org_id: str) -> dict[str, Any]:
+    now = datetime.now(UTC).replace(microsecond=0)
+    current_start = now - timedelta(days=28)
+
+    def time_range(start: datetime, end: datetime) -> dict[str, str]:
+        return {
+            "start": start.isoformat().replace("+00:00", "Z"),
+            "end": end.isoformat().replace("+00:00", "Z"),
+            "timezone": "UTC",
+        }
+
+    return {
+        "schema_version": "dev_scope.v1",
+        "organization_id": org_id,
+        "direct_scope": "organization",
+        "repositories": [],
+        "entity_refs": [],
+        "team_ids": [],
+        "time_range": time_range(current_start, now),
+        "comparison_range": time_range(
+            current_start - timedelta(days=28), current_start
+        ),
+        "surface_context": None,
+    }
+
+
+def _post_sse(api: AcceptanceApi, path: str, payload: dict[str, Any]) -> list[SseFrame]:
+    if api.token is None:
+        raise AcceptanceFailure("SSE request requires authentication")
+    request = Request(
+        f"{api.base_url}{path}",
+        data=json.dumps(payload, separators=(",", ":")).encode(),
+        headers={
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {api.token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=60) as response:  # noqa: S310
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise AcceptanceFailure(
+            f"POST {path} returned HTTP {exc.code}: {detail}"
+        ) from exc
+    except URLError as exc:
+        raise AcceptanceFailure(f"POST {path} failed: {exc.reason}") from exc
+    return parse_sse_events(body)
+
+
+def _run_id_from_frames(frames: list[SseFrame]) -> str | None:
+    """Every ``DevStreamEvent`` carries ``run_id`` -- take it off the first
+    validated frame."""
+
+    return frames[0].data.get("run_id") if frames else None
+
+
+def _public_outcome_from_events(validated_events: list[DevStreamEvent]) -> str | None:
+    """Derive the wire-observable v2 ``PublicOutcome`` from a validated,
+    lifecycle-checked stream.
+
+    Codex round-2 finding (HIGH, confirmed): the original version read
+    ``answer.status`` directly and called it ``public_outcome`` --
+    ``AnswerStatus`` (v1: complete/partial/degraded/insufficient_evidence/
+    refused/error) and ``PublicOutcome`` (v2: answered/answered_with_gaps/
+    needs_clarification/not_found/temporarily_unavailable/unsupported/
+    denied/failed) are DIFFERENT, non-overlapping vocabularies -- a probe
+    of the real ``complete`` value against a profile-declared ``answered``
+    expectation fails every time, silently inverting every correctly
+    authored ``public_outcome_in`` assertion.
+
+    For an error terminal, the real mapping is production's own
+    ``PUBLIC_OUTCOME_BY_ERROR_CODE`` (``terminal_frames.py``) -- reused, not
+    reimplemented. For a real ``DevAnswer`` terminal, today's stack
+    ALWAYS maps to ``answered_with_gaps`` -- never plain ``answered`` --
+    per ``terminal_frames.wrap_legacy_answer_as_frame``'s own explicit,
+    unconditional documented behavior (the legacy v1 model-tool-choice loop
+    never computes a real completion block, so the frame it wraps into is
+    never eligible for plain ``answered``). A future v2-native orchestrator
+    path would need its own mapping once one exists; not guessed at here.
+    """
+
+    for event in validated_events:
+        if event.event is StreamEventType.ERROR and event.error is not None:
+            return PUBLIC_OUTCOME_BY_ERROR_CODE.get(event.error.code)
+    for event in validated_events:
+        if event.event is StreamEventType.ANSWER_COMPLETED and event.answer is not None:
+            return "answered_with_gaps"
+    return None
+
+
+def test_at_least_one_corpus_case_is_collected() -> None:
+    """The case_count>0 false-green guard: an ARMED run that collected zero
+    cases (executable OR declared-blocked) must fail loud, never silently
+    report a vacuous, technically zero-failures green session."""
+
+    assert len(_ALL_CASES) > 0, (
+        f"zero corpus cases found under {_CORPUS_DIR} in an ARMED run -- "
+        "Lane 2b's case content is missing from this checkout, or the "
+        "directory moved; a live corpus run must never silently proceed "
+        "with zero cases"
+    )
+
+
+@pytest.mark.parametrize(
+    "case", _BLOCKED_CASES, ids=[case.id for case in _BLOCKED_CASES]
+)
+def test_declared_blocked_case(case: CorpusCase) -> None:
+    """Declared-blocked cases never execute -- world-manifest discipline
+    (``world.json``/``sources.json``'s own declared-blocked/blocked_by
+    precedent) applied to the corpus receipt layer: loud, counted, never a
+    silent drop, never mistaken for a pass. No network/quota/script-
+    inventory fixtures needed -- this never touches the stack.
+    """
+
+    assert case.blocked_by is not None  # case_schema.py's own load-time guarantee
+    artifact = write_declared_blocked_receipt(
+        case_id=case.id,
+        question=case.question,
+        subject_class=case.subject_class,
+        resolution_profile_ref=case.resolution_profile_ref,
+        blocked_by=case.blocked_by,
+        path=_RECEIPTS_DIR / f"{case.id}.json",
+    )
+    assert artifact["status"] == "declared-blocked"
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[case.id for case in _CASES])
+def test_corpus_case(
+    case: CorpusCase,
+    acceptance_api: tuple[AcceptanceApi, str],
+    resolution_profiles: dict[str, Any],
+    quota_budget: QuotaBudget,
+    compose_context: ComposeContext,
+    _world_digest_pin: str,
+) -> None:
+    api, org_id = acceptance_api
+    expectations = resolve_case_expectations(case, resolution_profiles)
+    cost = estimate_run_cost_microusd(input_tokens=8_000, output_tokens=3_000)
+    quota_budget.reserve(case_id=case.id, requests=1, cost_microusd=cost)
+
+    scope = _scope(org_id)
+    try:
+        conversation = api.request(
+            "POST",
+            "/api/v1/dev/conversations",
+            {"current_scope": scope, "retention_days": 30, "title": f"wave4 {case.id}"},
+        )
+        conversation_id = (
+            conversation.get("conversation_id")
+            if isinstance(conversation, dict)
+            else None
+        )
+        if not conversation_id:
+            raise AcceptanceFailure(
+                f"case {case.id!r}: conversation response returned no id"
+            )
+    except Exception:
+        # Codex round-1 (MEDIUM) + round-2 (MEDIUM, confirmed) findings:
+        # release is now scoped to ONLY this call. Conversation creation is
+        # unambiguously pre-admission -- nothing has been sent to the
+        # message endpoint yet. The message POST below is NOT wrapped the
+        # same way: once that request may have reached the server, a
+        # timeout/parse failure on OUR side does not prove the server never
+        # admitted (and priced) it, so the reservation must be retained
+        # rather than released against understated real spend.
+        quota_budget.release(requests=1, cost_microusd=cost)
+        raise
+
+    frames = _post_sse(
+        api,
+        f"/api/v1/dev/conversations/{conversation_id}/messages",
+        {
+            "schema_version": "dev_message_request.v1",
+            "request_id": str(uuid.uuid4()),
+            "client_message_id": str(uuid.uuid4()),
+            "conversation_id": conversation_id,
+            "question": case.question,
+            "question_class": "status",
+            "scope": scope,
+        },
+    )
+
+    # Codex round-1 (HIGH) + round-2 (HIGH, confirmed) findings: per-frame
+    # validation alone still let an empty stream, a stream with no
+    # terminal, or an envelope/payload event-name mismatch through.
+    # `validate_stream` is the SAME production lifecycle contract the real
+    # web client enforces (non-empty, ordered, one run id, starts with
+    # run.started, exactly one terminal, ends with done) -- reused, not
+    # reimplemented. The envelope/payload cross-check closes a smuggling
+    # vector `no_internal_error` alone could not see: a payload whose OWN
+    # validated `event` field disagrees with the SSE `event:` line this
+    # runner's `events` list is keyed by.
+    validated_events: list[DevStreamEvent] = []
+    for frame in frames:
+        try:
+            validated = DevStreamEvent.model_validate(frame.data)
+        except ValidationError as exc:
+            raise AcceptanceFailure(
+                f"case {case.id!r}: SSE frame failed dev_stream_event.v1 "
+                f"validation: {exc}"
+            ) from exc
+        if validated.event.value != frame.event:
+            raise AcceptanceFailure(
+                f"case {case.id!r}: SSE envelope event {frame.event!r} does "
+                f"not match the validated payload's own event "
+                f"{validated.event.value!r}"
+            )
+        validated_events.append(validated)
+    try:
+        validate_stream(validated_events)
+    except ValueError as exc:
+        raise AcceptanceFailure(
+            f"case {case.id!r}: stream failed dev_stream_event.v1 lifecycle "
+            f"validation (non-empty/ordered/one-terminal/done): {exc}"
+        ) from exc
+
+    events = [{"event": frame.event, "data": frame.data} for frame in frames]
+    public_outcome = _public_outcome_from_events(validated_events)
+
+    run_id = _run_id_from_frames(frames)
+    resolution_path: str | None
+    ledger_classification_error: str | None = None
+    if run_id is None:
+        resolution_path = None
+    else:
+        ledger_entries = query_resolution_ledger_via_exec(
+            compose_context, run_id=run_id
+        )
+        try:
+            resolution_path = derive_resolution_path(ledger_entries)
+        except ResolutionPathError as exc:
+            # See the module docstring's residual-limitation note: a
+            # single-shot exact_match entry with no prior candidate offer
+            # needs mention_text this wire-only case object does not yet
+            # carry (Lane 2b schema addition). Recorded as a named, failed
+            # assertion -- never silently swallowed into a guessed path.
+            resolution_path = None
+            ledger_classification_error = str(exc)
+
+    # 2b codex round-1 addition (team-lead direction 2026-08-06): the third
+    # harness concern allowed through the exec verification plane --
+    # `terminal_persists_assistant_row` proves CHAOS-3423's own guarantee
+    # from the corpus side. Queried unconditionally (cheap, and every case
+    # gets the SAME context shape regardless of whether it declares this
+    # invariant) rather than gated behind "does this case need it".
+    assistant_schema_versions = (
+        query_transcript_assistant_schema_versions_via_exec(
+            compose_context, conversation_id=conversation_id
+        )
+        if conversation_id
+        else []
+    )
+
+    context = InvariantContext(
+        resolution_path=resolution_path,
+        public_outcome=public_outcome,
+        events=events,
+        expectations=expectations,
+        assistant_schema_versions=assistant_schema_versions,
+    )
+
+    recorder = Wave4CaseRecorder(
+        case_id=case.id,
+        question=case.question,
+        subject_class=case.subject_class,
+        resolution_profile_ref=case.resolution_profile_ref,
+    )
+    if ledger_classification_error is not None:
+        recorder.check(
+            category="subject-resolution",
+            name="resolution_path_classifiable",
+            condition=False,
+            detail=ledger_classification_error,
+        )
+    for entry in case.invariants:
+        result = evaluate_invariant(entry, context)
+        recorder.check(
+            category=entry["category"],
+            name=entry.get("name", entry["check"]),
+            condition=result.passed,
+            detail=result.detail,
+        )
+    recorder.set_resolution_path(resolution_path)
+    recorder.set_world_digest(_world_digest_pin)
+    artifact = recorder.write(_RECEIPTS_DIR / f"{case.id}.json")
+    assert artifact["status"] == "passed", (
+        f"case {case.id!r} failed one or more invariants -- see "
+        f"{_RECEIPTS_DIR / f'{case.id}.json'}"
+    )

--- a/tests/acceptance/test_wave4_corpus_runner_live_wiring.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live_wiring.py
@@ -1,0 +1,105 @@
+"""Unit coverage for the pure helper functions in
+``test_wave4_corpus_runner_live.py`` -- the parts that do not need pytest's
+own fixture injection or live infra to exercise directly.
+
+Importing helpers out of another test module is unconventional but matches
+this repo's own precedent (``tests._chaos_3292_preflight`` is a shared
+harness other test modules import from); done here rather than duplicating
+the arming/scope-building logic a second time.
+
+``_resolve_world_digest_pin`` itself is NOT unit tested here -- it is now a
+thin wrapper over ``db_verify.verify_world_digest_via_exec`` (already
+covered, with dependency-injected fake runners, by
+``tests/acceptance/corpus/test_db_verify.py``) and
+``world_digest_guard.require_world_digest_match`` (covered by
+``test_world_digest_guard.py``); testing it a third time here would only
+re-exercise those same seams through an extra layer of indirection.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import DevStreamEvent
+from scripts.acceptance.corpus.sse_client import SseFrame
+from tests.acceptance.test_wave4_corpus_runner_live import (
+    _public_outcome_from_events,
+    _run_id_from_frames,
+    _scope,
+)
+
+
+class TestScope:
+    def test_scope_carries_the_requesting_org(self) -> None:
+        scope = _scope("org-123")
+        assert scope["organization_id"] == "org-123"
+        assert scope["schema_version"] == "dev_scope.v1"
+        assert scope["direct_scope"] == "organization"
+
+    def test_scope_time_range_end_is_after_start(self) -> None:
+        scope = _scope("org-123")
+        assert scope["time_range"]["start"] < scope["time_range"]["end"]
+
+
+class TestRunIdFromFrames:
+    def test_empty_frames_returns_none(self) -> None:
+        assert _run_id_from_frames([]) is None
+
+    def test_takes_run_id_off_the_first_frame(self) -> None:
+        frames = [
+            SseFrame(event="run.started", data={"run_id": "run-abc", "sequence": 0}),
+            SseFrame(event="done", data={"run_id": "run-abc", "sequence": 5}),
+        ]
+        assert _run_id_from_frames(frames) == "run-abc"
+
+    def test_missing_run_id_key_returns_none(self) -> None:
+        frames = [SseFrame(event="run.started", data={"sequence": 0})]
+        assert _run_id_from_frames(frames) is None
+
+
+def _event(overrides: dict) -> DevStreamEvent:
+    base = deepcopy(positive_fixtures()["dev_stream_event.v1"])
+    base.update(overrides)
+    return DevStreamEvent.model_validate(base)
+
+
+class TestPublicOutcomeFromEvents:
+    """Codex round-2, HIGH, confirmed: AnswerStatus (v1) and PublicOutcome
+    (v2) are different vocabularies -- see the function's own docstring."""
+
+    def test_no_terminal_event_returns_none(self) -> None:
+        events = [_event({"sequence": 0, "event": "run.started"})]
+        assert _public_outcome_from_events(events) is None
+
+    def test_error_event_maps_via_production_table(self) -> None:
+        error_payload = deepcopy(positive_fixtures()["dev_error.v1"])
+        error_payload["code"] = "scope_ambiguous"
+        events = [
+            _event(
+                {
+                    "sequence": 1,
+                    "event": "error",
+                    "error": error_payload,
+                    "terminal_kind": None,
+                }
+            )
+        ]
+        assert _public_outcome_from_events(events) == "needs_clarification"
+
+    def test_real_answer_always_maps_to_answered_with_gaps_never_plain_answered(
+        self,
+    ) -> None:
+        answer_payload = deepcopy(positive_fixtures()["dev_answer.v1"])
+        events = [
+            _event(
+                {
+                    "sequence": 1,
+                    "event": "answer.completed",
+                    "answer": answer_payload,
+                }
+            )
+        ]
+        outcome = _public_outcome_from_events(events)
+        assert outcome == "answered_with_gaps"
+        assert outcome != "answered"

--- a/tests/acceptance/world/ask-dev-world.v1/resolution-profiles/README.md
+++ b/tests/acceptance/world/ask-dev-world.v1/resolution-profiles/README.md
@@ -1,0 +1,57 @@
+# `resolution-profiles/` — matcher-specific expected outcomes
+
+CHAOS-3219 Wave 4 Phase 2 Lane 2a, per the CHAOS-3389 fold-in design
+(`scratchpad/c3389-phase2-foldin.md`, 2026-08-05): a corpus case's
+`invariants` assert the CONTRACT (a named miss never silently widens, no
+`internal_error` on fuzzy labels, no unauthorized candidate ever surfaces,
+etc.) — those hold regardless of which subject-resolution matcher is
+running. Anything that depends on WHICH matcher is active (e.g. "an
+unquoted parenthetical label resolves to `deterministic-alias` under
+today's deterministic stack, but to `deterministic-exact` once QUA can
+resolve it directly") lives here instead, keyed by case id, in a file named
+after the profile it describes.
+
+## Format
+
+```jsonc
+{
+  "schema_version": "resolution-profile.v1",
+  "profile_id": "deterministic-v1",
+  "cases": {
+    "<registry-or-runner-selftest-case-id>": {
+      "expected_resolution_path": "deterministic-exact" | "deterministic-alias" | "miss-clarification",
+      "expected_public_outcome": "answered" | "answered_with_gaps" | "needs_clarification" | "..."
+      /* additional matcher-specific keys as case authoring needs them --
+         this object is opaque to case_schema.py/receipt.py; only a case's
+         own `invariants[].check` (e.g. `resolution_path_in`'s
+         `from_profile` arg, see invariants.py) decides which keys it
+         reads. */
+    }
+  }
+}
+```
+
+Loaded by `scripts.acceptance.corpus.case_schema.load_resolution_profile`.
+A case citing a `resolution_profile_ref` whose profile has no entry for
+that case id fails loud at expectation-resolution time
+(`resolve_case_expectations`) — never silently treated as "no
+expectations".
+
+## Today's profile: `deterministic-v1.json`
+
+The active profile for the current deterministic (regex/substring +
+CHAOS-3388 alias-matching) resolution stack — what every corpus case runs
+against until CHAOS-3389 (Question Understanding Agent) ships. Lane 2b
+populates this file's `cases` map as each corpus case is authored; Lane 2a
+(this directory's owner) only ships the schema and the loader/validator, not
+the corpus's own per-case expectation values.
+
+## Future: a QUA profile
+
+When CHAOS-3389 lands, a shadow (`qua-shadow-v1.json`) or committed
+(`qua-v1.json`) profile is added alongside this one with the SAME case ids
+but different `expected_resolution_path`/`expected_public_outcome` values
+for whichever cases QUA resolves differently — the case files themselves,
+this directory's loader, and the corpus runner all stay unchanged; only a
+new profile file is added and the runner is pointed at it (or both, for a
+shadow-vs-current diff run).

--- a/tests/acceptance/world/ask-dev-world.v1/resolution-profiles/deterministic-v1.json
+++ b/tests/acceptance/world/ask-dev-world.v1/resolution-profiles/deterministic-v1.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "resolution-profile.v1",
+  "profile_id": "deterministic-v1",
+  "$comment": "CHAOS-3219 Wave 4 Phase 2. The active profile for today's deterministic (regex/substring + CHAOS-3388 alias-matching) resolution stack -- see README.md in this directory for the format and the CHAOS-3389 fold-in design this seam exists for. Lane 2a (this file's schema/loader owner) ships this empty; Lane 2b populates `cases` as each corpus case referencing `resolution_profile_ref: \"deterministic-v1\"` is authored. An empty `cases` map is valid (case_schema.load_resolution_profile accepts it) -- a case that cites this profile before its entry is added fails loud at expectation-resolution time (resolve_case_expectations), which is the correct, visible signal that authoring is incomplete, not a defect in this file.",
+  "cases": {}
+}

--- a/tests/api/dev/test_wave4_resolution_path_live.py
+++ b/tests/api/dev/test_wave4_resolution_path_live.py
@@ -1,0 +1,287 @@
+"""CHAOS-3219 Phase 2 Lane 2a: prove ``resolution_path.derive_resolution_path``
+against REAL persisted ``dev_run_resolutions`` rows, not hand-built
+dataclasses.
+
+Drives the REAL ``DevOrchestrator`` -> real ``PersistenceRunRecorder`` ->
+real ``DevPersistenceService`` -> an ephemeral sqlite database, via
+``tests._chaos_3292_preflight.run_preflight_orchestrator`` -- the same
+production-shaped wiring ``test_chaos_3423_3424_persistence_prerequisites.py``
+uses, and for the same reason: a fake recorder's captured call list would
+prove nothing about what a corpus-runner query against the real
+``dev_run_resolutions`` table actually sees.
+
+Two single-run shapes are provable today with the existing harness (an
+unambiguous named-project match, and a two-candidate ambiguity): both are
+exercised here. The two-turn alias-disambiguation shape
+(``ambiguous_candidates`` then, on a follow-up turn, ``exact_match`` for the
+same or a fresh mention) is NOT yet provable live -- Lane 2b has not
+authored a scripted multi-turn corpus case, and fabricating one here would
+duplicate rather than validate that authoring. That branch's proof today is
+the pure-logic unit suite (``tests/acceptance/corpus/test_resolution_path.py``);
+this file's docstring says so rather than silently only covering the easy
+half.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.orchestrator_persistence import PersistenceRunRecorder
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunIntent,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+    DevRunSubjectSet,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from scripts.acceptance.corpus.resolution_path import (
+    ResolutionLedgerEntry,
+    derive_resolution_path,
+)
+from tests._chaos_3292_preflight import (
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
+    Recorder,
+    run_preflight_orchestrator,
+    scope_dict,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevAnswerFrame,
+    DevRunResolution,
+    DevRunNarrative,
+    DevRunSubjectSet,
+    DevRunIntent,
+    DevRunSourceObservation,
+    DevRunStageDiagnostic,
+)
+
+
+@pytest_asyncio.fixture
+async def seeded(tmp_path: Any):
+    database = tmp_path / "wave4-resolution-path.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev", name="Ask Dev"),
+                User(id=user_id, email="ask-dev@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+async def _seed_run(
+    maker: async_sessionmaker[AsyncSession],
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    question: str,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    seed_scope = scope_dict(organization_id=str(org_id))
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope=seed_scope
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question=question,
+            scope_snapshot=seed_scope,
+        )
+        await session.commit()
+        return conversation.id, accepted.run.id
+
+
+def _recorder_factory(
+    service: DevPersistenceService,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    run_id: uuid.UUID,
+):
+    def factory() -> Recorder:
+        return cast(
+            Recorder,
+            PersistenceRunRecorder(
+                service,
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                run_id=run_id,
+                provider_source="platform",
+            ),
+        )
+
+    return factory
+
+
+async def _ledger_entries_for_run(
+    session: AsyncSession, run_id: uuid.UUID
+) -> list[ResolutionLedgerEntry]:
+    """The real, on-disk shape a Lane 2a corpus-runner receipt would read.
+
+    ``mention_text`` cannot be read off the row (see the resolution_path
+    module docstring) -- the runner supplies it from the case's own known
+    mention text. This helper takes it as a lookup keyed by mention_id,
+    exactly mirroring how the real runner would cross-reference
+    ``subjects.json``.
+    """
+
+    rows = (
+        await session.scalars(
+            select(DevRunResolution)
+            .where(DevRunResolution.run_id == run_id)
+            .order_by(DevRunResolution.entry_ordinal)
+        )
+    ).all()
+    entries = []
+    for row in rows:
+        payload = row.payload
+        committed = payload.get("committed_entity_ref")
+        entries.append(
+            ResolutionLedgerEntry(
+                outcome=row.outcome,
+                mention_id=str(row.mention_id),
+                committed_label=committed["display_label"] if committed else None,
+            )
+        )
+    return entries
+
+
+@pytest.mark.asyncio
+async def test_exact_named_project_match_derives_deterministic_exact(seeded) -> None:
+    maker, org_id, user_id = seeded
+    question = "What's the status of the Ask Dev project?"
+    conversation_id, run_id = await _seed_run(maker, org_id, user_id, question=question)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        from tests._chaos_3292_preflight import ASK_DEV_PROJECT
+
+        output = await run_preflight_orchestrator(
+            question=question,
+            entities=[(str(org_id), ASK_DEV_PROJECT)],
+            org_id=str(org_id),
+            user_id=str(user_id),
+            conversation_id=str(conversation_id),
+            run_id=str(run_id),
+            answer_id=str(uuid.uuid4()),
+            script_id="wave4-exact",
+            recorder_factory=_recorder_factory(
+                service,
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                run_id=run_id,
+            ),
+        )
+        await session.commit()
+
+        # Setup control: a real committed exact match, not some other shape.
+        assert output.result.state is RunState.COMPLETED
+
+        entries = await _ledger_entries_for_run(session, run_id)
+        assert len(entries) >= 1, "expected at least one real ledger row"
+        assert entries[0].outcome == "exact_match"
+        # Supply the mention text the way the real runner would: from the
+        # case's own known mention list (subjects.json), not the row.
+        entries[0] = ResolutionLedgerEntry(
+            outcome=entries[0].outcome,
+            mention_id=entries[0].mention_id,
+            committed_label=entries[0].committed_label,
+            mention_text="Ask Dev",
+        )
+        assert derive_resolution_path(entries) == "deterministic-exact"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_candidates_derives_miss_clarification(seeded) -> None:
+    maker, org_id, user_id = seeded
+    question = "What's the status of the Atlas project?"
+    conversation_id, run_id = await _seed_run(maker, org_id, user_id, question=question)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        output = await run_preflight_orchestrator(
+            question=question,
+            entities=[
+                (str(org_id), ATLAS_PROJECT_ONE),
+                (str(org_id), ATLAS_PROJECT_TWO),
+            ],
+            org_id=str(org_id),
+            user_id=str(user_id),
+            conversation_id=str(conversation_id),
+            run_id=str(run_id),
+            answer_id=str(uuid.uuid4()),
+            script_id="wave4-ambiguous",
+            recorder_factory=_recorder_factory(
+                service,
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                run_id=run_id,
+            ),
+        )
+        await session.commit()
+
+        # Setup control: this really is the needs_clarification shape.
+        assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+        assert output.result.error is not None
+        assert output.result.error.code == "scope_ambiguous"
+
+        entries = await _ledger_entries_for_run(session, run_id)
+        assert len(entries) >= 1
+        assert entries[0].outcome == "ambiguous_candidates"
+        assert derive_resolution_path(entries) == "miss-clarification"


### PR DESCRIPTION
## CHAOS-3219 Wave 4 Phase 2 Lane 2a: pytest-based corpus runner

The runner/receipt/profile-loading layer for the Wave 4 acceptance corpus (Lane 2b authors the case content separately; merge order is this PR then 2b). Ruling D5 (pytest-based driver). Zero real corpus cases exist yet in this checkout — the live-driving test collects zero cases and is architecturally complete, not a stub.

### Module inventory (`scripts/acceptance/corpus/`)

- **`resolution_path.py`** — derives the `wave4_case_result.v1` receipt's `resolution_path` (`deterministic-exact | deterministic-alias | miss-clarification`, plus `qua-shadow`/`qua-committed` reserved for CHAOS-3389). Built on the recon finding that `alias_matching.py`'s own contract makes an alias/acronym hit **never auto-commit eligible** — it must always be offered as a candidate first — so `deterministic-alias` is derived from per-mention ledger *history* (did an earlier `ambiguous_candidates` entry precede the eventual `exact_match`?) plus a label-based fallback (`classify_match_kind`, equality-only against canonical id / raw label / primary label — mirrors `ClickHouseAuthorizedEntityCatalog.exact`'s real contract exactly, no substring matching). Proven live against the real `DevOrchestrator` + a real sqlite-backed `PersistenceRunRecorder` (`tests/api/dev/test_wave4_resolution_path_live.py`), not just fabricated fixtures.
- **`case_schema.py`** — case + resolution-profile loader/validator per the binding interface decision (`id`/`question`/`subject_class`/`invariants`/`resolution_profile_ref`). First-class `status: "declared-blocked"` handling (mirrors `world.json`/`sources.json`'s own `declared-blocked`/`blocked_by` discipline): a case blocked on an external ticket loads with zero invariants without crashing the whole corpus load, and `blocked_by` is validated against a real `CHAOS-<number>` ticket-reference format.
- **`script_inventory.py`** — the preflight production code itself never provides: every collected case id must have a scripted-provider entry for the active role, checked before any HTTP call. Proven against the real checked-in `registry-ids.v1.json`/`role-legacy_agent.json` (today's role file genuinely leaves cases unscripted).
- **`quota.py`** — budget tracker built on the real `_estimated_cost_microusd` pricing function, re-proving the same 134×3-run headroom claim Phase 1c's allowance-accounting test proves, through its own arithmetic. `release()` for pre-admission failures (never for a request that may have already reached the server).
- **`world_digest_guard.py` / `db_verify.py` / `_inner_*.py`** — WORLD_DIGEST verification (ruling D2) and two DB reads (the CHAOS-3424 resolution ledger; the CHAOS-3423 transcript row) via `docker compose exec -T`, per the team-lead's ruling: **no host port on postgres/clickhouse, no new product API endpoint**. Product-facing case execution stays wire-only against the public API. Digest verification is format-validated (64-char lowercase hex sha256) and `matched` is always *recomputed* from the two digest strings, never trusted from the inner script's own claim.
- **`receipt.py`** — the `wave4_case_result.v1` writer (ad-hoc schema, confirmed out of `export_contracts.py`'s scope — that's wire-contracts-only). Tamper-guarded: `set_extra` rejects every reserved schema key, and `write()` spreads extras *first* so the real computed fields always win even against a hypothetical bypass. A third receipt status (`declared-blocked`) distinct from `passed`/`failed`, and a session-summary aggregator with expected-vs-received set difference.
- **`invariants.py`** — the pluggable checker registry. Implemented: `resolution_path_in`, `public_outcome_in`, `no_internal_error`, `scope_resolution_outcome_in`, `no_unauthorized_candidate_surfaces`, `terminal_persists_assistant_row`. `NOT_YET_IMPLEMENTED_CATEGORIES` lists the remaining "for every case assert" matrix explicitly — a documented gap, not a silent one.
- **`tests/acceptance/test_wave4_corpus_runner_live.py`** — the pytest-native live driver. Armed-or-throw (skip when unarmed — this file is collected by the always-on unit-tier gate, unlike the pre-CHAOS-3219 smoke-script convention, so failing loud on a missing arm var would break the default gate for everyone); script-inventory/WORLD_DIGEST/quota guards fail loud, never skip, once armed. Validates every frame via the real `DevStreamEvent.model_validate` + production `validate_stream` lifecycle contract before any invariant runs.

### Three codex adversarial-review rounds (converged)

- **Round 1** (4 HIGH, 3 MEDIUM): unobserved `resolution_path`/`public_outcome` could still satisfy a passing receipt → unconditional `None` rejection + stream validation; `set_extra` reserved-key bypass; `classify_match_kind`'s bidirectional substring matching diverged from production (proved against real `subjects.json` data — "meridian/web-app extra" passed as exact); malformed terminal outcomes could pass. Plus: alias-vs-retry conflation in resolution history; quota reserved before admission; unarmed-CI-job risk (documented for Phase 5c, not fixed here — see below).
- **Round 2** (3 HIGH, 1 MEDIUM): DB-verify fails open on malformed output (`matched` trusted verbatim — a string `"false"` is truthy); stream validation still permitted empty/invalid streams (now uses the real `contracts.validate_stream` + an envelope-vs-payload event-name cross-check); **`public_outcome_in` was wired to `AnswerStatus` instead of `PublicOutcome`** — completely different vocabularies (`complete`/`partial`/... vs `answered`/`answered_with_gaps`/...). Fixed via the real `PUBLIC_OUTCOME_BY_ERROR_CODE` mapping for errors, and a documented finding for Lane 2b: today's legacy answer loop **always** maps to `answered_with_gaps`, never plain `answered`, per `wrap_legacy_answer_as_frame`'s own unconditional behavior — any case asserting `public_outcome_in: ["answered"]` against today's stack will never pass. Quota release narrowed to only the unambiguously pre-admission conversation-creation call.
- **Round 3, final** (3 HIGH, 2 MEDIUM): empty digest strings ("" == "") passed WORLD_DIGEST verification — now requires a real 64-char hex sha256 format; `scope_resolution_outcome_in`/`no_unauthorized_candidate_surfaces` only inspected the *first* `scope.resolved` event (production's `validate_stream` permits more than one) — now the outcome check uses the last event, the candidate check scans all of them; `terminal_persists_assistant_row` now requires exactly one row, not merely "at least one"; `blocked_by` format validated against a real ticket-reference pattern.

**Accepted, not fixed** (team-lead sign-off, tracked as **CHAOS-3453**): `no_unauthorized_candidate_surfaces` trusts `authorized_entity_ids` from the case/profile's own declaration — the same trust model every other `*_in` checker already has. Independently oracling it against the pinned world manifest is a separate design decision, not a defect in this checker; case-file review is the accepted mitigation for now.

**Documented, not fixed** (Phase 5c's territory): an armed-or-throw skip (guard 1) reads identically to a real pass if a CI job forgets to export `ASK_DEV_LIVE_ACCEPTANCE=1` — noted explicitly in the module docstring with a concrete ask (positively assert non-zero executed tests for this file, mirroring `test_live_openai_smoke.py`'s own two-tier `ASK_DEV_LIVE_GATE` pattern).

### Gate

`ci/local_validate.sh` fully green: `12303 passed, 105 skipped, 1 xfailed` — 0 failures (better than the CHAOS-3405 known-16 baseline). Lint/mypy/argMax live-exec proof all pass.
