### PR TITLE
CHAOS-3404: wire Ask Dev retention sweep + close a 0-day retention gap

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "$comment": "CUT-01 transitional workload inventory contract (CHAOS-3073). Maps every legacy Celery/Beat/API/registry/stream surface discovered in the Wave-0 audit to a target owner or explicit removal. See docs/architecture/transitional-workload-inventory.md for the update procedure and CI gate (ci/check_transitional_inventory.py).",
   "source_audit": "Wave-0 inventory audit, 147 surfaces (docs/plans/go-worker-cutover-implementation-plan.md CUT-01; TRD sec 6, 8.3)",
-  "row_count": 156,
+  "row_count": 158,
   "ownership_model": {
     "owner_role": "'primary' rows are the exclusive canonical claimant of a target_kind_id (a Beat entry, registry kind, stream, transport route, or a standalone celery task with no other owning row). 'contributor' rows are dispatch/trigger call sites, or implementation bodies, that feed an existing primary row and may freely share a target_owner value with other contributors.",
     "exclusivity_rule": "At most one row may be owner_role=primary for any given target_kind_id. CI enforces this; it does not require target_owner.value itself to be unique, since many contributor rows legitimately share one coarse target process description."
@@ -1569,12 +1569,12 @@
       "notes": ""
     },
     {
-      "id": "beat_entry_conditional:src/dev_health_ops/workers/config.py:311",
+      "id": "beat_entry_conditional:src/dev_health_ops/workers/config.py:325",
       "surface": "consume-pending-scheduled-sync-occurrences",
       "class": "beat_entry_conditional",
       "source": {
         "file": "src/dev_health_ops/workers/config.py",
-        "line": 311
+        "line": 325
       },
       "queue_or_cadence": "300s, default off (SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED)",
       "dispatches": "consume_pending_scheduled_sync_occurrences",
@@ -3739,12 +3739,12 @@
       "notes": "Keeps versioned exact-history projections warm; invalidated or missing projections return an explicit pending response until rebuilt."
     },
     {
-      "id": "beat_entry:src/dev_health_ops/workers/config.py:300",
+      "id": "beat_entry:src/dev_health_ops/workers/config.py:314",
       "surface": "refresh-sync-coverage-projections",
       "class": "beat_entry",
       "source": {
         "file": "src/dev_health_ops/workers/config.py",
-        "line": 300
+        "line": 314
       },
       "queue_or_cadence": "300s",
       "dispatches": "refresh_sync_coverage_projections",
@@ -3761,6 +3761,54 @@
       "deletion_evidence_requirement": "Remove the Beat entry only after a native cadence refreshes every configuration without starvation.",
       "acceptance_test_id": "tests/api/admin/test_sync_coverage_api.py::test_sync_coverage_projection_is_reused_when_source_is_unchanged",
       "notes": "Unconditional five-minute refresh for exact coverage projections."
+    },
+    {
+      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:163",
+      "surface": "run_ask_dev_retention_cleanup",
+      "class": "celery_task",
+      "source": {
+        "file": "src/dev_health_ops/workers/ask_dev_retention.py",
+        "line": 163
+      },
+      "queue_or_cadence": "default",
+      "dispatches": "self (Beat)",
+      "dispatch_mechanism": "celery_task_decorator",
+      "owner_role": "contributor",
+      "target_owner": {
+        "type": "native_process",
+        "value": "Go scheduler + ops worker"
+      },
+      "target_kind_id": "beat:ask-dev-retention-sweep",
+      "current_implementation_state": "celery_only",
+      "verification_status": "verified",
+      "compatibility_dependency": "Celery worker process consuming the Beat-scheduled dispatch.",
+      "deletion_evidence_requirement": "Deleted alongside Beat entry `ask-dev-retention-sweep` once its native replacement is proven.",
+      "acceptance_test_id": "tests/workers/test_ask_dev_retention_sweep.py::test_expired_30_day_conversation_is_purged",
+      "notes": "CHAOS-3404: production caller for DevPersistenceService.cleanup_expired (previously had none). Beat entry ask-dev-retention-sweep, crontab(5,30) UTC."
+    },
+    {
+      "id": "beat_entry:src/dev_health_ops/workers/config.py:309",
+      "surface": "ask-dev-retention-sweep",
+      "class": "beat_entry",
+      "source": {
+        "file": "src/dev_health_ops/workers/config.py",
+        "line": 309
+      },
+      "queue_or_cadence": "crontab(hour=5,minute=30) UTC",
+      "dispatches": "run_ask_dev_retention_cleanup",
+      "dispatch_mechanism": "beat_schedule_entry",
+      "owner_role": "primary",
+      "target_owner": {
+        "type": "native_process",
+        "value": "Go scheduler + ops worker"
+      },
+      "target_kind_id": "beat:ask-dev-retention-sweep",
+      "current_implementation_state": "celery_only",
+      "verification_status": "verified",
+      "compatibility_dependency": "Celery Beat scheduler process + Redis/Valkey broker.",
+      "deletion_evidence_requirement": "Beat entry `ask-dev-retention-sweep` removed from src/dev_health_ops/workers/config.py; cadence contract comparison (this inventory vs. the checked schedule definition) shows the entry no longer present; the equivalent Go schedule/producer proven to preserve cadence and missed-run policy.",
+      "acceptance_test_id": "tests/workers/test_ask_dev_retention_sweep.py::test_beat_schedule_has_the_retention_sweep_entry",
+      "notes": "CHAOS-3404: the only production caller of DevPersistenceService.cleanup_expired."
     }
   ]
 }

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, TypeAlias
 
 from pydantic import ValidationError as PydanticValidationError
-from sqlalchemy import and_, case, event, func, or_, select
+from sqlalchemy import and_, case, event, exists, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -2194,24 +2194,119 @@ class DevPersistenceService:
             run.ended_at = self._now()
         await self.session.flush()
 
+        ephemeral_conversation = None
+        if state in _TERMINAL_RUN_STATES:
+            ephemeral_conversation = await self._stamp_ephemeral_expiry_if_terminal(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=run.conversation_id,
+            )
+            if ephemeral_conversation is not None:
+                # Durable independent of the purge attempt below: flushed
+                # here so the caller's eventual commit persists the expiry
+                # stamp even if the purge itself fails or never runs.
+                await self.session.flush()
+
+        if (
+            ephemeral_conversation is not None
+            and await self._try_purge_ephemeral_conversation(
+                conversation=ephemeral_conversation, actor_user_id=user_id
+            )
+        ):
+            return None
+        return run
+
+    async def _stamp_ephemeral_expiry_if_terminal(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+    ) -> DevConversation | None:
+        """Mark a 0-day (ephemeral) conversation immediately expired the
+        instant its run goes terminal (CHAOS-3404).
+
+        Every path that can transition a run into a terminal state must call
+        this once that transition is decided -- ``update_run`` is the common
+        case; ``force_terminal_fallback`` and ``recover_stale_non_terminal_run``
+        are the documented last-resort recovery paths (CHAOS-3297 rounds
+        3/5/7) that used to skip this check entirely, leaving a 0-day
+        conversation whose run terminated via either path permanently
+        unpurgeable (``expires_at`` is otherwise never set for a
+        ``retention_days == 0`` row -- only the 30-day rolling window uses
+        it -- so ``cleanup_expired``'s safety-net sweep couldn't catch it
+        either).
+
+        This is deliberately the DURABLE half of the fix: a single column
+        mutation that cannot fail the way a cascading multi-table delete
+        can, and it MUST be committed together with (never conditioned on)
+        the terminal-state write itself -- see
+        ``_try_purge_ephemeral_conversation`` for the separate, best-effort
+        immediate-delete half. Once ``expires_at`` is set, the next
+        ``cleanup_expired`` sweep tick collects the row even if the
+        synchronous purge attempt right after this one never runs or fails:
+        the guarantee degrades from "purged immediately" to "purged within
+        one sweep interval," never to "leaked forever."
+        """
         conversation = await self._owned_conversation(
             org_id=org_id,
             user_id=user_id,
-            conversation_id=run.conversation_id,
+            conversation_id=conversation_id,
             include_expired=True,
         )
-        if (
-            state in _TERMINAL_RUN_STATES
-            and conversation is not None
-            and conversation.retention_days == 0
-        ):
-            await self._purge_conversation(
-                conversation=conversation,
-                reason="ephemeral_completed",
-                actor_user_id=user_id,
-            )
+        if conversation is None or conversation.retention_days != 0:
             return None
-        return run
+        conversation.expires_at = self._now()
+        return conversation
+
+    async def _try_purge_ephemeral_conversation(
+        self, *, conversation: DevConversation, actor_user_id: uuid.UUID | None
+    ) -> bool:
+        """Best-effort immediate purge of an already-expiry-stamped
+        ephemeral conversation (CHAOS-3404).
+
+        Only ``update_run`` calls this -- deliberately the ONE terminal-
+        transition site where an inline purge is safe. Neither
+        ``force_terminal_fallback`` nor ``recover_stale_non_terminal_run``
+        call it (they call ``_stamp_ephemeral_expiry_if_terminal`` alone):
+        both have a reader that immediately reads this same run's
+        answer/frame content back from the DB right after (a same-request
+        reader for ``recover_stale_non_terminal_run``, whose return value
+        the caller feeds straight into ``get_answer_message``/
+        ``get_answer_frame``; a concurrent duplicate-request reader for
+        ``force_terminal_fallback``, blocked on its ``SELECT ... FOR
+        UPDATE`` lock -- Codex adversarial-review rounds 2 and 3), and an
+        inline purge would delete that content out from under either read.
+        ``update_run`` has no such reader (the live SSE stream already has
+        the answer in memory; nothing re-reads it from the DB in the same
+        request), so it is the only site where deleting immediately is safe.
+
+        Must only be called AFTER the terminal state + expiry stamp from
+        ``_stamp_ephemeral_expiry_if_terminal`` are already durable (or at
+        least already flushed in a transaction the caller owns) -- a
+        failure here is caught and logged, never re-raised, so it can never
+        take the terminal-state write down with it. Runs inside a SAVEPOINT
+        (``begin_nested``, the same pattern ``append_assistant_answer`` uses
+        for its own idempotent-insert recovery) so a failed delete/tombstone
+        flush rolls back only itself, not the caller's outer transaction --
+        without this, a failed flush would leave a shared Postgres session
+        aborted, and ``update_run``'s own later commit (it does not commit
+        independently) would fail too.
+        """
+        try:
+            async with self.session.begin_nested():
+                await self._purge_conversation(
+                    conversation=conversation,
+                    reason="ephemeral_completed",
+                    actor_user_id=actor_user_id,
+                )
+        except Exception:
+            logger.exception(
+                "ask_dev_ephemeral_conversation_purge_failed",
+                extra={"conversation_id": str(conversation.id)},
+            )
+            return False
+        return True
 
     async def force_terminal_fallback(
         self, *, org_id: uuid.UUID, user_id: uuid.UUID, run_id: uuid.UUID
@@ -2250,6 +2345,35 @@ class DevPersistenceService:
         run.safe_error_code = "internal_error"
         run.terminal_error_payload = None
         run.ended_at = self._now()
+        # CHAOS-3404: stamp only -- deliberately NOT an immediate
+        # synchronous purge, even though THIS request has no same-request
+        # reader of the content (unlike recover_stale_non_terminal_run).
+        # Codex adversarial-review round 3 (MEDIUM, confirmed) found a
+        # different, CONCURRENT race an immediate purge here still has: a
+        # duplicate in-flight request for the same client_message_id can
+        # already be blocked in recover_stale_non_terminal_run's
+        # `SELECT ... FOR UPDATE` on this exact run, waiting on this
+        # method's commit below to release the lock. Once it does, that
+        # concurrent request reads the run as already-terminal and returns
+        # it immediately (recover_stale_non_terminal_run's own
+        # already-terminal early-return, which never stamps or purges) --
+        # then router.py's replay path reads THIS run's answer/frame
+        # content back to build ITS response. If this method had already
+        # purged inline, that concurrent reader's content would be gone
+        # too, degrading a response that should show real content, exactly
+        # the round-2 finding but via a different (concurrent, not
+        # same-request) path. Stamping expires_at is enough to make the
+        # row eligible for the next cleanup_expired sweep tick -- "purged
+        # within one sweep interval," never "leaked forever," and never
+        # racing any reader. The terminal-state write and the stamp commit
+        # together, unconditionally -- this durability guarantee is this
+        # method's entire purpose (CHAOS-3297 round 3) and must never be
+        # weakened by anything that follows.
+        await self._stamp_ephemeral_expiry_if_terminal(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=run.conversation_id,
+        )
         await self.session.commit()
 
     async def recover_stale_non_terminal_run(
@@ -2335,6 +2459,24 @@ class DevPersistenceService:
         run.safe_error_code = "internal_error"
         run.terminal_error_payload = None
         run.ended_at = self._now()
+        # CHAOS-3404: stamp only, same rationale as force_terminal_fallback
+        # -- this method's return value (`run`) is immediately read back by
+        # its caller (router.py's replay path: get_answer_message /
+        # get_answer_frame keyed off THIS run) to build a replay response.
+        # An immediate purge here would delete the conversation (and its
+        # cascaded messages/frames) out from under that same read, silently
+        # degrading a response that should show real content (Codex
+        # adversarial-review round 2, MEDIUM, confirmed). Stamping
+        # expires_at makes the row eligible for the next cleanup_expired
+        # sweep tick instead -- "purged within one sweep interval," not
+        # "purged before this replay reads it and not before this replay
+        # needs it." The terminal-state write and the stamp commit
+        # together, unconditionally, same as force_terminal_fallback.
+        await self._stamp_ephemeral_expiry_if_terminal(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=run.conversation_id,
+        )
         await self.session.commit()
         return run
 
@@ -3237,6 +3379,100 @@ class DevPersistenceService:
             selected=len(conversations),
             purged=len(conversations),
         )
+
+    async def count_expired(self) -> int:
+        """Count conversations currently due for retention purge (CHAOS-3404).
+
+        Deliberately a plain, non-locking ``COUNT`` -- unlike
+        ``cleanup_expired``'s selection query, this does NOT take
+        ``FOR UPDATE SKIP LOCKED``. That distinction is the whole point:
+        Postgres row locks block writers, not plain reads, so this count
+        sees every row matching the expiry predicate regardless of whether
+        another concurrent ``cleanup_expired`` invocation currently holds a
+        lock on some of them. The sweep caller uses this after its batch
+        loop to distinguish "genuinely drained" from "a batch merely
+        returned fewer than `limit` rows because a concurrent invocation
+        was holding the rest" -- a SKIP LOCKED short read alone cannot make
+        that distinction (Codex adversarial-review round 2, CHAOS-3404,
+        HIGH, confirmed: relying on it let a concurrently-contended,
+        still-nonempty backlog report a healthy "completed" sweep).
+        """
+        now = self._now()
+        return int(
+            await self.session.scalar(
+                select(func.count())
+                .select_from(DevConversation)
+                .where(
+                    DevConversation.expires_at.is_not(None),
+                    DevConversation.expires_at <= now,
+                )
+            )
+            or 0
+        )
+
+    async def backfill_stranded_ephemeral_expiry(self, *, limit: int = 500) -> int:
+        """One-time repair for 0-day conversations already stranded before
+        this fix existed (CHAOS-3404; Codex adversarial-review round 3,
+        HIGH, confirmed).
+
+        Before ``_stamp_ephemeral_expiry_if_terminal`` existed,
+        ``force_terminal_fallback``/``recover_stale_non_terminal_run``
+        could leave a ``retention_days == 0`` conversation with every one
+        of its runs already terminal but ``expires_at`` still ``NULL`` --
+        permanently invisible to ``cleanup_expired``, and this fix only
+        stops NEW rows from ending up that way; it does nothing for ones
+        already stranded in production before deployment. This finds
+        exactly those (a 0-day conversation with at least one run, and NO
+        run still non-terminal) and stamps ``expires_at = now()`` on them,
+        identically to the synchronous stamp -- the ordinary
+        ``cleanup_expired`` sweep then collects them on its next tick, same
+        as any other now-due row. Deliberately narrow: a conversation with
+        zero runs (freshly created, no message posted yet) or ANY
+        non-terminal run (genuinely still in flight) is never touched.
+
+        Bounded and idempotent -- returns the number stamped this call;
+        safe to run repeatedly (a resumable one-time operator action, e.g.
+        a ``dev-hops maintenance`` command) until it returns 0.
+        """
+        if limit < 1 or limit > 500:
+            raise DevPersistenceValidationError(
+                "backfill limit must be between 1 and 500"
+            )
+        now = self._now()
+        has_a_run = exists(
+            select(DevRun.id).where(DevRun.conversation_id == DevConversation.id)
+        )
+        has_a_non_terminal_run = exists(
+            select(DevRun.id).where(
+                DevRun.conversation_id == DevConversation.id,
+                DevRun.state.not_in(_TERMINAL_RUN_STATES),
+            )
+        )
+        stranded = (
+            (
+                await self.session.execute(
+                    select(DevConversation)
+                    .where(
+                        DevConversation.retention_days == 0,
+                        DevConversation.expires_at.is_(None),
+                        has_a_run,
+                        ~has_a_non_terminal_run,
+                    )
+                    .order_by(DevConversation.created_at, DevConversation.id)
+                    .limit(limit)
+                    .with_for_update(skip_locked=True)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for conversation in stranded:
+            conversation.expires_at = now
+        logger.info(
+            "ask_dev_ephemeral_expiry_backfill_completed",
+            extra={"stamped": len(stranded)},
+        )
+        return len(stranded)
 
     async def _owned_conversation(
         self,

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -147,6 +147,38 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
     return 0
 
 
+async def _run_ask_dev_ephemeral_expiry_backfill(*, limit: int = 500) -> int:
+    """One-time repair for CHAOS-3404: stamp expires_at on 0-day Ask Dev
+    conversations stranded before the fix existed (see
+    DevPersistenceService.backfill_stranded_ephemeral_expiry's own
+    docstring). Loops in committed batches until a batch comes back short,
+    so it drains the full backlog in one invocation; safe to re-run --
+    returns 0 once nothing is left to stamp.
+    """
+    from dev_health_ops.api.dev.persistence import DevPersistenceService
+
+    total = 0
+    async with get_postgres_session() as db:
+        service = DevPersistenceService(db)
+        while True:
+            stamped = await service.backfill_stranded_ephemeral_expiry(limit=limit)
+            await db.commit()
+            total += stamped
+            if stamped < limit:
+                break
+    return total
+
+
+async def _cmd_maintenance_backfill_ask_dev_ephemeral_expiry(
+    _ns: argparse.Namespace,
+) -> int:
+    total = await _run_ask_dev_ephemeral_expiry_backfill()
+    logging.getLogger(__name__).info(
+        "Ask Dev ephemeral-expiry backfill complete: stamped=%s", total
+    )
+    return 0
+
+
 def _cmd_maintenance_scrub_error_text(ns: argparse.Namespace) -> int:
     from dev_health_ops.maintenance.scrub_error_text import run_scrub_error_text
 
@@ -513,6 +545,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("backfill", "run"): frozenset({_REQ_POSTGRES}),
     ("backfill", "operational"): frozenset({_REQ_CLICKHOUSE}),
     ("maintenance", "scrub-error-text"): frozenset({_REQ_POSTGRES}),
+    ("maintenance", "backfill-ask-dev-ephemeral-expiry"): frozenset({_REQ_POSTGRES}),
     # --- migrations that connect to a live database ---
     ("migrate", "clickhouse", "upgrade"): frozenset({_REQ_CLICKHOUSE}),
     ("migrate", "clickhouse", "status"): frozenset({_REQ_CLICKHOUSE}),
@@ -838,6 +871,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Rows to scan per keyset-paginated batch (default: 1000).",
     )
     scrub_error_text_parser.set_defaults(func=_cmd_maintenance_scrub_error_text)
+
+    backfill_ephemeral_expiry_parser = maintenance_subparsers.add_parser(
+        "backfill-ask-dev-ephemeral-expiry",
+        help=(
+            "One-time repair (CHAOS-3404) for 0-day Ask Dev conversations "
+            "stranded (every owned run terminal, expires_at never stamped) "
+            "before the retention-sweep fix existed. Idempotent -- safe to "
+            "re-run; the ordinary retention sweep then collects the rows "
+            "this stamps."
+        ),
+    )
+    backfill_ephemeral_expiry_parser.set_defaults(
+        func=_cmd_maintenance_backfill_ask_dev_ephemeral_expiry
+    )
 
     _propagate_global_args_to_subparsers(parser)
     _attach_preflight_metadata(parser)

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -268,6 +268,42 @@ if _PROMETHEUS_AVAILABLE:
         )
     )
 
+    # ---------------------------------------------------------------------------
+    # Ask Dev retention sweep (CHAOS-3404): DevPersistenceService.cleanup_expired
+    # previously had no production caller, so the 0/30-day retention policy
+    # never actually ran. Now beat-scheduled (workers/ask_dev_retention.py).
+    # ---------------------------------------------------------------------------
+    ASK_DEV_RETENTION_SWEEP_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_retention_sweep_total",
+        "Ask Dev retention sweep (cleanup_expired) completions by status "
+        "(completed/partial/failed -- partial means it hit its batch cap "
+        "without draining the backlog, not that it errored). A dashboard/"
+        "alert should page on status=failed and, more importantly, on this "
+        "counter's own absence -- see "
+        "devhealth_ask_dev_retention_sweep_last_success_timestamp for the "
+        "skipped-or-falling-behind-sweep (dead-man's-switch) signal.",
+        ["status"],
+    )
+
+    ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_retention_sweep_purged_total",
+        "Ask Dev conversations purged by the retention sweep, cumulative. "
+        "Incremented for every batch that actually committed a purge, "
+        "regardless of the sweep run's overall status (completed/partial/"
+        "failed) -- a purge that committed is real and durable even if a "
+        "later batch in the same run then failed.",
+    )
+
+    ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP = _prometheus_client_module.Gauge(
+        "devhealth_ask_dev_retention_sweep_last_success_timestamp",
+        "Unix timestamp (seconds) of the last time the Ask Dev retention "
+        "sweep completed successfully. Only ever advances on success -- "
+        "never set on a failed or skipped run -- so "
+        "`time() - this` growing unbounded is the receipt that a sweep "
+        "was silently skipped (beat never fired, worker down, queue "
+        "starved), not just that one run failed.",
+    )
+
 else:
     # Graceful no-ops when prometheus_client is unavailable
     CELERY_TASKS_TOTAL = _noop_counter()
@@ -293,6 +329,9 @@ else:
     ASK_DEV_QUA_SHADOW_LATENCY_SECONDS = _noop_histogram()
     ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL = _noop_counter()
+    ASK_DEV_RETENTION_SWEEP_TOTAL = _noop_counter()
+    ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL = _noop_counter()
+    ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP = _noop_gauge()
 
 
 # ---------------------------------------------------------------------------
@@ -369,6 +408,38 @@ def record_investment_membership_scope_stale(
     INVESTMENT_MEMBERSHIP_SCOPE_LAG_SECONDS.labels(scope_mode=scope_mode).set(
         lag_seconds
     )
+
+
+def record_ask_dev_retention_sweep(
+    *, status: str, purged: int = 0, timestamp: float | None = None
+) -> None:
+    """Record one Ask Dev retention sweep completion (CHAOS-3404).
+
+    ``status`` is one of:
+
+    * ``"completed"`` -- the sweep drained its backlog with no error.
+    * ``"partial"`` -- the sweep ran error-free but hit its batch cap
+      before draining the backlog (a real, growing backlog, not a failure).
+    * ``"failed"`` -- the sweep raised. ``purged`` may still be > 0 (earlier
+      batches in the same run committed before a later one failed).
+
+    ``purged`` is recorded for every status, since a purge that committed is
+    real and durable regardless of how the overall run ended. The
+    last-success gauge, however, is deliberately advanced ONLY on
+    ``"completed"`` (Codex adversarial-review round 1, CHAOS-3404, HIGH,
+    confirmed: a "partial" run that still advanced it let retention debt
+    persist while the dead-man alert reported a healthy sweep) -- a failed,
+    partial, or never-run sweep must leave it stale so an alert on
+    ``time() - devhealth_ask_dev_retention_sweep_last_success_timestamp``
+    detects a failing, falling-behind, or silently skipped sweep alike.
+    """
+    ASK_DEV_RETENTION_SWEEP_TOTAL.labels(status=status).inc()
+    if purged:
+        ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL.inc(purged)
+    if status == "completed":
+        ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP.set(
+            timestamp if timestamp is not None else time.time()
+        )
 
 
 @contextmanager

--- a/src/dev_health_ops/workers/ask_dev_retention.py
+++ b/src/dev_health_ops/workers/ask_dev_retention.py
@@ -1,0 +1,178 @@
+"""Ask Dev retention sweep production caller (CHAOS-3404).
+
+``DevPersistenceService.cleanup_expired`` (``api/dev/persistence/service.py``)
+purges conversations whose persisted ``expires_at`` has passed, but until
+this module existed nothing ever called it in production: no Celery beat
+entry, no CLI command, no caller anywhere. The 30-day retention policy
+(``ask_dev_retention_days`` org setting) therefore never executed -- expired
+conversations were retained indefinitely regardless of configuration.
+
+This sweep is the ONLY mechanism for 30-day rows -- they only ever expire on
+a schedule, never synchronously. For 0-day (ephemeral) conversations it is
+the SAFETY NET, not the primary mechanism: ``update_run`` (the common,
+live-success path) purges an ephemeral conversation synchronously the
+instant its run completes. ``force_terminal_fallback`` and
+``recover_stale_non_terminal_run`` -- the documented CHAOS-3297 last-resort
+recovery paths -- deliberately do NOT purge synchronously (Codex
+adversarial-review round 2, CHAOS-3404, MEDIUM, confirmed: an immediate
+purge there can race the same request's own replay-response read of the
+run's answer/frame content). All three instead stamp ``expires_at = now()``
+on any 0-day conversation the instant its run goes terminal
+(``DevPersistenceService._stamp_ephemeral_expiry_if_terminal``, committed
+independently of any purge attempt), which is exactly what makes THIS sweep
+able to collect the ones the synchronous path didn't -- before that stamp
+existed, a 0-day conversation whose run terminated via either recovery path
+was permanently unpurgeable by anything, this sweep included, because
+``expires_at`` was never set at all for a ``retention_days == 0`` row.
+
+Wired via ``workers/config.py``'s ``beat_schedule`` (production caller) and
+instrumented via ``metrics/prometheus.py``'s
+``devhealth_ask_dev_retention_sweep_*`` series -- the
+``..._last_success_timestamp`` gauge only advances when a run actually
+drains its backlog (``status="completed"``); a run that errors
+(``"failed"``) or doesn't verify the backlog is genuinely empty
+(``"partial"``) never advances it, so an alert on ``time() - gauge``
+growing past the beat interval catches a skipped/failed/perpetually-behind
+sweep alike -- not just a per-run failure. Caveat, stated honestly rather
+than assumed: these are plain ``prometheus_client`` instruments updated
+inside the Celery worker process; this codebase's only ``/metrics`` HTTP
+endpoint is mounted on the FastAPI app (``api/_observability.py``), and no
+worker container exposes or is scraped for one (same pre-existing gap every
+other Celery-task metric in ``metrics/prometheus.py`` has -- not new here,
+not fixed here). The structured ``ask_dev_retention_sweep.*`` log lines
+below are therefore the one receipt actually guaranteed to reach wherever
+this deployment ships worker stdout; treat the gauge as best-effort until
+worker-side Prometheus export exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from dev_health_ops.workers.async_runner import run_async
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+# Bounded: one beat tick purges at most _DEFAULT_MAX_BATCHES * limit rows.
+# If a backlog is larger than that (e.g. after a long outage), the sweep
+# reports drained=False and the next scheduled tick continues the drain --
+# this keeps a single task run from blocking the worker indefinitely instead
+# of silently dropping the remainder.
+_DEFAULT_LIMIT = 500
+_DEFAULT_MAX_BATCHES = 20
+
+
+async def _run_ask_dev_retention_cleanup(
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    max_batches: int = _DEFAULT_MAX_BATCHES,
+    session_factory: Callable[[], Any] | None = None,
+) -> dict[str, Any]:
+    """Drain expired Ask Dev conversations in bounded, committed batches.
+
+    ``session_factory`` defaults to ``dev_health_ops.db.get_postgres_session``
+    (production) and is overridable so tests can drive the real sweep logic
+    against a seeded, DB-level-aged test database instead of a live Postgres.
+    Each batch is its own transaction (explicit commit), matching
+    ``prune_external_ingest_batches``' chunked-commit shape, so a crash
+    mid-drain loses at most the in-flight batch, never already-purged rows.
+    """
+
+    from dev_health_ops.api.dev.persistence import DevPersistenceService
+    from dev_health_ops.metrics.prometheus import record_ask_dev_retention_sweep
+
+    factory: Callable[[], Any]
+    if session_factory is None:
+        from dev_health_ops.db import get_postgres_session
+
+        factory = get_postgres_session
+    else:
+        factory = session_factory
+
+    total_purged = 0
+    batches_run = 0
+
+    try:
+        for _ in range(max(1, int(max_batches))):
+            batches_run += 1
+            async with factory() as session:
+                service = DevPersistenceService(session)
+                result = await service.cleanup_expired(limit=limit)
+                await session.commit()
+            total_purged += result.purged
+            if result.selected < limit:
+                break
+
+        # Codex adversarial-review round 2 (CHAOS-3404, HIGH, confirmed): a
+        # batch returning fewer than `limit` rows is NOT proof the backlog
+        # is empty -- `cleanup_expired` selects with `FOR UPDATE SKIP
+        # LOCKED`, so a genuinely concurrent invocation (a manual trigger
+        # overlapping the beat tick, say) can make a batch look short
+        # purely because it's holding the remaining expired rows' locks,
+        # not because none remain. `count_expired()` is a plain,
+        # non-locking COUNT -- row locks block writers, not reads, so it
+        # sees every still-due row regardless of who holds a lock on it.
+        # Only a confirmed-zero count may report "completed" (and advance
+        # the last-success gauge); anything else -- the batch cap, or a
+        # contended backlog a SKIP LOCKED read alone couldn't rule out --
+        # reports "partial", honestly withholding the gauge until a later,
+        # uncontended tick actually verifies the backlog is clear.
+        async with factory() as session:
+            drained = await DevPersistenceService(session).count_expired() == 0
+    except Exception:
+        logger.exception(
+            "ask_dev_retention_sweep.failed",
+            extra={"purged_before_failure": total_purged, "batches": batches_run},
+        )
+        record_ask_dev_retention_sweep(status="failed", purged=total_purged)
+        raise
+
+    status = "completed" if drained else "partial"
+    if not drained:
+        logger.warning(
+            "ask_dev_retention_sweep.backlog_not_verified_empty",
+            extra={
+                "purged": total_purged,
+                "batches": batches_run,
+                "limit": limit,
+                "max_batches": max_batches,
+            },
+        )
+
+    logger.info(
+        "ask_dev_retention_sweep.completed",
+        extra={
+            "status": status,
+            "purged": total_purged,
+            "batches": batches_run,
+            "drained": drained,
+        },
+    )
+    record_ask_dev_retention_sweep(status=status, purged=total_purged)
+    return {
+        "status": status,
+        "purged": total_purged,
+        "batches": batches_run,
+        "drained": drained,
+    }
+
+
+@celery_app.task(
+    queue="default",
+    name="dev_health_ops.workers.tasks.run_ask_dev_retention_cleanup",
+)
+def run_ask_dev_retention_cleanup(
+    limit: int = _DEFAULT_LIMIT, max_batches: int = _DEFAULT_MAX_BATCHES
+) -> dict[str, Any]:
+    """Beat-scheduled production caller for ``cleanup_expired`` (CHAOS-3404)."""
+
+    coro: Coroutine[Any, Any, dict[str, Any]] = _run_ask_dev_retention_cleanup(
+        limit=limit, max_batches=max_batches
+    )
+    return run_async(coro)
+
+
+__all__ = ["run_ask_dev_retention_cleanup"]

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -297,6 +297,20 @@ beat_schedule = {
         "schedule": crontab(hour=5, minute=15),
         "options": {"queue": "sync"},
     },
+    # Ask Dev retention sweep (CHAOS-3404): the only production caller of
+    # DevPersistenceService.cleanup_expired, which purges conversations past
+    # their persisted `expires_at` (the 30-day retention window; 0-day
+    # ephemeral conversations are purged synchronously on run completion --
+    # see workers/ask_dev_retention.py's module docstring). Previously had no
+    # beat entry, CLI, or caller at all, so retention never executed
+    # regardless of the org's configured ask_dev_retention_days. Scheduled
+    # immediately after prune-external-ingest-batches (5:15), clear of the
+    # other nightly jobs.
+    "ask-dev-retention-sweep": {
+        "task": "dev_health_ops.workers.tasks.run_ask_dev_retention_cleanup",
+        "schedule": crontab(hour=5, minute=30),
+        "options": {"queue": "default"},
+    },
     "refresh-sync-coverage-projections": {
         "task": "dev_health_ops.workers.tasks.refresh_sync_coverage_projections",
         "schedule": 300.0,

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -1,4 +1,5 @@
 import dev_health_ops.workers.external_ingest_recompute  # noqa: F401
+from dev_health_ops.workers.ask_dev_retention import run_ask_dev_retention_cleanup
 from dev_health_ops.workers.external_ingest_reconciler import (
     prune_external_ingest_batches,
 )
@@ -91,6 +92,7 @@ __all__ = [
     "prune_external_ingest_batches",
     "prune_rate_limit_observations",
     "reconcile_sync_dispatch",
+    "run_ask_dev_retention_cleanup",
     "refresh_sync_coverage_projections",
     "dispatch_membership_backfill",
     "run_capacity_forecast_job",

--- a/tests/api/dev/test_persistence.py
+++ b/tests/api/dev/test_persistence.py
@@ -194,6 +194,110 @@ async def test_retention_contract_is_exact_and_ephemeral_content_is_removed(
 
 
 @pytest.mark.asyncio
+async def test_update_run_survives_a_failing_immediate_purge(
+    persistence, monkeypatch: pytest.MonkeyPatch
+):
+    """Team-lead binding constraint, fault-injected directly against the
+    ONE place CHAOS-3404 attempts an immediate synchronous purge at all
+    (update_run -- the live/success path, safe because nothing reads this
+    run's content back from the DB afterward; the orchestrator already has
+    it in memory for the live SSE stream). Forces ``_purge_conversation``
+    to raise and proves BOTH halves of the durability contract:
+
+    1. The terminal-state write is NOT gated on the purge succeeding --
+       ``update_run`` returns normally (the caller's own commit persists
+       state + the expires_at stamp), never raising the purge's exception.
+       This is what ``_try_purge_ephemeral_conversation``'s SAVEPOINT
+       (``begin_nested``) buys: a failed purge rolls back only itself, not
+       update_run's shared, caller-owned outer transaction.
+    2. Nothing "retries the purge" itself -- the stamped expires_at makes
+       the row visible to cleanup_expired, and a real, unmocked sweep call
+       collects it later, exactly like a 30-day row: "purged within one
+       sweep interval," never "leaked forever."
+    """
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        ephemeral = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=ephemeral.id,
+            client_message_id=uuid.uuid4(),
+            question="Does the purge itself fail on an otherwise-successful run?",
+            scope_snapshot={},
+        )
+        answer_id = uuid.uuid4()
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=ephemeral.id,
+            answer_payload=_validated_answer(ephemeral.id, answer_id),
+            validator=_identity_validator,
+            scope_snapshot={},
+        )
+
+        async def _boom(self, *, conversation, reason, actor_user_id):
+            raise RuntimeError("simulated purge failure: connection dropped again")
+
+        monkeypatch.setattr(DevPersistenceService, "_purge_conversation", _boom)
+
+        # Must not raise: the terminal write is the durability guarantee,
+        # independent of the purge outcome.
+        result = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=accepted.run.id,
+            state="completed",
+            answer_id=answer_id,
+            provider_source="platform",
+            provider_fingerprint=_DIGEST,
+            model_fingerprint=_DIGEST,
+            prompt_version="dev-system.v1",
+            tool_contract_version="dev-tools.v1",
+            metric_version="metric-registry.v1",
+            query_version="dev-query.v1",
+        )
+        # Purge failed -- update_run returns the run (not None, unlike the
+        # successful-purge case), since nothing was actually deleted.
+        assert result is not None
+        assert result.state == "completed"
+        await session.commit()
+
+    async with maker() as session2:
+        conversation = await session2.get(DevConversation, ephemeral.id)
+        assert conversation is not None  # purge failed -- row still exists...
+        assert conversation.expires_at is not None
+        # SQLite (test harness only) round-trips a naive datetime even
+        # though it was written aware; normalize before comparing.
+        expires_at = conversation.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        assert expires_at <= datetime.now(UTC)  # ...but is now due
+
+    # Undo the fault injection explicitly -- monkeypatch only auto-reverts
+    # at test teardown, and this step must prove a REAL, unmocked sweep
+    # (not one still silently patched to fail) collects the row.
+    monkeypatch.undo()
+    async with maker() as session3:
+        sweep_service = DevPersistenceService(session3)
+        sweep_result = await sweep_service.cleanup_expired(limit=10)
+        await session3.commit()
+    assert sweep_result.purged == 1
+    async with maker() as session4:
+        assert await session4.get(DevConversation, ephemeral.id) is None
+        tombstone = await session4.scalar(
+            select(DevConversationTombstone).where(
+                DevConversationTombstone.conversation_id == ephemeral.id
+            )
+        )
+        assert tombstone is not None
+        assert tombstone.reason == "ephemeral_completed"
+
+
+@pytest.mark.asyncio
 async def test_client_message_id_is_idempotent_for_message_and_run(persistence):
     maker, org_id, _other_org_id, user_id, _other_user_id = persistence
     async with maker() as session:
@@ -746,6 +850,264 @@ async def test_deletion_expiry_and_cleanup_are_bounded_idempotent_and_content_fr
             ]
         )
         assert "Sensitive question content" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_force_terminal_fallback_stamps_expiry_for_the_sweep_to_collect(
+    persistence,
+):
+    """CHAOS-3404: force_terminal_fallback is the documented last-resort
+    recovery path for a dropped-connection/DB failure mid-finish() (CHAOS-3297
+    round 3) -- it used to set a run terminal without ever checking
+    retention_days == 0, leaving that conversation permanently unpurgeable
+    (expires_at is never set for 0-day rows, so cleanup_expired's async
+    sweep couldn't catch it either -- nothing could).
+
+    Fixed: stamps ``expires_at = now()`` on the conversation as part of the
+    SAME commit as the terminal-state write, and deliberately does NOT
+    attempt an immediate synchronous purge. Two independent races rule that
+    out (Codex adversarial-review, both confirmed):
+
+    * round 2 -- a same-request reader: recover_stale_non_terminal_run's
+      RETURN VALUE is read back immediately by its own caller to build a
+      replay response (see that method's own test).
+    * round 3 -- a CONCURRENT reader: a duplicate in-flight request can
+      already be blocked in recover_stale_non_terminal_run's
+      ``SELECT ... FOR UPDATE`` on this exact run, waiting on force_
+      terminal_fallback's commit to release the lock, then reading this
+      run's answer/frame content back the instant it does. An immediate
+      purge here would delete that content out from under that concurrent
+      reader too -- so this method never attempts one at all, matching
+      recover_stale_non_terminal_run exactly, even though (unlike that
+      method) IT has no same-request reader of its own.
+
+    This proves both halves: the conversation is intact immediately after
+    (so any reader, same-request or concurrent, still sees real content)
+    but is now immediately due, and a real cleanup_expired sweep call
+    collects it.
+    """
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        ephemeral = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=ephemeral.id,
+            client_message_id=uuid.uuid4(),
+            question="Did the connection drop mid-answer?",
+            scope_snapshot={},
+        )
+        await service.force_terminal_fallback(
+            org_id=org_id, user_id=user_id, run_id=accepted.run.id
+        )
+        # Intact immediately after -- never raced by an inline purge.
+        conversation = await session.get(DevConversation, ephemeral.id)
+        assert conversation is not None
+        assert conversation.expires_at is not None
+        assert conversation.expires_at <= datetime.now(UTC)
+        run = await session.get(DevRun, accepted.run.id)
+        assert run is not None
+        assert run.state == "failed"
+
+    # The real safety-net sweep collects it.
+    async with maker() as session2:
+        sweep_service = DevPersistenceService(session2)
+        result = await sweep_service.cleanup_expired(limit=10)
+        await session2.commit()
+    assert result.purged == 1
+    async with maker() as session3:
+        assert await session3.get(DevConversation, ephemeral.id) is None
+        tombstone = await session3.scalar(
+            select(DevConversationTombstone).where(
+                DevConversationTombstone.conversation_id == ephemeral.id
+            )
+        )
+        assert tombstone is not None
+        assert tombstone.reason == "ephemeral_completed"
+
+
+@pytest.mark.asyncio
+async def test_force_terminal_fallback_leaves_a_30_day_conversation_alone(persistence):
+    """Regression guard: the new purge check must not touch non-ephemeral
+    conversations -- force_terminal_fallback's forced-failed run stays
+    exactly as it was before CHAOS-3404 for the 30-day case."""
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=30
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Regression guard for the 30-day path.",
+            scope_snapshot={},
+        )
+        await service.force_terminal_fallback(
+            org_id=org_id, user_id=user_id, run_id=accepted.run.id
+        )
+        assert await session.get(DevConversation, conversation.id) is not None
+        run = await session.get(DevRun, accepted.run.id)
+        assert run is not None
+        assert run.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_non_terminal_run_stamps_expiry_for_the_sweep_to_collect(
+    persistence,
+):
+    """Same gap, the other documented recovery path (CHAOS-3297 rounds 5/7):
+    a stuck non-terminal run recovered on replay must also honor 0-day
+    retention when it forces the run terminal -- and, same as
+    force_terminal_fallback, via a stamp-then-sweep contract rather than an
+    inline purge, because THIS method's return value is immediately read
+    back by its caller (router.py's replay path) to build a response from
+    the run's answer/frame -- an inline purge would delete that content out
+    from under the very read that needs it (Codex adversarial-review
+    round 2, MEDIUM, confirmed).
+    """
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    clock = Clock(datetime(2026, 7, 28, 12, 0, tzinfo=UTC))
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        ephemeral = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=ephemeral.id,
+            client_message_id=uuid.uuid4(),
+            question="Stuck non-terminal, recovered on replay.",
+            scope_snapshot={},
+        )
+        clock.value += timedelta(hours=1)
+        recovered = await service.recover_stale_non_terminal_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=accepted.run.id,
+            stale_after=timedelta(minutes=1),
+        )
+        assert recovered is not None
+        assert recovered.state == "failed"
+        # Intact immediately after -- the router's own subsequent
+        # get_answer_message/get_answer_frame read (keyed off `recovered`)
+        # still sees a real, undeleted conversation/run.
+        conversation = await session.get(DevConversation, ephemeral.id)
+        assert conversation is not None
+        assert conversation.expires_at is not None
+        assert conversation.expires_at <= clock.value
+
+    # The real safety-net sweep collects it.
+    async with maker() as session2:
+        sweep_service = DevPersistenceService(session2, now=clock)
+        result = await sweep_service.cleanup_expired(limit=10)
+        await session2.commit()
+    assert result.purged == 1
+    async with maker() as session3:
+        assert await session3.get(DevConversation, ephemeral.id) is None
+        tombstone = await session3.scalar(
+            select(DevConversationTombstone).where(
+                DevConversationTombstone.conversation_id == ephemeral.id
+            )
+        )
+        assert tombstone is not None
+        assert tombstone.reason == "ephemeral_completed"
+
+
+@pytest.mark.asyncio
+async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persistence):
+    """Codex adversarial-review round 3 (CHAOS-3404, HIGH, confirmed): the
+    synchronous-stamp fix only stops NEW 0-day rows from being stranded --
+    it does nothing for rows already left with every run terminal and
+    expires_at=NULL by the pre-fix force_terminal_fallback/
+    recover_stale_non_terminal_run in production before this deploys.
+    Simulates exactly that pre-fix state directly (a raw state mutation,
+    bypassing update_run/force_terminal_fallback entirely -- those all
+    stamp now, so this is the only way to construct the stranded shape a
+    backfill needs to repair), then proves backfill_stranded_ephemeral_expiry
+    stamps it and the ordinary sweep collects it -- while leaving a
+    still-in-flight (non-terminal run) or run-less (freshly created,
+    nothing to retire) 0-day conversation untouched.
+    """
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        stranded = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        stranded_accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=stranded.id,
+            client_message_id=uuid.uuid4(),
+            question="Stranded by the pre-fix fallback path.",
+            scope_snapshot={},
+        )
+        # Raw mutation -- simulates the pre-fix force_terminal_fallback
+        # shape directly: terminal run, expires_at never stamped.
+        stranded_accepted.run.state = "failed"
+        await session.flush()
+
+        still_in_flight = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=still_in_flight.id,
+            client_message_id=uuid.uuid4(),
+            question="Genuinely still running -- must not be touched.",
+            scope_snapshot={},
+        )
+
+        run_less = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await session.commit()
+
+    async with maker() as session2:
+        service2 = DevPersistenceService(session2)
+        stamped = await service2.backfill_stranded_ephemeral_expiry(limit=10)
+        await session2.commit()
+    assert stamped == 1
+
+    async with maker() as session3:
+        stranded_row = await session3.get(DevConversation, stranded.id)
+        assert stranded_row is not None
+        assert stranded_row.expires_at is not None
+        expires_at = stranded_row.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        assert expires_at <= datetime.now(UTC)
+
+        # Untouched: still in flight, and never had a run at all.
+        assert (
+            await session3.get(DevConversation, still_in_flight.id)
+        ).expires_at is None
+        assert (await session3.get(DevConversation, run_less.id)).expires_at is None
+
+    # Idempotent: a second call finds nothing left to stamp.
+    async with maker() as session4:
+        service4 = DevPersistenceService(session4)
+        assert await service4.backfill_stranded_ephemeral_expiry(limit=10) == 0
+
+    # The ordinary sweep now collects the repaired row.
+    async with maker() as session5:
+        sweep_service = DevPersistenceService(session5)
+        result = await sweep_service.cleanup_expired(limit=10)
+        await session5.commit()
+    assert result.purged == 1
+    async with maker() as session6:
+        assert await session6.get(DevConversation, stranded.id) is None
+        assert await session6.get(DevConversation, still_in_flight.id) is not None
+        assert await session6.get(DevConversation, run_less.id) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_cleanup_command.py
+++ b/tests/test_cleanup_command.py
@@ -34,6 +34,49 @@ def test_cleanup_tokens_command_calls_cleanup_expired(monkeypatch):
     assert called["committed"] is True
 
 
+def test_backfill_ask_dev_ephemeral_expiry_command_drains_in_committed_batches(
+    monkeypatch,
+):
+    """CHAOS-3404: the CLI command must loop DevPersistenceService.
+    backfill_stranded_ephemeral_expiry in committed batches until a batch
+    comes back short of the limit, matching cleanup_expired's own
+    drain-loop shape, and must actually commit each batch (a backfill that
+    never commits stamps nothing durably)."""
+    calls = {"count": 0, "commits": 0}
+    # First batch full (limit), second batch short -> loop stops after 2.
+    responses = [500, 3]
+
+    class _FakeService:
+        def __init__(self, db):
+            self.db = db
+
+        async def backfill_stranded_ephemeral_expiry(self, *, limit):
+            assert limit == 500
+            calls["count"] += 1
+            return responses[calls["count"] - 1]
+
+    class _FakeDB:
+        async def commit(self) -> None:
+            calls["commits"] += 1
+
+    @asynccontextmanager
+    async def _fake_get_postgres_session():
+        yield _FakeDB()
+
+    monkeypatch.setattr(cli_module, "get_postgres_session", _fake_get_postgres_session)
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.persistence.DevPersistenceService", _FakeService
+    )
+
+    parser = cli_module.build_parser()
+    ns = parser.parse_args(["maintenance", "backfill-ask-dev-ephemeral-expiry"])
+    rc = asyncio.run(ns.func(ns))
+
+    assert rc == 0
+    assert calls["count"] == 2
+    assert calls["commits"] == 2
+
+
 def test_cleanup_all_command_calls_cleanup_expired(monkeypatch):
     called = {"count": 0, "committed": False}
 

--- a/tests/workers/test_ask_dev_retention_sweep.py
+++ b/tests/workers/test_ask_dev_retention_sweep.py
@@ -1,0 +1,534 @@
+"""CHAOS-3404: Ask Dev retention sweep must have a real production caller.
+
+``DevPersistenceService.cleanup_expired`` existed with unit coverage but no
+beat schedule, CLI command, or caller anywhere -- the 0/30-day retention
+policy never executed in production. These tests prove:
+
+* the wiring seam -- a registered Celery task + a beat entry that points at
+  it (mirrors ``tests/test_release_impact_schedule.py``'s precedent), and
+* the sweep helper actually purges expired rows end-to-end against a real
+  (sqlite) database, aged via a direct SQL UPDATE of the persisted
+  ``expires_at`` column -- never wall-clock waiting, never monkeypatching the
+  service's clock (D6: DB-level timestamp aging only).
+* a skipped/failed sweep is observable: the last-success gauge only advances
+  on success, and a mid-sweep failure still surfaces (never a silent empty
+  success).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from celery.schedules import crontab
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.models.dev_persistence import (
+    DevConversation,
+    DevConversationTombstone,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import closing_coroutine_runner, tables_of
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevConversationTombstone,
+)
+
+
+@pytest_asyncio.fixture
+async def persistence(tmp_path: Path):
+    database = tmp_path / "ask-dev-retention-sweep.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev", name="Ask Dev"),
+                User(id=user_id, email="ask-dev@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+async def _seed_conversation(maker, *, org_id, user_id, retention_days: int) -> Any:
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id,
+            user_id=user_id,
+            current_scope={},
+            retention_days=retention_days,
+        )
+        await session.commit()
+        return conversation.id
+
+
+async def _age_conversation(maker, conversation_id, *, expires_at: datetime) -> None:
+    """Age a persisted row's expiry directly in the DB (D6: no clock mocking)."""
+    async with maker() as session:
+        await session.execute(
+            update(DevConversation)
+            .where(DevConversation.id == conversation_id)
+            .values(expires_at=expires_at)
+        )
+        await session.commit()
+
+
+class TestTaskRegistration:
+    def test_task_importable_and_callable(self) -> None:
+        from dev_health_ops.workers.ask_dev_retention import (
+            run_ask_dev_retention_cleanup,
+        )
+
+        assert callable(run_ask_dev_retention_cleanup)
+
+    def test_task_exported_from_tasks_module(self) -> None:
+        from dev_health_ops.workers import tasks
+
+        assert "run_ask_dev_retention_cleanup" in tasks.__all__
+        assert hasattr(tasks, "run_ask_dev_retention_cleanup")
+
+    def test_task_is_celery_task_on_default_queue(self) -> None:
+        from dev_health_ops.workers.ask_dev_retention import (
+            run_ask_dev_retention_cleanup,
+        )
+
+        assert hasattr(run_ask_dev_retention_cleanup, "apply_async")
+        assert hasattr(run_ask_dev_retention_cleanup, "delay")
+        assert (
+            run_ask_dev_retention_cleanup.name
+            == "dev_health_ops.workers.tasks.run_ask_dev_retention_cleanup"
+        )
+        assert run_ask_dev_retention_cleanup.queue == "default"
+
+    def test_task_drives_the_async_sweep_via_run_async(self) -> None:
+        """The sync Celery task body must go through the shared run_async
+        helper (not a bare asyncio.run()), matching every other async task."""
+        from dev_health_ops.workers import ask_dev_retention
+
+        sentinel = closing_coroutine_runner(
+            return_value={"status": "completed", "purged": 0}
+        )
+        with patch.object(ask_dev_retention, "run_async", side_effect=sentinel):
+            result = ask_dev_retention.run_ask_dev_retention_cleanup.run()
+        assert result == {"status": "completed", "purged": 0}
+
+
+class TestBeatSchedule:
+    def test_beat_schedule_has_the_retention_sweep_entry(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        assert "ask-dev-retention-sweep" in beat_schedule
+        entry = beat_schedule["ask-dev-retention-sweep"]
+        assert (
+            entry["task"]
+            == "dev_health_ops.workers.tasks.run_ask_dev_retention_cleanup"
+        )
+        assert entry["options"]["queue"] == "default"
+
+    def test_beat_schedule_uses_a_daily_crontab(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        schedule = beat_schedule["ask-dev-retention-sweep"]["schedule"]
+        assert isinstance(schedule, crontab)
+
+    def test_beat_entry_kwargs_are_a_subset_of_the_task_signature(self) -> None:
+        """Signature-contract guard (team-lead design requirement, precedent:
+        test_daily_metrics_kwargs_subset_of_task_signature in
+        test_external_ingest_recompute_dispatch.py): whatever kwargs the
+        beat entry (or any future dispatcher) passes to
+        run_ask_dev_retention_cleanup must be real parameter names on the
+        task's own ``.run`` signature -- a renamed/removed `limit` or
+        `max_batches` kwarg would otherwise fail silently at call time
+        (TypeError swallowed inside Celery's task dispatch, not surfaced
+        until the sweep never runs)."""
+        import inspect
+
+        from dev_health_ops.workers.ask_dev_retention import (
+            run_ask_dev_retention_cleanup,
+        )
+        from dev_health_ops.workers.config import beat_schedule
+
+        params = set(inspect.signature(run_ask_dev_retention_cleanup.run).parameters)
+        assert {"limit", "max_batches"} <= params
+
+        entry_kwargs = beat_schedule["ask-dev-retention-sweep"].get("kwargs", {})
+        assert set(entry_kwargs) <= params
+
+
+class TestSweepPurgesDbLevelAgedRows:
+    @pytest.mark.asyncio
+    async def test_expired_30_day_conversation_is_purged(self, persistence) -> None:
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_id = await _seed_conversation(
+            maker, org_id=org_id, user_id=user_id, retention_days=30
+        )
+        # DB-level timestamp aging (D6): a direct SQL UPDATE of the persisted
+        # row, not a mocked clock and not a real wall-clock sleep.
+        await _age_conversation(
+            maker,
+            conversation_id,
+            expires_at=datetime.now(UTC) - timedelta(days=1),
+        )
+
+        with patch(
+            "dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"
+        ) as mock_record:
+            result = await _run_ask_dev_retention_cleanup(session_factory=maker)
+
+        assert result == {
+            "status": "completed",
+            "purged": 1,
+            "batches": 1,
+            "drained": True,
+        }
+        async with maker() as session:
+            assert await session.get(DevConversation, conversation_id) is None
+        mock_record.assert_called_once_with(status="completed", purged=1)
+
+    @pytest.mark.asyncio
+    async def test_not_yet_expired_conversation_is_left_alone(
+        self, persistence
+    ) -> None:
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_id = await _seed_conversation(
+            maker, org_id=org_id, user_id=user_id, retention_days=30
+        )
+        # Freshly created: expires_at is ~30 days out, not yet due.
+
+        result = await _run_ask_dev_retention_cleanup(session_factory=maker)
+
+        assert result["purged"] == 0
+        async with maker() as session:
+            assert await session.get(DevConversation, conversation_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_drains_across_multiple_batches(self, persistence) -> None:
+        """More expired rows than fit in one `limit`-sized batch still all
+        get purged in one sweep, as long as it stays under max_batches."""
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_ids = [
+            await _seed_conversation(
+                maker, org_id=org_id, user_id=user_id, retention_days=30
+            )
+            for _ in range(3)
+        ]
+        past = datetime.now(UTC) - timedelta(days=1)
+        for conversation_id in conversation_ids:
+            await _age_conversation(maker, conversation_id, expires_at=past)
+
+        result = await _run_ask_dev_retention_cleanup(
+            limit=1, max_batches=10, session_factory=maker
+        )
+
+        assert result["status"] == "completed"
+        assert result["purged"] == 3
+        assert result["batches"] >= 3
+        assert result["drained"] is True
+        async with maker() as session:
+            for conversation_id in conversation_ids:
+                assert await session.get(DevConversation, conversation_id) is None
+
+    @pytest.mark.asyncio
+    async def test_batch_cap_reports_undrained_instead_of_looping_forever(
+        self, persistence
+    ) -> None:
+        """A backlog bigger than limit*max_batches must be reported, not
+        silently dropped -- the next scheduled tick finishes the drain."""
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_ids = [
+            await _seed_conversation(
+                maker, org_id=org_id, user_id=user_id, retention_days=30
+            )
+            for _ in range(3)
+        ]
+        past = datetime.now(UTC) - timedelta(days=1)
+        for conversation_id in conversation_ids:
+            await _age_conversation(maker, conversation_id, expires_at=past)
+
+        with patch(
+            "dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"
+        ) as mock_record:
+            result = await _run_ask_dev_retention_cleanup(
+                limit=1, max_batches=2, session_factory=maker
+            )
+
+        assert result["status"] == "partial"
+        assert result["purged"] == 2
+        assert result["batches"] == 2
+        assert result["drained"] is False
+        # Codex adversarial-review round 1 (CHAOS-3404, HIGH, confirmed): a
+        # capped-but-error-free run must record "partial", never "completed"
+        # -- advancing the last-success gauge here would let retention debt
+        # persist while the dead-man alert reports a healthy sweep.
+        mock_record.assert_called_once_with(status="partial", purged=2)
+        # The third row is still there -- a real remaining backlog, not lost.
+        async with maker() as session:
+            remaining = [
+                cid
+                for cid in conversation_ids
+                if await session.get(DevConversation, cid) is not None
+            ]
+        assert len(remaining) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_falsely_short_batch_does_not_report_completed(
+        self, persistence
+    ) -> None:
+        """Codex adversarial-review round 2 (CHAOS-3404, HIGH, confirmed): a
+        batch returning fewer than `limit` rows is not proof the backlog is
+        empty -- cleanup_expired selects with FOR UPDATE SKIP LOCKED, so a
+        genuinely concurrent invocation holding the remaining expired rows'
+        locks can make a batch look short even though real work remains.
+        This simulates exactly that short-read shape (0 selected, 0 purged,
+        as a fully-lock-contended SKIP LOCKED read would report) while a
+        genuinely expired, unpurged conversation is still present in the
+        DB, and proves the definitive post-loop count_expired() check
+        catches it: the sweep must report "partial", never "completed",
+        and must not lose the still-pending row."""
+        from dev_health_ops.api.dev.persistence import (
+            CleanupResult,
+            DevPersistenceService,
+        )
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_id = await _seed_conversation(
+            maker, org_id=org_id, user_id=user_id, retention_days=30
+        )
+        await _age_conversation(
+            maker, conversation_id, expires_at=datetime.now(UTC) - timedelta(days=1)
+        )
+
+        async def _fake_lock_contended_batch(self, *, limit):
+            return CleanupResult(reason="retention_expired", selected=0, purged=0)
+
+        with (
+            patch.object(
+                DevPersistenceService, "cleanup_expired", _fake_lock_contended_batch
+            ),
+            patch(
+                "dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"
+            ) as mock_record,
+        ):
+            result = await _run_ask_dev_retention_cleanup(
+                limit=1, session_factory=maker
+            )
+
+        assert result["status"] == "partial"
+        assert result["drained"] is False
+        assert result["purged"] == 0
+        mock_record.assert_called_once_with(status="partial", purged=0)
+        # Not lost -- still there for the next, uncontended tick to collect.
+        async with maker() as session:
+            assert await session.get(DevConversation, conversation_id) is not None
+
+
+class TestSweepFailureIsObservableNotSilent:
+    @pytest.mark.asyncio
+    async def test_a_zeroth_batch_failure_raises_and_records_failed_status(
+        self,
+    ) -> None:
+        """The connection-never-opens case: nothing committed, purged=0."""
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        class _BoomSession:
+            async def __aenter__(self):
+                raise RuntimeError("postgres unavailable")
+
+            async def __aexit__(self, *exc_info):
+                return False
+
+        def _broken_factory():
+            return _BoomSession()
+
+        with patch(
+            "dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"
+        ) as mock_record:
+            with pytest.raises(RuntimeError, match="postgres unavailable"):
+                await _run_ask_dev_retention_cleanup(session_factory=_broken_factory)
+
+        # Never a silent empty success: status=failed was recorded, and the
+        # last-success gauge (asserted via record_ask_dev_retention_sweep's
+        # own contract, unit-tested separately below) was never touched.
+        mock_record.assert_called_once_with(status="failed", purged=0)
+
+    @pytest.mark.asyncio
+    async def test_a_second_batch_failure_preserves_the_first_batchs_purge(
+        self, persistence
+    ) -> None:
+        """Codex adversarial-review round 1 (CHAOS-3404, MEDIUM, confirmed):
+        the prior failure test never exercised a real committed batch before
+        the failure. This drives an actual first batch to a real commit
+        (row genuinely gone, durably, independent of the second failure),
+        then fails the second batch, and asserts the failure metric reports
+        the REAL committed count -- not 0, not silently dropped -- and that
+        DevPersistenceService.cleanup_expired was the thing actually called
+        (a mutation swapping it for a bare DELETE that skips the tombstone
+        must not be able to pass this test)."""
+        from dev_health_ops.api.dev.persistence import DevPersistenceService
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        conversation_ids = [
+            await _seed_conversation(
+                maker, org_id=org_id, user_id=user_id, retention_days=30
+            )
+            for _ in range(2)
+        ]
+        past = datetime.now(UTC) - timedelta(days=1)
+        for conversation_id in conversation_ids:
+            await _age_conversation(maker, conversation_id, expires_at=past)
+
+        real_calls: list[int] = []
+        real_cleanup_expired = DevPersistenceService.cleanup_expired
+
+        call_count = 0
+
+        async def _spy_cleanup_expired(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("connection dropped mid-second-batch")
+            result = await real_cleanup_expired(self, *args, **kwargs)
+            real_calls.append(result.purged)
+            return result
+
+        with (
+            patch.object(
+                DevPersistenceService, "cleanup_expired", _spy_cleanup_expired
+            ),
+            patch(
+                "dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"
+            ) as mock_record,
+        ):
+            with pytest.raises(RuntimeError, match="connection dropped"):
+                await _run_ask_dev_retention_cleanup(
+                    limit=1, max_batches=5, session_factory=maker
+                )
+
+        # cleanup_expired (the real service method, not a bare DELETE) was
+        # genuinely invoked, and batch one genuinely purged one row.
+        assert call_count == 2
+        assert real_calls == [1]
+        # That first purge is durable -- committed before the second batch
+        # ever started -- independent of the second batch's failure.
+        async with maker() as session:
+            remaining = [
+                cid
+                for cid in conversation_ids
+                if await session.get(DevConversation, cid) is not None
+            ]
+        assert len(remaining) == 1
+        # The failure metric reports the REAL committed count, not 0.
+        mock_record.assert_called_once_with(status="failed", purged=1)
+
+
+class TestRecordAskDevRetentionSweepGaugeContract:
+    """Unit contract for the metrics helper itself: the receipt that makes a
+    *skipped* sweep detectable (not just a failed one) is that the
+    last-success gauge only ever advances on status="completed"."""
+
+    def test_completed_status_advances_the_last_success_gauge(self) -> None:
+        from dev_health_ops.metrics import prometheus
+
+        with (
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_TOTAL, "labels"
+            ) as mock_total,
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP, "set"
+            ) as mock_gauge_set,
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL, "inc"
+            ) as mock_purged_inc,
+        ):
+            prometheus.record_ask_dev_retention_sweep(
+                status="completed", purged=5, timestamp=1234.0
+            )
+
+        mock_total.assert_called_once_with(status="completed")
+        mock_purged_inc.assert_called_once_with(5)
+        mock_gauge_set.assert_called_once_with(1234.0)
+
+    def test_partial_status_records_purged_but_never_advances_the_gauge(
+        self,
+    ) -> None:
+        from dev_health_ops.metrics import prometheus
+
+        with (
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_TOTAL, "labels"
+            ) as mock_total,
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP, "set"
+            ) as mock_gauge_set,
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL, "inc"
+            ) as mock_purged_inc,
+        ):
+            prometheus.record_ask_dev_retention_sweep(status="partial", purged=3)
+
+        mock_total.assert_called_once_with(status="partial")
+        mock_purged_inc.assert_called_once_with(3)
+        mock_gauge_set.assert_not_called()
+
+    def test_failed_status_never_advances_the_last_success_gauge(self) -> None:
+        from dev_health_ops.metrics import prometheus
+
+        with (
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_TOTAL, "labels"
+            ) as mock_total,
+            patch.object(
+                prometheus.ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP, "set"
+            ) as mock_gauge_set,
+        ):
+            prometheus.record_ask_dev_retention_sweep(status="failed")
+
+        mock_total.assert_called_once_with(status="failed")
+        mock_gauge_set.assert_not_called()

--- a/tests/workers/test_transitional_inventory_contract.py
+++ b/tests/workers/test_transitional_inventory_contract.py
@@ -60,8 +60,10 @@ def test_inventory_is_non_empty_and_matches_audit_row_count():
     # in round-3 hardening (an ordinary two-hop API trigger the call-graph
     # fallback missed: billing/router.py's Stripe webhook), + 1 added in
     # round-4 hardening (a separately deployed second FastAPI app,
-    # billing_edge.py, forwarding to that same handler cross-file).
-    assert inventory["row_count"] == 156
+    # billing_edge.py, forwarding to that same handler cross-file), + 2
+    # added for CHAOS-3404 (the new ask_dev_retention celery task and its
+    # ask-dev-retention-sweep Beat entry).
+    assert inventory["row_count"] == 158
 
 
 def test_discovered_keys_and_row_keys_are_identical_sets():


### PR DESCRIPTION
## CHAOS-3404: Ask Dev retention sweep is dead code — cleanup_expired has no beat schedule, CLI, or caller

`DevPersistenceService.cleanup_expired` existed with unit coverage but no production caller — no Celery beat entry, no CLI command, nothing invoked it. The 30-day retention policy therefore never executed in production; expired conversations were retained indefinitely regardless of configuration.

### What this ships

- **Beat-scheduled production caller**: `workers/ask_dev_retention.py`'s `run_ask_dev_retention_cleanup`, daily crontab(5:30 UTC), draining `cleanup_expired` in bounded, individually-committed batches.
- **Observability (the "receipt")**: `devhealth_ask_dev_retention_sweep_{total,purged_total,last_success_timestamp}`. The last-success gauge only advances once `count_expired()` (a plain, non-locking COUNT) confirms the backlog is genuinely empty — a batch that merely came back short (e.g. a `FOR UPDATE SKIP LOCKED` read racing a concurrent invocation) reports `"partial"`, never a false `"completed"`. Caveat documented in the module docstring: these Prometheus instruments are process-local to the Celery worker and not currently scraped (same pre-existing gap every other Celery-task metric in this codebase has) — the structured `ask_dev_retention_sweep.*` log lines are the actually-reliable receipt today.
- **A real 0-day (ephemeral) retention gap, found and closed**: `force_terminal_fallback` and `recover_stale_non_terminal_run` (the documented CHAOS-3297 last-resort recovery paths) used to set a run terminal without ever checking `retention_days == 0`, leaving that conversation permanently unpurgeable — `expires_at` is otherwise never set for a 0-day row, so `cleanup_expired`'s sweep couldn't catch it either. All three terminal-transition sites (`update_run` plus the two recovery paths) now stamp `expires_at = now()` on a 0-day conversation in the same commit as the terminal-state write. Only `update_run` also attempts an immediate, SAVEPOINT-isolated purge; the two recovery paths stay stamp-only because an inline purge there can race a reader of the same run's content (a same-request replay read for `recover_stale_non_terminal_run`; a concurrent duplicate-request read for `force_terminal_fallback`, blocked on that row's `FOR UPDATE` lock). Either way the guarantee degrades to "collected by the next sweep tick," never "leaked forever."

### Rollout — operator action required

⚠️ **After this deploys, run the one-time backfill once**: `dev-hops maintenance backfill-ask-dev-ephemeral-expiry`

This repairs 0-day conversations already stranded in production *before* this fix existed (terminal run, `expires_at` never stamped — the gap above only stops *new* strandings). Bounded and idempotent — safe to run repeatedly; it stamps only a 0-day conversation with ≥1 run and no non-terminal run, and returns 0 once nothing is left to repair. The ordinary retention sweep then collects the rows it stamps on its next tick. Also tracked on CHAOS-3404 and belongs in CHAOS-3220's rollout-proof checklist.

### Review trail

3 rounds of codex adversarial-review; every finding validated with evidence and fixed:
- round 1: partial/completed gauge semantics, honest worker-Prometheus-scrape documentation, the 0-day recovery-path gap, a strengthened mid-sweep-failure test.
- round 2: the SKIP LOCKED false-completion race (closed via `count_expired()`), the recovery-path purge-races-replay-read issue, a Prometheus help-text correction.
- round 3: a concurrent (not just same-request) reader race for `force_terminal_fallback`'s inline purge (fixed by making it stamp-only, matching `recover_stale_non_terminal_run`), and the pre-existing-stranded-row backfill above.

RED-first throughout — the durability and stamp-then-sweep guarantees are fault-injected and mutation-tested (e.g. `test_update_run_survives_a_failing_immediate_purge`, `test_a_falsely_short_batch_does_not_report_completed`), not just asserted.

2562 tests green across `tests/workers` + `tests/api/dev` + `tests/test_cleanup_command.py`, plus the full CLI regression suite (109 tests). Lint/mypy clean.

Closes CHAOS-3404.
