### PR TITLE
fix(tests): make sync_postgres_test_url one normalizer, not two (CHAOS-3450)

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -16,6 +16,8 @@ from sqlalchemy import Table
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.orm import Session
 
+from dev_health_ops.db import normalize_sync_postgres_uri
+
 
 def sync_postgres_test_url() -> URL:
     """Return ``DEV_HEALTH_POSTGRES_TEST_URI`` coerced to the blocking driver.
@@ -39,10 +41,23 @@ def sync_postgres_test_url() -> URL:
     the password as ``***``, so stringifying here swaps a ``MissingGreenlet``
     for a "password authentication failed" that reads like broken CI
     credentials rather than a broken test helper.
+
+    THE DRIVER IS NOT THE ONLY THING THAT DIFFERS between the async URI and a
+    blocking one, which is why this delegates to the PRODUCTION normalizer
+    rather than swapping ``drivername`` itself. ``asyncpg`` accepts
+    ``?ssl=`` and ``?channel_binding=``; psycopg2 accepts neither, and raises
+    ``invalid connection option "ssl"`` on a managed/TLS URI of the form
+    ``postgresql+asyncpg://...?ssl=require&channel_binding=require``.
+    ``normalize_sync_postgres_uri`` already owns that translation for
+    production (``ssl`` -> ``sslmode``, ``channel_binding`` dropped), so
+    reimplementing the driver half here left two normalizers that agreed on
+    CI's bare URI and disagreed on every TLS one -- a divergence found by
+    review after this helper replaced call sites that had been using the
+    production normalizer directly. One normalizer, not two.
     """
-    return make_url(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"]).set(
-        drivername="postgresql+psycopg2"
-    )
+    return make_url(
+        normalize_sync_postgres_uri(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    ).set(drivername="postgresql+psycopg2")
 
 
 def tables_of(*models: Any) -> list[Table]:

--- a/tests/test_sync_postgres_test_url_helper.py
+++ b/tests/test_sync_postgres_test_url_helper.py
@@ -1,0 +1,123 @@
+"""``tests._helpers.sync_postgres_test_url`` must not be a second normalizer.
+
+CHAOS-3450 (#1523) centralized the async->blocking coercion every
+Postgres-gated test needs. The first version swapped ``drivername`` and
+nothing else, which is correct for CI's bare
+``postgresql+asyncpg://user:pass@host:5432/db`` and wrong for every managed
+or TLS URI: ``asyncpg`` accepts ``?ssl=`` and ``?channel_binding=``, psycopg2
+accepts neither and fails with ``invalid connection option "ssl"``.
+
+Production already owned that translation in
+``dev_health_ops.db.normalize_sync_postgres_uri``. Several Postgres-gated
+tests called it directly until the helper replaced them, so the swap silently
+traded a working normalizer for a partial one -- invisible in CI, where the
+URI carries no query string at all.
+
+These tests pin the QUERY-PARAMETER half specifically. The driver half is
+already exercised by every Postgres-gated test that connects; the parameter
+half is not reachable from CI's URI, so without an explicit case it has no
+coverage and the divergence can return unobserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.engine import make_url
+
+from dev_health_ops.db import normalize_sync_postgres_uri
+from tests._helpers import sync_postgres_test_url
+
+_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
+
+_MANAGED_URI = (
+    "postgresql+asyncpg://someuser:s3cr3t@db.example.com:5432/appdb"
+    "?ssl=require&channel_binding=require"
+)
+
+
+def test_managed_uri_query_parameters_are_translated_for_psycopg2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ssl`` becomes ``sslmode``; ``channel_binding`` is dropped entirely.
+
+    Both are asyncpg-only spellings. Leaving either in place is not a cosmetic
+    difference -- psycopg2 rejects the connection outright.
+    """
+    monkeypatch.setenv(_ENV, _MANAGED_URI)
+
+    url = sync_postgres_test_url()
+
+    assert url.drivername == "postgresql+psycopg2"
+    assert url.query.get("sslmode") == "require", (
+        f"asyncpg's ssl= was not translated to psycopg2's sslmode=: {url.query}"
+    )
+    assert "ssl" not in url.query, (
+        f'psycopg2 rejects the connection with invalid connection option "ssl"; '
+        f"the parameter must not survive: {url.query}"
+    )
+    assert "channel_binding" not in url.query, (
+        f"channel_binding is asyncpg-only and must be dropped: {url.query}"
+    )
+
+
+def test_credentials_survive_the_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The password must not be masked on the way through.
+
+    ``normalize_sync_postgres_uri`` renders the URL back to a string, and
+    SQLAlchemy's default rendering replaces the password with ``***``. Passing
+    that through would turn a driver mismatch into a "password authentication
+    failed" that reads like broken CI credentials -- the exact failure the
+    helper's own docstring exists to prevent.
+    """
+    monkeypatch.setenv(_ENV, _MANAGED_URI)
+
+    url = sync_postgres_test_url()
+
+    assert url.password == "s3cr3t"
+    assert url.username == "someuser"
+    assert url.host == "db.example.com"
+    assert url.port == 5432
+    assert url.database == "appdb"
+
+
+def test_helper_agrees_with_the_production_normalizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One normalizer, not two.
+
+    Stated as a differential rather than a restatement of the expected query
+    string: whatever ``normalize_sync_postgres_uri`` decides about parameters
+    is what the helper must produce, so a future production change cannot
+    leave the test suite connecting differently from production.
+    """
+    monkeypatch.setenv(_ENV, _MANAGED_URI)
+
+    expected = make_url(normalize_sync_postgres_uri(_MANAGED_URI))
+    actual = sync_postgres_test_url()
+
+    assert dict(actual.query) == dict(expected.query), (
+        "the test helper and the production normalizer disagree about "
+        f"connection parameters: {dict(actual.query)} != {dict(expected.query)}"
+    )
+
+
+def test_bare_ci_uri_is_unchanged_apart_from_the_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CI shape keeps working, and keeps carrying no parameters.
+
+    This is the case that made the divergence invisible: it passes under both
+    the old and the new helper. It is here so that a future normalizer change
+    which starts injecting parameters into a bare URI is caught too.
+    """
+    monkeypatch.setenv(
+        _ENV, "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+
+    url = sync_postgres_test_url()
+
+    assert url.drivername == "postgresql+psycopg2"
+    assert dict(url.query) == {}
+    assert url.database == "test_db"


### PR DESCRIPTION
One line of behaviour in `tests/_helpers.py`, plus the test that keeps it there. Twin of the byte-identical change in #1530 — this one lands the fix where the file is actually owned, so the two sides converge instead of conflicting at the next sync.

## The divergence

CHAOS-3450 (#1523) centralized the async→blocking driver coercion every Postgres-gated test needs, and `sync_postgres_test_url()` swaps `drivername` only.

Not every call site it replaced was open-coding `create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])`. Several called the **production** normalizer, `dev_health_ops.db.normalize_sync_postgres_uri`, which does strictly more:

| | driver | `channel_binding` | `ssl` |
| --- | --- | --- | --- |
| `normalize_sync_postgres_uri` (production) | → bare `postgresql` | popped | → `sslmode` |
| `sync_postgres_test_url` (before this PR) | → `postgresql+psycopg2` | kept | kept |

The two agree on CI's bare `postgresql+asyncpg://postgres:postgres@localhost:5432/test_db` and disagree on every managed or TLS one. `asyncpg` accepts `?ssl=` and `?channel_binding=`; psycopg2 accepts neither and fails the connection outright with `invalid connection option "ssl"`. So

```
postgresql+asyncpg://user:pass@db.example.com:5432/appdb?ssl=require&channel_binding=require
```

connects through the production normalizer and does not connect through the helper.

**Latent against CI's URI, which is the argument for fixing it rather than noting it.** Two normalizers that silently disagree get discovered by whoever first points the suite at a managed database, not by the suite.

## The fix

`sync_postgres_test_url()` delegates to `normalize_sync_postgres_uri()` and then sets the psycopg2 driver. One normalizer, not two — the suite cannot connect differently from production, and a future change to the production rules carries the suite with it instead of leaving it behind.

## The test

`tests/test_sync_postgres_test_url_helper.py` pins the **query-parameter** half specifically. The driver half already has coverage — every Postgres-gated test that connects exercises it — but the parameter half is unreachable from CI's URI and therefore had none at all, which is exactly how this stayed invisible. Four cases:

- `ssl=require` → `sslmode=require`, `ssl` gone, `channel_binding` gone.
- Credentials survive the string round-trip (`normalize_sync_postgres_uri` renders back to a string; SQLAlchemy's default rendering masks the password as `***`, which would turn a driver mismatch into a "password authentication failed" that reads like broken CI credentials — the failure mode the helper's own docstring exists to prevent).
- A **differential** against the production normalizer, asserting the two agree rather than restating an expected query string, so this cannot pass while production has moved.
- The bare CI shape, unchanged apart from the driver. Kept deliberately: it passes under both the old and new helper, and it is here so a future normalizer that starts injecting parameters into a bare URI is caught too.

## Verification

Observed failing, not assumed. Against the unmodified helper on this branch's base:

```
FAILED test_managed_uri_query_parameters_are_translated_for_psycopg2
  assert None == 'require'
FAILED test_helper_agrees_with_the_production_normalizer
  assert {'channel_binding': 'require', 'ssl': 'require'} == {'sslmode': 'require'}
2 failed, 2 passed
```

With the fix: `4 passed`. The two that pass either way are the CI-shape and credential cases — that split is the point.

`ruff check`, `ruff format --check`, `mypy` clean (2127 source files).

Against **live PostgreSQL**, the full set of Postgres-gated suites that use this helper — `test_sync_planner.py`, `test_sync_reconciler.py`, `test_sync_watermarks.py`, `test_dispatch_outbox.py`, `api/admin/test_sync_coverage_concurrency.py`, plus the new file: **211 passed, 1 failed, 0 skipped**.

### The one failure is pre-existing on main and unrelated

`test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible` fails with

```
CheckViolation: new row for relation "sync_dispatch_outbox" violates check
constraint "ck_sync_dispatch_outbox_claim_route_coherence"
```

Confirmed pre-existing by running it on a **pristine checkout of this branch's base with the unmodified helper, against a freshly created database**: same failure, same count (`1 failed, 29 passed`). The failure set is identical before and after this change, so the fix is neutral on it.

Cause, since it is worth recording rather than leaving as "unrelated": the test builds its schema with `Base.metadata.create_all`, which installs the check constraint but cannot install migration 0049's trigger — the trigger is what binds the claim route before the constraint is evaluated, so the simulated pre-0049 worker's UPDATE violates it. It needs the migration replayed rather than `create_all`, which is out of scope for this PR. Flagging it because #1523 revived these tests precisely so failures like this stop being invisible.
