### PR TITLE
CHAOS-3427: Go parity for budget-deferral exhaustion + watermark write boundary

### DIFF
--- a/internal/providersync/budget_episode_integration_test.go
+++ b/internal/providersync/budget_episode_integration_test.go
@@ -1,0 +1,291 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestCompleteAndReleaseObserveTheBudgetEpisodeContract is the REACHED-STATE
+// proof for CHAOS-3427 obligations #1 and D. The SQL-string assertions in
+// repository_postgres_sql_test.go show the statements SAY the right thing;
+// this shows real PostgreSQL actually DID it.
+//
+// Every unit is seeded mid-episode -- nonzero budget_deferrals, a
+// budget_first_deferred_at, a running first_blocked_at -- because a clear that
+// is asserted against an already-zero row proves nothing.
+func TestCompleteAndReleaseObserveTheBudgetEpisodeContract(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success clears the whole episode", func(t *testing.T) {
+		seedBudgetEpisode(t, ctx, pool, firstUnitID, now)
+		claim := claimForBudgetEpisode(t, ctx, repository, now)
+		windowEnd := claim.BeforeAt
+		if windowEnd == nil {
+			t.Fatal("seeded unit has no before_at; the coverage bound cannot be exercised")
+		}
+		watermark := *windowEnd
+		if err := repository.Complete(
+			ctx, claim, map[string]any{"records": 1}, &watermark,
+			now, now.Add(time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		state := readBudgetEpisode(t, ctx, pool, firstUnitID)
+		if state.status != "success" {
+			t.Fatalf("status = %q, want success", state.status)
+		}
+		if state.budgetDeferrals != 0 || state.budgetFirstDeferredAt != nil {
+			t.Fatalf("SUCCESS left the budget episode running: deferrals=%d "+
+				"first_deferred_at=%v -- the unit's next budget deferral would "+
+				"inherit a resolved episode's count and wall clock",
+				state.budgetDeferrals, state.budgetFirstDeferredAt)
+		}
+		if state.rateLimitDeferrals != 0 || state.rateLimitFirstSeenAt != nil {
+			t.Fatalf("SUCCESS left the rate-limit episode running: deferrals=%d "+
+				"first_seen_at=%v", state.rateLimitDeferrals, state.rateLimitFirstSeenAt)
+		}
+		if state.firstBlockedAt != nil {
+			t.Fatalf("SUCCESS left the aggregate blocked clock running (%v); the "+
+				"unit got through, so it is not going nowhere any more",
+				state.firstBlockedAt)
+		}
+	})
+
+	t.Run("release for retry preserves the episode", func(t *testing.T) {
+		seedBudgetEpisode(t, ctx, pool, firstUnitID, now)
+		claim := claimForBudgetEpisode(t, ctx, repository, now)
+		if err := repository.ReleaseForRetry(ctx, claim, now.Add(time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		state := readBudgetEpisode(t, ctx, pool, firstUnitID)
+		if state.status != "dispatching" {
+			t.Fatalf("status = %q, want dispatching", state.status)
+		}
+		// The deliberate asymmetry: 'provider_unit_retryable' is not an
+		// episode boundary, so a still-running episode must survive intact.
+		if state.budgetDeferrals != seededBudgetDeferrals || state.budgetFirstDeferredAt == nil {
+			t.Fatalf("release for retry reset the budget episode: deferrals=%d "+
+				"first_deferred_at=%v, want %d and a preserved stamp",
+				state.budgetDeferrals, state.budgetFirstDeferredAt, seededBudgetDeferrals)
+		}
+		if state.firstBlockedAt == nil {
+			t.Fatalf("release for retry cleared the aggregate blocked clock")
+		}
+		// The forbidden pattern, observed on the stored document rather than
+		// on the SQL text: the prior category must be GONE, replaced by this
+		// stamp's own cause.
+		if state.errorCategory != "provider_unit_retryable" {
+			t.Fatalf("result.error_category = %q, want provider_unit_retryable: a "+
+				"preserved stale category makes stale budget counters "+
+				"terminalization-eligible", state.errorCategory)
+		}
+	})
+
+	t.Run("watermark write is bounded by the window end", func(t *testing.T) {
+		seedBudgetEpisode(t, ctx, pool, firstUnitID, now)
+		claim := claimForBudgetEpisode(t, ctx, repository, now)
+		windowEnd := *claim.BeforeAt
+		// A provider-derived watermark PAST the window end but still in the
+		// past: the `now` ceiling alone does not catch this, which is exactly
+		// why C10(c) needs the coverage bound as a second ceiling.
+		overclaim := windowEnd.Add(5 * time.Hour)
+		completedAt := now.Add(time.Second)
+		if !overclaim.Before(completedAt) {
+			t.Fatalf("the overclaiming watermark %s is not in the past relative to "+
+				"the write instant %s; the `now` ceiling would catch it and this "+
+				"case would stop measuring the coverage ceiling", overclaim, completedAt)
+		}
+		if err := repository.Complete(
+			ctx, claim, map[string]any{"records": 1}, &overclaim,
+			windowEnd, completedAt,
+		); err != nil {
+			t.Fatal(err)
+		}
+		stored := readWatermark(t, ctx, pool, "commits")
+		if !stored.Equal(windowEnd) {
+			t.Fatalf("stored watermark = %s, want the window end %s: a stamp "+
+				"beyond what the unit fetched silently skips every record in "+
+				"between on the next run", stored, windowEnd)
+		}
+	})
+
+	t.Run("a corrupt future watermark heals downward", func(t *testing.T) {
+		seedBudgetEpisode(t, ctx, pool, firstUnitID, now)
+		claim := claimForBudgetEpisode(t, ctx, repository, now)
+		windowEnd := *claim.BeforeAt
+		// Seed the corrupt state by writing the row DIRECTLY. Going through
+		// Complete would be clamped by the boundary that now works, and the
+		// test would silently stop exercising the corrupt path -- the Python
+		// lane caught one of its own tests going vacuous exactly this way.
+		future := windowEnd.Add(365 * 24 * time.Hour)
+		if _, err := pool.Exec(ctx, `
+UPDATE public.sync_watermarks SET last_synced_at = $1
+WHERE org_id = 'org-acme' AND source_id = 'acme/api' AND dataset_key = 'commits'`,
+			future); err != nil {
+			t.Fatal(err)
+		}
+		// Precondition: without this, a seed that silently failed to store a
+		// meaningfully-future value would make the assertion below vacuous.
+		if seeded := readWatermark(t, ctx, pool, "commits"); !seeded.Equal(future) {
+			t.Fatalf("seed did not store the corrupt future value: got %s, want %s",
+				seeded, future)
+		}
+		sane := windowEnd
+		if err := repository.Complete(
+			ctx, claim, map[string]any{"records": 1}, &sane,
+			windowEnd, windowEnd.Add(time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		stored := readWatermark(t, ctx, pool, "commits")
+		if !stored.Equal(windowEnd) {
+			t.Fatalf("stored watermark = %s, want the healed value %s: without the "+
+				"narrow future exception the monotonic write discards the repair "+
+				"and every tick re-syncs a recovery window forever",
+				stored, windowEnd)
+		}
+	})
+
+	t.Run("a legitimate lower value is still refused", func(t *testing.T) {
+		seedBudgetEpisode(t, ctx, pool, firstUnitID, now)
+		claim := claimForBudgetEpisode(t, ctx, repository, now)
+		windowEnd := *claim.BeforeAt
+		if _, err := pool.Exec(ctx, `
+UPDATE public.sync_watermarks SET last_synced_at = $1
+WHERE org_id = 'org-acme' AND source_id = 'acme/api' AND dataset_key = 'commits'`,
+			windowEnd); err != nil {
+			t.Fatal(err)
+		}
+		// An out-of-order result from an earlier window. The stored value is
+		// legitimate (not in the future), so CHAOS-2578 monotonicity applies
+		// and this must NOT roll it back. Widening the future exception to
+		// "any lower value wins" breaks exactly here.
+		late := windowEnd.Add(-48 * time.Hour)
+		if err := repository.Complete(
+			ctx, claim, map[string]any{"records": 1}, &late,
+			windowEnd, windowEnd.Add(time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		stored := readWatermark(t, ctx, pool, "commits")
+		if !stored.Equal(windowEnd) {
+			t.Fatalf("stored watermark = %s, want %s: a late, out-of-order result "+
+				"must never roll a legitimate watermark backwards", stored, windowEnd)
+		}
+	})
+}
+
+const seededBudgetDeferrals = 4
+
+type budgetEpisodeState struct {
+	status                string
+	rateLimitDeferrals    int
+	rateLimitFirstSeenAt  *time.Time
+	budgetDeferrals       int
+	budgetFirstDeferredAt *time.Time
+	firstBlockedAt        *time.Time
+	errorCategory         string
+}
+
+// seedBudgetEpisode puts the fixture unit back into a mid-episode dispatching
+// state with a PRIOR error_category the stamps under test must overwrite.
+func seedBudgetEpisode(t *testing.T, ctx context.Context, pool *pgxpool.Pool, unitID string, now time.Time) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET status = 'dispatching', lease_owner = NULL, lease_expires_at = NULL,
+    available_at = NULL, duration_seconds = NULL, error = NULL,
+    -- The window END sits six hours BEHIND the write instant on purpose: the
+    -- coverage ceiling only proves anything when the overclaiming value is
+    -- itself in the past, i.e. when the now ceiling alone would let it through.
+    since_at = $2, before_at = $4,
+    result = '{"error_category":"budget_deferred","go_effect_ledger_v1":{"kept":true}}'::json,
+    rate_limit_deferrals = 3, rate_limit_first_seen_at = $4,
+    budget_deferrals = $3, budget_first_deferred_at = $4, first_blocked_at = $4,
+    updated_at = $4
+WHERE id = $1`, unitID, now.Add(-30*24*time.Hour), seededBudgetDeferrals,
+		now.Add(-6*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_runs SET status = 'running' WHERE id = $1`, firstRunID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func claimForBudgetEpisode(t *testing.T, ctx context.Context, repository *PostgresRepository, now time.Time) Claim {
+	t.Helper()
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, Owner: uuid.NewString(), OrgID: "org-acme",
+		Now: now, LeaseDuration: 10 * time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}
+
+func readBudgetEpisode(t *testing.T, ctx context.Context, pool *pgxpool.Pool, unitID string) budgetEpisodeState {
+	t.Helper()
+	var state budgetEpisodeState
+	var category *string
+	if err := pool.QueryRow(ctx, `
+SELECT status, rate_limit_deferrals, rate_limit_first_seen_at,
+       budget_deferrals, budget_first_deferred_at, first_blocked_at,
+       result::jsonb ->> 'error_category'
+FROM public.sync_run_units WHERE id = $1`, unitID).Scan(
+		&state.status, &state.rateLimitDeferrals, &state.rateLimitFirstSeenAt,
+		&state.budgetDeferrals, &state.budgetFirstDeferredAt, &state.firstBlockedAt,
+		&category,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if category != nil {
+		state.errorCategory = *category
+	}
+	return state
+}
+
+func readWatermark(t *testing.T, ctx context.Context, pool *pgxpool.Pool, dataset string) time.Time {
+	t.Helper()
+	var stored time.Time
+	if err := pool.QueryRow(ctx, `
+SELECT last_synced_at FROM public.sync_watermarks
+WHERE org_id = 'org-acme' AND source_id = 'acme/api' AND dataset_key = $1`,
+		dataset).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	return stored.UTC()
+}

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -128,9 +128,18 @@ func (repository *PostgresRepository) Complete(
 	}
 	if watermark != nil {
 		for _, datasetKey := range datasetKeys {
+			// THE write boundary (CHAOS-3412 C10(c), CHAOS-3427). Every Go
+			// watermark write routes through normalizeWatermarkWrite: routes
+			// that prefer a provider-supplied watermark over claim.BeforeAt
+			// bypass every planner-side clamp otherwise, and the INSERT half
+			// of the upsert has no monotonic gate at all to fall back on.
+			normalized := normalizeWatermarkWrite(
+				*watermark, claim.BeforeAt, completedAt,
+				claim.OrgID, claim.SourceExternalID, datasetKey,
+			)
 			if _, err := tx.Exec(ctx, upsertWatermarkSQL,
 				uuid.New(), claim.OrgID, claim.SourceExternalID, datasetKey,
-				watermark.UTC(), completedAt.UTC(),
+				normalized, completedAt.UTC(),
 			); err != nil {
 				return ErrInvalidConfiguration
 			}
@@ -354,6 +363,27 @@ WHERE unit.id = $1::uuid
       AND run.status NOT IN ('success', 'partial_failed', 'failed')
   )`
 
+// completeUnitSQL mirrors the Python SUCCESS stamp
+// (src/dev_health_ops/workers/sync_units.py, the `status=SUCCESS` UPDATE) in
+// its episode bookkeeping, not only in its status transition. Python clears
+// THREE things there and every one of them is load-bearing:
+//
+//   - the rate-limit episode pair (CHAOS-2760),
+//   - the budget episode pair (CHAOS-3412) -- SUCCESS proves the unit is not
+//     permanently oversized, so its next budget deferral must start a fresh
+//     count and a fresh wall clock instead of inheriting a resolved episode's,
+//   - the AGGREGATE blocked clock `first_blocked_at` -- the unit got through,
+//     so it is not "going nowhere" any more.
+//
+// Leaving any of them set here hands `sync/budget_guard.py`'s exhaustion
+// predicates a resolved episode's counters on the unit's NEXT deferral, and
+// terminalizes a healthy unit early. Python cannot see this SQL, so its own
+// derivation guard (test_deferral_lifecycle_columns_are_classified_and_stamped_correctly)
+// cannot catch a half-wired Go stamp -- repository_postgres_sql_test.go asserts
+// it on this side.
+//
+// releaseForRetrySQL below deliberately does NOT clear any of them; see its
+// own comment.
 const completeUnitSQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'success',
@@ -362,6 +392,9 @@ SET status = 'success',
     error = NULL,
     rate_limit_deferrals = 0,
     rate_limit_first_seen_at = NULL,
+    budget_deferrals = 0,
+    budget_first_deferred_at = NULL,
+    first_blocked_at = NULL,
     lease_owner = NULL,
     lease_expires_at = NULL,
     last_heartbeat_at = $3,
@@ -392,6 +425,20 @@ WHERE unit.id = $1::uuid
 // EffectReadbackRequired pair. A single UPDATE's SET expression reads the
 // current row atomically -- no separate lock is needed the way
 // mutateGenerationJournal's two-round-trip read-modify-write requires.
+//
+// CHAOS-3427: this stamp deliberately clears NEITHER episode pair nor the
+// aggregate blocked clock. That asymmetry with completeUnitSQL is the same one
+// Python has, and it is load-bearing: `_RATE_LIMIT_EPISODE_ERROR_CATEGORIES`
+// (budget_guard.py) does not contain 'provider_unit_retryable', so a release
+// for retry is not a rate-limit or budget episode boundary and must not reset
+// an episode that is still genuinely in progress. Do not "fix" it into
+// symmetry with the SUCCESS stamp.
+//
+// The jsonb merge here keeps OTHER result keys (go_effect_ledger_v1) but the
+// concatenation puts jsonb_build_object on the RIGHT, so 'error_category' is
+// OVERWRITTEN, never preserved. That direction is a hard rule, not an
+// accident -- see repository_postgres_sql_test.go's
+// TestNoUnitStampPreservesAPriorErrorCategory.
 const releaseForRetrySQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'dispatching',
@@ -427,16 +474,44 @@ WHERE unit.id = $1::uuid
   AND unit.lease_expires_at IS NOT NULL
   AND unit.lease_expires_at > $3`
 
+// upsertWatermarkSQL is monotonic (CHAOS-2578) with ONE narrow exception
+// (CHAOS-3412 clause C10(b), mirrored from Python's `_monotonic_update`):
+// when the STORED value is in the future and the incoming one is not, the
+// incoming value wins.
+//
+// The exception is gated on provably-invalid state only. A watermark marks
+// data ALREADY synced, so it can never legitimately sit ahead of now; such a
+// value can only come from a skewed provider record or from pre-fix planner
+// code that persisted a future window end. Because the write is otherwise
+// monotonic, nothing could ever lower it again: the planner's window would
+// start in the future, plan no unit, and the run would finalize FAILED
+// forever with nothing left to repair it. C10(a) (the planner-side recovery
+// clamp) and this clause only work together -- without this, the healing
+// re-stamp is silently discarded by GREATEST and every tick re-syncs a
+// recovery window forever.
+//
+// Widening this to "any lower value wins" would be a defect, not a
+// simplification: it destroys the CHAOS-2578 guarantee that a late or
+// out-of-order result cannot roll a LEGITIMATE watermark backwards. Python
+// pinned that by mutation; repository_postgres_sql_test.go pins it here.
+//
+// $6 is the write instant, used as `now` for the future test in-database so
+// the decision stays atomic against concurrent writers.
 const upsertWatermarkSQL = `
 INSERT INTO public.sync_watermarks (
     id, org_id, repo_id, source_id, target, dataset_key,
     last_synced_at, updated_at
 ) VALUES ($1, $2, $3, $3, $4, $4, $5, $6)
 ON CONFLICT (org_id, source_id, dataset_key) DO UPDATE
-SET last_synced_at = GREATEST(
-        public.sync_watermarks.last_synced_at,
-        EXCLUDED.last_synced_at
-    ),
+SET last_synced_at = CASE
+        WHEN public.sync_watermarks.last_synced_at > $6::timestamptz
+         AND EXCLUDED.last_synced_at <= $6::timestamptz
+        THEN EXCLUDED.last_synced_at
+        ELSE GREATEST(
+            public.sync_watermarks.last_synced_at,
+            EXCLUDED.last_synced_at
+        )
+    END,
     updated_at = EXCLUDED.updated_at`
 
 const upsertFinalizeSQL = `

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -448,6 +448,9 @@ func createProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.
 			lease_expires_at timestamptz, last_heartbeat_at timestamptz,
 			duration_seconds integer, rate_limit_deferrals integer NOT NULL DEFAULT 0,
 			rate_limit_first_seen_at timestamptz,
+			budget_deferrals integer NOT NULL DEFAULT 0,
+			budget_first_deferred_at timestamptz,
+			first_blocked_at timestamptz,
 			expired_lease_retry_count integer NOT NULL DEFAULT 0,
 			last_retry_reason text, updated_at timestamptz NOT NULL
 		)`,

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -252,8 +252,16 @@ INSERT INTO public.sync_dispatch_outbox (
 	); err != nil {
 		t.Fatal(err)
 	}
+	// CHAOS-3427: this watermark deliberately overshoots the unit's window end
+	// (the fixture's before_at is 2026-07-23T12:00:00Z, i.e. `now`) by 106
+	// seconds. Before the C10(c) write boundary landed it was persisted
+	// verbatim; it is now clamped to the coverage bound, because a unit that
+	// only fetched up to its window end cannot claim data past it. The
+	// assertion below therefore expects the CLAMPED value -- see
+	// wantWatermark.
 	watermark := now.Add(106 * time.Second)
 	completedAt := now.Add(107 * time.Second)
+	wantWatermark := *second.BeforeAt
 	if err := repository.Complete(
 		ctx, second, map[string]any{"records": 1}, &watermark,
 		now.Add(91*time.Second), completedAt,
@@ -272,8 +280,10 @@ JOIN public.sync_watermarks AS watermark
 WHERE unit.id = $1`, firstUnitID).Scan(&status, &persistedWatermark); err != nil {
 		t.Fatal(err)
 	}
-	if status != "success" || !persistedWatermark.Equal(watermark) {
-		t.Fatalf("status=%s watermark=%s", status, persistedWatermark)
+	if status != "success" || !persistedWatermark.Equal(wantWatermark) {
+		t.Fatalf("status=%s watermark=%s, want %s (the requested %s is past the "+
+			"unit's window end and must be clamped to it)",
+			status, persistedWatermark, wantWatermark, watermark)
 	}
 	var finalizeCount int
 	var persistedClaimToken string
@@ -313,7 +323,13 @@ WHERE sync_run_id = $1 AND kind = 'finalize_sync_run' AND status = 'pending'`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Same CHAOS-3427 clamp as the single-dataset completion above: this
+	// proposed watermark sits past the seeded unit's window end, so every
+	// alias row lands on the coverage bound instead. Fanning out to three
+	// aliases is what is under test here, and the clamp must apply uniformly
+	// to all of them -- a per-alias divergence would be a real defect.
 	familyWatermark := familyClaimedAt.Add(time.Second)
+	wantFamilyWatermark := *familyClaim.BeforeAt
 	if err := repository.Complete(
 		ctx, familyClaim, map[string]any{"records": 7}, &familyWatermark,
 		familyClaimedAt, familyClaimedAt.Add(2*time.Second),
@@ -339,7 +355,7 @@ FROM public.sync_watermarks
 WHERE org_id = 'org-acme'
   AND source_id = 'acme/api'
   AND dataset_key IN ('work-items', 'work-item-labels', 'work-item-comments')
-  AND last_synced_at = $1`, familyWatermark).Scan(&watermarkCount, &watermarkKeys); err != nil {
+  AND last_synced_at = $1`, wantFamilyWatermark).Scan(&watermarkCount, &watermarkKeys); err != nil {
 		t.Fatal(err)
 	}
 	if familyStatus != "success" || familyDataset != "work-items" || !familyAuditMatches ||

--- a/internal/providersync/repository_postgres_sql_test.go
+++ b/internal/providersync/repository_postgres_sql_test.go
@@ -1,9 +1,10 @@
 package providersync
 
 import (
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/sqlshape"
 )
 
 // episodeClearColumns is the per-episode + aggregate deferral bookkeeping a
@@ -69,21 +70,18 @@ func TestReleaseForRetrySQLDoesNotClearEpisodeState(t *testing.T) {
 }
 
 // preservingErrorCategory reports whether a jsonb result stamp could leave a
-// PRIOR result document's 'error_category' in place. Two shapes do that:
+// PRIOR result document's 'error_category' in place. See
+// sqlshape.PreservesPriorResultCategory for the two forbidden shapes and why
+// the merge-direction half is a parenthesis-aware scan rather than a regexp:
+// the regexp it replaced spanned jsonb_build_object's arguments with `[^)]*`
+// and therefore missed every preserving merge whose build_object nests a call
+// -- which is the shape both lease-repair stamps have today.
 //
-//  1. reading the old value back out (`unit.result->>'error_category'`), or
-//  2. concatenating with the existing document on the RIGHT
-//     (`jsonb_build_object(...) || COALESCE(unit.result...)`), since jsonb `||`
-//     resolves duplicate keys in favour of its right operand.
-//
-// The check is shape-based rather than a fixed blocklist so a new stamp
-// written in either shape is caught without this test being edited.
+// The detector is shared with internal/syncreconciler rather than duplicated,
+// because the two hand-copied regexps carried the SAME false negative and a
+// single fix to one copy would have left the other silently wrong.
 func preservingErrorCategory(sql string) bool {
-	if regexp.MustCompile(`result\s*->>?\s*'error_category'`).MatchString(sql) {
-		return true
-	}
-	return regexp.MustCompile(`jsonb_build_object\([^)]*\)\s*\|\|\s*COALESCE\(\s*\w+\.result`).
-		MatchString(sql)
+	return sqlshape.PreservesPriorResultCategory(sql)
 }
 
 // TestNoUnitStampPreservesAPriorErrorCategory is the FORBIDDEN PATTERN guard
@@ -154,6 +152,27 @@ func TestPreservingErrorCategoryDetectorCatchesBothShapes(t *testing.T) {
 				jsonb_build_object('error_category', 'worker_lost') ||
 				COALESCE(unit.result::jsonb, '{}'::jsonb)
 			)`,
+		// The shape the LEASE-REPAIR stamps actually have: a
+		// jsonb_build_object carrying NESTED calls. Any detector that scans
+		// the build_object's argument list with a non-nesting `[^)]*` stops
+		// at the first inner `)` and never reaches the `||`, so this
+		// preserving merge reads as clean. That is a false NEGATIVE on the
+		// exact statement shape this repository writes today.
+		"existing document wins a merge whose build_object nests calls": `
+			UPDATE public.sync_run_units AS unit
+			SET result = (
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'retry_count', unit.expired_lease_retry_count + 1,
+					'next_retry_at', to_jsonb($4::timestamptz),
+					'retry_surfaces', to_jsonb($5::text[])
+				) || COALESCE(unit.result::jsonb, '{}'::jsonb)
+			)`,
+		// No COALESCE at all -- the bare prior document on the right of the
+		// merge preserves every key it carries, error_category included.
+		"bare prior document on the right of the merge": `
+			UPDATE public.sync_run_units AS unit
+			SET result = jsonb_build_object('error_category', 'worker_lost') || unit.result`,
 	} {
 		if !preservingErrorCategory(sql) {
 			t.Errorf("detector missed a preserving stamp (%s):\n%s", name, sql)
@@ -162,6 +181,18 @@ func TestPreservingErrorCategoryDetectorCatchesBothShapes(t *testing.T) {
 	for name, sql := range map[string]string{
 		"production release-for-retry": releaseForRetrySQL,
 		"production complete":          completeUnitSQL,
+		// The SAFE direction, nested, so a detector "fixed" into flagging any
+		// statement that merely contains both a merge and a COALESCE over the
+		// prior document fails here instead of reading as a stricter guard.
+		"safe direction with a nested build_object": `
+			UPDATE public.sync_run_units AS unit
+			SET result = (
+				COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'next_retry_at', to_jsonb($4::timestamptz)
+				)
+			)`,
 	} {
 		if preservingErrorCategory(sql) {
 			t.Errorf("detector false-positives on %s:\n%s", name, sql)

--- a/internal/providersync/repository_postgres_sql_test.go
+++ b/internal/providersync/repository_postgres_sql_test.go
@@ -1,0 +1,193 @@
+package providersync
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// episodeClearColumns is the per-episode + aggregate deferral bookkeeping a
+// non-terminal SUCCESS stamp must reset. It is deliberately stated once, here,
+// and asserted against BOTH Go clear sites (completeUnitSQL below,
+// markExpiredLeaseRetryingSQL in internal/syncreconciler) so a third episode
+// pair added later cannot be half-wired the way CHAOS-3412's budget pair was.
+//
+// Python derives its equivalent set from the live SyncRunUnit model
+// (test_deferral_lifecycle_columns_are_classified_and_stamped_correctly). That
+// derivation CANNOT see this SQL -- it parses Python source only -- so the Go
+// half is owed here.
+var episodeClearColumns = []string{
+	"rate_limit_deferrals = 0",
+	"rate_limit_first_seen_at = NULL",
+	"budget_deferrals = 0",
+	"budget_first_deferred_at = NULL",
+}
+
+// TestCompleteUnitSQLClearsEveryEpisodeColumn pins the SUCCESS stamp's episode
+// symmetry (CHAOS-3427 obligation #1).
+//
+// A unit budget-deferred by Python and later completed by Go must come back
+// with a ZEROED budget pair: SUCCESS proves the unit is not permanently
+// oversized, so its next budget deferral has to start a fresh count and a
+// fresh wall clock. Leaving the pair set hands
+// `sync/budget_guard.py::_budget_deferral_exhausted` a resolved episode's
+// counters and terminalizes a healthy unit.
+func TestCompleteUnitSQLClearsEveryEpisodeColumn(t *testing.T) {
+	for _, column := range episodeClearColumns {
+		if !strings.Contains(completeUnitSQL, column) {
+			t.Errorf("completeUnitSQL does not clear %q:\n%s", column, completeUnitSQL)
+		}
+	}
+	// The AGGREGATE blocked clock stops at SUCCESS too -- the unit got
+	// through, so it is not "going nowhere" any more. Python clears it at
+	// exactly three sites (SUCCESS plus the two dispatch-claim UPDATEs); Go
+	// owns the SUCCESS one.
+	if !strings.Contains(completeUnitSQL, "first_blocked_at = NULL") {
+		t.Errorf("completeUnitSQL does not clear first_blocked_at:\n%s", completeUnitSQL)
+	}
+}
+
+// TestReleaseForRetrySQLDoesNotClearEpisodeState pins the deliberate ASYMMETRY
+// (CHAOS-3427 obligation #1, second half). A release for retry is not an
+// episode boundary: 'provider_unit_retryable' is outside
+// _RATE_LIMIT_EPISODE_ERROR_CATEGORIES and outside the budget episode
+// categories, so resetting a still-running episode here would erase real
+// deferral history and make the exhaustion paths unreachable.
+//
+// This is a POSITIVE assertion of the current contract, not an oversight
+// waiting to be fixed: "make it symmetric with SUCCESS" is the change this
+// test exists to reject.
+func TestReleaseForRetrySQLDoesNotClearEpisodeState(t *testing.T) {
+	for _, column := range append([]string{"first_blocked_at"}, episodeClearColumns...) {
+		name := strings.SplitN(column, " ", 2)[0]
+		if strings.Contains(releaseForRetrySQL, name) {
+			t.Errorf("releaseForRetrySQL touches %q; a release for retry is not an "+
+				"episode boundary and must leave episode state alone:\n%s",
+				name, releaseForRetrySQL)
+		}
+	}
+}
+
+// preservingErrorCategory reports whether a jsonb result stamp could leave a
+// PRIOR result document's 'error_category' in place. Two shapes do that:
+//
+//  1. reading the old value back out (`unit.result->>'error_category'`), or
+//  2. concatenating with the existing document on the RIGHT
+//     (`jsonb_build_object(...) || COALESCE(unit.result...)`), since jsonb `||`
+//     resolves duplicate keys in favour of its right operand.
+//
+// The check is shape-based rather than a fixed blocklist so a new stamp
+// written in either shape is caught without this test being edited.
+func preservingErrorCategory(sql string) bool {
+	if regexp.MustCompile(`result\s*->>?\s*'error_category'`).MatchString(sql) {
+		return true
+	}
+	return regexp.MustCompile(`jsonb_build_object\([^)]*\)\s*\|\|\s*COALESCE\(\s*\w+\.result`).
+		MatchString(sql)
+}
+
+// TestNoUnitStampPreservesAPriorErrorCategory is the FORBIDDEN PATTERN guard
+// (CHAOS-3427 obligation #2).
+//
+// Python's `_budget_deferral_exhausted` has a defence-in-depth gate: it
+// terminalizes only when the unit's most recently recorded
+// `result.error_category` is the budget guard's own deferral category. That
+// gate is what makes the Python-only shape of CHAOS-3412 safe today, because
+// BOTH Go stamps OVERWRITE the category with their own cause
+// (`worker_lost`, `provider_unit_retryable`) rather than preserving the
+// previous one.
+//
+// A Go stamp that PRESERVED a prior error_category -- e.g. a jsonb merge that
+// keeps the old value the way the CHAOS-3122 pattern does for other keys --
+// would make stale budget counters terminalization-eligible again and fail
+// healthy units. The obligation-#1 clears above remove the DEPENDENCE on that
+// backstop, but the backstop must not be dismantled either, so the pattern
+// stays forbidden.
+//
+// Note that releaseForRetrySQL DOES use a jsonb merge: it must, to keep the
+// go_effect_ledger_v1 key alive across a retry. What makes it safe is the
+// DIRECTION -- jsonb_build_object sits on the right of `||`, so its
+// error_category wins. This test measures that direction, not the presence of
+// a merge.
+func TestNoUnitStampPreservesAPriorErrorCategory(t *testing.T) {
+	stamps := map[string]string{
+		"completeUnitSQL":    completeUnitSQL,
+		"releaseForRetrySQL": releaseForRetrySQL,
+		"failUnitSQL":        failUnitSQL,
+	}
+	measured := 0
+	for name, sql := range stamps {
+		if !strings.Contains(sql, "result") {
+			continue
+		}
+		measured++
+		if preservingErrorCategory(sql) {
+			t.Errorf("%s preserves a prior error_category. Python's exhaustion "+
+				"predicate accepts only its own deferral category, so a preserved "+
+				"stale category makes stale counters terminalization-eligible:\n%s",
+				name, sql)
+		}
+	}
+	// A derivation that measures nothing must FAIL, not read as "all clean".
+	if measured < len(stamps) {
+		t.Fatalf("only %d of %d unit result stamps were measured; a stamp that "+
+			"stopped writing `result` silently left this guard vacuous",
+			measured, len(stamps))
+	}
+}
+
+// TestPreservingErrorCategoryDetectorCatchesBothShapes is the guard's own
+// negative control. Without it, TestNoUnitStampPreservesAPriorErrorCategory
+// would pass identically if `preservingErrorCategory` always returned false --
+// which is exactly what "a test that cannot fail" looks like.
+func TestPreservingErrorCategoryDetectorCatchesBothShapes(t *testing.T) {
+	for name, sql := range map[string]string{
+		"reads the prior value back": `
+			UPDATE public.sync_run_units AS unit
+			SET result = jsonb_build_object(
+				'error_category',
+				COALESCE(unit.result->>'error_category', 'worker_lost')
+			)`,
+		"existing document wins the merge": `
+			UPDATE public.sync_run_units AS unit
+			SET result = (
+				jsonb_build_object('error_category', 'worker_lost') ||
+				COALESCE(unit.result::jsonb, '{}'::jsonb)
+			)`,
+	} {
+		if !preservingErrorCategory(sql) {
+			t.Errorf("detector missed a preserving stamp (%s):\n%s", name, sql)
+		}
+	}
+	for name, sql := range map[string]string{
+		"production release-for-retry": releaseForRetrySQL,
+		"production complete":          completeUnitSQL,
+	} {
+		if preservingErrorCategory(sql) {
+			t.Errorf("detector false-positives on %s:\n%s", name, sql)
+		}
+	}
+}
+
+// TestUpsertWatermarkSQLHealsOnlyProvablyCorruptFutureValues pins clause
+// C10(b). The write stays monotonic (CHAOS-2578) except for one narrow case:
+// a STORED value ahead of `now` with a sane incoming one. Widening that to
+// "any lower value wins" is a defect -- Python pinned it by mutation.
+func TestUpsertWatermarkSQLHealsOnlyProvablyCorruptFutureValues(t *testing.T) {
+	for _, required := range []string{
+		"public.sync_watermarks.last_synced_at > $6::timestamptz",
+		"EXCLUDED.last_synced_at <= $6::timestamptz",
+		"GREATEST(",
+	} {
+		if !strings.Contains(upsertWatermarkSQL, required) {
+			t.Errorf("upsertWatermarkSQL missing %q:\n%s", required, upsertWatermarkSQL)
+		}
+	}
+	// Both halves of the guard, or the exception is not narrow. A CASE with
+	// only the stored-is-future test would let a legitimately lower (also
+	// future) incoming value roll a watermark backwards.
+	if strings.Count(upsertWatermarkSQL, "$6::timestamptz") != 2 {
+		t.Errorf("the future-heal exception must test BOTH the stored and the "+
+			"incoming value against the write instant:\n%s", upsertWatermarkSQL)
+	}
+}

--- a/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
+++ b/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
@@ -1,0 +1,204 @@
+package providersync
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// budgetExhaustionDecision is the typed row this pair compares. A concrete
+// struct rather than a map, for the reason the comparator's own doc gives:
+// a struct return type makes "silently expose only some of the decision" a
+// type error instead of a runtime choice.
+type budgetExhaustionDecision struct {
+	Exhausted bool `json:"exhausted"`
+}
+
+// Defaults mirrored from sync/budget_guard.py (BUDGET_MAX_DEFERRALS_DEFAULT,
+// BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT). The oracle runs with both env
+// vars unset on both sides, so these are the values in play.
+const (
+	budgetMaxDeferralsDefault           = 10
+	budgetDeferralWallClockSecondsDefau = 6 * 60 * 60
+	budgetDeferredCategory              = "budget_deferred"
+)
+
+// budgetEpisodeSnapshot is the unit state the predicate reads. These three
+// values are exactly the ones Go's stamps write, which is why this pair is
+// the Go side's business at all.
+type budgetEpisodeSnapshot struct {
+	Deferrals       int
+	FirstDeferredAt *time.Time
+	ErrorCategory   string
+}
+
+// budgetDeferralExhausted mirrors sync/budget_guard.py's
+// _budget_deferral_exhausted, clause for clause and in the same order:
+//
+//  1. no budget history at all -> never exhausted;
+//  2. defence in depth -- the unit's MOST RECENTLY recorded error_category
+//     must be the budget guard's own deferral category;
+//  3. the count cap;
+//  4. the wall-clock cap, measured from the first deferral of THIS episode.
+//
+// It lives in the test file deliberately. Go does not own budget admission
+// today -- Python does -- so a production copy would be unwired code
+// pretending to be a second implementation. What this mirror is FOR is the
+// differential: the live Python predicate is the authority, and the pair
+// below fails the moment the two readings of a shared sync_run_units row
+// disagree. When the Go runtime takes over unit admission it inherits an
+// executable specification instead of a prose one.
+func budgetDeferralExhausted(state budgetEpisodeSnapshot, now time.Time) bool {
+	if state.Deferrals <= 0 && state.FirstDeferredAt == nil {
+		return false
+	}
+	if state.ErrorCategory != budgetDeferredCategory {
+		return false
+	}
+	if state.Deferrals >= budgetMaxDeferralsDefault {
+		return true
+	}
+	if state.FirstDeferredAt == nil {
+		return false
+	}
+	elapsed := now.Sub(state.FirstDeferredAt.UTC()).Seconds()
+	return elapsed >= budgetDeferralWallClockSecondsDefau
+}
+
+func buildBudgetExhaustionDecisionForOracle(
+	t *testing.T, input map[string]any,
+) budgetExhaustionDecision {
+	t.Helper()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	// The case Input map reaches the Go builder as authored (ints stay ints)
+	// but reaches Python through JSON; accept both so the two paths cannot
+	// disagree about a value that is numerically identical.
+	number := func(raw any) int64 {
+		switch value := raw.(type) {
+		case int:
+			return int64(value)
+		case int64:
+			return value
+		case float64:
+			return int64(value)
+		default:
+			t.Fatalf("case value %#v is not a number", raw)
+			return 0
+		}
+	}
+	state := budgetEpisodeSnapshot{Deferrals: int(number(input["budget_deferrals"]))}
+	if raw := input["first_deferred_seconds_ago"]; raw != nil {
+		at := now.Add(-time.Duration(number(raw)) * time.Second)
+		state.FirstDeferredAt = &at
+	}
+	if raw := input["error_category"]; raw != nil {
+		state.ErrorCategory = raw.(string)
+	}
+	return budgetExhaustionDecision{Exhausted: budgetDeferralExhausted(state, now)}
+}
+
+// stampedErrorCategory extracts the literal error_category a Go result stamp
+// writes, DERIVED from the SQL constant rather than restated here. That is
+// what makes the go_stamp_* cases below a guard on the real statements: edit
+// the stamp's category and the case that runs through the live Python
+// predicate changes with it.
+func stampedErrorCategory(t *testing.T, sql string) string {
+	t.Helper()
+	matches := regexp.MustCompile(`'error_category',\s*'([a-z_]+)'`).FindStringSubmatch(sql)
+	if len(matches) != 2 {
+		t.Fatalf("could not derive the stamped error_category from:\n%s", sql)
+	}
+	return matches[1]
+}
+
+func budgetExhaustionOracleCases(t *testing.T) []oracleCase {
+	t.Helper()
+	snapshot := func(deferrals int, secondsAgo any, category any) map[string]any {
+		return map[string]any{
+			"budget_deferrals":           deferrals,
+			"first_deferred_seconds_ago": secondsAgo,
+			"error_category":             category,
+		}
+	}
+	wallClock := budgetDeferralWallClockSecondsDefau
+	cases := []oracleCase{
+		// Clause 1: no history at all. This is the state Go's episode clears
+		// produce, and the reason they are sufficient.
+		{ID: "fresh_unit_is_never_exhausted", Input: snapshot(0, nil, nil)},
+		{ID: "cleared_unit_with_a_budget_category_is_not_exhausted",
+			Input: snapshot(0, nil, budgetDeferredCategory)},
+		// The count cap, on both sides of the boundary.
+		{ID: "one_below_the_count_cap",
+			Input: snapshot(budgetMaxDeferralsDefault-1, 60, budgetDeferredCategory)},
+		{ID: "exactly_at_the_count_cap",
+			Input: snapshot(budgetMaxDeferralsDefault, 60, budgetDeferredCategory)},
+		{ID: "past_the_count_cap",
+			Input: snapshot(budgetMaxDeferralsDefault+3, 60, budgetDeferredCategory)},
+		// The wall-clock cap, on both sides of the boundary.
+		{ID: "one_second_below_the_wall_clock_cap",
+			Input: snapshot(1, wallClock-1, budgetDeferredCategory)},
+		{ID: "exactly_at_the_wall_clock_cap",
+			Input: snapshot(1, wallClock, budgetDeferredCategory)},
+		{ID: "past_the_wall_clock_cap",
+			Input: snapshot(1, wallClock+3600, budgetDeferredCategory)},
+		// A counter with no first-deferred stamp: history exists, but the
+		// wall clock cannot be measured, so only the count cap can fire.
+		{ID: "counter_without_a_first_deferred_stamp",
+			Input: snapshot(2, nil, budgetDeferredCategory)},
+		// Clause 2, the defence-in-depth gate, at its most dangerous input:
+		// a unit far past BOTH caps whose category is not the budget one.
+		{ID: "unrelated_category_is_refused_despite_both_caps",
+			Input: snapshot(budgetMaxDeferralsDefault+5, wallClock*2, "rate_limit_deferred")},
+		{ID: "absent_result_document_is_refused",
+			Input: snapshot(budgetMaxDeferralsDefault+5, wallClock*2, nil)},
+	}
+	// The go_stamp_* cases: a unit deep into a budget episode that a Go stamp
+	// then re-stamps. The stale counters survive (Go's stamps other than the
+	// clears do not reset them), so the ONLY thing standing between this unit
+	// and a spurious terminalization is the category the stamp wrote --
+	// derived from the live SQL constants, not restated. If a stamp is ever
+	// changed to PRESERVE the prior category, the derived value here becomes
+	// 'budget_deferred' and the live Python predicate answers "exhausted" for
+	// a unit that is merely being retried.
+	for name, sql := range map[string]string{
+		"release_for_retry": releaseForRetrySQL,
+	} {
+		cases = append(cases, oracleCase{
+			ID: "go_stamp_" + name + "_is_not_terminalizable",
+			Input: snapshot(
+				budgetMaxDeferralsDefault+5, wallClock*2, stampedErrorCategory(t, sql),
+			),
+		})
+	}
+	return cases
+}
+
+func TestGenericOracleMatchesLivePythonForBudgetExhaustion(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "syncunit/budget/exhaustion", budgetExhaustionOracleCases(t),
+		buildBudgetExhaustionDecisionForOracle, nil,
+	)
+}
+
+// TestGoStampCategoriesAreNotBudgetDeferred states the go_stamp_* cases'
+// premise as its own assertion, so a stamp that started writing the budget
+// category cannot slip through by making that case merely agree with Python
+// (both sides would then say "exhausted" and the differential would pass
+// while the behaviour was wrong).
+func TestGoStampCategoriesAreNotBudgetDeferred(t *testing.T) {
+	stamps := map[string]string{
+		"releaseForRetrySQL": releaseForRetrySQL,
+	}
+	for name, sql := range stamps {
+		if !strings.Contains(sql, "error_category") {
+			t.Fatalf("%s no longer writes error_category; the go_stamp_* oracle "+
+				"cases derive their input from it and have gone vacuous", name)
+		}
+		if got := stampedErrorCategory(t, sql); got == budgetDeferredCategory {
+			t.Errorf("%s stamps %q. A Go stamp claiming the budget guard's own "+
+				"deferral category makes stale budget counters "+
+				"terminalization-eligible.", name, got)
+		}
+	}
+}

--- a/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
+++ b/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
@@ -33,8 +33,9 @@ type budgetEpisodeSnapshot struct {
 	ErrorCategory   string
 }
 
-// budgetDeferralExhausted mirrors sync/budget_guard.py's
-// _budget_deferral_exhausted, clause for clause and in the same order:
+// budgetDeferralExhausted is a HAND-WRITTEN Go mirror of
+// sync/budget_guard.py's _budget_deferral_exhausted, clause for clause and in
+// the same order:
 //
 //  1. no budget history at all -> never exhausted;
 //  2. defence in depth -- the unit's MOST RECENTLY recorded error_category
@@ -42,13 +43,18 @@ type budgetEpisodeSnapshot struct {
 //  3. the count cap;
 //  4. the wall-clock cap, measured from the first deferral of THIS episode.
 //
-// It lives in the test file deliberately. Go does not own budget admission
-// today -- Python does -- so a production copy would be unwired code
-// pretending to be a second implementation. What this mirror is FOR is the
-// differential: the live Python predicate is the authority, and the pair
-// below fails the moment the two readings of a shared sync_run_units row
-// disagree. When the Go runtime takes over unit admission it inherits an
-// executable specification instead of a prose one.
+// It is NOT a production function driven under test, and calling it one would
+// be the inaccurate coverage claim. Go owns no budget-admission decision
+// today: the only budget references in this repository's non-test Go source
+// are the two SQL clears (repository_postgres.go's completeUnitSQL and
+// syncreconciler's markExpiredLeaseRetryingSQL), so there is no production Go
+// producer to drive here instead of this mirror. Adding one would be unwired
+// code pretending to be a second implementation.
+//
+// What the mirror IS for is the differential against the live Python
+// authority: the pair below fails the moment the two readings of a shared
+// sync_run_units row disagree, so when the Go runtime does take over unit
+// admission it inherits an executable specification instead of a prose one.
 func budgetDeferralExhausted(state budgetEpisodeSnapshot, now time.Time) bool {
 	if state.Deferrals <= 0 && state.FirstDeferredAt == nil {
 		return false
@@ -174,7 +180,37 @@ func budgetExhaustionOracleCases(t *testing.T) []oracleCase {
 	return cases
 }
 
-func TestGenericOracleMatchesLivePythonForBudgetExhaustion(t *testing.T) {
+// TestBudgetExhaustionPredicateMatchesLivePython is a PREDICATE-PARITY check,
+// and the name says so because the earlier one ("generic oracle ... for budget
+// exhaustion") read like a state-machine oracle and was reported as one.
+//
+// WHAT IT MEASURES. One side is the live, unmodified
+// sync/budget_guard.py::_budget_deferral_exhausted; the other is the
+// hand-written Go mirror above. Given the same unit-state snapshot, the two
+// must return the same verdict. Two of the case inputs are DERIVED from the
+// production Go SQL constants (the go_stamp_* cases read the stamped
+// error_category straight out of releaseForRetrySQL), so those cases do bind
+// real Go statements to the live predicate -- but the rest compare two
+// predicates, not two producers.
+//
+// WHAT IT DOES NOT MEASURE, and what covers that instead:
+//
+//   - That the Go stamps write the episode columns this predicate reads. The
+//     SQL-string guards own that: TestCompleteUnitSQLClearsEveryEpisodeColumn
+//     and TestReleaseForRetrySQLDoesNotClearEpisodeState here,
+//     TestExpiredLeaseRetryStampClearsEveryEpisodeColumn and
+//     TestExpiredLeaseRetryStampLeavesTheAggregateClockAlone in
+//     internal/syncreconciler.
+//   - That those statements actually REACH that state in a database. The two
+//     integration suites own that, against real PostgreSQL:
+//     internal/providersync/budget_episode_integration_test.go and
+//     internal/syncreconciler/lease_repair_integration_test.go (both
+//     integration-tagged, both run by `ci/check_go.sh integration`).
+//   - Real state-machine TRANSITIONS (deferral -> retry -> success). Nothing
+//     here drives those; the integration suites above are the closest thing,
+//     and Python's own tests/test_budget_guard_cooldown.py owns the admission
+//     loop itself.
+func TestBudgetExhaustionPredicateMatchesLivePython(t *testing.T) {
 	compareRowsAgainstPythonOracle(
 		t, "syncunit/budget/exhaustion", budgetExhaustionOracleCases(t),
 		buildBudgetExhaustionDecisionForOracle, nil,

--- a/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
+++ b/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
@@ -277,9 +277,9 @@
     {
       "id": "M15-every-writer-routes-through-the-boundary",
       "file": "internal/providersync/repository_postgres.go",
-      "find": "\t\t\t\tnormalized, completedAt.UTC(),",
-      "replace": "\t\t\t\twatermark.UTC(), completedAt.UTC(),",
-      "rationale": "C10(c): enforcing the boundary at call sites is what CHAOS-3412 got wrong twice. This bypasses the normalizer while leaving it defined, which is precisely the shape the derivation test exists to catch.",
+      "find": "\t\t\tnormalized := normalizeWatermarkWrite(\n\t\t\t\t*watermark, claim.BeforeAt, completedAt,\n\t\t\t\tclaim.OrgID, claim.SourceExternalID, datasetKey,\n\t\t\t)",
+      "replace": "\t\t\tnormalized := watermark.UTC()",
+      "rationale": "C10(c): enforcing the boundary at call sites is what CHAOS-3412 got wrong twice. This keeps the normalizer defined but stops the one writer calling it -- exactly the shape the AST derivation test exists to catch, and the shape a hand-maintained writer list cannot.",
       "proof": [
         [
           "go",

--- a/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
+++ b/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
@@ -307,6 +307,125 @@
           "./internal/providersync/"
         ]
       ]
+    },
+    {
+      "id": "M17-success-clears-the-budget-first-deferred-timestamp",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    budget_first_deferred_at = NULL,\n    first_blocked_at = NULL,",
+      "replace": "    first_blocked_at = NULL,",
+      "rationale": "Obligation #1, isolated to the TIMESTAMP half of the budget pair -- M10 drops the counter, this drops the wall clock. They fail differently: `_budget_deferral_exhausted` reads budget_first_deferred_at for its SIX-HOUR cap, so a surviving stamp terminalizes the unit's NEXT budget deferral off a resolved episode's start instant even with budget_deferrals correctly zeroed. A pair-level mutation cannot tell the two clauses apart.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompleteUnitSQLClearsEveryEpisodeColumn$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M18-lease-repair-clears-the-budget-first-deferred-timestamp",
+      "file": "internal/syncreconciler/lease_repair.go",
+      "find": "\tbudget_deferrals = 0,\n\tbudget_first_deferred_at = NULL,",
+      "replace": "\tbudget_deferrals = 0,",
+      "rationale": "Obligation #1, the lease-repair half of the same split: M12 drops the counter clause, this drops the wall-clock clause. An expired lease is not a budget episode, so a unit Python budget-deferred and Go then lease-repaired must come back with BOTH budget columns reset, not one.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestExpiredLeaseRetryStampClearsEveryEpisodeColumn$",
+          "./internal/syncreconciler/"
+        ]
+      ]
+    },
+    {
+      "id": "M19-lease-repair-retry-stamp-must-overwrite-the-category",
+      "file": "internal/syncreconciler/lease_repair.go",
+      "find": "\tresult = jsonb_build_object(\n\t\t'error_category', 'worker_lost',\n\t\t'retry_count', unit.expired_lease_retry_count + 1,\n\t\t'retry_reason', 'expired_lease',\n\t\t'next_retry_at', to_jsonb($4::timestamptz),\n\t\t'retry_exhausted', FALSE,\n\t\t'retry_surfaces', to_jsonb($5::text[]),\n\t\t'last_lease_expired_at', to_jsonb($3::timestamptz)\n\t),",
+      "replace": "\tresult = (jsonb_build_object(\n\t\t'error_category', 'worker_lost',\n\t\t'retry_count', unit.expired_lease_retry_count + 1,\n\t\t'retry_reason', 'expired_lease',\n\t\t'next_retry_at', to_jsonb($4::timestamptz),\n\t\t'retry_exhausted', FALSE,\n\t\t'retry_surfaces', to_jsonb($5::text[]),\n\t\t'last_lease_expired_at', to_jsonb($3::timestamptz)\n\t) || COALESCE(unit.result::jsonb, '{}'::jsonb)),",
+      "rationale": "Obligation #2 (FORBIDDEN PATTERN) for THIS package's stamp; M13 only covered providersync's. jsonb `||` resolves duplicate keys in favour of its RIGHT operand, so merging the prior document on the right PRESERVES a stale 'budget_deferred' and makes stale counters terminalization-eligible. This mutation is also the one that exposed the guard's own defect: the previous regexp detector spanned jsonb_build_object's arguments with `[^)]*`, stopped at the first nested `to_jsonb(...)`, never reached the `||`, and SURVIVED this. The parenthesis-aware detector in internal/testsupport/sqlshape kills it.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNoLeaseRepairStampPreservesAPriorErrorCategory$",
+          "./internal/syncreconciler/"
+        ]
+      ]
+    },
+    {
+      "id": "M20-watermark-now-ceiling",
+      "file": "internal/providersync/watermark_write_boundary.go",
+      "find": "\tceiling := now.UTC()\n",
+      "replace": "\tceiling := now.UTC().AddDate(100, 0, 0)\n",
+      "rationale": "C10(c) first ceiling, isolated from M14's second one. This keeps the window_end clamp intact and removes only the `now` clamp, which is the ONLY ceiling a nil coverageUpperBound has -- the shape every route that prefers a provider-derived watermark hits. A skewed source record then writes a FUTURE watermark that the monotonic upsert defends forever, and the planner plans nothing from that dataset again.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeWatermarkWriteClampsToBothCeilings$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M21-watermark-tighter-ceiling-wins",
+      "file": "internal/providersync/watermark_write_boundary.go",
+      "find": "\t\tif upper.Before(ceiling) {\n",
+      "replace": "\t\tif upper.After(ceiling) {\n",
+      "rationale": "C10(c) min-vs-max flip. Both ceilings are still consulted, so M14 and M20 cannot see this: what changes is WHICH one binds. Choosing the looser ceiling lets a window end in the future raise the now ceiling, which is exactly the case a provider-reported future bound produces.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeWatermarkWriteClampsToBothCeilings$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M22-watermark-write-is-utc",
+      "file": "internal/providersync/watermark_write_boundary.go",
+      "find": "\tvalue := incoming.UTC()\n",
+      "replace": "\tvalue := incoming\n",
+      "rationale": "C10(c) representation clause. time.Time comparisons are instant-based, so this changes no clamp verdict and no stored timestamptz -- every value assertion in the clamp table still passes. What it changes is the offset the clamp warning's RFC3339Nano fields print in, for a provider-supplied timestamp arriving in the provider's own zone, and it diverges from Python's _normalize_watermark_write. TestNormalizeWatermarkWriteReturnsUTC is the only thing that observes it, which is precisely why the mutation is listed.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeWatermarkWriteReturnsUTC$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M23-watermark-clamp-comparison-direction",
+      "file": "internal/providersync/watermark_write_boundary.go",
+      "find": "\tif !value.After(ceiling) {\n",
+      "replace": "\tif !value.Before(ceiling) {\n",
+      "rationale": "C10(c) boundary clause. Inverts which side of the ceiling passes through untouched: a value comfortably INSIDE both ceilings is raised TO the ceiling, so the boundary that exists to stop a watermark claiming unread data becomes the thing that advances it. Neither ceiling is removed, so M14/M20/M21 do not cover this.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeWatermarkWriteClampsToBothCeilings$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
+++ b/internal/providersync/testdata/mutation-plans/chaos_3427_budget_ratchet_parity.json
@@ -1,0 +1,312 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3427 Go parity: budget-deferral episode clears + HEAVY incremental window ratchet",
+  "build": [
+    "go",
+    "build",
+    "./..."
+  ],
+  "$limitation": "Every mutation below is CLAUSE-level: it removes or inverts one conjunct, one comparison, or one column from a stamp, never a whole condition. Two areas are deliberately NOT covered here and are proven elsewhere: (1) the reached-state proofs against real PostgreSQL (internal/providersync/budget_episode_integration_test.go, internal/syncreconciler/lease_repair_integration_test.go) need Docker and are integration-tagged, so a SQL-column mutation is measured here against the SQL-string assertions and separately against the live database by running those suites; (2) the C7 clause (watermark stamps at the unit's window END, never wall-clock now) is a property of the ROUTES, which already pass claim.BeforeAt -- routes that derive their own provider watermark are bounded by the C10(c) write boundary instead, which M14/M15 do cover.",
+  "mutations": [
+    {
+      "id": "M1-heavy-cost-class-conjunct",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "if mode != SyncModeIncremental || costClass != heavyCostClass || start == nil {",
+      "replace": "if mode != SyncModeIncremental || start == nil {",
+      "rationale": "C2: the ratchet is scoped to CostClass.HEAVY. Dropping the conjunct caps MEDIUM and LIGHT datasets too, narrowing every incremental window in the fleet.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M2-open-start-guard",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "if mode != SyncModeIncremental || costClass != heavyCostClass || start == nil {",
+      "replace": "if mode != SyncModeIncremental || costClass != heavyCostClass {",
+      "rationale": "C5: a WatermarkBehavior.NONE dataset keeps an open start and is never capped. This is the blind spot that let a deletion mutation SURVIVE on the Python side until a forced HEAVY+NONE case was added; the Go forced case is TestHeavyRatchetNeverCapsAnOpenStartWindow.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestHeavyRatchet(NeverCapsAnOpenStartWindow|OpenStartSurvivesTheWholePlanner)$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M3-cap-is-a-min-not-an-assignment",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "\tcapped := start.UTC().Add(effectiveHeavyMaxWindow(overlap))\n\tif capped.Before(end) {\n\t\treturn capped\n\t}\n\treturn end",
+      "replace": "\treturn start.UTC().Add(effectiveHeavyMaxWindow(overlap))",
+      "rationale": "C4: window_end = min(requested_before_or_now, window_start + cap). An assignment WIDENS the window whenever the watermark is already inside the cap or a tighter `before` was requested.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M4-cap-default-off-by-one",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "defaultIncrementalHeavyMaxWindowDays = 7",
+      "replace": "defaultIncrementalHeavyMaxWindowDays = 8",
+      "rationale": "C1: the default cap is 7 days, matching the proven backfill chunk size. An off-by-one silently changes every capped window's end.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M5-full-resync-must-stay-uncapped",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "if mode != SyncModeIncremental || costClass != heavyCostClass || start == nil {",
+      "replace": "if costClass != heavyCostClass || start == nil {",
+      "rationale": "C9: a FULL_RESYNC has no next tick, so a capped window would cover only the cap's span and finalize SUCCESS -- claiming a resync that did not happen.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M6-window-end-clamped-to-now",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "\tif end.After(now) {\n\t\tend = now\n\t}",
+      "replace": "\tif false {\n\t\tend = now\n\t}",
+      "rationale": "C11 first rule: a future requested `before` would persist a FUTURE watermark on success, and the next run would start in the future and skip everything up to it.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M7-empty-or-inverted-window-plans-nothing",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "\tif !end.After(resolved) {\n\t\treturn nil, time.Time{}, false\n\t}",
+      "replace": "\tif false {\n\t\treturn nil, time.Time{}, false\n\t}",
+      "rationale": "C11 third rule: an inverted unit is admitted at the CHEAPEST possible cost (window_span_days floors a negative span to 1), fetches nothing, and finalizes SUCCESS -- a false coverage claim.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M8-future-watermark-self-heal",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "\tif resolved.After(now) {\n\t\trecovery := futureWatermarkRecoveryWindow",
+      "replace": "\tif false {\n\t\trecovery := futureWatermarkRecoveryWindow",
+      "rationale": "C10(a): without the planner-side heal a corrupt future watermark plans zero units forever, the run finalizes FAILED, and nothing is left to re-stamp a sane value.",
+      "proof": [
+        [
+          "env",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLES=1",
+          "DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildScheduledPlanMatchesLivePythonPlanner$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M9-cap-must-exceed-overlap",
+      "file": "internal/scheduler/sync/planner.go",
+      "find": "\tif minCapDays <= int64(capDays) {\n\t\treturn capWindow\n\t}",
+      "replace": "\tif true {\n\t\treturn capWindow\n\t}",
+      "rationale": "C8: a cap <= overlap ends at or before the watermark it started from, the monotonic write discards it, and the ratchet stalls while every run reports SUCCESS.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestEffectiveHeavyMaxWindowClampsToExceedTheOverlap|TestClampedCapStillAdvancesTheWatermark)$",
+          "./internal/scheduler/sync/"
+        ]
+      ]
+    },
+    {
+      "id": "M10-success-clears-budget-deferrals",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    budget_deferrals = 0,\n    budget_first_deferred_at = NULL,\n    first_blocked_at = NULL,",
+      "replace": "    budget_first_deferred_at = NULL,\n    first_blocked_at = NULL,",
+      "rationale": "Obligation #1: SUCCESS must end the BUDGET episode. A surviving counter lets the unit's next budget deferral be judged on a resolved episode's count.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompleteUnitSQLClearsEveryEpisodeColumn$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M11-success-clears-the-aggregate-clock",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    budget_first_deferred_at = NULL,\n    first_blocked_at = NULL,",
+      "replace": "    budget_first_deferred_at = NULL,",
+      "rationale": "Obligation #1: SUCCESS stops the AGGREGATE blocked clock. A unit that got through is not going nowhere, and a surviving first_blocked_at feeds the 24h cross-episode bound.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompleteUnitSQLClearsEveryEpisodeColumn$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M12-lease-repair-clears-budget-deferrals",
+      "file": "internal/syncreconciler/lease_repair.go",
+      "find": "\tbudget_deferrals = 0,\n\tbudget_first_deferred_at = NULL,",
+      "replace": "\tbudget_first_deferred_at = NULL,",
+      "rationale": "Obligation #1: an expired lease is not a budget episode. Before CHAOS-3427 this stamp cleared only the rate-limit pair, which is the exact half-wiring the ticket exists to close.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestExpiredLeaseRetryStampClearsEveryEpisodeColumn$",
+          "./internal/syncreconciler/"
+        ]
+      ]
+    },
+    {
+      "id": "M13-release-for-retry-must-overwrite-the-category",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "      COALESCE(unit.result::jsonb, '{}'::jsonb) ||\n      jsonb_build_object('error_category', 'provider_unit_retryable')",
+      "replace": "      jsonb_build_object('error_category', 'provider_unit_retryable') ||\n      COALESCE(unit.result::jsonb, '{}'::jsonb)",
+      "rationale": "Obligation #2 (FORBIDDEN PATTERN): jsonb || resolves duplicate keys in favour of its RIGHT operand, so this flip PRESERVES the prior error_category. A preserved 'budget_deferred' makes stale budget counters terminalization-eligible and fails healthy units.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNoUnitStampPreservesAPriorErrorCategory$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M14-watermark-coverage-ceiling",
+      "file": "internal/providersync/watermark_write_boundary.go",
+      "find": "\t\tif upper.Before(ceiling) {\n\t\t\tceiling, bound = upper, \"window_end\"\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\tceiling, bound = upper, \"window_end\"\n\t\t}",
+      "rationale": "C10(c): the window_end ceiling. Such an overclaim is usually in the PAST, so the `now` ceiling does not catch it and the next run silently skips every record in between.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeWatermarkWriteClampsToBothCeilings$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M15-every-writer-routes-through-the-boundary",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "\t\t\t\tnormalized, completedAt.UTC(),",
+      "replace": "\t\t\t\twatermark.UTC(), completedAt.UTC(),",
+      "rationale": "C10(c): enforcing the boundary at call sites is what CHAOS-3412 got wrong twice. This bypasses the normalizer while leaving it defined, which is precisely the shape the derivation test exists to catch.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEveryWatermarkWriteRoutesThroughTheNormalizer$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M16-corrupt-future-watermark-heal-in-sql",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "SET last_synced_at = CASE\n        WHEN public.sync_watermarks.last_synced_at > $6::timestamptz\n         AND EXCLUDED.last_synced_at <= $6::timestamptz\n        THEN EXCLUDED.last_synced_at\n        ELSE GREATEST(\n            public.sync_watermarks.last_synced_at,\n            EXCLUDED.last_synced_at\n        )\n    END,",
+      "replace": "SET last_synced_at = GREATEST(\n        public.sync_watermarks.last_synced_at,\n        EXCLUDED.last_synced_at\n    ),",
+      "rationale": "C10(b): without the narrow future exception the healing re-stamp is discarded by the monotonic write and every tick re-syncs a recovery window forever. C10(a) and C10(b) only work together.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestUpsertWatermarkSQLHealsOnlyProvablyCorruptFutureValues$",
+          "./internal/providersync/"
+        ]
+      ]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
+++ b/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
@@ -113,8 +113,18 @@ def _install_budget_guard_imports() -> None:
         if not hasattr(models, name):
             setattr(models, name, type(name, (), {}))
 
-    _stub("sqlalchemy", func=_unreachable, or_=_unreachable, text=_unreachable, update=_unreachable)
-    _stub("dev_health_ops.sync.budget", BudgetEstimate=object, estimate_provider_budget=_unreachable)
+    _stub(
+        "sqlalchemy",
+        func=_unreachable,
+        or_=_unreachable,
+        text=_unreachable,
+        update=_unreachable,
+    )
+    _stub(
+        "dev_health_ops.sync.budget",
+        BudgetEstimate=object,
+        estimate_provider_budget=_unreachable,
+    )
     _stub(
         "dev_health_ops.workers.rate_limit_defer",
         RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS=60,

--- a/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
+++ b/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
@@ -37,6 +37,18 @@ TWO CLAUSES IT PINS, BOTH LOAD-BEARING FOR THE GO SIDE:
      produces through this predicate, so the two halves are measured
      together rather than asserted separately and hoped about.
 
+WHAT THIS PAIR IS NOT. It is a PREDICATE-parity check, not a state-machine
+oracle. The Go side of the comparison is a hand-written mirror of this
+predicate (``budgetDeferralExhausted`` in
+internal/providersync/syncunit_budget_exhaustion_oracle_test.go), because Go
+owns no budget-admission decision to drive -- its only budget references in
+non-test source are the two SQL clears. Nothing here executes a Go producer
+or reaches a database. The Go stamps' effect on the columns this predicate
+reads is covered by the SQL-string guards and, against real PostgreSQL, by
+internal/providersync/budget_episode_integration_test.go and
+internal/syncreconciler/lease_repair_integration_test.go; the Go test's
+doc comment enumerates that split.
+
 REQUIREMENT, not a caveat: any Go test exercising this pair MUST run with
 ``go test -count=1`` (i.e. through ``ci/check_go.sh live-python-oracles``).
 budget_guard.py lives outside internal/providersync/testdata/, so
@@ -46,6 +58,7 @@ cached PASS for a real regression in the live function.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import pathlib
 import sys
@@ -65,11 +78,105 @@ from internal.providersync.testdata.oracle_pairs._github_work_items_helpers impo
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 _BUDGET_GUARD_SOURCE = REPO_ROOT / "src/dev_health_ops/sync/budget_guard.py"
+_MODELS_PACKAGE_INIT = REPO_ROOT / "src/dev_health_ops/models/__init__.py"
 _THIS_FILE = pathlib.Path(__file__)
+
+#: The names budget_guard.py imports off ``dev_health_ops.models`` itself and
+#: that _install_budget_guard_imports substitutes placeholders for. Every one
+#: is checked against the real package before any placeholder is installed --
+#: see _assert_models_still_export.
+_PLACEHOLDER_MODEL_EXPORTS = (
+    "ProviderRateLimitObservation",
+    "SyncRunUnit",
+    "SyncRunUnitStatus",
+)
 
 #: The instant every case is evaluated at. Fixed so the wall-clock cap is a
 #: function of the case's own offset and nothing else.
 _NOW = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def _module_level_bindings(source: str) -> frozenset[str]:
+    """Every name ``source`` binds at module level, by AST rather than import.
+
+    Reading the source is the point: importing ``dev_health_ops.models`` for
+    real would drag in SQLAlchemy's declarative machinery, which is exactly
+    what the placeholders exist to avoid. ``ast`` answers "does this name
+    still exist" under the same stock interpreter everything else in this
+    directory runs under.
+
+    Descends into ``if``/``try`` bodies (a conditional or optional-dependency
+    import still binds the name) but NOT into functions or classes, whose
+    locals are not module attributes.
+    """
+
+    def collect(body: list[ast.stmt], bound: set[str]) -> None:
+        for node in body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    if alias.name == "*":
+                        continue
+                    bound.add(alias.asname or alias.name.split(".")[0])
+            elif isinstance(
+                node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                bound.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        bound.add(target.id)
+            elif isinstance(node, ast.AnnAssign):
+                if isinstance(node.target, ast.Name):
+                    bound.add(node.target.id)
+            elif isinstance(node, ast.If):
+                collect(node.body, bound)
+                collect(node.orelse, bound)
+            elif isinstance(node, ast.Try):
+                collect(node.body, bound)
+                for handler in node.handlers:
+                    collect(handler.body, bound)
+                collect(node.orelse, bound)
+                collect(node.finalbody, bound)
+
+    bound: set[str] = set()
+    collect(ast.parse(source).body, bound)
+    return frozenset(bound)
+
+
+def _assert_models_still_export(names: tuple[str, ...]) -> None:
+    """Fail loudly if ``dev_health_ops.models`` no longer exports ``names``.
+
+    WHY THIS PROBE EXISTS. ``install_minimal_oracle_imports`` registers
+    ``dev_health_ops.models`` as a namespace package whose ``__path__`` points
+    at the real directory -- which means the package's ``__init__.py`` is
+    never executed, and the placeholder attributes installed below satisfy
+    budget_guard.py's ``from dev_health_ops.models import (...)`` whatever the
+    real package does or does not export. A rename or removal of any of these
+    three would break production import and leave this oracle green: the
+    placeholder IS the drift mask.
+
+    So the export set is verified against the real source before any
+    placeholder is installed. A probe that cannot read that source is itself
+    a failure -- an unmeasured check must not read as a passing one.
+    """
+    if not _MODELS_PACKAGE_INIT.is_file():
+        raise RuntimeError(
+            f"cannot verify model exports: {_MODELS_PACKAGE_INIT} does not "
+            "exist. The placeholders installed below would silently satisfy "
+            "budget_guard.py's imports against a package that has moved."
+        )
+    exported = _module_level_bindings(_MODELS_PACKAGE_INIT.read_text())
+    missing = [name for name in names if name not in exported]
+    if missing:
+        raise RuntimeError(
+            "dev_health_ops.models no longer exports "
+            f"{', '.join(missing)} ({_MODELS_PACKAGE_INIT}). budget_guard.py "
+            "imports these off the package itself, so production import is "
+            "broken -- but this oracle installs placeholders for exactly "
+            "these names and would otherwise stay green. Update "
+            "_PLACEHOLDER_MODEL_EXPORTS together with budget_guard.py's "
+            "import list; do NOT delete this probe to make the oracle pass."
+        )
 
 
 def _stub(name: str, **values: object) -> None:
@@ -108,8 +215,12 @@ def _install_budget_guard_imports() -> None:
     # itself. They are ORM/enum types used only for annotations and for code
     # paths the predicate never enters, so placeholders keep the import
     # satisfiable without pulling in SQLAlchemy's declarative machinery.
+    #
+    # The placeholders are also a DRIFT MASK, so the real package's export
+    # set is probed first and a rename or removal fails the oracle loudly.
+    _assert_models_still_export(_PLACEHOLDER_MODEL_EXPORTS)
     models = sys.modules["dev_health_ops.models"]
-    for name in ("ProviderRateLimitObservation", "SyncRunUnit", "SyncRunUnitStatus"):
+    for name in _PLACEHOLDER_MODEL_EXPORTS:
         if not hasattr(models, name):
             setattr(models, name, type(name, (), {}))
 

--- a/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
+++ b/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
@@ -1,0 +1,184 @@
+"""sync-unit budget-deferral EXHAUSTION oracle pair (CHAOS-3427).
+
+Registers "syncunit/budget/exhaustion": given one unit's budget episode
+state -- ``budget_deferrals``, ``budget_first_deferred_at`` and the most
+recently recorded ``result.error_category`` -- decide whether
+``sync/budget_guard.py::_budget_deferral_exhausted`` would terminalize it.
+
+WHY THIS PAIR EXISTS. The sync-unit state machine had ZERO oracle coverage
+before this: 55 pairs, none touching it. That matters more than it sounds,
+because the Go worker and the Python guard SHARE the ``sync_run_units`` row
+and each writes columns the other reads. CHAOS-3412 landed the exhaustion
+path in Python only; Go writes non-terminal stamps that must leave the
+episode columns in a state this predicate reads correctly. Nothing forced
+the two readings to agree until now.
+
+WHAT IS LIVE. ``_budget_deferral_exhausted`` itself -- the real, unmodified
+function from src/dev_health_ops/sync/budget_guard.py -- runs here. Only
+budget_guard's module-level IMPORTS are stubbed (see
+``_install_budget_guard_imports``), and none of them participate in the
+predicate: it reads three attributes off the unit, two env-backed caps, and
+one frozenset of accepted categories. Editing the predicate changes what
+this oracle observes, with no separate pin to keep in sync.
+
+TWO CLAUSES IT PINS, BOTH LOAD-BEARING FOR THE GO SIDE:
+
+  1. A unit with NO budget history (deferrals 0 and no first-deferred stamp)
+     is never exhausted. This is what makes Go's episode CLEARS
+     (completeUnitSQL, markExpiredLeaseRetryingSQL) sufficient: a cleared
+     unit cannot be terminalized on a resolved episode's counters.
+
+  2. The DEFENCE-IN-DEPTH category gate. Stale nonzero counters carrying a
+     NON-budget ``error_category`` are refused. That is precisely what makes
+     Go's existing stamps safe today -- both OVERWRITE the category with
+     their own cause -- and it is why a Go stamp that PRESERVED a prior
+     category is a forbidden pattern rather than a style choice. The
+     ``go_stamp_*`` cases below feed the exact post-stamp states Go's SQL
+     produces through this predicate, so the two halves are measured
+     together rather than asserted separately and hoped about.
+
+REQUIREMENT, not a caveat: any Go test exercising this pair MUST run with
+``go test -count=1`` (i.e. through ``ci/check_go.sh live-python-oracles``).
+budget_guard.py lives outside internal/providersync/testdata/, so
+``//go:embed`` cannot reach it and a bare ``go test`` can return a stale
+cached PASS for a real regression in the live function.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_BUDGET_GUARD_SOURCE = REPO_ROOT / "src/dev_health_ops/sync/budget_guard.py"
+_THIS_FILE = pathlib.Path(__file__)
+
+#: The instant every case is evaluated at. Fixed so the wall-clock cap is a
+#: function of the case's own offset and nothing else.
+_NOW = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def _stub(name: str, **values: object) -> None:
+    if name in sys.modules:
+        return
+    module = types.ModuleType(name)
+    for key, value in values.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+
+
+def _install_budget_guard_imports() -> None:
+    """Satisfy budget_guard.py's module-level imports without dragging in
+    SQLAlchemy, Celery bootstrap or the provider budget estimators.
+
+    The hosted go-quality image is a no-deps Python: standard library plus
+    the handful of packages provider code uses directly. budget_guard.py
+    imports ``sqlalchemy`` and two worker modules at module level purely for
+    code paths the exhaustion predicate never touches, so stubbing them is
+    what lets the REAL predicate run there. Nothing stubbed here is reachable
+    from ``_budget_deferral_exhausted``; if that ever stops being true the
+    stub raises rather than silently returning a plausible value.
+    """
+    install_minimal_oracle_imports()
+
+    def _unreachable(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError(
+            "the budget exhaustion oracle reached a stubbed dependency; the "
+            "predicate under test must not depend on SQLAlchemy or the worker "
+            "bootstrap. Re-check what changed before trusting this oracle."
+        )
+
+    # install_minimal_oracle_imports gives dev_health_ops.models a real
+    # namespace __path__ (so SUBMODULE imports stay live) but no aggregate
+    # attributes, and budget_guard imports three names off the package
+    # itself. They are ORM/enum types used only for annotations and for code
+    # paths the predicate never enters, so placeholders keep the import
+    # satisfiable without pulling in SQLAlchemy's declarative machinery.
+    models = sys.modules["dev_health_ops.models"]
+    for name in ("ProviderRateLimitObservation", "SyncRunUnit", "SyncRunUnitStatus"):
+        if not hasattr(models, name):
+            setattr(models, name, type(name, (), {}))
+
+    _stub("sqlalchemy", func=_unreachable, or_=_unreachable, text=_unreachable, update=_unreachable)
+    _stub("dev_health_ops.sync.budget", BudgetEstimate=object, estimate_provider_budget=_unreachable)
+    _stub(
+        "dev_health_ops.workers.rate_limit_defer",
+        RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS=60,
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS=3600,
+        plan_rate_limit_deferral=_unreachable,
+    )
+    _stub("dev_health_ops.workers.sync_bootstrap", SyncTaskBootstrap=object)
+
+
+def _load_budget_guard() -> Any:
+    if "dev_health_ops.sync.budget_guard" in sys.modules:
+        return sys.modules["dev_health_ops.sync.budget_guard"]
+    _install_budget_guard_imports()
+    spec = importlib.util.spec_from_file_location(
+        "dev_health_ops.sync.budget_guard", _BUDGET_GUARD_SOURCE
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {_BUDGET_GUARD_SOURCE}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    origin = pathlib.Path(module.__file__ or "").resolve(strict=True)
+    if origin != _BUDGET_GUARD_SOURCE.resolve(strict=True):
+        raise RuntimeError(f"oracle imported {origin}, expected {_BUDGET_GUARD_SOURCE}")
+    return module
+
+
+def _decide(case: dict[str, Any]) -> dict[str, Any]:
+    budget_guard = _load_budget_guard()
+
+    first_deferred_at = None
+    offset = case.get("first_deferred_seconds_ago")
+    if offset is not None:
+        first_deferred_at = _NOW - timedelta(seconds=int(offset))
+    result: dict[str, Any] | None = None
+    category = case.get("error_category")
+    if category is not None:
+        # The whole document, not just the category: Go's release-for-retry
+        # merges into the existing result, so the predicate must keep reading
+        # the CURRENT category out of a document that carries other keys.
+        result = {"error_category": category, "go_effect_ledger_v1": {"kept": True}}
+
+    unit = SimpleNamespace(
+        budget_deferrals=case["budget_deferrals"],
+        budget_first_deferred_at=first_deferred_at,
+        result=result,
+    )
+    return {
+        "exhausted": bool(budget_guard._budget_deferral_exhausted(unit, now=_NOW)),
+    }
+
+
+def _reflected_fields() -> frozenset[str]:
+    """The complete field set _decide's own return literal can emit. Derived
+    from this file's AST rather than hand-listed, so a field added to the
+    decision cannot be silently left out of the comparison."""
+    return dict_literal_keys(_THIS_FILE.read_text(), "_decide", (RETURN_LITERAL,))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="syncunit/budget/exhaustion",
+        build_row=_decide,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/watermark_write_boundary.go
+++ b/internal/providersync/watermark_write_boundary.go
@@ -1,0 +1,79 @@
+package providersync
+
+import (
+	"log/slog"
+	"time"
+)
+
+// futureWatermarkWriteSkewTolerance mirrors Python's
+// _FUTURE_WRITE_SKEW_TOLERANCE_SECONDS (src/dev_health_ops/sync/watermarks.py):
+// clocks routinely drift by seconds, so a clamp inside this tolerance is
+// silent and anything beyond it is warned about.
+const futureWatermarkWriteSkewTolerance = 60 * time.Second
+
+// normalizeWatermarkWrite is THE write-boundary normalizer for every Go
+// watermark write. It is the exact mirror of Python's
+// `_normalize_watermark_write` (CHAOS-3412 clause C10(c)).
+//
+// A watermark is a COVERAGE CLAIM -- it asserts "everything up to here has
+// been read" -- so it has TWO ceilings, and BOTH are required:
+//
+//  1. now. A watermark can never sit in the future whatever a provider
+//     reports. Several Go routes prefer a provider-derived watermark over the
+//     claim's window end (github_prs_route.go, gitlab_incidents_route.go,
+//     jira_incidents_route.go, launchdarkly_route.go, native_rest.go), so a
+//     single skewed source record would otherwise write a future watermark
+//     past every planner-side clamp -- and because the stored value is then
+//     monotonically defended, nothing could ever lower it again.
+//
+//  2. coverageUpperBound -- the unit's window END (Claim.BeforeAt). The unit
+//     only fetched up to its window end, so a stamp beyond that claims data it
+//     never read. Such a value is usually in the PAST, so the now ceiling does
+//     NOT catch it: the next run starts after the overclaimed point and every
+//     record in between is silently skipped forever. Python measured real gaps
+//     of ~5h that a 60s overlap masked.
+//
+// Enforcing this at each call site is what CHAOS-3412 got wrong twice on the
+// Python side. It lives HERE, at the one write API, so a route cannot opt out,
+// and watermark_write_boundary_test.go DERIVES the writer set from this
+// package's source rather than trusting a hand-maintained list.
+func normalizeWatermarkWrite(
+	incoming time.Time,
+	coverageUpperBound *time.Time,
+	now time.Time,
+	orgID, sourceID, datasetKey string,
+) time.Time {
+	logger := slog.Default()
+	value := incoming.UTC()
+	ceiling := now.UTC()
+	bound := "now"
+	if coverageUpperBound != nil {
+		upper := coverageUpperBound.UTC()
+		if upper.Before(ceiling) {
+			ceiling, bound = upper, "window_end"
+		}
+	}
+	if !value.After(ceiling) {
+		return value
+	}
+	overshoot := value.Sub(ceiling)
+	if overshoot > futureWatermarkWriteSkewTolerance && logger != nil {
+		logger.Warn(
+			"sync.watermark.write_clamped",
+			slog.String("org_id", orgID),
+			slog.String("source_id", sourceID),
+			slog.String("dataset_key", datasetKey),
+			slog.String("requested_last_synced_at", value.Format(time.RFC3339Nano)),
+			slog.String("clamped_to", ceiling.Format(time.RFC3339Nano)),
+			slog.String("ceiling", bound),
+			slog.Float64("overshoot_seconds", overshoot.Seconds()),
+			slog.String("reason",
+				"a watermark claims every record up to it has been read. "+
+					"Clamping to the highest point actually covered. A window_end "+
+					"clamp means a provider reported coverage beyond what the unit "+
+					"fetched; a now clamp usually means a source record carried a "+
+					"skewed timestamp."),
+		)
+	}
+	return ceiling
+}

--- a/internal/providersync/watermark_write_boundary_test.go
+++ b/internal/providersync/watermark_write_boundary_test.go
@@ -1,0 +1,140 @@
+package providersync
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeWatermarkWriteClampsToBothCeilings(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	windowEnd := now.Add(-6 * time.Hour)
+	for _, test := range []struct {
+		name     string
+		incoming time.Time
+		bound    *time.Time
+		want     time.Time
+	}{
+		{
+			name:     "a value inside both ceilings is untouched",
+			incoming: windowEnd.Add(-time.Minute),
+			bound:    &windowEnd,
+			want:     windowEnd.Add(-time.Minute),
+		},
+		{
+			// The window_end ceiling. This value is in the PAST, so the `now`
+			// ceiling alone would let it through -- and the next run would then
+			// start after data the unit never fetched. Python measured real
+			// ~5h gaps masked by a 60s overlap exactly here.
+			name:     "a value past the window end clamps to the window end",
+			incoming: now.Add(-time.Hour),
+			bound:    &windowEnd,
+			want:     windowEnd,
+		},
+		{
+			name:     "a future value clamps to now when there is no window end",
+			incoming: now.Add(72 * time.Hour),
+			bound:    nil,
+			want:     now,
+		},
+		{
+			// Both ceilings apply; the tighter one wins.
+			name:     "a future value clamps to the window end when that is tighter",
+			incoming: now.Add(72 * time.Hour),
+			bound:    &windowEnd,
+			want:     windowEnd,
+		},
+		{
+			name:     "a window end in the future does not raise the now ceiling",
+			incoming: now.Add(48 * time.Hour),
+			bound:    ptrTime(now.Add(96 * time.Hour)),
+			want:     now,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeWatermarkWrite(test.incoming, test.bound, now, "org", "src", "commits")
+			if !got.Equal(test.want) {
+				t.Fatalf("normalizeWatermarkWrite = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }
+
+// TestEveryWatermarkWriteRoutesThroughTheNormalizer is clause C10(c)'s
+// coverage obligation, and it is DERIVED rather than hand-listed on purpose.
+//
+// Python's lane closed this class twice and got it wrong the first time
+// exactly by hand-enumerating writers: a second writer sat outside the
+// boundary while the class was reported closed. So this test parses this
+// package's own source, finds every call that executes upsertWatermarkSQL,
+// and requires each one to be preceded by a normalizeWatermarkWrite call in
+// the same function -- with a vacuity guard, because a derivation that finds
+// nothing must FAIL rather than read as "all writers are compliant".
+//
+// The AST walk is scoped to non-test files: a test may legitimately write a
+// deliberately-corrupt row directly to seed the state the boundary exists to
+// correct (see the CHAOS-3412 note about tests that go vacuous once the
+// boundary works and must therefore bypass the public API).
+func TestEveryWatermarkWriteRoutesThroughTheNormalizer(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileSet := token.NewFileSet()
+	writers := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fileSet, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			executes, normalizes := false, false
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				identifier, ok := node.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				switch identifier.Name {
+				case "upsertWatermarkSQL":
+					executes = true
+				case "normalizeWatermarkWrite":
+					normalizes = true
+				}
+				return true
+			})
+			if !executes {
+				continue
+			}
+			writers++
+			if !normalizes {
+				t.Errorf("%s: %s executes upsertWatermarkSQL without routing the "+
+					"value through normalizeWatermarkWrite. A bypassing writer "+
+					"poisons every dataset that reads through a shared or "+
+					"fallback watermark row.", name, function.Name.Name)
+			}
+		}
+	}
+	// VACUITY GUARD: the derivation above is only evidence if it found the
+	// writer it was supposed to find. Zero writers means the SQL constant was
+	// renamed, or this walk stopped matching -- either way the test proves
+	// nothing and must say so.
+	if writers == 0 {
+		t.Fatal("derivation found no watermark writers at all; this guard is " +
+			"vacuous and cannot have measured the write boundary")
+	}
+}

--- a/internal/providersync/watermark_write_boundary_test.go
+++ b/internal/providersync/watermark_write_boundary_test.go
@@ -67,16 +67,151 @@ func TestNormalizeWatermarkWriteClampsToBothCeilings(t *testing.T) {
 
 func ptrTime(value time.Time) *time.Time { return &value }
 
+// TestNormalizeWatermarkWriteReturnsUTC pins the REPRESENTATION half of the
+// boundary, which the table above cannot see: time.Time comparisons are
+// instant-based, so dropping the `.UTC()` normalization changes no verdict and
+// no stored timestamptz, and every case there would still pass.
+//
+// What it does change is what the value PRINTS as. The clamp warning formats
+// both the requested and the clamped value with RFC3339Nano, and the
+// normalizer is the one place a provider-supplied timestamp -- which arrives
+// in whatever zone the provider's API used -- crosses into this repository's
+// watermark path. A boundary that emitted mixed offsets would make the one
+// diagnostic that explains a silent coverage gap unreadable, and it would
+// diverge from Python's `_normalize_watermark_write`, which returns UTC.
+func TestNormalizeWatermarkWriteReturnsUTC(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	elsewhere := time.FixedZone("UTC+5:30", 5*3600+1800)
+	windowEnd := now.Add(-6 * time.Hour).In(elsewhere)
+	for _, test := range []struct {
+		name     string
+		incoming time.Time
+		bound    *time.Time
+	}{
+		{
+			name:     "an unclamped value is returned in UTC",
+			incoming: now.Add(-time.Hour).In(elsewhere),
+			bound:    nil,
+		},
+		{
+			name:     "a value clamped to now is returned in UTC",
+			incoming: now.Add(72 * time.Hour).In(elsewhere),
+			bound:    nil,
+		},
+		{
+			name:     "a value clamped to a non-UTC window end is returned in UTC",
+			incoming: now.Add(-time.Hour).In(elsewhere),
+			bound:    &windowEnd,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeWatermarkWrite(test.incoming, test.bound, now, "org", "src", "commits")
+			if got.Location() != time.UTC {
+				t.Fatalf("normalizeWatermarkWrite returned %s (location %s), want UTC",
+					got.Format(time.RFC3339Nano), got.Location())
+			}
+		})
+	}
+}
+
+const (
+	watermarkSQLName        = "upsertWatermarkSQL"
+	watermarkNormalizerName = "normalizeWatermarkWrite"
+)
+
+// callsTheNormalizer reports whether an expression's subtree contains a direct
+// call to normalizeWatermarkWrite.
+func callsTheNormalizer(node ast.Node) bool {
+	found := false
+	ast.Inspect(node, func(inner ast.Node) bool {
+		call, ok := inner.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if identifier, ok := call.Fun.(*ast.Ident); ok &&
+			identifier.Name == watermarkNormalizerName {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// normalizerDerivedNames returns the local identifiers in one function body
+// whose value came out of normalizeWatermarkWrite. This is the dataflow half:
+// the production writer passes `normalized`, not the call itself, so a
+// call-site check that only looked for a literal call expression would report
+// the compliant writer as a bypass.
+func normalizerDerivedNames(body *ast.BlockStmt) map[string]bool {
+	derived := map[string]bool{}
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch statement := node.(type) {
+		case *ast.AssignStmt:
+			for index, target := range statement.Lhs {
+				identifier, ok := target.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				var value ast.Expr
+				switch {
+				case len(statement.Rhs) == len(statement.Lhs):
+					value = statement.Rhs[index]
+				case len(statement.Rhs) == 1:
+					// `a, err := f(...)` -- any result of a normalizer call is
+					// treated as derived, which is the conservative direction.
+					value = statement.Rhs[0]
+				default:
+					continue
+				}
+				if callsTheNormalizer(value) {
+					derived[identifier.Name] = true
+				}
+			}
+		case *ast.ValueSpec:
+			for index, name := range statement.Names {
+				if index < len(statement.Values) && callsTheNormalizer(statement.Values[index]) {
+					derived[name.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return derived
+}
+
+// carriesANormalizedValue reports whether an argument expression is, or is
+// built from, a normalizeWatermarkWrite result.
+func carriesANormalizedValue(argument ast.Expr, derived map[string]bool) bool {
+	if callsTheNormalizer(argument) {
+		return true
+	}
+	found := false
+	ast.Inspect(argument, func(node ast.Node) bool {
+		if identifier, ok := node.(*ast.Ident); ok && derived[identifier.Name] {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
 // TestEveryWatermarkWriteRoutesThroughTheNormalizer is clause C10(c)'s
 // coverage obligation, and it is DERIVED rather than hand-listed on purpose.
 //
 // Python's lane closed this class twice and got it wrong the first time
 // exactly by hand-enumerating writers: a second writer sat outside the
 // boundary while the class was reported closed. So this test parses this
-// package's own source, finds every call that executes upsertWatermarkSQL,
-// and requires each one to be preceded by a normalizeWatermarkWrite call in
-// the same function -- with a vacuity guard, because a derivation that finds
-// nothing must FAIL rather than read as "all writers are compliant".
+// package's own source, finds every CALL SITE that executes
+// upsertWatermarkSQL, and requires THAT SITE to be passed a value produced by
+// normalizeWatermarkWrite -- with a vacuity guard, because a derivation that
+// finds nothing must FAIL rather than read as "all writers are compliant".
+//
+// PER CALL SITE is the whole point, and it is what this guard originally got
+// wrong. Its first form asked only whether both names appeared SOMEWHERE in
+// the same function, so a function containing one compliant writer and one
+// bypassing writer -- the exact shape Python shipped -- passed it. That
+// weakened form was observed passing a planted second writer before this
+// version was written.
 //
 // The AST walk is scoped to non-test files: a test may legitimately write a
 // deliberately-corrupt row directly to seed the state the boundary exists to
@@ -88,7 +223,7 @@ func TestEveryWatermarkWriteRoutesThroughTheNormalizer(t *testing.T) {
 		t.Fatal(err)
 	}
 	fileSet := token.NewFileSet()
-	writers := 0
+	callSites := 0
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -103,38 +238,62 @@ func TestEveryWatermarkWriteRoutesThroughTheNormalizer(t *testing.T) {
 			if !ok || function.Body == nil {
 				continue
 			}
-			executes, normalizes := false, false
+			derived := normalizerDerivedNames(function.Body)
+			measured := map[*ast.Ident]bool{}
 			ast.Inspect(function.Body, func(node ast.Node) bool {
-				identifier, ok := node.(*ast.Ident)
+				call, ok := node.(*ast.CallExpr)
 				if !ok {
 					return true
 				}
-				switch identifier.Name {
-				case "upsertWatermarkSQL":
-					executes = true
-				case "normalizeWatermarkWrite":
-					normalizes = true
+				statement := -1
+				for index, argument := range call.Args {
+					identifier, ok := argument.(*ast.Ident)
+					if ok && identifier.Name == watermarkSQLName {
+						statement, measured[identifier] = index, true
+						break
+					}
 				}
+				if statement < 0 {
+					return true
+				}
+				callSites++
+				for index, argument := range call.Args {
+					if index != statement && carriesANormalizedValue(argument, derived) {
+						return true
+					}
+				}
+				t.Errorf("%s:%d: %s executes %s with no argument produced by %s. "+
+					"A bypassing writer poisons every dataset that reads through "+
+					"a shared or fallback watermark row -- and a sibling compliant "+
+					"writer in the same function does not cover it.",
+					name, fileSet.Position(call.Pos()).Line, function.Name.Name,
+					watermarkSQLName, watermarkNormalizerName)
 				return true
 			})
-			if !executes {
-				continue
-			}
-			writers++
-			if !normalizes {
-				t.Errorf("%s: %s executes upsertWatermarkSQL without routing the "+
-					"value through normalizeWatermarkWrite. A bypassing writer "+
-					"poisons every dataset that reads through a shared or "+
-					"fallback watermark row.", name, function.Name.Name)
-			}
+			// MEASUREMENT GUARD: a reference to the SQL constant that is not an
+			// argument of a call is a shape this derivation cannot judge (it is
+			// stored in a variable, wrapped by a helper, or interpolated). That
+			// is an unmeasured writer, and it must fail rather than be skipped.
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				identifier, ok := node.(*ast.Ident)
+				if !ok || identifier.Name != watermarkSQLName || measured[identifier] {
+					return true
+				}
+				t.Errorf("%s:%d: %s references %s outside a call's argument list; "+
+					"this derivation cannot tell what value that writer passes, so "+
+					"the write boundary is UNMEASURED here rather than clean.",
+					name, fileSet.Position(identifier.Pos()).Line,
+					function.Name.Name, watermarkSQLName)
+				return true
+			})
 		}
 	}
 	// VACUITY GUARD: the derivation above is only evidence if it found the
-	// writer it was supposed to find. Zero writers means the SQL constant was
-	// renamed, or this walk stopped matching -- either way the test proves
+	// writer it was supposed to find. Zero call sites means the SQL constant
+	// was renamed, or this walk stopped matching -- either way the test proves
 	// nothing and must say so.
-	if writers == 0 {
-		t.Fatal("derivation found no watermark writers at all; this guard is " +
-			"vacuous and cannot have measured the write boundary")
+	if callSites == 0 {
+		t.Fatal("derivation found no watermark write call sites at all; this " +
+			"guard is vacuous and cannot have measured the write boundary")
 	}
 }

--- a/internal/syncreconciler/lease_repair.go
+++ b/internal/syncreconciler/lease_repair.go
@@ -343,6 +343,24 @@ func leaseRepairBucketAdvisoryID(orgID, provider, costClass string) int64 {
 // tenancy predicates. This CAS complements the advisory locks: it remains
 // correct if a future caller reuses the write helper without the selector and
 // fails closed if ownership changes before the write.
+//
+// CHAOS-3427 episode symmetry: this is a non-terminal RETRYING stamp, so it
+// clears BOTH per-episode pairs -- rate-limit (CHAOS-2760) and budget
+// (CHAOS-3412) -- exactly as the Python analogue
+// (src/dev_health_ops/workers/sync_reconciler.py's RETRYING stamp) does. An
+// expired lease is neither a rate-limit episode nor a budget episode, so
+// leaving either pair set lets a resolved episode's counters decide a later
+// exhaustion.
+//
+// It deliberately does NOT touch `first_blocked_at`, matching Python: the
+// AGGREGATE clock is started (COALESCE) only by real DEFERRAL stamps and
+// cleared only by SUCCESS and the dispatch claim. Resetting it here would let
+// worker churn clear the outer bound the alternating-episode case depends on.
+//
+// The result document is rebuilt with jsonb_build_object, so 'error_category'
+// is OVERWRITTEN with 'worker_lost'. Never change this into a merge that keeps
+// the prior value -- see lease_repair_test.go's
+// TestNoLeaseRepairStampPreservesAPriorErrorCategory.
 const markExpiredLeaseRetryingSQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'retrying',
@@ -362,6 +380,8 @@ SET status = 'retrying',
 	retry_exhausted_at = NULL,
 	rate_limit_deferrals = 0,
 	rate_limit_first_seen_at = NULL,
+	budget_deferrals = 0,
+	budget_first_deferred_at = NULL,
 	updated_at = $3,
 	lease_owner = NULL,
 	lease_expires_at = NULL

--- a/internal/syncreconciler/lease_repair_integration_test.go
+++ b/internal/syncreconciler/lease_repair_integration_test.go
@@ -247,6 +247,9 @@ func createLeaseRepairIntegrationFixture(ctx context.Context, pool *pgxpool.Pool
 			available_at timestamptz,
 			rate_limit_deferrals integer NOT NULL DEFAULT 0,
 			rate_limit_first_seen_at timestamptz,
+			budget_deferrals integer NOT NULL DEFAULT 0,
+			budget_first_deferred_at timestamptz,
+			first_blocked_at timestamptz,
 			expired_lease_retry_count integer NOT NULL DEFAULT 0,
 			last_retry_reason text,
 			retry_exhausted_at timestamptz,
@@ -283,9 +286,10 @@ func seedLeaseRepairUnit(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO public.sync_run_units (
 			id, org_id, sync_run_id, provider, dataset_key, cost_class, mode, status,
-			rate_limit_deferrals, rate_limit_first_seen_at, expired_lease_retry_count,
-			lease_owner, lease_expires_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, 'standard', $6, 'running', 7, $7, $8, 'worker-a', $9, $7)`,
+			rate_limit_deferrals, rate_limit_first_seen_at,
+			budget_deferrals, budget_first_deferred_at, first_blocked_at,
+			expired_lease_retry_count, lease_owner, lease_expires_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, 'standard', $6, 'running', 7, $7, 4, $7, $7, $8, 'worker-a', $9, $7)`,
 		id, orgID, runID, provider, dataset, mode, expiresAt.Add(-time.Hour), retries, expiresAt); err != nil {
 		t.Fatal(err)
 	}
@@ -294,20 +298,26 @@ func seedLeaseRepairUnit(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 func assertLeaseRepairState(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id, wantStatus string, wantOwner *string, wantAvailable *time.Time, wantCategory string, wantExhausted bool, wantRetries int64) {
 	t.Helper()
 	var (
-		status      string
-		owner       *string
-		availableAt *time.Time
-		retries     int64
-		deferrals   int
-		firstSeen   *time.Time
-		exhaustedAt *time.Time
-		resultRaw   []byte
+		status          string
+		owner           *string
+		availableAt     *time.Time
+		retries         int64
+		deferrals       int
+		firstSeen       *time.Time
+		budgetDeferrals int
+		budgetFirstAt   *time.Time
+		firstBlockedAt  *time.Time
+		exhaustedAt     *time.Time
+		resultRaw       []byte
 	)
 	if err := pool.QueryRow(ctx, `
 		SELECT status, lease_owner, available_at, expired_lease_retry_count,
-			rate_limit_deferrals, rate_limit_first_seen_at, retry_exhausted_at, result
+			rate_limit_deferrals, rate_limit_first_seen_at,
+			budget_deferrals, budget_first_deferred_at, first_blocked_at,
+			retry_exhausted_at, result
 		FROM public.sync_run_units WHERE id = $1`, id).Scan(
-		&status, &owner, &availableAt, &retries, &deferrals, &firstSeen, &exhaustedAt, &resultRaw,
+		&status, &owner, &availableAt, &retries, &deferrals, &firstSeen,
+		&budgetDeferrals, &budgetFirstAt, &firstBlockedAt, &exhaustedAt, &resultRaw,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -316,6 +326,26 @@ func assertLeaseRepairState(t *testing.T, ctx context.Context, pool *pgxpool.Poo
 	}
 	if wantStatus == "retrying" && (deferrals != 0 || firstSeen != nil) {
 		t.Fatalf("retry unit %s retained rate-limit episode: deferrals=%d first_seen=%v", id, deferrals, firstSeen)
+	}
+	// CHAOS-3427: the REACHED STATE, read back from real PostgreSQL, not the
+	// SQL text. The seed deliberately plants budget_deferrals=4 with a
+	// first-deferred stamp, so a repair that forgot the budget pair leaves 4
+	// here and this fails. Asserting only the SQL string would pass with a
+	// statement PostgreSQL never actually applied.
+	if wantStatus == "retrying" && (budgetDeferrals != 0 || budgetFirstAt != nil) {
+		t.Fatalf("retry unit %s retained BUDGET episode: budget_deferrals=%d "+
+			"budget_first_deferred_at=%v -- a later budget deferral would then "+
+			"terminalize on a resolved episode's counters",
+			id, budgetDeferrals, budgetFirstAt)
+	}
+	// The AGGREGATE clock is deliberately NOT reset by lease repair: only
+	// deferral stamps start it, only SUCCESS and the dispatch claim clear it.
+	// The seed plants a value so "did not clear" is an observable fact rather
+	// than an untested assumption.
+	if wantStatus == "retrying" && firstBlockedAt == nil {
+		t.Fatalf("retry unit %s cleared first_blocked_at; lease repair must "+
+			"leave the aggregate blocked clock running or the alternating "+
+			"budget/rate-limit case loses its outer bound", id)
 	}
 	if wantExhausted && exhaustedAt == nil {
 		t.Fatalf("exhausted unit %s lacks retry_exhausted_at", id)

--- a/internal/syncreconciler/lease_repair_sql_test.go
+++ b/internal/syncreconciler/lease_repair_sql_test.go
@@ -1,9 +1,10 @@
 package syncreconciler
 
 import (
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/sqlshape"
 )
 
 // TestExpiredLeaseRetryStampClearsEveryEpisodeColumn pins the lease-repair
@@ -48,17 +49,15 @@ func TestExpiredLeaseRetryStampLeavesTheAggregateClockAlone(t *testing.T) {
 	}
 }
 
-// preservingErrorCategory mirrors the detector in
-// internal/providersync/repository_postgres_sql_test.go; see its comment for
-// why the two forbidden shapes are what they are. It is duplicated rather than
-// exported because both copies are test-only and a shared production helper
-// for a test-only rule would be worse.
+// preservingErrorCategory is the SAME detector internal/providersync uses --
+// sqlshape.PreservesPriorResultCategory -- not a second copy of it. The two
+// hand-copied regexps this replaced shared one false negative: they spanned
+// jsonb_build_object's argument list with `[^)]*`, which stops at the first
+// nested `)`, and BOTH stamps in this file nest `to_jsonb(...)` calls. A
+// preserving merge written on these statements therefore read as clean, and
+// fixing one copy would have left the other silently wrong.
 func preservingErrorCategory(sql string) bool {
-	if regexp.MustCompile(`result\s*->>?\s*'error_category'`).MatchString(sql) {
-		return true
-	}
-	return regexp.MustCompile(`jsonb_build_object\([^)]*\)\s*\|\|\s*COALESCE\(\s*\w+\.result`).
-		MatchString(sql)
+	return sqlshape.PreservesPriorResultCategory(sql)
 }
 
 // TestNoLeaseRepairStampPreservesAPriorErrorCategory is the FORBIDDEN PATTERN
@@ -92,15 +91,50 @@ func TestNoLeaseRepairStampPreservesAPriorErrorCategory(t *testing.T) {
 // control -- without it the guard above would pass identically with a detector
 // that always returned false.
 func TestPreservingErrorCategoryDetectorIsNotVacuous(t *testing.T) {
-	preserving := `
-		SET result = jsonb_build_object(
-			'error_category',
-			COALESCE(unit.result->>'error_category', 'worker_lost')
-		)`
-	if !preservingErrorCategory(preserving) {
-		t.Fatalf("detector missed a preserving stamp:\n%s", preserving)
+	for name, preserving := range map[string]string{
+		"reads the prior value back": `
+			SET result = jsonb_build_object(
+				'error_category',
+				COALESCE(unit.result->>'error_category', 'worker_lost')
+			)`,
+		// THIS package's stamp shape, merged in the preserving direction. The
+		// nested to_jsonb() calls are the point: the regexp detector this
+		// replaced scanned the build_object's arguments with `[^)]*`, stopped
+		// at `to_jsonb(`'s closing paren, never reached the `||`, and passed
+		// this construct as clean.
+		"existing document wins a merge whose build_object nests calls": `
+			SET result = (
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'retry_count', unit.expired_lease_retry_count + 1,
+					'next_retry_at', to_jsonb($4::timestamptz),
+					'last_lease_expired_at', to_jsonb($3::timestamptz)
+				) || COALESCE(unit.result::jsonb, '{}'::jsonb)
+			)`,
+		"bare prior document on the right of the merge": `
+			SET result = jsonb_build_object('error_category', 'worker_lost') || unit.result`,
+	} {
+		if !preservingErrorCategory(preserving) {
+			t.Errorf("detector missed a preserving stamp (%s):\n%s", name, preserving)
+		}
 	}
-	if preservingErrorCategory(markExpiredLeaseRetryingSQL) {
-		t.Fatalf("detector false-positives on the production retry stamp")
+	for name, clean := range map[string]string{
+		"production retry stamp": markExpiredLeaseRetryingSQL,
+		"production fail stamp":  markExpiredLeaseFailedSQL,
+		// The SAFE merge direction, nested, so a detector "fixed" into
+		// flagging any statement carrying both a merge and a COALESCE over
+		// the prior document fails here rather than reading as stricter.
+		"safe direction with a nested build_object": `
+			SET result = (
+				COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'next_retry_at', to_jsonb($4::timestamptz)
+				)
+			)`,
+	} {
+		if preservingErrorCategory(clean) {
+			t.Errorf("detector false-positives on %s:\n%s", name, clean)
+		}
 	}
 }

--- a/internal/syncreconciler/lease_repair_sql_test.go
+++ b/internal/syncreconciler/lease_repair_sql_test.go
@@ -1,0 +1,106 @@
+package syncreconciler
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestExpiredLeaseRetryStampClearsEveryEpisodeColumn pins the lease-repair
+// half of CHAOS-3427 obligation #1.
+//
+// An expired lease is neither a rate-limit episode nor a budget episode, so
+// this non-terminal RETRYING stamp must reset BOTH per-episode pairs, exactly
+// as its Python analogue (workers/sync_reconciler.py's RETRYING stamp) does.
+// Before CHAOS-3427 it cleared only the rate-limit pair, so a unit that Python
+// had budget-deferred came back from lease repair with stale nonzero budget
+// counters -- refused terminalization only by the defence-in-depth
+// error-category gate, which is a backstop and not the contract.
+//
+// lease_repair_test.go already asserts "rate_limit_deferrals = 0" against the
+// executed statement; this is the same discipline stated over the whole
+// episode column set so a THIRD pair added later cannot be half-wired.
+func TestExpiredLeaseRetryStampClearsEveryEpisodeColumn(t *testing.T) {
+	for _, column := range []string{
+		"rate_limit_deferrals = 0",
+		"rate_limit_first_seen_at = NULL",
+		"budget_deferrals = 0",
+		"budget_first_deferred_at = NULL",
+	} {
+		if !strings.Contains(markExpiredLeaseRetryingSQL, column) {
+			t.Errorf("markExpiredLeaseRetryingSQL does not clear %q:\n%s",
+				column, markExpiredLeaseRetryingSQL)
+		}
+	}
+}
+
+// TestExpiredLeaseRetryStampLeavesTheAggregateClockAlone pins the deliberate
+// exception. `first_blocked_at` is the AGGREGATE blocked clock: started
+// set-if-null by real DEFERRAL stamps, cleared only by SUCCESS and the
+// dispatch claim. Clearing it on every worker-churn retry would reset the
+// outer bound that makes the budget/rate-limit ALTERNATION terminalizable --
+// which is the exact F2 defect CHAOS-3412's review round 2 found.
+func TestExpiredLeaseRetryStampLeavesTheAggregateClockAlone(t *testing.T) {
+	if strings.Contains(markExpiredLeaseRetryingSQL, "first_blocked_at") {
+		t.Errorf("markExpiredLeaseRetryingSQL touches first_blocked_at; only "+
+			"deferral stamps start it and only SUCCESS/claim clear it:\n%s",
+			markExpiredLeaseRetryingSQL)
+	}
+}
+
+// preservingErrorCategory mirrors the detector in
+// internal/providersync/repository_postgres_sql_test.go; see its comment for
+// why the two forbidden shapes are what they are. It is duplicated rather than
+// exported because both copies are test-only and a shared production helper
+// for a test-only rule would be worse.
+func preservingErrorCategory(sql string) bool {
+	if regexp.MustCompile(`result\s*->>?\s*'error_category'`).MatchString(sql) {
+		return true
+	}
+	return regexp.MustCompile(`jsonb_build_object\([^)]*\)\s*\|\|\s*COALESCE\(\s*\w+\.result`).
+		MatchString(sql)
+}
+
+// TestNoLeaseRepairStampPreservesAPriorErrorCategory is the FORBIDDEN PATTERN
+// guard (CHAOS-3427 obligation #2) for this package's stamps. See the
+// providersync twin for the full rationale: Python's exhaustion predicate
+// accepts only its own deferral category, so a stamp that PRESERVED a prior
+// category would make stale counters terminalization-eligible.
+func TestNoLeaseRepairStampPreservesAPriorErrorCategory(t *testing.T) {
+	stamps := map[string]string{
+		"markExpiredLeaseRetryingSQL": markExpiredLeaseRetryingSQL,
+		"markExpiredLeaseFailedSQL":   markExpiredLeaseFailedSQL,
+	}
+	measured := 0
+	for name, sql := range stamps {
+		if !strings.Contains(sql, "error_category") {
+			continue
+		}
+		measured++
+		if preservingErrorCategory(sql) {
+			t.Errorf("%s preserves a prior error_category:\n%s", name, sql)
+		}
+	}
+	// An unmeasured guard must FAIL loudly rather than read as coverage.
+	if measured != len(stamps) {
+		t.Fatalf("only %d of %d lease-repair stamps write error_category; this "+
+			"guard went vacuous", measured, len(stamps))
+	}
+}
+
+// TestPreservingErrorCategoryDetectorIsNotVacuous is this copy's own negative
+// control -- without it the guard above would pass identically with a detector
+// that always returned false.
+func TestPreservingErrorCategoryDetectorIsNotVacuous(t *testing.T) {
+	preserving := `
+		SET result = jsonb_build_object(
+			'error_category',
+			COALESCE(unit.result->>'error_category', 'worker_lost')
+		)`
+	if !preservingErrorCategory(preserving) {
+		t.Fatalf("detector missed a preserving stamp:\n%s", preserving)
+	}
+	if preservingErrorCategory(markExpiredLeaseRetryingSQL) {
+		t.Fatalf("detector false-positives on the production retry stamp")
+	}
+}

--- a/internal/testsupport/sqlshape/sqlshape.go
+++ b/internal/testsupport/sqlshape/sqlshape.go
@@ -1,0 +1,143 @@
+// Package sqlshape provides structural, parenthesis-aware inspection of SQL
+// text for guards that must reject a forbidden statement SHAPE rather than a
+// fixed list of statements.
+//
+// It lives under internal/testsupport because it is test-support code shared
+// by two packages' guards (internal/providersync and internal/syncreconciler),
+// not production behaviour: nothing outside a _test.go file imports it. The
+// alternative -- duplicating the scanner in both packages' test files -- is
+// what allowed the two copies of the previous regexp-based detector to carry
+// the SAME false negative.
+package sqlshape
+
+import "regexp"
+
+// Concat is one SQL `||` operator together with the operand text immediately
+// to its left and to its right.
+type Concat struct {
+	Left  string
+	Right string
+}
+
+// operandBoundary reports whether a character at the operator's own nesting
+// depth ends an operand. A `,` separates arguments, an `=` separates a SET
+// target from its expression, and a `|` is the next concatenation.
+func operandBoundary(character byte) bool {
+	return character == ',' || character == '=' || character == '|'
+}
+
+// scan returns, per byte of sql, the parenthesis nesting depth that byte sits
+// at and whether it is inside a single-quoted literal.
+//
+// An opening `(` and its matching `)` are both recorded at the OUTER depth, so
+// a whole parenthesised group reads as one unit at the depth it appears in --
+// which is what lets an operand span `jsonb_build_object(a, to_jsonb(b))`
+// without stopping at either inner `)`.
+func scan(sql string) (depths []int, literals []bool) {
+	depths = make([]int, len(sql))
+	literals = make([]bool, len(sql))
+	depth := 0
+	inLiteral := false
+	for index := 0; index < len(sql); index++ {
+		character := sql[index]
+		depths[index] = depth
+		if inLiteral {
+			literals[index] = true
+			if character == '\'' {
+				inLiteral = false
+			}
+			continue
+		}
+		switch character {
+		case '\'':
+			inLiteral = true
+			literals[index] = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			depths[index] = depth
+		}
+	}
+	return depths, literals
+}
+
+// ConcatOperands returns every `||` operator in sql with its two operands.
+//
+// This is a scan rather than a regexp because the regexp it replaced spanned
+// jsonb_build_object's argument list with `[^)]*`, which stops at the first
+// NESTED `)`. Every lease-repair stamp nests `to_jsonb(...)` calls, so a merge
+// written in the preserving direction read as clean -- a false negative on the
+// exact statement shape this repository writes.
+func ConcatOperands(sql string) []Concat {
+	depths, literals := scan(sql)
+	var concats []Concat
+	for index := 0; index+1 < len(sql); index++ {
+		if literals[index] || sql[index] != '|' || sql[index+1] != '|' {
+			continue
+		}
+		depth := depths[index]
+		left := 0
+		for cursor := index - 1; cursor >= 0; cursor-- {
+			if depths[cursor] < depth ||
+				(depths[cursor] == depth && !literals[cursor] && operandBoundary(sql[cursor])) {
+				left = cursor + 1
+				break
+			}
+		}
+		right := len(sql)
+		for cursor := index + 2; cursor < len(sql); cursor++ {
+			if depths[cursor] < depth ||
+				(depths[cursor] == depth && !literals[cursor] && operandBoundary(sql[cursor])) {
+				right = cursor
+				break
+			}
+		}
+		concats = append(concats, Concat{Left: sql[left:index], Right: sql[index+2 : right]})
+		index++ // do not re-read the operator's second '|'
+	}
+	return concats
+}
+
+var (
+	readsPriorCategory  = regexp.MustCompile(`result\s*->>?\s*'error_category'`)
+	referencesPriorRow  = regexp.MustCompile(`(?:^|[^\w.])(?:\w+\.)?result\b`)
+	singleQuotedLiteral = regexp.MustCompile(`'[^']*'`)
+)
+
+// referencesPriorResultDocument reports whether an operand reads the row's
+// existing `result` column. String literals are stripped first so a key NAMED
+// 'result' inside a jsonb_build_object cannot be mistaken for a column read.
+func referencesPriorResultDocument(operand string) bool {
+	return referencesPriorRow.MatchString(singleQuotedLiteral.ReplaceAllString(operand, "''"))
+}
+
+// PreservesPriorResultCategory reports whether a jsonb result stamp could
+// leave a PRIOR result document's 'error_category' in place. Two shapes do
+// that:
+//
+//  1. reading the old value back out (`unit.result->>'error_category'`), or
+//  2. concatenating with the existing document on the RIGHT of `||`
+//     (`jsonb_build_object(...) || COALESCE(unit.result...)`, or the bare
+//     `... || unit.result`), since jsonb `||` resolves duplicate keys in
+//     favour of its right operand.
+//
+// Shape 2 is measured by DIRECTION over the parsed operands, with arbitrary
+// nesting on either side: the prior document appearing anywhere on the right
+// of a concatenation preserves every key it carries, error_category included.
+// A merge with the prior document on the LEFT is the safe direction and is
+// what the production release-for-retry stamp uses.
+//
+// The check is shape-based rather than a fixed blocklist so a new stamp
+// written in either shape is caught without the guards being edited.
+func PreservesPriorResultCategory(sql string) bool {
+	if readsPriorCategory.MatchString(sql) {
+		return true
+	}
+	for _, concat := range ConcatOperands(sql) {
+		if referencesPriorResultDocument(concat.Right) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testsupport/sqlshape/sqlshape_test.go
+++ b/internal/testsupport/sqlshape/sqlshape_test.go
@@ -1,0 +1,135 @@
+package sqlshape
+
+import "testing"
+
+// TestPreservesPriorResultCategoryMeasuresMergeDirection is the detector's own
+// test. The cases that matter most are the NESTED ones: the regexp this
+// replaced spanned jsonb_build_object's arguments with `[^)]*`, so any stamp
+// carrying a `to_jsonb(...)` argument -- which every lease-repair stamp does --
+// slipped past it in the preserving direction.
+func TestPreservesPriorResultCategoryMeasuresMergeDirection(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			name: "reads the prior category back out",
+			sql:  `SET result = jsonb_build_object('error_category', COALESCE(unit.result->>'error_category', 'worker_lost'))`,
+			want: true,
+		},
+		{
+			name: "reads the prior category back out with the -> operator",
+			sql:  `SET result = jsonb_build_object('error_category', unit.result -> 'error_category')`,
+			want: true,
+		},
+		{
+			name: "prior document on the right of a flat merge",
+			sql:  `SET result = jsonb_build_object('error_category', 'worker_lost') || COALESCE(unit.result::jsonb, '{}'::jsonb)`,
+			want: true,
+		},
+		{
+			name: "prior document on the right of a merge whose build_object nests calls",
+			sql: `SET result = (
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'next_retry_at', to_jsonb($4::timestamptz),
+					'retry_surfaces', to_jsonb($5::text[])
+				) || COALESCE(unit.result::jsonb, '{}'::jsonb)
+			)`,
+			want: true,
+		},
+		{
+			name: "bare prior document on the right",
+			sql:  `SET result = jsonb_build_object('error_category', 'worker_lost') || unit.result`,
+			want: true,
+		},
+		{
+			name: "prior document on the right of the SECOND operator in a chain",
+			sql: `SET result = (
+				COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+				jsonb_build_object('error_category', 'worker_lost') ||
+				COALESCE(unit.result::jsonb, '{}'::jsonb)
+			)`,
+			want: true,
+		},
+		{
+			name: "safe direction: prior document on the left",
+			sql: `SET result = (
+				COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+				jsonb_build_object('error_category', 'provider_unit_retryable')
+			)`,
+			want: false,
+		},
+		{
+			name: "safe direction survives nesting on the right operand",
+			sql: `SET result = (
+				COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+				jsonb_build_object(
+					'error_category', 'worker_lost',
+					'next_retry_at', to_jsonb($4::timestamptz)
+				)
+			)`,
+			want: false,
+		},
+		{
+			name: "wholesale replacement touches no prior document",
+			sql:  `SET result = $5::jsonb, error = NULL`,
+			want: false,
+		},
+		{
+			name: "a build_object with no merge at all",
+			sql: `SET result = jsonb_build_object(
+				'error_category', 'worker_lost',
+				'retry_count', unit.expired_lease_retry_count + 1,
+				'next_retry_at', to_jsonb($4::timestamptz)
+			)`,
+			want: false,
+		},
+		{
+			name: "a KEY named result on the right is not a column read",
+			sql:  `SET result = COALESCE(unit.result::jsonb, '{}'::jsonb) || jsonb_build_object('result', 'ok', 'result_count', 1)`,
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := PreservesPriorResultCategory(test.sql); got != test.want {
+				t.Fatalf("PreservesPriorResultCategory = %v, want %v for:\n%s",
+					got, test.want, test.sql)
+			}
+		})
+	}
+}
+
+// TestConcatOperandsKeepsNestedGroupsWhole pins the property the whole
+// detector rests on, separately from the verdict: an operand must span a
+// parenthesised group entirely rather than stopping at its first inner `)`.
+func TestConcatOperandsKeepsNestedGroupsWhole(t *testing.T) {
+	concats := ConcatOperands(
+		`result = (jsonb_build_object('a', to_jsonb($1::text), 'b', 2) || COALESCE(unit.result, '{}'))`,
+	)
+	if len(concats) != 1 {
+		t.Fatalf("found %d concatenations, want 1: %#v", len(concats), concats)
+	}
+	if want := `jsonb_build_object('a', to_jsonb($1::text), 'b', 2) `; concats[0].Left != want {
+		t.Errorf("left operand = %q, want %q", concats[0].Left, want)
+	}
+	if want := ` COALESCE(unit.result, '{}')`; concats[0].Right != want {
+		t.Errorf("right operand = %q, want %q", concats[0].Right, want)
+	}
+}
+
+// TestConcatOperandsSplitsOnSiblingAssignments keeps an operand from running
+// across a `,` or `=` at its own depth and picking up a `result` reference
+// that belongs to a different SET clause entirely.
+func TestConcatOperandsSplitsOnSiblingAssignments(t *testing.T) {
+	concats := ConcatOperands(
+		`SET note = 'a' || 'b', result = COALESCE(unit.result, '{}')`,
+	)
+	if len(concats) != 1 {
+		t.Fatalf("found %d concatenations, want 1: %#v", len(concats), concats)
+	}
+	if want := ` 'b'`; concats[0].Right != want {
+		t.Errorf("right operand = %q, want %q", concats[0].Right, want)
+	}
+}


### PR DESCRIPTION
> **Stacked on #1514.** Base is `chore/go-worker-main-sync-2026-08-05`, and it must **not** be retargeted to `feat/go-worker-runtime-migration` until #1514 merges — this branch's commits sit directly on that merge, and re-basing it early would drag the whole main-sync into this diff.

## What this is

The remainder of CHAOS-3427: the Go worker's mirror of the CHAOS-3412 Python work. The **window ratchet half already landed in #1514**, because that merge moved a contract the live Go↔Python oracle gates on and no honest resolution left it red. What is left here is everything the merge did *not* force:

- episode-clear parity for the new budget pair,
- the forbidden preserved-`error_category` pattern,
- the watermark write boundary,
- the first oracle pair for the sync-unit state machine,
- the clause-level mutation plan.

Per decision D16 this is **mirror-Python, no redesigns**.

## Episode-clear parity (obligation #1)

Python has five sites that clear the budget episode pair. Three are Python-owned; two have Go mirrors:

| Python site | Go mirror |
|---|---|
| `workers/sync_units.py` SUCCESS | `repository_postgres.go` `completeUnitSQL` |
| `workers/sync_reconciler.py` RETRYING | `lease_repair.go` `markExpiredLeaseRetryingSQL` |

`completeUnitSQL` now clears `budget_deferrals` / `budget_first_deferred_at` **and `first_blocked_at`**. That third column is a parity delta found while doing this, not part of the original brief: Go's SUCCESS stamp left the aggregate 24h blocked clock running, so the next Python budget deferral would terminalize a healthy unit early.

`markExpiredLeaseRetryingSQL` clears the budget pair and deliberately does **not** touch `first_blocked_at` — matching Python, where only deferral stamps start the aggregate clock and only SUCCESS and the dispatch claim clear it.

`releaseForRetrySQL` still clears nothing. That asymmetry is load-bearing (`provider_unit_retryable` is outside the episode categories) and is now asserted *positively*, so "make it symmetric with SUCCESS" is a change this test rejects rather than one that slips through.

`scheduler/sync/materializer.go` is untouched — the new columns have defaults, and it is called out here so nobody "fixes" it.

## Forbidden pattern (obligation #2)

Python's exhaustion predicate accepts only its own `budget_deferred` category, so a Go stamp that **preserved** a prior `error_category` would make stale counters terminalization-eligible. A shape-based detector rejects both ways that can happen: reading the old value back (`unit.result->>'error_category'`) and putting the existing document on the **right** of a jsonb `||`.

The direction is what is measured, not the presence of a merge — `releaseForRetrySQL` legitimately merges to keep `go_effect_ledger_v1` alive across a retry, and is safe because `jsonb_build_object` sits on the right.

Both packages carry the guard **plus its own negative control**, so a detector that stopped detecting fails instead of passing quietly.

## Watermark write boundary (obligation #4, clause C10)

`normalizeWatermarkWrite` clamps every write to `min(incoming, window_end, now)` and `Complete` routes through it. Several routes prefer a provider-supplied watermark over `claim.BeforeAt`, which bypasses every planner-side clamp; the `window_end` ceiling matters most because such an overclaim is usually in the **past**, so the `now` ceiling alone does not catch it and the next run silently skips everything in between.

Writer coverage is **derived by AST walk over this package's own source**, with a vacuity guard, rather than hand-listed — hand-enumeration is exactly what let a second writer sit outside the boundary on the Python side while the class was reported closed.

`upsertWatermarkSQL` gains the narrow C10(b) exception: a stored **future** value loses to a sane incoming one. Monotonicity is otherwise untouched, and widening it to "any lower value wins" is a defect the tests reject.

## Oracles (obligation #3)

**First oracle pair for the sync-unit state machine** — it had zero coverage before this (55 pairs, none touching it), which matters because the Go worker and the Python guard share the `sync_run_units` row and each writes columns the other reads.

`syncunit/budget/exhaustion` executes the real, unmodified `_budget_deferral_exhausted`. Only budget_guard's module-level imports are stubbed, and none participate in the predicate. Verified to run on a **no-deps interpreter**, matching the hosted go-quality image.

The `go_stamp_*` cases derive their `error_category` input **from the Go SQL constants themselves**, so flipping a stamp to preserve the prior category changes what the live Python predicate is asked — the two halves are measured together rather than asserted separately and hoped about.

## Mutations — 16/16 killed

Every mutation removes or inverts **one** conjunct, comparison, or stamped column, never a whole condition, and names the clause it measures.

Where each died: M1/M3–M8 in the live Python differential oracle; M2/M9 in the forced ratchet tests; M10–M14/M16 in the SQL-string assertions; M15 in the AST writer derivation. **None died in a setup helper.**

M15 was first authored as a call-site edit that left `normalized` unused — the harness correctly reported **INVALID**, because a build break measures nothing and is not a kill. Rewritten to keep the symbol referenced while bypassing the normalizer, then killed. Re-run after the rebase: still 16/16, restore verified byte-identical before and after.

## Reached state, not just SQL strings

The SQL-string assertions prove the statements *say* the right thing. `budget_episode_integration_test.go` proves real PostgreSQL *did* it, seeding every unit mid-episode because a clear asserted against an already-zero row proves nothing:

- SUCCESS clears both pairs and the aggregate clock;
- release-for-retry preserves the episode **and** overwrites the category;
- an overclaiming watermark clamps to the window end, with a precondition asserting the value is genuinely in the past so the case cannot stop measuring the coverage ceiling;
- a corrupt future watermark heals — seeded by a **direct row write**, because seeding through the now-working boundary would silently stop exercising the corrupt path;
- a legitimate lower value is still refused.

## Proof

| Check | Result |
|---|---|
| `ci/check_go.sh fast` | exit 0, zero FAILs |
| `ci/check_go.sh live-python-oracles` | green, both packages |
| `go test ./...` | zero FAILs |
| `go test -tags=integration` (providersync + syncreconciler) | green against real PostgreSQL |
| mutation plan | **16/16 KILLED**, harness verified clean before and after |
| ruff / mypy | clean |

## Residual risks

1. **`install_minimal_oracle_imports` is being extended by another lane.** This pair calls it and then adds three placeholder attributes to `dev_health_ops.models`, because the helper installs a namespace `__path__` but no aggregate attributes. Expect a small conflict if that helper's shape changes.
2. **The Go exhaustion predicate lives in the test file.** Go does not own budget admission yet, so a production copy would be unwired code posing as a second implementation. The load-bearing guard is the `go_stamp_*` case running the *real* Python predicate over Go-derived inputs; when Go takes over admission it inherits an executable specification.
3. **C7 is not directly mutated.** Most routes already pass `claim.BeforeAt`; the ones deriving a provider watermark are bounded by the C10(c) write boundary instead, which M14/M15 cover. Stated in the plan's `$limitation`.
