### PR TITLE
CHAOS-3452: isolated shadow quota so QUA shadow can carry a real provider

### DIFF
--- a/src/dev_health_ops/alembic/versions/0087_add_dev_qua_shadow_budget_reservations.py
+++ b/src/dev_health_ops/alembic/versions/0087_add_dev_qua_shadow_budget_reservations.py
@@ -1,0 +1,128 @@
+"""Add dev_qua_shadow_budget_reservations (CHAOS-3452 isolated shadow quota).
+
+Revision ID: 0087
+Revises: 0086
+Create Date: 2026-08-06 00:00:00
+
+Additive only: one new reservation table, structurally identical to 0071's
+``byo_llm_budget_reservations`` (same reservation/reconciliation CHECK
+constraints) but deliberately SEPARATE -- see
+``dev_health_ops.models.llm_budget.QUAShadowBudgetReservation`` and
+``dev_health_ops.llm.qua_shadow_budget`` for why a shadow attempt must never
+be recorded in, or read back from, the live BYO budget table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0087"
+down_revision: str | None = "0086"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dev_qua_shadow_budget_reservations",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=False),
+        sa.Column("reserved_micro_usd", sa.BigInteger(), nullable=False),
+        sa.Column("actual_micro_usd", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("pricing_version", sa.String(length=64), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("cached_input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reconciled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'succeeded', 'failed', 'cancelled', "
+            "'voided', 'usage_unavailable')",
+            name="ck_qua_shadow_budget_reservation_status",
+        ),
+        sa.CheckConstraint(
+            "reserved_micro_usd >= 0",
+            name="ck_qua_shadow_budget_reserved_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "actual_micro_usd IS NULL OR actual_micro_usd >= 0",
+            name="ck_qua_shadow_budget_actual_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0",
+            name="ck_qua_shadow_budget_input_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "cached_input_tokens IS NULL OR cached_input_tokens >= 0",
+            name="ck_qua_shadow_budget_cached_input_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0",
+            name="ck_qua_shadow_budget_output_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "cached_input_tokens IS NULL OR input_tokens IS NULL OR "
+            "cached_input_tokens <= input_tokens",
+            name="ck_qua_shadow_budget_cached_within_input",
+        ),
+        sa.CheckConstraint(
+            "(status = 'reserved' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NULL) OR "
+            "(status = 'usage_unavailable' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NOT NULL) OR "
+            "(status = 'voided' AND actual_micro_usd = 0 "
+            "AND input_tokens = 0 AND cached_input_tokens = 0 "
+            "AND output_tokens = 0 AND reconciled_at IS NOT NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled') "
+            "AND actual_micro_usd IS NOT NULL AND input_tokens IS NOT NULL "
+            "AND cached_input_tokens IS NOT NULL AND output_tokens IS NOT NULL "
+            "AND reconciled_at IS NOT NULL)",
+            name="ck_qua_shadow_budget_reconciliation_state",
+        ),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "org_id",
+            "window_start",
+            "idempotency_key",
+            name="uq_qua_shadow_budget_reservation_attempt",
+        ),
+    )
+    op.create_index(
+        "ix_qua_shadow_budget_org_window_status",
+        "dev_qua_shadow_budget_reservations",
+        ["org_id", "window_start", "status"],
+    )
+
+
+def downgrade() -> None:
+    # Same posture as 0086's own downgrade guard: this table holds real
+    # monetary reservation/usage evidence once the shadow flag is on in any
+    # environment, so an unconditional drop would silently erase it on a
+    # routine downgrade.
+    bind = op.get_bind()
+    if bind.dialect.has_table(bind, "dev_qua_shadow_budget_reservations"):
+        row_count = bind.execute(
+            sa.select(sa.func.count()).select_from(
+                sa.table("dev_qua_shadow_budget_reservations")
+            )
+        ).scalar()
+        if row_count:
+            raise RuntimeError(
+                f"refusing to downgrade 0087: dev_qua_shadow_budget_reservations "
+                f"has {row_count} row(s); this downgrade is for pre-release "
+                "rehearsal only"
+            )
+    op.drop_index(
+        "ix_qua_shadow_budget_org_window_status",
+        table_name="dev_qua_shadow_budget_reservations",
+    )
+    op.drop_table("dev_qua_shadow_budget_reservations")

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -63,6 +63,7 @@ from dev_health_ops.llm.providers import (
     resolve_provider_name,
 )
 from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
+from dev_health_ops.llm.qua_shadow_budget import attach_qua_shadow_budget_guard
 from dev_health_ops.models.settings import SettingCategory
 
 from .contracts import (
@@ -208,6 +209,19 @@ class ProductionProviderResolution:
     #: selected the platform provider acts on this -- see the dev router's
     #: message path. Codex CHAOS-3358 review, CONFIRMED reachable.
     platform_certification_stale: bool = False
+    #: CHAOS-3452. A SEPARATE, independently-constructed provider instance
+    #: already wrapped by ``attach_qua_shadow_budget_guard`` -- never the
+    #: SAME object as ``provider`` above, and never touched by
+    #: ``attach_agent_budget_guard``. ``None`` whenever the operator flag
+    #: ``ASK_DEV_QUA_SHADOW_ENABLED`` is unset (construction is skipped
+    #: entirely in that case, preserving CHAOS-3389's "an unset env var is
+    #: byte-identical to the seam not existing" invariant) or whenever
+    #: building it failed for any reason -- a shadow-provider construction
+    #: failure must never surface as a live-path failure; it degrades to the
+    #: existing typed ``SKIPPED_NO_PROVIDER`` outcome instead. Only
+    #: ``resolve_production_provider`` (the real production runtime path)
+    #: populates this; certification/admin routes never do.
+    qua_shadow_provider: AgentLLMProvider | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -330,6 +344,7 @@ async def resolve_production_provider(
         policy=policy,
         session=session,
         org_id=org_id,
+        include_qua_shadow=True,
     )
 
 
@@ -644,6 +659,38 @@ async def _provider_candidates(
     return byo, platform, policy
 
 
+def _qua_shadow_flag_enabled() -> bool:
+    return os.getenv("ASK_DEV_QUA_SHADOW_ENABLED") == "1"
+
+
+def _build_qua_shadow_provider(
+    selected: AgentProviderCandidate, *, org_id: str
+) -> AgentLLMProvider | None:
+    """A SECOND, independently-constructed provider instance for the QUA
+    shadow seam (CHAOS-3452) -- never ``provider.provider``'s object
+    identity, and guarded by the isolated shadow quota, never
+    ``attach_agent_budget_guard``. Never raises: a construction failure here
+    must degrade to the existing typed ``SKIPPED_NO_PROVIDER`` outcome, not
+    fail the live run that would otherwise be unaffected by this seam.
+    """
+
+    try:
+        return attach_qua_shadow_budget_guard(
+            _provider(selected),
+            org_id=org_id,
+            provider=selected.provider,
+            model=selected.model,
+            base_url=selected.credentials.base_url or None,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to construct isolated QUA shadow provider; the shadow "
+            "seam will resolve to SKIPPED_NO_PROVIDER for this run",
+            exc_info=True,
+        )
+        return None
+
+
 def _resolve_provider_selection(
     *,
     byo: AgentProviderCandidate | None,
@@ -651,6 +698,7 @@ def _resolve_provider_selection(
     policy: AgentProviderPolicy,
     session: AsyncSession,
     org_id: str,
+    include_qua_shadow: bool = False,
 ) -> ProductionProviderResolution:
     try:
         selected = resolve_agent_provider_selection(
@@ -679,8 +727,19 @@ def _resolve_provider_selection(
             model=selected.model,
             base_url=selected.credentials.base_url or None,
         )
+    # CHAOS-3452: constructed ONLY when both this call site opted in
+    # (``resolve_production_provider`` -- the real production runtime path;
+    # certification/admin routes never do) AND the operator flag is set, so
+    # an unset flag costs nothing extra here, preserving CHAOS-3389's
+    # "unset env var is byte-identical to the seam not existing" invariant.
+    qua_shadow_provider = (
+        _build_qua_shadow_provider(selected, org_id=org_id)
+        if include_qua_shadow and _qua_shadow_flag_enabled()
+        else None
+    )
     return ProductionProviderResolution(
         provider=provider,
+        qua_shadow_provider=qua_shadow_provider,
         source=selected.source,
         family=selected.provider,
         model=selected.model,
@@ -1484,6 +1543,11 @@ async def build_production_runtime(
             await provider.provider.aclose()
         except Exception:
             pass
+        if provider.qua_shadow_provider is not None:
+            try:
+                await provider.qua_shadow_provider.aclose()
+            except Exception:
+                pass
         raise
 
 
@@ -2399,26 +2463,26 @@ async def _assemble_production_runtime(
     # whole seam not existing (see qua_shadow.py's own module docstring and
     # the RED test proving it).
     #
-    # ``provider=None`` deliberately, even when the flag is on (Codex
-    # adversarial review round 1, HIGH, confirmed): ``provider.provider``
-    # here is the SAME instance ``attach_agent_budget_guard``
-    # (llm/budget.py) already wrapped for the live investigation call --
-    # `decide()` is monkeypatched in place, not copied, so a shadow call
-    # against it would consume the SAME org BYO budget/quota the live call
-    # needs, and could make the live call fail with budget_exhausted. That
-    # is a genuine live-outcome effect, exactly what shadow mode must never
-    # have. No isolated shadow quota exists yet, and no separate
-    # ``question_understanding`` role certification exists yet either (both
-    # explicitly follow-on work per the platform spec, comment 6fa38d88) --
-    # until one of those lands, `evaluate()` always resolves to
-    # SKIPPED_NO_PROVIDER in production, which is the correct, safe
-    # "unavailable" outcome this seam is built to degrade to. The QUA logic
-    # itself is fully implemented and exercised end-to-end by
-    # tests/api/dev/test_chaos_3389_qua_shadow.py's scripted (never
-    # budget-shared) providers.
+    # CHAOS-3452: ``provider.qua_shadow_provider`` is a SEPARATE,
+    # independently-constructed provider instance, guarded by the isolated
+    # shadow quota (``llm/qua_shadow_budget.py``) -- never
+    # ``provider.provider``'s object identity, and never touched by
+    # ``attach_agent_budget_guard`` (llm/budget.py). Before this, the shadow
+    # seam always passed ``provider=None`` because the only instance
+    # available was the SAME one ``attach_agent_budget_guard`` monkeypatches
+    # for the live investigation call -- a shadow call against it would have
+    # consumed the SAME org BYO budget/quota the live call needs (Codex
+    # adversarial review round 1 on CHAOS-3389, HIGH, confirmed; see design
+    # comment 16bd8fed). ``qua_shadow_provider`` is itself only populated
+    # when ``ASK_DEV_QUA_SHADOW_ENABLED=1`` (see
+    # ``_resolve_provider_selection``), so an unset flag still costs nothing
+    # extra and still resolves through the exact same typed
+    # ``SKIPPED_NO_PROVIDER`` path as before. The QUA logic itself is fully
+    # exercised end-to-end by tests/api/dev/test_chaos_3389_qua_shadow.py's
+    # scripted (never budget-shared) providers.
     qua_shadow = (
         QuestionUnderstandingShadow(
-            provider=None,
+            provider=provider.qua_shadow_provider,
             scope_service=scope_service,
             config=QUAShadowConfig(
                 enabled=os.getenv("ASK_DEV_QUA_SHADOW_ENABLED") == "1"
@@ -2493,6 +2557,12 @@ async def _assemble_production_runtime(
         platform_certification_stale=provider.platform_certification_stale,
         preflight=preflight,
         qua_shadow=qua_shadow,
+        # CHAOS-3452: closed alongside ``provider`` in ``BoundedDevRuntime.
+        # aclose()`` -- it is a genuinely separate provider instance/HTTP
+        # client and would otherwise leak a connection whenever the shadow
+        # flag is on, even on requests where wave_3_1 (and therefore
+        # ``qua_shadow`` itself) ends up ``None``.
+        qua_shadow_provider=provider.qua_shadow_provider,
         # CHAOS-3297 stack #3: the combined ten-plan lookup -- orchestrator.py's
         # own plan_registry.get(intent.intent_id) is intent-generic and needs
         # no change to reach the four new plans.

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -346,14 +346,36 @@ class QuestionUnderstandingShadow:
             # the SAME closed status this method's own asyncio.wait_for
             # timeout already uses -- both really are "the call did not
             # finish in time", just raised from two different layers.
-            # `error_class` carries the specific code (budget_exhausted,
-            # rate_limited, ...) for every OTHER AgentProviderError kind,
-            # so those stay distinguishable in the persisted record/logs
-            # without growing the closed status vocabulary itself.
+            # `error_class` carries the specific code (rate_limited, ...)
+            # for every OTHER AgentProviderError kind, so those stay
+            # distinguishable in the persisted record/logs without growing
+            # the closed status vocabulary itself.
+            #
+            # CHAOS-3452: BUDGET_EXHAUSTED/BUDGET_UNAVAILABLE -- raised by
+            # ``attach_qua_shadow_budget_guard`` (llm/qua_shadow_budget.py)
+            # when the ISOLATED shadow quota (never the live BYO budget) is
+            # exhausted or its accounting fails -- get their own case here
+            # rather than falling into the generic provider-error bucket:
+            # the isolated shadow quota running out is an expected,
+            # frequent, typed-skip outcome (this seam's OWN budget
+            # discipline working as designed), not a provider fault.
+            # Reuses ``SKIPPED_BUDGET_EXHAUSTED`` (previously only reached
+            # via the wall-clock deadline check above) since both really are
+            # "this call's own budget ran out", just in two different
+            # currencies (seconds vs. micro-USD) -- ``error_class`` keeps
+            # them distinguishable in the persisted record/logs.
             status = (
                 QUAShadowStatus.SKIPPED_TIMEOUT
                 if exc.code is AgentProviderErrorCode.TIMEOUT
-                else QUAShadowStatus.SKIPPED_PROVIDER_ERROR
+                else (
+                    QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED
+                    if exc.code
+                    in (
+                        AgentProviderErrorCode.BUDGET_EXHAUSTED,
+                        AgentProviderErrorCode.BUDGET_UNAVAILABLE,
+                    )
+                    else QUAShadowStatus.SKIPPED_PROVIDER_ERROR
+                )
             )
             logger.warning(
                 "ask_dev.qua_shadow.provider_error",

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -241,6 +241,11 @@ async def get_dev_capability_runtime(
             await provider.provider.aclose()
         except Exception:
             pass
+        if provider.qua_shadow_provider is not None:
+            try:
+                await provider.qua_shadow_provider.aclose()
+            except Exception:
+                pass
 
 
 async def get_dev_execution_runtime(

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -66,6 +66,13 @@ class BoundedDevRuntime:
     #: once ``preflight`` is also set (the shadow seam runs alongside the
     #: deterministic resolver, so it is meaningless without it).
     qua_shadow: QuestionUnderstandingShadow | None = None
+    #: CHAOS-3452. The SAME provider instance passed into ``qua_shadow``'s
+    #: constructor when the isolated shadow quota is wired -- carried here
+    #: separately so ``aclose()`` below can close it too. A genuinely
+    #: separate provider instance/HTTP client from ``self.provider``;
+    #: without this it would leak a connection on every request once the
+    #: shadow flag is enabled.
+    qua_shadow_provider: AgentLLMProvider | None = None
 
     async def run(
         self,
@@ -110,7 +117,17 @@ class BoundedDevRuntime:
         )
 
     async def aclose(self) -> None:
-        await self.provider.aclose()
+        # Codex round 1 (MEDIUM, confirmed): a ``finally`` -- not a second
+        # statement -- so the shadow provider's own client/connection is
+        # still closed even when ``self.provider.aclose()`` itself raises;
+        # every caller of ``aclose()`` (router.py) wraps the WHOLE call in a
+        # swallowing try/except, so a live-provider close failure used to
+        # silently skip shadow cleanup too, leaking its connection.
+        try:
+            await self.provider.aclose()
+        finally:
+            if self.qua_shadow_provider is not None:
+                await self.qua_shadow_provider.aclose()
 
 
 __all__ = ["BoundedDevRuntime", "DevRuntimeUnavailable"]

--- a/src/dev_health_ops/llm/qua_shadow_budget.py
+++ b/src/dev_health_ops/llm/qua_shadow_budget.py
@@ -1,0 +1,592 @@
+"""CHAOS-3452: isolated shadow-quota budget guard for the QUA shadow seam.
+
+Structurally separate from the live BYO LLM budget path in ``llm/budget.py``:
+own reservation table (``QUAShadowBudgetReservation`` /
+``dev_qua_shadow_budget_reservations``), own Postgres advisory-lock
+namespace, own in-process per-org ``asyncio.Lock``, and its own operator-wide
+monetary ceiling. A shadow call reserves against, exhausts, and is
+reconciled ENTIRELY within this pool -- it can never read, contend with, or
+draw down the live org's ``byo_llm_budget_reservations`` pool.
+
+Why this had to be a genuinely separate pool, not just a separate provider
+object: ``llm.budget.get_budget_status`` sums every reservation for an
+``(org_id, window_start)`` pair regardless of provider/model, so recording a
+shadow attempt in the live table would still consume the same organization
+monetary ceiling the live investigation call needs -- the exact incident
+CHAOS-3389 shipped ``provider=None`` to avoid (design comment 16bd8fed on
+that ticket has the full rationale). This module is the follow-on that makes
+a REAL provider safe to wire.
+
+Conservative-by-default and NOT organization-configurable (no new admin
+surface here -- out of scope for CHAOS-3452): the ceiling is a single
+operator env var, defaulting to a few cents per organization per calendar
+month, entirely independent of and unrelated to that organization's own
+``BYO_LLM_MAX_BUDGET_MICRO_USD`` / configured monetary ceiling.
+
+Fails CLOSED where the live path fails open: ``guard_byo_call`` lets an
+unpriced custom provider through unbudgeted (preserving pre-budget
+behavior for BYO configurations the pricing table doesn't cover).
+``guard_qua_shadow_call`` never does that -- an unpriced provider/model pair
+cannot be bounded, and staying bounded is this module's entire purpose, so
+it resolves to ``BUDGET_UNAVAILABLE`` (a typed skip at the call site,
+``QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED`` -- see ``qua_shadow.py``)
+instead.
+
+### Scope boundary, stated explicitly (Codex round 2, both CONFIRMED, both
+### deliberately NOT fixed here -- tracked on CHAOS-3464, see the
+### CHAOS-3452 design comment for the full rationale)
+
+* **This isolates the LOCAL Postgres monetary reservation, not the
+  underlying provider account.** For a BYO org, the shadow provider
+  instance is built from the SAME credentials/base_url as the live one
+  (``production_runtime.py``'s ``_build_qua_shadow_provider`` -- a
+  genuinely separate Python object and HTTP client, never the SAME
+  instance, but the SAME external account). This module cannot isolate
+  that account's own provider-side rate limits, request quotas, or
+  monetary credits -- only ``guard_byo_call``'s and
+  ``guard_qua_shadow_call``'s OWN independent Postgres-tracked ceilings are
+  isolated from each other. **For BYO orgs, this means the isolated
+  shadow quota is spending the CUSTOMER'S OWN provider credits on our
+  shadow experiment**, not just risking rate-limit contention with their
+  live calls -- a real cost/trust surface, not merely a performance one.
+  A genuinely separate credential/account for shadow traffic is the SAME
+  "separately certified ``question_understanding`` role provider" the
+  CHAOS-3389 design comment already named as explicit follow-on work, not
+  new scope discovered here (tracked on CHAOS-3464). Bound in practice by
+  construction: the shadow call is synchronously awaited inline within one
+  investigation run (never fire-and-forget), so shadow request VOLUME
+  against the shared account is structurally capped at exactly 1x live
+  request volume for orgs with both wave_3_1 and the shadow flag on --
+  never unbounded, never higher than doubling load on that account.
+* **The admission reservation is a conservative ESTIMATE, not a proven
+  upper bound.** It sizes ``maximum_input_tokens`` from
+  ``len(json.dumps({messages, tools, response_schema}).encode())`` --
+  exactly ``llm.budget.attach_agent_budget_guard``'s own, already-shipped
+  formula for the live path, deliberately kept at parity rather than
+  reimplemented, per CHAOS-3452's constraint against changing live-path
+  behavior. Reconciliation after the real call already corrects the
+  reservation to ACTUAL usage (or falls back to the reserved worst-case
+  when usage is unavailable -- see ``qua_shadow_budget_status``), so a rare
+  underestimate is a bounded post-hoc accounting drift, not an unbounded
+  one; building a formula proven to always dominate the provider's own
+  request-construction logic is deferred as the SAME kind of pre-existing,
+  accepted estimate the live guard has always used (tracked as the second
+  residual on CHAOS-3464 -- if ever tightened, tighten both guards
+  together rather than letting shadow diverge from live).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextvars import ContextVar
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Any, Final, TypeVar
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.models.llm_budget import QUAShadowBudgetReservation
+
+from .agent.errors import AgentProviderError, AgentProviderErrorCode
+from .budget import PRICING_VERSION, _window, cost_micro_usd
+
+__all__ = [
+    "DEFAULT_QUA_SHADOW_MAX_MICRO_USD",
+    "QUA_SHADOW_BUDGET_ENV_KEY",
+    "QUAShadowBudgetAccountingError",
+    "QUAShadowBudgetExceeded",
+    "attach_qua_shadow_budget_guard",
+    "guard_qua_shadow_call",
+    "qua_shadow_budget_status",
+    "qua_shadow_maximum_micro_usd",
+]
+
+#: Config-gated: an unset env var means the conservative default below,
+#: never "unlimited" (there is deliberately no env value that disables
+#: enforcement -- see ``qua_shadow_maximum_micro_usd``).
+QUA_SHADOW_BUDGET_ENV_KEY: Final = "ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD"
+#: ~$0.50/organization/calendar month -- enough for a meaningful sample of
+#: shadow evidence at the ~18-active-project scale this seam runs at today
+#: (CHAOS-3389 design comment 16bd8fed), far below any live BYO ceiling an
+#: org would configure for its real investigation traffic.
+DEFAULT_QUA_SHADOW_MAX_MICRO_USD: Final = 500_000
+
+
+class QUAShadowBudgetExceeded(RuntimeError):
+    """The isolated shadow quota is exhausted for this organization/window."""
+
+
+class QUAShadowBudgetAccountingError(RuntimeError):
+    """A shadow reservation, pricing decision, or reconciliation failed."""
+
+
+_T = TypeVar("_T")
+
+#: Deliberately a SEPARATE ContextVar from llm.budget's own
+#: ``_idempotency_key`` -- a caller binding one for the live call must never
+#: leak into a concurrent shadow call sharing the same asyncio task tree.
+_shadow_idempotency_key: ContextVar[str | None] = ContextVar(
+    "qua_shadow_budget_idempotency_key", default=None
+)
+
+#: Deliberately a SEPARATE in-process lock table from llm.budget's own
+#: ``_org_locks`` -- a live reservation transaction for an org must never
+#: block behind (or be blocked by) a concurrent shadow reservation
+#: transaction for the SAME org. Both are held only briefly, for the
+#: reservation-admission step, never across the network call.
+_shadow_locks_guard = Lock()
+_shadow_org_locks: dict[str, asyncio.Lock] = {}
+
+
+def qua_shadow_maximum_micro_usd() -> int:
+    """The operator-wide shadow ceiling. Unset -> the conservative default."""
+
+    raw = os.getenv(QUA_SHADOW_BUDGET_ENV_KEY)
+    if raw is None:
+        return DEFAULT_QUA_SHADOW_MAX_MICRO_USD
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return max(0, value)
+
+
+def _shadow_org_lock(org_id: str) -> asyncio.Lock:
+    with _shadow_locks_guard:
+        lock = _shadow_org_locks.get(org_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _shadow_org_locks[org_id] = lock
+        return lock
+
+
+async def _acquire_shadow_advisory_lock(session: AsyncSession, org_id: str) -> None:
+    bind = session.get_bind()
+    if bind is None or bind.dialect.name != "postgresql":
+        return
+    # Deliberately a DIFFERENT hash input than llm/budget.py's own
+    # "byo-llm-budget:{org_id}" advisory lock -- a live reservation and a
+    # shadow reservation for the SAME org must never serialize on the same
+    # Postgres advisory lock, or a slow/contended shadow reservation could
+    # stall the live call's own reservation transaction.
+    digest = hashlib.sha256(f"qua-shadow-llm-budget:{org_id}".encode()).digest()
+    lock_key = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_key)"), {"lock_key": lock_key}
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class QUAShadowBudgetStatus:
+    used_micro_usd: int
+    limit_micro_usd: int
+    remaining_micro_usd: int
+    exhausted: bool
+
+
+async def qua_shadow_budget_status(
+    session: AsyncSession, *, org_id: str, now: datetime | None = None
+) -> QUAShadowBudgetStatus:
+    effective_now = now or datetime.now(UTC)
+    window_start, _ = _window(effective_now)
+    limit = qua_shadow_maximum_micro_usd()
+    try:
+        org_uuid = uuid.UUID(org_id)
+    except (TypeError, ValueError):
+        return QUAShadowBudgetStatus(
+            used_micro_usd=0,
+            limit_micro_usd=limit,
+            remaining_micro_usd=limit,
+            exhausted=limit <= 0,
+        )
+    result = await session.execute(
+        select(QUAShadowBudgetReservation).where(
+            QUAShadowBudgetReservation.org_id == org_uuid,
+            QUAShadowBudgetReservation.window_start == window_start,
+        )
+    )
+    reservations = list(result.scalars().all())
+    # Codex round 1 (HIGH, confirmed): matches llm.budget.get_budget_status's
+    # OWN filter exactly -- ``!= "voided"``, nothing else excluded. A
+    # ``usage_unavailable`` reservation is STILL a dispatched call whose real
+    # cost could not be confirmed; counting it at its reserved (worst-case)
+    # amount is what keeps it real monetary exposure until reconciled,
+    # exactly as the live path's own comment states. The original
+    # ``not in ("voided", "usage_unavailable")`` filter let repeated
+    # dispatched-but-unreconciled shadow calls advance zero quota, silently
+    # defeating the cap this module exists to enforce.
+    used = sum(
+        row.actual_micro_usd
+        if row.actual_micro_usd is not None
+        else row.reserved_micro_usd
+        for row in reservations
+        if row.status != "voided"
+    )
+    remaining = max(0, limit - used)
+    return QUAShadowBudgetStatus(
+        used_micro_usd=used,
+        limit_micro_usd=limit,
+        remaining_micro_usd=remaining,
+        exhausted=remaining <= 0,
+    )
+
+
+async def guard_qua_shadow_call(
+    *,
+    session: AsyncSession,
+    org_id: str,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    idempotency_key: str,
+    maximum_input_tokens: int,
+    maximum_output_tokens: int,
+    invoke: Callable[[], Awaitable[_T]],
+    usage: Callable[[_T], tuple[int | None, int | None, int | None]],
+) -> tuple[_T, int | None]:
+    """Reserve against the ISOLATED shadow pool, execute, then reconcile.
+
+    Mirrors ``llm.budget.guard_byo_call``'s reservation/execute/reconcile
+    shape, but every step below touches ONLY
+    ``QUAShadowBudgetReservation`` / ``dev_qua_shadow_budget_reservations``
+    -- never ``BYOLLMBudgetReservation`` / ``byo_llm_budget_reservations``,
+    never the live path's in-process lock or advisory-lock namespace.
+    """
+
+    maximum_cost = cost_micro_usd(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        input_tokens=max(0, maximum_input_tokens),
+        output_tokens=max(0, maximum_output_tokens),
+        cached_input_tokens=0,
+    )
+    reservation: QUAShadowBudgetReservation | None = None
+    async with _shadow_org_lock(org_id):
+        try:
+            await _acquire_shadow_advisory_lock(session, org_id)
+            if maximum_cost is None:
+                await session.rollback()
+                # Unlike the live path, an unpriced provider/model is never
+                # let through unbudgeted here -- staying bounded is this
+                # module's entire purpose (see module docstring).
+                raise QUAShadowBudgetAccountingError(
+                    "QUA shadow pricing is unavailable for this provider/model."
+                )
+            status = await qua_shadow_budget_status(session, org_id=org_id)
+            if status.exhausted or maximum_cost > status.remaining_micro_usd:
+                await session.rollback()
+                raise QUAShadowBudgetExceeded(
+                    "Isolated QUA shadow quota is exhausted for this organization."
+                )
+            reservation = await _create_shadow_reservation(
+                session,
+                org_id=org_id,
+                provider=provider,
+                model=model,
+                idempotency_key=idempotency_key,
+                reserved_micro_usd=maximum_cost,
+            )
+            await session.commit()
+        except (QUAShadowBudgetAccountingError, QUAShadowBudgetExceeded):
+            if session.in_transaction():
+                await session.rollback()
+            raise
+        except Exception as accounting_exc:
+            await session.rollback()
+            raise QUAShadowBudgetAccountingError(
+                "QUA shadow budget reservation is temporarily unavailable."
+            ) from accounting_exc
+
+    if reservation is None:
+        raise QUAShadowBudgetAccountingError(
+            "QUA shadow budget reservation was not created."
+        )
+
+    # The reservation is committed and both locks released before invoking
+    # the provider -- same network transaction boundary as the live path.
+    try:
+        result = await invoke()
+    except BaseException as exc:
+        provider_dispatched = getattr(exc, "provider_dispatched", True)
+        # Codex round 1 (HIGH, confirmed): a dispatched-but-failed call can
+        # still carry REAL billable usage -- AgentProviderError.usage is the
+        # SAME AgentUsage type AgentDecisionResult.usage is, so
+        # ``_shadow_agent_usage`` (below) reads it identically; discarding
+        # it here reconciled every such call as ``usage_unavailable``
+        # regardless of whether real usage was available, one more way the
+        # cap could be silently defeated before the ``used`` filter fix
+        # above. Mirrors llm.budget's own exception-usage extraction
+        # (``_usage_from_exception``).
+        reported = (
+            (0, 0, 0) if provider_dispatched is False else _shadow_agent_usage(exc)
+        )
+        outcome = (
+            "voided"
+            if provider_dispatched is False
+            else ("cancelled" if isinstance(exc, asyncio.CancelledError) else "failed")
+        )
+        try:
+            await _reconcile_shadow_reservation(
+                session,
+                reservation=reservation,
+                provider=provider,
+                model=model,
+                base_url=base_url,
+                outcome=outcome,
+                reported=reported,
+            )
+        except Exception as accounting_exc:
+            await session.rollback()
+            raise QUAShadowBudgetAccountingError(
+                "QUA shadow budget accounting is temporarily unavailable."
+            ) from accounting_exc
+        raise
+
+    try:
+        billed = await _reconcile_shadow_reservation(
+            session,
+            reservation=reservation,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            outcome="succeeded",
+            reported=usage(result),
+        )
+    except Exception as accounting_exc:
+        await session.rollback()
+        raise QUAShadowBudgetAccountingError(
+            "QUA shadow budget accounting is temporarily unavailable."
+        ) from accounting_exc
+    # Codex round 2 (MEDIUM, confirmed): unlike the live BYO guard -- where
+    # an unpriceable SUCCESSFUL call must still fail closed to protect the
+    # ORG'S OWN configured monetary ceiling (guard_byo_call's own
+    # equivalent check) -- a successfully-decided shadow call is NEVER
+    # discarded just because its cost could not be confirmed (e.g. the
+    # provider omitted cache-usage detail, an OpenAICompatibleAgentProvider-
+    # documented possibility via ``_normalize_usage``). The admission
+    # reservation ALREADY counts its RESERVED, worst-case amount toward
+    # `used` regardless of how reconciliation turns out (see
+    # ``qua_shadow_budget_status``'s filter), so the quota cannot be
+    # evaded by this. Discarding the result here would only throw away the
+    # evaluated evidence the shadow seam exists to collect, for free --
+    # there is no organization-facing monetary guarantee at stake to
+    # protect the way there is on the live path.
+    return result, billed
+
+
+async def _create_shadow_reservation(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    provider: str,
+    model: str,
+    idempotency_key: str,
+    reserved_micro_usd: int,
+) -> QUAShadowBudgetReservation:
+    window_start, _ = _window(datetime.now(UTC))
+    org_uuid = uuid.UUID(org_id)
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+    existing = await session.execute(
+        select(QUAShadowBudgetReservation.id).where(
+            QUAShadowBudgetReservation.org_id == org_uuid,
+            QUAShadowBudgetReservation.window_start == window_start,
+            QUAShadowBudgetReservation.idempotency_key == digest,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise QUAShadowBudgetAccountingError(
+            "QUA shadow request has already been reserved."
+        )
+    reservation = QUAShadowBudgetReservation(
+        org_id=org_uuid,
+        window_start=window_start,
+        idempotency_key=digest,
+        provider=provider,
+        model=model,
+        reserved_micro_usd=reserved_micro_usd,
+        status="reserved",
+        pricing_version=PRICING_VERSION,
+    )
+    session.add(reservation)
+    return reservation
+
+
+async def _reconcile_shadow_reservation(
+    session: AsyncSession,
+    *,
+    reservation: QUAShadowBudgetReservation,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    outcome: str,
+    reported: tuple[int | None, int | None, int | None],
+) -> int | None:
+    input_tokens, output_tokens, cached_input_tokens = reported
+    row = await session.get(QUAShadowBudgetReservation, reservation.id)
+    if row is None:
+        raise RuntimeError(
+            "QUA shadow budget reservation disappeared before reconciliation"
+        )
+    await session.refresh(row)
+    if row.status != "reserved":
+        raise RuntimeError(
+            "QUA shadow budget reservation is no longer owned by this attempt"
+        )
+    row.input_tokens = input_tokens
+    row.output_tokens = output_tokens
+    row.cached_input_tokens = cached_input_tokens
+    row.reconciled_at = datetime.now(UTC)
+    if outcome == "voided":
+        row.status = "voided"
+        row.input_tokens = 0
+        row.output_tokens = 0
+        row.cached_input_tokens = 0
+        row.actual_micro_usd = 0
+        await session.commit()
+        return 0
+    if input_tokens is None or output_tokens is None or cached_input_tokens is None:
+        row.status = "usage_unavailable"
+        row.actual_micro_usd = None
+        await session.commit()
+        return None
+    billed = cost_micro_usd(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+    )
+    if billed is None:
+        row.status = "usage_unavailable"
+        row.actual_micro_usd = None
+        await session.commit()
+        return None
+    row.status = outcome
+    row.actual_micro_usd = billed
+    await session.commit()
+    return billed
+
+
+def _shadow_agent_usage(item: Any) -> tuple[int | None, int | None, int | None]:
+    """Mirrors ``llm.budget._agent_usage`` -- duplicated rather than
+    imported to keep this module decoupled from the live guard's private
+    surface (see module docstring on why the two paths must never share
+    state)."""
+
+    usage = getattr(item, "usage", None)
+    if usage is None:
+        return None, None, None
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    cached_input_tokens = getattr(usage, "cached_input_tokens", None)
+    if not isinstance(input_tokens, int) or isinstance(input_tokens, bool):
+        input_tokens = None
+    if not isinstance(output_tokens, int) or isinstance(output_tokens, bool):
+        output_tokens = None
+    if not isinstance(cached_input_tokens, int) or isinstance(
+        cached_input_tokens, bool
+    ):
+        cached_input_tokens = None
+    if input_tokens == 0 and output_tokens == 0:
+        return None, None, None
+    return input_tokens, output_tokens, cached_input_tokens
+
+
+def attach_qua_shadow_budget_guard(
+    provider_instance: Any,
+    *,
+    org_id: str,
+    provider: str,
+    model: str,
+    base_url: str | None,
+) -> Any:
+    """Decorate a provider instance DEDICATED to the QUA shadow seam.
+
+    The caller must pass a freshly-constructed provider instance -- never
+    the same object ``llm.budget.attach_agent_budget_guard`` has already
+    decorated for the live investigation call. This function does not (and
+    cannot) verify that; see ``production_runtime.py``'s call site for the
+    structural guarantee that a second, independent instance is what's
+    passed here.
+    """
+
+    original = provider_instance.decide
+    call_number = 0
+
+    async def decide(
+        messages: Sequence[Any],
+        tools: Sequence[Any],
+        response_schema: Mapping[str, Any],
+        timeout_seconds: float,
+        max_output_tokens: int,
+        signal: Any = None,
+    ) -> Any:
+        nonlocal call_number
+        call_number += 1
+        # Codex round 1 (HIGH, confirmed): the reservation must bound the
+        # COMPLETE wire request, not just the messages -- the real
+        # provider call also sends `tools` and `response_schema` (this
+        # seam's own JSON Schema can be sizeable once the shortlist is
+        # large), so a messages-only estimate was not a guaranteed upper
+        # bound and could let concurrent admissions jointly reconcile above
+        # the cap. Mirrors llm.budget.attach_agent_budget_guard's own
+        # payload-sizing formula exactly.
+        payload = json.dumps(
+            {
+                "messages": [str(item) for item in messages],
+                "tools": [str(item) for item in tools],
+                "response_schema": response_schema,
+            },
+            sort_keys=True,
+            default=str,
+        )
+        try:
+            async with get_postgres_session() as budget_session:
+                result, billed = await guard_qua_shadow_call(
+                    session=budget_session,
+                    org_id=org_id,
+                    provider=provider,
+                    model=model,
+                    base_url=base_url,
+                    idempotency_key=(
+                        _shadow_idempotency_key.get()
+                        or f"qua-shadow:{id(provider_instance)}:{call_number}"
+                    ),
+                    maximum_input_tokens=max(1, len(payload.encode("utf-8"))),
+                    maximum_output_tokens=max_output_tokens,
+                    invoke=lambda: original(
+                        messages,
+                        tools,
+                        response_schema,
+                        timeout_seconds,
+                        max_output_tokens,
+                        signal,
+                    ),
+                    usage=_shadow_agent_usage,
+                )
+        except (QUAShadowBudgetExceeded, QUAShadowBudgetAccountingError) as exc:
+            code = (
+                AgentProviderErrorCode.BUDGET_EXHAUSTED
+                if isinstance(exc, QUAShadowBudgetExceeded)
+                else AgentProviderErrorCode.BUDGET_UNAVAILABLE
+            )
+            raise AgentProviderError(code) from None
+        if billed is not None:
+            result = replace(
+                result,
+                usage=replace(result.usage, estimated_cost_microusd=billed),
+            )
+        return result
+
+    setattr(provider_instance, "decide", decide)
+    return provider_instance

--- a/src/dev_health_ops/models/llm_budget.py
+++ b/src/dev_health_ops/models/llm_budget.py
@@ -113,3 +113,109 @@ class BYOLLMBudgetReservation(Base):
             "status",
         ),
     )
+
+
+class QUAShadowBudgetReservation(Base):
+    """One QUA shadow-call attempt's committed maximum exposure and final
+    usage (CHAOS-3452).
+
+    Structurally identical in shape to ``BYOLLMBudgetReservation`` -- same
+    reservation/reconciliation lifecycle, same CHECK-constraint discipline --
+    but a DELIBERATELY SEPARATE table. ``get_budget_status`` in
+    ``llm/budget.py`` sums every reservation for an (org_id, window_start)
+    pair regardless of provider/model, so a shadow attempt recorded in the
+    live ``byo_llm_budget_reservations`` table would draw down the same
+    organization monetary ceiling the live investigation call needs (the
+    exact CHAOS-3389 incident this ticket closes -- design comment
+    16bd8fed). This table is read and written ONLY by
+    ``llm/qua_shadow_budget.py``; nothing in the live BYO budget path
+    (``llm/budget.py``, ``attach_agent_budget_guard``, ``guard_byo_call``)
+    ever queries it.
+    """
+
+    __tablename__ = "dev_qua_shadow_budget_reservations"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    reserved_micro_usd: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    actual_micro_usd: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[str] = mapped_column(String(24), nullable=False, default="reserved")
+    pricing_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cached_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "window_start",
+            "idempotency_key",
+            name="uq_qua_shadow_budget_reservation_attempt",
+        ),
+        CheckConstraint(
+            "status IN ('reserved', 'succeeded', 'failed', 'cancelled', "
+            "'voided', 'usage_unavailable')",
+            name="ck_qua_shadow_budget_reservation_status",
+        ),
+        CheckConstraint(
+            "reserved_micro_usd >= 0",
+            name="ck_qua_shadow_budget_reserved_nonnegative",
+        ),
+        CheckConstraint(
+            "actual_micro_usd IS NULL OR actual_micro_usd >= 0",
+            name="ck_qua_shadow_budget_actual_nonnegative",
+        ),
+        CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0",
+            name="ck_qua_shadow_budget_input_nonnegative",
+        ),
+        CheckConstraint(
+            "cached_input_tokens IS NULL OR cached_input_tokens >= 0",
+            name="ck_qua_shadow_budget_cached_input_nonnegative",
+        ),
+        CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0",
+            name="ck_qua_shadow_budget_output_nonnegative",
+        ),
+        CheckConstraint(
+            "cached_input_tokens IS NULL OR input_tokens IS NULL OR "
+            "cached_input_tokens <= input_tokens",
+            name="ck_qua_shadow_budget_cached_within_input",
+        ),
+        CheckConstraint(
+            "(status = 'reserved' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NULL) OR "
+            "(status = 'usage_unavailable' AND actual_micro_usd IS NULL "
+            "AND reconciled_at IS NOT NULL) OR "
+            "(status = 'voided' AND actual_micro_usd = 0 "
+            "AND input_tokens = 0 AND cached_input_tokens = 0 "
+            "AND output_tokens = 0 AND reconciled_at IS NOT NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled') "
+            "AND actual_micro_usd IS NOT NULL AND input_tokens IS NOT NULL "
+            "AND cached_input_tokens IS NOT NULL AND output_tokens IS NOT NULL "
+            "AND reconciled_at IS NOT NULL)",
+            name="ck_qua_shadow_budget_reconciliation_state",
+        ),
+        Index(
+            "ix_qua_shadow_budget_org_window_status",
+            "org_id",
+            "window_start",
+            "status",
+        ),
+    )

--- a/tests/_env_isolation.py
+++ b/tests/_env_isolation.py
@@ -167,11 +167,11 @@ SCRUB_ENV_NAMES: frozenset[str] = frozenset(
         "ASK_DEV_ACCEPTANCE_OPENAI_PORT",
         "ASK_DEV_LIVE_ACCEPTANCE",
         "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD",
-        "ASK_DEV_QUA_SHADOW_ENABLED",
-        "ASK_DEV_SCRIPTED_PROVIDER_ROLE",
-        "ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR",
         "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX",
         "ASK_DEV_QUA_SHADOW_ENABLED",
+        "ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD",
+        "ASK_DEV_SCRIPTED_PROVIDER_ROLE",
+        "ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR",
         "ATLASSIAN_API_TOKEN",
         "ATLASSIAN_CLIENT_ENABLED",
         "ATLASSIAN_CLIENT_ID",
@@ -318,8 +318,6 @@ SCRUB_ENV_NAMES: frozenset[str] = frozenset(
         "QWEN_API_KEY",
         "QWEN_LOCAL_MODEL",
         "QWEN_MODEL",
-        # Scrubbed by default; see CONDITIONAL_KEEP_ENV_NAMES for the one lane
-        # that gets it back.
         "REDIS_URL",
         "REPO_PATH",
         "REPO_UUID",
@@ -406,20 +404,32 @@ _ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 
 def _module_string_constants(tree: ast.Module) -> dict[str, str]:
-    """Module-level ``NAME = "STRING"`` bindings.
+    """Module-level ``NAME = "STRING"`` (and ``NAME: Final = "STRING"``)
+    bindings.
 
     ``api/auth/config.py`` reads ``os.getenv(AUTH_AUTO_CREATE_ORG_ENV)``; without
     resolving constants the scan misses the very variable that broke eight tests.
+    Both plain ``ast.Assign`` and annotated ``ast.AnnAssign`` (the ``: Final``
+    style already used throughout ``llm/budget.py`` and friends) are handled --
+    CHAOS-3452's ``QUA_SHADOW_BUDGET_ENV_KEY: Final = "..."`` was the first
+    ``os.getenv(CONST)`` read to use the annotated form, which the
+    ``ast.Assign``-only version of this function silently missed.
     """
     consts: dict[str, str] = {}
     for node in tree.body:
-        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
-            continue
-        if not isinstance(node.value.value, str):
-            continue
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                consts[target.id] = node.value.value
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if not isinstance(node.value.value, str):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            consts[node.target.id] = node.value.value
     return consts
 
 

--- a/tests/api/dev/test_chaos_3389_qua_shadow.py
+++ b/tests/api/dev/test_chaos_3389_qua_shadow.py
@@ -766,6 +766,75 @@ async def test_a_non_timeout_provider_error_keeps_its_own_code_as_error_class() 
     assert record.error_class == "rate_limited"
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        AgentProviderErrorCode.BUDGET_EXHAUSTED,
+        AgentProviderErrorCode.BUDGET_UNAVAILABLE,
+    ],
+)
+async def test_the_isolated_shadow_quota_running_out_is_a_typed_budget_skip(
+    code: AgentProviderErrorCode,
+) -> None:
+    """CHAOS-3452: ``attach_qua_shadow_budget_guard`` (llm/qua_shadow_budget.py)
+    raises exactly these two codes when the ISOLATED shadow quota -- never
+    the live BYO budget -- is exhausted or its accounting fails. Both must
+    read as the seam's OWN typed budget skip (``SKIPPED_BUDGET_EXHAUSTED``,
+    previously only reachable via the wall-clock deadline check), not fall
+    into the generic ``SKIPPED_PROVIDER_ERROR`` bucket every other
+    AgentProviderError kind uses."""
+
+    catalog = _catalog([(ORG_ID, ASK_DEV_PROJECT)])
+    scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    interpretation = await _interpretation("What's the status of the Ask Dev project?")
+    shadow = QuestionUnderstandingShadow(
+        provider=_RaisingProvider(AgentProviderError(code)),
+        scope_service=scope_service,
+        config=QUAShadowConfig(enabled=True),
+    )
+    record = await shadow.evaluate(
+        question="What's the status of the Ask Dev project?",
+        interpretation=interpretation,
+        org_id=ORG_ID,
+        permission_fingerprint=PERMISSION_FINGERPRINT,
+        deterministic_decision=PreflightDecision.PROCEED,
+        remaining_seconds=10.0,
+    )
+    assert record.status is QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED
+    assert record.error_class == code.value
+
+
+async def test_isolated_shadow_quota_exhaustion_is_byte_identical_for_a_proceed_run() -> (
+    None
+):
+    """The orchestrator-level companion to the unit test above: even a
+    shadow provider that always fails with the isolated quota's own
+    BUDGET_EXHAUSTED code -- exactly what a real exhausted
+    ``dev_qua_shadow_budget_reservations`` pool raises -- leaves the live
+    ``OrchestratorResult`` byte-identical to the flag being off."""
+
+    baseline = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-shadow-quota-baseline",
+    )
+    shadow_quota_exhausted = await run_preflight_orchestrator(
+        question="What's the status of the Ask Dev project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="qua-shadow-quota-exhausted",
+        qua_shadow=await _shadow(
+            enabled=True,
+            provider=_RaisingProvider(
+                AgentProviderError(AgentProviderErrorCode.BUDGET_EXHAUSTED)
+            ),
+        ),
+    )
+    assert shadow_quota_exhausted.outcome_tuple() == baseline.outcome_tuple()
+    [record] = _shadow_records(shadow_quota_exhausted)
+    assert record.status is QUAShadowStatus.SKIPPED_BUDGET_EXHAUSTED
+    assert record.error_class == "budget_exhausted"
+
+
 async def test_resolved_outcome_without_an_index_is_rejected_not_evaluated_clean() -> (
     None
 ):

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -15,7 +15,7 @@ from dev_health_ops.api.dev.platform_auto_certification import (
     PlatformAutoCertifier,
 )
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
-from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.dev.runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from dev_health_ops.api.dev.tool_registry import (
     TOOL_CONTRACT_VERSION,
     ToolExecutionContext,
@@ -1169,6 +1169,128 @@ async def test_byo_provider_resolution_attaches_shared_budget_guard(
             "base_url": "https://api.openai.com/v1",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_qua_shadow_provider_is_a_separate_instance_gated_on_its_own_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3452: ``resolve_production_provider`` populates
+    ``qua_shadow_provider`` with a SEPARATE constructed instance (never the
+    same object as ``.provider``), guarded by the isolated shadow quota
+    (never ``attach_agent_budget_guard``) -- and ONLY when
+    ``ASK_DEV_QUA_SHADOW_ENABLED=1``. An unset flag must not even construct
+    it, preserving CHAOS-3389's "unset env var is byte-identical to the
+    seam not existing" invariant.
+    """
+
+    monkeypatch.setattr(production_runtime, "SettingsService", FakeSettingsService)
+    constructed: list[FakeProvider] = []
+
+    def fake_provider_factory(_candidate):
+        instance = FakeProvider()
+        constructed.append(instance)
+        return instance
+
+    monkeypatch.setattr(production_runtime, "_provider", fake_provider_factory)
+    live_attached: list[dict[str, Any]] = []
+    shadow_attached: list[dict[str, Any]] = []
+
+    def fake_attach_live(value, **kwargs):
+        live_attached.append(kwargs)
+        return value
+
+    def fake_attach_shadow(value, **kwargs):
+        shadow_attached.append(kwargs)
+        return value
+
+    monkeypatch.setattr(
+        production_runtime, "attach_agent_budget_guard", fake_attach_live
+    )
+    monkeypatch.setattr(
+        production_runtime, "attach_qua_shadow_budget_guard", fake_attach_shadow
+    )
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    FakeSettingsService.values = {
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "api_key": "sk-org",
+        "base_url": "https://api.openai.com/v1",
+    }
+    session = cast(Any, object())
+
+    async def _resolve() -> ProductionProviderResolution:
+        settings = production_runtime.SettingsService(session, "org_01")
+        byo, platform, policy = await production_runtime._provider_candidates(
+            settings, byo_readiness=None, platform_readiness=None, certification=True
+        )
+        return production_runtime._resolve_provider_selection(
+            byo=byo,
+            platform=platform,
+            policy=policy,
+            session=session,
+            org_id="org_01",
+            include_qua_shadow=True,
+        )
+
+    monkeypatch.delenv("ASK_DEV_QUA_SHADOW_ENABLED", raising=False)
+    resolved_off = await _resolve()
+    assert resolved_off.qua_shadow_provider is None
+    assert len(constructed) == 1  # ONLY the live provider was constructed
+    assert shadow_attached == []
+
+    monkeypatch.setenv("ASK_DEV_QUA_SHADOW_ENABLED", "1")
+    resolved_on = await _resolve()
+    assert resolved_on.qua_shadow_provider is not None
+    assert resolved_on.qua_shadow_provider is not resolved_on.provider
+    assert len(constructed) == 3  # +1 live, +1 shadow this second resolution
+    assert len(shadow_attached) == 1
+    assert shadow_attached[0]["org_id"] == "org_01"
+    assert shadow_attached[0]["provider"] == "openai"
+    assert shadow_attached[0]["model"] == "gpt-5-mini"
+    # Never the live guard -- the whole point of CHAOS-3452's isolation.
+    assert len(live_attached) == 2  # one per resolution call, live path only
+
+
+@pytest.mark.asyncio
+async def test_bounded_dev_runtime_still_closes_the_shadow_provider_when_the_live_close_fails() -> (
+    None
+):
+    """Codex round 1 (MEDIUM, confirmed): ``BoundedDevRuntime.aclose()``
+    used to await the live provider's ``aclose()`` and the shadow
+    provider's ``aclose()`` as two independent statements -- if the FIRST
+    raised, the second was never reached. Every caller of ``aclose()``
+    (router.py) wraps the WHOLE call in a swallowing ``try/except``, so
+    that raised exception was silently discarded along with the fact that
+    the shadow provider's own connection was never closed. Fixed with a
+    ``finally``; this proves the shadow close now happens regardless."""
+
+    class _RaisingCloseProvider:
+        async def aclose(self) -> None:
+            raise RuntimeError("live close boom")
+
+    class _RecordingCloseProvider:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    shadow = _RecordingCloseProvider()
+    runtime = BoundedDevRuntime(
+        provider=cast(Any, _RaisingCloseProvider()),
+        provider_source="byo",
+        provider_family="openai",
+        registry=cast(Any, object()),
+        scope_resolver=cast(Any, object()),
+        versions=cast(Any, object()),
+        qua_shadow_provider=cast(Any, shadow),
+    )
+    with pytest.raises(RuntimeError, match="live close boom"):
+        await runtime.aclose()
+    assert shadow.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_chaos_3452_qua_shadow_budget.py
+++ b/tests/llm/test_chaos_3452_qua_shadow_budget.py
@@ -1,0 +1,727 @@
+"""CHAOS-3452: the isolated QUA shadow quota never touches the live BYO
+budget pool, in either direction.
+
+RED-first coverage:
+(1) structural isolation -- a shadow call NEVER writes into
+    ``byo_llm_budget_reservations`` and a live call NEVER writes into
+    ``dev_qua_shadow_budget_reservations``;
+(2) exhausting the live org's configured BYO ceiling does not block a
+    concurrent shadow call, and exhausting the isolated shadow quota does
+    not block a concurrent live call;
+(3) mutation-style proof that (1) actually discriminates: monkeypatching
+    the shadow guard to point at the LIVE reservation table makes a shadow
+    call write into ``byo_llm_budget_reservations`` -- i.e. the isolation
+    property is not vacuously true, and a future accidental pool-merge
+    would be caught here.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.llm import qua_shadow_budget
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentMessage,
+    AgentMessageRole,
+    AgentUsage,
+)
+from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErrorCode
+from dev_health_ops.llm.budget import (
+    attach_agent_budget_guard,
+    cost_micro_usd,
+    set_budget_limit,
+)
+from dev_health_ops.llm.qua_shadow_budget import (
+    DEFAULT_QUA_SHADOW_MAX_MICRO_USD,
+    QUA_SHADOW_BUDGET_ENV_KEY,
+    attach_qua_shadow_budget_guard,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.llm_budget import (
+    BYOLLMBudgetReservation,
+    QUAShadowBudgetReservation,
+)
+from dev_health_ops.models.settings import Setting
+from dev_health_ops.models.users import Organization
+from tests._helpers import tables_of
+
+_PROVIDER = "openai"
+_MODEL = "gpt-5-mini"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'qua_shadow.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    Organization,
+                    Setting,
+                    BYOLLMBudgetReservation,
+                    QUAShadowBudgetReservation,
+                ),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(session_maker, org_id: str) -> None:
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=uuid.UUID(org_id),
+                slug=f"qua-shadow-{org_id[:8]}",
+                name="QUA Shadow Test Organization",
+                tier="team",
+            )
+        )
+        await session.commit()
+
+
+class _FakeProvider:
+    """A minimal ``AgentLLMProvider``-shaped fake: `.decide()` returns a
+    fixed, cheap, well-formed result every call -- enough for the budget
+    guard's usage extraction and reconciliation, nothing more."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def decide(
+        self,
+        messages,
+        tools,
+        response_schema,
+        timeout_seconds,
+        max_output_tokens,
+        signal=None,
+    ) -> AgentDecisionResult:
+        self.calls += 1
+        return AgentDecisionResult(
+            decision=AgentFinalAnswer(value={"ok": True}),
+            usage=AgentUsage(input_tokens=5, output_tokens=5, cached_input_tokens=0),
+            latency_ms=1,
+            provider_fingerprint="fake",
+            model_fingerprint="fake",
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _RaisingProvider:
+    """A shadow provider whose `.decide()` always raises a fixed,
+    caller-supplied error -- used to exercise the exception-reconciliation
+    path directly."""
+
+    def __init__(self, error: AgentProviderError) -> None:
+        self._error = error
+        self.calls = 0
+
+    async def decide(
+        self,
+        messages,
+        tools,
+        response_schema,
+        timeout_seconds,
+        max_output_tokens,
+        signal=None,
+    ) -> AgentDecisionResult:
+        self.calls += 1
+        raise self._error
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_shadow_call_never_writes_the_live_reservation_table(
+    session_maker, monkeypatch
+):
+    """Structural isolation, direction 1: a shadow call reserves/reconciles
+    ONLY in dev_qua_shadow_budget_reservations."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    provider = _FakeProvider()
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    result = await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")], (), {"type": "object"}, 1, 64
+    )
+    assert result.decision.value == {"ok": True}
+    assert provider.calls == 1
+
+    async with session_maker() as session:
+        live_rows = list(
+            (await session.execute(select(BYOLLMBudgetReservation))).scalars()
+        )
+        shadow_rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert live_rows == []
+    assert len(shadow_rows) == 1
+    assert shadow_rows[0].status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_live_call_never_writes_the_shadow_reservation_table(
+    session_maker, monkeypatch
+):
+    """Structural isolation, direction 2: a live call reserves/reconciles
+    ONLY in byo_llm_budget_reservations."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+    async with session_maker() as session:
+        await set_budget_limit(SettingsService(session, org_id), 1_000_000)
+        await session.commit()
+
+    @asynccontextmanager
+    async def live_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", live_budget_session
+    )
+
+    provider = _FakeProvider()
+    async with session_maker() as unused_session:
+        guarded = attach_agent_budget_guard(
+            provider,
+            session=unused_session,
+            org_id=org_id,
+            provider=_PROVIDER,
+            model=_MODEL,
+            base_url=None,
+        )
+    result = await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")], (), {"type": "object"}, 1, 64
+    )
+    assert result.decision.value == {"ok": True}
+
+    async with session_maker() as session:
+        live_rows = list(
+            (await session.execute(select(BYOLLMBudgetReservation))).scalars()
+        )
+        shadow_rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert len(live_rows) == 1
+    assert shadow_rows == []
+
+
+@pytest.mark.asyncio
+async def test_exhausting_the_live_budget_does_not_block_a_concurrent_shadow_call(
+    session_maker, monkeypatch
+):
+    """The live org's ceiling is configured to zero -- a live call is
+    rejected outright -- but a shadow call for the SAME org, in the SAME
+    window, still succeeds: it draws from its own separate, unexhausted
+    pool, entirely unaware the live pool is exhausted."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+    async with session_maker() as session:
+        await set_budget_limit(SettingsService(session, org_id), 0)
+        await session.commit()
+
+    @asynccontextmanager
+    async def live_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", live_budget_session
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    live_provider = _FakeProvider()
+    async with session_maker() as unused_session:
+        live_guarded = attach_agent_budget_guard(
+            live_provider,
+            session=unused_session,
+            org_id=org_id,
+            provider=_PROVIDER,
+            model=_MODEL,
+            base_url=None,
+        )
+    with pytest.raises(AgentProviderError) as live_caught:
+        await live_guarded.decide(
+            [AgentMessage(AgentMessageRole.USER, "q1")], (), {"type": "object"}, 1, 64
+        )
+    assert live_caught.value.code is AgentProviderErrorCode.BUDGET_EXHAUSTED
+    assert live_provider.calls == 0
+
+    # A shadow call for the SAME org, SAME window, is entirely unaffected.
+    shadow_provider = _FakeProvider()
+    shadow_guarded = attach_qua_shadow_budget_guard(
+        shadow_provider,
+        org_id=org_id,
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+    )
+    shadow_result = await shadow_guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "q2")], (), {"type": "object"}, 1, 64
+    )
+    assert shadow_result.decision.value == {"ok": True}
+    assert shadow_provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_exhausting_the_shadow_quota_does_not_block_a_concurrent_live_call(
+    session_maker, monkeypatch
+):
+    """The mirror image: an isolated shadow quota configured to zero
+    rejects a shadow call outright, but the live call for the SAME org,
+    SAME window, still succeeds against its own, generously-configured
+    ceiling -- entirely unaware the shadow pool is exhausted."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+    async with session_maker() as session:
+        await set_budget_limit(SettingsService(session, org_id), 1_000_000)
+        await session.commit()
+    monkeypatch.setenv(QUA_SHADOW_BUDGET_ENV_KEY, "0")
+
+    @asynccontextmanager
+    async def live_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.budget.get_postgres_session", live_budget_session
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    shadow_provider = _FakeProvider()
+    shadow_guarded = attach_qua_shadow_budget_guard(
+        shadow_provider,
+        org_id=org_id,
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+    )
+    with pytest.raises(AgentProviderError) as shadow_caught:
+        await shadow_guarded.decide(
+            [AgentMessage(AgentMessageRole.USER, "q1")], (), {"type": "object"}, 1, 64
+        )
+    assert shadow_caught.value.code is AgentProviderErrorCode.BUDGET_EXHAUSTED
+    assert shadow_provider.calls == 0
+
+    live_provider = _FakeProvider()
+    async with session_maker() as unused_session:
+        live_guarded = attach_agent_budget_guard(
+            live_provider,
+            session=unused_session,
+            org_id=org_id,
+            provider=_PROVIDER,
+            model=_MODEL,
+            base_url=None,
+        )
+    live_result = await live_guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "q2")], (), {"type": "object"}, 1, 64
+    )
+    assert live_result.decision.value == {"ok": True}
+    assert live_provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unset_env_defaults_to_the_conservative_ceiling_not_unlimited():
+    assert (
+        qua_shadow_budget.qua_shadow_maximum_micro_usd()
+        == DEFAULT_QUA_SHADOW_MAX_MICRO_USD
+    )
+    assert DEFAULT_QUA_SHADOW_MAX_MICRO_USD > 0
+
+
+@pytest.mark.asyncio
+async def test_mutation_pointing_the_shadow_guard_at_the_live_table_breaks_isolation(
+    session_maker, monkeypatch
+):
+    """Mutation-style proof the isolation tests above actually discriminate:
+    if ``qua_shadow_budget``'s reservation model is mutated to the SAME
+    class the live guard uses, a shadow call now writes into
+    ``byo_llm_budget_reservations`` -- exactly the contamination the real
+    (unmutated) code must never produce. Confirms the two isolation tests
+    above would catch a future accidental pool-merge.
+    """
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+    # THE MUTATION: point the shadow module's reservation model at the
+    # live table's model class.
+    monkeypatch.setattr(
+        qua_shadow_budget, "QUAShadowBudgetReservation", BYOLLMBudgetReservation
+    )
+
+    provider = _FakeProvider()
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")], (), {"type": "object"}, 1, 64
+    )
+
+    async with session_maker() as session:
+        live_rows = list(
+            (await session.execute(select(BYOLLMBudgetReservation))).scalars()
+        )
+    # Under the real (unmutated) module this list is always empty -- see
+    # test_shadow_call_never_writes_the_live_reservation_table above. Under
+    # this deliberate mutation it is not, proving that test's assertion is
+    # load-bearing rather than vacuous.
+    assert len(live_rows) == 1
+    assert live_rows[0].provider == _PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# Codex round 1 findings: usage accounting and reservation sizing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_dispatched_failure_with_attached_usage_bills_its_real_cost(
+    session_maker, monkeypatch
+):
+    """Codex round 1 (HIGH, confirmed): a dispatched-but-failed call can
+    carry REAL billable usage (e.g. AgentProviderError.usage on
+    OUTPUT_EXHAUSTED) -- discarding it reconciled every such call as
+    ``usage_unavailable`` regardless of whether real usage was available.
+    The reservation must reconcile to its ACTUAL cost, not an unreported
+    one, whenever the provider attached it."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    error = AgentProviderError(
+        AgentProviderErrorCode.OUTPUT_EXHAUSTED,
+        usage=AgentUsage(input_tokens=40, output_tokens=256, cached_input_tokens=0),
+    )
+    provider = _RaisingProvider(error)
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    with pytest.raises(AgentProviderError) as caught:
+        await guarded.decide(
+            [AgentMessage(AgentMessageRole.USER, "q")], (), {"type": "object"}, 1, 64
+        )
+    assert caught.value.code is AgentProviderErrorCode.OUTPUT_EXHAUSTED
+
+    expected_cost = cost_micro_usd(
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+        input_tokens=40,
+        output_tokens=256,
+        cached_input_tokens=0,
+    )
+    assert expected_cost is not None
+
+    async with session_maker() as session:
+        rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert rows[0].actual_micro_usd == expected_cost
+
+
+@pytest.mark.asyncio
+async def test_a_dispatched_failure_with_no_usage_still_counts_its_reserved_amount(
+    session_maker, monkeypatch
+):
+    """Codex round 1 (HIGH, confirmed): the original `used` filter excluded
+    BOTH 'voided' and 'usage_unavailable' reservations, so a dispatched
+    call that failed with no usage attached advanced ZERO quota -- a
+    provider that always fails this way could be called forever without
+    ever exhausting the isolated cap, defeating it entirely. A
+    'usage_unavailable' reservation must still count at its RESERVED
+    (worst-case) amount, exactly like llm.budget.get_budget_status's own
+    filter for the live pool -- proven here by configuring the ceiling to
+    exactly one such reservation's size and showing a second call is
+    rejected."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    messages = [AgentMessage(AgentMessageRole.USER, "q1")]
+    tools: tuple = ()
+    response_schema = {"type": "object"}
+    payload = json.dumps(
+        {
+            "messages": [str(item) for item in messages],
+            "tools": [str(item) for item in tools],
+            "response_schema": response_schema,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    maximum_input_tokens = max(1, len(payload.encode("utf-8")))
+    reserved = cost_micro_usd(
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+        input_tokens=maximum_input_tokens,
+        output_tokens=64,
+        cached_input_tokens=0,
+    )
+    assert reserved is not None
+    # Exactly enough for the first call's reservation -- nothing left over.
+    monkeypatch.setenv(QUA_SHADOW_BUDGET_ENV_KEY, str(reserved))
+
+    error = AgentProviderError(AgentProviderErrorCode.PROVIDER_UNAVAILABLE)
+    provider = _RaisingProvider(error)
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    with pytest.raises(AgentProviderError) as first:
+        await guarded.decide(messages, tools, response_schema, 1, 64)
+    assert first.value.code is AgentProviderErrorCode.PROVIDER_UNAVAILABLE
+
+    async with session_maker() as session:
+        rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert len(rows) == 1
+    assert rows[0].status == "usage_unavailable"
+    assert rows[0].actual_micro_usd is None
+
+    # A SECOND shadow call is rejected: the first failure's RESERVED
+    # amount already counts toward the (now fully consumed) quota -- the
+    # cap cannot be evaded by repeated dispatched-but-unreconciled failures.
+    with pytest.raises(AgentProviderError) as second:
+        await guarded.decide(messages, tools, response_schema, 1, 64)
+    assert second.value.code is AgentProviderErrorCode.BUDGET_EXHAUSTED
+    assert provider.calls == 1  # the second call never dispatched
+
+
+@pytest.mark.asyncio
+async def test_reservation_accounts_for_the_full_wire_payload_not_just_messages(
+    session_maker, monkeypatch
+):
+    """Codex round 1 (HIGH, confirmed): the reservation must bound the
+    COMPLETE wire request -- messages AND tools AND response_schema -- not
+    just the messages. A messages-only estimate is not a guaranteed upper
+    bound on the real request (this seam's own JSON Schema can be sizeable
+    once the shortlist is large), so it could admit a call a full-payload
+    estimate would correctly reject. Proven by picking a ceiling strictly
+    between the two estimates for the SAME call and showing the real guard
+    rejects it (a messages-only guard would have wrongly admitted it)."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    tiny_messages = [AgentMessage(AgentMessageRole.USER, "q")]
+    large_schema = {
+        "type": "object",
+        "properties": {f"field_{i}": {"type": "string"} for i in range(500)},
+    }
+
+    messages_only_estimate = max(1, sum(len(str(item)) for item in tiny_messages))
+    full_payload = json.dumps(
+        {
+            "messages": [str(item) for item in tiny_messages],
+            "tools": [],
+            "response_schema": large_schema,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    full_payload_estimate = max(1, len(full_payload.encode("utf-8")))
+    assert full_payload_estimate > messages_only_estimate * 10  # sanity
+
+    messages_only_cost = cost_micro_usd(
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+        input_tokens=messages_only_estimate,
+        output_tokens=64,
+        cached_input_tokens=0,
+    )
+    full_payload_cost = cost_micro_usd(
+        provider=_PROVIDER,
+        model=_MODEL,
+        base_url=None,
+        input_tokens=full_payload_estimate,
+        output_tokens=64,
+        cached_input_tokens=0,
+    )
+    assert messages_only_cost is not None
+    assert full_payload_cost is not None
+    assert full_payload_cost > messages_only_cost
+
+    ceiling = (messages_only_cost + full_payload_cost) // 2
+    assert messages_only_cost <= ceiling < full_payload_cost
+    monkeypatch.setenv(QUA_SHADOW_BUDGET_ENV_KEY, str(ceiling))
+
+    provider = _FakeProvider()
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    with pytest.raises(AgentProviderError) as caught:
+        await guarded.decide(tiny_messages, (), large_schema, 1, 64)
+    assert caught.value.code is AgentProviderErrorCode.BUDGET_EXHAUSTED
+    assert provider.calls == 0  # rejected before dispatch -- never admitted
+
+
+@pytest.mark.asyncio
+async def test_a_successful_call_with_unreported_cache_usage_is_not_discarded(
+    session_maker, monkeypatch
+):
+    """Codex round 2 (MEDIUM, confirmed): the shadow guard used to RAISE
+    (discarding an otherwise-successful, evaluated decision) whenever
+    reconciliation could not confirm a cost -- e.g. the provider's response
+    omitted cache-usage detail, which OpenAICompatibleAgentProvider's own
+    ``_normalize_usage`` explicitly leaves as ``None`` rather than
+    defaulting to 0 when absent. Unlike the live BYO guard (protecting the
+    org's own configured monetary ceiling), the shadow quota already counts
+    this reservation's RESERVED amount toward `used` regardless (round 1's
+    fix) -- so the call's real, successful decision must be returned to the
+    caller, not thrown away."""
+
+    org_id = str(uuid.uuid4())
+    await _seed_org(session_maker, org_id)
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    class _NoCacheDetailProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def decide(
+            self,
+            messages,
+            tools,
+            response_schema,
+            timeout_seconds,
+            max_output_tokens,
+            signal=None,
+        ) -> AgentDecisionResult:
+            self.calls += 1
+            return AgentDecisionResult(
+                decision=AgentFinalAnswer(value={"real": "decision"}),
+                # cached_input_tokens left at its dataclass default (None)
+                # -- exactly what _normalize_usage produces when the
+                # provider's response omits prompt_tokens_details.
+                usage=AgentUsage(input_tokens=5, output_tokens=5),
+                latency_ms=1,
+                provider_fingerprint="fake",
+                model_fingerprint="fake",
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    provider = _NoCacheDetailProvider()
+    guarded = attach_qua_shadow_budget_guard(
+        provider, org_id=org_id, provider=_PROVIDER, model=_MODEL, base_url=None
+    )
+    # Must NOT raise -- the real decision is returned.
+    result = await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "q")], (), {"type": "object"}, 1, 64
+    )
+    assert result.decision.value == {"real": "decision"}
+    assert provider.calls == 1
+
+    async with session_maker() as session:
+        rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert len(rows) == 1
+    assert rows[0].status == "usage_unavailable"
+    assert rows[0].actual_micro_usd is None

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0087"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0087"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0087"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0087"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_migration.py
+++ b/tests/test_ask_dev_v2_persistence_migration.py
@@ -402,6 +402,77 @@ def test_0086_downgrade_refuses_with_populated_shadow_data() -> None:
         engine.dispose()
 
 
+def test_0087_downgrade_refuses_with_populated_shadow_budget_data() -> None:
+    """CHAOS-3452: ``dev_qua_shadow_budget_reservations`` gets the SAME
+    populated-data downgrade guard 0086 established for
+    ``dev_run_qua_shadow`` -- this table holds real monetary
+    reservation/usage evidence once the shadow flag is on, and an
+    unconditional drop would silently erase it on a routine downgrade
+    rehearsal. Fail-before/pass-after, mirroring
+    ``test_0086_downgrade_refuses_with_populated_shadow_data`` above.
+
+    Only ``organizations`` is needed as a parent: unlike ``dev_run_qua_shadow``
+    (FK'd to ``dev_runs``), this table FKs directly to ``organizations.id``
+    (CHAOS-3452's isolation design deliberately keeps it OUT of the
+    ``dev_runs``-owned audit-table family -- see
+    ``QUAShadowBudgetReservation``'s own docstring).
+    """
+
+    m87 = _load("0087_add_dev_qua_shadow_budget_reservations")
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as connection:
+            _parent_and_v1_tables(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                m87.upgrade()
+
+            tables = set(sa.inspect(connection).get_table_names())
+            assert "dev_qua_shadow_budget_reservations" in tables
+
+            org_id = str(uuid.uuid4())
+            connection.execute(
+                sa.text("INSERT INTO organizations (id, name) VALUES (:id, 'o')"),
+                {"id": org_id},
+            )
+            connection.commit()
+
+            reservation_id = str(uuid.uuid4())
+            connection.execute(
+                sa.text(
+                    "INSERT INTO dev_qua_shadow_budget_reservations "
+                    "(id, org_id, window_start, idempotency_key, provider, "
+                    "model, reserved_micro_usd, status, pricing_version, "
+                    "created_at) VALUES "
+                    "(:id, :org_id, CURRENT_TIMESTAMP, 'k', 'openai', "
+                    "'gpt-5-mini', 1, 'reserved', 'v1', CURRENT_TIMESTAMP)"
+                ),
+                {"id": reservation_id, "org_id": org_id},
+            )
+            connection.commit()
+
+            with Operations.context(context):
+                with pytest.raises(
+                    RuntimeError, match="dev_qua_shadow_budget_reservations"
+                ):
+                    m87.downgrade()
+
+            connection.execute(
+                sa.text(
+                    "DELETE FROM dev_qua_shadow_budget_reservations WHERE id = :id"
+                ),
+                {"id": reservation_id},
+            )
+            connection.commit()
+            with Operations.context(context):
+                m87.downgrade()  # now succeeds
+            tables = set(sa.inspect(connection).get_table_names())
+            assert "dev_qua_shadow_budget_reservations" not in tables
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.skipif(
     not os.getenv(_POSTGRES_URI_ENV), reason=f"requires {_POSTGRES_URI_ENV}"
 )

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0086",)
+    assert heads == ("0087",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0086"}
+    assert set(heads) == {"0066", "0087"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_env_isolation_contract.py
+++ b/tests/test_env_isolation_contract.py
@@ -63,6 +63,12 @@ def test_discovery_finds_env_reads_in_src():
     # literals would miss the cause of eight of the fifteen failures.
     assert "LOG_LEVEL" in names
     assert "AUTH_AUTO_CREATE_ORG_ON_REGISTER" in names
+    # CHAOS-3452: an ANNOTATED module constant (``NAME: Final = "..."``,
+    # llm/qua_shadow_budget.py's own style) is a THIRD constant-resolution
+    # shape, distinct from AUTH_AUTO_CREATE_ORG_ON_REGISTER's plain
+    # ``NAME = "..."`` above -- _module_string_constants originally only
+    # matched ast.Assign, silently missing every ast.AnnAssign constant.
+    assert "ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD" in names
 
 
 def test_discovery_finds_declarations_in_env_example():

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0086"}
+        assert set(heads) == {"0066", "0087"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0086"
+        assert script.get_revision("application_schema@head").revision == "0087"
         assert revisions
 
 

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0086"}
-        assert scripts.get_revision("application_schema@head").revision == "0086"
-        assert _database_has_revision(cfg, ("0086",), "0065")
-        assert not _database_has_revision(cfg, ("0086",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0087"}
+        assert scripts.get_revision("application_schema@head").revision == "0087"
+        assert _database_has_revision(cfg, ("0087",), "0065")
+        assert not _database_has_revision(cfg, ("0087",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## CHAOS-3452: isolated shadow quota so QUA shadow can carry a real provider

Follow-on from the CHAOS-3389 shadow-mode changeset (#1517, design comment 16bd8fed): production shipped the QUA shadow seam with `provider=None` because the only provider instance available was the SAME one `attach_agent_budget_guard` (`llm/budget.py`) monkeypatches for the live investigation call, and `get_budget_status` sums every reservation for an `(org_id, window_start)` pair regardless of provider/model — a shadow call sharing that instance/table would draw down the SAME organization monetary ceiling the live call needs.

### What shipped

- New table `dev_qua_shadow_budget_reservations` (migration 0087, `QUAShadowBudgetReservation` model) — identical reservation/reconciliation CHECK-constraint shape to `byo_llm_budget_reservations` (0071), but a wholly separate table, own Postgres advisory-lock namespace, own in-process per-org lock, own operator-only ceiling (`ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD`, default $0.50/org/month, config-gated, NOT organization-configurable). Same populated-data downgrade-refusal guard 0086 established.
- `llm/qua_shadow_budget.py`: `attach_qua_shadow_budget_guard`/`guard_qua_shadow_call` — fails CLOSED on unpriced providers (the live guard fails open), reconciles usage the same way the live guard does but never discards a successful decision just because its cost couldn't be confirmed (no customer-facing monetary guarantee is at stake on the shadow path the way there is on live).
- `production_runtime.py`: `resolve_production_provider` now builds a SECOND, independently-constructed `AgentLLMProvider` (own HTTP client) wrapped in the new guard — never `provider.provider`'s object identity, never touched by `attach_agent_budget_guard`. Constructed ONLY when `ASK_DEV_QUA_SHADOW_ENABLED=1`, preserving "unset env var is byte-identical to the seam not existing." Falls back to `None` (existing typed `SKIPPED_NO_PROVIDER`) on any construction failure.
- `qua_shadow.py`: `evaluate()` maps `BUDGET_EXHAUSTED`/`BUDGET_UNAVAILABLE` onto the existing `SKIPPED_BUDGET_EXHAUSTED` status instead of the generic `SKIPPED_PROVIDER_ERROR` bucket.
- `runtime.py`/`router.py`: the shadow provider's connection is closed alongside the live one everywhere the live one is.
- `tests/_env_isolation.py`: the new `ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD` env var is the first `os.getenv(CONST)` read in `src/` to use an ANNOTATED module constant (`NAME: Final = "..."`) — a shape `_module_string_constants` only resolved for plain `NAME = "..."` assignments, silently missing it from the derived scrub list. Fixed the scanner to handle `ast.AnnAssign` too and regenerated the checked-in `SCRUB_ENV_NAMES` snapshot (same mechanism #1522 used for `ASK_DEV_QUA_SHADOW_ENABLED`).

### Review

Three rounds of Codex adversarial review:
- **Round 1**: 3 findings (2 HIGH, 1 MEDIUM), all confirmed and fixed — the used-quota filter excluded `usage_unavailable` reservations (repeated dispatched-but-unreconciled failures could evade the cap entirely), the admission reservation sized input from messages only (not tools/response_schema, so it wasn't a guaranteed upper bound), and `BoundedDevRuntime.aclose()` skipped shadow cleanup when the live provider's close raised.
- **Round 2**: 3 findings, 1 fixed (a successful call was discarded rather than returned whenever reconciliation couldn't confirm cost), 2 validated as real architectural residuals — documented explicitly in `qua_shadow_budget.py`'s own module docstring and tracked on CHAOS-3464 (shared BYO provider account for shadow traffic, which for BYO orgs means spending the customer's own provider credits on our shadow experiment; the admission estimate is a conservative parity-with-live estimate, not a proven upper bound) — neither blocks this ticket's stated scope of an isolated reservation pool.
- **Round 3** (scoped verification pass): approve, no material findings.

Every fix RED-tested: reverted individually, confirmed the paired test flips green→red, restored, confirmed green. 13 new/changed tests total. Design decisions documented on CHAOS-3452 in the same changeset.

### Gate

`ci/local_validate.sh` green except one pre-existing, proven-unrelated failure: `tests/tooling/test_local_validate_lock.py::test_reclaim_is_compare_and_delete_under_widened_window` — reproduces identically on a clean detached `c894beef7` worktree with a fresh venv (zero diff overlap between this PR and `ci/local_validate.sh`/`tests/tooling/`). Filed as CHAOS-3468 with full forensics (including a separate xdist/execnet deadlock symptom from the same suite hit during investigation).

Closes CHAOS-3452.
