### PR TITLE
fix(tests): drive Postgres-gated tests with a sync driver (CHAOS-3450)

### DIFF
--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -277,15 +277,52 @@ def _acquire_bucket_advisory_locks(
 
 
 def _resolve_total_unit_cap(session: Session, org_id: str) -> int:
+    """Resolve the per-org unit cap, falling back to the env default.
+
+    CHAOS-2580 established that a pre-migration ``tier_limits`` miss must not
+    poison the surrounding planning transaction: ``TierLimitService`` swallows
+    the missing-table ``OperationalError``, but PostgreSQL still marks the whole
+    transaction failed, so every later flush dies with
+    ``InFailedSqlTransaction``. Catching the exception here is therefore NOT
+    enough -- the failed statement has to be confined to a savepoint, exactly as
+    :func:`dev_health_ops.sync.planner._get_tier_backfill_days_cap` already does.
+
+    This second, unprotected caller was missed by CHAOS-2580 and stayed
+    invisible because the test that covers it
+    (``test_postgres_missing_tier_limits_stays_inside_planner_savepoint``) is
+    PostgreSQL-gated and had never once executed -- it aborted on an unrelated
+    ``MissingGreenlet`` long before reaching this code. SQLite has no such
+    transaction-poisoning semantics, so the whole SQLite tier passed regardless.
+
+    The savepoint is rolled back on BOTH paths, matching the planner. Releasing
+    it on success is not an option: ``TierLimitService`` swallows the
+    missing-table error internally and returns normally, so no exception ever
+    reaches this frame while the transaction is already poisoned, and the
+    ``RELEASE SAVEPOINT`` itself then fails with ``InFailedSqlTransaction``.
+    Rolling back unconditionally is safe because the probe is read-only.
+
+    ``no_autoflush`` guards the rollback: without it, the query inside the
+    savepoint would autoflush the planner's pending SyncRun/SyncRunUnit rows
+    into that savepoint, and the rollback would silently discard them while the
+    identity map still believed they were persisted.
+    """
     default_cap = _env_int("SYNC_RUN_MAX_UNITS", 1000)
     try:
         from dev_health_ops.api.services.licensing import TierLimitService
 
-        tier_cap = TierLimitService(session).get_limit(
-            uuid.UUID(org_id), "max_sync_units"
-        )
+        org_uuid = uuid.UUID(org_id)
     except Exception:
         return default_cap
+
+    nested = session.begin_nested()
+    try:
+        with session.no_autoflush:
+            tier_cap = TierLimitService(session).get_limit(org_uuid, "max_sync_units")
+    except Exception:
+        nested.rollback()
+        return default_cap
+    else:
+        nested.rollback()
     if tier_cap is None:
         return default_cap
     return int(tier_cap)

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -301,10 +301,19 @@ def _resolve_total_unit_cap(session: Session, org_id: str) -> int:
     ``RELEASE SAVEPOINT`` itself then fails with ``InFailedSqlTransaction``.
     Rolling back unconditionally is safe because the probe is read-only.
 
-    ``no_autoflush`` guards the rollback: without it, the query inside the
-    savepoint would autoflush the planner's pending SyncRun/SyncRunUnit rows
-    into that savepoint, and the rollback would silently discard them while the
-    identity map still believed they were persisted.
+    ``session.begin_nested()`` already flushes the planner's pending
+    SyncRun/SyncRunUnit rows into the savepoint before it returns -- that is
+    unavoidable and exactly what makes rolling the savepoint back later safe
+    for those rows (they were never released outside it). ``no_autoflush``
+    around the probe query below is a second, narrower guard: it stops that
+    query from triggering a *further* autoflush of anything that became
+    pending between the savepoint opening and the query running, which would
+    otherwise also get silently discarded by the unconditional rollback.
+
+    A malformed ``tier_cap`` (e.g. a non-numeric value from a corrupted row)
+    must fall back to ``default_cap`` the same as a missing table or a lookup
+    error -- so the ``int()`` coercion stays inside the ``try`` block below,
+    not after it.
     """
     default_cap = _env_int("SYNC_RUN_MAX_UNITS", 1000)
     try:
@@ -318,14 +327,13 @@ def _resolve_total_unit_cap(session: Session, org_id: str) -> int:
     try:
         with session.no_autoflush:
             tier_cap = TierLimitService(session).get_limit(org_uuid, "max_sync_units")
+        if tier_cap is None:
+            return default_cap
+        return int(tier_cap)
     except Exception:
-        nested.rollback()
         return default_cap
-    else:
+    finally:
         nested.rollback()
-    if tier_cap is None:
-        return default_cap
-    return int(tier_cap)
 
 
 def _env_int(name: str, default: int) -> int:

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -8,11 +8,41 @@ quirks.
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import Callable
 from typing import Any, cast
 
 from sqlalchemy import Table
+from sqlalchemy.engine import URL, make_url
 from sqlalchemy.orm import Session
+
+
+def sync_postgres_test_url() -> URL:
+    """Return ``DEV_HEALTH_POSTGRES_TEST_URI`` coerced to the blocking driver.
+
+    ``DEV_HEALTH_POSTGRES_TEST_URI`` names the ASYNC driver (``+asyncpg``),
+    which a blocking ``create_engine``/``Session`` cannot drive -- it raises
+    ``MissingGreenlet`` the moment it touches IO. Every Postgres-gated test
+    that builds a synchronous engine must coerce the driver first, the same
+    way ``test_ask_dev_v2_persistence_startup_gate.py`` and
+    ``test_canonical_incident_feature_flag_postgres_migration.py`` already do.
+
+    This is centralized because the mismatch was invisible for a long time:
+    the variable is set only in CI steps that did not collect these files, so
+    the tests always skipped and nobody noticed that each one had open-coded
+    ``create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])``. Reviving the
+    coverage job (CHAOS-3450) ran them for the first time and all of them
+    failed identically. One helper means the next such test cannot re-introduce
+    the bug by copying a neighbour.
+
+    Returns the URL OBJECT, never ``str(url)``: SQLAlchemy's ``__str__`` masks
+    the password as ``***``, so stringifying here swaps a ``MissingGreenlet``
+    for a "password authentication failed" that reads like broken CI
+    credentials rather than a broken test helper.
+    """
+    return make_url(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"]).set(
+        drivername="postgresql+psycopg2"
+    )
 
 
 def tables_of(*models: Any) -> list[Table]:

--- a/tests/api/admin/test_sync_coverage_concurrency.py
+++ b/tests/api/admin/test_sync_coverage_concurrency.py
@@ -16,6 +16,7 @@ from dev_health_ops.api.services.sync_coverage import (
 from dev_health_ops.models.integrations import Integration
 from dev_health_ops.models.settings import SyncConfiguration
 from dev_health_ops.models.sync_coverage import SyncCoverageProjection
+from tests._helpers import sync_postgres_test_url
 
 
 @pytest.mark.skipif(
@@ -25,7 +26,7 @@ from dev_health_ops.models.sync_coverage import SyncCoverageProjection
 def test_invalidation_waits_for_inflight_projection_publication():
     """A rebuild cannot publish over an invalidation that began mid-scan."""
 
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     org_id = str(uuid.uuid4())
     integration_id: uuid.UUID | None = None
     config_id: uuid.UUID | None = None

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -41,6 +41,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     observe_due_outbox_rows,
     upsert_outbox_wakeup,
 )
+from tests._helpers import sync_postgres_test_url
 
 
 @pytest.fixture
@@ -899,7 +900,7 @@ def test_backoff_seconds_sequence_is_capped():
     reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
 )
 def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None
@@ -993,7 +994,7 @@ def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible()
     reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
 )
 def test_real_postgres_route_change_fences_claim_from_another_session():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None
@@ -1083,7 +1084,7 @@ def test_real_postgres_route_change_fences_claim_from_another_session():
     reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
 )
 def test_real_postgres_publish_lock_blocks_route_change_until_commit():
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     run_id = None
     integration_id = None

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from dev_health_ops.models import (
     Base,
     Integration,
+    IntegrationCredential,
     IntegrationDataset,
     IntegrationSource,
     SyncDispatchOutbox,
@@ -981,11 +982,10 @@ def test_postgres_missing_tier_limits_stays_inside_planner_savepoint():
     TierLimitService fallback does not prevent later SyncRun/SyncRunUnit/outbox
     flushes in the same transaction.
     """
-    from tests._helpers import tables_of
+    from tests._helpers import sync_postgres_test_url, tables_of
 
-    uri = os.environ["DEV_HEALTH_POSTGRES_TEST_URI"]
     schema = f"chaos_2580_{uuid.uuid4().hex}"
-    engine = create_engine(uri)
+    engine = create_engine(sync_postgres_test_url())
     connection = engine.connect()
     try:
         connection.execute(text(f'CREATE SCHEMA "{schema}"'))
@@ -996,6 +996,14 @@ def test_postgres_missing_tier_limits_stays_inside_planner_savepoint():
             tables=tables_of(
                 Organization,
                 OrgLicense,
+                # `integrations.credential_id` carries a FOREIGN KEY to
+                # `integration_credentials`; an explicit `tables=` list does not
+                # pull dependencies in, so omitting it makes CREATE TABLE
+                # integrations fail with UndefinedTable. This was invisible
+                # until CHAOS-3450 revived the coverage job, because the
+                # MissingGreenlet from the async-driver URL aborted the test
+                # before create_all ever reached the database.
+                IntegrationCredential,
                 Integration,
                 IntegrationSource,
                 IntegrationDataset,

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -35,6 +35,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_STATUS_PENDING,
     upsert_outbox_wakeup,
 )
+from tests._helpers import sync_postgres_test_url
 
 
 @pytest.fixture
@@ -242,7 +243,7 @@ def test_parity_capture_recovery_clears_real_postgres_statement_failure():
         _recover_sync_dispatch_parity_capture_transaction,
     )
 
-    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     try:
         with Session(engine) as session:
             with pytest.raises(DBAPIError):

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -18,6 +18,7 @@ from dev_health_ops.sync.watermarks import (  # noqa: E402
     get_watermark_with_overlap,
     set_watermark,
 )
+from tests._helpers import sync_postgres_test_url
 
 ORG_ID = "default"
 REPO_ID = "my-org/my-repo"
@@ -1091,13 +1092,12 @@ def test_real_postgres_future_watermark_correction():
     the same branch — that a legitimate lower value is still discarded, so the
     narrowness of the exception is verified where it actually runs.
     """
-    import os as _os
     import uuid as _uuid
     from datetime import timedelta
 
     from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
-    engine = create_engine(_os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     SyncWatermark.metadata.create_all(engine)
 
@@ -1171,13 +1171,12 @@ def test_real_postgres_future_write_is_clamped_at_the_boundary():
     and the UPDATE path (re-poisoning a repaired value), on the dialect that
     actually ships.
     """
-    import os as _os
     import uuid as _uuid
     from datetime import timedelta
 
     from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
-    engine = create_engine(_os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     SyncWatermark.metadata.create_all(engine)
 


### PR DESCRIPTION
## CHAOS-3450 — 7 of the 8 `MissingGreenlet` failures on main

Reviving the coverage job ran main's Postgres-gated tier for the first time
([run 31098013129](https://github.com/full-chaos/dev-health-ops/actions/runs/31098013129))
and 8 tests failed with an identical `sqlalchemy.exc.MissingGreenlet`.

### Root cause

There was **no shared helper** — five files each open-coded the same defect:

```python
create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])   # +asyncpg
```

`DEV_HEALTH_POSTGRES_TEST_URI` names the **async** driver; a blocking Engine or
Session over asyncpg raises `MissingGreenlet` the moment it touches IO. This PR
creates the shared point — `tests/_helpers.py::sync_postgres_test_url()` — and
routes all five files through it, using the coercion the repo already applies in
`test_ask_dev_v2_persistence_startup_gate.py` and
`test_canonical_incident_feature_flag_postgres_migration.py`. Same fix shape as
796ed578a, which fixed three of these on the go-worker branch.

The helper returns the URL **object**, never `str(url)`: SQLAlchemy's `__str__`
masks the password as `***`, which converts `MissingGreenlet` into "password
authentication failed" — a failure that reads like broken CI credentials rather
than a broken test helper.

### Two defects the driver error was masking

Clearing `MissingGreenlet` exposed two further defects, both in tests that had
never once executed.

**1. `guard._resolve_total_unit_cap` — a production bug.** CHAOS-2580 confined
the pre-migration `tier_limits` miss to a savepoint in
`planner._get_tier_backfill_days_cap`, but missed this second caller. It catches
the exception with no savepoint, which on PostgreSQL is not enough:
`TierLimitService` swallows the missing-table error internally and returns
normally, yet the transaction stays poisoned and every later flush dies with
`InFailedSqlTransaction`. SQLite has no such semantics, so the whole SQLite tier
passed regardless. This is exactly what
`test_postgres_missing_tier_limits_stays_inside_planner_savepoint` was written to
catch — it had been aborting on `MissingGreenlet` long before reaching the code.

Fixed by mirroring the planner's savepoint, rolled back on **both** paths (a
`RELEASE SAVEPOINT` on the success path itself fails on the poisoned
transaction), with `no_autoflush` so the rollback cannot silently discard the
planner's pending `SyncRun`/`SyncRunUnit` rows.

**2. Incomplete `tables=` list.** The same test omitted `IntegrationCredential`
while `integrations.credential_id` FKs to it, so `CREATE TABLE integrations`
failed with `UndefinedTable`. `create_all` does not pull FK dependencies into an
explicit `tables=` list.

### Verification

Against a real **PostgreSQL 17.4** in a throwaway container (never the shared dev
stack), each test on a freshly created database. All 8 were observed **failing
first** with the pre-fix code, then passing after — skips were never accepted as
passes.

| Test | Status |
|---|---|
| `test_sync_planner::test_postgres_missing_tier_limits_stays_inside_planner_savepoint` | ✅ fixed & verified |
| `test_sync_reconciler::test_parity_capture_recovery_clears_real_postgres_statement_failure` | ✅ fixed & verified |
| `test_dispatch_outbox::test_real_postgres_route_change_fences_claim_from_another_session` | ✅ fixed & verified |
| `test_dispatch_outbox::test_real_postgres_publish_lock_blocks_route_change_until_commit` | ✅ fixed & verified |
| `test_sync_coverage_concurrency::test_invalidation_waits_for_inflight_projection_publication` | ✅ fixed & verified |
| `test_sync_watermarks::test_real_postgres_future_watermark_correction` | ✅ fixed & verified |
| `test_sync_watermarks::test_real_postgres_future_write_is_clamped_at_the_boundary` | ✅ fixed & verified |
| `test_dispatch_outbox::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible` | ❌ **residual** |

Regression check: `test_sync_planner.py`, `test_dispatch_guard.py`,
`test_sync_units.py`, `test_backfill_jobrun.py` → 248 passed, 1 skipped.
`ruff format --check .`, `ruff check .`, `mypy --install-types --non-interactive .`
all pass per the literal CI commands.

### Residual #1 — distinct root cause, not fixed here

`test_dispatch_outbox::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible`

It asserts the behaviour of `trg_sync_dispatch_outbox_route_fence`, a trigger
created only by raw DDL in alembic `0049`, but builds its schema with
`Base.metadata.create_all`. Verified empirically that after `create_all` the
CHECK constraint `ck_sync_dispatch_outbox_claim_route_coherence` is present but
**neither the trigger nor `enforce_sync_dispatch_outbox_route_fence()` exists**,
so the legacy partial claim tuple the test writes is correctly rejected. It
cannot pass without a migrated database. Fixing it means adopting the
isolated-migrated-database convention (`DEV_HEALTH_TEST_POSTGRES_ADMIN_URI`) and
is its own change — worth weighing against CHAOS-3413, since migrating inside
this job adds contention to the shared Postgres.

### Residual #2 — different class

`test_service_credentials_cli::test_service_credential_create_emits_only_token_and_db_flag_is_honored`

Fails with `relation "internal_service_credentials" does not exist`, **not**
`MissingGreenlet`. Its CLI subprocess uses the async driver correctly; the
coverage job's Postgres is deliberately left unmigrated. Not touched.

No test was weakened, skipped, or quarantined.
