### PR TITLE
CHAOS-3441: open record_frame's SAVEPOINT before its SELECTs, and stop _touch escaping it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
           # 4 vCPUs, so this matches `-n auto` there while staying predictable on
           # larger runners. Override PYTEST_XDIST_WORKERS to tune.
           PYTEST_XDIST_WORKERS: "4"
-          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --ignore=tests/test_chaos_3337_source_class_postgres_migration.py --ignore=tests/api/admin/test_add_member_visibility.py
+          PYTEST_ADDOPTS: --ignore=tests/test_0066_celery_river_cutover_postgres.py --ignore=tests/test_chaos_3337_source_class_postgres_migration.py --ignore=tests/api/admin/test_add_member_visibility.py --ignore=tests/api/dev/test_persistence_postgres.py
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
@@ -157,7 +157,8 @@ jobs:
             tests/test_0066_celery_river_cutover_postgres.py \
             tests/test_chaos_3337_source_class_postgres_migration.py \
             tests/test_canonical_incident_feature_flag_postgres_migration.py \
-            tests/api/admin/test_add_member_visibility.py
+            tests/api/admin/test_add_member_visibility.py \
+            tests/api/dev/test_persistence_postgres.py
 
       - name: Upload junit test reports
         if: always()

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1251,19 +1251,43 @@ class DevOrchestrator:
                         # resolution ledger, subject sets, intent -- and
                         # unlike the two preflight rollback sites below,
                         # nothing re-persists them afterward. It is kept
-                        # anyway, deliberately: `record_frame` can only
-                        # reach this handler with a POISONED session when
-                        # some earlier write already failed mid-flush (those
-                        # telemetry writes are not savepoint-isolated), and
-                        # in exactly that case dropping this rollback would
-                        # trade a specific, user-visible terminal
-                        # (`scope_not_found`, a clarification) for a generic
-                        # `internal_error` from
-                        # streaming.stream_orchestrator plus a
-                        # force_terminal_fallback hop. Forensic rows are
-                        # worth less than the terminal the user actually
-                        # sees, and both failures have to coincide for
-                        # either cost to be paid.
+                        # anyway, and round 3's frequency objection does not
+                        # survive contact with what a poisoned session
+                        # actually means. Two cases, and only one costs
+                        # anything:
+                        #
+                        # * Session POISONED -- one earlier failure is enough:
+                        #   none of the telemetry writes (record_run_
+                        #   diagnostics, append_tool_call, append_resolution,
+                        #   record_subject_set, record_intent) is
+                        #   savepoint-isolated, and a mid-flush failure in any
+                        #   of them makes record_error_message and
+                        #   record_frame fail in turn, landing here with
+                        #   error_message_written False. Those forensic rows
+                        #   are ALREADY unrecoverable: the transaction cannot
+                        #   commit, so nothing flushed on it will ever land,
+                        #   with or without this rollback. The rollback
+                        #   discards nothing that had a future, and buys back
+                        #   a specific, user-visible terminal
+                        #   (`scope_not_found`, a clarification) in place of a
+                        #   generic `internal_error` from
+                        #   streaming.stream_orchestrator plus a
+                        #   force_terminal_fallback hop. Proven by
+                        #   test_chaos_3441_a_poisoned_session_has_already_lost_its_rows.
+                        # * Session HEALTHY -- only here does the rollback
+                        #   destroy rows that would otherwise have committed,
+                        #   and reaching it takes TWO independent failures:
+                        #   record_error_message failing inside its own
+                        #   savepoint AND record_frame failing inside its own.
+                        #
+                        # The incremental cost is the two-failure case; the
+                        # benefit covers the one-failure case. Telling them
+                        # apart in code would mean asking the session whether
+                        # it needs a rollback, and that cannot live inside
+                        # PersistenceRunRecorder.rollback(): the two preflight
+                        # call sites below re-persist rows immediately after
+                        # their own rollback, so a rollback that silently
+                        # became a no-op would double-write them.
                         await self._recorder.rollback()
                     # else: record_answer (answer is not None) or
                     # record_error_message (CHAOS-3423 Codex adversarial

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1247,24 +1247,36 @@ class DevOrchestrator:
                     # is not, so this path deliberately leaves the session
                     # as-is and proceeds frame-less.
                     #
-                    # Codex adversarial review round 2 (honest residual, not
-                    # closed here): if `record_frame`'s failure was a real
-                    # mid-flush database error (not a pre-flush/construction
-                    # exception), the session may already be rollback-only,
-                    # and the `terminal()` write further below could still
-                    # raise `PendingRollbackError` regardless of this
-                    # branch -- a pre-existing risk this codebase already
-                    # accepts for a real `DevAnswer` (see
-                    # `DevPersistenceService.force_terminal_fallback`'s own
-                    # docstring, CHAOS-3297 round 3 Finding 2: the system
-                    # still reaches a coherent terminal state via that
-                    # fresh-session fallback, but the just-flushed row can
-                    # rarely be lost in that narrow correlated-failure
-                    # window). This makes the no-answer path symmetric with
-                    # that existing tradeoff, not worse than it -- closing
-                    # it for both would mean SAVEPOINT-wrapping
-                    # `record_frame`/`record_narrative` generally, out of
-                    # this ticket's scope.
+                    # CHAOS-3441: leaving the session as-is is safe for a real
+                    # mid-flush database failure too, not just a pre-flush
+                    # construction one. `record_frame` -- like
+                    # `record_narrative` and `append_assistant_answer`/
+                    # `append_assistant_error` -- isolates its own flush in a
+                    # SAVEPOINT (persistence/service.py), so a mid-flush error
+                    # unwinds to that savepoint and never leaves this session
+                    # rollback-only: the answer/error transcript row already
+                    # flushed above survives, and the `terminal()` write below
+                    # still lands. Proven for BOTH paths by a real database
+                    # failure, each of which fails if that `begin_nested` is
+                    # removed --
+                    # test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session
+                    # (no-answer row, duplicate-insert IntegrityError) and
+                    # tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+                    # (real `DevAnswer` row, connection-level fault).
+                    #
+                    # Residual, stated honestly: the savepoint wraps the
+                    # write, not `record_frame`'s PRE-write SELECTs (run
+                    # ownership, clarification-candidate authorization). A
+                    # server-side failure there -- a statement timeout, say --
+                    # aborts the whole PostgreSQL transaction, so the
+                    # transcript row is still lost in that narrower
+                    # correlated-failure window and the run reaches a coherent
+                    # terminal state only via
+                    # `DevPersistenceService.force_terminal_fallback`'s fresh
+                    # session (CHAOS-3297 round 3 Finding 2). Deliberately not
+                    # closed here: sqlite does not reproduce
+                    # transaction-abort-on-failed-statement, so a test for it
+                    # would pass whether the code were fixed or not.
                 else:
                     # CHAOS-3297 stack #4: narrative synthesis only runs for
                     # a frame that actually persisted -- record_narrative's

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1281,12 +1281,21 @@ class DevOrchestrator:
                     # `append_assistant_error` -- runs inside a SAVEPOINT
                     # (persistence/service.py), and that savepoint now opens
                     # before its ownership/authorization SELECTs as well as
-                    # its flush, so no failure it can raise leaves this
-                    # session rollback-only: the answer/error transcript row
-                    # already flushed above survives, and the `terminal()`
-                    # write below still lands. Proven for BOTH transcript
-                    # paths against a REAL database failure, each proof
-                    # failing if that `begin_nested` is removed --
+                    # its flush. Given a caller that enters with nothing
+                    # unflushed -- which the transcript writes now guarantee,
+                    # each of them touching its conversation inside its own
+                    # savepoint (test_chaos_3441_transcript_writes_leave_no_
+                    # unflushed_state) -- no failure record_frame can raise
+                    # leaves this session rollback-only: the answer/error
+                    # transcript row already flushed above survives, and the
+                    # `terminal()` write below still lands. The one exception
+                    # is stated where it lives: pending state a caller DOES
+                    # leave is flushed at savepoint entry, before the
+                    # SAVEPOINT is emitted, so a failure there is outside
+                    # every savepoint (Codex adversarial review round 2).
+                    # Proven for BOTH transcript paths against a REAL
+                    # database failure, each proof failing if that
+                    # `begin_nested` is removed --
                     # test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session
                     # (no-answer row, duplicate-insert IntegrityError) and
                     # tests/api/dev/test_chaos_3441_record_frame_savepoint.py

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -1232,11 +1232,38 @@ class DevOrchestrator:
                     # v1 answer/error above is authoritative and safe to
                     # terminate on alone.
                     if answer is None and not error_message_written:
-                        # No prior write in this flush to protect, so it is
-                        # safe to roll back a poisoned session -- otherwise
-                        # the terminal() write below could raise
-                        # PendingRollbackError (mirrors the preflight
-                        # TERMINATE branch, CHAOS-3297 Codex review).
+                        # No TRANSCRIPT row in this flush to protect (the
+                        # answer path never reaches here, and
+                        # record_error_message above failed), so a rollback
+                        # cannot discard the one row that is unrecoverable,
+                        # and it buys an inline terminal if the session is
+                        # poisoned -- otherwise the terminal() write below
+                        # could raise PendingRollbackError (mirrors the
+                        # preflight TERMINATE branch, CHAOS-3297 Codex
+                        # review).
+                        #
+                        # CHAOS-3441 Codex adversarial review round 1
+                        # (MEDIUM, confirmed as to fact, fix declined with
+                        # reasoning): "no prior write to protect" was too
+                        # broad a claim and is corrected here. This rollback
+                        # DOES discard this run's already-flushed forensic
+                        # rows -- stage diagnostics, tool calls, the
+                        # resolution ledger, subject sets, intent -- and
+                        # unlike the two preflight rollback sites below,
+                        # nothing re-persists them afterward. It is kept
+                        # anyway, deliberately: `record_frame` can only
+                        # reach this handler with a POISONED session when
+                        # some earlier write already failed mid-flush (those
+                        # telemetry writes are not savepoint-isolated), and
+                        # in exactly that case dropping this rollback would
+                        # trade a specific, user-visible terminal
+                        # (`scope_not_found`, a clarification) for a generic
+                        # `internal_error` from
+                        # streaming.stream_orchestrator plus a
+                        # force_terminal_fallback hop. Forensic rows are
+                        # worth less than the terminal the user actually
+                        # sees, and both failures have to coincide for
+                        # either cost to be paid.
                         await self._recorder.rollback()
                     # else: record_answer (answer is not None) or
                     # record_error_message (CHAOS-3423 Codex adversarial
@@ -1251,32 +1278,28 @@ class DevOrchestrator:
                     # mid-flush database failure too, not just a pre-flush
                     # construction one. `record_frame` -- like
                     # `record_narrative` and `append_assistant_answer`/
-                    # `append_assistant_error` -- isolates its own flush in a
-                    # SAVEPOINT (persistence/service.py), so a mid-flush error
-                    # unwinds to that savepoint and never leaves this session
-                    # rollback-only: the answer/error transcript row already
-                    # flushed above survives, and the `terminal()` write below
-                    # still lands. Proven for BOTH paths by a real database
-                    # failure, each of which fails if that `begin_nested` is
-                    # removed --
+                    # `append_assistant_error` -- runs inside a SAVEPOINT
+                    # (persistence/service.py), and that savepoint now opens
+                    # before its ownership/authorization SELECTs as well as
+                    # its flush, so no failure it can raise leaves this
+                    # session rollback-only: the answer/error transcript row
+                    # already flushed above survives, and the `terminal()`
+                    # write below still lands. Proven for BOTH transcript
+                    # paths against a REAL database failure, each proof
+                    # failing if that `begin_nested` is removed --
                     # test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session
                     # (no-answer row, duplicate-insert IntegrityError) and
                     # tests/api/dev/test_chaos_3441_record_frame_savepoint.py
-                    # (real `DevAnswer` row, connection-level fault).
+                    # (real `DevAnswer` row, a driver-level write rejection
+                    # plus the savepoint-boundary and diagnostics-survival
+                    # proofs).
                     #
-                    # Residual, stated honestly: the savepoint wraps the
-                    # write, not `record_frame`'s PRE-write SELECTs (run
-                    # ownership, clarification-candidate authorization). A
-                    # server-side failure there -- a statement timeout, say --
-                    # aborts the whole PostgreSQL transaction, so the
-                    # transcript row is still lost in that narrower
-                    # correlated-failure window and the run reaches a coherent
-                    # terminal state only via
+                    # What no savepoint can cover, stated plainly: if the
+                    # CONNECTION dies there is no session left to roll back,
+                    # and an uncommitted transcript row is lost by
+                    # definition -- recovered at the system level only, by
                     # `DevPersistenceService.force_terminal_fallback`'s fresh
-                    # session (CHAOS-3297 round 3 Finding 2). Deliberately not
-                    # closed here: sqlite does not reproduce
-                    # transaction-abort-on-failed-statement, so a test for it
-                    # would pass whether the code were fixed or not.
+                    # session (CHAOS-3297 round 3 Finding 2).
                 else:
                     # CHAOS-3297 stack #4: narrative synthesis only runs for
                     # a frame that actually persisted -- record_narrative's

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -3601,6 +3601,16 @@ class DevPersistenceService:
         )
         for conversation in stranded:
             conversation.expires_at = now
+        # CHAOS-3441 Codex adversarial review round 3 (MEDIUM, confirmed):
+        # flushed here rather than left dirty for whatever the caller does
+        # next. Every mutating method on this service returns with nothing
+        # pending, and that is load-bearing, not tidiness:
+        # SessionTransaction._take_snapshot() flushes pending state BEFORE
+        # emitting a SAVEPOINT, so a stamp left dirty here would be emitted
+        # by the next operation's savepoint entry -- outside that savepoint,
+        # where a failure poisons the whole transaction and takes the
+        # unrelated rows already flushed on it (see record_frame).
+        await self.session.flush()
         logger.info(
             "ask_dev_ephemeral_expiry_backfill_completed",
             extra={"stamped": len(stranded)},

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -1755,20 +1755,6 @@ class DevPersistenceService:
                 await self.session.flush()
                 run.user_message_id = message.id
                 self.session.add(run)
-                # CHAOS-3441: the conversation mutation is made INSIDE the
-                # savepoint so its `UPDATE dev_conversations` flushes here,
-                # with the row this method exists to write. Left until after
-                # the block, it stayed dirty on the caller's session and was
-                # emitted by the NEXT operation's savepoint-entry flush --
-                # SessionTransaction._take_snapshot() flushes pending state
-                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
-                # every savepoint. A server-side failure on it therefore
-                # poisoned the session and took this just-flushed transcript
-                # row down with it: the exact loss this ticket closes,
-                # reached by a statement nobody was looking at. Pinned by
-                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
-                conversation.current_scope = scope
-                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self._message_run_by_client_id(
@@ -1781,6 +1767,31 @@ class DevPersistenceService:
                 raise
             return existing
 
+        # CHAOS-3441: the conversation mutation gets its OWN savepoint, and
+        # deliberately not a place inside the row-write savepoint above.
+        # Two failure modes are being closed at once:
+        #
+        # 1. Left dirty until after this method returned (as it was), the
+        #    `UPDATE dev_conversations` was emitted by the NEXT operation's
+        #    savepoint entry -- SessionTransaction._take_snapshot() flushes
+        #    pending state BEFORE emitting the SAVEPOINT, so that UPDATE ran
+        #    outside every savepoint. A server-side failure on it poisoned
+        #    the session and took the transcript row just flushed above down
+        #    with it: this ticket's exact loss, via a statement nobody was
+        #    looking at.
+        # 2. Folded INTO the row-write savepoint, its rollback on the
+        #    idempotent-duplicate path would expire this conversation object
+        #    while the caller still holds it, so a later attribute read
+        #    would emit lazy IO from async code (Codex adversarial review
+        #    round 2, MEDIUM). Its own savepoint keeps the duplicate path
+        #    byte-identical to before: the conversation is never touched
+        #    when the insert loses that race.
+        #
+        # Pinned by test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+        async with self.session.begin_nested():
+            conversation.current_scope = scope
+            self._touch(conversation)
+            await self.session.flush()
         return MessageRunResult(message=message, run=run, created=True)
 
     async def append_assistant_answer(
@@ -1850,19 +1861,6 @@ class DevPersistenceService:
         try:
             async with self.session.begin_nested():
                 self.session.add(message)
-                # CHAOS-3441: the conversation mutation is made INSIDE the
-                # savepoint so its `UPDATE dev_conversations` flushes here,
-                # with the row this method exists to write. Left until after
-                # the block, it stayed dirty on the caller's session and was
-                # emitted by the NEXT operation's savepoint-entry flush --
-                # SessionTransaction._take_snapshot() flushes pending state
-                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
-                # every savepoint. A server-side failure on it therefore
-                # poisoned the session and took this just-flushed transcript
-                # row down with it: the exact loss this ticket closes,
-                # reached by a statement nobody was looking at. Pinned by
-                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
-                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self.session.scalar(
@@ -1877,6 +1875,30 @@ class DevPersistenceService:
             if existing is None:
                 raise
             return existing
+        # CHAOS-3441: the conversation mutation gets its OWN savepoint, and
+        # deliberately not a place inside the row-write savepoint above.
+        # Two failure modes are being closed at once:
+        #
+        # 1. Left dirty until after this method returned (as it was), the
+        #    `UPDATE dev_conversations` was emitted by the NEXT operation's
+        #    savepoint entry -- SessionTransaction._take_snapshot() flushes
+        #    pending state BEFORE emitting the SAVEPOINT, so that UPDATE ran
+        #    outside every savepoint. A server-side failure on it poisoned
+        #    the session and took the transcript row just flushed above down
+        #    with it: this ticket's exact loss, via a statement nobody was
+        #    looking at.
+        # 2. Folded INTO the row-write savepoint, its rollback on the
+        #    idempotent-duplicate path would expire this conversation object
+        #    while the caller still holds it, so a later attribute read
+        #    would emit lazy IO from async code (Codex adversarial review
+        #    round 2, MEDIUM). Its own savepoint keeps the duplicate path
+        #    byte-identical to before: the conversation is never touched
+        #    when the insert loses that race.
+        #
+        # Pinned by test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+        async with self.session.begin_nested():
+            self._touch(conversation)
+            await self.session.flush()
         return message
 
     async def append_assistant_error(
@@ -1960,19 +1982,6 @@ class DevPersistenceService:
         try:
             async with self.session.begin_nested():
                 self.session.add(message)
-                # CHAOS-3441: the conversation mutation is made INSIDE the
-                # savepoint so its `UPDATE dev_conversations` flushes here,
-                # with the row this method exists to write. Left until after
-                # the block, it stayed dirty on the caller's session and was
-                # emitted by the NEXT operation's savepoint-entry flush --
-                # SessionTransaction._take_snapshot() flushes pending state
-                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
-                # every savepoint. A server-side failure on it therefore
-                # poisoned the session and took this just-flushed transcript
-                # row down with it: the exact loss this ticket closes,
-                # reached by a statement nobody was looking at. Pinned by
-                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
-                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self.session.scalar(
@@ -1987,6 +1996,30 @@ class DevPersistenceService:
             if existing is None:
                 raise
             return existing
+        # CHAOS-3441: the conversation mutation gets its OWN savepoint, and
+        # deliberately not a place inside the row-write savepoint above.
+        # Two failure modes are being closed at once:
+        #
+        # 1. Left dirty until after this method returned (as it was), the
+        #    `UPDATE dev_conversations` was emitted by the NEXT operation's
+        #    savepoint entry -- SessionTransaction._take_snapshot() flushes
+        #    pending state BEFORE emitting the SAVEPOINT, so that UPDATE ran
+        #    outside every savepoint. A server-side failure on it poisoned
+        #    the session and took the transcript row just flushed above down
+        #    with it: this ticket's exact loss, via a statement nobody was
+        #    looking at.
+        # 2. Folded INTO the row-write savepoint, its rollback on the
+        #    idempotent-duplicate path would expire this conversation object
+        #    while the caller still holds it, so a later attribute read
+        #    would emit lazy IO from async code (Codex adversarial review
+        #    round 2, MEDIUM). Its own savepoint keeps the duplicate path
+        #    byte-identical to before: the conversation is never touched
+        #    when the insert loses that race.
+        #
+        # Pinned by test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+        async with self.session.begin_nested():
+            self._touch(conversation)
+            await self.session.flush()
         return message
 
     async def record_run_diagnostics(
@@ -3003,7 +3036,25 @@ class DevPersistenceService:
         # BEFORE emitting the SAVEPOINT, so outer pending writes land in the
         # outer transaction and a savepoint rollback never takes them
         # (verified, and pinned by
-        # test_chaos_3441_savepoint_opens_before_the_pre_write_selects).
+        # test_chaos_3441_savepoint_opens_before_the_pre_write_selects; the
+        # semantics -- ROLLBACK TO SAVEPOINT actually recovering an aborted
+        # PostgreSQL transaction, which sqlite cannot express -- are proven on
+        # the real engine by
+        # test_persistence_postgres.py::test_chaos_3441_savepoint_recovers_an_aborted_transaction,
+        # which fails with InFailedSQLTransactionError if this savepoint is
+        # moved back after the ownership SELECT).
+        #
+        # The flip side of that entry-flush, stated where it lives (Codex
+        # adversarial review round 2, HIGH): pending state the CALLER left
+        # unflushed is flushed BEFORE the SAVEPOINT exists, so a failure on
+        # it is outside this savepoint and does poison the session. Every
+        # write in this service returns with nothing dirty -- the transcript
+        # writes' conversation touch is the one that did not, and now runs
+        # inside its own savepoint (see append_assistant_answer) -- so no
+        # production caller reaches here with pending state. That is an
+        # invariant of the callers, not something this method can enforce,
+        # and it is guarded by
+        # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
         #
         # One failure class remains outside any savepoint's reach, stated
         # plainly rather than implied: if the CONNECTION itself dies, there

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -3014,7 +3014,14 @@ class DevPersistenceService:
         # (a real IntegrityError, not the round-2 finding's abstract
         # concern), verified against a genuine duplicate-insert test
         # (test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session)
-        # rather than only documented as a residual.
+        # rather than only documented as a residual. CHAOS-3441 completes that
+        # proof for the OTHER path and a second fault class -- an already
+        # flushed real ``DevAnswer`` transcript row plus a connection-level
+        # (not constraint) mid-flush failure, and the run tags below never
+        # surviving the savepoint's rollback:
+        # tests/api/dev/test_chaos_3441_record_frame_savepoint.py. The
+        # savepoint covers this write, not the SELECTs above it; see
+        # ``orchestrator.finish()``'s frame-failure handler for that residual.
         async with self.session.begin_nested():
             self.session.add(record)
             run.contract_generation = "v2"

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -1755,6 +1755,20 @@ class DevPersistenceService:
                 await self.session.flush()
                 run.user_message_id = message.id
                 self.session.add(run)
+                # CHAOS-3441: the conversation mutation is made INSIDE the
+                # savepoint so its `UPDATE dev_conversations` flushes here,
+                # with the row this method exists to write. Left until after
+                # the block, it stayed dirty on the caller's session and was
+                # emitted by the NEXT operation's savepoint-entry flush --
+                # SessionTransaction._take_snapshot() flushes pending state
+                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
+                # every savepoint. A server-side failure on it therefore
+                # poisoned the session and took this just-flushed transcript
+                # row down with it: the exact loss this ticket closes,
+                # reached by a statement nobody was looking at. Pinned by
+                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+                conversation.current_scope = scope
+                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self._message_run_by_client_id(
@@ -1767,8 +1781,6 @@ class DevPersistenceService:
                 raise
             return existing
 
-        conversation.current_scope = scope
-        self._touch(conversation)
         return MessageRunResult(message=message, run=run, created=True)
 
     async def append_assistant_answer(
@@ -1838,6 +1850,19 @@ class DevPersistenceService:
         try:
             async with self.session.begin_nested():
                 self.session.add(message)
+                # CHAOS-3441: the conversation mutation is made INSIDE the
+                # savepoint so its `UPDATE dev_conversations` flushes here,
+                # with the row this method exists to write. Left until after
+                # the block, it stayed dirty on the caller's session and was
+                # emitted by the NEXT operation's savepoint-entry flush --
+                # SessionTransaction._take_snapshot() flushes pending state
+                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
+                # every savepoint. A server-side failure on it therefore
+                # poisoned the session and took this just-flushed transcript
+                # row down with it: the exact loss this ticket closes,
+                # reached by a statement nobody was looking at. Pinned by
+                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self.session.scalar(
@@ -1852,7 +1877,6 @@ class DevPersistenceService:
             if existing is None:
                 raise
             return existing
-        self._touch(conversation)
         return message
 
     async def append_assistant_error(
@@ -1936,6 +1960,19 @@ class DevPersistenceService:
         try:
             async with self.session.begin_nested():
                 self.session.add(message)
+                # CHAOS-3441: the conversation mutation is made INSIDE the
+                # savepoint so its `UPDATE dev_conversations` flushes here,
+                # with the row this method exists to write. Left until after
+                # the block, it stayed dirty on the caller's session and was
+                # emitted by the NEXT operation's savepoint-entry flush --
+                # SessionTransaction._take_snapshot() flushes pending state
+                # BEFORE emitting the SAVEPOINT, so that UPDATE ran outside
+                # every savepoint. A server-side failure on it therefore
+                # poisoned the session and took this just-flushed transcript
+                # row down with it: the exact loss this ticket closes,
+                # reached by a statement nobody was looking at. Pinned by
+                # test_chaos_3441_transcript_writes_leave_no_unflushed_state.
+                self._touch(conversation)
                 await self.session.flush()
         except IntegrityError:
             existing = await self.session.scalar(
@@ -1950,7 +1987,6 @@ class DevPersistenceService:
             if existing is None:
                 raise
             return existing
-        self._touch(conversation)
         return message
 
     async def record_run_diagnostics(
@@ -2950,79 +2986,96 @@ class DevPersistenceService:
         row identity closure.
         """
 
-        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
-        if run is None:
-            raise DevPersistenceNotFound("run not found")
-        if public_outcome not in _PUBLIC_OUTCOMES:
-            raise DevPersistenceValidationError("invalid public_outcome")
-        try:
-            validated = DevAnswerFrameContract.model_validate(payload)
-        except PydanticValidationError as exc:
-            raise DevPersistenceValidationError(
-                f"frame_payload is not a valid dev_answer_frame.v1: {exc}"
-            ) from exc
-        if validated.frame_id != str(frame_id):
-            raise DevPersistenceValidationError(
-                "frame_payload.frame_id does not match the frame_id argument"
-            )
-        if validated.run_id != str(run_id):
-            raise DevPersistenceValidationError(
-                "frame_payload.run_id does not match the run_id argument"
-            )
-        if validated.public_outcome.value != public_outcome:
-            raise DevPersistenceValidationError(
-                "frame_payload.public_outcome does not match the "
-                "public_outcome argument"
-            )
-        # CHAOS-3325 Codex review (NO-SHIP, confirmed): the contract only
-        # enforces wire shape, not provenance -- see
-        # _authorize_clarification_candidates's own docstring. Runs before
-        # the row is constructed, so an unauthorized candidate list never
-        # reaches the payload-bearing row at all.
-        await _authorize_clarification_candidates(
-            self.session,
-            run_id=run_id,
-            org_id=org_id,
-            user_id=user_id,
-            validated=validated,
-        )
-        record = await self._construct_validated_payload_row(
-            model_cls=DevAnswerFrame,
-            payload_dict=validated.model_dump(mode="json"),
-            field_name="frame_payload",
-            max_bytes=_FRAME_PAYLOAD_MAX_BYTES,
-            run_id=run.id,
-            org_id=org_id,
-            user_id=user_id,
-            frame_id=frame_id,
-            public_outcome=public_outcome,
-            created_at=self._now(),
-        )
-        # CHAOS-3423 Codex adversarial review round 3 (HIGH, confirmed):
-        # isolated in a SAVEPOINT, matching append_assistant_answer/
-        # append_assistant_error's own pattern -- a real mid-flush database
-        # failure here (not just a pre-flush construction exception) used
-        # to be able to mark the WHOLE outer session rollback-only, which
-        # could silently discard an already-flushed answer or no-answer
-        # transcript row the moment finish()'s own failure handler chose
-        # not to roll back (to protect that exact row). Any exception here
-        # now unwinds only to this savepoint -- the outer session, and
-        # every write already flushed on it, stays healthy regardless of
-        # what kind of failure this was. This is CHAOS-3441's own scope,
-        # brought forward and closed inline here rather than deferred: round
-        # 3's finding supplied a concrete, reproducible mid-flush failure
-        # (a real IntegrityError, not the round-2 finding's abstract
-        # concern), verified against a genuine duplicate-insert test
-        # (test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session)
-        # rather than only documented as a residual. CHAOS-3441 completes that
-        # proof for the OTHER path and a second fault class -- an already
-        # flushed real ``DevAnswer`` transcript row plus a connection-level
-        # (not constraint) mid-flush failure, and the run tags below never
-        # surviving the savepoint's rollback:
-        # tests/api/dev/test_chaos_3441_record_frame_savepoint.py. The
-        # savepoint covers this write, not the SELECTs above it; see
-        # ``orchestrator.finish()``'s frame-failure handler for that residual.
+        # CHAOS-3441 Codex adversarial review round 1 (HIGH, confirmed): the
+        # SAVEPOINT opens HERE, before the ownership and authorization
+        # SELECTs, not just around the write. Wrapping only the flush left a
+        # real window open: on PostgreSQL a server-side failure on any
+        # statement -- a `statement_timeout` firing on one of the SELECTs
+        # below is the realistic case -- aborts the WHOLE transaction, so
+        # every later statement fails with InFailedSqlTransaction and the
+        # caller's already-flushed transcript row, diagnostics, tool calls
+        # and resolutions all die with the commit that can no longer happen.
+        # A SAVEPOINT entered before the first statement makes that
+        # recoverable: `ROLLBACK TO SAVEPOINT` returns an aborted PostgreSQL
+        # transaction to a usable state, which is the whole reason savepoints
+        # exist. Entering the savepoint first is behavior-preserving for the
+        # write path: `begin_nested()` flushes the caller's pending state
+        # BEFORE emitting the SAVEPOINT, so outer pending writes land in the
+        # outer transaction and a savepoint rollback never takes them
+        # (verified, and pinned by
+        # test_chaos_3441_savepoint_opens_before_the_pre_write_selects).
+        #
+        # One failure class remains outside any savepoint's reach, stated
+        # plainly rather than implied: if the CONNECTION itself dies, there
+        # is no session left to roll back to a savepoint and an uncommitted
+        # transaction is lost by definition. That is recovered at the system
+        # level only, by force_terminal_fallback's fresh session.
         async with self.session.begin_nested():
+            run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+            if run is None:
+                raise DevPersistenceNotFound("run not found")
+            if public_outcome not in _PUBLIC_OUTCOMES:
+                raise DevPersistenceValidationError("invalid public_outcome")
+            try:
+                validated = DevAnswerFrameContract.model_validate(payload)
+            except PydanticValidationError as exc:
+                raise DevPersistenceValidationError(
+                    f"frame_payload is not a valid dev_answer_frame.v1: {exc}"
+                ) from exc
+            if validated.frame_id != str(frame_id):
+                raise DevPersistenceValidationError(
+                    "frame_payload.frame_id does not match the frame_id argument"
+                )
+            if validated.run_id != str(run_id):
+                raise DevPersistenceValidationError(
+                    "frame_payload.run_id does not match the run_id argument"
+                )
+            if validated.public_outcome.value != public_outcome:
+                raise DevPersistenceValidationError(
+                    "frame_payload.public_outcome does not match the "
+                    "public_outcome argument"
+                )
+            # CHAOS-3325 Codex review (NO-SHIP, confirmed): the contract only
+            # enforces wire shape, not provenance -- see
+            # _authorize_clarification_candidates's own docstring. Runs before
+            # the row is constructed, so an unauthorized candidate list never
+            # reaches the payload-bearing row at all.
+            await _authorize_clarification_candidates(
+                self.session,
+                run_id=run_id,
+                org_id=org_id,
+                user_id=user_id,
+                validated=validated,
+            )
+            record = await self._construct_validated_payload_row(
+                model_cls=DevAnswerFrame,
+                payload_dict=validated.model_dump(mode="json"),
+                field_name="frame_payload",
+                max_bytes=_FRAME_PAYLOAD_MAX_BYTES,
+                run_id=run.id,
+                org_id=org_id,
+                user_id=user_id,
+                frame_id=frame_id,
+                public_outcome=public_outcome,
+                created_at=self._now(),
+            )
+            # CHAOS-3423 Codex adversarial review round 3 (HIGH, confirmed):
+            # the write is isolated by the SAVEPOINT above, matching
+            # append_assistant_answer/append_assistant_error's own pattern --
+            # a real mid-flush database failure here (not just a pre-flush
+            # construction exception) used to be able to mark the WHOLE outer
+            # session rollback-only, which could silently discard an
+            # already-flushed answer or no-answer transcript row the moment
+            # finish()'s own failure handler chose not to roll back (to
+            # protect that exact row). Any exception now unwinds only to this
+            # savepoint -- the outer session, and every write already flushed
+            # on it, stays healthy regardless of what kind of failure this
+            # was. Verified by REAL database failures on both transcript
+            # paths, each of which fails if the begin_nested is removed:
+            # test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session
+            # (no-answer row, duplicate-insert IntegrityError) and
+            # tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+            # (real DevAnswer row, driver-level write rejection).
             self.session.add(record)
             run.contract_generation = "v2"
             run.public_outcome = public_outcome
@@ -3062,102 +3115,124 @@ class DevPersistenceService:
         any mismatch rejects, no write.
         """
 
-        run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
-        if run is None:
-            raise DevPersistenceNotFound("run not found")
-        if mode not in _NARRATIVE_MODES:
-            raise DevPersistenceValidationError("invalid narrative mode")
-        frame = await self.session.scalar(
-            select(DevAnswerFrame).where(
-                DevAnswerFrame.run_id == run.id,
-                DevAnswerFrame.org_id == org_id,
-                DevAnswerFrame.user_id == user_id,
-            )
-        )
-        if frame is None or frame.frame_id != frame_id:
-            raise DevPersistenceValidationError(
-                "narrative frame_id must match the run's recorded answer frame"
-            )
-        reconstructed = dict(payload)
-        reconstructed["body"] = narrative_text
-        try:
-            validated = DevNarrativeContract.model_validate(reconstructed)
-        except PydanticValidationError as exc:
-            raise DevPersistenceValidationError(
-                f"narrative payload is not a valid dev_narrative.v1: {exc}"
-            ) from exc
-        if validated.narrative_id != str(narrative_id):
-            raise DevPersistenceValidationError(
-                "narrative payload's narrative_id does not match the "
-                "narrative_id argument"
-            )
-        if validated.run_id != str(run_id):
-            raise DevPersistenceValidationError(
-                "narrative payload's run_id does not match the run_id argument"
-            )
-        if validated.frame_id != str(frame_id):
-            raise DevPersistenceValidationError(
-                "narrative payload's frame_id does not match the frame_id argument"
-            )
-        if validated.mode != mode:
-            raise DevPersistenceValidationError(
-                "narrative payload's mode does not match the mode argument"
-            )
-        # provider_fingerprint arrives already hashed (the caller -- see
-        # orchestrator_persistence.PersistenceRunRecorder.record_narrative --
-        # digests narrative.provider_metadata.model_fingerprint before this
-        # call); _digest here only validates that shape. To cross-check it
-        # against the *payload's own* raw model_fingerprint, that raw value
-        # must be hashed the identical way, not passed through the
-        # shape-only validator.
-        expected_provider_fingerprint = (
-            _sha256_digest(validated.provider_metadata.model_fingerprint)
-            if validated.provider_metadata is not None
-            else None
-        )
-        safe_provider_fingerprint = _digest(
-            provider_fingerprint, field="provider_fingerprint"
-        )
-        if expected_provider_fingerprint != safe_provider_fingerprint:
-            raise DevPersistenceValidationError(
-                "narrative payload's provider_metadata does not match the "
-                "provider_fingerprint argument"
-            )
-        text = _bounded_text(
-            validated.body, field="narrative_text", max_bytes=_NARRATIVE_TEXT_MAX_BYTES
-        )
-        if not text:
-            raise DevPersistenceValidationError("narrative_text must not be empty")
-        record = await self._construct_validated_payload_row(
-            model_cls=DevRunNarrative,
-            payload_dict=validated.model_dump(mode="json", exclude={"body"}),
-            field_name="narrative_payload",
-            max_bytes=_NARRATIVE_PAYLOAD_MAX_BYTES,
-            run_id=run.id,
-            org_id=org_id,
-            user_id=user_id,
-            narrative_id=narrative_id,
-            frame_id=frame_id,
-            mode=mode,
-            provider_fingerprint=safe_provider_fingerprint,
-            narrative_text=text,
-            created_at=self._now(),
-        )
-        # codex NO-SHIP finding round 1 (HIGH #2b): the narrative row is an
-        # *optional* write on a session that may already carry a
-        # successfully-flushed frame/answer earlier in the same request
-        # (orchestrator.finish() calls this after record_frame). A flush
-        # failure here (a CHECK-constraint violation, a byte-bound
-        # rejection) previously poisoned the WHOLE session -- the
-        # terminal() write that follows would then raise
-        # PendingRollbackError, and recovery would roll back the
-        # already-flushed frame/answer along with it, downgrading an
-        # otherwise-valid run. A SAVEPOINT isolates this one flush: on
-        # failure, only the savepoint rolls back (automatic, on exception
-        # exit from this block) -- the outer transaction, and everything
-        # already flushed on it, stays intact and the session stays usable
-        # for the terminal() write that follows.
+        # CHAOS-3441 Codex adversarial review round 1 (HIGH, confirmed): the
+        # SAVEPOINT opens before the ownership/frame SELECTs, not just around
+        # the write, for the same reason as record_frame -- see that method's
+        # own comment. A narrative failure is the worst place to lose the
+        # outer transaction: by the time this runs, the transcript row AND
+        # the frame are already flushed on it.
         async with self.session.begin_nested():
+            run = await self._owned_run(org_id=org_id, user_id=user_id, run_id=run_id)
+            if run is None:
+                raise DevPersistenceNotFound("run not found")
+            if mode not in _NARRATIVE_MODES:
+                raise DevPersistenceValidationError("invalid narrative mode")
+            frame = await self.session.scalar(
+                select(DevAnswerFrame).where(
+                    DevAnswerFrame.run_id == run.id,
+                    DevAnswerFrame.org_id == org_id,
+                    DevAnswerFrame.user_id == user_id,
+                )
+            )
+            if frame is None or frame.frame_id != frame_id:
+                raise DevPersistenceValidationError(
+                    "narrative frame_id must match the run's recorded answer frame"
+                )
+            reconstructed = dict(payload)
+            reconstructed["body"] = narrative_text
+            try:
+                validated = DevNarrativeContract.model_validate(reconstructed)
+            except PydanticValidationError as exc:
+                raise DevPersistenceValidationError(
+                    f"narrative payload is not a valid dev_narrative.v1: {exc}"
+                ) from exc
+            if validated.narrative_id != str(narrative_id):
+                raise DevPersistenceValidationError(
+                    "narrative payload's narrative_id does not match the "
+                    "narrative_id argument"
+                )
+            if validated.run_id != str(run_id):
+                raise DevPersistenceValidationError(
+                    "narrative payload's run_id does not match the run_id argument"
+                )
+            if validated.frame_id != str(frame_id):
+                raise DevPersistenceValidationError(
+                    "narrative payload's frame_id does not match the frame_id argument"
+                )
+            if validated.mode != mode:
+                raise DevPersistenceValidationError(
+                    "narrative payload's mode does not match the mode argument"
+                )
+            # provider_fingerprint arrives already hashed (the caller -- see
+            # orchestrator_persistence.PersistenceRunRecorder.record_narrative --
+            # digests narrative.provider_metadata.model_fingerprint before this
+            # call); _digest here only validates that shape. To cross-check it
+            # against the *payload's own* raw model_fingerprint, that raw value
+            # must be hashed the identical way, not passed through the
+            # shape-only validator.
+            expected_provider_fingerprint = (
+                _sha256_digest(validated.provider_metadata.model_fingerprint)
+                if validated.provider_metadata is not None
+                else None
+            )
+            safe_provider_fingerprint = _digest(
+                provider_fingerprint, field="provider_fingerprint"
+            )
+            if expected_provider_fingerprint != safe_provider_fingerprint:
+                raise DevPersistenceValidationError(
+                    "narrative payload's provider_metadata does not match the "
+                    "provider_fingerprint argument"
+                )
+            text = _bounded_text(
+                validated.body,
+                field="narrative_text",
+                max_bytes=_NARRATIVE_TEXT_MAX_BYTES,
+            )
+            if not text:
+                raise DevPersistenceValidationError("narrative_text must not be empty")
+            record = await self._construct_validated_payload_row(
+                model_cls=DevRunNarrative,
+                payload_dict=validated.model_dump(mode="json", exclude={"body"}),
+                field_name="narrative_payload",
+                max_bytes=_NARRATIVE_PAYLOAD_MAX_BYTES,
+                run_id=run.id,
+                org_id=org_id,
+                user_id=user_id,
+                narrative_id=narrative_id,
+                frame_id=frame_id,
+                mode=mode,
+                provider_fingerprint=safe_provider_fingerprint,
+                narrative_text=text,
+                created_at=self._now(),
+            )
+            # codex NO-SHIP finding round 1 (HIGH #2b): the narrative row is an
+            # *optional* write on a session that may already carry a
+            # successfully-flushed frame/answer earlier in the same request
+            # (orchestrator.finish() calls this after record_frame). A flush
+            # failure here (a CHECK-constraint violation, a byte-bound
+            # rejection) previously poisoned the WHOLE session -- the
+            # terminal() write that follows would then raise
+            # PendingRollbackError, and recovery would roll back the
+            # already-flushed frame/answer along with it, downgrading an
+            # otherwise-valid run. A SAVEPOINT isolates this one flush: on
+            # failure, only the savepoint rolls back (automatic, on exception
+            # exit from this block) -- the outer transaction, and everything
+            # already flushed on it, stays intact and the session stays usable
+            # for the terminal() write that follows.
+            # codex NO-SHIP finding round 1 (HIGH #2b): the narrative row is
+            # an *optional* write on a session that may already carry a
+            # successfully-flushed frame/answer earlier in the same request
+            # (orchestrator.finish() calls this after record_frame). A flush
+            # failure here (a CHECK-constraint violation, a byte-bound
+            # rejection) previously poisoned the WHOLE session -- the
+            # terminal() write that follows would then raise
+            # PendingRollbackError, and recovery would roll back the
+            # already-flushed frame/answer along with it, downgrading an
+            # otherwise-valid run. The SAVEPOINT isolates this flush: on
+            # failure only the savepoint rolls back (automatic, on exception
+            # exit from the block) -- the outer transaction, and everything
+            # already flushed on it, stays intact and the session stays
+            # usable for the terminal() write that follows.
             self.session.add(record)
             await self.session.flush()
         return record

--- a/tests/api/dev/test_chaos_3423_3424_persistence_prerequisites.py
+++ b/tests/api/dev/test_chaos_3423_3424_persistence_prerequisites.py
@@ -617,26 +617,22 @@ async def test_chaos_3423_frame_write_failure_does_not_discard_the_transcript_ro
     ``DevPersistenceService.record_frame`` failure (not a recorder fake) and
     asserts the row survives.
 
-    Scope, stated honestly (Codex adversarial review round 2): this
-    ``record_frame`` failure is raised BEFORE any real ``session.flush()``
-    runs, so it proves the pre-flush/construction-failure case (e.g.
-    ``UnregisteredTerminalCode``, an unrelated Python bug in frame
-    construction) -- never a genuine mid-flush database error that marks
-    the session rollback-only. That narrower case is a PRE-EXISTING,
-    documented residual (``DevPersistenceService.force_terminal_fallback``'s
-    own docstring, CHAOS-3297 round 3 Finding 2): a real ``record_frame``
-    flush failure can already leave ``terminal()`` raising
-    ``PendingRollbackError`` for a genuine ``DevAnswer`` today (that write
-    is ALSO left un-rolled-back, for the identical "don't discard a
-    successful write" reason), recovered only at the system level (the run
-    still reaches a coherent terminal state via ``force_terminal_fallback``
-    on a fresh session -- the transcript row can rarely be lost in that
-    narrow correlated-failure window, exactly as a real answer already
-    could be). This change makes the no-answer path symmetric with that
-    existing, accepted tradeoff -- not worse than it -- rather than closing
-    it for either path; closing it fully would mean SAVEPOINT-wrapping
-    ``record_frame``/``record_narrative`` generally, which is a materially
-    larger change than this ticket's persistence-prerequisite scope.
+    Scope of THIS test (Codex adversarial review round 2): the failure is
+    raised BEFORE any real ``session.flush()``, so it proves only the
+    pre-flush/construction-failure case (e.g. ``UnregisteredTerminalCode``,
+    an unrelated Python bug in frame construction). The mid-flush case --
+    a genuine database error that used to mark the whole session
+    rollback-only -- is a separate proof, and it is closed, not a residual
+    (CHAOS-3441): ``record_frame`` isolates its flush in a SAVEPOINT, and
+    the mid-flush window is covered for both paths --
+    ``test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session``
+    below (no-answer path, real ``IntegrityError``) and
+    ``tests/api/dev/test_chaos_3441_record_frame_savepoint.py``
+    (real-``DevAnswer`` path, connection-level fault). Both fail if the
+    ``begin_nested`` is removed. What remains uncovered by a savepoint is
+    narrower and stated in ``orchestrator.finish()``'s own handler: a
+    server-side failure on ``record_frame``'s PRE-write SELECTs, which sits
+    outside the savepoint.
     """
 
     maker, org_id, user_id = seeded

--- a/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+++ b/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
@@ -3,7 +3,7 @@ frame write.
 
 Scope check first (this file is the closure evidence, so it states what was
 already true on ``main``): ``DevPersistenceService.record_frame`` and
-``record_narrative`` already isolate their flush in a SAVEPOINT
+``record_narrative`` already isolated their FLUSH in a SAVEPOINT
 (``begin_nested``), landed with CHAOS-3423/3424 (#1507), and
 ``test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session``
 already proves the NO-ANSWER path survives a real duplicate-insert
@@ -11,9 +11,20 @@ already proves the NO-ANSWER path survives a real duplicate-insert
 
 * the REAL-ANSWER path (an already-flushed ``DevAnswer`` transcript row --
   the pre-existing, accepted tradeoff CHAOS-3297 round 3 Finding 2
-  documented and this ticket exists to close), driven by a
-  connection-level mid-flush fault rather than a constraint violation, so
-  the proof is not specific to ``IntegrityError``;
+  documented and this ticket exists to close), driven by a database-side
+  rejection of the frame INSERT rather than a duplicate-key collision;
+* the savepoint BOUNDARY: it now opens before the ownership/authorization
+  SELECTs, not only around the flush, because on PostgreSQL a server-side
+  failure on any statement aborts the whole transaction. sqlite cannot
+  reproduce that, so the proof here is the statement order and the semantic
+  proof lives on the real engine --
+  ``test_persistence_postgres.py::test_chaos_3441_savepoint_recovers_an_aborted_transaction``
+  fails with ``InFailedSQLTransactionError`` against the pre-fix boundary;
+* the pending-state hazard found while building that fault injection:
+  ``SessionTransaction._take_snapshot()`` flushes the session's pending
+  state BEFORE emitting the SAVEPOINT, so the conversation ``UPDATE`` the
+  transcript writes used to leave dirty was emitted by the NEXT operation's
+  savepoint entry -- outside every savepoint;
 * the ORM half of "rolls back only the frame write". ``record_frame`` tags
   its owned run INSIDE the savepoint (``contract_generation = 'v2'``,
   ``public_outcome``) -- in-Python mutations on a *persistent* object, which
@@ -42,6 +53,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.dev import terminal_frames as dev_terminal_frames
+from dev_health_ops.api.dev.contracts import DevError
 from dev_health_ops.api.dev.persistence import (
     DevPersistenceService,
     DevPersistenceValidationError,
@@ -125,6 +137,16 @@ def _validated_answer(
         "metrics": [],
         "evidence": [],
     }
+
+
+def _error_payload() -> dict[str, Any]:
+    return DevError(
+        schema_version="dev_error.v1",
+        request_id="request-chaos-3441",
+        code="scope_not_found",
+        safe_message="The requested scope was not found.",
+        retryable=False,
+    ).model_dump(mode="json")
 
 
 def _identity_validator(payload: Any) -> Any:
@@ -594,31 +616,67 @@ async def test_chaos_3441_transcript_writes_leave_no_unflushed_state(
         if recording["on"]:
             captured.append(" ".join(statement.split()))
 
-    async with maker() as session:
-        service = DevPersistenceService(session)
+    async def _assert_touch_is_inside_a_savepoint(session, write) -> None:
+        captured.clear()
         recording["on"] = True
-        await service.append_assistant_answer(
-            org_id=org_id,
-            user_id=user_id,
-            conversation_id=conversation_id,
-            answer_payload=_validated_answer(conversation_id, answer_id),
-            validator=_identity_validator,
-            scope_snapshot={},
-        )
+        await write()
         recording["on"] = False
 
-        savepoint = next(i for i, s in enumerate(captured) if s.startswith("SAVEPOINT"))
-        release = next(
-            i for i, s in enumerate(captured) if s.startswith("RELEASE SAVEPOINT")
-        )
+        boundaries = ("SAVEPOINT", "RELEASE SAVEPOINT", "ROLLBACK TO SAVEPOINT")
         conversation_update = next(
             i
             for i, s in enumerate(captured)
             if s.startswith("UPDATE dev_conversations")
         )
-        assert savepoint < conversation_update < release, captured
-
+        before = [s for s in captured[:conversation_update] if s.startswith(boundaries)]
+        after = [s for s in captured[conversation_update:] if s.startswith(boundaries)]
+        # The nearest savepoint boundary before the UPDATE must be an OPEN and
+        # the next one after it a RELEASE: that is what "inside a savepoint"
+        # means, and it stays true however many savepoints the method uses.
+        assert before and before[-1].startswith("SAVEPOINT"), captured
+        assert after and after[0].startswith("RELEASE SAVEPOINT"), captured
         # Nothing is left for the next savepoint entry to flush outside its
         # own savepoint.
         assert not session.dirty, session.dirty
         assert not session.new, session.new
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        # All three transcript writes, not just one: each touches its
+        # conversation, so each is its own instance of the same hazard.
+        await _assert_touch_is_inside_a_savepoint(
+            session,
+            lambda: service.append_assistant_answer(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                answer_payload=_validated_answer(conversation_id, answer_id),
+                validator=_identity_validator,
+                scope_snapshot={},
+            ),
+        )
+        await _assert_touch_is_inside_a_savepoint(
+            session,
+            lambda: service.append_assistant_error(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                message_id=uuid.uuid4(),
+                error_payload=_error_payload(),
+                validator=_identity_validator,
+                scope_snapshot={},
+                rendered_content="The requested scope was not found.",
+            ),
+        )
+        await _assert_touch_is_inside_a_savepoint(
+            session,
+            lambda: service.append_user_message_and_run(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                client_message_id=uuid.uuid4(),
+                question="And a fresh submission on the same conversation?",
+                scope_snapshot={},
+            ),
+        )

--- a/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+++ b/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
@@ -1,0 +1,337 @@
+"""CHAOS-3441: a mid-flush ``record_frame`` failure must roll back ONLY the
+frame write.
+
+Scope check first (this file is the closure evidence, so it states what was
+already true on ``main``): ``DevPersistenceService.record_frame`` and
+``record_narrative`` already isolate their flush in a SAVEPOINT
+(``begin_nested``), landed with CHAOS-3423/3424 (#1507), and
+``test_chaos_3423_record_frame_integrity_failure_never_poisons_the_session``
+already proves the NO-ANSWER path survives a real duplicate-insert
+``IntegrityError``. What this file adds is the rest of the ticket:
+
+* the REAL-ANSWER path (an already-flushed ``DevAnswer`` transcript row --
+  the pre-existing, accepted tradeoff CHAOS-3297 round 3 Finding 2
+  documented and this ticket exists to close), driven by a
+  connection-level mid-flush fault rather than a constraint violation, so
+  the proof is not specific to ``IntegrityError``;
+* the ORM half of "rolls back only the frame write". ``record_frame`` tags
+  its owned run INSIDE the savepoint (``contract_generation = 'v2'``,
+  ``public_outcome``) -- in-Python mutations on a *persistent* object, which
+  a SAVEPOINT rollback does not undo by itself. Investigating that as a
+  suspected leak REFUTED it: SQLAlchemy expires the attributes touched by
+  the failed flush, so the next flush on the outer session does not re-emit
+  the tags and no ``contract_generation = 'v2'`` run without a frame row is
+  ever committed (the CHAOS-3299 / migration-0074 downgrade-guard shape).
+  The second test below is therefore a lock on an invariant that already
+  holds, not a bug fix -- and it is not vacuous: it fails when
+  ``record_frame``'s ``begin_nested`` is removed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev import terminal_frames as dev_terminal_frames
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.models.dev_persistence import (
+    DevAnswerFrame,
+    DevConversation,
+    DevConversationTombstone,
+    DevFeedback,
+    DevMessage,
+    DevRun,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunStageDiagnostic,
+    DevToolCall,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._chaos_3292_preflight import versions
+from tests._helpers import tables_of
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    DevConversation,
+    DevMessage,
+    DevRun,
+    DevToolCall,
+    DevFeedback,
+    DevConversationTombstone,
+    DevAnswerFrame,
+    DevRunNarrative,
+    DevRunResolution,
+    DevRunStageDiagnostic,
+)
+_DIGEST = "sha256:" + ("a" * 64)
+
+
+@pytest_asyncio.fixture
+async def seeded(tmp_path: Path):
+    database = tmp_path / "chaos-3441-record-frame-savepoint.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev", name="Ask Dev"),
+                User(id=user_id, email="ask-dev@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield engine, maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+def _validated_answer(
+    conversation_id: uuid.UUID, answer_id: uuid.UUID
+) -> dict[str, Any]:
+    return {
+        "schema_version": "dev_answer.v1",
+        "answer_id": str(answer_id),
+        "conversation_id": str(conversation_id),
+        "summary": "The evidence-backed answer can be rendered from storage.",
+        "claims": [],
+        "metrics": [],
+        "evidence": [],
+    }
+
+
+def _identity_validator(payload: Any) -> Any:
+    return payload
+
+
+async def _seed_run(
+    maker: async_sessionmaker[AsyncSession],
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="How is Nightfall doing?",
+            scope_snapshot={},
+        )
+        await session.commit()
+        return conversation.id, accepted.run.id
+
+
+def _error_frame(run_id: uuid.UUID):
+    return dev_terminal_frames.build_error_frame(
+        code="scope_not_found",
+        run_id=str(run_id),
+        generated_at=datetime.now(UTC),
+        versions=versions(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_mid_flush_frame_fault_keeps_the_real_answer_row(
+    seeded,
+) -> None:
+    """The real-answer half of the window CHAOS-3441 closes.
+
+    A connection-level failure raised while the frame INSERT is being
+    executed (the ticket's "dropped connection", not a constraint
+    violation) must unwind to ``record_frame``'s SAVEPOINT only: the
+    ``DevAnswer`` transcript row flushed just before it survives, and the
+    outer session stays usable for ``terminal()``'s own ``update_run``
+    write -- with no ``session.rollback()`` in between, which is what
+    ``orchestrator.finish()`` actually does on this path (it deliberately
+    does NOT roll back when a transcript row is already flushed).
+    """
+
+    engine, maker, org_id, user_id = seeded
+    conversation_id, run_id = await _seed_run(maker, org_id, user_id)
+    answer_id = uuid.uuid4()
+
+    fault_armed = {"value": False}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _fail_frame_insert(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if fault_armed["value"] and "INSERT INTO dev_answer_frames" in statement:
+            raise OperationalError(
+                statement, parameters, Exception("simulated dropped connection")
+            )
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            answer_payload=_validated_answer(conversation_id, answer_id),
+            validator=_identity_validator,
+            scope_snapshot={},
+        )
+
+        frame = _error_frame(run_id)
+        fault_armed["value"] = True
+        with pytest.raises(OperationalError):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(frame.frame_id),
+                public_outcome=frame.public_outcome.value,
+                payload=frame.model_dump(mode="json"),
+            )
+        fault_armed["value"] = False
+
+        # The outer session is NOT rollback-only: terminal()'s write lands
+        # without a rollback() call and without PendingRollbackError.
+        run = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="completed",
+            answer_id=answer_id,
+            provider_source="platform",
+            provider_fingerprint=_DIGEST,
+            model_fingerprint=_DIGEST,
+            prompt_version="dev-system.v1",
+            tool_contract_version="dev-tools.v1",
+            metric_version="metric-registry.v1",
+            query_version="dev-query.v1",
+        )
+        assert run is not None
+        await session.commit()
+
+    async with maker() as reader:
+        rows = (
+            await reader.scalars(
+                select(DevMessage).where(
+                    DevMessage.conversation_id == conversation_id,
+                    DevMessage.role == "assistant",
+                )
+            )
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].answer_id == answer_id
+        run_row = await reader.get(DevRun, run_id)
+        assert run_row is not None
+        assert run_row.state == "completed"
+        assert (
+            await reader.scalar(
+                select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
+            )
+        ) is None
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_failed_frame_write_never_leaks_a_v2_contract_tag(
+    seeded,
+) -> None:
+    """The ORM half of "rolls back only the frame write" -- an invariant
+    lock, honestly labelled: the suspected leak it was written to catch does
+    not exist (see this module's docstring).
+
+    ``record_frame`` tags its owned run (``contract_generation = 'v2'``,
+    ``public_outcome``) inside the SAVEPOINT, as in-Python mutations on a
+    persistent object. A savepoint rollback restores the database, and
+    SQLAlchemy additionally expires what the failed flush touched, so the
+    next flush on the outer session does not re-emit those tags: no run is
+    committed as v2, with a ``public_outcome``, and no frame row -- the
+    inconsistency migration 0074's downgrade guard exists to detect. This
+    test pins that end state so a future rework of the savepoint (or of the
+    flush-error handling it relies on) cannot reintroduce it silently; it
+    fails today if ``record_frame``'s ``begin_nested`` is removed.
+    """
+
+    _engine, maker, org_id, user_id = seeded
+    _conversation_id, run_id = await _seed_run(maker, org_id, user_id)
+    frame = _error_frame(run_id)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        # A conflicting frame row for the SAME run, written directly (never
+        # through record_frame, which would tag the run itself) so the
+        # failing call below is the FIRST one to touch those tags. The
+        # payload is a real, contract-valid frame: the session's own
+        # flush-time payload guard rejects anything less.
+        squatter = dev_terminal_frames.build_error_frame(
+            code="internal_error",
+            run_id=str(run_id),
+            generated_at=datetime.now(UTC),
+            versions=versions(),
+        )
+        session.add(
+            DevAnswerFrame(
+                run_id=run_id,
+                org_id=org_id,
+                user_id=user_id,
+                frame_id=uuid.UUID(squatter.frame_id),
+                public_outcome=squatter.public_outcome.value,
+                payload=squatter.model_dump(mode="json"),
+            )
+        )
+        await session.flush()
+
+        with pytest.raises(IntegrityError):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(frame.frame_id),
+                public_outcome=frame.public_outcome.value,
+                payload=frame.model_dump(mode="json"),
+            )
+
+        run = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="failed",
+            safe_error_code="scope_not_found",
+        )
+        assert run is not None
+        await session.commit()
+
+    async with maker() as reader:
+        run_row = await reader.get(DevRun, run_id)
+        assert run_row is not None
+        assert run_row.state == "failed"
+        # The frame write failed, so its run tags must never have landed.
+        assert run_row.contract_generation == "v1"
+        assert run_row.public_outcome is None

--- a/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+++ b/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
@@ -49,7 +49,7 @@ from typing import Any
 import pytest
 import pytest_asyncio
 from sqlalchemy import event, select, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, PendingRollbackError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.dev import terminal_frames as dev_terminal_frames
@@ -679,4 +679,89 @@ async def test_chaos_3441_transcript_writes_leave_no_unflushed_state(
                 question="And a fresh submission on the same conversation?",
                 scope_snapshot={},
             ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_a_poisoned_session_has_already_lost_its_rows(
+    seeded,
+) -> None:
+    """Evidence for the one design decision this ticket declines to change:
+    ``orchestrator.finish()`` keeping its ``rollback()`` on the
+    no-transcript-row branch (Codex adversarial review rounds 1-3, MEDIUM).
+
+    The objection is that the rollback discards the run's already-flushed
+    forensic rows -- diagnostics, tool calls, the resolution ledger -- and
+    that one failure in a non-savepointed telemetry write is enough to reach
+    it, not two. The first half is true and is now stated in that handler.
+    The second half does not cost anything, and this is why: once a write
+    outside a savepoint fails mid-flush, the transaction cannot commit at
+    all, so every row already flushed on it is gone whether or not anyone
+    calls rollback. The rollback only destroys rows with a future in the
+    other case -- a HEALTHY session, which needs record_error_message and
+    record_frame to fail independently inside their own savepoints.
+
+    Asserted here on the real thing: a stage diagnostic flushed, then a
+    non-savepointed telemetry write failing mid-flush, then a commit that
+    cannot happen and a database with nothing in it.
+    """
+
+    _engine, maker, org_id, user_id = seeded
+    _conversation_id, run_id = await _seed_run(maker, org_id, user_id)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        await service.append_stage_diagnostic(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=1,
+            stage_id="resolving_subjects",
+            status="completed",
+            latency_ms=12,
+            counts={"candidates": 3},
+        )
+
+        # A second, later diagnostic fails at the database. append_stage_
+        # diagnostic is NOT savepoint-isolated, so this poisons the session.
+        await session.execute(
+            text(
+                """
+                CREATE TRIGGER chaos_3441_diagnostic_fault
+                BEFORE INSERT ON dev_run_stage_diagnostics
+                WHEN NEW.ordinal = 2
+                BEGIN
+                    SELECT RAISE(ABORT, 'simulated diagnostic storage failure');
+                END
+                """
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await service.append_stage_diagnostic(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                ordinal=2,
+                stage_id="planning",
+                status="completed",
+                latency_ms=8,
+                counts={},
+            )
+
+        # No rollback() called here, deliberately: the point is that the
+        # rows are already lost without one.
+        with pytest.raises(PendingRollbackError):
+            await session.commit()
+
+    async with maker() as reader:
+        diagnostics = (
+            await reader.scalars(
+                select(DevRunStageDiagnostic).where(
+                    DevRunStageDiagnostic.run_id == run_id
+                )
+            )
+        ).all()
+        assert diagnostics == [], (
+            "a poisoned transaction cannot commit, so the rows flushed on it "
+            "were already lost before anything called rollback()"
         )

--- a/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
+++ b/tests/api/dev/test_chaos_3441_record_frame_savepoint.py
@@ -29,6 +29,7 @@ already proves the NO-ANSWER path survives a real duplicate-insert
 
 from __future__ import annotations
 
+import sqlite3
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -36,12 +37,15 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import event, select
-from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy import event, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.dev import terminal_frames as dev_terminal_frames
-from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.api.dev.persistence import (
+    DevPersistenceService,
+    DevPersistenceValidationError,
+)
 from dev_health_ops.models.dev_persistence import (
     DevAnswerFrame,
     DevConversation,
@@ -149,6 +153,32 @@ async def _seed_run(
         return conversation.id, accepted.run.id
 
 
+_FRAME_INSERT_FAULT = """
+CREATE TRIGGER chaos_3441_frame_insert_fault
+BEFORE INSERT ON dev_answer_frames
+BEGIN
+    SELECT RAISE(ABORT, 'simulated storage failure on the frame insert');
+END
+"""
+
+
+async def _arm_frame_insert_fault(session: AsyncSession) -> None:
+    """Make the database itself reject the frame INSERT, and nothing else.
+
+    A trigger is used rather than a listener that raises before the driver
+    runs (which proves only SQLAlchemy's plumbing -- Codex adversarial
+    review round 1) and rather than a blanket ``PRAGMA query_only`` (which
+    also fails unrelated statements, including the savepoint-entry flush,
+    so the test would stop being about the frame write at all).
+    """
+
+    await session.execute(text(_FRAME_INSERT_FAULT))
+
+
+async def _disarm_frame_insert_fault(session: AsyncSession) -> None:
+    await session.execute(text("DROP TRIGGER chaos_3441_frame_insert_fault"))
+
+
 def _error_frame(run_id: uuid.UUID):
     return dev_terminal_frames.build_error_frame(
         code="scope_not_found",
@@ -164,35 +194,33 @@ async def test_chaos_3441_mid_flush_frame_fault_keeps_the_real_answer_row(
 ) -> None:
     """The real-answer half of the window CHAOS-3441 closes.
 
-    A connection-level failure raised while the frame INSERT is being
-    executed (the ticket's "dropped connection", not a constraint
-    violation) must unwind to ``record_frame``'s SAVEPOINT only: the
-    ``DevAnswer`` transcript row flushed just before it survives, and the
-    outer session stays usable for ``terminal()``'s own ``update_run``
-    write -- with no ``session.rollback()`` in between, which is what
-    ``orchestrator.finish()`` actually does on this path (it deliberately
-    does NOT roll back when a transcript row is already flushed).
+    The fault is a genuine database-side rejection of the frame INSERT: a
+    trigger raises ABORT, so the error comes back through the driver from
+    the statement executing inside the savepoint, not from a listener that
+    short-circuits before the driver ever sees it. That distinction is the
+    point -- an earlier version of this test raised a hand-built
+    ``OperationalError`` from ``before_cursor_execute`` and so proved only
+    SQLAlchemy's exception plumbing (Codex adversarial review round 1,
+    HIGH). It is also targeted at that one statement, so the proof cannot
+    quietly become about some other write failing.
+
+    What must hold: the failure unwinds to ``record_frame``'s SAVEPOINT
+    only. The ``DevAnswer`` transcript row flushed just before it survives,
+    and the outer session stays usable for ``terminal()``'s own
+    ``update_run`` write with no ``session.rollback()`` in between -- which
+    is exactly what ``orchestrator.finish()`` does on this path (it
+    deliberately does NOT roll back once a transcript row is flushed).
+
+    What this does NOT claim, since no savepoint could deliver it: survival
+    of a physical connection loss. If the connection dies there is no
+    session left to roll back to a savepoint and an uncommitted row is gone
+    by definition; that case is recovered only by
+    ``force_terminal_fallback``'s fresh session.
     """
 
-    engine, maker, org_id, user_id = seeded
+    _engine, maker, org_id, user_id = seeded
     conversation_id, run_id = await _seed_run(maker, org_id, user_id)
     answer_id = uuid.uuid4()
-
-    fault_armed = {"value": False}
-
-    @event.listens_for(engine.sync_engine, "before_cursor_execute")
-    def _fail_frame_insert(
-        conn: Any,
-        cursor: Any,
-        statement: str,
-        parameters: Any,
-        context: Any,
-        executemany: bool,
-    ) -> None:
-        if fault_armed["value"] and "INSERT INTO dev_answer_frames" in statement:
-            raise OperationalError(
-                statement, parameters, Exception("simulated dropped connection")
-            )
 
     async with maker() as session:
         service = DevPersistenceService(session)
@@ -206,8 +234,9 @@ async def test_chaos_3441_mid_flush_frame_fault_keeps_the_real_answer_row(
         )
 
         frame = _error_frame(run_id)
-        fault_armed["value"] = True
-        with pytest.raises(OperationalError):
+        # The database, not the test harness, refuses the write.
+        await _arm_frame_insert_fault(session)
+        with pytest.raises(IntegrityError) as raised:
             await service.record_frame(
                 org_id=org_id,
                 user_id=user_id,
@@ -216,7 +245,12 @@ async def test_chaos_3441_mid_flush_frame_fault_keeps_the_real_answer_row(
                 public_outcome=frame.public_outcome.value,
                 payload=frame.model_dump(mode="json"),
             )
-        fault_armed["value"] = False
+        # Proof the failure came from the driver executing the INSERT, so
+        # this test cannot silently degrade into asserting on a fault the
+        # harness itself raised.
+        assert isinstance(raised.value.orig, sqlite3.IntegrityError)
+        assert "simulated storage failure on the frame insert" in str(raised.value.orig)
+        await _disarm_frame_insert_fault(session)
 
         # The outer session is NOT rollback-only: terminal()'s write lands
         # without a rollback() call and without PendingRollbackError.
@@ -335,3 +369,256 @@ async def test_chaos_3441_failed_frame_write_never_leaks_a_v2_contract_tag(
         # The frame write failed, so its run tags must never have landed.
         assert run_row.contract_generation == "v1"
         assert run_row.public_outcome is None
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_savepoint_opens_before_the_pre_write_selects(
+    seeded,
+) -> None:
+    """Codex adversarial review round 1 (HIGH, confirmed): the savepoint has
+    to enclose ``record_frame``'s and ``record_narrative``'s PRE-write
+    SELECTs, not only their flush.
+
+    Why the boundary itself is the assertion, rather than a fault-injection:
+    the failure this closes is a server-side statement failure -- a
+    PostgreSQL ``statement_timeout`` firing on the ownership or
+    authorization SELECT -- which aborts the WHOLE transaction, so every
+    later statement fails with ``InFailedSqlTransaction`` and the caller's
+    already-flushed transcript row dies with the commit that can no longer
+    happen. ``ROLLBACK TO SAVEPOINT`` is what makes an aborted PostgreSQL
+    transaction usable again, and it can only do that if the SAVEPOINT was
+    emitted BEFORE the statement that failed. sqlite does not abort a
+    transaction on a failed statement, so a fault-injected test here would
+    pass whether the savepoint enclosed those SELECTs or not -- a test that
+    cannot fail. The statement ORDER is the part sqlite can observe
+    faithfully, and it is exactly the property the fix establishes: this
+    test fails on the pre-fix code, where the SELECTs ran first.
+    """
+
+    engine, maker, org_id, user_id = seeded
+    _conversation_id, run_id = await _seed_run(maker, org_id, user_id)
+    frame = _error_frame(run_id)
+
+    captured: list[str] = []
+    recording = {"on": False}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if recording["on"]:
+            captured.append(" ".join(statement.split()))
+
+    def _first(predicate) -> int:
+        for index, statement in enumerate(captured):
+            if predicate(statement):
+                return index
+        raise AssertionError(f"no statement matched in the captured window: {captured}")
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+
+        recording["on"] = True
+        await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(frame.frame_id),
+            public_outcome=frame.public_outcome.value,
+            payload=frame.model_dump(mode="json"),
+        )
+        recording["on"] = False
+
+        savepoint = _first(lambda s: s.startswith("SAVEPOINT"))
+        ownership_select = _first(lambda s: "FROM dev_runs" in s)
+        frame_insert = _first(lambda s: s.startswith("INSERT INTO dev_answer_frames"))
+        assert savepoint < ownership_select < frame_insert, captured
+
+        # record_narrative's own pre-write SELECTs (run ownership + the
+        # run's recorded frame) must sit inside its savepoint too. A
+        # rejected narrative is enough to exercise them: the SELECTs run
+        # before the payload cross-checks that reject it.
+        captured.clear()
+        recording["on"] = True
+        with pytest.raises(DevPersistenceValidationError):
+            await service.record_narrative(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                narrative_id=uuid.uuid4(),
+                frame_id=uuid.uuid4(),  # not the run's recorded frame
+                mode="deterministic_fallback",
+                provider_fingerprint=None,
+                narrative_text="rejected before any write",
+                payload={},
+            )
+        recording["on"] = False
+
+        narrative_savepoint = _first(lambda s: s.startswith("SAVEPOINT"))
+        narrative_select = _first(lambda s: "FROM dev_runs" in s)
+        frame_lookup = _first(lambda s: "FROM dev_answer_frames" in s)
+        assert narrative_savepoint < narrative_select, captured
+        assert narrative_savepoint < frame_lookup, captured
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_frame_failure_keeps_the_runs_flushed_diagnostics(
+    seeded,
+) -> None:
+    """The ticket's own words: a mid-flush frame failure must leave the outer
+    session usable "for the transcript row + diagnostics".
+
+    The transcript row is covered above; this covers the diagnostics. A
+    stage diagnostic and a tool call are flushed on the outer session (as
+    ``PersistenceRunRecorder`` does throughout a run), then the frame write
+    fails at the driver. Both forensic rows must still commit -- they are
+    the only evidence an operator has for a run that failed here, and
+    nothing re-persists them if they are lost.
+    """
+
+    _engine, maker, org_id, user_id = seeded
+    _conversation_id, run_id = await _seed_run(maker, org_id, user_id)
+    frame = _error_frame(run_id)
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        await service.append_stage_diagnostic(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=1,
+            stage_id="resolving_subjects",
+            status="completed",
+            latency_ms=12,
+            counts={"candidates": 3},
+        )
+        await service.append_tool_call(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=1,
+            tool_id="team_workload",
+            tool_version="dev-tools.v1",
+            canonical_input_hash=_DIGEST,
+            safe_scope_summary={"teams": 1},
+            status="completed",
+            latency_ms=34,
+            row_count=7,
+        )
+
+        await _arm_frame_insert_fault(session)
+        with pytest.raises(IntegrityError):
+            await service.record_frame(
+                org_id=org_id,
+                user_id=user_id,
+                run_id=run_id,
+                frame_id=uuid.UUID(frame.frame_id),
+                public_outcome=frame.public_outcome.value,
+                payload=frame.model_dump(mode="json"),
+            )
+        await _disarm_frame_insert_fault(session)
+
+        run = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="failed",
+            safe_error_code="internal_error",
+        )
+        assert run is not None
+        await session.commit()
+
+    async with maker() as reader:
+        diagnostics = (
+            await reader.scalars(
+                select(DevRunStageDiagnostic).where(
+                    DevRunStageDiagnostic.run_id == run_id
+                )
+            )
+        ).all()
+        tool_calls = (
+            await reader.scalars(
+                select(DevToolCall).where(DevToolCall.run_id == run_id)
+            )
+        ).all()
+        assert [d.stage_id for d in diagnostics] == ["resolving_subjects"]
+        assert [c.tool_id for c in tool_calls] == ["team_workload"]
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_transcript_writes_leave_no_unflushed_state(
+    seeded,
+) -> None:
+    """A savepoint cannot protect a write that is flushed outside it, and
+    that is what unflushed state guarantees.
+
+    ``SessionTransaction._take_snapshot()`` flushes the session's pending
+    state BEFORE emitting the SAVEPOINT (sqlalchemy/orm/session.py), so any
+    dirty attribute a persistence method leaves behind is emitted by the
+    NEXT operation's savepoint entry -- outside every savepoint. The
+    transcript writes all touch their conversation (``updated_at``, and the
+    30-day ``expires_at``), and that mutation used to be made after their
+    savepoint block: the resulting ``UPDATE dev_conversations`` was carried
+    into ``record_frame``'s savepoint-entry flush, where a server-side
+    failure on it poisons the session and destroys the transcript row that
+    had just been flushed -- this ticket's exact loss, via a statement
+    nobody was looking at. Found while building the fault injection for the
+    test above, which failed for precisely this reason.
+
+    Two assertions, because either alone is weak: the conversation UPDATE
+    lands INSIDE the savepoint (statement order), and the method returns
+    with nothing dirty left for someone else's savepoint entry to flush.
+    """
+
+    engine, maker, org_id, user_id = seeded
+    conversation_id, _run_id = await _seed_run(maker, org_id, user_id)
+    answer_id = uuid.uuid4()
+
+    captured: list[str] = []
+    recording = {"on": False}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        if recording["on"]:
+            captured.append(" ".join(statement.split()))
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        recording["on"] = True
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            answer_payload=_validated_answer(conversation_id, answer_id),
+            validator=_identity_validator,
+            scope_snapshot={},
+        )
+        recording["on"] = False
+
+        savepoint = next(i for i, s in enumerate(captured) if s.startswith("SAVEPOINT"))
+        release = next(
+            i for i, s in enumerate(captured) if s.startswith("RELEASE SAVEPOINT")
+        )
+        conversation_update = next(
+            i
+            for i, s in enumerate(captured)
+            if s.startswith("UPDATE dev_conversations")
+        )
+        assert savepoint < conversation_update < release, captured
+
+        # Nothing is left for the next savepoint entry to flush outside its
+        # own savepoint.
+        assert not session.dirty, session.dirty
+        assert not session.new, session.new

--- a/tests/api/dev/test_persistence.py
+++ b/tests/api/dev/test_persistence.py
@@ -1075,6 +1075,13 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
     async with maker() as session2:
         service2 = DevPersistenceService(session2)
         stamped = await service2.backfill_stranded_ephemeral_expiry(limit=10)
+        # CHAOS-3441 Codex adversarial review round 3 (MEDIUM, confirmed):
+        # the stamp must be flushed before returning, not left dirty for
+        # whatever this session does next. Unflushed state is emitted by the
+        # NEXT operation's savepoint entry -- before the SAVEPOINT is
+        # emitted, so outside it -- where a failure poisons the whole
+        # transaction and takes unrelated already-flushed rows with it.
+        assert not session2.dirty, session2.dirty
         await session2.commit()
     assert stamped == 1
 

--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -163,10 +163,39 @@ def _session_level_payload_guards_disabled():
         event.listen(Session, "do_orm_execute", on_bulk_dml)
 
 
-pytestmark = pytest.mark.skipif(
-    not os.getenv(_POSTGRES_URI_ENV),
-    reason=f"requires {_POSTGRES_URI_ENV}",
-)
+def _require_postgres_test_uri() -> None:
+    """Same contract as ``tests/api/admin/test_add_member_visibility.py``'s
+    ``_require_postgres_test_uri`` (CHAOS-3411): skip locally when the URI is
+    not configured, but hard-``pytest.fail`` under CI.
+
+    This module used a plain module-level ``skipif`` (CHAOS-3441 Codex round 1
+    follow-up), which is the same silent-skip trap CHAOS-3411 closed for its
+    own module, and it had been open here the whole time: the PR-gated unit
+    step (`.github/workflows/test.yml`, "Run parallel unit test contract")
+    never sets this URI, the PR-gated "Run PostgreSQL migration tests" step
+    named four files and not this one, and the only job that does set it
+    (`coverage`) is gated `if: github.event_name != 'pull_request'`. So all
+    of this module took the skip branch on every PR -- not just CHAOS-3441's
+    two savepoint proofs, but the CHAOS-3297/3325 duplicate-key and NUL-alias
+    trigger proofs that have guarded the payload contract since they landed.
+    A stripped commit would have passed the required gate. Missing coverage
+    under CI must be a loud failure, not a silent pass -- and the module is
+    now named in that step's file list so CI genuinely runs it.
+    """
+
+    if os.getenv(_POSTGRES_URI_ENV):
+        return
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        pytest.fail(
+            f"{_POSTGRES_URI_ENV} must be configured for the Ask Dev "
+            "persistence PostgreSQL proofs"
+        )
+    pytest.skip(f"requires {_POSTGRES_URI_ENV}")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def require_postgres_test_uri() -> None:
+    _require_postgres_test_uri()
 
 
 @pytest_asyncio.fixture

--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -1482,3 +1482,127 @@ async def test_chaos_3441_savepoint_recovers_an_aborted_transaction(
                 select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
             )
         ) is None
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_narrative_savepoint_recovers_an_aborted_transaction(
+    postgres_persistence: tuple[
+        async_sessionmaker[AsyncSession], AsyncEngine, uuid.UUID, uuid.UUID
+    ],
+) -> None:
+    """The same proof for ``record_narrative`` (Codex adversarial review
+    round 3: the frame proof did not cover it).
+
+    A narrative failure is the worst place to lose the outer transaction --
+    by the time it runs, the transcript row AND the frame are already
+    flushed on it -- so its savepoint has to open before its own ownership
+    and frame-lookup SELECTs, and be able to recover a transaction the
+    server has aborted. Fault injected into the frame-lookup SELECT this
+    time, so the proof covers a different statement than the frame test.
+    """
+
+    maker, engine, org_id, user_id = postgres_persistence
+    fault_armed = {"value": False}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute", retval=True)
+    def _abort_the_frame_lookup(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> tuple[str, Any]:
+        if (
+            fault_armed["value"]
+            and statement.lstrip().upper().startswith("SELECT")
+            and "FROM dev_answer_frames" in statement
+        ):
+            return statement + " AND 1 / 0 = 0", parameters
+        return statement, parameters
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="What is the status of this project?",
+            scope_snapshot={},
+        )
+        await session.commit()
+        run_id = accepted.run.id
+
+        frame_payload = _frame_payload(run_id=run_id, outcome="not_found")
+        frame = await service.record_frame(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            frame_id=uuid.UUID(frame_payload["frame_id"]),
+            public_outcome="not_found",
+            payload=frame_payload,
+        )
+
+        narrative_id = uuid.uuid4()
+        narrative_payload: dict[str, Any] = {
+            "schema_version": "dev_narrative.v1",
+            "narrative_id": str(narrative_id),
+            "run_id": str(run_id),
+            "frame_id": str(frame.frame_id),
+            "mode": "deterministic_fallback",
+            "referenced_fact_ids": [],
+            "referenced_section_ids": [],
+            "provider_metadata": None,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "validation_warnings": [],
+        }
+
+        fault_armed["value"] = True
+        try:
+            with pytest.raises(DBAPIError) as raised:
+                await service.record_narrative(
+                    org_id=org_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    narrative_id=narrative_id,
+                    frame_id=frame.frame_id,
+                    mode="deterministic_fallback",
+                    provider_fingerprint=None,
+                    narrative_text="A safe presentation summary.",
+                    payload=narrative_payload,
+                )
+        finally:
+            fault_armed["value"] = False
+        assert "division by zero" in str(raised.value.orig).lower()
+
+        run = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="failed",
+            safe_error_code="scope_not_found",
+        )
+        assert run is not None
+        await session.commit()
+
+    async with maker() as reader:
+        # The frame flushed before the aborted narrative call survives, and
+        # its run reached a terminal state on the same session.
+        surviving = await reader.scalar(
+            select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
+        )
+        assert surviving is not None
+        assert surviving.frame_id == frame.frame_id
+        assert (
+            await reader.scalar(
+                select(DevRunNarrative).where(DevRunNarrative.run_id == run_id)
+            )
+        ) is None
+        run_row = await reader.get(DevRun, run_id)
+        assert run_row is not None
+        assert run_row.state == "failed"
+        assert run_row.contract_generation == "v2"

--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -1318,3 +1318,167 @@ async def test_postgres_already_rejects_nul_alias_narrative_update(
         reloaded = await session.get(DevRunNarrative, narrative_pk)
         assert reloaded is not None
         assert reloaded.narrative_text == narrative_text
+
+
+@pytest.mark.asyncio
+async def test_chaos_3441_savepoint_recovers_an_aborted_transaction(
+    postgres_persistence: tuple[
+        async_sessionmaker[AsyncSession], AsyncEngine, uuid.UUID, uuid.UUID
+    ],
+) -> None:
+    """CHAOS-3441 Codex adversarial review rounds 1-2 (HIGH): the real proof,
+    on the real engine.
+
+    The failure this ticket closes is PostgreSQL-specific and sqlite cannot
+    express it: a server-side error on ANY statement aborts the whole
+    transaction, so every later statement raises ``InFailedSqlTransaction``
+    and the caller's already-flushed transcript row dies with the commit that
+    can no longer happen. ``ROLLBACK TO SAVEPOINT`` is what makes an aborted
+    transaction usable again, and it can only do that if the SAVEPOINT was
+    emitted BEFORE the failing statement. The sqlite suite can only observe
+    statement ORDER
+    (``test_chaos_3441_savepoint_opens_before_the_pre_write_selects``); this
+    test observes the semantics.
+
+    The fault is injected into ``record_frame``'s own ownership SELECT --
+    the statement that used to run outside the savepoint -- by rewriting it
+    into one PostgreSQL rejects server-side (a division by zero). The server
+    raises it, not the test harness, and the transaction is genuinely
+    aborted. What must survive: the ``DevAnswer`` transcript row and the
+    stage diagnostic flushed before the call, plus a usable session for
+    ``terminal()``'s own ``update_run``.
+    """
+
+    maker, engine, org_id, user_id = postgres_persistence
+    answer_id = uuid.uuid4()
+
+    fault_armed = {"value": False}
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute", retval=True)
+    def _abort_the_ownership_select(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> tuple[str, Any]:
+        if (
+            fault_armed["value"]
+            and statement.lstrip().upper().startswith("SELECT")
+            and "FROM dev_runs" in statement
+        ):
+            # Still a real statement the server parses, plans and REJECTS --
+            # not an exception raised in-process before the driver runs.
+            return statement + " AND 1 / 0 = 0", parameters
+        return statement, parameters
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="What is the status of this project?",
+            scope_snapshot={},
+        )
+        await session.commit()
+        run_id = accepted.run.id
+
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            answer_payload={
+                "schema_version": "dev_answer.v1",
+                "answer_id": str(answer_id),
+                "conversation_id": str(conversation.id),
+                "summary": "The evidence-backed answer can be rendered from storage.",
+                "claims": [],
+                "metrics": [],
+                "evidence": [],
+            },
+            validator=lambda payload: payload,
+            scope_snapshot={},
+        )
+        await service.append_stage_diagnostic(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            ordinal=1,
+            stage_id="resolving_subjects",
+            status="completed",
+            latency_ms=12,
+            counts={"candidates": 3},
+        )
+
+        payload = _frame_payload(run_id=run_id, outcome="not_found")
+        fault_armed["value"] = True
+        try:
+            with pytest.raises(DBAPIError) as raised:
+                await service.record_frame(
+                    org_id=org_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    frame_id=uuid.UUID(payload["frame_id"]),
+                    public_outcome="not_found",
+                    payload=payload,
+                )
+        finally:
+            fault_armed["value"] = False
+        assert "division by zero" in str(raised.value.orig).lower()
+
+        # The transaction was aborted by the server and recovered by the
+        # savepoint: this write lands with no session.rollback() in between,
+        # exactly as orchestrator.finish() proceeds after a frame failure.
+        run = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="completed",
+            answer_id=answer_id,
+            provider_source="platform",
+            provider_fingerprint="sha256:" + ("a" * 64),
+            model_fingerprint="sha256:" + ("a" * 64),
+            prompt_version="dev-system.v1",
+            tool_contract_version="dev-tools.v1",
+            metric_version="metric-registry.v1",
+            query_version="dev-query.v1",
+        )
+        assert run is not None
+        await session.commit()
+
+    async with maker() as reader:
+        messages = (
+            await reader.scalars(
+                select(DevMessage).where(
+                    DevMessage.conversation_id == conversation.id,
+                    DevMessage.role == "assistant",
+                )
+            )
+        ).all()
+        assert [m.answer_id for m in messages] == [answer_id], (
+            "the flushed transcript row must survive a server-aborted "
+            "transaction inside record_frame"
+        )
+        diagnostics = (
+            await reader.scalars(
+                select(DevRunStageDiagnostic).where(
+                    DevRunStageDiagnostic.run_id == run_id
+                )
+            )
+        ).all()
+        assert [d.stage_id for d in diagnostics] == ["resolving_subjects"]
+        run_row = await reader.get(DevRun, run_id)
+        assert run_row is not None
+        assert run_row.state == "completed"
+        assert run_row.contract_generation == "v1"
+        assert (
+            await reader.scalar(
+                select(DevAnswerFrame).where(DevAnswerFrame.run_id == run_id)
+            )
+        ) is None

--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -1,4 +1,16 @@
-"""Live PostgreSQL proofs for Ask Dev submission admission."""
+"""Live PostgreSQL proofs for Ask Dev submission admission.
+
+Point ``DEV_HEALTH_POSTGRES_TEST_URI`` at a SCRATCH database when running this
+module locally -- never at the dev ``devhealth`` database. The fixture isolates
+itself with ``CREATE SCHEMA`` and drops it on teardown, but a teardown that
+does not complete leaves that schema and its tables behind: one such orphan
+(``ask_dev_admission_005af009e3ae4442bc8c0f2d3b4e4b0b``, 5 tables) was found
+sitting in ``devhealth`` on 2026-08-06, and the fixture's own teardown comment
+explains why it can be left there -- a leaked session holding ACCESS SHARE
+makes ``DROP SCHEMA ... CASCADE`` wait, and there is no server-side timeout by
+default. In CI the target is a throwaway service container, so a leak costs
+nothing; on a dev box it accumulates in the database holding real data.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## CHAOS-3441 — a mid-flush failure in `record_frame` must not drop the transcript row

The ticket's stated fix — a SAVEPOINT around `record_frame`/`record_narrative` — was **already on main**, landed inline by #1507 (CHAOS-3423/3424). Two things were nevertheless still broken, and both are the ticket's own failure: **the savepoint's boundary was in the wrong place**, and **a second statement was escaping every savepoint entirely**.

### 1. The savepoint wrapped the flush, not the statements before it

`record_frame` and `record_narrative` ran their ownership and authorization SELECTs *outside* the savepoint. On PostgreSQL a server-side failure on **any** statement aborts the whole transaction — a `statement_timeout` on one of those SELECTs is the realistic case — after which every later statement raises `InFailedSqlTransaction` and the already-flushed transcript row, diagnostics and tool calls die with the commit that can no longer happen. `ROLLBACK TO SAVEPOINT` is what recovers an aborted transaction, and only for statements issued after the SAVEPOINT.

Both savepoints now open before their first statement.

### 2. `_touch` was flushed outside every savepoint

`SessionTransaction._take_snapshot()` flushes the session's pending state **before** emitting the SAVEPOINT. The three transcript writes left their conversation `_touch` dirty, so that `UPDATE dev_conversations` was carried into the *next* operation's savepoint entry — outside every savepoint. A failure there poisons the session and destroys the transcript row just flushed: this ticket's exact loss, reached by a statement nobody was looking at. Found while building the fault injection, which failed for precisely this reason.

Each transcript write now touches its conversation inside its own savepoint (its own, not the row-write savepoint — folding it in would expire the caller's conversation object on the idempotent-duplicate path). `backfill_stranded_ephemeral_expiry` was a third instance of the same pattern and now flushes before returning.

## Evidence

The semantics are PostgreSQL-specific and sqlite cannot express them, so the proofs are split deliberately:

| Proof | Engine | What it observes |
| --- | --- | --- |
| `test_chaos_3441_savepoint_recovers_an_aborted_transaction` | **PostgreSQL 17** | `record_frame`'s own ownership SELECT rewritten into one the server rejects → transaction genuinely aborted → transcript row, stage diagnostic and `update_run` all survive |
| `test_chaos_3441_narrative_savepoint_recovers_an_aborted_transaction` | **PostgreSQL 17** | same for `record_narrative`, fault on its frame-lookup SELECT |
| `test_chaos_3441_savepoint_opens_before_the_pre_write_selects` | sqlite | statement order: SAVEPOINT precedes the SELECTs (the only part sqlite can show faithfully) |
| `test_chaos_3441_mid_flush_frame_fault_keeps_the_real_answer_row` | sqlite | the **real-answer** path (a flushed `DevAnswer`), which had no coverage at all, under a database-side rejection of the frame INSERT |
| `test_chaos_3441_transcript_writes_leave_no_unflushed_state` | sqlite | all three writes: the conversation UPDATE sits between a SAVEPOINT and its RELEASE, and nothing is dirty on return |
| `test_chaos_3441_frame_failure_keeps_the_runs_flushed_diagnostics` | sqlite | the ticket's "+ diagnostics" clause |
| `test_chaos_3441_a_poisoned_session_has_already_lost_its_rows` | sqlite | evidence for the one decision declined below |

**Mutation-checked, green → red → green, every restore verified by content digest (never by a build or `git`):**

- remove `record_frame`'s `begin_nested` → 5 sqlite tests + the existing CHAOS-3423 integrity test + both PostgreSQL proofs fail
- move the savepoint back after the ownership SELECT → **only** the boundary test and the PostgreSQL proof fail
- hoist `record_narrative`'s SELECT out → the narrative PostgreSQL proof fails with `InFailedSQLTransactionError`
- `_touch` back outside its savepoint → **only** the unflushed-state guard fails
- drop the backfill's flush → **only** the backfill test fails

## Two things stated rather than claimed closed

- **A physical connection loss is out of reach of any savepoint.** No session left to roll back; an uncommitted row is lost by definition. `force_terminal_fallback`'s fresh session remains the system-level recovery.
- **`finish()`'s `rollback()` on the no-transcript-row branch is kept, deliberately.** Its comment now states both sides: the forensic-row loss only costs anything on a *healthy* session (two independent failures), while in the poisoned case those rows are already unrecoverable and the rollback buys back a specific user-visible terminal instead of a generic `internal_error`. Codex challenged this in all three rounds; the disagreement is recorded with the test that settles it.

**Adjacent gap filed as CHAOS-3476:** none of the telemetry writes (`record_run_diagnostics`, `append_tool_call`, `append_resolution`, `record_subject_set`, `record_intent`, …) is savepoint-isolated, so one mid-flush failure there still erases a run's whole evidence set.

## Also corrected

Three comments asserted the mid-flush window was an open residual requiring "SAVEPOINT-wrapping `record_frame`/`record_narrative`, out of this ticket's scope" — false since #1507, and the kind of stale claim a reader stops checking behind. One claim of my own from round 1 ("no failure `record_frame` can raise leaves this session rollback-only") was too broad and is narrowed to the caller-side invariant that now actually holds.

One hypothesis was **refuted and reported as such**: the run tags (`contract_generation='v2'`, `public_outcome`) are mutated inside the savepoint on a persistent object, and I expected them to survive its rollback and commit a v2-tagged run with no frame row. They do not — SQLAlchemy expires what the failed flush touched. That test is labelled an invariant lock, not a bug fix.

Three Codex adversarial-review rounds; every medium-or-higher finding validated with evidence before being fixed or declined.

## The proofs above did not actually run in CI — now they do

Worth stating separately, because it is a material hardening beyond this ticket and it was **pre-existing**: every test in `tests/api/dev/test_persistence_postgres.py` silently skipped on `pull_request`. Not only this branch's two savepoint proofs — also the **CHAOS-3297/3325 duplicate-key and NUL-alias trigger proofs**, which have been guarding the payload contract since they landed and have never once been PR-enforced. A commit that stripped them would have passed the required gate.

The mechanism, since "CI sets the URI" is true and still not sufficient — env is per *step*, and pytest only runs the files it is given:

- the PR-gated unit step (`Run parallel unit test contract`) does not set `DEV_HEALTH_POSTGRES_TEST_URI`, and the module was collected there, so its module-level `skipif` skipped all 15;
- the PR-gated `Run PostgreSQL migration tests` step *does* set the URI, but its `run:` named four files and not this one;
- the only job setting it for a whole run, `coverage`, is gated `if: github.event_name != 'pull_request'` — and per the CHAOS-3413 comment above it, that job has hung and been auto-cancelled for days, with `cancelled` not counting as red;
- `grep -c test_persistence_postgres .github/workflows/test.yml` → `0`.

This is the identical trap CHAOS-3411 closed for `tests/api/admin/test_add_member_visibility.py`, and it was fixed the same way — plus the loud-fail half, so it cannot silently reopen:

1. the module is named in the PR-gated PostgreSQL step's file list;
2. its `skipif` becomes the repo's `require_postgres_test_uri` contract — skip locally, **`pytest.fail`** when `CI`/`GITHUB_ACTIONS` is set and the URI is absent;
3. the unit tier, which legitimately has no URI, ignores the module alongside its three siblings.

Verified as a guard *failing*, not merely present: `CI=1` with no URI now fails with the configured message, where the pre-change gating reported `15 skipped`. URI-less and non-CI still skips, so the local gate stays green. The expanded five-file step command runs green against a real PostgreSQL 17 — 28 passed.
