### PR TITLE
CHAOS-3465: spend a pass's leftover sync budget retrying deferred units

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -422,7 +422,7 @@
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1158
+        "line": 1165
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -446,7 +446,7 @@
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2013
+        "line": 2020
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2294,7 +2294,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1054
+        "line": 1061
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2318,7 +2318,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1644
+        "line": 1651
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2342,7 +2342,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2464
+        "line": 2471
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -422,7 +422,7 @@
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1150
+        "line": 1158
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -446,7 +446,7 @@
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2005
+        "line": 2013
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2294,7 +2294,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1046
+        "line": 1054
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2318,7 +2318,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1636
+        "line": 1644
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2342,7 +2342,7 @@
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2456
+        "line": 2464
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/docs/reference/configuration/environment.md
+++ b/docs/reference/configuration/environment.md
@@ -83,6 +83,17 @@ themselves. A unit is only ever failed by one of these caps on a pass where it
 is confirmed to still be blocked; one that has become admissible is dispatched
 instead, however long it was previously held back.
 
+A pass that finishes admission with budget left over spends it retrying units
+an earlier deferral is still holding back, longest-deferred first, so a unit
+does not sit out its full deferral interval against a bucket that has since
+drained. `SYNC_BUDGET_SURPLUS_MAX_CANDIDATES` (default 16) bounds how many
+such units one pass estimates; `0` disables surplus retry entirely. The
+surplus is strictly in-cycle — unused budget is never banked for a later pass,
+which would let an idle period fund a burst and re-create the starvation the
+bucket caps exist to prevent. It relaxes budget admission and nothing else:
+the per-bucket concurrency cap, tier and total unit caps, provider cooldowns,
+and the exhaustion outcome above all still bind.
+
 A setting that enables a route is not sufficient evidence that the corresponding worker owns production work. The checked-in route, handler coverage, profile, and migration state must agree.
 
 ## External services and telemetry

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from types import MappingProxyType
 from typing import Any
 
 from sqlalchemy import func, or_, text, update
@@ -148,6 +149,12 @@ class BudgetGuardResult:
     #: deferral) but were pulled forward into it by the surplus phase
     #: (CHAOS-3465). They are claimable by ``_claim_units`` on this same pass.
     surplus_admitted_unit_ids: frozenset[str] = frozenset()
+    #: Each surplus-admitted unit's ``available_at`` from BEFORE the promotion,
+    #: so a later stage that must withdraw the promotion can put the unit back
+    #: exactly where it was instead of leaving it due (CHAOS-3465 review). The
+    #: keys are ``surplus_admitted_unit_ids``; kept as a separate mapping
+    #: because the restore VALUE is what makes the withdrawal a no-op.
+    surplus_prior_available_at: Mapping[str, datetime] = field(default_factory=dict)
     # CHAOS-2760 TOCTOU closure: the candidate units and their (already
     # loaded, credential-decryption-free-to-reuse) estimates from THIS pass,
     # so the caller can run one more cheap cooldown re-check
@@ -514,7 +521,7 @@ class BudgetGuard:
         # taken its share. consumed_by_bucket now holds durable consumption
         # plus this pass's own admissions, which is exactly the baseline a
         # surplus admission must fit on top of.
-        surplus_admitted_ids = _admit_surplus_retries(
+        surplus_prior_available_at = _admit_surplus_retries(
             session,
             sync_run_id,
             candidates=surplus_candidates,
@@ -536,18 +543,21 @@ class BudgetGuard:
             # Surplus-admitted units join the candidate set the caller hands to
             # reconfirm_cooldowns: they are about to be claimed on this pass,
             # so they need the same last-read-before-the-claim cooldown check
-            # every other dispatched unit gets.
+            # every other dispatched unit gets. The caller MUST also pass
+            # surplus_prior_available_at, or that check will end their budget
+            # episode -- see reconfirm_cooldowns.
             candidate_units=(
                 *units,
                 *(
                     unit
                     for unit in surplus_candidates
-                    if str(unit.id) in surplus_admitted_ids
+                    if str(unit.id) in surplus_prior_available_at
                 ),
             ),
             estimates_by_unit=estimates_by_unit,
             jitter_seconds=jitter_seconds,
-            surplus_admitted_unit_ids=frozenset(surplus_admitted_ids),
+            surplus_admitted_unit_ids=frozenset(surplus_prior_available_at),
+            surplus_prior_available_at=dict(surplus_prior_available_at),
         )
 
     @staticmethod
@@ -559,6 +569,7 @@ class BudgetGuard:
         estimates_by_unit: Mapping[str, tuple[BudgetEstimate, ...]],
         already_excluded_ids: frozenset[str],
         jitter_seconds: int,
+        surplus_prior_available_at: Mapping[str, datetime] = MappingProxyType({}),
         now: datetime | None = None,
     ) -> CooldownReconfirmResult:
         """Close the TOCTOU window between ``enforce_run``'s cooldown
@@ -601,6 +612,35 @@ class BudgetGuard:
         the earliest new ``available_at``, so the caller can fold it into
         ``next_deferred_at`` for the ``_schedule_redispatch`` re-arm.
 
+        SURPLUS-ADMITTED UNITS ARE WITHDRAWN, NOT DEFERRED (CHAOS-3465 review,
+        CRITICAL). A unit the surplus phase pulled forward is here only
+        because this pass OFFERED it a slot it was not otherwise going to get.
+        Running the normal cooldown deferral on it would send it through
+        ``_apply_cooldown_deferral``, which -- correctly, for a unit that was
+        genuinely about to dispatch -- ends the budget episode:
+        ``budget_deferrals=0``, ``budget_first_deferred_at=None``, and a
+        ``rate_limit_cooldown_deferred`` category. For a surplus unit that is
+        a fabricated episode change: absent the surplus phase it would have
+        kept counting down with its episode intact, so "the guard tried to
+        help" would silently reset the CHAOS-3412 exhaustion evidence. A unit
+        at 9/10 deferrals, promoted and caught each pass, would never reach
+        the specific budget verdict at all.
+
+        So the offer is simply WITHDRAWN: ``available_at`` goes back to the
+        value it had before promotion and nothing else is touched -- the same
+        rule the surplus phase already follows for a candidate that does not
+        fit. This is the ONLY correct reading of "a surplus attempt that does
+        not end in dispatch is a no-op".
+
+        Two consequences, both deliberate. The withdrawn unit is not folded
+        into ``next_deferred_at``: it is back on its ORIGINAL countdown, whose
+        wakeup was armed when it was originally deferred, and re-arming from
+        here would claim this pass deferred something it did not. And an
+        exhaustion verdict that ``_resolve_cooldown_blocked_unit`` might have
+        reached for it is not lost, only postponed to the pass where the unit
+        is genuinely due -- which is exactly where it would have been reached
+        had the surplus phase never looked at it.
+
         This does not achieve full serializability (a commit landing in the
         few-microsecond gap between this query and the claim's own
         ``UPDATE`` could still slip through), but it collapses the window
@@ -640,6 +680,21 @@ class BudgetGuard:
                     cooldown_by_dimension=cooldown_by_dimension,
                 )
             log_ctx = _unit_log_context(sync_run_id, unit)
+            prior_available_at = surplus_prior_available_at.get(str(unit.id))
+            if cooldown_expiry is not None and prior_available_at is not None:
+                # Withdraw the surplus offer instead of deferring (see the
+                # docstring): this unit was never going to dispatch this pass
+                # without the promotion, so the promotion is undone and its
+                # budget episode is left exactly as it was.
+                if _withdraw_surplus_admission(
+                    session,
+                    unit,
+                    prior_available_at=prior_available_at,
+                    now=checked_at,
+                    log_ctx=log_ctx,
+                ):
+                    excluded.add(str(unit.id))
+                continue
             if cooldown_expiry is not None:
                 # Same helper enforce_run uses (review round 2, R2-F2): this
                 # path previously had its own copy of the ordering that also
@@ -840,9 +895,15 @@ def _admit_surplus_retries(
     cooldown_by_dimension: Mapping[tuple[str, str, uuid.UUID, str], datetime],
     observations: list[dict[str, Any]],
     now: datetime,
-) -> set[str]:
+) -> dict[str, datetime]:
     """Spend this pass's leftover budget on deferred units, in
-    longest-deferred-first order, and return the ids actually admitted.
+    longest-deferred-first order.
+
+    Returns ``{unit_id: available_at BEFORE the promotion}`` for each unit
+    admitted. The prior value is returned, not merely the id, because a later
+    stage may have to WITHDRAW the promotion (see
+    ``reconfirm_cooldowns``), and putting the unit back exactly where it was
+    is what keeps the whole surplus attempt a no-op.
 
     COUNTER SEMANTICS -- the decision this phase turns on:
 
@@ -885,7 +946,7 @@ def _admit_surplus_retries(
       admission loop does not ask about a fitting candidate either (R2-F1:
       a unit that would be admitted now must be admitted, not killed).
     """
-    admitted: set[str] = set()
+    admitted: dict[str, datetime] = {}
     for unit in candidates:
         log_ctx = _unit_log_context(sync_run_id, unit)
         estimates = estimates_by_unit.get(str(unit.id), ())
@@ -953,9 +1014,20 @@ def _admit_surplus_retries(
             )
             continue
 
+        # Captured BEFORE the promotion overwrites it: this is what a later
+        # withdrawal restores. A candidate always has one (the selection query
+        # requires ``available_at > now``), but if that ever stops holding,
+        # skip rather than promote a unit we could not put back.
+        prior_available_at = unit.available_at
+        if prior_available_at is None:
+            logger.warning(
+                "dispatch_sync_run.budget_surplus_skipped",
+                extra={**log_ctx, "reason": "no_prior_available_at"},
+            )
+            continue
         if not _admit_unit_from_surplus(session, unit, now=now, log_ctx=log_ctx):
-            # CAS lost: the unit moved on concurrently (claimed, reconciled,
-            # re-deferred). Its budget stays unspent for the next candidate.
+            # CAS lost: the unit moved on concurrently. Its budget stays
+            # unspent and is offered to the next candidate.
             continue
 
         for estimate in estimates:
@@ -964,7 +1036,7 @@ def _admit_surplus_retries(
             )
             consumed_by_bucket[budget_key] += estimate.estimated_units
         slot_headroom[slot_key] -= 1
-        admitted.add(str(unit.id))
+        admitted[str(unit.id)] = _as_aware(prior_available_at)
         observations.extend(surplus_observations)
         for observation in surplus_observations:
             logger.info(
@@ -992,8 +1064,16 @@ def _admit_unit_from_surplus(
     lifecycle contract, which is precisely the semantics this must not have.
 
     The CAS re-asserts the exact predicate that made the unit a surplus
-    candidate (retrying, and still not due), so a concurrent pass that claimed
-    or re-deferred it in the meantime wins and this returns ``False``.
+    candidate (retrying, and still not due), so a concurrent pass that already
+    promoted or terminalized it wins and this returns ``False``. It is
+    deliberately NOT claimed here as protection against a concurrent
+    re-deferral: no write path in the tree can re-defer a unit that is not yet
+    due -- ``_defer_unit_for_budget`` and ``_apply_cooldown_deferral`` both
+    require the claim predicate (planned / due-retrying / stale-dispatching),
+    and the reconciler's retry stamp targets expired-lease RUNNING units. The
+    single-winner property for the dispatch that follows is owned by
+    ``_claim_units``' atomic UPDATE under the bucket advisory locks, not by
+    this statement.
     """
     result: Any = session.execute(
         update(SyncRunUnit)
@@ -1015,6 +1095,69 @@ def _admit_unit_from_surplus(
             **log_ctx,
             "budget_deferrals": int(unit.budget_deferrals or 0),
             "available_at": now.isoformat(),
+        },
+    )
+    return True
+
+
+def _withdraw_surplus_admission(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    prior_available_at: datetime,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> bool:
+    """Undo a surplus promotion, putting the unit back on its ORIGINAL
+    countdown (CHAOS-3465 review, CRITICAL).
+
+    The exact inverse of :func:`_admit_unit_from_surplus` and nothing more:
+    ``available_at`` returns to its pre-promotion value, and every column any
+    exhaustion predicate reads -- ``budget_deferrals``,
+    ``budget_first_deferred_at``, ``first_blocked_at``, ``result`` -- is left
+    untouched, because from the unit's point of view this pass never happened.
+
+    That is the whole point. The alternative, routing a withdrawn unit through
+    the ordinary cooldown deferral, resets the budget episode and rewrites the
+    error category, so a promotion the guard offered and then took back would
+    destroy the evidence CHAOS-3412's exhaustion verdict is built on.
+
+    ``updated_at`` does move, and that is intended: the row WAS written twice,
+    and an operator reading it deserves to see that rather than a row that
+    silently rewound. Nothing keys off ``updated_at`` for a RETRYING unit (the
+    staleness cutoff applies only to DISPATCHING).
+
+    The CAS pins ``available_at`` to the promoted value, so if anything else
+    moved the unit between the promotion and here, this leaves it alone and
+    returns ``False``.
+    """
+    promoted_available_at = unit.available_at
+    result: Any = session.execute(
+        update(SyncRunUnit)
+        .where(
+            SyncRunUnit.id == unit.id,
+            SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value,
+            SyncRunUnit.available_at == promoted_available_at,
+        )
+        .values(available_at=prior_available_at, updated_at=now)
+        .execution_options(synchronize_session=False)
+    )
+    if int(result.rowcount or 0) == 0:
+        logger.warning(
+            "dispatch_sync_run.budget_surplus_withdrawal_lost_race",
+            extra={**log_ctx, "prior_available_at": prior_available_at.isoformat()},
+        )
+        return False
+    unit.available_at = prior_available_at
+    logger.info(
+        "dispatch_sync_run.budget_surplus_withdrawn",
+        extra={
+            **log_ctx,
+            "reason": "cooldown_landed_after_admission",
+            "restored_available_at": prior_available_at.isoformat(),
+            # Proof, in the log line itself, that the episode survived the
+            # round trip -- this is the value the CRITICAL finding zeroed.
+            "budget_deferrals": int(unit.budget_deferrals or 0),
         },
     )
     return True

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -686,14 +686,25 @@ class BudgetGuard:
                 # docstring): this unit was never going to dispatch this pass
                 # without the promotion, so the promotion is undone and its
                 # budget episode is left exactly as it was.
-                if _withdraw_surplus_admission(
+                _withdraw_surplus_admission(
                     session,
                     unit,
                     prior_available_at=prior_available_at,
                     now=checked_at,
                     log_ctx=log_ctx,
-                ):
-                    excluded.add(str(unit.id))
+                )
+                # UNCONDITIONAL, including when the withdrawal CAS lost
+                # (review round 2). The ordinary path below may treat a lost
+                # race as "leave it to _claim_units" because there a ``None``
+                # outcome PROVES the unit stopped being claimable. Here it
+                # proves nothing: a failed withdrawal leaves the unit due at
+                # the promoted available_at with a cooldown we have just
+                # matched, so skipping the exclusion would dispatch it
+                # straight into that cooldown -- the exact thing this whole
+                # re-check exists to prevent. Excluding costs one pass, and a
+                # withdrawal that lost means another writer owns the row
+                # anyway.
+                excluded.add(str(unit.id))
                 continue
             if cooldown_expiry is not None:
                 # Same helper enforce_run uses (review round 2, R2-F2): this

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -67,6 +67,29 @@ _BUDGET_DEFERRAL_EXHAUSTED_CATEGORY = "budget_deferral_exhausted"
 #: Count cap: how many consecutive budget deferrals a unit may accumulate
 #: before it fails loudly (``SYNC_BUDGET_MAX_DEFERRALS``).
 BUDGET_MAX_DEFERRALS_DEFAULT = 10
+# --- In-cycle surplus retry (CHAOS-3465) ----------------------------------
+# A pass that finishes admission with budget to spare used to let that spare
+# capacity lapse: units budget-deferred moments earlier sit at
+# ``available_at = now + SYNC_BUDGET_DEFERRAL_SECONDS`` and are not candidates
+# again until that countdown expires, however empty the bucket became in the
+# meantime. The surplus phase spends the leftover on exactly those units,
+# longest-deferred first.
+#
+# REJECTED, deliberately: persistent cross-cycle BANKING of unused budget.
+# A bank lets an idle hour accumulate capacity that a later pass spends all at
+# once -- the burst-then-starve behaviour this guard exists to prevent, and one
+# that would also make the bucket cap describe an average rather than a
+# ceiling. Surplus here is in-cycle only: it is measured from THIS pass's
+# ``consumed_by_bucket`` against THIS pass's limits, and anything unspent when
+# the pass returns is simply gone.
+#
+#: How many not-yet-due budget-deferred units one pass may CONSIDER for
+#: surplus admission (``SYNC_BUDGET_SURPLUS_MAX_CANDIDATES``). Each one costs a
+#: ``SyncTaskBootstrap.load`` plus credential decryption to estimate, so the
+#: work a pass takes on for units it may not admit is bounded. Set to 0 to
+#: disable surplus retry entirely. Truncation is logged, never silent.
+BUDGET_SURPLUS_MAX_CANDIDATES_DEFAULT = 16
+
 #: Wall-clock cap measured from ``budget_first_deferred_at``
 #: (``SYNC_BUDGET_DEFERRAL_WALL_CLOCK_SECONDS``). Deliberately longer than
 #: the count cap times the default 60s deferral: a run whose budget frees up
@@ -121,6 +144,10 @@ class BudgetGuardResult:
     observations: list[dict[str, Any]] = field(default_factory=list)
     deferred_unit_ids: frozenset[str] = frozenset()
     next_deferred_at: datetime | None = None
+    #: Units that were NOT candidates this pass (still counting down a budget
+    #: deferral) but were pulled forward into it by the surplus phase
+    #: (CHAOS-3465). They are claimable by ``_claim_units`` on this same pass.
+    surplus_admitted_unit_ids: frozenset[str] = frozenset()
     # CHAOS-2760 TOCTOU closure: the candidate units and their (already
     # loaded, credential-decryption-free-to-reuse) estimates from THIS pass,
     # so the caller can run one more cheap cooldown re-check
@@ -212,8 +239,21 @@ class BudgetGuard:
         sync_run_id: str,
         *,
         capped_unit_ids: Iterable[str] = (),
+        slot_headroom: Mapping[tuple[str, str, str], int] | None = None,
         now: datetime | None = None,
     ) -> BudgetGuardResult:
+        """Admit or defer this pass's dispatch candidates against the budget,
+        then spend whatever budget is left over retrying units an EARLIER
+        deferral is still holding back (CHAOS-3465).
+
+        ``slot_headroom`` is ``DispatchGuard``'s per-``(org_id, provider,
+        cost_class)`` count of concurrency slots still free after this pass's
+        own candidates. Surplus retry admits units the concurrency guard never
+        saw, so without it there is no way to know whether admitting one would
+        breach ``SYNC_UNIT_CONCURRENCY_PER_BUCKET``. Omitting it therefore
+        DISABLES surplus retry rather than guessing -- surplus relaxes the
+        budget admission and nothing else.
+        """
         enforced_at = now or datetime.now(timezone.utc)
         ignored_unit_ids = {str(unit_id) for unit_id in capped_unit_ids}
         units = _dispatch_candidate_units(
@@ -222,7 +262,14 @@ class BudgetGuard:
             ignored_unit_ids=ignored_unit_ids,
             now=enforced_at,
         )
-        if not units:
+        surplus_candidates = _surplus_retry_candidates(
+            session,
+            sync_run_id,
+            ignored_unit_ids=ignored_unit_ids,
+            slot_headroom=slot_headroom,
+            now=enforced_at,
+        )
+        if not units and not surplus_candidates:
             return BudgetGuardResult()
 
         limits = _enforced_budget_limits()
@@ -233,7 +280,13 @@ class BudgetGuard:
         budget_keys: set[str] = set()
         observations: list[dict[str, Any]] = []
 
-        for unit in units:
+        # Surplus candidates are estimated HERE, alongside the real candidates,
+        # rather than after admission: their budget keys have to join the same
+        # sorted advisory-lock batch below. A second, later acquisition would
+        # take locks out of order relative to a concurrent pass that already
+        # holds them, which is how the sorting rule stops being a deadlock
+        # defence.
+        for unit in (*units, *surplus_candidates):
             log_ctx = _unit_log_context(sync_run_id, unit)
             try:
                 ctx = SyncTaskBootstrap.load(session, str(unit.id))
@@ -264,7 +317,11 @@ class BudgetGuard:
         cooldown_by_family, cooldown_by_dimension = _active_cooldowns(
             session,
             sync_run_id=sync_run_id,
-            candidates=units,
+            # Surplus candidates are included so the ONE observation query per
+            # pass also covers the org/provider/integration tuples only they
+            # bring, and the surplus phase can gate on the same maps rather
+            # than issuing a second read.
+            candidates=(*units, *surplus_candidates),
             now=enforced_at,
         )
         for unit in units:
@@ -452,13 +509,45 @@ class BudgetGuard:
                     )
             observations.extend(unit_observations)
 
+        # --- In-cycle surplus retry (CHAOS-3465) — AFTER admission, because
+        # "what is left over" is only knowable once every real candidate has
+        # taken its share. consumed_by_bucket now holds durable consumption
+        # plus this pass's own admissions, which is exactly the baseline a
+        # surplus admission must fit on top of.
+        surplus_admitted_ids = _admit_surplus_retries(
+            session,
+            sync_run_id,
+            candidates=surplus_candidates,
+            estimates_by_unit=estimates_by_unit,
+            consumed_by_bucket=consumed_by_bucket,
+            limits=limits,
+            default_limit=default_limit,
+            slot_headroom=dict(slot_headroom or {}),
+            cooldown_by_family=cooldown_by_family,
+            cooldown_by_dimension=cooldown_by_dimension,
+            observations=observations,
+            now=enforced_at,
+        )
+
         return BudgetGuardResult(
             observations=observations,
             deferred_unit_ids=frozenset(deferred_unit_ids),
             next_deferred_at=next_deferred_at,
-            candidate_units=tuple(units),
+            # Surplus-admitted units join the candidate set the caller hands to
+            # reconfirm_cooldowns: they are about to be claimed on this pass,
+            # so they need the same last-read-before-the-claim cooldown check
+            # every other dispatched unit gets.
+            candidate_units=(
+                *units,
+                *(
+                    unit
+                    for unit in surplus_candidates
+                    if str(unit.id) in surplus_admitted_ids
+                ),
+            ),
             estimates_by_unit=estimates_by_unit,
             jitter_seconds=jitter_seconds,
+            surplus_admitted_unit_ids=frozenset(surplus_admitted_ids),
         )
 
     @staticmethod
@@ -627,6 +716,308 @@ def _dispatch_candidate_units(
         .all()
     )
     return [unit for unit in units if str(unit.id) not in ignored_unit_ids]
+
+
+# ---------------------------------------------------------------------------
+# In-cycle surplus retry (CHAOS-3465)
+# ---------------------------------------------------------------------------
+
+
+def _budget_surplus_max_candidates() -> int:
+    return _env_int(
+        "SYNC_BUDGET_SURPLUS_MAX_CANDIDATES", BUDGET_SURPLUS_MAX_CANDIDATES_DEFAULT
+    )
+
+
+def _surplus_retry_order(unit: SyncRunUnit) -> tuple[datetime, datetime, str]:
+    """Longest-deferred first.
+
+    Ordering by ``budget_first_deferred_at`` ASCENDING is the whole point:
+    surplus must make the exhaustion path RARER, not merely rearrange who
+    reaches it. The unit closest to its deferral caps is the one a spare slot
+    is worth most to, and serving the newest deferral first would let a
+    steady trickle of fresh deferrals starve the oldest indefinitely --
+    re-creating, inside one pass, the starvation the ticket is about.
+
+    ``first_blocked_at`` breaks ties (blocked longer overall wins), then the
+    id, so the order is total and reproducible. Sorted in Python rather than
+    SQL because SQLite and PostgreSQL disagree on where NULLs land in an ASC
+    ordering, and an ordering rule that means different things per dialect is
+    not an ordering rule.
+    """
+    far_future = datetime.max.replace(tzinfo=timezone.utc)
+    first_deferred = unit.budget_first_deferred_at
+    first_blocked = unit.first_blocked_at
+    return (
+        _as_aware(first_deferred) if first_deferred is not None else far_future,
+        _as_aware(first_blocked) if first_blocked is not None else far_future,
+        str(unit.id),
+    )
+
+
+def _surplus_retry_candidates(
+    session: Any,
+    sync_run_id: str,
+    *,
+    ignored_unit_ids: set[str],
+    slot_headroom: Mapping[tuple[str, str, str], int] | None,
+    now: datetime,
+) -> list[SyncRunUnit]:
+    """The units a surplus may be spent on: this run's NOT-YET-DUE budget
+    deferrals, longest-deferred first.
+
+    Membership is exactly the population the ticket is about -- a unit that
+    was budget-deferred, whose ``available_at`` countdown has not expired, and
+    which therefore would sit out this pass no matter how empty its bucket
+    became. Units already due are excluded because they are ordinary
+    candidates and were handled by the admission loop.
+
+    Three exclusions, each of them a guard surplus must not relax:
+
+    * ``slot_headroom`` missing/empty -> no candidates at all. Without the
+      concurrency guard's headroom there is no way to admit anything without
+      possibly breaching the per-bucket cap, so the phase fails CLOSED.
+    * FAILED units are not reachable by this query at all. A budget-exhausted
+      unit stays failed: reviving it would relax the exhaustion outcome, which
+      is a deliberate, operator-visible signal that a configuration is wrong
+      (CHAOS-3412), not a queue state to be undone by spare capacity.
+    * A unit whose own last recorded cause is NOT ``budget_deferred`` is
+      skipped. A cooldown-deferred unit is waiting on the provider, not on the
+      budget, and spare budget is no reason to shorten that wait.
+
+    The category test runs in Python for the same dialect-portability reason
+    as the ordering: ``result`` is a JSON column and the SQL to reach inside it
+    differs per backend. A run's unit count is capped (``SYNC_RUN_MAX_UNITS``),
+    so the filtered scan is bounded by construction.
+    """
+    if not slot_headroom:
+        return []
+    run_uuid = uuid.UUID(str(sync_run_id))
+    deferred = [
+        unit
+        for unit in (
+            session.query(SyncRunUnit)
+            .filter(
+                SyncRunUnit.sync_run_id == run_uuid,
+                SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value,
+                SyncRunUnit.available_at.is_not(None),
+                SyncRunUnit.available_at > now,
+            )
+            .order_by(SyncRunUnit.id)
+            .all()
+        )
+        if str(unit.id) not in ignored_unit_ids
+        and _unit_last_error_category(unit) == _BUDGET_DEFERRED_CATEGORY
+    ]
+    deferred.sort(key=_surplus_retry_order)
+    considered = _budget_surplus_max_candidates()
+    if len(deferred) > considered:
+        # A silent cap reads as "surplus considered everything and nothing
+        # else fitted", which is a different fact entirely.
+        logger.info(
+            "dispatch_sync_run.budget_surplus_candidates_truncated",
+            extra={
+                "sync_run_id": sync_run_id,
+                "deferred_units": len(deferred),
+                "considered_units": considered,
+            },
+        )
+        deferred = deferred[:considered]
+    return deferred
+
+
+def _admit_surplus_retries(
+    session: Any,
+    sync_run_id: str,
+    *,
+    candidates: list[SyncRunUnit],
+    estimates_by_unit: Mapping[str, tuple[BudgetEstimate, ...]],
+    consumed_by_bucket: dict[str, int],
+    limits: Mapping[str, int],
+    default_limit: int,
+    slot_headroom: dict[tuple[str, str, str], int],
+    cooldown_by_family: Mapping[tuple[str, str, uuid.UUID, str], datetime],
+    cooldown_by_dimension: Mapping[tuple[str, str, uuid.UUID, str], datetime],
+    observations: list[dict[str, Any]],
+    now: datetime,
+) -> set[str]:
+    """Spend this pass's leftover budget on deferred units, in
+    longest-deferred-first order, and return the ids actually admitted.
+
+    COUNTER SEMANTICS -- the decision this phase turns on:
+
+    A surplus attempt that does NOT succeed is a complete no-op. It leaves
+    ``budget_deferrals``, ``budget_first_deferred_at``, ``first_blocked_at``,
+    ``available_at`` and ``result`` exactly as the deferral that put the unit
+    here left them. The unit was already counted once, for that deferral;
+    counting an opportunistic second look would add one deferral per pass per
+    unit purely because the guard TRIED to help, dragging the exhaustion caps
+    forward fastest for the units this feature exists to rescue. That is the
+    "must not double-increment within a cycle" rule, resolved at its root:
+    the only place the counter moves is ``_defer_unit_for_budget``, and the
+    surplus phase never calls it.
+
+    A surplus attempt that SUCCEEDS also leaves the episode columns alone. It
+    writes ``available_at`` and nothing else, because the episode's end is
+    already owned elsewhere and duplicating it here would create a second
+    interpretation to drift: ``_claim_units`` clears ``first_blocked_at`` when
+    the unit is actually claimed, and the SUCCESS stamp clears the budget
+    pair when it actually completes. Rewriting ``result`` here would be worse
+    than redundant -- ``_budget_deferral_exhausted``'s defence-in-depth gate
+    reads ``result.error_category``, so a surplus admission that overwrote it
+    would quietly disarm the exhaustion path for that unit.
+
+    Consequence, and it is the correct one: a unit promoted but not claimed
+    (it lost the claim race) is simply a due candidate next pass, and takes
+    one ordinary deferral there if it no longer fits.
+
+    WHAT SURPLUS DOES NOT RELAX. Every other guard still decides:
+
+    * concurrency -- ``slot_headroom`` is decremented per admission, so the
+      per-bucket cap binds a surplus admission exactly as it binds a candidate.
+    * cooldowns -- a unit matching an active shared cooldown is skipped, left
+      deferred; spare budget is not a reason to hit a limited provider.
+    * total/tier unit caps -- untouched: a surplus unit is already a unit of
+      this run and was counted by ``DispatchGuard.authorize_run``.
+    * exhaustion -- neither relaxed nor triggered. The exhaustion predicates
+      are only ever asked about a unit that would DEFER; a surplus admission
+      is by construction a unit that FITS, which is the same reason the
+      admission loop does not ask about a fitting candidate either (R2-F1:
+      a unit that would be admitted now must be admitted, not killed).
+    """
+    admitted: set[str] = set()
+    for unit in candidates:
+        log_ctx = _unit_log_context(sync_run_id, unit)
+        estimates = estimates_by_unit.get(str(unit.id), ())
+        if not estimates:
+            continue
+
+        if (cooldown_by_family or cooldown_by_dimension) and _matching_cooldown_expiry(
+            estimates,
+            org_id=str(unit.org_id),
+            provider=str(unit.provider),
+            integration_id=unit.integration_id,
+            cooldown_by_family=cooldown_by_family,
+            cooldown_by_dimension=cooldown_by_dimension,
+        ) is not None:
+            logger.info(
+                "dispatch_sync_run.budget_surplus_skipped",
+                extra={**log_ctx, "reason": "cooldown_active"},
+            )
+            continue
+
+        slot_key = (str(unit.org_id), str(unit.provider), str(unit.cost_class))
+        if slot_headroom.get(slot_key, 0) <= 0:
+            logger.info(
+                "dispatch_sync_run.budget_surplus_skipped",
+                extra={**log_ctx, "reason": "no_concurrency_slot"},
+            )
+            continue
+
+        # Fit is decided across ALL of the unit's estimates before ANY of them
+        # is charged, mirroring the admission loop's whole-unit semantics: a
+        # unit that fits three buckets and overflows a fourth is not admitted,
+        # and must not leave three buckets charged for work that never ran.
+        surplus_observations: list[dict[str, Any]] = []
+        fits = True
+        for estimate in estimates:
+            bucket = estimate.bucket.to_dict()
+            budget_key = _budget_key(bucket, route_family=estimate.route_family)
+            limit = _limit_for_bucket(
+                bucket,
+                route_family=estimate.route_family,
+                limits=limits,
+                default_limit=default_limit,
+            )
+            projected_units = consumed_by_bucket[budget_key] + estimate.estimated_units
+            if projected_units > limit:
+                fits = False
+            surplus_observations.append(
+                {
+                    **log_ctx,
+                    "decision": "surplus_admitted",
+                    "bucket": bucket,
+                    "budget_key": budget_key,
+                    "estimated_units": estimate.estimated_units,
+                    "projected_units": projected_units,
+                    "budget_limit": limit,
+                    "confidence": estimate.confidence,
+                    "route_family": estimate.route_family,
+                    "budget_deferrals": int(unit.budget_deferrals or 0),
+                }
+            )
+        if not fits:
+            logger.info(
+                "dispatch_sync_run.budget_surplus_skipped",
+                extra={**log_ctx, "reason": "insufficient_surplus"},
+            )
+            continue
+
+        if not _admit_unit_from_surplus(session, unit, now=now, log_ctx=log_ctx):
+            # CAS lost: the unit moved on concurrently (claimed, reconciled,
+            # re-deferred). Its budget stays unspent for the next candidate.
+            continue
+
+        for estimate in estimates:
+            budget_key = _budget_key(
+                estimate.bucket.to_dict(), route_family=estimate.route_family
+            )
+            consumed_by_bucket[budget_key] += estimate.estimated_units
+        slot_headroom[slot_key] -= 1
+        admitted.add(str(unit.id))
+        observations.extend(surplus_observations)
+        for observation in surplus_observations:
+            logger.info(
+                "dispatch_sync_run.budget_surplus_admitted",
+                extra=observation,
+            )
+    return admitted
+
+
+def _admit_unit_from_surplus(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> bool:
+    """Pull a not-yet-due budget deferral forward into THIS pass.
+
+    The whole write is ``available_at`` (plus ``updated_at``): the unit is
+    already ``RETRYING``, and becoming due is the only thing that has to
+    change for ``_claim_units`` to pick it up later in the same transaction.
+    Status is deliberately not re-assigned -- see ``_admit_surplus_retries``
+    for why the episode columns are left alone, and note that a stamp which
+    DID re-assign status would owe every per-episode column a value under the
+    lifecycle contract, which is precisely the semantics this must not have.
+
+    The CAS re-asserts the exact predicate that made the unit a surplus
+    candidate (retrying, and still not due), so a concurrent pass that claimed
+    or re-deferred it in the meantime wins and this returns ``False``.
+    """
+    result: Any = session.execute(
+        update(SyncRunUnit)
+        .where(
+            SyncRunUnit.id == unit.id,
+            SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value,
+            SyncRunUnit.available_at.is_not(None),
+            SyncRunUnit.available_at > now,
+        )
+        .values(available_at=now, updated_at=now)
+        .execution_options(synchronize_session=False)
+    )
+    if int(result.rowcount or 0) == 0:
+        return False
+    unit.available_at = now
+    logger.info(
+        "dispatch_sync_run.budget_surplus_pulled_forward",
+        extra={
+            **log_ctx,
+            "budget_deferrals": int(unit.budget_deferrals or 0),
+            "available_at": now.isoformat(),
+        },
+    )
+    return True
 
 
 def _observe_estimate(

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -19,6 +19,13 @@ Decision shapes
   a delayed redispatch; it MUST NOT mark the run FAILED.
 * **Full allow** — ``GuardDecision(allowed=True, concurrency_capped=False)``.
 
+Every allowed decision also carries ``slot_headroom`` (CHAOS-3465): the slots
+still free per bucket once this pass's candidates are counted as dispatched.
+It is the only sanctioned way for another admission path to add work this
+guard did not see, and is computed for buckets holding not-yet-due RETRYING
+units too — those have no candidate this pass, so omitting them would report
+"no slots" for exactly the units surplus retry exists to unblock.
+
 Concurrency model
 -----------------
 Two disjoint sets per (org_id, provider, cost_class) bucket:
@@ -72,6 +79,7 @@ import hashlib
 import os
 import uuid
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -96,12 +104,23 @@ class GuardDecision:
       them.  The caller must leave those units PLANNED and schedule a delayed
       redispatch — it must NOT mark the run FAILED.
     * **Full allow**: ``allowed=True, concurrency_capped=False``.
+
+    ``slot_headroom`` is the concurrency slots left in each
+    ``(org_id, provider, cost_class)`` bucket AFTER this pass's own candidates
+    are assumed to dispatch (CHAOS-3465). It exists so that a caller admitting
+    work the candidate set did NOT contain -- the budget guard's surplus retry
+    of not-yet-due deferred units -- can still be held to the same concurrency
+    cap this guard enforces, instead of stepping around it. Deliberately
+    conservative: every candidate is counted as if it will dispatch, even
+    though some are about to be budget-deferred, so the headroom can only ever
+    under-admit.
     """
 
     allowed: bool
     reason: str | None = None
     capped_unit_ids: tuple[str, ...] = field(default_factory=tuple)
     concurrency_capped: bool = False
+    slot_headroom: Mapping[tuple[str, str, str], int] = field(default_factory=dict)
 
 
 class DispatchGuard:
@@ -157,6 +176,14 @@ class DispatchGuard:
         candidates_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = (
             defaultdict(list)
         )
+        # Buckets holding only NOT-YET-DUE retrying units (CHAOS-3465). They
+        # have no candidate this pass, so the loop below would never visit
+        # them and ``slot_headroom`` would report nothing -- which the budget
+        # guard's surplus retry reads as "no slots", silently making a
+        # deferred unit alone in its bucket the one case surplus can never
+        # help. Tracked separately so those buckets get an active_count read
+        # (and an advisory lock) without becoming candidates.
+        deferred_buckets: set[tuple[str, str, str]] = set()
         for unit in units:
             bucket = (str(unit.org_id), unit.provider, unit.cost_class)
             if unit.status == SyncRunUnitStatus.PLANNED.value:
@@ -168,9 +195,11 @@ class DispatchGuard:
             elif (
                 unit.status == SyncRunUnitStatus.RETRYING.value
                 and unit.available_at is not None
-                and _as_aware_guard(unit.available_at) <= now
             ):
-                candidates_by_bucket[bucket].append(unit)
+                if _as_aware_guard(unit.available_at) <= now:
+                    candidates_by_bucket[bucket].append(unit)
+                else:
+                    deferred_buckets.add(bucket)
             # RUNNING (any age) → capacity consumer only; never a candidate (F2).
             # Fresh DISPATCHING → consumer only (counted in active_count below).
             # Future RETRYING → deferred, no capacity consumption.
@@ -186,11 +215,13 @@ class DispatchGuard:
         #
         # Key derivation reuses the same deterministic 63-bit integer pattern
         # as _bucket_advisory_lock_key() below (mirrors sync.py:224-239).
-        all_buckets = sorted(candidates_by_bucket.keys())
+        all_buckets = sorted(set(candidates_by_bucket) | deferred_buckets)
         _acquire_bucket_advisory_locks(session, all_buckets)
 
         capped_unit_ids: list[str] = []
-        for bucket, bucket_candidates in candidates_by_bucket.items():
+        slot_headroom: dict[tuple[str, str, str], int] = {}
+        for bucket in all_buckets:
+            bucket_candidates = candidates_by_bucket.get(bucket, [])
             org_id, provider, cost_class = bucket
 
             # Count the CAPACITY-CONSUMER set across ALL runs (including this
@@ -230,6 +261,7 @@ class DispatchGuard:
                 capped_unit_ids.extend(
                     str(unit.id) for unit in bucket_candidates[allowed_slots:]
                 )
+            slot_headroom[bucket] = max(0, allowed_slots - len(bucket_candidates))
 
         if capped_unit_ids:
             return GuardDecision(
@@ -237,9 +269,10 @@ class DispatchGuard:
                 f"sync unit concurrency cap exceeded: {len(capped_unit_ids)} capped",
                 tuple(capped_unit_ids),
                 concurrency_capped=True,
+                slot_headroom=slot_headroom,
             )
 
-        return GuardDecision(True)
+        return GuardDecision(True, slot_headroom=slot_headroom)
 
 
 def _bucket_advisory_lock_key(org_id: str, provider: str, cost_class: str) -> int:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -927,8 +927,16 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             )
 
         BudgetGuard.observe_run(session, sync_run_id, capped_unit_ids=capped_ids)
+        # CHAOS-3465: slot_headroom is what lets the budget guard spend a
+        # leftover budget on units an EARLIER deferral is still holding back
+        # without stepping around this pass's concurrency cap. Surplus retry
+        # is disabled outright if it is absent, so this is the wiring that
+        # makes the feature exist -- not a hint it can do without.
         budget_result = BudgetGuard.enforce_run(
-            session, sync_run_id, capped_unit_ids=capped_ids
+            session,
+            sync_run_id,
+            capped_unit_ids=capped_ids,
+            slot_headroom=decision.slot_headroom,
         )
         capped_ids = frozenset((*capped_ids, *budget_result.deferred_unit_ids))
 

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -960,6 +960,13 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             estimates_by_unit=budget_result.estimates_by_unit,
             already_excluded_ids=capped_ids,
             jitter_seconds=budget_result.jitter_seconds,
+            # CHAOS-3465 review (CRITICAL): candidate_units now includes units
+            # the surplus phase pulled forward. Without their pre-promotion
+            # available_at, a cooldown landing in this window would deferral-
+            # stamp them and wipe the budget episode that was the whole reason
+            # they were deferred -- the guard's own offer, withdrawn, costing
+            # the unit its CHAOS-3412 exhaustion evidence.
+            surplus_prior_available_at=budget_result.surplus_prior_available_at,
         )
         capped_ids = frozenset((*capped_ids, *reconfirm_result.excluded_unit_ids))
         next_deferred_at = budget_result.next_deferred_at

--- a/tests/test_chaos_3465_budget_surplus_retry.py
+++ b/tests/test_chaos_3465_budget_surplus_retry.py
@@ -659,21 +659,36 @@ def test_candidate_cap_is_reported_rather_than_silently_applied(
 _POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
 
 
-def _require_postgres_test_url():
+#: Absence of the URI SKIPS, matching every other PostgreSQL-gated suite in
+#: this repo (``tests/api/dev/test_persistence_postgres.py``,
+#: ``tests/test_sync_watermarks.py``). "Unmeasured must fail loudly" is
+#: answered by the venue, not by this marker: the per-PR unit lane
+#: deliberately does not provision Postgres, and the post-merge coverage lane
+#: -- which does set this env -- executes these for real. Failing here instead
+#: would make the test unpassable on a main PR, which is not a stricter
+#: measurement, only a red lane.
+_requires_postgres = pytest.mark.skipif(
+    not os.getenv(_POSTGRES_URI_ENV),
+    reason=f"requires {_POSTGRES_URI_ENV}",
+)
+
+
+def _postgres_test_url():
     """The configured Postgres, forced onto the SYNC driver.
 
     ``BudgetGuard`` runs inside ``get_postgres_session_sync``; driving it from
     an async driver is what made an earlier PostgreSQL-gated test abort on
     ``MissingGreenlet`` long before it reached the code it claimed to cover
-    (CHAOS-3450). A skip is only acceptable locally -- in CI an unconfigured
-    URI FAILS, because a test that silently does not run reads as coverage.
+    (CHAOS-3450).
+
+    A URI that is set but does not name PostgreSQL still FAILS: that is a
+    misconfigured lane silently measuring the wrong backend, which no skip
+    marker can express.
     """
-    uri = os.getenv(_POSTGRES_URI_ENV)
-    if not uri:
-        if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
-            pytest.fail(f"{_POSTGRES_URI_ENV} must be configured for PostgreSQL tests")
-        pytest.skip(f"requires {_POSTGRES_URI_ENV}")
-    return make_url(uri).set(drivername="postgresql+psycopg2")
+    url = make_url(os.environ[_POSTGRES_URI_ENV])
+    if url.get_backend_name() != "postgresql":
+        pytest.fail(f"{_POSTGRES_URI_ENV} must use PostgreSQL, got {url.drivername!r}")
+    return url.set(drivername="postgresql+psycopg2")
 
 
 @pytest.fixture
@@ -685,7 +700,7 @@ def postgres_session():
     them, and every write lands in the developer's real database instead.
     Mirrors ``test_0066_celery_river_cutover_postgres``'s harness.
     """
-    url = _require_postgres_test_url()
+    url = _postgres_test_url()
     database = f"chaos3465_{uuid.uuid4().hex}"
     admin = create_engine(url.set(database="postgres"), isolation_level="AUTOCOMMIT")
     engine = None
@@ -708,6 +723,7 @@ def postgres_session():
         admin.dispose()
 
 
+@_requires_postgres
 def test_surplus_ordering_and_selection_hold_on_postgres(postgres_session, monkeypatch):
     """The same "longest-deferred wins a surplus that fits one" assertion, on
     the backend production runs.

--- a/tests/test_chaos_3465_budget_surplus_retry.py
+++ b/tests/test_chaos_3465_budget_surplus_retry.py
@@ -767,6 +767,72 @@ def test_cooldown_landing_after_promotion_withdraws_it_without_ending_the_episod
     assert beta.available_at == deferred_until
 
 
+def test_a_failed_withdrawal_still_excludes_the_unit_from_the_claim(
+    db_session, monkeypatch
+):
+    """The withdrawal path must fail SAFE.
+
+    If the withdrawal CAS loses, the unit is still sitting at the promoted
+    ``available_at`` -- i.e. due -- with a cooldown this pass has just
+    matched. Excluding it only when the CAS succeeded (the shape copied from
+    the ordinary path below) hands it straight to ``_claim_units``, which
+    dispatches it into the active cooldown: precisely what the late re-check
+    exists to prevent.
+
+    The two paths are not analogous. Below, a ``None`` outcome PROVES the unit
+    stopped being claimable, so falling through is safe. Here, CAS failure
+    proves nothing about claimability -- so the exclusion is unconditional.
+    Excluding costs one pass; dispatching into a live cooldown costs a worker
+    slot and a 429.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        db_session.add(
+            _observation(
+                run,
+                alpha,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=datetime.now(timezone.utc) + timedelta(seconds=180),
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+    # Force the CAS loss, leaving the row exactly as a lost race would: still
+    # promoted, still due. Patching the whole helper (rather than mutating its
+    # SQL) is deliberate -- an SQL-only change would be undone by the ORM
+    # autoflush rewriting the row from the in-memory object, so the write
+    # would silently still happen and the test would prove nothing.
+    monkeypatch.setattr(
+        budget_guard, "_withdraw_surplus_admission", lambda *a, **k: False
+    )
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status != SyncRunUnitStatus.DISPATCHING.value, (
+        "a unit whose withdrawal CAS lost was dispatched into the cooldown "
+        "the late re-check had just matched"
+    )
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+
+
 def test_withdrawal_does_not_apply_to_an_ordinary_due_candidate(
     db_session, monkeypatch
 ):

--- a/tests/test_chaos_3465_budget_surplus_retry.py
+++ b/tests/test_chaos_3465_budget_surplus_retry.py
@@ -26,6 +26,16 @@ Covers:
   * surplus relaxes budget admission and nothing else: the per-bucket
     concurrency cap, an active provider cooldown, and the terminal outcome of
     budget exhaustion each still bind.
+  * eligibility is budget deferrals ONLY -- a cooldown-deferred unit is
+    waiting on the provider, not on the budget, and is never pulled forward.
+  * a deferred unit ALONE in its concurrency bucket is still reachable (the
+    DispatchGuard half: a bucket with no candidate this pass still gets a
+    headroom entry).
+  * the surplus offer, WITHDRAWN: a cooldown landing in the enforce_run ->
+    reconfirm TOCTOU window puts the unit back on its original countdown with
+    its budget episode intact, rather than deferral-stamping it and wiping the
+    CHAOS-3412 exhaustion evidence -- while an ordinary due candidate caught
+    the same way still takes the full cooldown deferral.
   * fail-closed: without DispatchGuard's slot headroom there is no surplus
     retry at all.
   * the candidate cap is logged, never silently applied.
@@ -595,6 +605,221 @@ def test_surplus_is_disabled_without_concurrency_headroom(db_session, monkeypatc
     db_session.refresh(beta)
     assert result.surplus_admitted_unit_ids == frozenset()
     assert beta.available_at == deferred_until
+
+
+def test_only_budget_deferred_units_are_surplus_eligible(db_session, monkeypatch):
+    """The third eligibility filter, which nothing else covers.
+
+    A unit deferred by the COOLDOWN gate is waiting on the provider, not on
+    the budget, and a `rate_limit_cooldown_deferred` backoff routinely
+    outlives ``_active_cooldowns``' lookback window -- so the in-pass cooldown
+    check does NOT double-cover this. Without the category filter such a unit
+    (and any `worker_lost` / `provider_unit_retryable` retry) would be pulled
+    forward by spare budget it was never waiting for.
+    """
+    from dev_health_ops.sync.budget_guard import _surplus_retry_candidates
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    now = datetime.now(timezone.utc)
+    # Same shape as a budget deferral -- RETRYING, not yet due -- differing
+    # ONLY in why it is waiting. Producible: this is what
+    # _apply_cooldown_deferral leaves behind.
+    beta.result = {
+        "error_category": "rate_limit_cooldown_deferred",
+        "not_before": (now + timedelta(minutes=30)).isoformat(),
+        "rate_limit_deferrals": 1,
+    }
+    beta.available_at = now + timedelta(minutes=30)
+    beta.rate_limit_deferrals = 1
+    beta.rate_limit_first_seen_at = now - timedelta(minutes=5)
+    beta.budget_deferrals = 0
+    beta.budget_first_deferred_at = None
+    db_session.flush()
+
+    candidates = _surplus_retry_candidates(
+        db_session,
+        str(run.id),
+        ignored_unit_ids=set(),
+        slot_headroom={(str(run.org_id), "github", "medium"): 4},
+        now=now,
+    )
+
+    assert [str(unit.id) for unit in candidates] == [], (
+        "a cooldown-deferred unit was offered to the surplus phase; it is "
+        "waiting on the provider, not on the budget"
+    )
+
+
+def test_surplus_rescues_a_deferred_unit_alone_in_its_bucket(db_session, monkeypatch):
+    """Covers the DispatchGuard half of this change.
+
+    The deferred unit sits in its OWN (org, provider, cost_class) bucket, so
+    that bucket has no candidate this pass. Before the guard was taught to
+    compute headroom for deferred-only buckets, `slot_headroom` simply had no
+    entry for it, the surplus phase read that as "no slots", and the one unit
+    surplus most obviously exists to rescue was the one case it could never
+    reach. Every other fixture here co-buckets the deferred unit with a
+    PLANNED candidate, which hides that entirely.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    # A different cost_class is a different concurrency bucket; alpha stays in
+    # 'medium', so 'heavy' contains beta and nothing else.
+    beta.cost_class = "heavy"
+    db_session.flush()
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == SyncRunUnitStatus.DISPATCHING.value, (
+        "a deferred unit alone in its bucket was never offered a slot, so "
+        "the surplus could not reach it"
+    )
+    assert result["queued_units"] == 2
+
+
+# ---------------------------------------------------------------------------
+# The surplus offer, withdrawn (review CRITICAL)
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_landing_after_promotion_withdraws_it_without_ending_the_episode(
+    db_session, monkeypatch
+):
+    """CRITICAL: the guard's own offer, taken back, must not cost the unit its
+    budget episode.
+
+    Drives the real TOCTOU chain. No observation exists while `enforce_run`
+    runs, so beta is genuinely surplus-admitted and joins `candidate_units`; a
+    429 is then committed at the `reconfirm_cooldowns` seam — exactly where a
+    concurrent transaction's commit lands. `reconfirm_cooldowns` matches it.
+
+    Routing that match through the ordinary cooldown deferral (which is what
+    happened before this fix) calls `_apply_cooldown_deferral`, zeroing
+    `budget_deferrals`, nulling `budget_first_deferred_at` and rewriting the
+    category to `rate_limit_cooldown_deferred`. A unit at 9/10 deferrals
+    promoted and caught on every pass would then never reach CHAOS-3412's
+    specific budget verdict at all — only the much later aggregate backstop,
+    under the wrong category.
+
+    Absent the surplus phase this unit would have sat out the pass with its
+    episode intact, so the only correct outcome is that it still does.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    deferred_until = beta.available_at
+    first_deferred_at = beta.budget_first_deferred_at
+    blocked_at = beta.first_blocked_at
+
+    reset_at = datetime.now(timezone.utc) + timedelta(seconds=180)
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        # Lands strictly AFTER enforce_run's cooldown snapshot (and after the
+        # promotion), strictly BEFORE the claim.
+        db_session.add(
+            _observation(
+                run,
+                alpha,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=reset_at,
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    # Not dispatched — the cooldown is real and must be honoured.
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    # THE finding, asserted first so it is the assertion that reports: the
+    # episode survived the round trip. This is what the defect wiped.
+    assert beta.budget_deferrals == 2, (
+        "the withdrawn surplus promotion reset the budget episode; a unit "
+        "near its deferral cap would never reach the budget exhaustion verdict"
+    )
+    assert beta.budget_first_deferred_at == first_deferred_at
+    assert beta.first_blocked_at == blocked_at
+    assert (beta.result or {})["error_category"] == "budget_deferred", (
+        "the withdrawn promotion rewrote the unit's cause to a rate-limit "
+        "one, which also disarms _budget_deferral_exhausted's evidence gate"
+    )
+    # The offer was withdrawn: back on its ORIGINAL countdown, not a fresh
+    # cooldown backoff.
+    assert beta.available_at == deferred_until
+
+
+def test_withdrawal_does_not_apply_to_an_ordinary_due_candidate(
+    db_session, monkeypatch
+):
+    """The withdrawal is scoped to surplus promotions only.
+
+    An ordinary DUE retrying unit caught by the same late cooldown check must
+    still take the full cooldown deferral — episode change included — because
+    it genuinely was about to dispatch. Without this, "don't end the episode"
+    would quietly become a blanket rule and CHAOS-2760's binding decision
+    (cooldown deferrals count against the shared rate-limit budget) would be
+    lost for every budget-deferred unit.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    # Due, so it is an ordinary candidate -- never a surplus promotion.
+    beta.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    db_session.flush()
+
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        db_session.add(
+            _observation(
+                run,
+                alpha,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=datetime.now(timezone.utc) + timedelta(seconds=180),
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    assert (beta.result or {})["error_category"] == "rate_limit_cooldown_deferred"
+    assert beta.rate_limit_deferrals == 1
+    # The budget episode ends here, by design: this unit really was about to
+    # run and was stopped by the provider, not by the guard changing its mind.
+    assert beta.budget_deferrals == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chaos_3465_budget_surplus_retry.py
+++ b/tests/test_chaos_3465_budget_surplus_retry.py
@@ -1,0 +1,759 @@
+"""In-cycle budget surplus retry (CHAOS-3465).
+
+CHAOS-3412 gave the budget guard an exit for units it can never admit. It did
+not give a unit it CAN admit a way back in before its deferral countdown
+expires: a unit deferred at the top of a pass sits at ``available_at = now +
+SYNC_BUDGET_DEFERRAL_SECONDS``, so the very next pass -- however much of the
+bucket has since drained -- does not even consider it. The spare capacity
+lapses and the unit waits out a full cycle it did not need to wait.
+
+This module covers the surplus phase that spends that leftover, and -- just as
+importantly -- every guard it must NOT spend its way past.
+
+Covers:
+  * a not-yet-due budget-deferred unit is admitted from THIS pass's surplus
+    and dispatches in the same cycle (the behaviour that did not exist; with
+    surplus disabled the same fixture leaves it waiting, which is the
+    pre-change behaviour planted as a negative control).
+  * counter semantics: a surplus attempt that cannot fit is a total no-op --
+    it never advances budget_deferrals, so trying to help a unit can never
+    drag its exhaustion caps forward.
+  * counter semantics: a surplus attempt that succeeds writes availability
+    only, leaving the episode's end to the claim and the SUCCESS stamp that
+    already own it (asserted behaviourally AND over the source of the stamp).
+  * ordering: the LONGEST-deferred unit wins a surplus that only stretches to
+    one, in either candidate order.
+  * surplus relaxes budget admission and nothing else: the per-bucket
+    concurrency cap, an active provider cooldown, and the terminal outcome of
+    budget exhaustion each still bind.
+  * fail-closed: without DispatchGuard's slot headroom there is no surplus
+    retry at all.
+  * the candidate cap is logged, never silently applied.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
+from tests._helpers import seed_sync_dispatch_transport_routes
+from tests.test_budget_guard_cooldown import _observation, _sibling_unit
+from tests.test_sync_units import (
+    _patch_db_session,
+    _patch_worker_enqueues,
+    _seed_run,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        seed_sync_dispatch_transport_routes(session)
+        yield session
+    engine.dispose()
+
+
+def _estimate_of(org_id, units_cost: int) -> tuple[BudgetEstimate, ...]:
+    return (
+        BudgetEstimate(
+            bucket=BudgetBucketKey(
+                provider="github",
+                org_id=str(org_id),
+                host="api.github.com",
+                credential_fingerprint="fp",
+                dimension=BudgetDimension.REST_CORE,
+            ),
+            estimated_units=units_cost,
+            confidence="high",
+            route_family="git",
+        ),
+    )
+
+
+def _mark_budget_deferred(
+    unit: SyncRunUnit,
+    *,
+    now: datetime,
+    deferrals: int = 2,
+    deferred_ago: timedelta = timedelta(minutes=5),
+    available_in: timedelta = timedelta(seconds=60),
+) -> None:
+    """Put a unit in the exact state ``_defer_unit_for_budget`` leaves it in:
+    RETRYING, counting down, carrying a live budget episode. Producible state
+    matters -- a fixture the real deferral path cannot emit would be asserting
+    against a row that never occurs."""
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = now + available_in
+    unit.budget_deferrals = deferrals
+    unit.budget_first_deferred_at = now - deferred_ago
+    unit.first_blocked_at = now - deferred_ago
+    unit.rate_limit_deferrals = 0
+    unit.rate_limit_first_seen_at = None
+    unit.result = {
+        "error_category": "budget_deferred",
+        "not_before": (now + available_in).isoformat(),
+        "budget_guard": [],
+    }
+
+
+def _two_unit_run(db_session, monkeypatch, *, costs: dict[str, int], limit: int):
+    """One PLANNED candidate ('alpha') plus one not-yet-due budget-deferred
+    unit ('beta') in the same bucket, with injected estimates so the surplus
+    left after admitting alpha is an exact, stated number rather than whatever
+    the live estimators happen to produce."""
+    from dev_health_ops.sync import budget_guard
+
+    run, alpha = _seed_run(db_session)
+    alpha.dataset_key = "alpha"
+    beta = _sibling_unit(
+        run, alpha, dataset_key="beta", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(beta)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    _mark_budget_deferred(beta, now=now)
+    db_session.flush()
+
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate_of(run.org_id, costs[ctx.dataset_key]),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", f'{{"github:rest_core": {limit}}}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    return run, alpha, beta
+
+
+# ---------------------------------------------------------------------------
+# The capability itself, and the pre-change behaviour as its negative control
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_unit_is_admitted_from_this_cycles_surplus(db_session, monkeypatch):
+    """The reached state, not "the code ran": a unit that was still counting
+    down a budget deferral is DISPATCHING at the end of this pass.
+
+    alpha costs 1 of a cap of 10, so 9 units of budget were about to lapse.
+    beta costs 1 and was 59 seconds from being reconsidered. Before this
+    change beta was not in the candidate set at all -- ``queued_units`` was 1
+    and beta was still ``retrying`` -- which is what
+    ``test_surplus_disabled_leaves_the_deferred_unit_waiting`` pins as the old
+    behaviour.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(alpha)
+    db_session.refresh(beta)
+    assert result == {"status": "dispatched", "queued_units": 2}
+    assert alpha.status == SyncRunUnitStatus.DISPATCHING.value
+    assert beta.status == SyncRunUnitStatus.DISPATCHING.value, (
+        "the deferred unit was left to wait out its countdown while the "
+        "budget it needed went unspent -- the CHAOS-3465 defect"
+    )
+
+
+def test_surplus_disabled_leaves_the_deferred_unit_waiting(db_session, monkeypatch):
+    """NEGATIVE CONTROL: the same fixture, with the surplus phase turned off,
+    reproduces the pre-change behaviour exactly -- beta stays ``retrying``
+    with its countdown untouched and only alpha dispatches.
+
+    Without this pairing the test above would pass on any code that dispatches
+    two units for any reason; with it, the two tests differ in nothing but
+    whether surplus retry runs.
+    """
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_BUDGET_SURPLUS_MAX_CANDIDATES", "0")
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    deferred_until = beta.available_at
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(alpha)
+    db_session.refresh(beta)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert alpha.status == SyncRunUnitStatus.DISPATCHING.value
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    assert beta.available_at == deferred_until
+
+
+# ---------------------------------------------------------------------------
+# Counter semantics
+# ---------------------------------------------------------------------------
+
+
+def test_surplus_attempt_that_cannot_fit_is_a_total_no_op(db_session, monkeypatch):
+    """A surplus attempt is not a deferral, and must not be counted as one.
+
+    alpha takes 9 of a cap of 10; beta needs 4 and does not fit the leftover.
+    Every column the exhaustion predicates read has to come out of this pass
+    byte-identical -- if a failed attempt incremented ``budget_deferrals``, a
+    unit would burn one deferral per pass merely because the guard looked at
+    it, and the units surplus exists to rescue would reach
+    SYNC_BUDGET_MAX_DEFERRALS FASTEST.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 9, "beta": 4}, limit=10
+    )
+    before = {
+        "available_at": beta.available_at,
+        "budget_deferrals": beta.budget_deferrals,
+        "budget_first_deferred_at": beta.budget_first_deferred_at,
+        "first_blocked_at": beta.first_blocked_at,
+        "result": dict(beta.result or {}),
+        "status": beta.status,
+    }
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == before["status"]
+    assert beta.available_at == before["available_at"]
+    assert beta.budget_deferrals == before["budget_deferrals"]
+    assert beta.budget_first_deferred_at == before["budget_first_deferred_at"]
+    assert beta.first_blocked_at == before["first_blocked_at"]
+    assert dict(beta.result or {}) == before["result"]
+
+
+def test_repeated_surplus_misses_never_advance_the_exhaustion_caps(
+    db_session, monkeypatch
+):
+    """The consequence of the rule above, over the laps that would expose it.
+
+    Ten passes in which beta is looked at and rejected leave its deferral
+    count exactly where the ONE real deferral put it. A per-attempt increment
+    would show up here as 12 and would have terminalized the unit.
+    """
+    from dev_health_ops.sync.budget_guard import BUDGET_MAX_DEFERRALS_DEFAULT
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 9, "beta": 4}, limit=10
+    )
+    beta.available_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.flush()
+
+    for _ in range(BUDGET_MAX_DEFERRALS_DEFAULT):
+        sync_units.dispatch_sync_run(str(run.id))
+        db_session.refresh(beta)
+        # Re-arm alpha so every lap really re-runs admission with the same
+        # surplus shortfall rather than short-circuiting on an empty run.
+        db_session.refresh(alpha)
+        alpha.status = SyncRunUnitStatus.PLANNED.value
+        alpha.available_at = None
+        db_session.flush()
+
+    db_session.refresh(beta)
+    assert beta.budget_deferrals == 2
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+
+
+def test_surplus_admission_leaves_the_episode_columns_alone(db_session, monkeypatch):
+    """A successful surplus admission writes availability and nothing else.
+
+    Asserted at the ``enforce_run`` boundary, before ``_claim_units`` runs, so
+    the surplus stamp is measured on its own rather than through the claim
+    that clears ``first_blocked_at`` immediately afterwards. Clearing the
+    budget pair here would be a second interpretation of "the episode ended"
+    competing with the SUCCESS stamp that owns it; rewriting ``result`` would
+    disarm ``_budget_deferral_exhausted``'s error-category gate for the unit.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    blocked_at = beta.first_blocked_at
+    first_deferred_at = beta.budget_first_deferred_at
+    now = datetime.now(timezone.utc)
+
+    result = BudgetGuard.enforce_run(
+        db_session,
+        str(run.id),
+        slot_headroom={(str(run.org_id), "github", "medium"): 4},
+        now=now,
+    )
+
+    db_session.refresh(beta)
+    assert result.surplus_admitted_unit_ids == frozenset({str(beta.id)})
+    # Due now -- that is the entire effect of the stamp.
+    assert beta.available_at is not None
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    # The episode is untouched: not cleared, not advanced.
+    assert beta.budget_deferrals == 2
+    assert beta.budget_first_deferred_at == first_deferred_at
+    assert beta.first_blocked_at == blocked_at
+    assert (beta.result or {})["error_category"] == "budget_deferred"
+
+
+def test_surplus_admitted_unit_clears_the_aggregate_clock_at_the_claim(
+    db_session, monkeypatch
+):
+    """...and the episode does still end, in the place that already owns it.
+
+    The claim is what stops the aggregate blocked clock, exactly as it does
+    for any other dispatched unit. Pinned so "the surplus stamp leaves the
+    columns alone" cannot quietly become "a surplus-admitted unit keeps a
+    stale first_blocked_at forever".
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    assert beta.first_blocked_at is not None
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == SyncRunUnitStatus.DISPATCHING.value
+    assert beta.first_blocked_at is None
+    # The budget pair is the SUCCESS stamp's to clear, not the claim's, so it
+    # is still the history of a real episode at this point.
+    assert beta.budget_deferrals == 2
+
+
+def test_surplus_stamp_writes_no_deferral_lifecycle_column(db_session):
+    """Source-derived guard for the counter semantics above.
+
+    The behavioural tests show the columns unchanged for the fixtures they
+    run; this shows the stamp CANNOT change them for any fixture. The column
+    set is derived from the live model, so a lifecycle column added later is
+    covered without anyone remembering to list it here -- and a derivation
+    that finds nothing fails rather than reading as clean.
+    """
+    import ast
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    module = ast.parse(
+        (repo_root / "src/dev_health_ops/sync/budget_guard.py").read_text()
+    )
+    model_columns = {
+        statement.target.id
+        for node in ast.walk(
+            ast.parse(
+                (repo_root / "src/dev_health_ops/models/integrations.py").read_text()
+            )
+        )
+        if isinstance(node, ast.ClassDef) and node.name == "SyncRunUnit"
+        for statement in node.body
+        if isinstance(statement, ast.AnnAssign)
+        and isinstance(statement.target, ast.Name)
+    }
+    lifecycle_columns = {
+        name
+        for name in model_columns
+        if name.startswith("rate_limit_") or name.startswith("budget_")
+    } | {"first_blocked_at"}
+    assert len(lifecycle_columns) >= 5, lifecycle_columns
+
+    stamps = [
+        node
+        for function in ast.walk(module)
+        if isinstance(function, ast.FunctionDef)
+        and function.name == "_admit_unit_from_surplus"
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "values"
+    ]
+    assert len(stamps) == 1, (
+        f"expected exactly one values(...) stamp in _admit_unit_from_surplus, "
+        f"found {len(stamps)} -- the stamp this guard measures moved."
+    )
+    assigned = {kw.arg for kw in stamps[0].keywords if kw.arg is not None}
+    assert assigned == {"available_at", "updated_at"}, assigned
+    assert not (assigned & lifecycle_columns), sorted(assigned & lifecycle_columns)
+    # No status re-assignment: a surplus admission does not change what the
+    # unit IS, only when it is due. (It is also what keeps this stamp out of
+    # the per-episode "every RETRYING stamp assigns every pair" rule, whose
+    # semantics would be wrong here.)
+    assert "status" not in assigned
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("older_first", [True, False])
+def test_longest_deferred_unit_wins_a_surplus_that_only_fits_one(
+    db_session, monkeypatch, older_first
+):
+    """Surplus must make the exhaustion path RARER, not merely rearrange who
+    reaches it, so the unit closest to its caps is served first.
+
+    Two deferred units cost 3 each against a leftover of 4: exactly one can be
+    admitted. Parametrized over which was created (and therefore id-ordered)
+    first, so passing cannot be an accident of row order.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+
+    run, alpha = _seed_run(db_session)
+    alpha.dataset_key = "alpha"
+    now = datetime.now(timezone.utc)
+    names = ["old", "new"] if older_first else ["new", "old"]
+    deferred: dict[str, SyncRunUnit] = {}
+    for name in names:
+        unit = _sibling_unit(
+            run, alpha, dataset_key=name, processor_flags={"sync_git": True}
+        )
+        db_session.add(unit)
+        db_session.flush()
+        deferred[name] = unit
+    run.total_units = 3
+    _mark_budget_deferred(deferred["old"], now=now, deferred_ago=timedelta(hours=3))
+    _mark_budget_deferred(deferred["new"], now=now, deferred_ago=timedelta(minutes=1))
+    db_session.flush()
+
+    costs = {"alpha": 6, "old": 3, "new": 3}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate_of(run.org_id, costs[ctx.dataset_key]),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = BudgetGuard.enforce_run(
+        db_session,
+        str(run.id),
+        slot_headroom={(str(run.org_id), "github", "medium"): 4},
+        now=now,
+    )
+
+    assert result.surplus_admitted_unit_ids == frozenset({str(deferred["old"].id)}), (
+        "the surplus went to the more recently deferred unit; the one nearest "
+        "its exhaustion caps was passed over"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Surplus relaxes budget admission and NOTHING else
+# ---------------------------------------------------------------------------
+
+
+def test_surplus_never_breaches_the_per_bucket_concurrency_cap(db_session, monkeypatch):
+    """Budget headroom is not dispatch headroom.
+
+    The bucket has 9 units of budget going spare, and the concurrency cap is
+    1 -- consumed by alpha. beta must stay deferred: admitting it would put
+    two units in a bucket the concurrency guard sized for one, and the
+    concurrency guard never saw beta at all (a not-yet-due RETRYING unit is
+    not in its candidate set).
+    """
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    deferred_until = beta.available_at
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(alpha)
+    db_session.refresh(beta)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert alpha.status == SyncRunUnitStatus.DISPATCHING.value
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    assert beta.available_at == deferred_until
+
+
+def test_surplus_never_admits_into_an_active_provider_cooldown(db_session, monkeypatch):
+    """A cooldown is a statement about the provider, not about the budget.
+
+    beta fits the surplus comfortably, but its route family is cooling down
+    from a sibling's 429. Spare budget is no reason to shorten that wait --
+    the unit stays deferred, and is not re-stamped by the surplus phase
+    either.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    now = datetime.now(timezone.utc)
+    deferred_until = beta.available_at
+    db_session.add(
+        _observation(
+            run,
+            alpha,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(minutes=10),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == SyncRunUnitStatus.RETRYING.value
+    assert beta.available_at == deferred_until
+    assert (beta.result or {})["error_category"] == "budget_deferred"
+
+
+def test_surplus_does_not_revive_a_budget_exhausted_unit(db_session, monkeypatch):
+    """Exhaustion is a deliberate, operator-visible verdict that the
+    configuration is wrong (CHAOS-3412), not a queue state spare capacity may
+    undo. A FAILED unit is not a surplus candidate however much budget is
+    free -- reviving it would relax the exhaustion outcome, and surplus
+    relaxes budget admission only.
+
+    The end-to-end assertion alone cannot fail: three independent conditions
+    keep a FAILED unit out (the candidate query's status filter, the
+    error-category filter, and the promotion CAS's own ``status == RETRYING``
+    predicate), so removing any one -- or even the first two together --
+    leaves it passing. Asserting the SELECTION directly is what actually
+    measures the outermost barrier; the end-to-end assertion below then pins
+    the outcome an operator sees.
+    """
+    from dev_health_ops.sync.budget_guard import _surplus_retry_candidates
+    from dev_health_ops.workers import sync_units
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    beta.status = SyncRunUnitStatus.FAILED.value
+    beta.error = "sync budget deferral exhausted after 10 deferrals"
+    beta.result = {
+        "error_category": "budget_deferral_exhausted",
+        "budget_deferrals": 10,
+    }
+    db_session.flush()
+
+    candidates = _surplus_retry_candidates(
+        db_session,
+        str(run.id),
+        ignored_unit_ids=set(),
+        slot_headroom={(str(run.org_id), "github", "medium"): 4},
+        now=datetime.now(timezone.utc),
+    )
+    assert [str(unit.id) for unit in candidates] == [], (
+        "a budget-exhausted unit was offered to the surplus phase; exhaustion "
+        "is a verdict, not a queue state spare capacity may undo"
+    )
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(beta)
+    assert beta.status == SyncRunUnitStatus.FAILED.value
+    assert (beta.result or {})["error_category"] == "budget_deferral_exhausted"
+
+
+def test_surplus_is_disabled_without_concurrency_headroom(db_session, monkeypatch):
+    """Fail closed. ``slot_headroom`` is the only evidence the surplus phase
+    has that admitting a unit will not breach the concurrency cap; with none,
+    it admits nothing rather than guessing.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+
+    run, alpha, beta = _two_unit_run(
+        db_session, monkeypatch, costs={"alpha": 1, "beta": 1}, limit=10
+    )
+    deferred_until = beta.available_at
+
+    result = BudgetGuard.enforce_run(db_session, str(run.id))
+
+    db_session.refresh(beta)
+    assert result.surplus_admitted_unit_ids == frozenset()
+    assert beta.available_at == deferred_until
+
+
+# ---------------------------------------------------------------------------
+# Bounded work, stated out loud
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_cap_is_reported_rather_than_silently_applied(
+    db_session, monkeypatch, caplog
+):
+    """A cap that truncates without saying so reads as "surplus considered
+    everything and nothing else fitted", which is a different fact.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+
+    run, alpha = _seed_run(db_session)
+    alpha.dataset_key = "alpha"
+    now = datetime.now(timezone.utc)
+    for index, name in enumerate(("old", "new")):
+        unit = _sibling_unit(
+            run, alpha, dataset_key=name, processor_flags={"sync_git": True}
+        )
+        db_session.add(unit)
+        db_session.flush()
+        _mark_budget_deferred(unit, now=now, deferred_ago=timedelta(hours=3 - index))
+    run.total_units = 3
+    db_session.flush()
+
+    costs = {"alpha": 1, "old": 1, "new": 1}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate_of(run.org_id, costs[ctx.dataset_key]),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 100}')
+    monkeypatch.setenv("SYNC_BUDGET_SURPLUS_MAX_CANDIDATES", "1")
+
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.sync.budget_guard"):
+        result = BudgetGuard.enforce_run(
+            db_session,
+            str(run.id),
+            slot_headroom={(str(run.org_id), "github", "medium"): 4},
+            now=now,
+        )
+
+    assert len(result.surplus_admitted_unit_ids) == 1
+    truncations = [
+        record
+        for record in caplog.records
+        if record.msg == "dispatch_sync_run.budget_surplus_candidates_truncated"
+    ]
+    assert len(truncations) == 1, "the cap dropped a candidate without saying so"
+    assert truncations[0].deferred_units == 2
+    assert truncations[0].considered_units == 1
+
+
+# ---------------------------------------------------------------------------
+# Postgres: the dialect the ordering and JSON filtering actually ship against
+# ---------------------------------------------------------------------------
+
+_POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+
+def _require_postgres_test_url():
+    """The configured Postgres, forced onto the SYNC driver.
+
+    ``BudgetGuard`` runs inside ``get_postgres_session_sync``; driving it from
+    an async driver is what made an earlier PostgreSQL-gated test abort on
+    ``MissingGreenlet`` long before it reached the code it claimed to cover
+    (CHAOS-3450). A skip is only acceptable locally -- in CI an unconfigured
+    URI FAILS, because a test that silently does not run reads as coverage.
+    """
+    uri = os.getenv(_POSTGRES_URI_ENV)
+    if not uri:
+        if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+            pytest.fail(f"{_POSTGRES_URI_ENV} must be configured for PostgreSQL tests")
+        pytest.skip(f"requires {_POSTGRES_URI_ENV}")
+    return make_url(uri).set(drivername="postgresql+psycopg2")
+
+
+@pytest.fixture
+def postgres_session():
+    """A throwaway DATABASE, not a schema in the configured one.
+
+    A schema sharing ``search_path`` with ``public`` is not isolation:
+    ``create_all`` finds the existing tables through the path, skips creating
+    them, and every write lands in the developer's real database instead.
+    Mirrors ``test_0066_celery_river_cutover_postgres``'s harness.
+    """
+    url = _require_postgres_test_url()
+    database = f"chaos3465_{uuid.uuid4().hex}"
+    admin = create_engine(url.set(database="postgres"), isolation_level="AUTOCOMMIT")
+    engine = None
+    created = False
+    try:
+        with admin.connect() as connection:
+            connection.exec_driver_sql(f'CREATE DATABASE "{database}"')
+            created = True
+        engine = create_engine(url.set(database=database))
+        Base.metadata.create_all(engine)
+        with Session(engine) as session:
+            seed_sync_dispatch_transport_routes(session)
+            yield session
+    finally:
+        if engine is not None:
+            engine.dispose()
+        if created:
+            with admin.connect() as connection:
+                connection.exec_driver_sql(f'DROP DATABASE "{database}"')
+        admin.dispose()
+
+
+def test_surplus_ordering_and_selection_hold_on_postgres(postgres_session, monkeypatch):
+    """The same "longest-deferred wins a surplus that fits one" assertion, on
+    the backend production runs.
+
+    Two things this exercises that SQLite cannot: the advisory locks the
+    surplus candidates' budget keys join, and the fact that candidate
+    selection and ordering do not depend on backend-specific NULL ordering or
+    JSON operators (both are done in Python for exactly that reason). A
+    dialect divergence here would mean the surplus served a different unit in
+    production than in every unit test.
+    """
+    from dev_health_ops.sync import budget_guard
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+
+    run, alpha = _seed_run(postgres_session)
+    alpha.dataset_key = "alpha"
+    now = datetime.now(timezone.utc)
+    deferred: dict[str, SyncRunUnit] = {}
+    for name in ("new", "old"):
+        unit = _sibling_unit(
+            run, alpha, dataset_key=name, processor_flags={"sync_git": True}
+        )
+        postgres_session.add(unit)
+        postgres_session.flush()
+        deferred[name] = unit
+    run.total_units = 3
+    _mark_budget_deferred(deferred["old"], now=now, deferred_ago=timedelta(hours=3))
+    _mark_budget_deferred(deferred["new"], now=now, deferred_ago=timedelta(minutes=1))
+    postgres_session.flush()
+
+    costs = {"alpha": 6, "old": 3, "new": 3}
+    monkeypatch.setattr(
+        budget_guard,
+        "estimate_provider_budget",
+        lambda ctx: _estimate_of(run.org_id, costs[ctx.dataset_key]),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 10}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = BudgetGuard.enforce_run(
+        postgres_session,
+        str(run.id),
+        slot_headroom={(str(run.org_id), "github", "medium"): 4},
+        now=now,
+    )
+
+    assert result.surplus_admitted_unit_ids == frozenset({str(deferred["old"].id)})
+    postgres_session.refresh(deferred["new"])
+    assert deferred["new"].budget_deferrals == 2

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -985,3 +985,95 @@ def test_long_running_unit_counts_against_cap_and_is_not_re_enqueued(
     assert units[1].status == SyncRunUnitStatus.PLANNED.value, (
         "PLANNED unit must remain PLANNED when cap is consumed by RUNNING"
     )
+
+
+# ---------------------------------------------------------------------------
+# slot_headroom (CHAOS-3465): the only sanctioned way another admission path
+# may add work this guard did not see.
+# ---------------------------------------------------------------------------
+
+
+def test_slot_headroom_reports_slots_left_after_this_pass_candidates(
+    db_session, monkeypatch
+):
+    """Headroom is the cap minus consumers minus THIS pass's candidates.
+
+    Deliberately conservative: every candidate is counted as if it will
+    dispatch, even though some are about to be budget-deferred, so headroom
+    can only ever under-admit. Cap 5, two PLANNED candidates, no consumers
+    -> 3.
+    """
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "5")
+    run, units, _, _ = _seed_run(db_session, unit_count=2)
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    org_id = str(units[0].org_id)
+    assert decision.allowed is True
+    assert decision.slot_headroom == {(org_id, "github", "medium"): 3}
+
+
+def test_slot_headroom_is_zero_when_candidates_fill_the_cap(db_session, monkeypatch):
+    """The boundary that actually gates a surplus admission: a full bucket
+    must report 0, never a negative number that would read as capacity."""
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    run, units, _, _ = _seed_run(db_session, unit_count=3)
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    org_id = str(units[0].org_id)
+    assert decision.slot_headroom[(org_id, "github", "medium")] == 0
+
+
+def test_slot_headroom_counts_live_consumers_not_just_candidates(
+    db_session, monkeypatch
+):
+    """Work already running consumes the slots a surplus admission would
+    otherwise be told are free."""
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "4")
+    run, units, _, _ = _seed_run(db_session, unit_count=2)
+    units[0].status = SyncRunUnitStatus.RUNNING.value
+    units[0].lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    org_id = str(units[0].org_id)
+    # 4 cap - 1 live RUNNING consumer - 1 remaining PLANNED candidate = 2.
+    assert decision.slot_headroom[(org_id, "github", "medium")] == 2
+
+
+def test_slot_headroom_covers_a_bucket_holding_only_not_yet_due_units(
+    db_session, monkeypatch
+):
+    """CHAOS-3465: a bucket whose only unit is a not-yet-due RETRYING deferral
+    has NO candidate this pass, so the candidate-driven loop never visited it
+    and the map had no entry at all.
+
+    An absent entry reads as "no slots" to the budget guard's surplus phase,
+    which made the one unit alone in its bucket -- the case surplus most
+    obviously exists to rescue -- the one case it could never reach.
+    """
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "4")
+    run, units, _, _ = _seed_run(db_session, unit_count=2)
+    deferred = units[1]
+    deferred.cost_class = "heavy"  # a bucket of its own
+    deferred.status = SyncRunUnitStatus.RETRYING.value
+    deferred.available_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    org_id = str(units[0].org_id)
+    assert (org_id, "github", "heavy") in decision.slot_headroom, (
+        "the deferred-only bucket has no headroom entry, so surplus retry "
+        "can never rescue a unit that is alone in its bucket"
+    )
+    # A future RETRYING unit is neither a consumer nor a candidate, so the
+    # whole cap is free.
+    assert decision.slot_headroom[(org_id, "github", "heavy")] == 4
+    assert decision.slot_headroom[(org_id, "github", "medium")] == 3


### PR DESCRIPTION
## What

A dispatch pass that finished budget admission with capacity to spare let it lapse. Units the guard deferred moments earlier sit at `available_at = now + SYNC_BUDGET_DEFERRAL_SECONDS`, so they are not dispatch candidates again until that countdown expires — however much of the bucket drained in the meantime. They waited out a full cycle they did not need to wait.

`BudgetGuard.enforce_run` now runs a **surplus phase** after admission: whatever budget is left over is spent retrying this run's not-yet-due budget deferrals, longest-deferred first.

Follow-up to CHAOS-3412 (option c). Refs CHAOS-3465, CHAOS-3412, CHAOS-3430.

## Design

**Where the surplus is observable.** At the end of `enforce_run`'s admission loop. `consumed_by_bucket` already holds durable consumption (work DISPATCHING/RUNNING) plus this pass's own admissions, and `limits`/`default_limit` give the caps — so `limit - consumed` per budget key is exactly "what this cycle did not spend". The dispatch pass (`dispatch_sync_run`) is the cycle boundary.

**Who is eligible.** Units of the same run that are `RETRYING` with `available_at > now` and whose own last recorded `result.error_category` is `budget_deferred`. That is precisely the population that "waits for the next cycle" today — already-due units are ordinary candidates and the admission loop handled them.

**Ordering.** `budget_first_deferred_at` ascending, tie-broken by `first_blocked_at` then id. Longest-deferred first, so surplus makes the exhaustion path **rarer** rather than rearranging who reaches it; serving the newest deferral first would let a trickle of fresh deferrals starve the oldest. Selection and ordering are done in Python, not SQL: SQLite and PostgreSQL disagree on NULL ordering, and `result` is a JSON column whose access syntax differs per backend — an ordering rule that means different things per dialect is not an ordering rule. Pinned on real PostgreSQL by a gated test.

**Counter semantics** (the "must not double-increment in a cycle" question):

- A surplus attempt that **cannot fit is a total no-op** — `budget_deferrals`, `budget_first_deferred_at`, `first_blocked_at`, `available_at` and `result` all come out of the pass unchanged. The counter moves in exactly one place, `_defer_unit_for_budget`, which the surplus phase never calls. Counting an opportunistic look-again would add one deferral per pass per unit *purely because the guard tried to help*, dragging `SYNC_BUDGET_MAX_DEFERRALS` forward fastest for the units this feature exists to rescue — exactly backwards.
- A surplus attempt that **succeeds writes `available_at` (and `updated_at`) and nothing else.** The episode's end is already owned elsewhere and duplicating it here would create a second interpretation to drift from: `_claim_units` clears `first_blocked_at` when the unit is actually claimed, and the SUCCESS stamp clears the budget pair when it actually completes. Rewriting `result` would be worse than redundant — `_budget_deferral_exhausted`'s defence-in-depth gate reads `result.error_category`, so a surplus admission that overwrote it would quietly disarm the exhaustion path for that unit.
- Consequence, and it is the right one: a unit promoted but not claimed (lost race) is simply a due candidate next pass and takes one ordinary deferral there if it no longer fits. No path double-increments.

**Rejected: persistent cross-cycle banking.** Documented in `budget_guard.py` next to the phase. A bank lets an idle hour accumulate capacity that a later pass spends at once — the burst-then-starve behaviour this guard exists to prevent — and would make the bucket cap describe an average rather than a ceiling. The surplus is measured from *this* pass's `consumed_by_bucket` against *this* pass's limits, and anything unspent when the pass returns is gone.

**Surplus relaxes budget admission and nothing else:**

| Guard | How it still binds |
| --- | --- |
| Per-bucket concurrency | `DispatchGuard.authorize_run` now returns `slot_headroom` per `(org_id, provider, cost_class)`; the surplus phase decrements it per admission. Without it the phase is **disabled outright** rather than guessing. |
| Provider cooldowns | Surplus candidates join the single `_active_cooldowns` query; a match is skipped and left deferred. Spare budget is not a reason to hit a limited provider. |
| Tier / total unit caps | Untouched — a surplus unit is already a unit of this run and was counted by `authorize_run`. |
| Exhaustion thresholds | Neither relaxed nor triggered. The exhaustion predicates are only ever asked about a unit that *would defer*; a surplus admission is by construction a unit that **fits**, which is the same reason the admission loop does not ask about a fitting candidate (R2-F1: a unit admissible now must be admitted, not killed). |
| Budget-**failed** units | Not revived. See "Not implemented" below. |

**Two supporting changes this needed:**

1. `DispatchGuard` computes `slot_headroom` for buckets that hold *only* not-yet-due RETRYING units too. Those have no candidate this pass, so the existing loop never visited them and would have reported "no slots" for exactly the units surplus exists to unblock. Those buckets now also take an advisory lock, in the same sorted batch (no new deadlock ordering).
2. Surplus candidates are estimated **up front**, alongside real candidates, so their budget keys join the same single sorted `_acquire_budget_advisory_locks` call. A second, later acquisition would take locks out of order relative to a concurrent pass, which is how the sorting rule stops being a deadlock defence. The extra estimation cost is bounded by `SYNC_BUDGET_SURPLUS_MAX_CANDIDATES` (default 16; `0` disables), and truncation is **logged, never silent**.

Surplus-admitted units also join `candidate_units`, so they get the same last-read-before-the-claim `reconfirm_cooldowns` check every other dispatched unit gets.

## Not implemented, deliberately — please confirm

- **Reviving budget-`FAILED` units.** The plain-language spec said "budget-deferred (and budget-failed)", but the design constraint "must still pass … exhaustion thresholds" points the other way, and I took the constraint: terminalization in CHAOS-3412 is a deliberate, operator-visible verdict that a *configuration* is wrong, not a queue state spare capacity may undo. Reviving it is a one-line change to the candidate query if that call should go the other way.
- **An extra incremental run for lagging HEAVY units.** It does not fall out of the admission loop: admitting an *additional* run means planning a new unit over a new window, which is planner work, not admission. Filed as the follow-up rather than bolted on here. `SYNC_INCREMENTAL_HEAVY_MAX_WINDOW_DAYS=7` is untouched.

## Go mirror — pending, not accidental

**This lands Python-only on `main`.** The Go planner on `feat/go-worker-runtime-migration` mirrors the ratchet under live oracles and will disagree with Python until the mirror lands. That is expected and follows the CHAOS-3427 pattern: the Go mirror is a separate feature-branch PR after this merges. The semantics are specified above so the mirror is mechanical — in particular the counter rule (miss = no-op, hit = availability only) and the ordering key.

## Verification

`uv run pytest tests/test_chaos_3465_budget_surplus_retry.py tests/test_dispatch_guard.py tests/test_budget_guard_cooldown.py tests/test_sync_planner.py tests/test_sync_units.py -q` → **295 passed**. Ruff + mypy clean (full-tree mypy via lefthook: 2126 files, no issues).

**Old behaviour observed failing.** With `src/` reverted to pre-change and the new tests unchanged, 8 fail — including the headline one, on the exact defect:

```
FAILED test_deferred_unit_is_admitted_from_this_cycles_surplus
E   assert 'retrying' == 'dispatching'
E   {'queued_units': 2} != {'queued_units': 1}
```

The 6 that pass against old code are the "must not" guards, which hold vacuously when the feature is absent — so each was killed by planting its specific defect instead:

| Mutation | Result |
| --- | --- |
| A surplus miss counts itself as a deferral | **KILLED** — `assert 3 == 2`, and `assert 12 == 2` over 10 laps (the exact one-per-pass inflation predicted) |
| Surplus ignores `slot_headroom` | **KILLED** — `{'queued_units': 2} != {'queued_units': 1}` under a cap of 1 |
| Surplus ignores active cooldowns | **KILLED** — `available_at` pulled forward into a live cooldown |
| Newest deferral served first | **KILLED** on both SQLite and PostgreSQL |
| Drop only the FAILED-unit status filter | **survived** (the error-category filter still catches it) |
| Drop both selection barriers | **KILLED** — after strengthening the test |

That last row is worth calling out: the no-revive test as first written asserted only the end-to-end outcome and **could not fail** — three independent conditions keep a FAILED unit out (status filter, category filter, and the promotion CAS's own `status == RETRYING`). It now asserts `_surplus_retry_candidates` selection directly, which is what actually measures the barrier.

One earlier mutation (`_defer_unit_for_budget` on the miss path) was **INVALID, not killed** — its CAS predicate does not match a not-yet-due unit, so it wrote nothing. Recorded rather than counted as coverage.

**PostgreSQL-gated test ran for real**, against a throwaway database on the compose Postgres — not skipped:

```
DEV_HEALTH_POSTGRES_TEST_URI=postgresql+psycopg2://... uv run pytest -k postgres → 1 passed
```

It uses a throwaway *database*, not a schema: a schema sharing `search_path` with `public` is not isolation — `create_all` finds the existing tables through the path, skips creating them, and every write lands in the developer's real database. (That is not hypothetical; the first attempt did exactly that and failed on a unique violation against the live `public` tables.) Verified afterwards that no `chaos3465_*` schema or database was left behind.

## Test coverage added

- the capability, plus the pre-change behaviour as an explicit negative control (`SYNC_BUDGET_SURPLUS_MAX_CANDIDATES=0`, same fixture)
- counter semantics: single-pass no-op, and no drift across 10 laps
- counter semantics asserted at the `enforce_run` boundary (before the claim clears `first_blocked_at`), plus a source-derived AST guard that the surplus stamp writes **only** `available_at`/`updated_at` and no lifecycle column — with the model-derived column set asserted non-empty so a derivation that finds nothing fails rather than reading clean
- the episode *does* still end: `first_blocked_at` cleared at the claim
- ordering, parametrized over both creation orders
- concurrency cap, active cooldown, no-revive (selection-level), fail-closed without headroom
- candidate cap logged rather than silently applied
- PostgreSQL: ordering and selection on the backend production runs

Do not merge without a review of the `slot_headroom` addition to `GuardDecision` — it widens a contract the module docstring marks FROZEN.

---

## Review round 1 — three findings, all fixed (ab9d12051)

### 1. CRITICAL — a withdrawn surplus promotion wiped the budget episode

Surplus-admitted units join `candidate_units`, so `dispatch_sync_run` hands them to `reconfirm_cooldowns`. A 429 committing in the `enforce_run` → reconfirm window matched them and ran the ordinary cooldown deferral, which — correctly, for a unit genuinely about to dispatch — ends the budget episode: `budget_deferrals=0`, `budget_first_deferred_at=None`, category rewritten to `rate_limit_cooldown_deferred`.

For a **surplus** unit that episode change is fabricated. Absent the surplus phase it would have kept counting down untouched, so the guard offering a slot and then taking it back silently destroyed the CHAOS-3412 exhaustion evidence. A unit at 9/10 deferrals, promoted and caught on every pass, would never reach the specific budget verdict — only the much later aggregate backstop, under the wrong category.

**Fix (reviewer's option (a), as directed):** the offer is now **withdrawn**, not deferred. `available_at` returns to its pre-promotion value; `budget_deferrals`, `budget_first_deferred_at`, `first_blocked_at` and `result` are untouched. That is the same rule the surplus phase already applies to a candidate that does not fit — which is what "a surplus attempt that does not end in dispatch is a no-op" has to mean. `enforce_run` now returns each promotion's **prior** `available_at`, not just the id: the restore value is what makes the withdrawal a no-op.

Two consequences, deliberate and documented in the code: a withdrawn unit is **not** folded into `next_deferred_at` (it is back on its original countdown, whose wakeup was armed when it was first deferred, so re-arming would claim this pass deferred something it did not); and an exhaustion verdict `_resolve_cooldown_blocked_unit` might have reached is postponed to the pass where the unit is genuinely due — exactly where it would have been reached had surplus never looked at it.

An ordinary **due** candidate caught by the same late check still takes the full cooldown deferral, episode change included — pinned by its own test, so "don't end the episode" cannot creep into a blanket rule and quietly undo CHAOS-2760's binding decision.

### 2. IMPORTANT — the `budget_deferred` eligibility filter had zero coverage

Deleting it left 184 tests green. It is what keeps `rate_limit_cooldown_deferred` / `worker_lost` / `provider_unit_retryable` units out of surplus, and since a cooldown backoff routinely outlives the `_active_cooldowns` lookback the in-pass cooldown gate does **not** double-cover it. Now asserted directly at the selection boundary.

### 3. IMPORTANT — the whole `guard.py` change was untested

Every fixture co-bucketed the deferred unit with a PLANNED candidate, so reverting the `deferred_buckets` union left 202 tests green. Added an end-to-end rescue of a unit **alone** in its bucket (`cost_class="heavy"`), plus four direct `slot_headroom` tests in `tests/test_dispatch_guard.py` (headroom after candidates, zero at the cap, live consumers counted, deferred-only bucket present).

### Also

Dropped the docstring overclaim that the promotion CAS guards against a concurrent **re-deferral**. No write path in the tree can re-defer a not-yet-due unit: `_defer_unit_for_budget` and `_apply_cooldown_deferral` both require the claim predicate, and the reconciler's retry stamp targets expired-lease RUNNING units. The single-winner property for the dispatch that follows belongs to `_claim_units`' atomic UPDATE under the bucket advisory locks.

### Each new guard observed failing against its planted defect

| Planted defect | Result |
| --- | --- |
| Remove the withdrawal branch (the CRITICAL defect) | **KILLED** — `assert 0 == 2` on `budget_deferrals`, i.e. the wipe itself |
| Delete the `budget_deferred` eligibility filter | **KILLED** — a cooldown-deferred unit appears in `candidates` |
| Revert the `deferred_buckets` union | **KILLED** — both the end-to-end rescue (`'retrying' == 'dispatching'`) and the direct headroom test (bucket absent from the map) |
| Drop `slot_headroom` computation entirely | **KILLED** — all four direct guard tests |

369 passed across the affected suites with the Postgres-gated test running live. Ruff clean; full-tree mypy clean (2126 files).

### Perf note (reviewer's, recorded here deliberately)

Surplus candidates are estimated **before** the pass knows whether any surplus will exist — each costs a `SyncTaskBootstrap.load` plus credential decryption. That ordering is forced, not accidental: their budget keys must join the single sorted `_acquire_budget_advisory_locks` batch, and acquiring locks in a second, later batch would take them out of order relative to a concurrent pass, which is exactly what makes the sorting rule a deadlock defence. The cost is bounded by `SYNC_BUDGET_SURPLUS_MAX_CANDIDATES` (default 16, `0` disables) and truncation is logged. If this shows up in dispatch latency, the knob is the dial; removing the up-front estimation would require moving lock acquisition, which is a larger change than it looks.

---

## Review round 2 — one finding, fixed (c043e6d57)

### IMPORTANT — the withdrawal path failed open

`reconfirm_cooldowns` added a withdrawn surplus unit to `excluded` only when `_withdraw_surplus_admission`'s CAS succeeded. On CAS failure it fell through with a bare `continue`, leaving the unit at the **promoted** `available_at` — due — with a cooldown this pass had just matched, so `_claim_units` dispatched it straight into that cooldown. Forcing the CAS loss reproduces it: the unit goes to `dispatching`.

The shape was copied from the ordinary path below, where it is safe for a reason that does not hold here: there a `None` outcome **proves** the unit stopped being claimable, so falling through leaves it to a writer that already owns it. CAS failure on the withdrawal proves nothing about claimability. The branch picked the unsafe side of an ambiguity.

**Fix:** the exclusion is unconditional. It costs one pass, and a withdrawal that lost means another writer owns the row anyway — against dispatching into a live cooldown, which costs a worker slot and a 429. Reachability is low (the promoting UPDATE is uncommitted in-transaction, so competitors block on the row lock), but that is a reason to keep the branch cheap, not a reason to leave it wrong.

New test forces the CAS loss and asserts the unit is not dispatched; observed failing against the conditional-exclusion defect with `'dispatching' != 'dispatching'`.

### Mutation practice for this file — verified, not assumed

A row-writing statement in `budget_guard.py` must be mutated at **both** the `.values()` SQL and the in-memory ORM mirror. Mutating only the SQL is masked: the autoflush rewrites the row from the ORM object, so the intended corruption never lands and the mutation reports as survived when it in fact never happened.

Confirmed directly on this code rather than taken on trust:

| Mutation of `_withdraw_surplus_admission`'s restore | Result |
| --- | --- |
| `.values(available_at=now, …)` — SQL only, ORM mirror left correct | CRITICAL test **PASSED** — INVALID mutation, not a coverage gap |
| same, plus `unit.available_at = now` on the mirror | **KILLED** |

The new fail-open test patches the whole helper for exactly this reason, and says so in a comment. Anyone extending the mutation plan for this file should follow the same rule — a survived SQL-only mutation here is evidence of nothing.

**370 passed** across the affected suites with the Postgres-gated test live; ruff clean, full-tree mypy clean (2126 files); transitional-inventory gate green.
