### PR TITLE
CHAOS-3479: add types-grpcio stub package to unblock mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ dev = [
   "pip-audit>=2.7.0",
   "mako>=1.3.12",
   "pandas-stubs>=3.0.3.260530",
+  # CHAOS-3479: grpc arrives transitively via opentelemetry-exporter-otlp-proto-grpc;
+  # stubs needed for tests/workers/test_celery_otel_export.py's direct `import grpc`.
+  "types-grpcio>=1.83.0.20260730",
   # CHAOS-3034 compatibility probe only. Production Python code must enqueue
   # through the worker_job_outbox fallback unless a compatible client ships.
   "riverqueue==0.7.0",


### PR DESCRIPTION
## CHAOS-3479: unblock repo-wide mypy — add types-grpcio stub package

`mypy src tests` failed repo-wide at `tests/workers/test_celery_otel_export.py:8`
(`import grpc`) with `Library stubs not installed for "grpc" [import-untyped]`.
`grpcio` arrives transitively via `opentelemetry-exporter-otlp-proto-grpc`; the
stub package for it (`types-grpcio`) was undeclared in `pyproject.toml`. This
blocked the repo-wide lefthook mypy gate (pre-commit and pre-push) for every
Python-touching commit, forcing lanes to bypass with `--no-verify`.

### Fix

Added `types-grpcio` to the `dev` optional-dependency group in
`pyproject.toml`, following the existing `pandas-stubs>=...` convention for
stub packages rather than adding a new `ignore_missing_imports` override
(unlike `celery`/`radon`/`lizard`/etc., which have no official stubs, `grpc`
has an official `types-grpcio` package on PyPI).

### Scope

Minimal, single-line dependency addition. Did not touch `uv.lock` (repo's
`pyproject.toml` is the pip-style source of truth; `uv sync` resolves lazily
in CI) or fix anything unrelated.

### Verification

Before (on `origin/main`, worktree):
```
$ uv run mypy
tests/workers/test_celery_otel_export.py:8: error: Library stubs not installed
for "grpc"  [import-untyped]
    import grpc
    ^
tests/workers/test_celery_otel_export.py:8: note: Hint: "python3 -m pip install types-grpcio"
tests/workers/test_celery_otel_export.py:8: note: (or run "mypy --install-types" to install all missing stub packages)
tests/workers/test_celery_otel_export.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 2126 source files)
```

After:
```
$ uv run mypy
Success: no issues found in 2126 source files

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
2112 files already formatted
```

(The `unused section(s)` mypy note for other override-list modules is
pre-existing on `main` and unrelated to this change.)
