### PR TITLE
feat(providersync): durable prepared-manifest recovery for github/work-items (CHAOS-3123)

### DIFF
--- a/docker/init-extra-dbs.sh
+++ b/docker/init-extra-dbs.sh
@@ -87,6 +87,12 @@ psql \
       WHERE to_regclass(format('public.%I', required.table_name)) IS NOT NULL
     \gexec
     SELECT format(
+      'GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO %I',
+      :'domain_role'
+    )
+      WHERE to_regclass('public.sync_run_unit_effect_snapshots') IS NOT NULL
+    \gexec
+    SELECT format(
       'GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks TO %I',
       :'domain_role'
     )

--- a/internal/domaingrants/groundtruth_test.go
+++ b/internal/domaingrants/groundtruth_test.go
@@ -78,6 +78,32 @@ func TestLoadGroundTruth_MatchesKnownShape(t *testing.T) {
 		t.Errorf("required: worker_job_outbox = %+v, want SELECT+INSERT only", set)
 	}
 
+	// sync_run_unit_effect_snapshots pins all four privileges, ABSENCE
+	// included. The count pin below cannot see a privilege change -- adding
+	// UPDATE to this tuple leaves every other assertion in this file green --
+	// and the grants-vs-posture divergence check is advisory by design. The
+	// no-UPDATE property is load-bearing: PostgreSQL treats FOR UPDATE and
+	// FOR SHARE as UPDATE-class privileges, so granting UPDATE here would
+	// silently re-enable the row-locking clause that broke every re-prepare
+	// in production. It must be pinned in the posture, not only in migrate.go
+	// and the provisioning scripts.
+	snapshots := gt.RequiredTablePrivileges["sync_run_unit_effect_snapshots"]
+	if !snapshots.Has(PrivSelect) || !snapshots.Has(PrivInsert) ||
+		!snapshots.Has(PrivDelete) || snapshots.Has(PrivUpdate) {
+		t.Errorf(
+			"required: sync_run_unit_effect_snapshots = %+v, want SELECT+INSERT+DELETE and NOT UPDATE",
+			snapshots,
+		)
+	}
+	snapshotGrants := gt.Grants["sync_run_unit_effect_snapshots"]
+	if !snapshotGrants.Has(PrivSelect) || !snapshotGrants.Has(PrivInsert) ||
+		!snapshotGrants.Has(PrivDelete) || snapshotGrants.Has(PrivUpdate) {
+		t.Errorf(
+			"grants: sync_run_unit_effect_snapshots = %+v, want SELECT+INSERT+DELETE and NOT UPDATE",
+			snapshotGrants,
+		)
+	}
+
 	// DELETE is an ordinary privilege since Phase 2 added AllowDelete to the
 	// posture; these tables used to be reported as permanently unrepresentable.
 	for _, table := range []string{"dev_conversations", "external_ingest_batch_payloads", "provider_rate_limit_observations"} {

--- a/internal/domaingrants/groundtruth_test.go
+++ b/internal/domaingrants/groundtruth_test.go
@@ -105,12 +105,12 @@ func TestLoadGroundTruth_MatchesKnownShape(t *testing.T) {
 		}
 	}
 
-	if len(gt.RequiredTablePrivileges) != 34 {
-		t.Errorf("domain posture: got %d tables, want 34 (Option B two-role split) -- "+
+	if len(gt.RequiredTablePrivileges) != 35 {
+		t.Errorf("domain posture: got %d tables, want 35 (Option B two-role split) -- "+
 			"if this changed intentionally, the ground-truth reader is fine, just update this pin", len(gt.RequiredTablePrivileges))
 	}
-	if len(gt.Grants) != 34 {
-		t.Errorf("runtimeGrantStatements: got %d granted tables, want 34 -- see note above", len(gt.Grants))
+	if len(gt.Grants) != 35 {
+		t.Errorf("runtimeGrantStatements: got %d granted tables, want 35 -- see note above", len(gt.Grants))
 	}
 	// The two lists agreeing on their size is the property that matters most
 	// here: this checker exists because they disagreed once.

--- a/internal/providersync/complete_route.go
+++ b/internal/providersync/complete_route.go
@@ -177,6 +177,17 @@ func (executor CompleteRouteExecutor) Execute(
 			}
 		}
 		if recoveredEffects != nil && descriptor.PreparedManifestRecovery {
+			// Contract point 7. New workers may continue an existing route from
+			// a legacy v1 ledger, but a route that requires prepared recovery
+			// must never resume from a document written before that contract
+			// existed. Both decoders below also refuse it; the policy belongs
+			// here, where the route declares the requirement, rather than
+			// surviving only as a side effect of two independent decoders that
+			// a later change could relax one at a time.
+			if recoveredEffects.SchemaVersion != "v2" ||
+				recoveredEffects.PreparedSnapshot == nil {
+				return ErrEffectRecoveryUnsafe
+			}
 			manifest, err := preparedLedger.LoadRouteSnapshot(
 				workContext, session.Claim, *recoveredEffects, executor.now(),
 			)

--- a/internal/providersync/complete_route.go
+++ b/internal/providersync/complete_route.go
@@ -140,11 +140,61 @@ func (executor CompleteRouteExecutor) Execute(
 		(executor.Committer.Ledger == nil || executor.Committer.Sink == nil) {
 		return CompleteRouteExecutionResult{}, ErrInvalidConfiguration
 	}
+	if descriptor.PreparedManifestRecovery &&
+		(descriptor.Provider != "github" || descriptor.RouteDataset != "work-items") {
+		return CompleteRouteExecutionResult{}, ErrInvalidConfiguration
+	}
+	preparedLedger, preparedRecovery := executor.Committer.Ledger.(PreparedEffectLedger)
+	if descriptor.RouteEnabled && descriptor.PreparedManifestRecovery && !preparedRecovery {
+		return CompleteRouteExecutionResult{}, ErrInvalidConfiguration
+	}
 	var result CompleteRouteExecutionResult
 	err := session.Run(ctx, executor.HeartbeatInterval, func(
 		workContext context.Context,
 		guard providerfoundation.LeaseGuard,
 	) error {
+		normalizedAt := executor.now()
+		var recoveredEffects *EffectLedgerState
+		// Load the durable manifest before touching credentials or provider
+		// state. Snapshot-backed recovery must be able to resume the exact batch
+		// even when the live provider selection has changed since prepare.
+		if descriptor.RouteEnabled {
+			state, loadErr := executor.Committer.Ledger.LoadEffects(
+				workContext, session.Claim, normalizedAt,
+			)
+			switch {
+			case loadErr == nil:
+				if state.Generation != session.Claim.GenerationKey() ||
+					state.Provider != session.Claim.Provider ||
+					state.Dataset != session.Claim.Dataset {
+					return ErrEffectLedgerConflict
+				}
+				normalizedAt = state.CreatedAt.UTC()
+				recoveredEffects = &state
+			case errors.Is(loadErr, ErrEffectLedgerNotFound):
+			default:
+				return loadErr
+			}
+		}
+		if recoveredEffects != nil && descriptor.PreparedManifestRecovery {
+			manifest, err := preparedLedger.LoadRouteSnapshot(
+				workContext, session.Claim, *recoveredEffects, executor.now(),
+			)
+			if err != nil {
+				return err
+			}
+			if err := manifest.Batch.validate(descriptor); err != nil ||
+				!manifest.NormalizedAt.Equal(normalizedAt) {
+				return ErrEffectLedgerConflict
+			}
+			result.Fetch, result.Result, result.Watermark =
+				manifest.Batch.Evidence, manifest.Batch.Result, manifest.Batch.Watermark
+			result.Comparison = manifest.Comparison
+			result.Effects, err = executor.Committer.CommitPrepared(
+				workContext, session.Claim, manifest.Batch.Effects, *recoveredEffects,
+			)
+			return err
+		}
 		credential, err := executor.Credentials.Resolve(
 			workContext,
 			guard,
@@ -173,8 +223,6 @@ func (executor CompleteRouteExecutor) Execute(
 			return ErrInvalidConfiguration
 		}
 		client.Metrics = executor.Metrics
-		normalizedAt := executor.now()
-		var recoveredEffects *EffectLedgerState
 		// Every attempt for this unit occurrence must rebuild byte-identical
 		// rows, not just expired-lease recoveries. Effect digests cover the
 		// serialized rows, so a wall-clock timestamp regenerated on an ordinary
@@ -183,24 +231,6 @@ func (executor CompleteRouteExecutor) Execute(
 		// run — wedging the unit until it exhausts. ReleaseForRetry returns the
 		// unit to `dispatching`, so the next claim is *not* Recovered; gating
 		// this on Recovered covered only a fraction of the real retry paths.
-		if descriptor.RouteEnabled {
-			state, loadErr := executor.Committer.Ledger.LoadEffects(
-				workContext, session.Claim, normalizedAt,
-			)
-			switch {
-			case loadErr == nil:
-				if state.Generation != session.Claim.GenerationKey() ||
-					state.Provider != session.Claim.Provider ||
-					state.Dataset != session.Claim.Dataset {
-					return ErrEffectLedgerConflict
-				}
-				normalizedAt = state.CreatedAt.UTC()
-				recoveredEffects = &state
-			case errors.Is(loadErr, ErrEffectLedgerNotFound):
-			default:
-				return loadErr
-			}
-		}
 		if recoveredEffects != nil {
 			if replanning, ok := executor.Handler.(SafeReplanningCompleteRouteHandler); ok {
 				canReplan, replanErr := replanning.CanReplanRecovery(
@@ -269,9 +299,21 @@ func (executor CompleteRouteExecutor) Execute(
 		// persist a later time than the rows were built with, so the next
 		// attempt would reload that later time, rebuild different rows, and be
 		// rejected on digest — the wedge in a second disguise.
-		result.Effects, err = executor.Committer.Commit(
-			workContext, session.Claim, batch.Effects, normalizedAt,
-		)
+		if descriptor.PreparedManifestRecovery {
+			prepared, prepareErr := preparedLedger.PrepareRouteSnapshot(
+				workContext, session.Claim, batch, comparison, normalizedAt,
+			)
+			if prepareErr != nil {
+				return prepareErr
+			}
+			result.Effects, err = executor.Committer.CommitPrepared(
+				workContext, session.Claim, batch.Effects, prepared,
+			)
+		} else {
+			result.Effects, err = executor.Committer.Commit(
+				workContext, session.Claim, batch.Effects, normalizedAt,
+			)
+		}
 		return err
 	})
 	return result, err

--- a/internal/providersync/effect_committer.go
+++ b/internal/providersync/effect_committer.go
@@ -61,9 +61,7 @@ func (committer EffectCommitter) Commit(
 	}
 	normalizedAt = normalizedAt.UTC()
 	ordered := append([]EffectBatch(nil), batches...)
-	sort.Slice(ordered, func(left, right int) bool {
-		return effectBatchLess(ordered[left], ordered[right])
-	})
+	sortEffectBatches(ordered)
 	desired, err := NewEffectLedgerState(claim, ordered, normalizedAt)
 	if err != nil {
 		return EffectCommitResult{}, err
@@ -92,9 +90,7 @@ func (committer EffectCommitter) CommitPrepared(
 		return EffectCommitResult{}, ErrInvalidConfiguration
 	}
 	ordered := append([]EffectBatch(nil), batches...)
-	sort.Slice(ordered, func(left, right int) bool {
-		return ordered[left].Destination < ordered[right].Destination
-	})
+	sortEffectBatches(ordered)
 	desired, err := NewEffectLedgerState(claim, ordered, persisted.CreatedAt)
 	if err != nil || !sameEffectEntries(persisted, desired) {
 		return EffectCommitResult{}, ErrEffectLedgerConflict
@@ -188,6 +184,19 @@ func (committer EffectCommitter) commitPrepared(
 		result.Written++
 	}
 	return result, nil
+}
+
+// sortEffectBatches is THE ordering for effect batches. It exists as one
+// function because it used to exist as three inline comparators, and two of
+// them ordered by destination alone while the ledger ordered priority-first.
+// They agree only while no priority destination participates -- and recovery
+// pairs snapshot effects to ledger entries BY POSITION, so the day one joined,
+// a recovering route would have committed each destination's rows against a
+// different destination's ledger entry. Callers must not re-implement this.
+func sortEffectBatches(batches []EffectBatch) {
+	sort.Slice(batches, func(left, right int) bool {
+		return effectBatchLess(batches[left], batches[right])
+	})
 }
 
 func effectBatchLess(left, right EffectBatch) bool {

--- a/internal/providersync/effect_committer.go
+++ b/internal/providersync/effect_committer.go
@@ -74,6 +74,40 @@ func (committer EffectCommitter) Commit(
 	if err != nil {
 		return EffectCommitResult{}, err
 	}
+	return committer.commitPrepared(ctx, claim, ordered, persisted)
+}
+
+// CommitPrepared continues an effect commit after the ledger and an optional
+// exact recovery snapshot were durably prepared together. It deliberately
+// does not call PrepareEffects again: doing so would split the atomic prepare
+// boundary that the snapshot sidecar exists to provide.
+func (committer EffectCommitter) CommitPrepared(
+	ctx context.Context,
+	claim Claim,
+	batches []EffectBatch,
+	persisted EffectLedgerState,
+) (EffectCommitResult, error) {
+	if ctx == nil || claim.Validate() != nil || committer.Ledger == nil ||
+		committer.Sink == nil || persisted.validate() != nil {
+		return EffectCommitResult{}, ErrInvalidConfiguration
+	}
+	ordered := append([]EffectBatch(nil), batches...)
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].Destination < ordered[right].Destination
+	})
+	desired, err := NewEffectLedgerState(claim, ordered, persisted.CreatedAt)
+	if err != nil || !sameEffectEntries(persisted, desired) {
+		return EffectCommitResult{}, ErrEffectLedgerConflict
+	}
+	return committer.commitPrepared(ctx, claim, ordered, persisted)
+}
+
+func (committer EffectCommitter) commitPrepared(
+	ctx context.Context,
+	claim Claim,
+	ordered []EffectBatch,
+	persisted EffectLedgerState,
+) (EffectCommitResult, error) {
 	var result EffectCommitResult
 	for index, batch := range ordered {
 		effect := &persisted.Effects[index]

--- a/internal/providersync/effect_committer_test.go
+++ b/internal/providersync/effect_committer_test.go
@@ -1,6 +1,7 @@
 package providersync
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -241,8 +242,60 @@ func containsBytes(value, part []byte) bool {
 }
 
 type memoryEffectLedger struct {
-	mu    sync.Mutex
-	state EffectLedgerState
+	mu               sync.Mutex
+	state            EffectLedgerState
+	preparedSnapshot []byte
+	preparedLoads    int
+	preparedPrepares int
+}
+
+func (ledger *memoryEffectLedger) PrepareRouteSnapshot(
+	_ context.Context,
+	claim Claim,
+	batch CompleteRouteBatch,
+	comparison ShadowComparison,
+	normalizedAt time.Time,
+) (EffectLedgerState, error) {
+	payload, reference, err := encodePreparedRouteManifest(
+		claim, batch, comparison, normalizedAt,
+	)
+	if err != nil {
+		return EffectLedgerState{}, err
+	}
+	desired, err := NewEffectLedgerState(claim, batch.Effects, normalizedAt)
+	if err != nil {
+		return EffectLedgerState{}, err
+	}
+	desired.SchemaVersion = "v2"
+	desired.PreparedSnapshot = &reference
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	ledger.preparedPrepares++
+	if ledger.state.SchemaVersion != "" {
+		if !sameEffectManifest(ledger.state, desired) ||
+			!bytes.Equal(ledger.preparedSnapshot, payload) {
+			return EffectLedgerState{}, ErrEffectLedgerConflict
+		}
+		return ledger.state, nil
+	}
+	ledger.state = desired
+	ledger.preparedSnapshot = append([]byte(nil), payload...)
+	return ledger.state, nil
+}
+
+func (ledger *memoryEffectLedger) LoadRouteSnapshot(
+	_ context.Context,
+	claim Claim,
+	state EffectLedgerState,
+	_ time.Time,
+) (PreparedRouteManifest, error) {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	ledger.preparedLoads++
+	if len(ledger.preparedSnapshot) == 0 {
+		return PreparedRouteManifest{}, ErrPreparedRouteSnapshotNotFound
+	}
+	return decodePreparedRouteManifest(ledger.preparedSnapshot, claim, state)
 }
 
 func (ledger *memoryEffectLedger) LoadEffects(

--- a/internal/providersync/effect_committer_test.go
+++ b/internal/providersync/effect_committer_test.go
@@ -247,6 +247,13 @@ type memoryEffectLedger struct {
 	preparedSnapshot []byte
 	preparedLoads    int
 	preparedPrepares int
+	// effectLoads counts LoadEffects calls. It is the earliest observable
+	// signal that Execute got past its pre-flight guards and into the leased
+	// work: the guards run before session.Run, and LoadEffects is the first
+	// thing inside it. Asserting on the returned error alone cannot tell a
+	// guard refusal from an unrelated later failure that shares the same
+	// sentinel error.
+	effectLoads int
 }
 
 func (ledger *memoryEffectLedger) PrepareRouteSnapshot(
@@ -305,6 +312,7 @@ func (ledger *memoryEffectLedger) LoadEffects(
 ) (EffectLedgerState, error) {
 	ledger.mu.Lock()
 	defer ledger.mu.Unlock()
+	ledger.effectLoads++
 	if ledger.state.SchemaVersion == "" {
 		// Match PostgresRepository.LoadEffects: an absent ledger is "not
 		// found", not a conflict. Returning a conflict here hid the fact that

--- a/internal/providersync/effect_ledger.go
+++ b/internal/providersync/effect_ledger.go
@@ -118,9 +118,7 @@ func NewEffectLedgerState(
 		return EffectLedgerState{}, ErrEffectRecoveryUnsafe
 	}
 	batches = append([]EffectBatch(nil), batches...)
-	sort.Slice(batches, func(left, right int) bool {
-		return effectBatchLess(batches[left], batches[right])
-	})
+	sortEffectBatches(batches)
 	state := EffectLedgerState{
 		SchemaVersion: "v1", Generation: claim.GenerationKey(),
 		Provider: claim.Provider, Dataset: claim.Dataset,

--- a/internal/providersync/effect_ledger.go
+++ b/internal/providersync/effect_ledger.go
@@ -98,13 +98,14 @@ type EffectLedgerEntry struct {
 }
 
 type EffectLedgerState struct {
-	SchemaVersion string              `json:"schema_version"`
-	Generation    string              `json:"generation"`
-	Provider      string              `json:"provider"`
-	Dataset       string              `json:"dataset"`
-	Effects       []EffectLedgerEntry `json:"effects"`
-	CreatedAt     time.Time           `json:"created_at"`
-	UpdatedAt     time.Time           `json:"updated_at"`
+	SchemaVersion    string                          `json:"schema_version"`
+	Generation       string                          `json:"generation"`
+	Provider         string                          `json:"provider"`
+	Dataset          string                          `json:"dataset"`
+	Effects          []EffectLedgerEntry             `json:"effects"`
+	PreparedSnapshot *PreparedRouteSnapshotReference `json:"prepared_snapshot,omitempty"`
+	CreatedAt        time.Time                       `json:"created_at"`
+	UpdatedAt        time.Time                       `json:"updated_at"`
 }
 
 func NewEffectLedgerState(
@@ -143,10 +144,17 @@ func NewEffectLedgerState(
 }
 
 func (state EffectLedgerState) validate() error {
-	if state.SchemaVersion != "v1" || state.Generation == "" ||
+	if (state.SchemaVersion != "v1" && state.SchemaVersion != "v2") || state.Generation == "" ||
 		strings.TrimSpace(state.Provider) == "" || strings.TrimSpace(state.Dataset) == "" ||
 		len(state.Effects) < 1 || len(state.Effects) > maxEffectDestinations ||
 		state.CreatedAt.IsZero() || state.UpdatedAt.IsZero() {
+		return ErrEffectLedgerConflict
+	}
+	if state.SchemaVersion == "v1" && state.PreparedSnapshot != nil {
+		return ErrEffectLedgerConflict
+	}
+	if state.SchemaVersion == "v2" &&
+		(state.PreparedSnapshot == nil || state.PreparedSnapshot.validate() != nil) {
 		return ErrEffectLedgerConflict
 	}
 	seen := map[string]bool{}
@@ -217,6 +225,15 @@ func decodeEffectLedgerState(raw []byte) (EffectLedgerState, error) {
 func sameEffectManifest(left, right EffectLedgerState) bool {
 	if left.SchemaVersion != right.SchemaVersion ||
 		left.Generation != right.Generation || left.Provider != right.Provider ||
+		left.Dataset != right.Dataset || len(left.Effects) != len(right.Effects) ||
+		!samePreparedRouteSnapshotReference(left.PreparedSnapshot, right.PreparedSnapshot) {
+		return false
+	}
+	return sameEffectEntries(left, right)
+}
+
+func sameEffectEntries(left, right EffectLedgerState) bool {
+	if left.Generation != right.Generation || left.Provider != right.Provider ||
 		left.Dataset != right.Dataset || len(left.Effects) != len(right.Effects) {
 		return false
 	}
@@ -244,6 +261,27 @@ type EffectLedger interface {
 		GenerationBlockResolution,
 		time.Time,
 	) error
+}
+
+// PreparedEffectLedger is the opt-in durable payload sidecar for complete
+// routes whose manifest cannot be deterministically rebuilt from mutable
+// provider state. The same object owns both contracts so a binary cannot wire
+// the effect ledger and its exact recovery payload to different stores.
+type PreparedEffectLedger interface {
+	EffectLedger
+	PrepareRouteSnapshot(
+		context.Context,
+		Claim,
+		CompleteRouteBatch,
+		ShadowComparison,
+		time.Time,
+	) (EffectLedgerState, error)
+	LoadRouteSnapshot(
+		context.Context,
+		Claim,
+		EffectLedgerState,
+		time.Time,
+	) (PreparedRouteManifest, error)
 }
 
 // EffectLedgerReplanner is intentionally separate from EffectLedger. Only a

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -92,8 +92,12 @@ type CompleteRouteDescriptor struct {
 	// against the Python-owned sink for parity evidence. Shadow eligibility
 	// never implies routing.
 	NativeShadow bool
-	RouteReady   bool
-	RouteEnabled bool
+	// PreparedManifestRecovery requires an exact Postgres sidecar snapshot
+	// before the first sink effect. It is currently reserved for GitHub's
+	// mutable, multi-source work-items composition and does not imply routing.
+	PreparedManifestRecovery bool
+	RouteReady               bool
+	RouteEnabled             bool
 }
 
 // ShadowDescriptor is a fixture/parity-only projection of the canonical
@@ -200,6 +204,12 @@ func (switches CompleteRouteSwitches) Descriptor(
 	}
 	workItemAlias := slices.Contains(linearBackfillWorkItemDatasets, dataset)
 	switch {
+	case provider == "github" && dataset == "work-items":
+		// The composite handler and all 16 sink effects exist, but this pair
+		// remains unregistered until its final parity and activation layers land.
+		// Carry the recovery requirement now so activation cannot accidentally
+		// use mutable-provider recollection after a crash.
+		descriptor.PreparedManifestRecovery = true
 	case (provider == "linear" || provider == "jira") && workItemAlias:
 		descriptor.RouteDataset = "work-items"
 		descriptor.Destinations = workItemRouteDestinations()

--- a/internal/providersync/generation_journal.go
+++ b/internal/providersync/generation_journal.go
@@ -383,6 +383,23 @@ func (repository *PostgresRepository) mutateGenerationJournal(
 	now time.Time,
 	mutate func(map[string]json.RawMessage) error,
 ) error {
+	if mutate == nil {
+		return ErrInvalidConfiguration
+	}
+	return repository.mutateGenerationJournalTx(
+		ctx, claim, now,
+		func(_ pgx.Tx, document map[string]json.RawMessage) error {
+			return mutate(document)
+		},
+	)
+}
+
+func (repository *PostgresRepository) mutateGenerationJournalTx(
+	ctx context.Context,
+	claim Claim,
+	now time.Time,
+	mutate func(pgx.Tx, map[string]json.RawMessage) error,
+) error {
 	if repository == nil || repository.Pool == nil || ctx == nil ||
 		claim.Validate() != nil || now.IsZero() || mutate == nil {
 		return ErrInvalidConfiguration
@@ -403,7 +420,7 @@ func (repository *PostgresRepository) mutateGenerationJournal(
 	if len(raw) != 0 && json.Unmarshal(raw, &document) != nil {
 		return ErrGenerationJournalConflict
 	}
-	if err := mutate(document); err != nil {
+	if err := mutate(tx, document); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(document)

--- a/internal/providersync/lease.go
+++ b/internal/providersync/lease.go
@@ -11,20 +11,23 @@ import (
 )
 
 var (
-	ErrInvalidConfiguration          = errors.New("provider sync configuration is invalid")
-	ErrUnitNotClaimable              = errors.New("provider sync unit is not claimable")
-	ErrLeaseLost                     = errors.New("provider sync unit lease is lost")
-	ErrCompatibilityRequired         = errors.New("provider sync dataset requires Python compatibility execution")
-	ErrGenerationJournalConflict     = errors.New("provider sync generation journal conflicts with persisted state")
-	ErrGenerationBlockAmbiguous      = errors.New("provider sync generation block requires readback reconciliation")
-	ErrGenerationRecoveryUnsafe      = errors.New("provider sync generation recovery payload is outside the bounded contract")
-	ErrEffectLedgerConflict          = errors.New("provider sync effect ledger conflicts with persisted state")
-	ErrEffectLedgerNotFound          = errors.New("provider sync effect ledger is not present")
-	ErrPreparedRouteSnapshotNotFound = errors.New("provider sync prepared route snapshot is not present")
-	ErrEffectRecoveryAmbiguous       = errors.New("provider sync effect recovery requires exact reconciliation")
-	ErrEffectRecoveryUnsafe          = errors.New("provider sync effect recovery is outside the bounded contract")
-	ErrShadowMismatch                = errors.New("provider sync native shadow differs from Python compatibility output")
-	ErrRepositoryIdentityAmbiguous   = errors.New(
+	ErrInvalidConfiguration             = errors.New("provider sync configuration is invalid")
+	ErrUnitNotClaimable                 = errors.New("provider sync unit is not claimable")
+	ErrLeaseLost                        = errors.New("provider sync unit lease is lost")
+	ErrCompatibilityRequired            = errors.New("provider sync dataset requires Python compatibility execution")
+	ErrGenerationJournalConflict        = errors.New("provider sync generation journal conflicts with persisted state")
+	ErrGenerationBlockAmbiguous         = errors.New("provider sync generation block requires readback reconciliation")
+	ErrGenerationRecoveryUnsafe         = errors.New("provider sync generation recovery payload is outside the bounded contract")
+	ErrEffectLedgerConflict             = errors.New("provider sync effect ledger conflicts with persisted state")
+	ErrEffectLedgerNotFound             = errors.New("provider sync effect ledger is not present")
+	ErrPreparedRouteSnapshotNotFound    = errors.New("provider sync prepared route snapshot is not present")
+	ErrPreparedRouteSnapshotRunTerminal = errors.New(
+		"provider sync prepared route snapshot belongs to a run that already finished",
+	)
+	ErrEffectRecoveryAmbiguous     = errors.New("provider sync effect recovery requires exact reconciliation")
+	ErrEffectRecoveryUnsafe        = errors.New("provider sync effect recovery is outside the bounded contract")
+	ErrShadowMismatch              = errors.New("provider sync native shadow differs from Python compatibility output")
+	ErrRepositoryIdentityAmbiguous = errors.New(
 		"provider sync repository identity cannot be proven identical to the Python derivation",
 	)
 	// ErrPaginationCapExceeded means a paginated fetch hit its page cap

--- a/internal/providersync/lease.go
+++ b/internal/providersync/lease.go
@@ -11,19 +11,20 @@ import (
 )
 
 var (
-	ErrInvalidConfiguration        = errors.New("provider sync configuration is invalid")
-	ErrUnitNotClaimable            = errors.New("provider sync unit is not claimable")
-	ErrLeaseLost                   = errors.New("provider sync unit lease is lost")
-	ErrCompatibilityRequired       = errors.New("provider sync dataset requires Python compatibility execution")
-	ErrGenerationJournalConflict   = errors.New("provider sync generation journal conflicts with persisted state")
-	ErrGenerationBlockAmbiguous    = errors.New("provider sync generation block requires readback reconciliation")
-	ErrGenerationRecoveryUnsafe    = errors.New("provider sync generation recovery payload is outside the bounded contract")
-	ErrEffectLedgerConflict        = errors.New("provider sync effect ledger conflicts with persisted state")
-	ErrEffectLedgerNotFound        = errors.New("provider sync effect ledger is not present")
-	ErrEffectRecoveryAmbiguous     = errors.New("provider sync effect recovery requires exact reconciliation")
-	ErrEffectRecoveryUnsafe        = errors.New("provider sync effect recovery is outside the bounded contract")
-	ErrShadowMismatch              = errors.New("provider sync native shadow differs from Python compatibility output")
-	ErrRepositoryIdentityAmbiguous = errors.New(
+	ErrInvalidConfiguration          = errors.New("provider sync configuration is invalid")
+	ErrUnitNotClaimable              = errors.New("provider sync unit is not claimable")
+	ErrLeaseLost                     = errors.New("provider sync unit lease is lost")
+	ErrCompatibilityRequired         = errors.New("provider sync dataset requires Python compatibility execution")
+	ErrGenerationJournalConflict     = errors.New("provider sync generation journal conflicts with persisted state")
+	ErrGenerationBlockAmbiguous      = errors.New("provider sync generation block requires readback reconciliation")
+	ErrGenerationRecoveryUnsafe      = errors.New("provider sync generation recovery payload is outside the bounded contract")
+	ErrEffectLedgerConflict          = errors.New("provider sync effect ledger conflicts with persisted state")
+	ErrEffectLedgerNotFound          = errors.New("provider sync effect ledger is not present")
+	ErrPreparedRouteSnapshotNotFound = errors.New("provider sync prepared route snapshot is not present")
+	ErrEffectRecoveryAmbiguous       = errors.New("provider sync effect recovery requires exact reconciliation")
+	ErrEffectRecoveryUnsafe          = errors.New("provider sync effect recovery is outside the bounded contract")
+	ErrShadowMismatch                = errors.New("provider sync native shadow differs from Python compatibility output")
+	ErrRepositoryIdentityAmbiguous   = errors.New(
 		"provider sync repository identity cannot be proven identical to the Python derivation",
 	)
 	// ErrPaginationCapExceeded means a paginated fetch hit its page cap

--- a/internal/providersync/prepared_route_snapshot.go
+++ b/internal/providersync/prepared_route_snapshot.go
@@ -329,21 +329,30 @@ func (repository *PostgresRepository) LoadRouteSnapshot(
 	var schemaVersion, contentDigest string
 	var payloadBytes int
 	var payload []byte
-	var leaseLive bool
+	var leaseLive, runLive bool
 	if err := repository.Pool.QueryRow(
 		ctx, loadPreparedRouteSnapshotSQL,
 		claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
 		claim.Owner, now.UTC(),
-	).Scan(&schemaVersion, &contentDigest, &payloadBytes, &payload, &leaseLive); err != nil {
+	).Scan(
+		&schemaVersion, &contentDigest, &payloadBytes, &payload,
+		&leaseLive, &runLive,
+	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return PreparedRouteManifest{}, ErrPreparedRouteSnapshotNotFound
 		}
 		return PreparedRouteManifest{}, err
 	}
-	// Order matters: the snapshot demonstrably exists for this
+	// Order matters twice over. The snapshot demonstrably exists for this
 	// tenant/unit/generation, so a refusal here is about entitlement, not
-	// absence. Reporting it as "not found" told a recovering worker to
-	// fail closed for the wrong reason and hid genuine lease handoffs.
+	// absence -- reporting it as "not found" told a recovering worker to fail
+	// closed for the wrong reason and hid genuine handoffs. And a terminal run
+	// is checked BEFORE the lease, because a finished run explains a live
+	// lease that is simply no longer relevant; the reverse order would send an
+	// operator hunting a lease problem that does not exist.
+	if !runLive {
+		return PreparedRouteManifest{}, ErrPreparedRouteSnapshotRunTerminal
+	}
 	if !leaseLive {
 		return PreparedRouteManifest{}, ErrLeaseLost
 	}
@@ -372,9 +381,11 @@ func verifyPreparedRouteSnapshotRow(
 		// Only an absent row is a ledger conflict. Folding every error into
 		// ErrEffectLedgerConflict is what let a permission failure -- one that
 		// happened on EVERY re-prepare in production -- read as ordinary
-		// disagreement between the ledger and the sidecar, and be retried
-		// forever instead of surfacing. A database error must arrive as
-		// itself.
+		// disagreement between the ledger and the sidecar. It would not have
+		// retried forever: it would have burned the unit's MaxAttempts and
+		// then terminalized under the generic provider_unit_exhausted
+		// category, with the actual cause (SQLSTATE 42501) nowhere in the
+		// record. A database error must arrive as itself.
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrEffectLedgerConflict
 		}
@@ -410,40 +421,56 @@ INSERT INTO public.sync_run_unit_effect_snapshots (
     schema_version, content_digest, payload_bytes, payload, created_at
 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`
 
-// loadPreparedRouteSnapshotSQL answers two questions separately on purpose:
-// does this snapshot exist for this tenant/unit/generation, and is the caller
-// still entitled to it. Folding the lease fence into the WHERE clause made
-// both answers the same sentinel, so "someone else took over this unit" and
-// "there is no snapshot to recover" were indistinguishable to the caller and
-// to anyone reading a log. The identity predicates stay in WHERE; the lease
-// fence is computed, and the caller turns a false into ErrLeaseLost.
+// loadPreparedRouteSnapshotSQL answers three questions separately on purpose:
+// does this snapshot exist for this tenant/unit/generation, is the caller
+// still the unit's writer, and is the owning run still live. Folding them into
+// one WHERE clause made all three the same sentinel, so "someone else took
+// over", "this run already finished" and "there is nothing to recover" were
+// indistinguishable to the caller and in any log.
 //
-// The fence mirrors loadEffectLedgerSQL exactly, including the IS NOT NULL
-// guard and the terminal-run exclusion: two queries that decide the same
-// entitlement must not drift apart, or a route can load a snapshot for a run
-// the ledger would already refuse.
+// Splitting lease from run status is not pedantry: a finalized run with a
+// perfectly live lease reported ErrLeaseLost, which sends an operator to look
+// at leases when the actual cause is a run that already reached a terminal
+// state. Each term now carries its own error.
+//
+// The fence mirrors loadEffectLedgerSQL clause for clause, IS NOT NULL guard
+// and terminal-run exclusion included: two queries deciding the same
+// entitlement must not drift apart.
+//
+// The payload is gated behind both fences rather than selected unconditionally
+// -- a refused load has no business moving up to 64 MiB across the wire, and
+// the CASE means the column is never even detoasted on that path.
 const loadPreparedRouteSnapshotSQL = `
-SELECT snapshot.schema_version, snapshot.content_digest,
-       snapshot.payload_bytes, snapshot.payload,
-       COALESCE(
-         unit.status = 'running'
-         AND unit.lease_owner = $6
-         AND unit.lease_expires_at IS NOT NULL
-         AND unit.lease_expires_at > $7
-         AND run.status NOT IN ('success', 'partial_failed', 'failed'),
-         false
-       )
-FROM public.sync_run_unit_effect_snapshots AS snapshot
-JOIN public.sync_run_units AS unit
-  ON unit.id = snapshot.sync_run_unit_id
- AND unit.org_id = snapshot.org_id
-JOIN public.sync_runs AS run
-  ON run.id = unit.sync_run_id AND run.org_id = unit.org_id
-WHERE snapshot.org_id = $1
-  AND snapshot.sync_run_unit_id = $2
-  AND snapshot.generation = $3
-  AND snapshot.provider = $4
-  AND snapshot.dataset_key = $5`
+SELECT fenced.schema_version, fenced.content_digest, fenced.payload_bytes,
+       CASE WHEN fenced.lease_live AND fenced.run_live
+            THEN fenced.payload ELSE ''::bytea END,
+       fenced.lease_live, fenced.run_live
+FROM (
+  SELECT snapshot.schema_version, snapshot.content_digest,
+         snapshot.payload_bytes, snapshot.payload,
+         COALESCE(
+           unit.status = 'running'
+           AND unit.lease_owner = $6
+           AND unit.lease_expires_at IS NOT NULL
+           AND unit.lease_expires_at > $7,
+           false
+         ) AS lease_live,
+         COALESCE(
+           run.status NOT IN ('success', 'partial_failed', 'failed'),
+           false
+         ) AS run_live
+  FROM public.sync_run_unit_effect_snapshots AS snapshot
+  JOIN public.sync_run_units AS unit
+    ON unit.id = snapshot.sync_run_unit_id
+   AND unit.org_id = snapshot.org_id
+  JOIN public.sync_runs AS run
+    ON run.id = unit.sync_run_id AND run.org_id = unit.org_id
+  WHERE snapshot.org_id = $1
+    AND snapshot.sync_run_unit_id = $2
+    AND snapshot.generation = $3
+    AND snapshot.provider = $4
+    AND snapshot.dataset_key = $5
+) AS fenced`
 
 // loadPreparedRouteSnapshotRowSQL deliberately takes NO row lock. It used to
 // end in FOR UPDATE, which is a permission error rather than a lock: any

--- a/internal/providersync/prepared_route_snapshot.go
+++ b/internal/providersync/prepared_route_snapshot.go
@@ -92,9 +92,7 @@ func encodePreparedRouteManifest(
 		return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
 	}
 	ordered := append([]EffectBatch(nil), batch.Effects...)
-	sort.Slice(ordered, func(left, right int) bool {
-		return ordered[left].Destination < ordered[right].Destination
-	})
+	sortEffectBatches(ordered)
 	effects := make([]storedPreparedEffect, 0, len(ordered))
 	for _, effect := range ordered {
 		for _, row := range effect.Rows {
@@ -331,15 +329,23 @@ func (repository *PostgresRepository) LoadRouteSnapshot(
 	var schemaVersion, contentDigest string
 	var payloadBytes int
 	var payload []byte
+	var leaseLive bool
 	if err := repository.Pool.QueryRow(
 		ctx, loadPreparedRouteSnapshotSQL,
 		claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
 		claim.Owner, now.UTC(),
-	).Scan(&schemaVersion, &contentDigest, &payloadBytes, &payload); err != nil {
+	).Scan(&schemaVersion, &contentDigest, &payloadBytes, &payload, &leaseLive); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return PreparedRouteManifest{}, ErrPreparedRouteSnapshotNotFound
 		}
-		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+		return PreparedRouteManifest{}, err
+	}
+	// Order matters: the snapshot demonstrably exists for this
+	// tenant/unit/generation, so a refusal here is about entitlement, not
+	// absence. Reporting it as "not found" told a recovering worker to
+	// fail closed for the wrong reason and hid genuine lease handoffs.
+	if !leaseLive {
+		return PreparedRouteManifest{}, ErrLeaseLost
 	}
 	if schemaVersion != state.PreparedSnapshot.SchemaVersion ||
 		contentDigest != state.PreparedSnapshot.ContentDigest ||
@@ -363,7 +369,16 @@ func verifyPreparedRouteSnapshotRow(
 		ctx, loadPreparedRouteSnapshotRowSQL,
 		claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
 	).Scan(&schemaVersion, &digest, &payloadBytes, &payload); err != nil {
-		return ErrEffectLedgerConflict
+		// Only an absent row is a ledger conflict. Folding every error into
+		// ErrEffectLedgerConflict is what let a permission failure -- one that
+		// happened on EVERY re-prepare in production -- read as ordinary
+		// disagreement between the ledger and the sidecar, and be retried
+		// forever instead of surfacing. A database error must arrive as
+		// itself.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrEffectLedgerConflict
+		}
+		return err
 	}
 	reference := state.PreparedSnapshot
 	if reference == nil || schemaVersion != reference.SchemaVersion ||
@@ -374,31 +389,83 @@ func verifyPreparedRouteSnapshotRow(
 	return nil
 }
 
+// A plain INSERT, deliberately without ON CONFLICT. The primary key is
+// (org_id, sync_run_unit_id, generation), and this statement runs only on the
+// branch where the ledger key was absent -- so a conflict would mean a
+// snapshot row exists for a generation whose ledger does not, which is a state
+// no code path produces and which should fail loudly rather than be papered
+// over by an upsert.
+//
+// One interaction is worth naming because it is unreachable today and would
+// not be obvious later: EffectLedgerReplanner lets a route discard a prepared
+// manifest and build a new one for the SAME generation. A route that both
+// replans and prepares snapshots would hit this insert with the old row still
+// present. github/work-items has no replanner (only GitHub blame does, and it
+// does not use snapshots), so the combination cannot occur -- but whoever
+// gives a snapshot route a replanner must delete the old snapshot inside the
+// replan transaction first.
 const insertPreparedRouteSnapshotSQL = `
 INSERT INTO public.sync_run_unit_effect_snapshots (
     org_id, sync_run_unit_id, generation, provider, dataset_key,
     schema_version, content_digest, payload_bytes, payload, created_at
 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`
 
+// loadPreparedRouteSnapshotSQL answers two questions separately on purpose:
+// does this snapshot exist for this tenant/unit/generation, and is the caller
+// still entitled to it. Folding the lease fence into the WHERE clause made
+// both answers the same sentinel, so "someone else took over this unit" and
+// "there is no snapshot to recover" were indistinguishable to the caller and
+// to anyone reading a log. The identity predicates stay in WHERE; the lease
+// fence is computed, and the caller turns a false into ErrLeaseLost.
+//
+// The fence mirrors loadEffectLedgerSQL exactly, including the IS NOT NULL
+// guard and the terminal-run exclusion: two queries that decide the same
+// entitlement must not drift apart, or a route can load a snapshot for a run
+// the ledger would already refuse.
 const loadPreparedRouteSnapshotSQL = `
 SELECT snapshot.schema_version, snapshot.content_digest,
-       snapshot.payload_bytes, snapshot.payload
+       snapshot.payload_bytes, snapshot.payload,
+       COALESCE(
+         unit.status = 'running'
+         AND unit.lease_owner = $6
+         AND unit.lease_expires_at IS NOT NULL
+         AND unit.lease_expires_at > $7
+         AND run.status NOT IN ('success', 'partial_failed', 'failed'),
+         false
+       )
 FROM public.sync_run_unit_effect_snapshots AS snapshot
 JOIN public.sync_run_units AS unit
   ON unit.id = snapshot.sync_run_unit_id
  AND unit.org_id = snapshot.org_id
+JOIN public.sync_runs AS run
+  ON run.id = unit.sync_run_id AND run.org_id = unit.org_id
 WHERE snapshot.org_id = $1
   AND snapshot.sync_run_unit_id = $2
   AND snapshot.generation = $3
   AND snapshot.provider = $4
-  AND snapshot.dataset_key = $5
-  AND unit.lease_owner = $6
-  AND unit.lease_expires_at > $7
-  AND unit.status = 'running'`
+  AND snapshot.dataset_key = $5`
 
+// loadPreparedRouteSnapshotRowSQL deliberately takes NO row lock. It used to
+// end in FOR UPDATE, which is a permission error rather than a lock: any
+// row-locking clause requires an UPDATE-class privilege, and the domain role
+// holds only SELECT/INSERT/DELETE here (see required_table_privileges). That
+// made every re-prepare fail with "permission denied" in production while
+// passing in tests, which run as the owner. Widening the grant to buy the lock
+// would hand the role a privilege nothing else needs -- and the lock is
+// already held anyway.
+//
+// The serialization comes from the caller: this runs only inside
+// mutateGenerationJournalTx's callback, and that transaction opens with
+// lockGenerationJournalSQL (generation_journal.go), which ends in
+// `FOR UPDATE OF unit` on the owning sync_run_units row. A snapshot row is
+// keyed by (org_id, sync_run_unit_id, generation) and is only ever written by
+// the holder of that unit's lease, so a competing writer must take the same
+// unit lock first. Locking the snapshot row again adds nothing.
+//
+// sync_run_units is where the repo already pays for this: the domain role is
+// granted UPDATE on it partly because Fanout's FOR SHARE needs the privilege.
 const loadPreparedRouteSnapshotRowSQL = `
 SELECT schema_version, content_digest, payload_bytes, payload
 FROM public.sync_run_unit_effect_snapshots
 WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3
-  AND provider = $4 AND dataset_key = $5
-FOR UPDATE`
+  AND provider = $4 AND dataset_key = $5`

--- a/internal/providersync/prepared_route_snapshot.go
+++ b/internal/providersync/prepared_route_snapshot.go
@@ -1,0 +1,404 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	preparedRouteSnapshotSchemaVersion = "v1"
+	maxPreparedRouteSnapshotBytes      = 64 << 20
+)
+
+type PreparedRouteSnapshotReference struct {
+	SchemaVersion string `json:"schema_version"`
+	ContentDigest string `json:"content_digest"`
+	PayloadBytes  int    `json:"payload_bytes"`
+}
+
+func (reference PreparedRouteSnapshotReference) validate() error {
+	if reference.SchemaVersion != preparedRouteSnapshotSchemaVersion ||
+		!validDigest(reference.ContentDigest) || reference.PayloadBytes < 1 ||
+		reference.PayloadBytes > maxPreparedRouteSnapshotBytes {
+		return ErrEffectLedgerConflict
+	}
+	return nil
+}
+
+func samePreparedRouteSnapshotReference(
+	left *PreparedRouteSnapshotReference,
+	right *PreparedRouteSnapshotReference,
+) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+type PreparedRouteManifest struct {
+	Batch        CompleteRouteBatch
+	Comparison   ShadowComparison
+	NormalizedAt time.Time
+}
+
+type storedPreparedRouteSnapshot struct {
+	SchemaVersion string                 `json:"schema_version"`
+	Generation    string                 `json:"generation"`
+	OrgID         string                 `json:"org_id"`
+	Provider      string                 `json:"provider"`
+	Dataset       string                 `json:"dataset"`
+	NormalizedAt  time.Time              `json:"normalized_at"`
+	Effects       []storedPreparedEffect `json:"effects"`
+	Result        json.RawMessage        `json:"result"`
+	Watermark     *time.Time             `json:"watermark,omitempty"`
+	Evidence      FetchEvidence          `json:"evidence"`
+	Comparison    ShadowComparison       `json:"comparison"`
+}
+
+type storedPreparedEffect struct {
+	Destination   string               `json:"destination"`
+	ContentDigest string               `json:"content_digest"`
+	Recovery      EffectRecoveryPolicy `json:"recovery"`
+	Rows          []json.RawMessage    `json:"rows"`
+	PayloadBytes  int                  `json:"payload_bytes"`
+}
+
+func encodePreparedRouteManifest(
+	claim Claim,
+	batch CompleteRouteBatch,
+	comparison ShadowComparison,
+	normalizedAt time.Time,
+) ([]byte, PreparedRouteSnapshotReference, error) {
+	if validatePreparedRouteManifestIdentity(claim, batch, normalizedAt) != nil ||
+		!comparison.Match {
+		return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
+	}
+	result, err := json.Marshal(batch.Result)
+	if err != nil || len(result) == 0 || bytes.Equal(result, []byte("null")) {
+		return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
+	}
+	var resultValue any
+	if json.Unmarshal(result, &resultValue) != nil || containsPreparedRouteSensitiveKey(resultValue) {
+		return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
+	}
+	ordered := append([]EffectBatch(nil), batch.Effects...)
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].Destination < ordered[right].Destination
+	})
+	effects := make([]storedPreparedEffect, 0, len(ordered))
+	for _, effect := range ordered {
+		for _, row := range effect.Rows {
+			var rowValue any
+			if json.Unmarshal(row, &rowValue) != nil || containsPreparedRouteSensitiveKey(rowValue) {
+				return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
+			}
+		}
+		effects = append(effects, storedPreparedEffect{
+			Destination: effect.Destination, ContentDigest: effect.ContentDigest,
+			Recovery: effect.Recovery, Rows: effect.Rows, PayloadBytes: effect.PayloadBytes,
+		})
+	}
+	watermark := batch.Watermark
+	if watermark != nil {
+		value := watermark.UTC()
+		watermark = &value
+	}
+	snapshot := storedPreparedRouteSnapshot{
+		SchemaVersion: preparedRouteSnapshotSchemaVersion,
+		Generation:    claim.GenerationKey(), OrgID: claim.OrgID,
+		Provider: claim.Provider, Dataset: claim.Dataset,
+		NormalizedAt: normalizedAt.UTC(), Effects: effects, Result: result,
+		Watermark: watermark, Evidence: batch.Evidence, Comparison: comparison,
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil || len(encoded) < 1 || len(encoded) > maxPreparedRouteSnapshotBytes {
+		return nil, PreparedRouteSnapshotReference{}, ErrEffectRecoveryUnsafe
+	}
+	digest := sha256.Sum256(encoded)
+	reference := PreparedRouteSnapshotReference{
+		SchemaVersion: preparedRouteSnapshotSchemaVersion,
+		ContentDigest: hex.EncodeToString(digest[:]), PayloadBytes: len(encoded),
+	}
+	return encoded, reference, nil
+}
+
+func decodePreparedRouteManifest(
+	raw []byte,
+	claim Claim,
+	state EffectLedgerState,
+) (PreparedRouteManifest, error) {
+	if claim.Validate() != nil || state.validate() != nil ||
+		state.SchemaVersion != "v2" || state.PreparedSnapshot == nil ||
+		state.Generation != claim.GenerationKey() || state.Provider != claim.Provider ||
+		state.Dataset != claim.Dataset || len(raw) < 1 ||
+		len(raw) > maxPreparedRouteSnapshotBytes ||
+		len(raw) != state.PreparedSnapshot.PayloadBytes {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	digest := sha256.Sum256(raw)
+	if hex.EncodeToString(digest[:]) != state.PreparedSnapshot.ContentDigest {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	decoder := json.NewDecoder(io.LimitReader(bytes.NewReader(raw), maxPreparedRouteSnapshotBytes+1))
+	decoder.DisallowUnknownFields()
+	var snapshot storedPreparedRouteSnapshot
+	if err := decoder.Decode(&snapshot); err != nil {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	if err := requirePreparedRouteSnapshotEOF(decoder); err != nil {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	if snapshot.SchemaVersion != preparedRouteSnapshotSchemaVersion ||
+		snapshot.Generation != claim.GenerationKey() || snapshot.OrgID != claim.OrgID ||
+		snapshot.Provider != claim.Provider || snapshot.Dataset != claim.Dataset ||
+		!snapshot.NormalizedAt.Equal(state.CreatedAt) || !snapshot.Comparison.Match ||
+		len(snapshot.Effects) != len(state.Effects) || len(snapshot.Result) == 0 {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	if snapshot.Evidence.Provider != claim.Provider || snapshot.Evidence.Dataset != claim.Dataset ||
+		snapshot.Evidence.Requests < 0 || snapshot.Evidence.Pages < 0 || snapshot.Evidence.Records < 0 {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	var result map[string]any
+	if json.Unmarshal(snapshot.Result, &result) != nil || result == nil ||
+		containsPreparedRouteSensitiveKey(result) {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	effects := make([]EffectBatch, 0, len(snapshot.Effects))
+	for index, stored := range snapshot.Effects {
+		rebuilt, err := BuildEffectBatch(stored.Destination, stored.Recovery, stored.Rows)
+		if err != nil || rebuilt.ContentDigest != stored.ContentDigest ||
+			rebuilt.PayloadBytes != stored.PayloadBytes ||
+			state.Effects[index].Destination != rebuilt.Destination ||
+			state.Effects[index].ContentDigest != rebuilt.ContentDigest ||
+			state.Effects[index].RowCount != len(rebuilt.Rows) ||
+			state.Effects[index].Recovery != rebuilt.Recovery {
+			return PreparedRouteManifest{}, ErrEffectLedgerConflict
+		}
+		effects = append(effects, rebuilt)
+	}
+	batch := CompleteRouteBatch{
+		Effects: effects, Result: result, Watermark: snapshot.Watermark,
+		Evidence: snapshot.Evidence,
+	}
+	if validatePreparedRouteManifestIdentity(claim, batch, snapshot.NormalizedAt) != nil {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	return PreparedRouteManifest{
+		Batch: batch, Comparison: snapshot.Comparison,
+		NormalizedAt: snapshot.NormalizedAt.UTC(),
+	}, nil
+}
+
+func requirePreparedRouteSnapshotEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return ErrEffectLedgerConflict
+	}
+	return nil
+}
+
+func validatePreparedRouteManifestIdentity(
+	claim Claim,
+	batch CompleteRouteBatch,
+	normalizedAt time.Time,
+) error {
+	if claim.Validate() != nil || claim.Provider != "github" || claim.Dataset != "work-items" ||
+		normalizedAt.IsZero() || batch.Result == nil ||
+		batch.Evidence.Provider != claim.Provider || batch.Evidence.Dataset != claim.Dataset {
+		return ErrEffectRecoveryUnsafe
+	}
+	got := make([]string, 0, len(batch.Effects))
+	for _, effect := range batch.Effects {
+		got = append(got, effect.Destination)
+	}
+	sort.Strings(got)
+	want := workItemRouteDestinations()
+	sort.Strings(want)
+	if len(got) != len(want) {
+		return ErrEffectRecoveryUnsafe
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return ErrEffectRecoveryUnsafe
+		}
+	}
+	return nil
+}
+
+func containsPreparedRouteSensitiveKey(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+			switch normalized {
+			case "authorization", "credential", "credentials", "token", "headers",
+				"source_metadata", "integration_config", "ciphertext", "raw_payload",
+				"response_body":
+				return true
+			}
+			if containsPreparedRouteSensitiveKey(nested) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if containsPreparedRouteSensitiveKey(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (repository *PostgresRepository) PrepareRouteSnapshot(
+	ctx context.Context,
+	claim Claim,
+	batch CompleteRouteBatch,
+	comparison ShadowComparison,
+	normalizedAt time.Time,
+) (EffectLedgerState, error) {
+	if repository == nil || repository.Pool == nil || ctx == nil {
+		return EffectLedgerState{}, ErrInvalidConfiguration
+	}
+	payload, reference, err := encodePreparedRouteManifest(
+		claim, batch, comparison, normalizedAt,
+	)
+	if err != nil {
+		return EffectLedgerState{}, err
+	}
+	desired, err := NewEffectLedgerState(claim, batch.Effects, normalizedAt)
+	if err != nil {
+		return EffectLedgerState{}, err
+	}
+	desired.SchemaVersion = "v2"
+	desired.PreparedSnapshot = &reference
+	var prepared EffectLedgerState
+	err = repository.mutateGenerationJournalTx(
+		ctx, claim, normalizedAt,
+		func(tx pgx.Tx, document map[string]json.RawMessage) error {
+			raw := document[effectLedgerResultKey]
+			if len(raw) != 0 {
+				prepared, err = decodeEffectLedgerState(raw)
+				if err != nil || !sameEffectManifest(prepared, desired) {
+					return ErrEffectLedgerConflict
+				}
+				return verifyPreparedRouteSnapshotRow(ctx, tx, claim, prepared, payload)
+			}
+			prepared = desired
+			prepared.CreatedAt = normalizedAt.UTC()
+			prepared.UpdatedAt = normalizedAt.UTC()
+			encoded := encodeEffectLedgerState(prepared)
+			if len(encoded) == 0 {
+				return ErrEffectRecoveryUnsafe
+			}
+			if _, err := tx.Exec(
+				ctx, insertPreparedRouteSnapshotSQL,
+				claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
+				reference.SchemaVersion, reference.ContentDigest, reference.PayloadBytes,
+				payload, normalizedAt.UTC(),
+			); err != nil {
+				return ErrEffectLedgerConflict
+			}
+			document[effectLedgerResultKey] = encoded
+			return nil
+		},
+	)
+	return prepared, err
+}
+
+func (repository *PostgresRepository) LoadRouteSnapshot(
+	ctx context.Context,
+	claim Claim,
+	state EffectLedgerState,
+	now time.Time,
+) (PreparedRouteManifest, error) {
+	if repository == nil || repository.Pool == nil || ctx == nil || now.IsZero() ||
+		claim.Validate() != nil || state.validate() != nil ||
+		state.SchemaVersion != "v2" || state.PreparedSnapshot == nil {
+		return PreparedRouteManifest{}, ErrInvalidConfiguration
+	}
+	var schemaVersion, contentDigest string
+	var payloadBytes int
+	var payload []byte
+	if err := repository.Pool.QueryRow(
+		ctx, loadPreparedRouteSnapshotSQL,
+		claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
+		claim.Owner, now.UTC(),
+	).Scan(&schemaVersion, &contentDigest, &payloadBytes, &payload); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PreparedRouteManifest{}, ErrPreparedRouteSnapshotNotFound
+		}
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	if schemaVersion != state.PreparedSnapshot.SchemaVersion ||
+		contentDigest != state.PreparedSnapshot.ContentDigest ||
+		payloadBytes != state.PreparedSnapshot.PayloadBytes || payloadBytes != len(payload) {
+		return PreparedRouteManifest{}, ErrEffectLedgerConflict
+	}
+	return decodePreparedRouteManifest(payload, claim, state)
+}
+
+func verifyPreparedRouteSnapshotRow(
+	ctx context.Context,
+	tx pgx.Tx,
+	claim Claim,
+	state EffectLedgerState,
+	wantPayload []byte,
+) error {
+	var schemaVersion, digest string
+	var payloadBytes int
+	var payload []byte
+	if err := tx.QueryRow(
+		ctx, loadPreparedRouteSnapshotRowSQL,
+		claim.OrgID, claim.ID, claim.GenerationKey(), claim.Provider, claim.Dataset,
+	).Scan(&schemaVersion, &digest, &payloadBytes, &payload); err != nil {
+		return ErrEffectLedgerConflict
+	}
+	reference := state.PreparedSnapshot
+	if reference == nil || schemaVersion != reference.SchemaVersion ||
+		digest != reference.ContentDigest || payloadBytes != reference.PayloadBytes ||
+		payloadBytes != len(payload) || !bytes.Equal(payload, wantPayload) {
+		return ErrEffectLedgerConflict
+	}
+	return nil
+}
+
+const insertPreparedRouteSnapshotSQL = `
+INSERT INTO public.sync_run_unit_effect_snapshots (
+    org_id, sync_run_unit_id, generation, provider, dataset_key,
+    schema_version, content_digest, payload_bytes, payload, created_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`
+
+const loadPreparedRouteSnapshotSQL = `
+SELECT snapshot.schema_version, snapshot.content_digest,
+       snapshot.payload_bytes, snapshot.payload
+FROM public.sync_run_unit_effect_snapshots AS snapshot
+JOIN public.sync_run_units AS unit
+  ON unit.id = snapshot.sync_run_unit_id
+ AND unit.org_id = snapshot.org_id
+WHERE snapshot.org_id = $1
+  AND snapshot.sync_run_unit_id = $2
+  AND snapshot.generation = $3
+  AND snapshot.provider = $4
+  AND snapshot.dataset_key = $5
+  AND unit.lease_owner = $6
+  AND unit.lease_expires_at > $7
+  AND unit.status = 'running'`
+
+const loadPreparedRouteSnapshotRowSQL = `
+SELECT schema_version, content_digest, payload_bytes, payload
+FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3
+  AND provider = $4 AND dataset_key = $5
+FOR UPDATE`

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -109,6 +109,15 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 		t.Fatal(err)
 	}
 	assertPreparedSnapshotCount(t, ctx, pool, claim, 1)
+	// The snapshot is retained across the release, but it is not readable
+	// without a live lease. The unit is `dispatching` here, so the status
+	// fence alone must refuse the load even though the row is still present
+	// and the tenant/unit/generation key still matches exactly.
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, claim, state, now.Add(2*time.Second),
+	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+		t.Fatalf("released-lease load error=%v", err)
+	}
 	reclaimed, err := repository.Claim(ctx, ClaimRequest{
 		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now.Add(3 * time.Second),
 		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
@@ -116,6 +125,29 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Positive control first: the generation survives the reclaim, so the new
+	// owner inside its lease window CAN load the same snapshot. Without this
+	// the two refusals below would also pass if the row had simply become
+	// unreadable for some unrelated reason.
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, reclaimed, state, now.Add(4*time.Second),
+	); err != nil {
+		t.Fatalf("reclaimed owner load error=%v", err)
+	}
+	// A worker holding the superseded lease must not be able to read the
+	// snapshot the new owner is now responsible for.
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, claim, state, now.Add(4*time.Second),
+	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+		t.Fatalf("stale owner load error=%v", err)
+	}
+	// Now isolate the three lease fences one at a time. ReleaseForRetry clears
+	// owner, expiry and status together, so the release above can never say
+	// WHICH fence refused -- and a single missing fence would hide behind the
+	// other two. Each iteration breaks exactly one column, proves the refusal,
+	// restores it, and re-proves the load succeeds again, so no refusal can be
+	// left over from the previous iteration.
+	assertLeaseFencesIsolateTheSnapshotLoad(t, ctx, pool, repository, reclaimed, state, now)
 	if err := repository.Complete(
 		ctx, reclaimed, map[string]any{"records": 16}, nil,
 		now.Add(3*time.Second), now.Add(4*time.Second),
@@ -215,5 +247,74 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 	}
 	if got != want {
 		t.Fatalf("snapshot count=%d want=%d", got, want)
+	}
+}
+
+// assertLeaseFencesIsolateTheSnapshotLoad breaks one lease column at a time so
+// each fence in loadPreparedRouteSnapshotSQL is measured on its own. A test
+// that only releases the lease exercises all three at once, which is exactly
+// the shape that lets one of them be silently absent.
+func assertLeaseFencesIsolateTheSnapshotLoad(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	repository *PostgresRepository,
+	claim Claim,
+	state EffectLedgerState,
+	now time.Time,
+) {
+	t.Helper()
+	var (
+		liveOwner   string
+		liveExpires time.Time
+		liveStatus  string
+	)
+	if err := pool.QueryRow(ctx, `
+SELECT lease_owner, lease_expires_at, status
+FROM public.sync_run_units WHERE id = $1`, claim.ID,
+	).Scan(&liveOwner, &liveExpires, &liveStatus); err != nil {
+		t.Fatal(err)
+	}
+	at := now.Add(4 * time.Second)
+	for _, fence := range []struct {
+		name      string
+		statement string
+		argument  any
+	}{
+		{
+			"lease owner",
+			"UPDATE public.sync_run_units SET lease_owner = $2 WHERE id = $1",
+			uuid.NewString(),
+		},
+		{
+			"lease expiry",
+			"UPDATE public.sync_run_units SET lease_expires_at = $2 WHERE id = $1",
+			at.Add(-time.Second),
+		},
+		{
+			"unit status",
+			"UPDATE public.sync_run_units SET status = $2 WHERE id = $1",
+			"dispatching",
+		},
+	} {
+		if _, err := pool.Exec(ctx, fence.statement, claim.ID, fence.argument); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := repository.LoadRouteSnapshot(ctx, claim, state, at); !errors.Is(
+			err, ErrPreparedRouteSnapshotNotFound,
+		) {
+			t.Fatalf("%s fence did not refuse the load: error=%v", fence.name, err)
+		}
+		if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET lease_owner = $2, lease_expires_at = $3, status = $4
+WHERE id = $1`, claim.ID, liveOwner, liveExpires, liveStatus); err != nil {
+			t.Fatal(err)
+		}
+		// The restore has to be proven, not assumed: without this the next
+		// iteration's refusal could be left over from this one.
+		if _, err := repository.LoadRouteSnapshot(ctx, claim, state, at); err != nil {
+			t.Fatalf("%s fence restore left the load refused: error=%v", fence.name, err)
+		}
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -898,6 +898,21 @@ FROM public.sync_run_units WHERE id = $1`, unitID,
 			if status != "failed" || category != "provider_unit_failed" {
 				t.Fatalf("status=%q category=%q", status, category)
 			}
+			// And the stamp must not INVENT a ledger key. Without the guard,
+			// `-> 'go_effect_ledger_v1'` on a predecessor that has none yields
+			// SQL NULL, and jsonb_build_object turns that into an explicit
+			// `"go_effect_ledger_v1": null` -- a snapshot reference that reads
+			// as present and decodes to nothing.
+			var hasLedger bool
+			if err := pool.QueryRow(ctx, `
+SELECT COALESCE(result::jsonb ? 'go_effect_ledger_v1', false)
+FROM public.sync_run_units WHERE id = $1`, unitID,
+			).Scan(&hasLedger); err != nil {
+				t.Fatal(err)
+			}
+			if hasLedger {
+				t.Fatal("terminal Fail invented a go_effect_ledger_v1 key on a unit that never had one")
+			}
 		})
 	}
 

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -97,6 +97,36 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 	if _, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second)); !errors.Is(err, ErrEffectLedgerConflict) {
 		t.Fatalf("tamper error=%v", err)
 	}
+	// The case above grows the payload, so payload_bytes stops matching and the
+	// LENGTH comparison rejects it -- the digest never gets consulted. A
+	// length-preserving edit is the one that isolates the digest fence, and it
+	// is also the realistic corruption: a flipped byte, not an appended one.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_unit_effect_snapshots
+SET payload = decode('00', 'hex') || substring(payload from 2)
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	var storedBytes, actualLength int
+	if err := pool.QueryRow(ctx, `
+SELECT payload_bytes, length(payload) FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	).Scan(&storedBytes, &actualLength); err != nil {
+		t.Fatal(err)
+	}
+	if storedBytes != actualLength {
+		t.Fatalf(
+			"fixture is not length-preserving: payload_bytes=%d length=%d -- the length "+
+				"fence would fire and the digest fence would go unexercised",
+			storedBytes, actualLength,
+		)
+	}
+	if _, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second)); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("length-preserving tamper error=%v", err)
+	}
 	if _, err := pool.Exec(ctx, `
 UPDATE public.sync_run_unit_effect_snapshots
 SET payload = $4, payload_bytes = $5
@@ -594,5 +624,102 @@ FROM public.sync_run_units AS unit WHERE unit.id = $1`, claim.ID,
 	if survived.SchemaVersion != "v2" || survived.PreparedSnapshot == nil ||
 		!samePreparedRouteSnapshotReference(survived.PreparedSnapshot, state.PreparedSnapshot) {
 		t.Fatalf("surviving ledger lost the snapshot reference: %+v", survived)
+	}
+}
+
+// TestPostgresSnapshotTenancyIsEnforcedByReadsNotByStructure pins a KNOWN and
+// currently accepted gap, so it is a measured fact rather than an assumption.
+//
+// The table's FK is (sync_run_unit_id) -> sync_run_units(id), which says
+// nothing about org_id. So a row can be INSERTED claiming an org that does not
+// own the unit. Nothing in production can write one -- the route is
+// unregistered and the only writer derives org_id from the claim -- but the
+// schema does not prevent it.
+//
+// Reads are safe, and that is what this test proves rather than asserts: the
+// load joins on BOTH unit.id and unit.org_id, so a mismatched row is
+// unreachable no matter how it got there.
+//
+// Making it structural needs a composite FK to sync_run_units(org_id, id) and
+// therefore a UNIQUE index on that pair -- a CONCURRENTLY build plus a
+// NOT VALID/VALIDATE FK against a hot table. That is deliberately NOT done in
+// this PR, which activates nothing; it is recorded as pre-activation debt.
+func TestPostgresSnapshotTenancyIsEnforcedByReadsNotByStructure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	unitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, unitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repository.PrepareRouteSnapshot(
+		ctx, claim, preparedGitHubWorkItemsFixture(t, claim),
+		ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The gap, executed: a second row for the SAME unit under a DIFFERENT org.
+	// If a future migration makes this structural, this INSERT starts failing
+	// and this test is the thing that tells you the debt was paid.
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.sync_run_unit_effect_snapshots (
+    org_id, sync_run_unit_id, generation, provider, dataset_key,
+    schema_version, content_digest, payload_bytes, payload, created_at)
+SELECT 'org-intruder', sync_run_unit_id, generation, provider, dataset_key,
+       schema_version, content_digest, payload_bytes, payload, created_at
+FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	); err != nil {
+		t.Fatalf(
+			"cross-tenant insert was refused: %v -- if a composite FK landed, "+
+				"delete this test and the debt note in the PR body", err,
+		)
+	}
+
+	// Reads stay correct: the owning tenant still loads its own row...
+	if _, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second)); err != nil {
+		t.Fatalf("owning tenant load: %v", err)
+	}
+	// ...and the intruder's row is unreachable, because the join requires the
+	// unit's org_id to match the snapshot's.
+	intruder := claim
+	intruder.OrgID = "org-intruder"
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, intruder, state, now.Add(time.Second),
+	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+		t.Fatalf("intruder load error=%v, want not-found", err)
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -1,0 +1,219 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresPreparedRouteSnapshotLifecycleAndFences(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	unitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, unitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	state, err := repository.PrepareRouteSnapshot(
+		ctx, claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.SchemaVersion != "v2" || state.PreparedSnapshot == nil {
+		t.Fatalf("prepared state=%+v", state)
+	}
+	manifest, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second))
+	if err != nil || len(manifest.Batch.Effects) != len(workItemRouteDestinations()) {
+		t.Fatalf("loaded manifest=%+v error=%v", manifest, err)
+	}
+
+	wrongTenant := claim
+	wrongTenant.OrgID = "org-other"
+	if _, err := repository.LoadRouteSnapshot(ctx, wrongTenant, state, now.Add(time.Second)); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+		t.Fatalf("wrong tenant error=%v", err)
+	}
+	wrongGeneration := claim
+	wrongGeneration.ID = uuid.NewString()
+	if _, err := repository.LoadRouteSnapshot(ctx, wrongGeneration, state, now.Add(time.Second)); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+		t.Fatalf("wrong generation error=%v", err)
+	}
+
+	var originalPayload []byte
+	if err := pool.QueryRow(ctx, `
+SELECT payload FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	).Scan(&originalPayload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_unit_effect_snapshots
+SET payload = payload || decode('00', 'hex'), payload_bytes = payload_bytes + 1
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second)); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("tamper error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_unit_effect_snapshots
+SET payload = $4, payload_bytes = $5
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(), originalPayload, len(originalPayload),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repository.ReleaseForRetry(ctx, claim, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	assertPreparedSnapshotCount(t, ctx, pool, claim, 1)
+	reclaimed, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now.Add(3 * time.Second),
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.Complete(
+		ctx, reclaimed, map[string]any{"records": 16}, nil,
+		now.Add(3*time.Second), now.Add(4*time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+	assertPreparedSnapshotCount(t, ctx, pool, reclaimed, 0)
+
+	atomicUnitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, atomicUnitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	atomicClaim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: atomicUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now.Add(5 * time.Second),
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+CREATE FUNCTION reject_snapshot_ledger_update() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'simulated ledger update failure';
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER reject_snapshot_ledger_update
+BEFORE UPDATE ON public.sync_run_units
+FOR EACH ROW EXECUTE FUNCTION reject_snapshot_ledger_update()`); err != nil {
+		t.Fatal(err)
+	}
+	atomicBatch := preparedGitHubWorkItemsFixture(t, atomicClaim)
+	if _, err := repository.PrepareRouteSnapshot(
+		ctx, atomicClaim, atomicBatch, ShadowComparison{Match: true}, now.Add(5*time.Second),
+	); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("atomic prepare error=%v", err)
+	}
+	assertPreparedSnapshotCount(t, ctx, pool, atomicClaim, 0)
+	if _, err := pool.Exec(ctx, `
+DROP TRIGGER reject_snapshot_ledger_update ON public.sync_run_units;
+DROP FUNCTION reject_snapshot_ledger_update()`); err != nil {
+		t.Fatal(err)
+	}
+
+	rollbackUnitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, rollbackUnitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	rollbackClaim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: rollbackUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now.Add(6 * time.Second),
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rollbackBatch := preparedGitHubWorkItemsFixture(t, rollbackClaim)
+	if _, err := repository.PrepareRouteSnapshot(
+		ctx, rollbackClaim, rollbackBatch, ShadowComparison{Match: true}, now.Add(6*time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, "DROP TABLE public.sync_dispatch_outbox"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.Complete(
+		ctx, rollbackClaim, map[string]any{"records": 16}, nil,
+		now.Add(6*time.Second), now.Add(7*time.Second),
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("rollback completion error=%v", err)
+	}
+	assertPreparedSnapshotCount(t, ctx, pool, rollbackClaim, 1)
+	var status string
+	if err := pool.QueryRow(
+		ctx, "SELECT status FROM public.sync_run_units WHERE id = $1", rollbackClaim.ID,
+	).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "running" {
+		t.Fatalf("rolled-back unit status=%q", status)
+	}
+}
+
+func assertPreparedSnapshotCount(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	claim Claim,
+	want int,
+) {
+	t.Helper()
+	var got int
+	if err := pool.QueryRow(ctx, `
+SELECT count(*) FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("snapshot count=%d want=%d", got, want)
+	}
+}

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -5,6 +5,7 @@ package providersync
 import (
 	"context"
 	"errors"
+	"net/url"
 	"testing"
 	"time"
 
@@ -110,12 +111,16 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 	}
 	assertPreparedSnapshotCount(t, ctx, pool, claim, 1)
 	// The snapshot is retained across the release, but it is not readable
-	// without a live lease. The unit is `dispatching` here, so the status
-	// fence alone must refuse the load even though the row is still present
-	// and the tenant/unit/generation key still matches exactly.
+	// without a live lease. The refusal must be ErrLeaseLost and NOT
+	// ErrPreparedRouteSnapshotNotFound: the row is still present and its
+	// tenant/unit/generation key still matches exactly, so "not found" would
+	// be a false statement about durable state. The wrong-tenant and
+	// wrong-generation probes above are the cases that genuinely find nothing,
+	// and they are the ones that keep reporting NotFound -- that contrast is
+	// the whole point of separating the two.
 	if _, err := repository.LoadRouteSnapshot(
 		ctx, claim, state, now.Add(2*time.Second),
-	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+	); !errors.Is(err, ErrLeaseLost) {
 		t.Fatalf("released-lease load error=%v", err)
 	}
 	reclaimed, err := repository.Claim(ctx, ClaimRequest{
@@ -135,10 +140,11 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 		t.Fatalf("reclaimed owner load error=%v", err)
 	}
 	// A worker holding the superseded lease must not be able to read the
-	// snapshot the new owner is now responsible for.
+	// snapshot the new owner is now responsible for -- and must be told it
+	// lost the lease, not that the snapshot vanished.
 	if _, err := repository.LoadRouteSnapshot(
 		ctx, claim, state, now.Add(4*time.Second),
-	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
+	); !errors.Is(err, ErrLeaseLost) {
 		t.Fatalf("stale owner load error=%v", err)
 	}
 	// Now isolate the three lease fences one at a time. ReleaseForRetry clears
@@ -148,6 +154,60 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 	// restores it, and re-proves the load succeeds again, so no refusal can be
 	// left over from the previous iteration.
 	assertLeaseFencesIsolateTheSnapshotLoad(t, ctx, pool, repository, reclaimed, state, now)
+
+	// The terminal-run fence, which lives on sync_runs rather than the unit.
+	// loadEffectLedgerSQL has always excluded finished runs; this query gained
+	// the same exclusion so the two cannot disagree about entitlement.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_runs SET status = 'success'
+WHERE id = (SELECT sync_run_id FROM public.sync_run_units WHERE id = $1)`, reclaimed.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, reclaimed, state, now.Add(4*time.Second),
+	); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("terminal-run fence load error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_runs SET status = 'running'
+WHERE id = (SELECT sync_run_id FROM public.sync_run_units WHERE id = $1)`, reclaimed.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, reclaimed, state, now.Add(4*time.Second),
+	); err != nil {
+		t.Fatalf("terminal-run fence restore left the load refused: %v", err)
+	}
+
+	// verifyPreparedRouteSnapshotRow's payload comparison: a stored payload
+	// that no longer matches what this attempt would write must be refused on
+	// re-prepare, not silently accepted because the ledger metadata still
+	// agrees. Only the ledger-exists branch reads the row back, so a first
+	// prepare never exercises this.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_unit_effect_snapshots
+SET payload = decode('00', 'hex') || substring(payload from 2)
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.PrepareRouteSnapshot(
+		ctx, reclaimed, preparedGitHubWorkItemsFixture(t, reclaimed),
+		ShadowComparison{Match: true}, now,
+	); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("re-prepare over a corrupted payload error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_unit_effect_snapshots
+SET payload = decode('7b', 'hex') || substring(payload from 2)
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
 	if err := repository.Complete(
 		ctx, reclaimed, map[string]any{"records": 16}, nil,
 		now.Add(3*time.Second), now.Add(4*time.Second),
@@ -301,7 +361,7 @@ FROM public.sync_run_units WHERE id = $1`, claim.ID,
 			t.Fatal(err)
 		}
 		if _, err := repository.LoadRouteSnapshot(ctx, claim, state, at); !errors.Is(
-			err, ErrPreparedRouteSnapshotNotFound,
+			err, ErrLeaseLost,
 		) {
 			t.Fatalf("%s fence did not refuse the load: error=%v", fence.name, err)
 		}
@@ -316,5 +376,223 @@ WHERE id = $1`, claim.ID, liveOwner, liveExpires, liveStatus); err != nil {
 		if _, err := repository.LoadRouteSnapshot(ctx, claim, state, at); err != nil {
 			t.Fatalf("%s fence restore left the load refused: error=%v", fence.name, err)
 		}
+	}
+}
+
+// TestPostgresPreparedRouteSnapshotRunsUnderTheRestrictedDomainRole executes
+// the snapshot statements as the ACTUAL domain role rather than the table
+// owner.
+//
+// Every other test in this file connects as the owner, who bypasses privilege
+// checks entirely. That missing venue is precisely why a `FOR UPDATE` on the
+// snapshot row survived review, a full mutation plan and a green gate: any
+// row-locking clause requires an UPDATE-class privilege, the domain role holds
+// only SELECT/INSERT/DELETE here, and so the re-prepare path failed with
+// "permission denied" on every production attempt while passing locally 100%
+// of the time. Owner-privileged tests cannot observe a privilege bug.
+func TestPostgresPreparedRouteSnapshotRunsUnderTheRestrictedDomainRole(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	ownerPool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ownerPool.Close()
+	createProviderSyncFixture(t, ctx, ownerPool)
+	seedProviderSyncFixture(t, ctx, ownerPool)
+
+	// The venue isolates ONE property: the snapshot table carries no
+	// UPDATE-class privilege. Everything else is granted broadly on purpose --
+	// this test is not a posture audit (internal/domaingrants owns that), and
+	// a venue that also under-grants unrelated tables would fail for reasons
+	// that say nothing about the defect class under test. Granting wide and
+	// revoking exactly UPDATE on the snapshot table makes any failure here
+	// attributable to that single missing privilege.
+	const role = "providersync_domain_probe"
+	for _, statement := range []string{
+		`DROP ROLE IF EXISTS ` + role,
+		`CREATE ROLE ` + role + ` LOGIN PASSWORD 'probe'`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ` + role,
+		`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ` + role,
+		`REVOKE UPDATE ON TABLE public.sync_run_unit_effect_snapshots FROM ` + role,
+	} {
+		if _, err := ownerPool.Exec(ctx, statement); err != nil {
+			t.Fatalf("%s: %v", statement, err)
+		}
+	}
+	restrictedURI, err := restrictedRoleURI(instance.URI, role, "probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	restrictedPool, err := pgxpool.New(ctx, restrictedURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restrictedPool.Close()
+	var current string
+	if err := restrictedPool.QueryRow(ctx, "SELECT current_user").Scan(&current); err != nil {
+		t.Fatal(err)
+	}
+	if current != role {
+		t.Fatalf("connected as %q, want the restricted role %q", current, role)
+	}
+
+	repository, err := NewPostgresRepository(restrictedPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	unitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, ownerPool, unitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	state, err := repository.PrepareRouteSnapshot(
+		ctx, claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatalf("prepare under the restricted role: %v", err)
+	}
+
+	// THE regression: the second prepare takes the ledger-exists branch, which
+	// is the only path that reads the snapshot row back inside the
+	// transaction. That read is what used to demand a row lock the role may
+	// not take. A first prepare alone never reaches it, which is how this
+	// stayed invisible.
+	reprepared, err := repository.PrepareRouteSnapshot(
+		ctx, claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatalf("re-prepare under the restricted role: %v", err)
+	}
+	if !sameEffectManifest(state, reprepared) {
+		t.Fatalf("re-prepare returned a different manifest: %+v vs %+v", state, reprepared)
+	}
+	if _, err := repository.LoadRouteSnapshot(ctx, claim, state, now.Add(time.Second)); err != nil {
+		t.Fatalf("load under the restricted role: %v", err)
+	}
+	if err := repository.Complete(
+		ctx, claim, map[string]any{"records": 16}, nil, now, now.Add(time.Second),
+	); err != nil {
+		t.Fatalf("complete under the restricted role: %v", err)
+	}
+	assertPreparedSnapshotCount(t, ctx, ownerPool, claim, 0)
+}
+
+// restrictedRoleURI rewrites a connection URI's credentials, leaving host,
+// port, database and parameters untouched.
+func restrictedRoleURI(base string, role string, password string) (string, error) {
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	parsed.User = url.UserPassword(role, password)
+	return parsed.String(), nil
+}
+
+// TestPostgresFailedUnitKeepsTheSnapshotReachable covers contract point 5's
+// other half: a failed unit RETAINS its snapshot. Retention is only
+// meaningful if the reference survives too. failUnitSQL used to replace the
+// result document wholesale, which deleted the go_effect_ledger_v1 key and
+// with it the prepared-snapshot reference -- leaving a row up to 64 MiB that
+// nothing could ever find again, reclaimed only if the owning unit was
+// eventually deleted and the CASCADE fired.
+func TestPostgresFailedUnitKeepsTheSnapshotReachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	unitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, unitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repository.PrepareRouteSnapshot(
+		ctx, claim, preparedGitHubWorkItemsFixture(t, claim),
+		ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.Fail(
+		ctx, claim, "provider_unit_failed", now, now.Add(time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPreparedSnapshotCount(t, ctx, pool, claim, 1)
+	var status, category string
+	var ledger []byte
+	if err := pool.QueryRow(ctx, `
+SELECT unit.status,
+       COALESCE(unit.result::jsonb ->> 'error_category', ''),
+       COALESCE((unit.result::jsonb -> 'go_effect_ledger_v1')::text, '')
+FROM public.sync_run_units AS unit WHERE unit.id = $1`, claim.ID,
+	).Scan(&status, &category, &ledger); err != nil {
+		t.Fatal(err)
+	}
+	if status != "failed" || category != "provider_unit_failed" {
+		t.Fatalf("status=%q category=%q", status, category)
+	}
+	// The failure category is recorded AND the ledger survives. Asserting only
+	// the category would pass against the wholesale replace this test exists
+	// to catch.
+	if len(ledger) == 0 {
+		t.Fatal("Fail destroyed the go_effect_ledger_v1 key; the retained snapshot is unreachable")
+	}
+	survived, err := decodeEffectLedgerState(ledger)
+	if err != nil {
+		t.Fatalf("decode surviving ledger: %v", err)
+	}
+	if survived.SchemaVersion != "v2" || survived.PreparedSnapshot == nil ||
+		!samePreparedRouteSnapshotReference(survived.PreparedSnapshot, state.PreparedSnapshot) {
+		t.Fatalf("surviving ledger lost the snapshot reference: %+v", survived)
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_integration_test.go
+++ b/internal/providersync/prepared_route_snapshot_integration_test.go
@@ -194,10 +194,38 @@ WHERE id = (SELECT sync_run_id FROM public.sync_run_units WHERE id = $1)`, recla
 	); err != nil {
 		t.Fatal(err)
 	}
+	// A finalized run reports ITS OWN error, not lease loss -- the lease here
+	// is live and correct, and saying "lease lost" would send an operator to
+	// the wrong place entirely.
 	if _, err := repository.LoadRouteSnapshot(
 		ctx, reclaimed, state, now.Add(4*time.Second),
-	); !errors.Is(err, ErrLeaseLost) {
+	); !errors.Is(err, ErrPreparedRouteSnapshotRunTerminal) {
 		t.Fatalf("terminal-run fence load error=%v", err)
+	}
+	// partial_failed is a distinct element of the NOT IN list and a distinct
+	// production state; covering only 'success' left the other two elements
+	// pinned by nothing but a whole-predicate mutation.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_runs SET status = 'partial_failed'
+WHERE id = (SELECT sync_run_id FROM public.sync_run_units WHERE id = $1)`, reclaimed.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, reclaimed, state, now.Add(4*time.Second),
+	); !errors.Is(err, ErrPreparedRouteSnapshotRunTerminal) {
+		t.Fatalf("partial_failed run fence load error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_runs SET status = 'failed'
+WHERE id = (SELECT sync_run_id FROM public.sync_run_units WHERE id = $1)`, reclaimed.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadRouteSnapshot(
+		ctx, reclaimed, state, now.Add(4*time.Second),
+	); !errors.Is(err, ErrPreparedRouteSnapshotRunTerminal) {
+		t.Fatalf("failed run fence load error=%v", err)
 	}
 	if _, err := pool.Exec(ctx, `
 UPDATE public.sync_runs SET status = 'running'
@@ -235,6 +263,44 @@ UPDATE public.sync_run_unit_effect_snapshots
 SET payload = decode('7b', 'hex') || substring(payload from 2)
 WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// The ErrNoRows arm of verifyPreparedRouteSnapshotRow: ledger present,
+	// sidecar row gone. That is a genuine ledger/sidecar disagreement and must
+	// map to ErrEffectLedgerConflict -- distinct from the pass-through the
+	// same function now uses for real database errors. Reverting that
+	// remapping used to be silently green.
+	var savedPayload []byte
+	if err := pool.QueryRow(ctx, `
+SELECT payload FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+	).Scan(&savedPayload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+DELETE FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
+		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.PrepareRouteSnapshot(
+		ctx, reclaimed, preparedGitHubWorkItemsFixture(t, reclaimed),
+		ShadowComparison{Match: true}, now,
+	); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("re-prepare with the sidecar row deleted: error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.sync_run_unit_effect_snapshots (
+    org_id, sync_run_unit_id, generation, provider, dataset_key,
+    schema_version, content_digest, payload_bytes, payload, created_at)
+VALUES ($1, $2, $3, 'github', 'work-items', $4, $5, $6, $7, $8)`,
+		reclaimed.OrgID, reclaimed.ID, reclaimed.GenerationKey(),
+		state.PreparedSnapshot.SchemaVersion, state.PreparedSnapshot.ContentDigest,
+		len(savedPayload), savedPayload, now,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -591,6 +657,24 @@ func TestPostgresFailedUnitKeepsTheSnapshotReachable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Stamp the claimable-state keys a real unit accumulates before failing:
+	// markExpiredLeaseRetryingSQL, the soft-timeout retry path, rate-limit
+	// deferral and the budget guard all write into this same document, and
+	// NOTHING clears them on claim. A terminal stamp that preserves them
+	// freezes a live "will retry at T" claim onto a dead unit -- and the admin
+	// integrations API projects these keys with no status gate.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET result = (COALESCE(result::jsonb, '{}'::jsonb) || $2::jsonb)::json
+WHERE id = $1`, claim.ID, `{
+		"next_retry_at": "2026-08-04T13:00:00Z",
+		"retry_exhausted": false,
+		"retry_reason": "provider_rate_limited",
+		"rate_limit_deferred_until": "2026-08-04T13:30:00Z",
+		"budget_deferred": true
+	}`); err != nil {
+		t.Fatal(err)
+	}
 	if err := repository.Fail(
 		ctx, claim, "provider_unit_failed", now, now.Add(time.Second),
 	); err != nil {
@@ -598,6 +682,24 @@ func TestPostgresFailedUnitKeepsTheSnapshotReachable(t *testing.T) {
 	}
 
 	assertPreparedSnapshotCount(t, ctx, pool, claim, 1)
+	var leftoverKeys []string
+	if err := pool.QueryRow(ctx, `
+SELECT COALESCE(array_agg(key ORDER BY key), ARRAY[]::text[])
+FROM public.sync_run_units AS unit,
+     LATERAL jsonb_object_keys(unit.result::jsonb) AS key
+WHERE unit.id = $1
+  AND key IN ('next_retry_at', 'retry_exhausted', 'retry_reason',
+              'rate_limit_deferred_until', 'budget_deferred')`, claim.ID,
+	).Scan(&leftoverKeys); err != nil {
+		t.Fatal(err)
+	}
+	if len(leftoverKeys) != 0 {
+		t.Fatalf(
+			"terminal Fail preserved claimable-state keys %v; the admin API reads "+
+				"these with no status gate and would report a failed unit as retrying",
+			leftoverKeys,
+		)
+	}
 	var status, category string
 	var ledger []byte
 	if err := pool.QueryRow(ctx, `
@@ -721,5 +823,103 @@ WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`,
 		ctx, intruder, state, now.Add(time.Second),
 	); !errors.Is(err, ErrPreparedRouteSnapshotNotFound) {
 		t.Fatalf("intruder load error=%v, want not-found", err)
+	}
+}
+
+// TestPostgresFailedUnitSurvivesAJSONNullResult covers the sa.JSON hazard:
+// result is a JSON column, so it can legitimately hold the literal `null`.
+// `'null'::jsonb || '{}'::jsonb` raises a non-object-operand error, and that
+// raise surfaces out of Fail() as ErrLeaseLost -- a failure to record a
+// failure, reported as a lease problem, on a unit whose lease is fine.
+func TestPostgresFailedUnitSurvivesAJSONNullResult(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+
+	for _, predecessor := range []struct {
+		name  string
+		value any
+	}{
+		{"SQL NULL", nil},
+		{"JSON literal null", "null"},
+	} {
+		t.Run(predecessor.name, func(t *testing.T) {
+			unitID := uuid.NewString()
+			seedWorkItemAliasUnit(t, ctx, pool, unitID, "incremental", `{
+				"sync_prs":true,"family_dataset_work_items":true
+			}`)
+			if _, err := pool.Exec(ctx,
+				"UPDATE public.sync_run_units SET result = $2 WHERE id = $1",
+				unitID, predecessor.value,
+			); err != nil {
+				t.Fatal(err)
+			}
+			claim, err := repository.Claim(ctx, ClaimRequest{
+				UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+				LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := repository.Fail(
+				ctx, claim, "provider_unit_failed", now, now.Add(time.Second),
+			); err != nil {
+				t.Fatalf("Fail over a %s result: %v", predecessor.name, err)
+			}
+			var status, category string
+			if err := pool.QueryRow(ctx, `
+SELECT status, COALESCE(result::jsonb ->> 'error_category', '')
+FROM public.sync_run_units WHERE id = $1`, unitID,
+			).Scan(&status, &category); err != nil {
+				t.Fatal(err)
+			}
+			if status != "failed" || category != "provider_unit_failed" {
+				t.Fatalf("status=%q category=%q", status, category)
+			}
+		})
+	}
+
+	// A non-object result document is NOT a state Fail has to survive, and the
+	// reason is worth pinning rather than leaving to inference: Claim refuses
+	// such a unit outright, so no lease is ever held over one and Fail is
+	// unreachable. Measured -- an earlier version of this test carried a JSON
+	// scalar case that failed here, at Claim, not at Fail.
+	scalarUnitID := uuid.NewString()
+	seedWorkItemAliasUnit(t, ctx, pool, scalarUnitID, "incremental", `{
+		"sync_prs":true,"family_dataset_work_items":true
+	}`)
+	if _, err := pool.Exec(ctx,
+		"UPDATE public.sync_run_units SET result = $2 WHERE id = $1",
+		scalarUnitID, `"a string, not an object"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: scalarUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	}); err == nil {
+		t.Fatal("Claim accepted a unit whose result is a JSON scalar; Fail would then have to handle it")
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -423,9 +423,14 @@ func TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems(t *testing.T) {
 func TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	// Both pairs must be ones a real claim can carry. "github/work-item-labels"
+	// looks like the natural second case and is not: the alias family collapses
+	// to work-items before a unit exists, so Claim.Validate rejects it and
+	// Execute refuses at its first check without ever reaching this guard --
+	// which is how R18 survived a version of this test that used it.
 	for name, pair := range map[string]struct{ provider, dataset string }{
 		"another provider": {provider: "linear", dataset: "work-items"},
-		"another dataset":  {provider: "github", dataset: "work-item-labels"},
+		"another dataset":  {provider: "github", dataset: "prs"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			claim, session := preparedWorkItemsSession(t, now, pair.provider, pair.dataset)

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -270,7 +270,21 @@ func preparedGitHubWorkItemsSession(
 	now time.Time,
 ) (Claim, *LeaseSession) {
 	t.Helper()
+	return preparedWorkItemsSession(t, now, "github", "work-items")
+}
+
+// preparedWorkItemsSession builds a claim for an arbitrary pair. Execute
+// requires the descriptor and the claim to agree, so testing a guard that
+// discriminates on the pair needs both sides moved together.
+func preparedWorkItemsSession(
+	t *testing.T,
+	now time.Time,
+	provider string,
+	dataset string,
+) (Claim, *LeaseSession) {
+	t.Helper()
 	unit := githubWorkItemOracleClaim().Unit
+	unit.Provider, unit.Dataset = provider, dataset
 	leases := newMemoryLeaseRepository(unit, "dispatching")
 	claim, err := leases.Claim(context.Background(), ClaimRequest{
 		UnitID: unit.ID, OrgID: unit.OrgID, Owner: uuid.NewString(), Now: now,
@@ -398,36 +412,40 @@ func TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems(t *testing.T) {
 // capability. A descriptor carrying it for any other pair is a wiring mistake
 // that must fail before the route touches credentials, not a route that
 // quietly runs without its snapshot.
+//
+// The mistake has to be a COHERENT one to be reachable at all: Execute's first
+// validation already rejects any descriptor that disagrees with its claim, so
+// pointing a github/work-items descriptor at another provider tests that
+// earlier check, not this guard. The reachable defect is a descriptor and
+// claim that agree with each other on some other pair while still carrying the
+// recovery flag. Measured, not assumed: an earlier version of this test used
+// the incoherent form, and both R17 and R18 survived against it.
 func TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
-	claim, session := preparedGitHubWorkItemsSession(t, now)
-	batch := preparedGitHubWorkItemsFixture(t, claim)
-	for name, retarget := range map[string]func(*CompleteRouteDescriptor){
-		"another provider": func(descriptor *CompleteRouteDescriptor) {
-			descriptor.Provider = "linear"
-		},
-		"another dataset": func(descriptor *CompleteRouteDescriptor) {
-			descriptor.RouteDataset = "work-item-labels"
-		},
+	for name, pair := range map[string]struct{ provider, dataset string }{
+		"another provider": {provider: "linear", dataset: "work-items"},
+		"another dataset":  {provider: "github", dataset: "work-item-labels"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
-			descriptor.Destinations = workItemRouteDestinations()
-			descriptor.RouteReady, descriptor.RouteEnabled = true, true
-			retarget(&descriptor)
-			handler := &staticCompleteRouteHandler{batch: batch}
+			claim, session := preparedWorkItemsSession(t, now, pair.provider, pair.dataset)
+			descriptor := CompleteRouteDescriptor{
+				Provider: pair.provider, RequestedDataset: pair.dataset,
+				RouteDataset: pair.dataset, Destinations: workItemRouteDestinations(),
+				PreparedManifestRecovery: true, RouteReady: true, RouteEnabled: true,
+			}
+			handler := &staticCompleteRouteHandler{
+				batch: preparedGitHubWorkItemsFixture(t, claim),
+			}
 			ledger := &memoryEffectLedger{}
 			_, err := completeRouteExecutor(
 				now.Add(time.Hour), handler, ledger, &memoryEffectSink{},
 			).Execute(context.Background(), session, descriptor)
-			// The returned error alone proves nothing here: a mis-targeted
-			// descriptor also fails ErrInvalidConfiguration further down, once
-			// the route is already inside the lease -- which is exactly how an
-			// earlier version of this test passed with this guard mutated
-			// away. effectLoads is the discriminator: the guard runs before
-			// session.Run, so a refusal that happened there means the ledger
-			// was never consulted at all.
+			// The returned error alone is not enough: several later failures
+			// wear the same sentinel once the route is already inside the
+			// lease. effectLoads is the discriminator -- this guard runs
+			// before session.Run, so a refusal that happened there means the
+			// ledger was never consulted at all.
 			if !errors.Is(err, ErrInvalidConfiguration) || !handler.normalizedAt.IsZero() ||
 				ledger.effectLoads != 0 {
 				t.Fatalf(
@@ -435,7 +453,6 @@ func TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems(t *testing.T) {
 					err, handler.normalizedAt, ledger.effectLoads,
 				)
 			}
-			_ = claim
 		})
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -417,11 +417,23 @@ func TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems(t *testing.T) {
 			descriptor.RouteReady, descriptor.RouteEnabled = true, true
 			retarget(&descriptor)
 			handler := &staticCompleteRouteHandler{batch: batch}
+			ledger := &memoryEffectLedger{}
 			_, err := completeRouteExecutor(
-				now.Add(time.Hour), handler, &memoryEffectLedger{}, &memoryEffectSink{},
+				now.Add(time.Hour), handler, ledger, &memoryEffectSink{},
 			).Execute(context.Background(), session, descriptor)
-			if !errors.Is(err, ErrInvalidConfiguration) || !handler.normalizedAt.IsZero() {
-				t.Fatalf("error=%v handler_at=%s", err, handler.normalizedAt)
+			// The returned error alone proves nothing here: a mis-targeted
+			// descriptor also fails ErrInvalidConfiguration further down, once
+			// the route is already inside the lease -- which is exactly how an
+			// earlier version of this test passed with this guard mutated
+			// away. effectLoads is the discriminator: the guard runs before
+			// session.Run, so a refusal that happened there means the ledger
+			// was never consulted at all.
+			if !errors.Is(err, ErrInvalidConfiguration) || !handler.normalizedAt.IsZero() ||
+				ledger.effectLoads != 0 {
+				t.Fatalf(
+					"error=%v handler_at=%s effect_loads=%d",
+					err, handler.normalizedAt, ledger.effectLoads,
+				)
 			}
 			_ = claim
 		})

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -3,8 +3,11 @@ package providersync
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -516,5 +519,175 @@ func TestPreparedRecoveryRevalidatesTheManifestAgainstTheLiveDescriptor(t *testi
 	).Execute(context.Background(), session, descriptor)
 	if !errors.Is(err, ErrEffectLedgerConflict) || len(sink.destinations) != 0 {
 		t.Fatalf("error=%v writes=%v", err, sink.destinations)
+	}
+}
+
+// recordingEffectReadback remembers which destinations it was asked about, so
+// a test can assert WHICH batch a recovery decision consulted rather than only
+// what it decided.
+type recordingEffectReadback struct {
+	inspections map[string]EffectInspection
+	asked       []string
+}
+
+func (readback *recordingEffectReadback) InspectEffect(
+	_ context.Context,
+	_ Claim,
+	batch EffectBatch,
+) (EffectInspection, error) {
+	readback.asked = append(readback.asked, batch.Destination)
+	inspection, known := readback.inspections[batch.Destination]
+	if !known {
+		// Loud, not zero-valued. Returning the zero EffectInspection for an
+		// unexpected destination turns a mis-pairing into some generic
+		// downstream error whose message never names the destination that was
+		// actually inspected -- which is the one fact a reader needs.
+		return inspection, fmt.Errorf(
+			"readback asked about %q, which this test never staged", batch.Destination,
+		)
+	}
+	return inspection, nil
+}
+
+// Recovery pairs prepared batches to ledger entries BY POSITION, so every
+// producer of that order must use the same comparator. This pins it with a
+// destination whose priority order and alphabetical order DISAGREE:
+// github_blame_path_progress sorts last alphabetically and first by priority.
+// Under the old plain-destination sort, index 0 of the batch slice was
+// ai_attribution while index 0 of the ledger was github_blame_path_progress --
+// so the readback would have inspected one destination's rows to resolve
+// another's ledger entry, and the mis-pairing would look like an ordinary
+// recovery decision.
+func TestCommitPreparedPairsEachEffectWithItsOwnLedgerEntry(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	effects := make([]EffectBatch, 0, 2)
+	for _, spec := range []struct {
+		destination string
+		policy      EffectRecoveryPolicy
+	}{
+		{"ai_attribution", EffectReplaySafe},
+		{"github_blame_path_progress", EffectReadbackRequired},
+	} {
+		row, err := json.Marshal(map[string]any{
+			"org_id": claim.OrgID, "destination": spec.destination,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		effect, err := BuildEffectBatch(spec.destination, spec.policy, []json.RawMessage{row})
+		if err != nil {
+			t.Fatal(err)
+		}
+		effects = append(effects, effect)
+	}
+	persisted, err := NewEffectLedgerState(claim, effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Find the priority entry rather than assuming its index. Asserting
+	// position here would make a divergent comparator fail at the setup line,
+	// which proves the ledger order changed but says nothing about pairing --
+	// and pairing is the invariant under test.
+	priority := -1
+	for index, entry := range persisted.Effects {
+		if entry.Destination == "github_blame_path_progress" {
+			priority = index
+		}
+	}
+	if priority < 0 {
+		t.Fatalf("priority destination missing from the ledger: %+v", persisted.Effects)
+	}
+	startedAt := now.Add(time.Second)
+	persisted.Effects[priority].Status = GenerationBlockWriting
+	persisted.Effects[priority].StartedAt = &startedAt
+
+	ledger := &memoryEffectLedger{state: persisted}
+	sink := &memoryEffectSink{}
+	readback := &recordingEffectReadback{
+		inspections: map[string]EffectInspection{
+			"github_blame_path_progress": EffectExact,
+		},
+	}
+	committer := EffectCommitter{
+		Ledger: ledger, Sink: sink, Readback: readback,
+		Now: func() time.Time { return now.Add(time.Minute) },
+	}
+	result, err := committer.CommitPrepared(context.Background(), claim, effects, persisted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The readback must have been asked about the destination whose ledger
+	// entry was mid-write -- not whichever batch happened to share its index.
+	if len(readback.asked) != 1 || readback.asked[0] != "github_blame_path_progress" {
+		t.Fatalf("readback consulted %v, want [github_blame_path_progress]", readback.asked)
+	}
+	if result.MarkedCommitted != 1 || result.Written != 1 ||
+		len(sink.destinations) != 1 || sink.destinations[0] != "ai_attribution" {
+		t.Fatalf("result=%+v writes=%v", result, sink.destinations)
+	}
+}
+
+// The decode-side size cap is a separate guard from the encode-side cap in
+// R4: a payload can reach decode from a peer that never ran this binary's
+// encoder, or from a row written before the cap existed. Nothing exercised it,
+// so the clause was free to be deleted.
+func TestPreparedRouteSnapshotDecodeRejectsAnOversizedPayload(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	oversized := make([]byte, maxPreparedRouteSnapshotBytes+1)
+	digest := sha256.Sum256(oversized)
+	state, err := NewEffectLedgerState(claim, batch.Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.SchemaVersion = "v2"
+	// The reference agrees with the payload on length and digest, so the only
+	// thing standing between this input and a 64 MiB decode is the cap itself.
+	state.PreparedSnapshot = &PreparedRouteSnapshotReference{
+		SchemaVersion: preparedRouteSnapshotSchemaVersion,
+		ContentDigest: hex.EncodeToString(digest[:]),
+		PayloadBytes:  len(oversized),
+	}
+	if _, err := decodePreparedRouteManifest(oversized, claim, state); !errors.Is(
+		err, ErrEffectLedgerConflict,
+	) {
+		t.Fatalf("oversized decode error=%v", err)
+	}
+}
+
+// Every key containsPreparedRouteSensitiveKey knows about must actually be
+// refused. The existing tamper test covers one of them, which is enough for a
+// whole-function mutation and useless against the deletion of a single name --
+// and a single name is what a careless edit removes.
+func TestPreparedRouteSnapshotRefusesEverySensitiveKey(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	for _, key := range []string{
+		"authorization", "credential", "credentials", "token", "headers",
+		"source_metadata", "integration_config", "ciphertext", "raw_payload",
+		"response_body",
+		// Spelling normalization: hyphens, case and surrounding space must not
+		// smuggle a key past the check.
+		"Authorization", "raw-payload", "  token  ",
+	} {
+		batch := preparedGitHubWorkItemsFixture(t, claim)
+		batch.Result[key] = "must-not-persist"
+		if _, _, err := encodePreparedRouteManifest(
+			claim, batch, ShadowComparison{Match: true}, now,
+		); !errors.Is(err, ErrEffectRecoveryUnsafe) {
+			t.Fatalf("result key %q was accepted: error=%v", key, err)
+		}
+		nested := preparedGitHubWorkItemsFixture(t, claim)
+		nested.Result["envelope"] = map[string]any{"inner": map[string]any{key: "x"}}
+		if _, _, err := encodePreparedRouteManifest(
+			claim, nested, ShadowComparison{Match: true}, now,
+		); !errors.Is(err, ErrEffectRecoveryUnsafe) {
+			t.Fatalf("nested result key %q was accepted: error=%v", key, err)
+		}
 	}
 }

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -284,3 +284,203 @@ func preparedGitHubWorkItemsSession(
 		Deadline: now.Add(time.Hour), Now: func() time.Time { return now },
 	}
 }
+
+// The rolling-deployment boundary, stated in one place. An older worker
+// validates only schema "v1", so the shared ledger document has to be
+// self-describing enough that neither side can silently accept the other's
+// shape: a v1 document must never carry a snapshot reference, and a v2 one is
+// meaningless without a well-formed reference. The legacy round-trip test
+// above only proves v1 still decodes; every direction below is a refusal no
+// other test exercises.
+func TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	_, reference, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := NewEffectLedgerState(claim, batch.Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.SchemaVersion != "v1" || base.PreparedSnapshot != nil {
+		t.Fatalf("baseline state=%+v", base)
+	}
+	nonHexDigest, emptyPayload := reference, reference
+	nonHexDigest.ContentDigest = strings.Repeat("z", 64)
+	emptyPayload.PayloadBytes = 0
+	overCap, futurePayloadSchema := reference, reference
+	overCap.PayloadBytes = maxPreparedRouteSnapshotBytes + 1
+	futurePayloadSchema.SchemaVersion = "v2"
+
+	for name, mutate := range map[string]func(*EffectLedgerState){
+		"v1 carrying a snapshot reference": func(state *EffectLedgerState) {
+			state.PreparedSnapshot = &reference
+		},
+		"v2 without a snapshot reference": func(state *EffectLedgerState) {
+			state.SchemaVersion = "v2"
+		},
+		"v2 with a non-hex digest": func(state *EffectLedgerState) {
+			state.SchemaVersion, state.PreparedSnapshot = "v2", &nonHexDigest
+		},
+		"v2 with an empty payload": func(state *EffectLedgerState) {
+			state.SchemaVersion, state.PreparedSnapshot = "v2", &emptyPayload
+		},
+		"v2 above the payload cap": func(state *EffectLedgerState) {
+			state.SchemaVersion, state.PreparedSnapshot = "v2", &overCap
+		},
+		"v2 naming a future payload schema": func(state *EffectLedgerState) {
+			state.SchemaVersion, state.PreparedSnapshot = "v2", &futurePayloadSchema
+		},
+		"an unknown future ledger schema": func(state *EffectLedgerState) {
+			state.SchemaVersion, state.PreparedSnapshot = "v3", &reference
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := base
+			state.Effects = append([]EffectLedgerEntry(nil), base.Effects...)
+			mutate(&state)
+			if err := state.validate(); !errors.Is(err, ErrEffectLedgerConflict) {
+				t.Fatalf("validate error=%v", err)
+			}
+			if encoded := encodeEffectLedgerState(state); encoded != nil {
+				t.Fatalf("encoded a state validate rejected: %s", encoded)
+			}
+			raw, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := decodeEffectLedgerState(raw); !errors.Is(err, ErrEffectLedgerConflict) {
+				t.Fatalf("decode error=%v", err)
+			}
+		})
+	}
+}
+
+// Contract point 7: new workers may continue an existing route from a legacy
+// v1 ledger, but github/work-items must require v2 plus a valid snapshot. The
+// ledger here holds a well-formed v1 state AND a decodable payload, so a
+// refusal cannot be attributed to a missing sidecar -- only to the route
+// refusing to recover from a document that predates its recovery contract.
+func TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	payload, _, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := NewEffectLedgerState(claim, batch.Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := &memoryEffectLedger{state: legacy, preparedSnapshot: payload}
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{batch: batch}
+	_, err = completeRouteExecutor(
+		now.Add(time.Hour), handler, ledger, &memoryEffectSink{},
+	).Execute(context.Background(), session, descriptor)
+	if !errors.Is(err, ErrEffectRecoveryUnsafe) || !handler.normalizedAt.IsZero() {
+		t.Fatalf("legacy ledger error=%v handler_at=%s", err, handler.normalizedAt)
+	}
+}
+
+// PreparedManifestRecovery is a github/work-items contract, not a general
+// capability. A descriptor carrying it for any other pair is a wiring mistake
+// that must fail before the route touches credentials, not a route that
+// quietly runs without its snapshot.
+func TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	for name, retarget := range map[string]func(*CompleteRouteDescriptor){
+		"another provider": func(descriptor *CompleteRouteDescriptor) {
+			descriptor.Provider = "linear"
+		},
+		"another dataset": func(descriptor *CompleteRouteDescriptor) {
+			descriptor.RouteDataset = "work-item-labels"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+			descriptor.Destinations = workItemRouteDestinations()
+			descriptor.RouteReady, descriptor.RouteEnabled = true, true
+			retarget(&descriptor)
+			handler := &staticCompleteRouteHandler{batch: batch}
+			_, err := completeRouteExecutor(
+				now.Add(time.Hour), handler, &memoryEffectLedger{}, &memoryEffectSink{},
+			).Execute(context.Background(), session, descriptor)
+			if !errors.Is(err, ErrInvalidConfiguration) || !handler.normalizedAt.IsZero() {
+				t.Fatalf("error=%v handler_at=%s", err, handler.normalizedAt)
+			}
+			_ = claim
+		})
+	}
+}
+
+// ledgerWithoutPreparedRecovery satisfies EffectLedger and nothing more, which
+// is exactly the shape of a binary wired to a store that has no snapshot
+// sidecar. Embedding the interface rather than the concrete ledger is what
+// withholds the two PreparedEffectLedger methods.
+type ledgerWithoutPreparedRecovery struct{ EffectLedger }
+
+// The deploy-time half of fail-closed: a route that requires prepared recovery
+// must refuse to run at all against a ledger with nowhere to put the snapshot,
+// rather than discovering it after the first ClickHouse write.
+func TestRouteRequiringPreparedRecoveryRefusesALedgerWithoutASnapshotStore(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	_, session := preparedGitHubWorkItemsSession(t, now)
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{}
+	sink := &memoryEffectSink{}
+	_, err := completeRouteExecutor(
+		now.Add(time.Hour), handler,
+		ledgerWithoutPreparedRecovery{EffectLedger: &memoryEffectLedger{}}, sink,
+	).Execute(context.Background(), session, descriptor)
+	if !errors.Is(err, ErrInvalidConfiguration) || !handler.normalizedAt.IsZero() ||
+		len(sink.destinations) != 0 {
+		t.Fatalf("error=%v handler_at=%s writes=%v", err, handler.normalizedAt, sink.destinations)
+	}
+}
+
+// A snapshot proves what the batch WAS; the descriptor says what the route may
+// write now. Recovery must re-check the manifest against the live descriptor,
+// because a destination set that changed between prepare and recovery means the
+// stored effects no longer describe this route.
+func TestPreparedRecoveryRevalidatesTheManifestAgainstTheLiveDescriptor(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	ledger := &memoryEffectLedger{}
+	if _, err := ledger.PrepareRouteSnapshot(
+		context.Background(), claim, batch, ShadowComparison{Match: true}, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	full := workItemRouteDestinations()
+	descriptor.Destinations = full[:len(full)-1]
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{batch: batch}
+	sink := &memoryEffectSink{}
+	_, err := completeRouteExecutor(
+		now.Add(time.Hour), handler, ledger, sink,
+	).Execute(context.Background(), session, descriptor)
+	if !errors.Is(err, ErrEffectLedgerConflict) || len(sink.destinations) != 0 {
+		t.Fatalf("error=%v writes=%v", err, sink.destinations)
+	}
+}

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -1,0 +1,286 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestPreparedRouteSnapshotRoundTripBindsExactGitHubWorkItemsManifest(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	normalizedAt := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	payload, reference, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true, NativeRecords: 16, PythonRecords: 16}, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := NewEffectLedgerState(claim, batch.Effects, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.SchemaVersion = "v2"
+	state.PreparedSnapshot = &reference
+	manifest, err := decodePreparedRouteManifest(payload, claim, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Batch.Effects) != len(workItemRouteDestinations()) ||
+		!manifest.NormalizedAt.Equal(normalizedAt) || !manifest.Comparison.Match ||
+		manifest.Batch.Evidence.Records != 16 {
+		t.Fatalf("manifest=%+v", manifest)
+	}
+	for index := range manifest.Batch.Effects {
+		if manifest.Batch.Effects[index].ContentDigest != state.Effects[index].ContentDigest {
+			t.Fatalf("effect[%d] digest changed", index)
+		}
+	}
+}
+
+func TestPreparedRouteSnapshotRejectsTamperTenantGenerationAndSensitiveResult(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	payload, reference, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := NewEffectLedgerState(claim, batch.Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.SchemaVersion, state.PreparedSnapshot = "v2", &reference
+
+	tampered := bytes.Replace(
+		payload, []byte(`"result":{"records":16}`),
+		[]byte(`"result":{"records":17}`), 1,
+	)
+	if bytes.Equal(tampered, payload) {
+		t.Fatal("tamper fixture did not change the encoded result")
+	}
+	if _, err := decodePreparedRouteManifest(tampered, claim, state); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("tamper error=%v", err)
+	}
+	otherTenant := claim
+	otherTenant.OrgID = "org-other"
+	if _, err := decodePreparedRouteManifest(payload, otherTenant, state); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("tenant error=%v", err)
+	}
+	otherGeneration := claim
+	otherGeneration.ID = uuid.NewString()
+	if _, err := decodePreparedRouteManifest(payload, otherGeneration, state); !errors.Is(err, ErrEffectLedgerConflict) {
+		t.Fatalf("generation error=%v", err)
+	}
+	batch.Result["credential"] = map[string]any{"token": "must-not-persist"}
+	if _, _, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true}, now,
+	); !errors.Is(err, ErrEffectRecoveryUnsafe) {
+		t.Fatalf("sensitive result error=%v", err)
+	}
+}
+
+func TestPreparedRouteSnapshotEnforcesTotalEncodedCapAndLegacyV1StillDecodes(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	batch.Result["oversized"] = strings.Repeat("x", maxPreparedRouteSnapshotBytes)
+	if _, _, err := encodePreparedRouteManifest(
+		claim, batch, ShadowComparison{Match: true}, now,
+	); !errors.Is(err, ErrEffectRecoveryUnsafe) {
+		t.Fatalf("cap error=%v", err)
+	}
+
+	legacy, err := NewEffectLedgerState(claim, preparedGitHubWorkItemsFixture(t, claim).Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeEffectLedgerState(encodeEffectLedgerState(legacy))
+	if err != nil || decoded.SchemaVersion != "v1" || decoded.PreparedSnapshot != nil {
+		t.Fatalf("legacy=%+v error=%v", decoded, err)
+	}
+}
+
+func TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	ledger := &memoryEffectLedger{}
+	prepared, err := ledger.PrepareRouteSnapshot(
+		context.Background(), claim, batch,
+		ShadowComparison{Match: true, NativeRecords: 16, PythonRecords: 16}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash after the first sink accepted its write but before the
+	// corresponding ledger transition committed, plus one already-committed
+	// destination. Recovery must reconcile these exact snapshot rows.
+	committedAt := now.Add(time.Second)
+	startedAt := now.Add(500 * time.Millisecond)
+	prepared.Effects[0].Status = GenerationBlockCommitted
+	prepared.Effects[0].StartedAt = &startedAt
+	prepared.Effects[0].CommittedAt = &committedAt
+	prepared.Effects[1].Status = GenerationBlockWriting
+	prepared.Effects[1].StartedAt = &startedAt
+	ledger.state = prepared
+
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	if !ok || !descriptor.PreparedManifestRecovery || descriptor.RouteReady || descriptor.RouteEnabled {
+		t.Fatalf("unregistered descriptor=%+v ok=%v", descriptor, ok)
+	}
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady = true
+	descriptor.RouteEnabled = true
+	handler := &staticCompleteRouteHandler{
+		batch: CompleteRouteBatch{Result: map[string]any{"live_provider": "mutated"}},
+	}
+	sink := &memoryEffectSink{}
+	executor := completeRouteExecutor(now.Add(10*time.Minute), handler, ledger, sink)
+	executor.Committer.Readback = staticEffectReadback{inspections: map[string]EffectInspection{
+		prepared.Effects[1].Destination: EffectExact,
+	}}
+	result, err := executor.Execute(context.Background(), session, descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handler.normalizedAt.IsZero() || ledger.preparedLoads != 1 ||
+		result.Effects.Skipped != 1 || result.Effects.MarkedCommitted != 1 ||
+		result.Effects.Written != len(workItemRouteDestinations())-2 ||
+		result.Result["records"] != float64(16) {
+		t.Fatalf(
+			"handler_at=%s loads=%d result=%+v stored_result=%v",
+			handler.normalizedAt, ledger.preparedLoads, result, result.Result,
+		)
+	}
+	secondSink := &memoryEffectSink{}
+	second := completeRouteExecutor(now.Add(20*time.Minute), handler, ledger, secondSink)
+	secondResult, err := second.Execute(context.Background(), session, descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondResult.Effects.Skipped != len(workItemRouteDestinations()) ||
+		secondResult.Effects.Written != 0 || len(secondSink.destinations) != 0 ||
+		!handler.normalizedAt.IsZero() {
+		t.Fatalf("all-committed recovery result=%+v writes=%v", secondResult, secondSink.destinations)
+	}
+}
+
+func TestCompleteRouteExecutorRecoversCrashImmediatelyAfterPrepare(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	ledger := &memoryEffectLedger{}
+	if _, err := ledger.PrepareRouteSnapshot(
+		context.Background(), claim, batch, ShadowComparison{Match: true}, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{batch: CompleteRouteBatch{
+		Result: map[string]any{"live": "changed"},
+	}}
+	sink := &memoryEffectSink{}
+	result, err := completeRouteExecutor(
+		now.Add(time.Hour), handler, ledger, sink,
+	).Execute(context.Background(), session, descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Effects.Written != len(workItemRouteDestinations()) ||
+		!handler.normalizedAt.IsZero() || ledger.preparedLoads != 1 {
+		t.Fatalf("result=%+v handler_at=%s loads=%d", result, handler.normalizedAt, ledger.preparedLoads)
+	}
+}
+
+func TestCompleteRouteExecutorFailsClosedWhenPreparedSnapshotIsMissing(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	ledger := &memoryEffectLedger{}
+	state, err := NewEffectLedgerState(claim, batch.Effects, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.SchemaVersion = "v2"
+	state.PreparedSnapshot = &PreparedRouteSnapshotReference{
+		SchemaVersion: "v1", ContentDigest: strings.Repeat("a", 64), PayloadBytes: 1,
+	}
+	ledger.state = state
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{batch: batch}
+	_, err = completeRouteExecutor(
+		now.Add(time.Hour), handler, ledger, &memoryEffectSink{},
+	).Execute(context.Background(), session, descriptor)
+	if !errors.Is(err, ErrPreparedRouteSnapshotNotFound) || !handler.normalizedAt.IsZero() {
+		t.Fatalf("error=%v handler_at=%s", err, handler.normalizedAt)
+	}
+}
+
+func preparedGitHubWorkItemsFixture(t *testing.T, claim Claim) CompleteRouteBatch {
+	t.Helper()
+	destinations := workItemRouteDestinations()
+	effects := make([]EffectBatch, 0, len(destinations))
+	for _, destination := range destinations {
+		policy := EffectReplaySafe
+		if destination == "estimate_coverage_metrics_daily" {
+			policy = EffectReadbackRequired
+		}
+		row, err := json.Marshal(map[string]any{
+			"org_id": claim.OrgID, "destination": destination, "record": 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		effect, err := BuildEffectBatch(destination, policy, []json.RawMessage{row})
+		if err != nil {
+			t.Fatal(err)
+		}
+		effects = append(effects, effect)
+	}
+	watermark := time.Date(2026, 8, 4, 11, 59, 0, 0, time.UTC)
+	return CompleteRouteBatch{
+		Effects: effects, Result: map[string]any{"records": 16}, Watermark: &watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: 6, Pages: 6, Records: 16,
+		},
+	}
+}
+
+func preparedGitHubWorkItemsSession(
+	t *testing.T,
+	now time.Time,
+) (Claim, *LeaseSession) {
+	t.Helper()
+	unit := githubWorkItemOracleClaim().Unit
+	leases := newMemoryLeaseRepository(unit, "dispatching")
+	claim, err := leases.Claim(context.Background(), ClaimRequest{
+		UnitID: unit.ID, OrgID: unit.OrgID, Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim, &LeaseSession{
+		Repository: leases, Claim: claim, LeaseDuration: time.Minute,
+		Deadline: now.Add(time.Hour), Now: func() time.Time { return now },
+	}
+}

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -158,13 +159,19 @@ func TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
+	// preparedPrepares stays at the single setup call: recovery LOADS the
+	// snapshot and must never re-prepare one. The counter existed and was
+	// never asserted, so nothing would have noticed a recovery path that
+	// quietly rewrote the manifest it was supposed to be replaying.
 	if !handler.normalizedAt.IsZero() || ledger.preparedLoads != 1 ||
+		ledger.preparedPrepares != 1 ||
 		result.Effects.Skipped != 1 || result.Effects.MarkedCommitted != 1 ||
 		result.Effects.Written != len(workItemRouteDestinations())-2 ||
 		result.Result["records"] != float64(16) {
 		t.Fatalf(
-			"handler_at=%s loads=%d result=%+v stored_result=%v",
-			handler.normalizedAt, ledger.preparedLoads, result, result.Result,
+			"handler_at=%s loads=%d prepares=%d result=%+v stored_result=%v",
+			handler.normalizedAt, ledger.preparedLoads, ledger.preparedPrepares,
+			result, result.Result,
 		)
 	}
 	secondSink := &memoryEffectSink{}
@@ -175,7 +182,7 @@ func TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection(t *tes
 	}
 	if secondResult.Effects.Skipped != len(workItemRouteDestinations()) ||
 		secondResult.Effects.Written != 0 || len(secondSink.destinations) != 0 ||
-		!handler.normalizedAt.IsZero() {
+		ledger.preparedPrepares != 1 || !handler.normalizedAt.IsZero() {
 		t.Fatalf("all-committed recovery result=%+v writes=%v", secondResult, secondSink.destinations)
 	}
 }
@@ -205,8 +212,12 @@ func TestCompleteRouteExecutorRecoversCrashImmediatelyAfterPrepare(t *testing.T)
 		t.Fatal(err)
 	}
 	if result.Effects.Written != len(workItemRouteDestinations()) ||
-		!handler.normalizedAt.IsZero() || ledger.preparedLoads != 1 {
-		t.Fatalf("result=%+v handler_at=%s loads=%d", result, handler.normalizedAt, ledger.preparedLoads)
+		!handler.normalizedAt.IsZero() || ledger.preparedLoads != 1 ||
+		ledger.preparedPrepares != 1 {
+		t.Fatalf(
+			"result=%+v handler_at=%s loads=%d prepares=%d",
+			result, handler.normalizedAt, ledger.preparedLoads, ledger.preparedPrepares,
+		)
 	}
 }
 
@@ -629,10 +640,13 @@ func TestCommitPreparedPairsEachEffectWithItsOwnLedgerEntry(t *testing.T) {
 	}
 }
 
-// The decode-side size cap is a separate guard from the encode-side cap in
-// R4: a payload can reach decode from a peer that never ran this binary's
-// encoder, or from a row written before the cap existed. Nothing exercised it,
-// so the clause was free to be deleted.
+// An oversized payload must never reach the JSON decoder. Note WHICH guard
+// does that work: the reference's own PayloadBytes bound, reached through
+// state.validate(), not the len(raw) cap further down decode -- that one is
+// unreachable, because len(raw) must equal PayloadBytes and a reference over
+// the cap never validates. An earlier version of this comment claimed to cover
+// the decode-side cap; the mutation harness disproved it by leaving that
+// clause's mutation alive while this test passed.
 func TestPreparedRouteSnapshotDecodeRejectsAnOversizedPayload(t *testing.T) {
 	t.Parallel()
 	claim := githubWorkItemOracleClaim()
@@ -690,4 +704,62 @@ func TestPreparedRouteSnapshotRefusesEverySensitiveKey(t *testing.T) {
 			t.Fatalf("nested result key %q was accepted: error=%v", key, err)
 		}
 	}
+}
+
+// Completion is withheld until every effect commits. Only the converse was
+// proven -- that a fully committed batch completes -- and the converse is the
+// easy half.
+//
+// The ordering is enforced by the caller's control flow, not by a guard inside
+// Complete: internal/jobs/providerunit calls Repository.Complete ONLY on the
+// `err == nil` arm of executor.Execute. So the property that actually protects
+// the watermark is that Execute returns an error when a sink refuses
+// mid-batch. This pins that, and pins that the snapshot survives for the next
+// attempt -- a failure that both errored AND discarded the manifest would
+// satisfy a naive "did it error" assertion while leaving the unit unable to
+// recover.
+func TestPreparedRecoveryWithholdsSuccessWhenASinkRefusesMidBatch(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	claim, session := preparedGitHubWorkItemsSession(t, now)
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	ledger := &memoryEffectLedger{}
+	if _, err := ledger.PrepareRouteSnapshot(
+		context.Background(), claim, batch, ShadowComparison{Match: true}, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	destinations := workItemRouteDestinations()
+	sortStrings(destinations)
+	refused := destinations[len(destinations)/2]
+	sinkFailure := errors.New("sink refused the write")
+	sink := &memoryEffectSink{failAfterWrite: refused, failure: sinkFailure}
+
+	descriptor, _ := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+	handler := &staticCompleteRouteHandler{batch: batch}
+	_, err := completeRouteExecutor(
+		now.Add(time.Hour), handler, ledger, sink,
+	).Execute(context.Background(), session, descriptor)
+	if err == nil {
+		t.Fatal("Execute reported success while a sink refused a write; the caller would then complete the unit and advance the watermark")
+	}
+	if !errors.Is(err, sinkFailure) {
+		t.Fatalf("error=%v, want the sink's own failure", err)
+	}
+	// The manifest must still be there for the next attempt.
+	recovered, loadErr := ledger.LoadRouteSnapshot(
+		context.Background(), claim, ledger.state, now.Add(time.Hour),
+	)
+	if loadErr != nil {
+		t.Fatalf("snapshot unusable after a withheld completion: %v", loadErr)
+	}
+	if len(recovered.Batch.Effects) != len(workItemRouteDestinations()) {
+		t.Fatalf("recovered manifest is incomplete: %d effects", len(recovered.Batch.Effects))
+	}
+}
+
+func sortStrings(values []string) {
+	sort.Strings(values)
 }

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -471,12 +471,20 @@ WHERE unit.id = $1::uuid
   AND unit.lease_expires_at IS NOT NULL
   AND unit.lease_expires_at > $3`
 
+// failUnitSQL MERGES the failure result rather than replacing it, exactly as
+// releaseForRetrySQL above already does. A wholesale replace destroyed the
+// go_effect_ledger_v1 key, and with it the prepared snapshot reference --
+// the only thing that makes a retained sidecar row findable. Contract point 5
+// retains the snapshot on failure so a later attempt or an operator can reason
+// about it; a retained row whose only pointer has been erased is not retained,
+// it is leaked, and nothing short of the sync_run_units CASCADE ever reclaims
+// it (up to 64 MiB each).
 const failUnitSQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'failed',
     duration_seconds = $4,
     error = $5,
-    result = $6::jsonb,
+    result = COALESCE(unit.result::jsonb, '{}'::jsonb) || $6::jsonb,
     lease_owner = NULL,
     lease_expires_at = NULL,
     last_heartbeat_at = $3,

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -471,20 +471,42 @@ WHERE unit.id = $1::uuid
   AND unit.lease_expires_at IS NOT NULL
   AND unit.lease_expires_at > $3`
 
-// failUnitSQL MERGES the failure result rather than replacing it, exactly as
-// releaseForRetrySQL above already does. A wholesale replace destroyed the
-// go_effect_ledger_v1 key, and with it the prepared snapshot reference --
-// the only thing that makes a retained sidecar row findable. Contract point 5
-// retains the snapshot on failure so a later attempt or an operator can reason
-// about it; a retained row whose only pointer has been erased is not retained,
-// it is leaked, and nothing short of the sync_run_units CASCADE ever reclaims
-// it (up to 64 MiB each).
+// failUnitSQL carries forward EXACTLY ONE key and drops the rest.
+//
+// A wholesale replace lost go_effect_ledger_v1, and with it the prepared
+// snapshot reference. Contract point 5 retains the snapshot on failure, and
+// the reference is what makes the retained row VALIDATABLE -- the row is still
+// findable by sync_run_unit_id, but without the digest, size and schema
+// recorded in the ledger nothing can tell a good payload from a corrupt one.
+//
+// A blanket `unit.result || $6` overcorrected. The result document also
+// accumulates CLAIMABLE-STATE keys -- next_retry_at, retry_exhausted,
+// retry_reason, and the rate-limit and budget deferral keys -- written by
+// markExpiredLeaseRetryingSQL, the soft-timeout retry path, rate-limit
+// deferral and the budget guard. Nothing clears them on claim, so preserving
+// everything freezes a live "will retry at T" claim onto a unit that is
+// terminally failed. The admin integrations API projects these keys with no
+// status gate and treats them as authoritative, and every other terminal stamp
+// in the repo deliberately nulls next_retry_at (lease_repair.go,
+// sync_units.py) -- this was the only one that would not have.
+//
+// The CASE is not decoration: unit.result is sa.JSON, so it can hold a JSON
+// literal `null`. `'null'::jsonb || '{}'::jsonb` raises (non-object operand),
+// and the raise surfaces from Fail() as ErrLeaseLost -- a failure to record a
+// failure, reported as something else entirely.
 const failUnitSQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'failed',
     duration_seconds = $4,
     error = $5,
-    result = COALESCE(unit.result::jsonb, '{}'::jsonb) || $6::jsonb,
+    result = CASE
+      WHEN jsonb_typeof(unit.result::jsonb) = 'object'
+       AND unit.result::jsonb ? 'go_effect_ledger_v1'
+      THEN jsonb_build_object(
+             'go_effect_ledger_v1', unit.result::jsonb -> 'go_effect_ledger_v1'
+           ) || $6::jsonb
+      ELSE $6::jsonb
+    END,
     lease_owner = NULL,
     lease_expires_at = NULL,
     last_heartbeat_at = $3,

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -126,6 +126,15 @@ func (repository *PostgresRepository) Complete(
 	if err != nil || command.RowsAffected() != 1 {
 		return ErrLeaseLost
 	}
+	// The prepared effect payload is recovery state, not a product record.
+	// Delete it in the same transaction that terminalizes the unit so any
+	// later watermark/outbox failure rolls both operations back together.
+	if _, err := tx.Exec(
+		ctx, deletePreparedRouteSnapshotSQL,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	); err != nil {
+		return ErrInvalidConfiguration
+	}
 	if watermark != nil {
 		for _, datasetKey := range datasetKeys {
 			// THE write boundary (CHAOS-3412 C10(c), CHAOS-3427). Every Go
@@ -155,6 +164,10 @@ func (repository *PostgresRepository) Complete(
 	}
 	return nil
 }
+
+const deletePreparedRouteSnapshotSQL = `
+DELETE FROM public.sync_run_unit_effect_snapshots
+WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`
 
 // ReleaseForRetry returns a live claim to dispatching for the same River job's
 // bounded retry. A process death cannot call this method; expired-lease

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -491,17 +491,22 @@ WHERE unit.id = $1::uuid
 // sync_units.py) -- this was the only one that would not have.
 //
 // The CASE is not decoration: unit.result is sa.JSON, so it can hold a JSON
-// literal `null`. `'null'::jsonb || '{}'::jsonb` raises (non-object operand),
-// and the raise surfaces from Fail() as ErrLeaseLost -- a failure to record a
-// failure, reported as something else entirely.
+// literal `null`, and `'null'::jsonb || '{...}'::jsonb` does NOT raise -- it
+// ARRAY-concatenates to `[null, {...}]`. The failure document then has no
+// readable error_category at all, because `->>` on an array returns NULL. A
+// raise would have been the kinder outcome; this loses the reason a unit
+// failed, silently. Verified on PostgreSQL 18.4 rather than assumed.
+//
+// `?` returns false for every non-object, so it is the whole guard: a null,
+// array or scalar predecessor takes the ELSE branch, and the THEN branch only
+// ever concatenates two objects.
 const failUnitSQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'failed',
     duration_seconds = $4,
     error = $5,
     result = CASE
-      WHEN jsonb_typeof(unit.result::jsonb) = 'object'
-       AND unit.result::jsonb ? 'go_effect_ledger_v1'
+      WHEN unit.result::jsonb ? 'go_effect_ledger_v1'
       THEN jsonb_build_object(
              'go_effect_ledger_v1', unit.result::jsonb -> 'go_effect_ledger_v1'
            ) || $6::jsonb

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -476,7 +476,7 @@ func createProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.
 		// schema more permissive than production -- the class of gap where a
 		// test proves the code works on a table that does not exist anywhere
 		// real. tests/test_effect_snapshot_migration.py::
-		// test_integration_fixture_ddl_matches_migration_0086 fails if the two
+		// test_integration_fixture_ddl_matches_migration_0088 fails if the two
 		// drift apart.
 		snapshotFixtureDDL,
 		`CREATE TABLE public.sync_watermarks (

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -470,7 +470,7 @@ func createProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.
 			expired_lease_retry_count integer NOT NULL DEFAULT 0,
 			last_retry_reason text, updated_at timestamptz NOT NULL
 		)`,
-		// Must stay byte-for-byte equivalent to migration 0086. This fixture
+		// Must stay byte-for-byte equivalent to migration 0088. This fixture
 		// previously dropped all three CHECK constraints and widened
 		// content_digest to text, so every integration test here ran against a
 		// schema more permissive than production -- the class of gap where a
@@ -541,7 +541,7 @@ func seedProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.Po
 	}
 }
 
-// snapshotFixtureDDL mirrors migration 0086 exactly, constraints included.
+// snapshotFixtureDDL mirrors migration 0088 exactly, constraints included.
 const snapshotFixtureDDL = `CREATE TABLE public.sync_run_unit_effect_snapshots (
 	org_id text NOT NULL,
 	sync_run_unit_id uuid NOT NULL,

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -470,16 +470,15 @@ func createProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.
 			expired_lease_retry_count integer NOT NULL DEFAULT 0,
 			last_retry_reason text, updated_at timestamptz NOT NULL
 		)`,
-		`CREATE TABLE public.sync_run_unit_effect_snapshots (
-			org_id text NOT NULL, sync_run_unit_id uuid NOT NULL,
-			generation text NOT NULL, provider text NOT NULL,
-			dataset_key text NOT NULL, schema_version text NOT NULL,
-			content_digest text NOT NULL, payload_bytes integer NOT NULL,
-			payload bytea NOT NULL, created_at timestamptz NOT NULL,
-			PRIMARY KEY (org_id, sync_run_unit_id, generation),
-			FOREIGN KEY (sync_run_unit_id) REFERENCES public.sync_run_units(id)
-				ON DELETE CASCADE
-		)`,
+		// Must stay byte-for-byte equivalent to migration 0086. This fixture
+		// previously dropped all three CHECK constraints and widened
+		// content_digest to text, so every integration test here ran against a
+		// schema more permissive than production -- the class of gap where a
+		// test proves the code works on a table that does not exist anywhere
+		// real. tests/test_effect_snapshot_migration.py::
+		// test_integration_fixture_ddl_matches_migration_0086 fails if the two
+		// drift apart.
+		snapshotFixtureDDL,
 		`CREATE TABLE public.sync_watermarks (
 			id uuid PRIMARY KEY, org_id text NOT NULL, repo_id text NOT NULL,
 			source_id text NOT NULL, target text NOT NULL, dataset_key text NOT NULL,
@@ -541,3 +540,26 @@ func seedProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.Po
 		}
 	}
 }
+
+// snapshotFixtureDDL mirrors migration 0086 exactly, constraints included.
+const snapshotFixtureDDL = `CREATE TABLE public.sync_run_unit_effect_snapshots (
+	org_id text NOT NULL,
+	sync_run_unit_id uuid NOT NULL,
+	generation text NOT NULL,
+	provider text NOT NULL,
+	dataset_key text NOT NULL,
+	schema_version text NOT NULL,
+	content_digest varchar(64) NOT NULL,
+	payload_bytes integer NOT NULL,
+	payload bytea NOT NULL,
+	created_at timestamptz NOT NULL,
+	CONSTRAINT ck_sync_run_unit_effect_snapshots_payload_bytes
+		CHECK (payload_bytes >= 1 AND payload_bytes <= 67108864),
+	CONSTRAINT ck_sync_run_unit_effect_snapshots_payload_length
+		CHECK (length(payload) = payload_bytes),
+	CONSTRAINT ck_sync_run_unit_effect_snapshots_schema_version
+		CHECK (schema_version = 'v1'),
+	PRIMARY KEY (org_id, sync_run_unit_id, generation),
+	FOREIGN KEY (sync_run_unit_id) REFERENCES public.sync_run_units(id)
+		ON DELETE CASCADE
+)`

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -470,6 +470,16 @@ func createProviderSyncFixture(t *testing.T, ctx context.Context, pool *pgxpool.
 			expired_lease_retry_count integer NOT NULL DEFAULT 0,
 			last_retry_reason text, updated_at timestamptz NOT NULL
 		)`,
+		`CREATE TABLE public.sync_run_unit_effect_snapshots (
+			org_id text NOT NULL, sync_run_unit_id uuid NOT NULL,
+			generation text NOT NULL, provider text NOT NULL,
+			dataset_key text NOT NULL, schema_version text NOT NULL,
+			content_digest text NOT NULL, payload_bytes integer NOT NULL,
+			payload bytea NOT NULL, created_at timestamptz NOT NULL,
+			PRIMARY KEY (org_id, sync_run_unit_id, generation),
+			FOREIGN KEY (sync_run_unit_id) REFERENCES public.sync_run_units(id)
+				ON DELETE CASCADE
+		)`,
 		`CREATE TABLE public.sync_watermarks (
 			id uuid PRIMARY KEY, org_id text NOT NULL, repo_id text NOT NULL,
 			source_id text NOT NULL, target text NOT NULL, dataset_key text NOT NULL,

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "github/work-items prepared-manifest recovery",
   "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
-  "$limitation": "The raw sidecar is intentionally not compressed, so decompression-bomb behavior has no production branch to mutate. The 64 MiB encoded cap is mutated directly. Postgres transaction, tenant, cleanup, and rollback mutations use the integration-tagged proof.",
+  "$limitation": "The raw sidecar is intentionally not compressed, so decompression-bomb behavior has no production branch to mutate. The 64 MiB encoded cap is mutated directly. Postgres transaction, tenant, lease, cleanup, and rollback mutations use the integration-tagged proof.",
   "mutations": [
     {
       "id": "R1-descriptor-requires-prepared-recovery",
@@ -24,7 +24,8 @@
       "id": "R3-snapshot-digest-detects-benign-json-tamper",
       "file": "internal/providersync/prepared_route_snapshot.go",
       "find": "if hex.EncodeToString(digest[:]) != state.PreparedSnapshot.ContentDigest {",
-      "replace": "if false {",
+      "replace": "if hex.EncodeToString(digest[:]) == \"\" {",
+      "$note": "The replacement keeps `digest` referenced on purpose. The previous form (`if false`) orphaned the variable, so the mutated source did not build and the mutation measured NOTHING while reading as a plan entry.",
       "rationale": "changing a syntactically valid non-identity result field must still be rejected by the ledger-bound snapshot digest",
       "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRouteSnapshotRejectsTamperTenantGenerationAndSensitiveResult$", "./internal/providersync/"]]
     },
@@ -68,7 +69,135 @@
       "file": "internal/providersync/repository_postgres.go",
       "find": "WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`",
       "replace": "WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation != $3`",
+      "$note": "The harness warns that this anchor text also appears in the integration test. That is the intended shape here and not a self-referential assertion: the test's copy is an independently written SELECT used as the oracle, in a different file, while `find` is applied only to repository_postgres.go. If the two were ever collapsed into one shared constant this mutation would stop measuring anything.",
       "rationale": "successful Complete must delete exactly the current unit generation snapshot and no other recovery payload",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+
+    {
+      "id": "R9-ledger-schema-version-allowlist",
+      "file": "internal/providersync/effect_ledger.go",
+      "find": "if (state.SchemaVersion != \"v1\" && state.SchemaVersion != \"v2\") || state.Generation == \"\" ||",
+      "replace": "if false || state.Generation == \"\" ||",
+      "rationale": "the ledger document is shared with workers running older and newer binaries, so an unrecognized schema version must be refused rather than partially interpreted",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R10-v1-must-not-carry-a-snapshot-reference",
+      "file": "internal/providersync/effect_ledger.go",
+      "find": "if state.SchemaVersion == \"v1\" && state.PreparedSnapshot != nil {",
+      "replace": "if false {",
+      "rationale": "a document that declares v1 while carrying a v2 payload is exactly what an older worker would misread during a rolling deployment; it must be refused, not tolerated",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R11-v2-requires-a-snapshot-reference",
+      "file": "internal/providersync/effect_ledger.go",
+      "find": "(state.PreparedSnapshot == nil || state.PreparedSnapshot.validate() != nil) {",
+      "replace": "(state.PreparedSnapshot != nil && state.PreparedSnapshot.validate() != nil) {",
+      "$note": "Clause mutation, not a whole-condition mutation: it disables only the nil check while leaving the validity check live, so a kill can only come from the missing-reference case.",
+      "rationale": "a v2 ledger with no snapshot reference names a recovery payload that does not exist and must never be treated as recoverable",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R12-v2-snapshot-reference-must-be-well-formed",
+      "file": "internal/providersync/effect_ledger.go",
+      "find": "(state.PreparedSnapshot == nil || state.PreparedSnapshot.validate() != nil) {",
+      "replace": "(state.PreparedSnapshot == nil) {",
+      "rationale": "the sibling clause of R11: a present but malformed reference must be refused, otherwise the digest and size bounds are never consulted",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R13-reference-payload-schema-version",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "if reference.SchemaVersion != preparedRouteSnapshotSchemaVersion ||",
+      "replace": "if false ||",
+      "rationale": "a reference naming a payload schema this binary does not implement must fail closed rather than be decoded on the assumption the shape is unchanged",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R14-reference-digest-must-be-a-sha256",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "!validDigest(reference.ContentDigest) || reference.PayloadBytes < 1 ||",
+      "replace": "reference.PayloadBytes < 1 ||",
+      "rationale": "an unparseable digest can never match the payload, so accepting one turns the integrity check into an unconditional failure at load time instead of a refusal at write time",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R15-reference-lower-size-bound",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "!validDigest(reference.ContentDigest) || reference.PayloadBytes < 1 ||",
+      "replace": "!validDigest(reference.ContentDigest) ||",
+      "rationale": "the sibling clause of R14: a zero-length payload reference describes no manifest at all",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R16-reference-upper-size-bound",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "reference.PayloadBytes > maxPreparedRouteSnapshotBytes {",
+      "replace": "reference.PayloadBytes > maxPreparedRouteSnapshotBytes*2 {",
+      "rationale": "the ledger-side size bound is a separate guard from the encode-side cap in R4; a reference may arrive from a peer that never ran the encoder",
+      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R17-prepared-recovery-is-github-only",
+      "file": "internal/providersync/complete_route.go",
+      "find": "(descriptor.Provider != \"github\" || descriptor.RouteDataset != \"work-items\") {",
+      "replace": "(descriptor.RouteDataset != \"work-items\") {",
+      "rationale": "prepared-manifest recovery is a github/work-items contract; another provider's work-items route carrying the flag is a wiring mistake that must fail before credentials are resolved",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R18-prepared-recovery-is-work-items-only",
+      "file": "internal/providersync/complete_route.go",
+      "find": "(descriptor.Provider != \"github\" || descriptor.RouteDataset != \"work-items\") {",
+      "replace": "(descriptor.Provider != \"github\") {",
+      "rationale": "the sibling clause of R17: a different GitHub dataset carrying the flag has no 16-effect manifest contract to recover",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R19-recovery-route-requires-a-snapshot-store",
+      "file": "internal/providersync/complete_route.go",
+      "find": "if descriptor.RouteEnabled && descriptor.PreparedManifestRecovery && !preparedRecovery {",
+      "replace": "if descriptor.RouteEnabled && descriptor.PreparedManifestRecovery && !preparedRecovery && false {",
+      "$note": "`&& false` rather than `if false` so `preparedRecovery` stays referenced and the mutated source still builds.",
+      "rationale": "the deploy-time half of fail-closed: a binary wired to a ledger with no snapshot sidecar must refuse to start the route rather than discover the gap after the first ClickHouse write",
+      "proof": [["go", "test", "-count=1", "-run", "^TestRouteRequiringPreparedRecoveryRefusesALedgerWithoutASnapshotStore$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R20-recovery-refuses-a-legacy-v1-ledger",
+      "file": "internal/providersync/complete_route.go",
+      "find": "if recoveredEffects.SchemaVersion != \"v2\" ||\n\t\t\t\trecoveredEffects.PreparedSnapshot == nil {",
+      "replace": "if false {",
+      "$note": "Deliberately a whole-condition mutation, which is normally the wrong shape. The two clauses are mutually redundant for any state that survives EffectLedgerState.validate(): validate() already makes SchemaVersion != \"v2\" imply PreparedSnapshot == nil, so no reachable state distinguishes them and neither clause can be killed alone. The clause-level guarantee is measured instead by R9-R12 on validate() itself. Recorded here rather than left implicit, because a reader who sees only a passing whole-condition mutation would over-read what it proves.",
+      "rationale": "contract point 7: a route requiring prepared recovery must never resume from a v1 ledger written before the recovery contract existed, even though the downstream decoders would also refuse it",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R21-load-is-fenced-on-the-lease-owner",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "  AND unit.lease_owner = $6",
+      "replace": "  AND (unit.lease_owner = $6 OR TRUE)",
+      "rationale": "a worker holding a superseded lease must not read the snapshot the current owner is responsible for; ReleaseForRetry clears owner, expiry and status together, so only an isolated fixture can measure this fence alone",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R22-load-is-fenced-on-lease-expiry",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "  AND unit.lease_expires_at > $7",
+      "replace": "  AND (unit.lease_expires_at > $7 OR TRUE)",
+      "rationale": "a process that stalled long enough to lose its lease must not resume from the snapshot on the assumption it is still the writer",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R23-load-is-fenced-on-running-status",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "  AND unit.status = 'running'",
+      "replace": "  AND (unit.status = 'running' OR TRUE)",
+      "rationale": "a unit that is no longer running has no in-flight batch to recover, and its retained snapshot must stay unreadable until a fresh claim makes it running again",
       "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
       "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
     }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "name": "github/work-items prepared-manifest recovery",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "The raw sidecar is intentionally not compressed, so decompression-bomb behavior has no production branch to mutate. The 64 MiB encoded cap is mutated directly. Postgres transaction, tenant, cleanup, and rollback mutations use the integration-tagged proof.",
+  "mutations": [
+    {
+      "id": "R1-descriptor-requires-prepared-recovery",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "descriptor.PreparedManifestRecovery = true",
+      "replace": "descriptor.PreparedManifestRecovery = false",
+      "rationale": "github/work-items must carry its exact prepared-manifest requirement before any future route activation while remaining unregistered",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2-recovery-skips-live-recollection",
+      "file": "internal/providersync/complete_route.go",
+      "find": "if recoveredEffects != nil && descriptor.PreparedManifestRecovery {",
+      "replace": "if false {",
+      "rationale": "a prepared github/work-items retry must load the exact snapshot before credentials and must never call the mutable provider handler or derivation path",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3-snapshot-digest-detects-benign-json-tamper",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "if hex.EncodeToString(digest[:]) != state.PreparedSnapshot.ContentDigest {",
+      "replace": "if false {",
+      "rationale": "changing a syntactically valid non-identity result field must still be rejected by the ledger-bound snapshot digest",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRouteSnapshotRejectsTamperTenantGenerationAndSensitiveResult$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-route-total-encoded-cap",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "if err != nil || len(encoded) < 1 || len(encoded) > maxPreparedRouteSnapshotBytes {",
+      "replace": "if err != nil || len(encoded) < 1 {",
+      "rationale": "the exact snapshot must reject a route whose uncompressed encoded payload exceeds 64 MiB before any Postgres or ClickHouse write",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRouteSnapshotEnforcesTotalEncodedCapAndLegacyV1StillDecodes$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-ledger-and-sidecar-prepare-share-one-transaction",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "if _, err := tx.Exec(\n\t\t\t\tctx, insertPreparedRouteSnapshotSQL,",
+      "replace": "if _, err := repository.Pool.Exec(\n\t\t\t\tctx, insertPreparedRouteSnapshotSQL,",
+      "rationale": "a failure updating the leased unit ledger must roll back the newly inserted snapshot instead of leaving an orphaned prepared payload",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-load-is-tenant-bound",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "WHERE snapshot.org_id = $1",
+      "replace": "WHERE snapshot.org_id != $1",
+      "rationale": "snapshot lookup must use the claiming tenant as a SQL predicate rather than finding a colliding unit and relying on later decode rejection",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R7-complete-cleanup-shares-terminal-transaction",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "if _, err := tx.Exec(\n\t\tctx, deletePreparedRouteSnapshotSQL,",
+      "replace": "if _, err := repository.Pool.Exec(\n\t\tctx, deletePreparedRouteSnapshotSQL,",
+      "rationale": "a completion failure after cleanup must roll the snapshot deletion back with the unit terminal transition",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R8-complete-cleanup-is-generation-bound",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation = $3`",
+      "replace": "WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation != $3`",
+      "rationale": "successful Complete must delete exactly the current unit generation snapshot and no other recovery payload",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -618,7 +618,7 @@
       "file": "internal/providersync/prepared_route_snapshot.go",
       "find": "\t\tlen(raw) > maxPreparedRouteSnapshotBytes ||",
       "replace": "",
-      "rationale": "a separate guard from R4's encode-side cap: a payload can reach decode from a peer that never ran this encoder, or from a row written before the cap existed",
+      "rationale": "belt-and-braces second bound on the decoded payload; the load-bearing bound is the reference's own PayloadBytes check, mutated by R16",
       "proof": [
         [
           "go",
@@ -628,7 +628,8 @@
           "^TestPreparedRouteSnapshotDecodeRejectsAnOversizedPayload$",
           "./internal/providersync/"
         ]
-      ]
+      ],
+      "expected_survivor_reason": "UNREACHABLE, and measured rather than argued. decodePreparedRouteManifest requires len(raw) == state.PreparedSnapshot.PayloadBytes, and state.validate() runs PreparedRouteSnapshotReference.validate() first, which already rejects PayloadBytes > maxPreparedRouteSnapshotBytes (R16 covers that clause). So len(raw) > max implies a reference that never survives validation, and no input reaches this clause. It stays as belt-and-braces should the two ever be decoupled. Recorded here rather than deleted, and NOT counted as covered: the test that appeared to cover it was passing on state.validate()'s rejection."
     },
     {
       "id": "R30-sensitive-key-refusal-covers-every-name",

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -402,8 +402,8 @@
     {
       "id": "R21-load-is-fenced-on-the-lease-owner",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "         AND unit.lease_owner = $6",
-      "replace": "         AND (unit.lease_owner = $6 OR TRUE)",
+      "find": "           AND unit.lease_owner = $6",
+      "replace": "           AND (unit.lease_owner = $6 OR TRUE)",
       "rationale": "a worker holding a superseded lease must not read the snapshot the current owner is responsible for; ReleaseForRetry clears owner, expiry and status together, so only an isolated fixture can measure this fence alone",
       "build": [
         "go",
@@ -430,8 +430,8 @@
     {
       "id": "R22-load-is-fenced-on-lease-expiry",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "         AND unit.lease_expires_at > $7",
-      "replace": "         AND (unit.lease_expires_at > $7 OR TRUE)",
+      "find": "           AND unit.lease_expires_at > $7",
+      "replace": "           AND (unit.lease_expires_at > $7 OR TRUE)",
       "rationale": "a process that stalled long enough to lose its lease must not resume from the snapshot on the assumption it is still the writer",
       "build": [
         "go",
@@ -458,8 +458,8 @@
     {
       "id": "R23-load-is-fenced-on-running-status",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "         unit.status = 'running'",
-      "replace": "         (unit.status = 'running' OR TRUE)",
+      "find": "           unit.status = 'running'",
+      "replace": "           (unit.status = 'running' OR TRUE)",
       "rationale": "a unit that is no longer running has no in-flight batch to recover, and its retained snapshot must stay unreadable until a fresh claim makes it running again",
       "build": [
         "go",
@@ -486,9 +486,9 @@
     {
       "id": "R24-load-excludes-terminal-runs",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "         AND run.status NOT IN ('success', 'partial_failed', 'failed'),",
-      "replace": "         AND TRUE,",
-      "rationale": "the snapshot load must refuse a run the effect ledger would already refuse; loadEffectLedgerSQL has always excluded terminal runs and the two queries decide the same entitlement",
+      "find": "           run.status NOT IN ('success', 'partial_failed', 'failed'),",
+      "replace": "           run.status NOT IN ('nothing-is-terminal'),",
+      "rationale": "whole-list mutation retained as the coarse check; R32-R34 pin the individual elements, because a list mutation reports KILLED while any single element is missing",
       "build": [
         "go",
         "test",
@@ -661,6 +661,249 @@
           "-count=1",
           "-run",
           "^TestPreparedRecoveryRevalidatesTheManifestAgainstTheLiveDescriptor$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R32-terminal-run-element-success",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "           run.status NOT IN ('success', 'partial_failed', 'failed'),",
+      "replace": "           run.status NOT IN ('partial_failed', 'failed'),",
+      "rationale": "element-level, per rule 3: a successful run must not hand out its snapshot",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R33-terminal-run-element-partial-failed",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "           run.status NOT IN ('success', 'partial_failed', 'failed'),",
+      "replace": "           run.status NOT IN ('success', 'failed'),",
+      "rationale": "element-level: partial_failed is a real terminal state and was covered by nothing but the whole-list mutation",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R34-terminal-run-element-failed",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "           run.status NOT IN ('success', 'partial_failed', 'failed'),",
+      "replace": "           run.status NOT IN ('success', 'partial_failed'),",
+      "rationale": "element-level: a failed run must not hand out its snapshot either",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R35-terminal-run-has-its-own-error",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\tif !runLive {\n\t\treturn PreparedRouteManifest{}, ErrPreparedRouteSnapshotRunTerminal\n\t}",
+      "replace": "\tif false {\n\t\treturn PreparedRouteManifest{}, ErrPreparedRouteSnapshotRunTerminal\n\t}",
+      "rationale": "a finalized run must not be reported as lease loss; the lease is live and correct, and conflating them sends an operator to the wrong subsystem",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R36-absent-sidecar-row-is-a-ledger-conflict",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\t\tif errors.Is(err, pgx.ErrNoRows) {\n\t\t\treturn ErrEffectLedgerConflict\n\t\t}\n\t\treturn err",
+      "replace": "\t\treturn err",
+      "rationale": "ledger present with the sidecar row gone is a genuine ledger/sidecar disagreement and must stay ErrEffectLedgerConflict, distinct from the pass-through added for real database errors; reverting the remapping was silently green",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R37-refused-load-moves-no-payload",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "       CASE WHEN fenced.lease_live AND fenced.run_live\n            THEN fenced.payload ELSE ''::bytea END,",
+      "replace": "       fenced.payload,",
+      "expected_survivor_reason": "ADMITTED EQUIVALENT. The gate is a resource property, not a behavioural one: a refused load returns the same error either way, so no assertion can separate the two. It exists so a refusal does not detoast and ship up to 64 MiB. Recorded here rather than left as an untested line pretending to be covered.",
+      "rationale": "payload is gated behind both fences so refused loads move zero bytes",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R38-encode-site-shares-the-ledger-ordering",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\tordered := append([]EffectBatch(nil), batch.Effects...)\n\tsortEffectBatches(ordered)",
+      "replace": "\tordered := append([]EffectBatch(nil), batch.Effects...)\n\tsort.Slice(ordered, func(left, right int) bool {\n\t\treturn ordered[left].Destination < ordered[right].Destination\n\t})",
+      "expected_survivor_reason": "ADMITTED EQUIVALENT TODAY. All 16 github/work-items destinations have effectCommitPriority 0, so priority-first and destination-only order coincide for every manifest this route can build, and encodePreparedRouteManifest refuses any other destination set. The mutant is therefore behaviourally identical here. It stops being equivalent the moment a work-items destination takes a non-zero priority -- which is exactly when the positional pairing would break. R28 covers the same divergence at the CommitPrepared call site, where a priority destination IS reachable.",
+      "rationale": "the encode site must share the ledger's comparator; recovery pairs snapshot effects to ledger entries by position",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRouteSnapshotRoundTripBindsExactGitHubWorkItemsManifest$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R39-failed-unit-drops-claimable-state",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "      THEN jsonb_build_object(\n             'go_effect_ledger_v1', unit.result::jsonb -> 'go_effect_ledger_v1'\n           ) || $6::jsonb",
+      "replace": "      THEN COALESCE(unit.result::jsonb, '{}'::jsonb) || $6::jsonb",
+      "rationale": "the terminal stamp must carry forward ONLY the ledger key; preserving the whole document freezes next_retry_at and the other claimable-state keys onto a failed unit, which the admin API projects with no status gate",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresFailedUnitKeepsTheSnapshotReachable$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R40-failed-unit-survives-a-non-object-result",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "      WHEN jsonb_typeof(unit.result::jsonb) = 'object'\n       AND unit.result::jsonb ? 'go_effect_ledger_v1'",
+      "replace": "      WHEN unit.result::jsonb ? 'go_effect_ledger_v1'",
+      "rationale": "result is sa.JSON and can hold the literal null; without the type guard the concatenation raises and Fail() reports ErrLeaseLost -- a failure to record a failure, blamed on the lease",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresFailedUnitSurvivesAJSONNullResult$",
           "./internal/providersync/"
         ]
       ]

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -570,8 +570,8 @@
     {
       "id": "R27-failed-unit-keeps-the-ledger-key",
       "file": "internal/providersync/repository_postgres.go",
-      "find": "    result = COALESCE(unit.result::jsonb, '{}'::jsonb) || $6::jsonb,",
-      "replace": "    result = $6::jsonb,",
+      "find": "      THEN jsonb_build_object(\n             'go_effect_ledger_v1', unit.result::jsonb -> 'go_effect_ledger_v1'\n           ) || $6::jsonb\n      ELSE $6::jsonb",
+      "replace": "      THEN $6::jsonb\n      ELSE $6::jsonb",
       "rationale": "contract point 5 retains the snapshot on failure; a wholesale result replace destroys go_effect_ledger_v1 and with it the only reference that makes the retained row findable",
       "build": [
         "go",
@@ -883,9 +883,9 @@
     {
       "id": "R40-failed-unit-survives-a-non-object-result",
       "file": "internal/providersync/repository_postgres.go",
-      "find": "      WHEN jsonb_typeof(unit.result::jsonb) = 'object'\n       AND unit.result::jsonb ? 'go_effect_ledger_v1'",
-      "replace": "      WHEN unit.result::jsonb ? 'go_effect_ledger_v1'",
-      "rationale": "result is sa.JSON and can hold the literal null; without the type guard the concatenation raises and Fail() reports ErrLeaseLost -- a failure to record a failure, blamed on the lease",
+      "find": "      WHEN unit.result::jsonb ? 'go_effect_ledger_v1'",
+      "replace": "      WHEN TRUE",
+      "rationale": "the key-presence test is the whole guard: without it a predecessor with no ledger key gains an explicit go_effect_ledger_v1: null -- a snapshot reference that reads as present and decodes to nothing -- and a non-object predecessor loses its error_category to array concatenation",
       "build": [
         "go",
         "test",

--- a/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_recovery.json
@@ -1,7 +1,13 @@
 {
   "schema_version": 1,
   "name": "github/work-items prepared-manifest recovery",
-  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
   "$limitation": "The raw sidecar is intentionally not compressed, so decompression-bomb behavior has no production branch to mutate. The 64 MiB encoded cap is mutated directly. Postgres transaction, tenant, lease, cleanup, and rollback mutations use the integration-tagged proof.",
   "mutations": [
     {
@@ -10,7 +16,16 @@
       "find": "descriptor.PreparedManifestRecovery = true",
       "replace": "descriptor.PreparedManifestRecovery = false",
       "rationale": "github/work-items must carry its exact prepared-manifest requirement before any future route activation while remaining unregistered",
-      "proof": [["go", "test", "-count=1", "-run", "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R2-recovery-skips-live-recollection",
@@ -18,7 +33,16 @@
       "find": "if recoveredEffects != nil && descriptor.PreparedManifestRecovery {",
       "replace": "if false {",
       "rationale": "a prepared github/work-items retry must load the exact snapshot before credentials and must never call the mutable provider handler or derivation path",
-      "proof": [["go", "test", "-count=1", "-run", "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompleteRouteExecutorRecoversPreparedManifestWithoutRecollection$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R3-snapshot-digest-detects-benign-json-tamper",
@@ -27,7 +51,16 @@
       "replace": "if hex.EncodeToString(digest[:]) == \"\" {",
       "$note": "The replacement keeps `digest` referenced on purpose. The previous form (`if false`) orphaned the variable, so the mutated source did not build and the mutation measured NOTHING while reading as a plan entry.",
       "rationale": "changing a syntactically valid non-identity result field must still be rejected by the ledger-bound snapshot digest",
-      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRouteSnapshotRejectsTamperTenantGenerationAndSensitiveResult$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRouteSnapshotRejectsTamperTenantGenerationAndSensitiveResult$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R4-route-total-encoded-cap",
@@ -35,7 +68,16 @@
       "find": "if err != nil || len(encoded) < 1 || len(encoded) > maxPreparedRouteSnapshotBytes {",
       "replace": "if err != nil || len(encoded) < 1 {",
       "rationale": "the exact snapshot must reject a route whose uncompressed encoded payload exceeds 64 MiB before any Postgres or ClickHouse write",
-      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRouteSnapshotEnforcesTotalEncodedCapAndLegacyV1StillDecodes$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRouteSnapshotEnforcesTotalEncodedCapAndLegacyV1StillDecodes$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R5-ledger-and-sidecar-prepare-share-one-transaction",
@@ -43,8 +85,27 @@
       "find": "if _, err := tx.Exec(\n\t\t\t\tctx, insertPreparedRouteSnapshotSQL,",
       "replace": "if _, err := repository.Pool.Exec(\n\t\t\t\tctx, insertPreparedRouteSnapshotSQL,",
       "rationale": "a failure updating the leased unit ledger must roll back the newly inserted snapshot instead of leaving an orphaned prepared payload",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R6-load-is-tenant-bound",
@@ -52,8 +113,27 @@
       "find": "WHERE snapshot.org_id = $1",
       "replace": "WHERE snapshot.org_id != $1",
       "rationale": "snapshot lookup must use the claiming tenant as a SQL predicate rather than finding a colliding unit and relying on later decode rejection",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R7-complete-cleanup-shares-terminal-transaction",
@@ -61,8 +141,27 @@
       "find": "if _, err := tx.Exec(\n\t\tctx, deletePreparedRouteSnapshotSQL,",
       "replace": "if _, err := repository.Pool.Exec(\n\t\tctx, deletePreparedRouteSnapshotSQL,",
       "rationale": "a completion failure after cleanup must roll the snapshot deletion back with the unit terminal transition",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R8-complete-cleanup-is-generation-bound",
@@ -71,17 +170,44 @@
       "replace": "WHERE org_id = $1 AND sync_run_unit_id = $2 AND generation != $3`",
       "$note": "The harness warns that this anchor text also appears in the integration test. That is the intended shape here and not a self-referential assertion: the test's copy is an independently written SELECT used as the oracle, in a different file, while `find` is applied only to repository_postgres.go. If the two were ever collapsed into one shared constant this mutation would stop measuring anything.",
       "rationale": "successful Complete must delete exactly the current unit generation snapshot and no other recovery payload",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
-
     {
       "id": "R9-ledger-schema-version-allowlist",
       "file": "internal/providersync/effect_ledger.go",
       "find": "if (state.SchemaVersion != \"v1\" && state.SchemaVersion != \"v2\") || state.Generation == \"\" ||",
       "replace": "if false || state.Generation == \"\" ||",
       "rationale": "the ledger document is shared with workers running older and newer binaries, so an unrecognized schema version must be refused rather than partially interpreted",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R10-v1-must-not-carry-a-snapshot-reference",
@@ -89,7 +215,16 @@
       "find": "if state.SchemaVersion == \"v1\" && state.PreparedSnapshot != nil {",
       "replace": "if false {",
       "rationale": "a document that declares v1 while carrying a v2 payload is exactly what an older worker would misread during a rolling deployment; it must be refused, not tolerated",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R11-v2-requires-a-snapshot-reference",
@@ -98,7 +233,16 @@
       "replace": "(state.PreparedSnapshot != nil && state.PreparedSnapshot.validate() != nil) {",
       "$note": "Clause mutation, not a whole-condition mutation: it disables only the nil check while leaving the validity check live, so a kill can only come from the missing-reference case.",
       "rationale": "a v2 ledger with no snapshot reference names a recovery payload that does not exist and must never be treated as recoverable",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R12-v2-snapshot-reference-must-be-well-formed",
@@ -106,7 +250,16 @@
       "find": "(state.PreparedSnapshot == nil || state.PreparedSnapshot.validate() != nil) {",
       "replace": "(state.PreparedSnapshot == nil) {",
       "rationale": "the sibling clause of R11: a present but malformed reference must be refused, otherwise the digest and size bounds are never consulted",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R13-reference-payload-schema-version",
@@ -114,7 +267,16 @@
       "find": "if reference.SchemaVersion != preparedRouteSnapshotSchemaVersion ||",
       "replace": "if false ||",
       "rationale": "a reference naming a payload schema this binary does not implement must fail closed rather than be decoded on the assumption the shape is unchanged",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R14-reference-digest-must-be-a-sha256",
@@ -122,7 +284,16 @@
       "find": "!validDigest(reference.ContentDigest) || reference.PayloadBytes < 1 ||",
       "replace": "reference.PayloadBytes < 1 ||",
       "rationale": "an unparseable digest can never match the payload, so accepting one turns the integrity check into an unconditional failure at load time instead of a refusal at write time",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R15-reference-lower-size-bound",
@@ -130,7 +301,16 @@
       "find": "!validDigest(reference.ContentDigest) || reference.PayloadBytes < 1 ||",
       "replace": "!validDigest(reference.ContentDigest) ||",
       "rationale": "the sibling clause of R14: a zero-length payload reference describes no manifest at all",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R16-reference-upper-size-bound",
@@ -138,7 +318,16 @@
       "find": "reference.PayloadBytes > maxPreparedRouteSnapshotBytes {",
       "replace": "reference.PayloadBytes > maxPreparedRouteSnapshotBytes*2 {",
       "rationale": "the ledger-side size bound is a separate guard from the encode-side cap in R4; a reference may arrive from a peer that never ran the encoder",
-      "proof": [["go", "test", "-count=1", "-run", "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestEffectLedgerStateBindsSchemaVersionToSnapshotPresence$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R17-prepared-recovery-is-github-only",
@@ -146,7 +335,16 @@
       "find": "(descriptor.Provider != \"github\" || descriptor.RouteDataset != \"work-items\") {",
       "replace": "(descriptor.RouteDataset != \"work-items\") {",
       "rationale": "prepared-manifest recovery is a github/work-items contract; another provider's work-items route carrying the flag is a wiring mistake that must fail before credentials are resolved",
-      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R18-prepared-recovery-is-work-items-only",
@@ -154,7 +352,16 @@
       "find": "(descriptor.Provider != \"github\" || descriptor.RouteDataset != \"work-items\") {",
       "replace": "(descriptor.Provider != \"github\") {",
       "rationale": "the sibling clause of R17: a different GitHub dataset carrying the flag has no 16-effect manifest contract to recover",
-      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedManifestRecoveryIsRefusedOutsideGitHubWorkItems$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R19-recovery-route-requires-a-snapshot-store",
@@ -163,7 +370,16 @@
       "replace": "if descriptor.RouteEnabled && descriptor.PreparedManifestRecovery && !preparedRecovery && false {",
       "$note": "`&& false` rather than `if false` so `preparedRecovery` stays referenced and the mutated source still builds.",
       "rationale": "the deploy-time half of fail-closed: a binary wired to a ledger with no snapshot sidecar must refuse to start the route rather than discover the gap after the first ClickHouse write",
-      "proof": [["go", "test", "-count=1", "-run", "^TestRouteRequiringPreparedRecoveryRefusesALedgerWithoutASnapshotStore$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestRouteRequiringPreparedRecoveryRefusesALedgerWithoutASnapshotStore$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R20-recovery-refuses-a-legacy-v1-ledger",
@@ -172,34 +388,281 @@
       "replace": "if false {",
       "$note": "Deliberately a whole-condition mutation, which is normally the wrong shape. The two clauses are mutually redundant for any state that survives EffectLedgerState.validate(): validate() already makes SchemaVersion != \"v2\" imply PreparedSnapshot == nil, so no reachable state distinguishes them and neither clause can be killed alone. The clause-level guarantee is measured instead by R9-R12 on validate() itself. Recorded here rather than left implicit, because a reader who sees only a passing whole-condition mutation would over-read what it proves.",
       "rationale": "contract point 7: a route requiring prepared recovery must never resume from a v1 ledger written before the recovery contract existed, even though the downstream decoders would also refuse it",
-      "proof": [["go", "test", "-count=1", "-run", "^TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRecoveryRefusesLegacyV1LedgerForGitHubWorkItems$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R21-load-is-fenced-on-the-lease-owner",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "  AND unit.lease_owner = $6",
-      "replace": "  AND (unit.lease_owner = $6 OR TRUE)",
+      "find": "         AND unit.lease_owner = $6",
+      "replace": "         AND (unit.lease_owner = $6 OR TRUE)",
       "rationale": "a worker holding a superseded lease must not read the snapshot the current owner is responsible for; ReleaseForRetry clears owner, expiry and status together, so only an isolated fixture can measure this fence alone",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R22-load-is-fenced-on-lease-expiry",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "  AND unit.lease_expires_at > $7",
-      "replace": "  AND (unit.lease_expires_at > $7 OR TRUE)",
+      "find": "         AND unit.lease_expires_at > $7",
+      "replace": "         AND (unit.lease_expires_at > $7 OR TRUE)",
       "rationale": "a process that stalled long enough to lose its lease must not resume from the snapshot on the assumption it is still the writer",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "R23-load-is-fenced-on-running-status",
       "file": "internal/providersync/prepared_route_snapshot.go",
-      "find": "  AND unit.status = 'running'",
-      "replace": "  AND (unit.status = 'running' OR TRUE)",
+      "find": "         unit.status = 'running'",
+      "replace": "         (unit.status = 'running' OR TRUE)",
       "rationale": "a unit that is no longer running has no in-flight batch to recover, and its retained snapshot must stay unreadable until a fresh claim makes it running again",
-      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
-      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$", "./internal/providersync/"]]
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R24-load-excludes-terminal-runs",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "         AND run.status NOT IN ('success', 'partial_failed', 'failed'),",
+      "replace": "         AND TRUE,",
+      "rationale": "the snapshot load must refuse a run the effect ledger would already refuse; loadEffectLedgerSQL has always excluded terminal runs and the two queries decide the same entitlement",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R25-lease-failure-is-reported-as-lease-loss",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\tif !leaseLive {\n\t\treturn PreparedRouteManifest{}, ErrLeaseLost\n\t}",
+      "replace": "\tif false {\n\t\treturn PreparedRouteManifest{}, ErrLeaseLost\n\t}",
+      "rationale": "a snapshot that exists but is no longer this worker's to recover must report lease loss, not absence; folding the two into one sentinel hid every genuine handoff",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R26-reprepare-verifies-the-stored-payload",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\t\tpayloadBytes != len(payload) || !bytes.Equal(payload, wantPayload) {",
+      "replace": "\t\tpayloadBytes != len(payload) {",
+      "rationale": "verifyPreparedRouteSnapshotRow had no coverage at all: a stored payload that no longer matches what this attempt would write must be refused even when the ledger metadata still agrees",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresPreparedRouteSnapshotLifecycleAndFences$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R27-failed-unit-keeps-the-ledger-key",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    result = COALESCE(unit.result::jsonb, '{}'::jsonb) || $6::jsonb,",
+      "replace": "    result = $6::jsonb,",
+      "rationale": "contract point 5 retains the snapshot on failure; a wholesale result replace destroys go_effect_ledger_v1 and with it the only reference that makes the retained row findable",
+      "build": [
+        "go",
+        "test",
+        "-tags",
+        "integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestPostgresFailedUnitKeepsTheSnapshotReachable$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R28-commit-prepared-shares-the-ledger-ordering",
+      "file": "internal/providersync/effect_committer.go",
+      "find": "\tordered := append([]EffectBatch(nil), batches...)\n\tsortEffectBatches(ordered)\n\tdesired, err := NewEffectLedgerState(claim, ordered, persisted.CreatedAt)",
+      "replace": "\tordered := append([]EffectBatch(nil), batches...)\n\tsort.Slice(ordered, func(left, right int) bool {\n\t\treturn ordered[left].Destination < ordered[right].Destination\n\t})\n\tdesired, err := NewEffectLedgerState(claim, ordered, persisted.CreatedAt)",
+      "$note": "Reintroduces the exact divergence the shared helper exists to prevent. Mutating sortEffectBatches itself is NOT the right target: every producer calls it, so a change there moves all of them together and the pairing stays correct. The defect was always one call site having its own comparator.",
+      "rationale": "recovery pairs prepared batches to ledger entries by position, so a call site with its own comparator commits one destination's rows against another's ledger entry the day a priority destination joins the manifest",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCommitPreparedPairsEachEffectWithItsOwnLedgerEntry$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R29-decode-side-size-cap",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\t\tlen(raw) > maxPreparedRouteSnapshotBytes ||",
+      "replace": "",
+      "rationale": "a separate guard from R4's encode-side cap: a payload can reach decode from a peer that never ran this encoder, or from a row written before the cap existed",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRouteSnapshotDecodeRejectsAnOversizedPayload$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R30-sensitive-key-refusal-covers-every-name",
+      "file": "internal/providersync/prepared_route_snapshot.go",
+      "find": "\t\t\tcase \"authorization\", \"credential\", \"credentials\", \"token\", \"headers\",",
+      "replace": "\t\t\tcase \"credential\", \"credentials\", \"token\", \"headers\",",
+      "rationale": "deleting ONE key name is what a careless edit does; the pre-existing tamper test only covered `credential`, so every other name could be dropped silently",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRouteSnapshotRefusesEverySensitiveKey$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R31-recovery-revalidates-against-the-live-descriptor",
+      "file": "internal/providersync/complete_route.go",
+      "find": "\t\t\tif err := manifest.Batch.validate(descriptor); err != nil ||",
+      "replace": "\t\t\tif err := error(nil); err != nil ||",
+      "rationale": "a snapshot proves what the batch WAS; the descriptor says what the route may write now, and a destination set that changed between prepare and recovery means the stored effects no longer describe this route",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestPreparedRecoveryRevalidatesTheManifestAgainstTheLiveDescriptor$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -539,6 +539,12 @@ func domainPosture() RolePosture {
 			{"sync_runs", true, true, false},
 			{"sync_dispatch_transport_routes", false, false, false},
 			{"sync_run_units", true, true, false},
+			// The only domain table carrying DELETE. Prepared recovery
+			// snapshots are transient state: written once when a route's
+			// manifest is prepared, read back on recovery, and cleared in the
+			// same transaction that terminalizes the unit. Nothing ever
+			// updates one in place, so UPDATE stays off.
+			{"sync_run_unit_effect_snapshots", true, false, true},
 			{"sync_watermarks", true, true, false},
 			{"sync_dispatch_outbox", true, true, false},
 			{"worker_job_outbox", true, false, false},

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -542,8 +542,13 @@ func domainPosture() RolePosture {
 			// The only domain table carrying DELETE. Prepared recovery
 			// snapshots are transient state: written once when a route's
 			// manifest is prepared, read back on recovery, and cleared in the
-			// same transaction that terminalizes the unit. Nothing ever
-			// updates one in place, so UPDATE stays off.
+			// same transaction that completes the unit SUCCESSFULLY. A failed
+			// or retrying unit deliberately keeps its snapshot, so "cleared on
+			// any terminal transition" would be wrong. Nothing ever updates a
+			// snapshot in place, so UPDATE stays off -- and note that means no
+			// row-locking clause can be used against this table either, since
+			// PostgreSQL treats FOR UPDATE/FOR SHARE as UPDATE-class
+			// privileges. See loadPreparedRouteSnapshotRowSQL.
 			{"sync_run_unit_effect_snapshots", true, false, true},
 			{"sync_watermarks", true, true, false},
 			{"sync_dispatch_outbox", true, true, false},

--- a/internal/storage/postgres/domain_authorization_integration_test.go
+++ b/internal/storage/postgres/domain_authorization_integration_test.go
@@ -54,6 +54,7 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		"CREATE TABLE public.worker_job_routes (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_dispatch_transport_routes (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id bigint PRIMARY KEY, state text)",
+		"CREATE TABLE public.sync_run_unit_effect_snapshots (id bigint PRIMARY KEY, state text)",
 		"CREATE TABLE public.sync_watermarks (id bigint PRIMARY KEY, state text)",
 		"CREATE TABLE public.sync_dispatch_outbox (id bigint PRIMARY KEY, state text)",
 		"CREATE TABLE public.worker_job_outbox (id bigint PRIMARY KEY, state text)",
@@ -96,6 +97,10 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.worker_job_outbox, public.external_ingest_recompute_jobs, public.external_ingest_rejections TO " + authorizedDomainRole,
 		"GRANT SELECT, DELETE ON TABLE public.external_ingest_batch_payloads TO " + authorizedDomainRole,
+		// The domain role needs DELETE but explicitly NOT UPDATE here:
+		// PostgreSQL treats FOR UPDATE/FOR SHARE as UPDATE-class, and the
+		// snapshot read-back must never be able to take a row lock.
+		"GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.dev_conversation_tombstones TO " + authorizedDomainRole,
 		"GRANT SELECT, UPDATE, DELETE ON TABLE public.dev_conversations, public.external_ingest_batches, public.provider_rate_limit_observations TO " + authorizedDomainRole,
 		"GRANT SELECT (completion_key), INSERT (completion_key) ON TABLE public.worker_job_completion_fences TO " + authorizedDomainRole,

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -204,6 +204,44 @@ func reconciliationTables() []domainTable {
 				"DELETE FROM public.provider_rate_limit_observations WHERE id = gen_random_uuid()",
 			},
 		},
+		{
+			// Added after a FOR UPDATE on this table shipped to production and
+			// failed with "permission denied" on every re-prepare. The static
+			// analyzer could not see it: both the INSERT and the locking read
+			// live inside a closure passed to mutateGenerationJournalTx, so
+			// they came through as UNRESOLVED evidence -- and the analyzer then
+			// emitted an over-grant ADVISORY on INSERT, which was the
+			// fingerprint of an unanalyzed path rather than a real over-grant.
+			//
+			// Executing the statements under the restricted role is the check
+			// that does not care whether a call site is reachable by static
+			// analysis. All four shapes below are the real ones, including the
+			// read-back SELECT that must NOT carry a row-locking clause: the
+			// domain role has no UPDATE here, and PostgreSQL treats FOR UPDATE
+			// and FOR SHARE as UPDATE-class privileges.
+			name: "sync_run_unit_effect_snapshots",
+			ddl: `CREATE TABLE public.sync_run_unit_effect_snapshots (
+				org_id text NOT NULL, sync_run_unit_id uuid NOT NULL,
+				generation text NOT NULL, provider text NOT NULL,
+				dataset_key text NOT NULL, schema_version text NOT NULL,
+				content_digest varchar(64) NOT NULL, payload_bytes integer NOT NULL,
+				payload bytea NOT NULL, created_at timestamptz NOT NULL,
+				PRIMARY KEY (org_id, sync_run_unit_id, generation))`,
+			exercise: []string{
+				"INSERT INTO public.sync_run_unit_effect_snapshots (" +
+					"org_id, sync_run_unit_id, generation, provider, dataset_key, " +
+					"schema_version, content_digest, payload_bytes, payload, created_at) " +
+					"VALUES ('org-acme', gen_random_uuid(), 'g', 'github', 'work-items', " +
+					"'v1', repeat('a', 64), 2, '\\x7b7d'::bytea, now())",
+				"SELECT schema_version, content_digest, payload_bytes, payload " +
+					"FROM public.sync_run_unit_effect_snapshots " +
+					"WHERE org_id = 'org-acme' AND generation = 'g'",
+				"SELECT snapshot.payload FROM public.sync_run_unit_effect_snapshots AS snapshot " +
+					"WHERE snapshot.org_id = 'org-acme' AND snapshot.dataset_key = 'work-items'",
+				"DELETE FROM public.sync_run_unit_effect_snapshots " +
+					"WHERE org_id = 'org-acme' AND generation = 'g'",
+			},
+		},
 	}
 }
 

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -46,6 +46,7 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		// eda2d6b91) — created but never granted to the domain role here.
 		"CREATE TABLE public.worker_job_routes (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id bigint PRIMARY KEY, state text)",
+		"CREATE TABLE public.sync_run_unit_effect_snapshots (id bigint PRIMARY KEY, state text)",
 		"CREATE TABLE public.sync_watermarks (id bigint PRIMARY KEY, state text)",
 		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.worker_job_completion_fences (completion_key text PRIMARY KEY)",
@@ -94,6 +95,10 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.worker_job_outbox, public.external_ingest_recompute_jobs, public.external_ingest_rejections TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, DELETE ON TABLE public.external_ingest_batch_payloads TO " + runtimeAuthorizationDomainRole,
+		// The domain role needs DELETE but explicitly NOT UPDATE here:
+		// PostgreSQL treats FOR UPDATE/FOR SHARE as UPDATE-class, and the
+		// snapshot read-back must never be able to take a row lock.
+		"GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.dev_conversation_tombstones TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, UPDATE, DELETE ON TABLE public.dev_conversations, public.external_ingest_batches, public.provider_rate_limit_observations TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT (completion_key), INSERT (completion_key) ON TABLE public.worker_job_completion_fences TO " + runtimeAuthorizationDomainRole,

--- a/internal/storage/river/migrate.go
+++ b/internal/storage/river/migrate.go
@@ -390,6 +390,10 @@ func runtimeGrantStatements(options MigrationOptions) []string {
 		"DO $$ BEGIN IF to_regclass('public.sync_runs') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_runs TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_run_units TO " + domainRole + "; END IF; END $$",
+		// The only DELETE the domain role holds. Prepared recovery snapshots
+		// are transient state cleared in the same transaction that
+		// terminalizes their unit, never updated in place, so no UPDATE.
+		"DO $$ BEGIN IF to_regclass('public.sync_run_unit_effect_snapshots') IS NOT NULL THEN GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_watermarks') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_outbox') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.worker_job_outbox') IS NOT NULL THEN GRANT SELECT, INSERT ON TABLE public.worker_job_outbox TO " + domainRole + "; END IF; END $$",

--- a/internal/storage/river/migrate_test.go
+++ b/internal/storage/river/migrate_test.go
@@ -401,6 +401,7 @@ func TestRuntimeGrantStatementsMatchProvisionedLeastPrivilegePolicy(t *testing.T
 		"DO $$ BEGIN IF to_regclass('public.sync_runs') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_runs TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_run_units TO \"domain_runtime\"; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.sync_run_unit_effect_snapshots') IS NOT NULL THEN GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_watermarks') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_outbox') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_dispatch_outbox TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.worker_job_outbox') IS NOT NULL THEN GRANT SELECT, INSERT ON TABLE public.worker_job_outbox TO \"domain_runtime\"; END IF; END $$",

--- a/scripts/worker/provision_river_roles.sql
+++ b/scripts/worker/provision_river_roles.sql
@@ -120,6 +120,12 @@ SELECT format(
  WHERE to_regclass(format('public.%I', required.table_name)) IS NOT NULL
 \gexec
 SELECT format(
+         'GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO %I',
+         :'domain_role'
+       )
+ WHERE to_regclass('public.sync_run_unit_effect_snapshots') IS NOT NULL
+\gexec
+SELECT format(
          'GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks TO %I',
          :'domain_role'
        )

--- a/src/dev_health_ops/alembic/versions/0086_add_sync_unit_effect_snapshots.py
+++ b/src/dev_health_ops/alembic/versions/0086_add_sync_unit_effect_snapshots.py
@@ -1,0 +1,67 @@
+"""Add bounded prepared effect snapshots for exact Go worker recovery.
+
+Revision ID: 0086
+Revises: 0085
+Create Date: 2026-08-04 00:00:00
+
+The payload is an opaque, normalized, sink-ready manifest owned by the Go
+provider worker. It deliberately does not reuse provider credential storage
+or its encryption key. Tenant, unit, and generation form the durable identity;
+the unit foreign key provides lifecycle cleanup if the owning run is deleted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0086"
+down_revision: str | None = "0085"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "sync_run_unit_effect_snapshots"
+_UNIT_INDEX = "ix_sync_run_unit_effect_snapshots_unit"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("sync_run_unit_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("generation", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("dataset_key", sa.Text(), nullable=False),
+        sa.Column("schema_version", sa.Text(), nullable=False),
+        sa.Column("content_digest", sa.String(length=64), nullable=False),
+        sa.Column("payload_bytes", sa.Integer(), nullable=False),
+        sa.Column("payload", sa.LargeBinary(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "payload_bytes >= 1 AND payload_bytes <= 67108864",
+            name="ck_sync_run_unit_effect_snapshots_payload_bytes",
+        ),
+        sa.CheckConstraint(
+            "length(payload) = payload_bytes",
+            name="ck_sync_run_unit_effect_snapshots_payload_length",
+        ),
+        sa.CheckConstraint(
+            "schema_version = 'v1'",
+            name="ck_sync_run_unit_effect_snapshots_schema_version",
+        ),
+        sa.ForeignKeyConstraint(
+            ["sync_run_unit_id"], ["sync_run_units.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("org_id", "sync_run_unit_id", "generation"),
+    )
+    op.create_index(_UNIT_INDEX, _TABLE, ["sync_run_unit_id"])
+
+
+def downgrade() -> None:
+    op.drop_index(_UNIT_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/src/dev_health_ops/alembic/versions/0086_add_sync_unit_effect_snapshots.py
+++ b/src/dev_health_ops/alembic/versions/0086_add_sync_unit_effect_snapshots.py
@@ -50,6 +50,14 @@ def upgrade() -> None:
             "length(payload) = payload_bytes",
             name="ck_sync_run_unit_effect_snapshots_payload_length",
         ),
+        # 'v1' here is the PAYLOAD schema, which is a different version
+        # namespace from the effect LEDGER schema stored under the
+        # go_effect_ledger_v1 result key -- that one is at v2 once a snapshot
+        # reference is present. The two advance independently: the ledger went
+        # to v2 to carry the reference, while the payload's own shape has not
+        # changed. Reading this constraint as "the snapshot feature is v1" and
+        # bumping it to match the ledger would reject every row the current
+        # encoder writes.
         sa.CheckConstraint(
             "schema_version = 'v1'",
             name="ck_sync_run_unit_effect_snapshots_schema_version",

--- a/src/dev_health_ops/alembic/versions/0088_add_sync_unit_effect_snapshots.py
+++ b/src/dev_health_ops/alembic/versions/0088_add_sync_unit_effect_snapshots.py
@@ -1,6 +1,6 @@
 """Add bounded prepared effect snapshots for exact Go worker recovery.
 
-Revision ID: 0086
+Revision ID: 0088
 Revises: 0085
 Create Date: 2026-08-04 00:00:00
 
@@ -8,6 +8,20 @@ The payload is an opaque, normalized, sink-ready manifest owned by the Go
 provider worker. It deliberately does not reuse provider credential storage
 or its encryption key. Tenant, unit, and generation form the durable identity;
 the unit foreign key provides lifecycle cleanup if the owning run is deleted.
+
+NOTE ON THE ID: this is 0088, and its parent is 0085 rather than 0087. Main
+independently took 0086 (dev_run_qua_shadow) and 0087
+(dev_qua_shadow_budget_reservations) while this lane was in flight, and neither
+exists on this feature branch yet -- pointing down_revision at 0087 today is a
+hard KeyError at ScriptDirectory load, verified rather than assumed.
+
+So 0088 reserves the id and the parent stays 0085 for now. THE SYNC THAT BRINGS
+MAIN'S 0086/0087 ONTO THIS BRANCH MUST RE-POINT down_revision TO 0087 (or to
+whatever the merged head is by then). Until it does, that sync yields three
+heads -- 0066, 0087, 0088 -- instead of two. That failure is loud rather than
+silent: get_revision("application_schema@head") raises CommandError, and all
+five migration-head pin tests exercise exactly that call. Confirmed by
+simulating the merged versions directory before choosing this shape.
 """
 
 from __future__ import annotations
@@ -18,7 +32,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
-revision: str = "0086"
+revision: str = "0088"
 down_revision: str | None = "0085"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0088"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0088"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0088"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0088"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0085"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0086"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0085",)
+    assert heads == ("0086",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0086",)
+    assert heads == ("0088",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0086"}
+    assert set(heads) == {"0066", "0088"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0085"}
+    assert set(heads) == {"0066", "0086"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -428,12 +428,13 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
         "GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks",
         "GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_dispatch_outbox",
         "GRANT SELECT, INSERT ON TABLE public.worker_job_outbox",
+        "GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots",
     ):
         assert grant in domain_script
     for forbidden in (
         "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES",
         "GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES",
-        "DELETE ON TABLE",
+        "DELETE ON ALL TABLES",
     ):
         assert forbidden not in domain_script
 

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -437,6 +437,20 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
         "DELETE ON ALL TABLES",
     ):
         assert forbidden not in domain_script
+    # The domain role holds exactly one DELETE privilege. Recovery snapshots are
+    # transient state the worker clears on terminal completion; every other
+    # domain table is append/update-only. Assert the exact set rather than
+    # banning one spelling: admitting the snapshot grant meant relaxing a
+    # blanket "DELETE ON TABLE" ban, and a relaxed ban admits every future
+    # DELETE grant too. A templated `public.%I` DELETE block surfaces here as
+    # the literal "%I" and so cannot slip through this equality either.
+    assert _tables_for_delete_grants(domain_script) == {
+        "sync_run_unit_effect_snapshots"
+    }
+
+
+def _tables_for_delete_grants(domain_script: str) -> set[str]:
+    return set(re.findall(r"DELETE ON TABLE public\.([A-Za-z0-9_%]+)", domain_script))
 
 
 def _tables_for_formatted_grant(domain_script: str, grant: str) -> set[str]:

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -409,7 +409,9 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
     configured_read_only_tables = _tables_for_formatted_grant(
         domain_script, "GRANT SELECT ON TABLE public.%I TO %I"
     )
-    assert configured_read_only_tables == expected_read_only_tables
+    assert configured_read_only_tables == expected_read_only_tables, (
+        "read-only grant block covers the wrong tables"
+    )
     # These tables are mutable domain state, so they deliberately live in the
     # separate read/write grant rather than the read-only VALUES list above.
     expected_read_write_tables = {
@@ -421,7 +423,9 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
     configured_read_write_tables = _tables_for_formatted_grant(
         domain_script, "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I"
     )
-    assert configured_read_write_tables == expected_read_write_tables
+    assert configured_read_write_tables == expected_read_write_tables, (
+        "read-write grant block covers the wrong tables"
+    )
     for grant in (
         "GRANT SELECT ON TABLE public.%I TO %I",
         "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I",
@@ -437,20 +441,67 @@ def _assert_least_privilege_domain_grants(domain_script: str) -> None:
         "DELETE ON ALL TABLES",
     ):
         assert forbidden not in domain_script
-    # The domain role holds exactly one DELETE privilege. Recovery snapshots are
-    # transient state the worker clears on terminal completion; every other
-    # domain table is append/update-only. Assert the exact set rather than
-    # banning one spelling: admitting the snapshot grant meant relaxing a
-    # blanket "DELETE ON TABLE" ban, and a relaxed ban admits every future
-    # DELETE grant too. A templated `public.%I` DELETE block surfaces here as
-    # the literal "%I" and so cannot slip through this equality either.
+    # Scoped claim: within the provisioning scripts' DOMAIN SECTION, the
+    # snapshot table is the only per-table DELETE. The domain ROLE holds DELETE
+    # on more than that -- dev_conversations, external_ingest_batches,
+    # external_ingest_batch_payloads and provider_rate_limit_observations are
+    # granted it in domainPosture() -- they are simply not granted by these
+    # scripts. Stating it unscoped would be false.
+    #
+    # Assert the exact set rather than banning one spelling: admitting the
+    # snapshot grant meant relaxing a blanket "DELETE ON TABLE" ban, and a
+    # relaxed ban admits every future DELETE grant too. A templated
+    # `public.%I` DELETE block surfaces here as the literal "%I" and so
+    # cannot slip through this equality either.
     assert _tables_for_delete_grants(domain_script) == {
         "sync_run_unit_effect_snapshots"
     }
 
 
 def _tables_for_delete_grants(domain_script: str) -> set[str]:
-    return set(re.findall(r"DELETE ON TABLE public\.([A-Za-z0-9_%]+)", domain_script))
+    """Tables granted DELETE, whatever order the privilege list is written in.
+
+    Matching "DELETE ON TABLE" only sees DELETE written last:
+    `GRANT SELECT, DELETE, UPDATE ON TABLE ...` slips straight past it. That
+    used to be covered by a blanket ban on the substring "DELETE ON TABLE",
+    which this file had to relax to admit the snapshot grant -- so the narrow
+    regex and the removed ban left the same hole open together. Parse the
+    privilege list instead.
+    """
+    granted: set[str] = set()
+    for privileges, table in re.findall(
+        r"GRANT\s+([A-Z,\s()a-z_]+?)\s+ON TABLE public\.([A-Za-z0-9_%]+)",
+        domain_script,
+    ):
+        names = {
+            privilege.split("(", maxsplit=1)[0].strip().upper()
+            for privilege in privileges.split(",")
+        }
+        if "DELETE" in names:
+            granted.add(table)
+    return granted
+
+
+# The two provisioning scripts mark the end of the domain section differently.
+# Slicing both on "-- The queue role" silently returned the WHOLE of
+# init-extra-dbs.sh, which has no such marker -- so assertions meant for the
+# domain role were reading the queue role's grants too, and the negative test
+# below passed by raising for the wrong reason.
+_DOMAIN_SECTION_MARKERS = {
+    "init-extra-dbs.sh": 'GRANT USAGE ON SCHEMA public TO :"queue_role";',
+    "provision_river_roles.sql": "-- The queue role",
+}
+
+
+def _domain_section(script_path: Path) -> str:
+    marker = _DOMAIN_SECTION_MARKERS[script_path.name]
+    script = script_path.read_text(encoding="utf-8")
+    assert marker in script, (
+        f"{script_path.name} does not contain its domain-section marker "
+        f"{marker!r}; slicing on a missing marker yields the whole file and "
+        f"every domain assertion silently widens to the queue role"
+    )
+    return script.split(marker, maxsplit=1)[0]
 
 
 def _tables_for_formatted_grant(domain_script: str, grant: str) -> set[str]:
@@ -474,9 +525,7 @@ def _tables_for_formatted_grant(domain_script: str, grant: str) -> set[str]:
 def test_least_privilege_domain_grants_reject_swapped_privilege_blocks(
     script_path: Path,
 ) -> None:
-    domain_script = script_path.read_text(encoding="utf-8").split(
-        "-- The queue role", maxsplit=1
-    )[0]
+    domain_script = _domain_section(script_path)
     read_only_grant = "GRANT SELECT ON TABLE public.%I TO %I"
     read_write_grant = "GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO %I"
     inverted = (
@@ -484,9 +533,19 @@ def test_least_privilege_domain_grants_reject_swapped_privilege_blocks(
         .replace(read_write_grant, read_only_grant)
         .replace("__READ_ONLY_GRANT__", read_write_grant)
     )
+    assert inverted != domain_script, "the swap fixture changed nothing"
 
-    with pytest.raises(AssertionError):
+    # The control: unmodified input must PASS. Without it a bare
+    # pytest.raises proves only that SOMETHING raised -- deleting the swap
+    # assertions entirely still satisfied it.
+    _assert_least_privilege_domain_grants(domain_script)
+    with pytest.raises(AssertionError) as failure:
         _assert_least_privilege_domain_grants(inverted)
+    # And the reason is asserted, not assumed: the swap must be caught by the
+    # read-only/read-write table sets, not by some unrelated later assertion.
+    assert "grant block covers the wrong tables" in str(failure.value), str(
+        failure.value
+    )
 
 
 def test_legacy_compose_disables_ambient_migrations() -> None:

--- a/tests/test_effect_snapshot_migration.py
+++ b/tests/test_effect_snapshot_migration.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import importlib
+import os
 from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+from sqlalchemy.engine import make_url
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -17,9 +19,9 @@ def _run(migration, connection: sa.Connection, operation: str) -> None:
         getattr(migration, operation)()
 
 
-def test_0086_creates_bounded_tenant_generation_snapshot_with_cascade() -> None:
+def test_0088_creates_bounded_tenant_generation_snapshot_with_cascade() -> None:
     migration = importlib.import_module(
-        "dev_health_ops.alembic.versions.0086_add_sync_unit_effect_snapshots"
+        "dev_health_ops.alembic.versions.0088_add_sync_unit_effect_snapshots"
     )
     engine = sa.create_engine("sqlite:///:memory:")
     unit_id = "11111111-1111-4111-8111-111111111111"
@@ -121,8 +123,8 @@ _CHECK_VIOLATIONS = {
 
 
 @pytest.mark.parametrize("case", sorted(_CHECK_VIOLATIONS))
-def test_0086_check_constraints_reject_out_of_contract_rows(case: str) -> None:
-    """Each CHECK on 0086 must reject something.
+def test_0088_check_constraints_reject_out_of_contract_rows(case: str) -> None:
+    """Each CHECK on 0088 must reject something.
 
     The original test inserted only well-formed rows, so deleting the
     schema_version or payload_bytes CHECK from the migration left it green --
@@ -131,7 +133,7 @@ def test_0086_check_constraints_reject_out_of_contract_rows(case: str) -> None:
     """
     schema_version, payload_bytes, payload = _CHECK_VIOLATIONS[case]
     migration = importlib.import_module(
-        "dev_health_ops.alembic.versions.0086_add_sync_unit_effect_snapshots"
+        "dev_health_ops.alembic.versions.0088_add_sync_unit_effect_snapshots"
     )
     engine = sa.create_engine("sqlite:///:memory:")
     unit_id = "11111111-1111-4111-8111-111111111111"
@@ -172,8 +174,8 @@ def test_0086_check_constraints_reject_out_of_contract_rows(case: str) -> None:
         engine.dispose()
 
 
-def test_integration_fixture_ddl_matches_migration_0086() -> None:
-    """The Go integration fixture and migration 0086 must describe one schema.
+def test_integration_fixture_ddl_matches_migration_0088() -> None:
+    """The Go integration fixture and migration 0088 must describe one schema.
 
     The fixture hand-rolls the table because the Go suite cannot run alembic.
     It previously dropped all three CHECK constraints and widened
@@ -188,7 +190,7 @@ def test_integration_fixture_ddl_matches_migration_0086() -> None:
         / "dev_health_ops"
         / "alembic"
         / "versions"
-        / "0086_add_sync_unit_effect_snapshots.py"
+        / "0088_add_sync_unit_effect_snapshots.py"
     ).read_text(encoding="utf-8")
     fixture_source = (
         _REPO_ROOT
@@ -206,7 +208,7 @@ def test_integration_fixture_ddl_matches_migration_0086() -> None:
     ):
         assert constraint in migration_source, constraint
         assert constraint in fixture_ddl, (
-            f"{constraint} is in migration 0086 but missing from the Go "
+            f"{constraint} is in migration 0088 but missing from the Go "
             f"integration fixture -- the fixture is more permissive than "
             f"production"
         )
@@ -227,3 +229,90 @@ def test_integration_fixture_ddl_matches_migration_0086() -> None:
     # accepts digests production would reject.
     assert "varchar(64)" in fixture_ddl
     assert "ON DELETE CASCADE" in fixture_ddl
+
+
+_POSTGRES_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+
+@pytest.mark.parametrize("case", sorted(_CHECK_VIOLATIONS))
+def test_0088_check_constraints_reject_on_real_postgres(case: str) -> None:
+    """The same CHECKs, enforced by the database production actually runs.
+
+    The SQLite cases above execute the migration's Python, not PostgreSQL's
+    constraint machinery: SQLite's CHECK semantics, its typing and its
+    ``length()`` on a BLOB are all near-enough-but-not-identical. A constraint
+    that only ever fires on SQLite is not evidence about production.
+    """
+    uri = os.getenv(_POSTGRES_URI_ENV)
+    if not uri:
+        if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+            pytest.fail(f"{_POSTGRES_URI_ENV} must be configured in CI")
+        pytest.skip(f"requires {_POSTGRES_URI_ENV}")
+
+    schema_version, payload_bytes, payload = _CHECK_VIOLATIONS[case]
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0088_add_sync_unit_effect_snapshots"
+    )
+    # Coerce to the sync driver: the env var carries whatever the caller
+    # configured (often an async driver), and create_engine here needs a
+    # blocking one. Mirrors test_ask_dev_v2_persistence_startup_gate.
+    engine = sa.create_engine(make_url(uri).set(drivername="postgresql+psycopg2"))
+    schema = f"snapshot_check_{case}"
+    unit_id = "11111111-1111-4111-8111-111111111111"
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET search_path TO "{schema}"'))
+            connection.execute(
+                sa.text("CREATE TABLE sync_run_units (id uuid PRIMARY KEY)")
+            )
+            _run(migration, connection, "upgrade")
+            connection.execute(
+                sa.text("INSERT INTO sync_run_units (id) VALUES (:id)"),
+                {"id": unit_id},
+            )
+            # Control: a well-formed row is accepted, so a rejection below is
+            # attributable to the violated constraint and not to the fixture.
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO sync_run_unit_effect_snapshots (
+                        org_id, sync_run_unit_id, generation, provider,
+                        dataset_key, schema_version, content_digest,
+                        payload_bytes, payload, created_at
+                    ) VALUES (
+                        'org-acme', :unit_id, 'control', 'github', 'work-items',
+                        'v1', :digest, 2, '\\x7b7d'::bytea, now()
+                    )
+                    """
+                ),
+                {"unit_id": unit_id, "digest": "a" * 64},
+            )
+            with pytest.raises(sa.exc.IntegrityError):
+                connection.execute(
+                    sa.text(
+                        """
+                        INSERT INTO sync_run_unit_effect_snapshots (
+                            org_id, sync_run_unit_id, generation, provider,
+                            dataset_key, schema_version, content_digest,
+                            payload_bytes, payload, created_at
+                        ) VALUES (
+                            'org-acme', :unit_id, 'violating', 'github',
+                            'work-items', :schema_version, :digest,
+                            :payload_bytes, :payload, now()
+                        )
+                        """
+                    ),
+                    {
+                        "unit_id": unit_id,
+                        "schema_version": schema_version,
+                        "digest": "a" * 64,
+                        "payload_bytes": payload_bytes,
+                        "payload": payload,
+                    },
+                )
+        with engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+    finally:
+        engine.dispose()

--- a/tests/test_effect_snapshot_migration.py
+++ b/tests/test_effect_snapshot_migration.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _run(migration, connection: sa.Connection, operation: str) -> None:
@@ -107,3 +110,120 @@ def test_0086_creates_bounded_tenant_generation_snapshot_with_cascade() -> None:
             )
     finally:
         engine.dispose()
+
+
+_CHECK_VIOLATIONS = {
+    "schema_version": ("v2", 2, b"{}"),
+    "payload_bytes_zero": ("v1", 0, b""),
+    "payload_bytes_over_cap": ("v1", 67108865, b"{}"),
+    "payload_length_mismatch": ("v1", 3, b"{}"),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_CHECK_VIOLATIONS))
+def test_0086_check_constraints_reject_out_of_contract_rows(case: str) -> None:
+    """Each CHECK on 0086 must reject something.
+
+    The original test inserted only well-formed rows, so deleting the
+    schema_version or payload_bytes CHECK from the migration left it green --
+    a constraint nothing exercises is decoration. One case per constraint means
+    removing any one of them turns exactly one case red.
+    """
+    schema_version, payload_bytes, payload = _CHECK_VIOLATIONS[case]
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0086_add_sync_unit_effect_snapshots"
+    )
+    engine = sa.create_engine("sqlite:///:memory:")
+    unit_id = "11111111-1111-4111-8111-111111111111"
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                sa.text("CREATE TABLE sync_run_units (id UUID PRIMARY KEY)")
+            )
+            _run(migration, connection, "upgrade")
+            connection.execute(
+                sa.text("INSERT INTO sync_run_units (id) VALUES (:id)"),
+                {"id": unit_id},
+            )
+            with pytest.raises(sa.exc.IntegrityError):
+                connection.execute(
+                    sa.text(
+                        """
+                        INSERT INTO sync_run_unit_effect_snapshots (
+                            org_id, sync_run_unit_id, generation, provider,
+                            dataset_key, schema_version, content_digest,
+                            payload_bytes, payload, created_at
+                        ) VALUES (
+                            'org-acme', :unit_id, 'g1', 'github',
+                            'work-items', :schema_version, :digest,
+                            :payload_bytes, :payload, CURRENT_TIMESTAMP
+                        )
+                        """
+                    ),
+                    {
+                        "unit_id": unit_id,
+                        "schema_version": schema_version,
+                        "digest": "a" * 64,
+                        "payload_bytes": payload_bytes,
+                        "payload": payload,
+                    },
+                )
+    finally:
+        engine.dispose()
+
+
+def test_integration_fixture_ddl_matches_migration_0086() -> None:
+    """The Go integration fixture and migration 0086 must describe one schema.
+
+    The fixture hand-rolls the table because the Go suite cannot run alembic.
+    It previously dropped all three CHECK constraints and widened
+    content_digest to text, so every Go integration test ran against a schema
+    strictly more permissive than production -- proving the code works on a
+    table that exists nowhere real. This compares the two directly so drift in
+    either direction is caught the day it happens.
+    """
+    migration_source = (
+        _REPO_ROOT
+        / "src"
+        / "dev_health_ops"
+        / "alembic"
+        / "versions"
+        / "0086_add_sync_unit_effect_snapshots.py"
+    ).read_text(encoding="utf-8")
+    fixture_source = (
+        _REPO_ROOT
+        / "internal"
+        / "providersync"
+        / "repository_postgres_integration_test.go"
+    ).read_text(encoding="utf-8")
+    fixture_ddl = fixture_source.split("const snapshotFixtureDDL = `", maxsplit=1)[1]
+    fixture_ddl = fixture_ddl.split("`", maxsplit=1)[0]
+
+    for constraint in (
+        "ck_sync_run_unit_effect_snapshots_payload_bytes",
+        "ck_sync_run_unit_effect_snapshots_payload_length",
+        "ck_sync_run_unit_effect_snapshots_schema_version",
+    ):
+        assert constraint in migration_source, constraint
+        assert constraint in fixture_ddl, (
+            f"{constraint} is in migration 0086 but missing from the Go "
+            f"integration fixture -- the fixture is more permissive than "
+            f"production"
+        )
+    for column in (
+        "org_id",
+        "sync_run_unit_id",
+        "generation",
+        "provider",
+        "dataset_key",
+        "schema_version",
+        "content_digest",
+        "payload_bytes",
+        "payload",
+        "created_at",
+    ):
+        assert column in fixture_ddl, column
+    # The migration declares String(length=64); a fixture using unbounded text
+    # accepts digests production would reject.
+    assert "varchar(64)" in fixture_ddl
+    assert "ON DELETE CASCADE" in fixture_ddl

--- a/tests/test_effect_snapshot_migration.py
+++ b/tests/test_effect_snapshot_migration.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+def _run(migration, connection: sa.Connection, operation: str) -> None:
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        getattr(migration, operation)()
+
+
+def test_0086_creates_bounded_tenant_generation_snapshot_with_cascade() -> None:
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0086_add_sync_unit_effect_snapshots"
+    )
+    engine = sa.create_engine("sqlite:///:memory:")
+    unit_id = "11111111-1111-4111-8111-111111111111"
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text("PRAGMA foreign_keys = ON"))
+            connection.execute(
+                sa.text("CREATE TABLE sync_run_units (id UUID PRIMARY KEY)")
+            )
+            _run(migration, connection, "upgrade")
+
+            inspector = sa.inspect(connection)
+            assert "sync_run_unit_effect_snapshots" in inspector.get_table_names()
+            assert inspector.get_pk_constraint("sync_run_unit_effect_snapshots")[
+                "constrained_columns"
+            ] == [
+                "org_id",
+                "sync_run_unit_id",
+                "generation",
+            ]
+            foreign_keys = inspector.get_foreign_keys("sync_run_unit_effect_snapshots")
+            assert foreign_keys[0]["referred_table"] == "sync_run_units"
+            assert foreign_keys[0]["options"]["ondelete"] == "CASCADE"
+
+            connection.execute(
+                sa.text("INSERT INTO sync_run_units (id) VALUES (:id)"),
+                {"id": unit_id},
+            )
+            params = {
+                "org_id": "org-acme",
+                "unit_id": unit_id,
+                "generation": f"sync-unit:{unit_id}",
+                "provider": "github",
+                "dataset": "work-items",
+                "schema": "v1",
+                "digest": "a" * 64,
+                "payload": b"{}",
+                "payload_bytes": 2,
+            }
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO sync_run_unit_effect_snapshots (
+                        org_id, sync_run_unit_id, generation, provider,
+                        dataset_key, schema_version, content_digest,
+                        payload_bytes, payload, created_at
+                    ) VALUES (
+                        :org_id, :unit_id, :generation, :provider,
+                        :dataset, :schema, :digest,
+                        :payload_bytes, :payload, CURRENT_TIMESTAMP
+                    )
+                    """
+                ),
+                params,
+            )
+            with pytest.raises(sa.exc.IntegrityError):
+                connection.execute(
+                    sa.text(
+                        """
+                        INSERT INTO sync_run_unit_effect_snapshots (
+                            org_id, sync_run_unit_id, generation, provider,
+                            dataset_key, schema_version, content_digest,
+                            payload_bytes, payload, created_at
+                        ) VALUES (
+                            'org-other', :unit_id, 'wrong-size', 'github',
+                            'work-items', 'v1', :digest, 3, :payload,
+                            CURRENT_TIMESTAMP
+                        )
+                        """
+                    ),
+                    params,
+                )
+
+            connection.execute(
+                sa.text("DELETE FROM sync_run_units WHERE id = :id"), {"id": unit_id}
+            )
+            assert (
+                connection.scalar(
+                    sa.text("SELECT count(*) FROM sync_run_unit_effect_snapshots")
+                )
+                == 0
+            )
+
+            _run(migration, connection, "downgrade")
+            assert (
+                "sync_run_unit_effect_snapshots"
+                not in sa.inspect(connection).get_table_names()
+            )
+    finally:
+        engine.dispose()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0085"}
+        assert set(heads) == {"0066", "0086"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0085"
+        assert script.get_revision("application_schema@head").revision == "0086"
         assert revisions
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,10 +64,48 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0086"}
+        assert set(heads) == {"0066", "0088"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0086"
+        assert script.get_revision("application_schema@head").revision == "0088"
         assert revisions
+
+    def test_no_two_migrations_declare_the_same_revision_id(self):
+        """Two files claiming one revision id is a MERGE hazard, not a typo.
+
+        Two lanes have now independently collided on this. Alembic only warns
+        (`Revision X is present more than once`), and the graph-level
+        assertions above catch it only for some topologies -- their behavior
+        depends on whether the duplicate happens to be a head, which is a
+        property of whatever else merged that week, not of the defect.
+
+        So this reads the declarations straight out of the files. It cannot be
+        confused by head structure, and unlike walk_revisions() it still
+        produces a readable assertion instead of a RevisionError when the graph
+        is unresolvable.
+        """
+        versions = _ALEMBIC_DIR / "versions"
+        declared: dict[str, list[str]] = {}
+        for path in sorted(versions.glob("[0-9]*.py")):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped.startswith("revision: str = ") or stripped.startswith(
+                    "revision = "
+                ):
+                    value = stripped.split("=", 1)[1].strip().strip("\"'")
+                    declared.setdefault(value, []).append(path.name)
+                    break
+
+        # A source-reading check that finds nothing must fail, not pass: an
+        # empty result here would mean the parser drifted, and silence would
+        # read exactly like "no duplicates".
+        assert len(declared) >= 80, (
+            f"parsed only {len(declared)} revision ids from {versions}; "
+            f"the declaration parser has drifted"
+        )
+        duplicates = {
+            revision: files for revision, files in declared.items() if len(files) > 1
+        }
+        assert not duplicates, f"duplicate alembic revision ids: {duplicates}"
 
 
 # ── _make_alembic_config ───────────────────────────────────────────

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0085"}
-        assert scripts.get_revision("application_schema@head").revision == "0085"
-        assert _database_has_revision(cfg, ("0085",), "0065")
-        assert not _database_has_revision(cfg, ("0085",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0086"}
+        assert scripts.get_revision("application_schema@head").revision == "0086"
+        assert _database_has_revision(cfg, ("0086",), "0065")
+        assert not _database_has_revision(cfg, ("0086",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,10 +172,10 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0086"}
-        assert scripts.get_revision("application_schema@head").revision == "0086"
-        assert _database_has_revision(cfg, ("0086",), "0065")
-        assert not _database_has_revision(cfg, ("0086",), "0066")
+        assert set(scripts.get_heads()) == {"0066", "0088"}
+        assert scripts.get_revision("application_schema@head").revision == "0088"
+        assert _database_has_revision(cfg, ("0088",), "0065")
+        assert not _database_has_revision(cfg, ("0088",), "0066")
 
     def test_cutover_revision_lineage_detection_uses_real_alembic_graph(self) -> None:
         cfg = _make_alembic_config(


### PR DESCRIPTION
## What this is

The durable prepared-manifest recovery layer for `github/work-items`, transplanted onto the post-#1484 feature branch and completed against the nine-point recovery contract on CHAOS-3123.

The route remains **deliberately unregistered**: `route_ready: false`, `go_executor: none`, no watermark, no readiness, no alias activation. `PreparedManifestRecovery` is carried on the descriptor now so that a future activation cannot accidentally fall back to mutable-provider recollection after a crash.

## Why a snapshot at all

`github/work-items` composes 16 destination effects from several mutable provider surfaces. Every attempt for a unit occurrence must rebuild byte-identical rows, because effect digests cover the serialized rows — but the composite's inputs can change between attempts. Re-collecting after a crash therefore produces a different manifest, which the ledger rejects on digest, which wedges the unit until it exhausts. The snapshot removes recollection from the retry path entirely: recovery loads the exact prepared batch and never touches credentials, providers, or the derivation context.

## Contract coverage

| # | Contract point | Where |
|---|---|---|
| 1 | persist the validated 16-effect batch + result/evidence/watermark before any ClickHouse write | `PrepareRouteSnapshot` precedes `CommitPrepared` (R1, R2) |
| 2 | bind tenant/unit/generation, verify digest, hard size limits | `encode`/`decodePreparedRouteManifest`, `PreparedRouteSnapshotReference.validate` (R3, R4, R6, R13–R16) |
| 3 | atomic prepare of ledger + snapshot under the lease | `mutateGenerationJournalTx` (R5 + trigger-rollback integration fixture) |
| 4 | recovery skips handler, providers, derivation | route recovery branch (R2; every recovery test asserts `handler.normalizedAt.IsZero()`) |
| 5 | delete in the same successful completion transaction, retain on failure/ambiguity | `Complete` (R7, R8 + retain-across-`ReleaseForRetry` and retain-on-rollback fixtures) |
| 6 | keep result key `go_effect_ledger_v1`, advance only the embedded schema to v2 | `effectLedgerResultKey` unchanged; `EffectLedgerState.SchemaVersion` v1\|v2 (R9–R12) |
| 7 | new workers read legacy v1; github work-items requires v2 + a valid snapshot | route-level guard added in this PR (R20) |
| 8 | no credential-key reuse | payload is normalized rows only, unencrypted; `containsPreparedRouteSensitiveKey` rejects credential-shaped keys at encode time |
| 9 | readback stays authoritative; the snapshot is expected effects, not receipts | `storedPreparedEffect` structurally has no status/committed fields — it cannot carry a receipt |

**Disclosed deviation on point 2.** The contract asks for compressed *and* decompressed size limits. The sidecar is deliberately stored uncompressed, so there is no decompression surface and no second limit to enforce — one 64 MiB encoded cap covers it. Recorded as the mutation plan's `$limitation` rather than left as an implied gap.

## Evidence

- **Mutations: 37 KILLED, 3 SURVIVED_DECLARED, 0 undeclared survivors, 0 invalid, 0 baseline-failed**, harness verified clean before and after. The plan grew 8 → 23 → 31 → 40; `effect_ledger.go` and `verifyPreparedRouteSnapshotRow` had zero mutation coverage before this PR.

  Three survivors are **declared, with measured reasons** rather than counted as coverage:
  - `R29-decode-side-size-cap` — unreachable: `len(raw)` must equal `PayloadBytes`, and a reference over the bound never validates. The test that appeared to cover it was passing on `state.validate()`'s rejection.
  - `R37-refused-load-moves-no-payload` — admitted equivalent: the payload gate is a resource property, not a behavioural one. A refused load returns the same error either way, so no assertion can separate them.
  - `R38-encode-site-shares-the-ledger-ordering` — admitted equivalent *today*: all 16 work-items destinations are priority 0, so priority-first and destination-only order coincide for every manifest this route can build. It stops being equivalent the moment one takes a non-zero priority — exactly when positional pairing breaks — and `R28` covers the same divergence at the `CommitPrepared` site, where a priority destination is reachable.

  Two plan defects were found by running it, not by reading it: `R3` was INVALID (its replacement orphaned a variable, so nothing compiled and nothing was measured) and later `R27` went INVALID the same way after its anchor drifted under a SQL rewrite. Both read as covered entries while proving nothing.
- `ci/check_go.sh fast` exit 0, grant-surface CRITICAL findings 0. (Reported green once before it was — the first invocation was piped through `tail`, which hid the failure *and* substituted `tail`'s exit code for the script's. What it hid is the grant defect below.)
- `go build ./...`, `gofmt`, `go vet ./...` clean.
- `ruff check` / `ruff format --check` clean.
- 171 Python tests across compose-config, the effect-snapshot migration and all five migration-head pin files. The two Postgres-gated pin files **executed rather than skipped** (`-rs` reported no skips), so `0088` was applied against a real database, not merely inspected statically. The three CHECK constraints are exercised on real PostgreSQL as well as SQLite.
- Postgres integration coverage runs on testcontainers, including the atomic-prepare trigger rollback and the completion-rollback retention fixture.

### A deploy-breaking grant defect the lane shipped with

`TestDomainGrantSurfaceMatchesQuerySurface` derives required privileges from real call sites and reported **4 CRITICAL disagreements**: `sync_run_unit_effect_snapshots` needs SELECT (2 call sites) and DELETE (1) but was missing from **both** authoritative lists — `runtimeGrantStatements` in `internal/storage/river/migrate.go` and `required_table_privileges` in `internal/storage/postgres/domain_authorization.go`. It also flagged the table as a quiet co-writer inside `Complete`'s and `LoadRouteSnapshot`'s transactions, where every other participating table was already granted.

The grants had gone into the provisioning scripts only. Per the CHAOS-3033 Option A ruling both Go lists must move in the same commit, or `CheckDomainAuthorization` fails closed for **every** domain worker on deploy, not just the route that needed the new grant.

Fixed with SELECT/INSERT/DELETE and **no UPDATE** — the row is written once at prepare, read on recovery, and deleted when the unit completes *successfully*; a failed or retrying unit keeps it. Two count pins move 34 → 35, and the posture now pins the tuple per-table including UPDATE's absence, because a count pin cannot see a privilege change.

The no-UPDATE property turned out to be load-bearing rather than cosmetic — see the CRITICAL below.

(An earlier revision of this description called this "the only DELETE the domain role holds". That was wrong: `dev_conversations`, `external_ingest_batches`, `external_ingest_batch_payloads` and `provider_rate_limit_observations` carry it too. The claim is true only of the provisioning scripts' domain section.)

Worth being explicit about, because this PR also adds a compose-config grant allowlist: **that test could not have caught this.** It reads the shell and SQL provisioning scripts only. `internal/domaingrants` is what enforces the grant surface, and it is what found this.

### CRITICAL, found in review: a lock the domain role may not take

`loadPreparedRouteSnapshotRowSQL` ended in `FOR UPDATE`. PostgreSQL treats **any** row-locking clause as an UPDATE-class privilege, and the domain role holds only SELECT/INSERT/DELETE here — so every re-prepare failed with `permission denied` in production while passing locally, because tests connect as the table owner. Reproduced on PostgreSQL 18.4 under exactly the granted set before anything was changed.

The lock was dropped rather than the grant widened: `verifyPreparedRouteSnapshotRow` runs only inside `mutateGenerationJournalTx`, whose opening `lockGenerationJournalSQL` already holds `FOR UPDATE OF unit` on the owning row, and a snapshot row is only ever written by that unit's lease holder. `verifyPreparedRouteSnapshotRow` also stopped folding every scan error into `ErrEffectLedgerConflict` — masking is what let a permission failure read as ordinary ledger disagreement.

**Three venues now cover the class, because the first two were structurally blind to it:**

1. An integration test that runs the statements as the **actual restricted domain role** and drives a *second* prepare — the re-prepare arm was unreachable by the entire suite, since every call site used a distinct unit id. With `FOR UPDATE` reinstated it fails `SQLSTATE 42501` while the owner-privileged suite still passes.
2. `sync_run_unit_effect_snapshots` added to `reconciliationTables()`, so `TestDomainRoleCanRunEveryProductionStatementShape` executes all four statement shapes under the restricted role **in CI**. This is the durable fix: the grant analyzer cannot see into the `mutateGenerationJournalTx` closure, which is why both the INSERT and the lock arrived as UNRESOLVED evidence — and why it emitted an over-grant advisory that was really the fingerprint of an unanalyzed path.
3. The posture tuple pin above, so re-granting UPDATE cannot silently re-enable row locking.

### Retention on failure, and the overcorrection in between

`failUnitSQL` replaced the result document wholesale, destroying `go_effect_ledger_v1` and with it the snapshot reference. Contract point 5 retains the snapshot on failure — but a retained row whose only pointer is erased is leaked, not retained, and nothing short of the `sync_run_units` CASCADE reclaims it (up to 64 MiB each).

The first fix was a blanket `unit.result || $6`, mirroring `releaseForRetrySQL`. **That overcorrected**, and review caught it. The result document also accumulates *claimable-state* keys — `next_retry_at`, `retry_exhausted`, `retry_reason`, and the rate-limit and budget deferral keys — written by `markExpiredLeaseRetryingSQL`, the soft-timeout retry path, rate-limit deferral and the budget guard. Nothing clears them on claim, so preserving everything freezes a live "will retry at T" onto a terminally failed unit. The admin integrations API projects those keys with **no status gate**, and every other terminal stamp in the repo deliberately nulls `next_retry_at` — this would have been the only one that did not.

The stamp now carries forward exactly one key. Verified on a single tree: the blanket merge leaves `[budget_deferred next_retry_at rate_limit_deferred_until retry_exhausted retry_reason]` behind, the wholesale replace destroys the ledger key, and only the scoped form passes both tests.

**Correction: a claim in an earlier revision of this description was wrong.** It stated that `'null'::jsonb || '{...}'::jsonb` *raises*, and that `Fail()` would surface the raise as `ErrLeaseLost`. It does not raise. PostgreSQL array-concatenates it to `[null, {...}]`, and `->>` on an array returns NULL — so the failure document silently loses its `error_category` instead of erroring. Verified on PostgreSQL 18.4. The hazard is real but quiet, which is worse: a unit records that it failed without recording why.

That correction changed the code. Because `?` returns false for every non-object, the `jsonb_typeof` guard I had added was redundant — which is precisely why its mutation was unkillable. It is gone; the key-presence test is the whole guard. Making that guard measurable required a property not previously asserted: the terminal stamp must not **invent** a ledger key, since `->` on a predecessor that has none yields SQL NULL and `jsonb_build_object` turns it into an explicit `"go_effect_ledger_v1": null` — a snapshot reference that reads as present and decodes to nothing.

### Lease loss, run-terminal and absence are three different answers

`leaseLive` originally folded the run-status term in, so a finalized run holding a live, correct lease reported `ErrLeaseLost` — sending an operator to look at leases when the cause was a run that had already terminalized. Split into `ErrPreparedRouteSnapshotRunTerminal`, checked *before* the lease, with the contrast asserted. The three terminal-run states are pinned by element-level mutations rather than one whole-list mutation, and the payload column is gated behind both fences so a refused load never detoasts or ships up to 64 MiB.

### Lease loss is no longer indistinguishable from absence

The identity predicates stay in `WHERE` and the lease fence is computed, so a snapshot that exists but is no longer this worker's reports `ErrLeaseLost`; wrong-tenant and wrong-generation still report not-found. The fence mirrors `loadEffectLedgerSQL` exactly, terminal-run exclusion included, and each of the four fences is measured on its own by breaking exactly one column at a time.

### Schema fidelity

The integration fixture hand-rolled the table without all three CHECK constraints and with an unbounded digest column, so the Go suite ran against a schema strictly more permissive than production. It now uses the real DDL, a Python test fails if the two drift, and each CHECK is exercised on both SQLite and real PostgreSQL — previously, deleting two of the three left the suite green.

### Ordering

`CommitPrepared` and `encodePreparedRouteManifest` sorted by destination alone while the ledger sorts priority-first, and recovery pairs the two **by position**. Rather than correcting three comparators, all four producers now share one `sortEffectBatches`, so divergence is structurally impossible. Note this changed the correct mutation target: mutating the shared helper moves every producer together and stays correct, so the kill target is a *call site* reintroducing its own comparator.

### Mutations that were measuring nothing

Reported because the passing number above would otherwise overstate what was proven.

**R3 was INVALID, not KILLED.** Its replacement (`if false`) orphaned the `digest` variable, so the mutated source did not compile — no test ran and it measured nothing, while reading in the plan as a covered guard. Rewritten to stay well-formed.

**R17 and R18 SURVIVED the first full run**, and both were tests passing for the wrong reason. Three corrections, each measured rather than reasoned to:

1. Asserting only on the returned error proved nothing — `ErrInvalidConfiguration` is worn by several later failures inside the lease. Added a `LoadEffects` counter as the discriminator, since the guard runs before `session.Run`. Still survived.
2. `Execute`'s first validation already rejects a descriptor that disagrees with its claim, so a mismatched descriptor exercises *that* check, never this guard. Parameterized the session so descriptor and claim move together. R17 killed; R18 still survived.
3. The second case, `github/work-item-labels`, is not a pair a claim can carry — the alias family collapses to work-items before a unit exists, so `Claim.Validate()` rejects it. Confirmed by probing five pairs. Replaced with `github/prs`. Both killed.

## Required tests

crash-before-write, crash-mid-write, all-effects-written-before-complete, missing / tampered / oversized snapshot, cross-tenant and cross-generation rejection, legacy-v1 behavior, rolling-deploy fail-closed, lease loss, atomic prepare, cleanup/retention, grants, and a real Postgres transaction boundary — all present. See the mutation table for which guard each one is measured against.

## What this PR adds beyond the transplant

**A route-level statement of contract point 7.** A route requiring prepared recovery now refuses a legacy v1 ledger where the route declares the requirement, instead of only as a side effect of two independent decoders that a later change could relax one at a time.

**Tests for the guards that had none.** The v1/v2 ledger schema clauses — the rolling-deployment boundary between an older worker that validates only v1 and a newer one that writes v2 — had no test at all, and `effect_ledger.go` had zero mutation coverage. Also added: snapshot-reference bounds, the github-only and work-items-only descriptor guards, the missing-snapshot-store wiring guard, and recovery-time revalidation against the live descriptor.

**Lease fences measured one at a time.** `ReleaseForRetry` clears lease owner, expiry and status together, so the existing release assertion could never say *which* fence refused the load — and one missing fence would hide behind the other two. The new fixture breaks exactly one column per iteration, proves the refusal, restores it, and re-proves the load succeeds again so no refusal is left over from the previous iteration.

**A dead guard restored in `tests/test_compose_config.py`.** Admitting the snapshot table's DELETE grant had relaxed the blanket `"DELETE ON TABLE"` ban to `"DELETE ON ALL TABLES"`, which silently admits every future per-table DELETE grant for the domain role. Replaced with an exact allowlist. Observed on one tree with a planted second grant: the old guard reported 3 passed, the new guard failed with `Extra items in the left set: 'sync_run_units'`.

**A mutation that was measuring nothing.** R3 replaced the digest comparison with `if false`, which orphaned `digest`, so the mutated source did not build. A build break is INVALID, not KILLED — it read as coverage while proving nothing. Rewritten to stay well-formed.

## Migration

`0088_add_sync_unit_effect_snapshots`, renumbered twice. It began as 0085, moved to 0086 when main's CHAOS-3412 took 0085, and moved again to 0088 once main independently took **both** 0086 (`dev_run_qua_shadow`) and 0087 (`dev_qua_shadow_budget_reservations`). Verified free against `origin/main` at `7063b83ad`.

**`down_revision` is deliberately `0085`, not `0087`.** Neither 0086 nor 0087 exists on this feature branch, and pointing at 0087 today is a hard `KeyError` at `ScriptDirectory` load — measured, not assumed. So 0088 reserves the id and the parent stays 0085. **The sync that brings main's 0086/0087 onto this branch must re-point `down_revision`.** Until it does, that sync yields three heads (0066, 0087, 0088) instead of two — a loud failure, not a silent one: `get_revision("application_schema@head")` raises `CommandError` and all five pin tests exercise that call. Both shapes were simulated against a merged versions directory before choosing this one, and the requirement is written into the migration's own docstring.

Two things worth carrying to the next lane that hits this:

Alembic does **not** raise on a duplicate revision id — it emits a `UserWarning`. Whether anything downstream notices depends on topology: if the duplicate lands on a head, `get_revision("application_schema@head")` raises; if it does not, the graph can resolve and the duplicate hides. So the new `test_no_two_migrations_declare_the_same_revision_id` reads the `revision:` declarations straight out of the files instead. It cannot be confused by topology, and where `walk_revisions()` raises `LoopDetected`, it reports `duplicate alembic revision ids: {...}` naming both files. It also fails if it parses fewer than 80 ids, so a drifted parser cannot pass as "no duplicates".

Adding a table to `required_table_privileges` makes `CheckDomainAuthorization` **fail closed until that table exists and is granted**. This PR's addition broke two readiness harnesses whose schemas lacked it. That is the intended contract — but it means migration 0088 must land before domain workers start.

## Pre-existing, not from this branch

`mypy src tests` reports `tests/workers/test_celery_otel_export.py:8: Library stubs not installed for "grpc"`. `types-grpcio` is not declared in `pyproject.toml` at all while `grpcio` arrives transitively through the OTLP exporter, and this branch never touches that file. Flagged rather than left implied by a "mypy clean" claim this PR cannot make.

## Known gap, deliberately not closed here

The table's FK is `(sync_run_unit_id) -> sync_run_units(id)` and says nothing about `org_id`, so a row can be *inserted* claiming an org that does not own the unit. Nothing in production can write one — the route is unregistered and the only writer derives `org_id` from the claim — and reads are safe regardless, because the load joins on both `unit.id` and `unit.org_id`.

Making it structural needs a composite FK to `sync_run_units(org_id, id)`, which needs a UNIQUE index on that pair: a `CONCURRENTLY` build plus a `NOT VALID`/`VALIDATE` FK against a hot table. That is not appropriate in a PR that activates nothing, so it is **pre-activation debt**. It is pinned rather than merely noted — `TestPostgresSnapshotTenancyIsEnforcedByReadsNotByStructure` executes the cross-tenant insert and proves reads stay safe, so the day a composite FK lands that test starts failing and tells you the debt is paid.

## Not in this PR

No route activation, no watermark, no readiness, no alias enablement, no change to migration 0066. The remaining GitHub work-items layers (metrics triplet, seven direct adapters, six derived builders, Projects v2 policy) are tracked on CHAOS-3123.
