### PR TITLE
CHAOS-3422: rank the named kind first in Ask Dev close matches

### DIFF
--- a/src/dev_health_ops/api/dev/scope_catalog.py
+++ b/src/dev_health_ops/api/dev/scope_catalog.py
@@ -79,6 +79,57 @@ def _entity_sort_key(entity: AuthorizedEntity) -> tuple[str, str, str]:
     return (entity.label.casefold(), entity.kind.value, entity.canonical_id)
 
 
+def merge_search_candidates(
+    *,
+    alias_hits: Iterable[AuthorizedEntity],
+    substring_hits: Iterable[AuthorizedEntity],
+    preferred_kinds: frozenset[EntityKind],
+    limit: int,
+) -> list[AuthorizedEntity]:
+    """The one ranking of a search page, applied *before* its truncation.
+
+    Three keys, in this order:
+
+    1. **The kind the user named** (CHAOS-3422). A typed mention states a
+       kind; "the ACR project" asks about a project. Ranking is all this key
+       does — nothing is ever dropped for being another kind, because the
+       CHAOS-3366 fallback exists precisely for the case where the thing the
+       user meant sits one kind over ("the Go workers project", where the
+       catalog holds only issues). A filter would return zero candidates
+       there and regress that ticket to a bare not-found.
+    2. **Alias equality over incidental substring containment** (CHAOS-3388).
+       An acronym/parenthetical-alias hit is a strictly more precise signal
+       than a label that happens to contain the query.
+    3. **Label, kind, id** — the deterministic tiebreak.
+
+    Ranking here, rather than over whatever survives the bound, is the whole
+    point: with more incidental hits than ``limit``, reordering the survivors
+    cannot recover a same-kind entity that the truncation already discarded.
+    An empty ``preferred_kinds`` collapses key 1 to a constant, which is
+    byte-for-byte the alias-then-substring order this replaced.
+    """
+
+    alias_by_key: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+    for entity in alias_hits:
+        alias_by_key.setdefault((entity.kind, entity.canonical_id), entity)
+    ranked: dict[tuple[EntityKind, str], tuple[int, AuthorizedEntity]] = {
+        key: (0, entity) for key, entity in alias_by_key.items()
+    }
+    for entity in substring_hits:
+        key = (entity.kind, entity.canonical_id)
+        if key not in ranked:
+            ranked[key] = (1, entity)
+    ordered = sorted(
+        ranked.values(),
+        key=lambda item: (
+            0 if item[1].kind in preferred_kinds else 1,
+            item[0],
+            _entity_sort_key(item[1]),
+        ),
+    )
+    return [entity for _, entity in ordered[:limit]]
+
+
 _WATERMARK_TABLES: dict[EntityKind, tuple[str, str]] = {
     EntityKind.REPOSITORY: ("repos", "last_synced"),
     EntityKind.PROJECT: ("projects", "updated_at"),
@@ -145,6 +196,7 @@ class ClickHouseAuthorizedEntityCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         rows_by_kind = await asyncio.gather(
             *(
@@ -175,29 +227,22 @@ class ClickHouseAuthorizedEntityCatalog:
             )
             for kind_hits in alias_hits:
                 alias_entities.extend(kind_hits)
-        # Alias/acronym hits are ordered AHEAD of plain substring hits, before
-        # either is truncated to `limit` -- never merged into one alphabetical
-        # sort. CHAOS-3388 live finding: a real organization can hold far more
-        # than `limit` incidental substring hits for a short query
-        # (issue/work-unit titles that happen to contain "acr" as a literal
-        # substring, e.g. "Harden ACR runtime client boundary") than it holds
-        # true acronym matches. A single combined alphabetical sort let that
-        # noise crowd the one real acronym match for the named project out of
-        # the returned page entirely -- the closest-matches offer named
-        # everything BUT the thing the acronym actually stood for. An
-        # acronym/alias equality is a strictly more precise signal than an
-        # incidental substring containment, so it always survives the bound.
-        alias_by_key: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
-        for entity in alias_entities:
-            alias_by_key.setdefault((entity.kind, entity.canonical_id), entity)
-        ordered_alias = sorted(alias_by_key.values(), key=_entity_sort_key)
-        substring_by_key: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
-        for entity in entities:
-            key = (entity.kind, entity.canonical_id)
-            if key not in alias_by_key:
-                substring_by_key.setdefault(key, entity)
-        ordered_substring = sorted(substring_by_key.values(), key=_entity_sort_key)
-        return (ordered_alias + ordered_substring)[:limit]
+        # The named kind, then alias-over-substring, then label -- all applied
+        # before the truncation, never after it. CHAOS-3388 live finding: a
+        # real organization can hold far more than `limit` incidental
+        # substring hits for a short query (issue/work-unit titles that happen
+        # to contain "acr" as a literal substring, e.g. "Harden ACR runtime
+        # client boundary") than it holds true acronym matches, so a single
+        # combined alphabetical sort crowded the one real acronym match out of
+        # the returned page entirely. CHAOS-3422 is the same failure one level
+        # up: the surviving page was still kind-blind, so the one real
+        # *project* the user asked for ranked 5th of 5 behind four issues.
+        return merge_search_candidates(
+            alias_hits=alias_entities,
+            substring_hits=entities,
+            preferred_kinds=preferred_kinds,
+            limit=limit,
+        )
 
     async def _alias_matches(
         self, org_id: str, kind: EntityKind, query: str, *, limit: int

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -455,9 +455,23 @@ def _dedupe_preserving_rank(
 
     Not a behaviour change for the alias-unaware callers: with
     ``include_alias_matches=False`` the catalog's own order *is* label order,
-    the identical sequence ``_dedupe_entities`` produced. Only the
-    closest-matches fallback, the one caller that enables alias matching, sees
-    a different page — which is precisely the ranking this ticket restores.
+    the identical sequence ``_dedupe_entities`` produced.
+
+    Exactly **two** callers enable alias matching and therefore see a
+    different page — counted, because an earlier draft of this docstring
+    claimed there was only one and a reviewer had to find the other:
+
+    * ``subject_preflight._close_matches`` — the closest-matches fallback,
+      whose ranking is what this ticket restores.
+    * ``qua_shadow.QUAShadowEvaluator._shortlist`` — the CHAOS-3389 shadow
+      seam. Its shortlist is reordered the same way, which is safe because
+      the model is shown the very list its returned indices are resolved
+      against, so there is no index/list skew, and because nothing downstream
+      reads the record it produces. It needs no ``preferred_kinds`` of its
+      own: it already searches a single kind for a typed mention, so a
+      preference would be vacuous, and for an untyped one the kind is a
+      declared default that must not be preferred at all.
+
     ``resolve()``'s exact path still uses ``_dedupe_entities``: those entities
     come from ``exact()``, which has no rank of its own to preserve.
     """

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -283,6 +283,17 @@ class ScopeSearchRequest:
     #: something close" -- that is exactly the outcome and copy the
     #: closest-matches fallback already owns.
     include_alias_matches: bool = False
+    #: CHAOS-3422. The kind a *typed* mention actually named. Purely a ranking
+    #: key -- candidates of this kind sort ahead of every other kind, before
+    #: each of the two truncations on this path (the catalog's page bound and
+    #: this service's own), and nothing is ever excluded for being another
+    #: kind. Excluding would regress CHAOS-3366, whose whole premise is that
+    #: the thing the user meant may sit one kind over. Empty for every caller
+    #: that has no user-stated kind to honour, which is today's behaviour
+    #: exactly; an untyped bare name is one of those, because its
+    #: ``requested_entity_kind`` is a declared default, not something the user
+    #: typed (``question_interpreter._add_untyped_mentions``).
+    preferred_kinds: frozenset[EntityKind] = frozenset()
 
     def __post_init__(self) -> None:
         query = self.query.strip()
@@ -294,6 +305,8 @@ class ScopeSearchRequest:
             raise ValueError("Caller allowlist exceeds the searchable entity ceiling")
         if any(kind not in self.allowed_kinds for kind in self.kinds):
             raise ValueError("Only approved searchable V1 direct scopes are allowed")
+        if not self.preferred_kinds <= set(self.kinds):
+            raise ValueError("A preferred kind must be one of the searched kinds")
         if self.limit < 1 or self.limit > MAX_CANDIDATES:
             raise ValueError(f"Search limit must be between 1 and {MAX_CANDIDATES}")
         object.__setattr__(self, "query", query)
@@ -353,6 +366,7 @@ class AuthorizedEntityCatalog(Protocol):
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]: ...
 
     async def organization_repository_ids(
@@ -421,6 +435,32 @@ def _dedupe_entities(
 ) -> tuple[AuthorizedEntity, ...]:
     unique = {(entity.kind, entity.canonical_id): entity for entity in entities}
     return tuple(sorted(unique.values(), key=_entity_order))
+
+
+def _rank_preferred_kinds(
+    entities: Sequence[AuthorizedEntity], preferred_kinds: frozenset[EntityKind]
+) -> tuple[AuthorizedEntity, ...]:
+    """CHAOS-3422: the kind the user named leads, everything else follows.
+
+    ``_dedupe_entities`` orders the whole page by label, which is what buried
+    the one real project behind four incidental issue matches in the live
+    repro. This is a **stable** partition on top of that order, so with no
+    preference the result is the identical tuple, and with one the relative
+    order inside each side is still the label order every other caller sees.
+
+    Known residual, deliberately not widened here: ``_dedupe_entities``'s
+    alphabetical sort also discards the catalog's alias-before-substring rank
+    within a kind, since ``AuthorizedEntity`` carries no match provenance for
+    this layer to preserve. That is pre-existing and unchanged; the catalog's
+    own ``merge_search_candidates`` still applies both keys where it matters,
+    which is before the page bound truncates.
+    """
+
+    if not preferred_kinds:
+        return tuple(entities)
+    preferred = [entity for entity in entities if entity.kind in preferred_kinds]
+    rest = [entity for entity in entities if entity.kind not in preferred_kinds]
+    return tuple(preferred + rest)
 
 
 def _request_payload(request: ScopeResolveRequest) -> dict[str, object]:
@@ -712,6 +752,11 @@ class ScopeResolutionService:
             # candidate sets, so sharing a cache key would let whichever
             # request happened to run first silently answer the other's call.
             "include_alias_matches": request.include_alias_matches,
+            # CHAOS-3422, for the same reason: a preference changes both which
+            # candidates survive the catalog's page bound and the order they
+            # arrive in, so a preferred and an unpreferred search of the same
+            # query/kinds/limit must never share a cache entry.
+            "preferred_kinds": sorted(kind.value for kind in request.preferred_kinds),
         }
         cache_key = self._cache_key(
             "search", org_id, permission_fingerprint, payload, watermark
@@ -725,9 +770,12 @@ class ScopeResolutionService:
             kinds,
             limit=request.limit,
             include_alias_matches=request.include_alias_matches,
+            preferred_kinds=request.preferred_kinds,
         )
         result = ScopeSearchResult(
-            candidates=_dedupe_entities(entities)[: request.limit],
+            candidates=_rank_preferred_kinds(
+                _dedupe_entities(entities), request.preferred_kinds
+            )[: request.limit],
             query_version=QUERY_VERSION,
             catalog_watermark=watermark,
         )

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -437,23 +437,47 @@ def _dedupe_entities(
     return tuple(sorted(unique.values(), key=_entity_order))
 
 
+def _dedupe_preserving_rank(
+    entities: Sequence[AuthorizedEntity],
+) -> tuple[AuthorizedEntity, ...]:
+    """Deduplicate a search page **without** re-ordering it.
+
+    Search results arrive already ranked by ``merge_search_candidates`` — the
+    named kind, then alias-equality over incidental substring containment,
+    then label. Passing them through ``_dedupe_entities`` re-sorted the whole
+    page by label and destroyed both of the first two keys, because an
+    ``AuthorizedEntity`` carries no match provenance for a later layer to
+    recover. That is what listed the one real project last in the CHAOS-3422
+    repro even though the catalog had ranked it first, and it silently
+    undid CHAOS-3388's alias precedence for every same-kind pair
+    (codex review round 3, confirmed: alias ``Zeta Runtime (ACR)`` lost its
+    lead to substring-only ``Aardvark ACR Notes``).
+
+    Not a behaviour change for the alias-unaware callers: with
+    ``include_alias_matches=False`` the catalog's own order *is* label order,
+    the identical sequence ``_dedupe_entities`` produced. Only the
+    closest-matches fallback, the one caller that enables alias matching, sees
+    a different page — which is precisely the ranking this ticket restores.
+    ``resolve()``'s exact path still uses ``_dedupe_entities``: those entities
+    come from ``exact()``, which has no rank of its own to preserve.
+    """
+
+    unique: dict[tuple[EntityKind, str], AuthorizedEntity] = {}
+    for entity in entities:
+        unique.setdefault((entity.kind, entity.canonical_id), entity)
+    return tuple(unique.values())
+
+
 def _rank_preferred_kinds(
     entities: Sequence[AuthorizedEntity], preferred_kinds: frozenset[EntityKind]
 ) -> tuple[AuthorizedEntity, ...]:
     """CHAOS-3422: the kind the user named leads, everything else follows.
 
-    ``_dedupe_entities`` orders the whole page by label, which is what buried
-    the one real project behind four incidental issue matches in the live
-    repro. This is a **stable** partition on top of that order, so with no
-    preference the result is the identical tuple, and with one the relative
-    order inside each side is still the label order every other caller sees.
-
-    Known residual, deliberately not widened here: ``_dedupe_entities``'s
-    alphabetical sort also discards the catalog's alias-before-substring rank
-    within a kind, since ``AuthorizedEntity`` carries no match provenance for
-    this layer to preserve. That is pre-existing and unchanged; the catalog's
-    own ``merge_search_candidates`` still applies both keys where it matters,
-    which is before the page bound truncates.
+    A **stable** partition, so with no preference the result is the identical
+    tuple and with one the catalog's rank still decides the order inside each
+    side. Applied here as well as in the catalog because the two truncate
+    separately: the catalog bounds its page, this bounds what a caller asked
+    for, and a rank applied at only one of them is a rank applied after a cut.
     """
 
     if not preferred_kinds:
@@ -774,7 +798,7 @@ class ScopeResolutionService:
         )
         result = ScopeSearchResult(
             candidates=_rank_preferred_kinds(
-                _dedupe_entities(entities), request.preferred_kinds
+                _dedupe_preserving_rank(entities), request.preferred_kinds
             )[: request.limit],
             query_version=QUERY_VERSION,
             catalog_watermark=watermark,

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -1210,12 +1210,30 @@ class SubjectPreflight:
         searched — and that path can legitimately return a *same-kind*
         candidate, which is why the offered reason below says nothing about
         kinds.
+
+        **The named kind ranks the page, it never filters it** (CHAOS-3422).
+        Searching every kind is right; presenting the result kind-blind is
+        not. The live repro: "the ACR project" found the one real project by
+        acronym and listed it *5th of 5*, behind four issues whose titles
+        merely contain "acr", because both truncation points ordered the page
+        by label alone. ``preferred_kinds`` moves same-kind candidates to the
+        front before either bound applies, so a same-kind entity can no longer
+        be crowded off the page — while every other kind stays on it, which is
+        what keeps "the Go workers project" answerable.
+
+        ``mention`` here is always a *typed* mention: ``blocking_ids`` excludes
+        every untyped id, so an untyped bare name can never be the terminating
+        mention and never reaches this method. That matters because an untyped
+        mention's ``requested_entity_kind`` is a declared default of
+        ``PROJECT`` (``question_interpreter._add_untyped_mentions``), and
+        ranking on a kind the user never typed would be inventing intent.
         """
 
         resolution = await self._close_matches(
             org_id=org_id,
             permission_fingerprint=permission_fingerprint,
             lookup_text=mention.normalized_lookup_text,
+            preferred_kind=EntityKind(mention.requested_entity_kind.value),
         )
         if resolution is None:
             return ledger, False
@@ -1245,6 +1263,7 @@ class SubjectPreflight:
         org_id: str,
         permission_fingerprint: str,
         lookup_text: str,
+        preferred_kind: EntityKind,
     ) -> MentionResolution | None:
         """One bounded tenant-scoped search, or ``None`` for "nothing to offer".
 
@@ -1280,6 +1299,13 @@ class SubjectPreflight:
             # commit-eligible primary resolution (see ScopeSearchRequest.
             # include_alias_matches).
             include_alias_matches=True,
+            # CHAOS-3422: the search still covers every searchable kind -- the
+            # kind the user typed only *ranks* it. Filtering to that kind
+            # instead would return nothing for this method's own founding case
+            # ("the Go workers project", where the catalog holds only issues)
+            # and put the mention straight back to the bare not-found this
+            # fallback exists to replace.
+            preferred_kinds=frozenset({preferred_kind}),
         )
         try:
             result = await self._scope_service.search(

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -41,6 +41,7 @@ from dev_health_ops.api.dev.contracts_v2 import DevInvestigationResult, DevSubje
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator, OrchestratorResult
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_catalog import merge_search_candidates
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
     EntityKind,
@@ -131,6 +132,7 @@ class SeededCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         self.search_calls.append((org_id, query))
         if self.fail_search:
@@ -166,14 +168,16 @@ class SeededCatalog:
                         matched_ids.add((entity.kind, entity.canonical_id))
         # ORDER BY lowerUTF8(label), canonical_id ... LIMIT n — the ordering and
         # the truncation both happen in SQL, so an exact label sorted past the
-        # page boundary never reaches the caller at all. Alias/acronym hits
-        # are ordered AHEAD of plain substring hits, before the truncation --
-        # mirrors ClickHouseAuthorizedEntityCatalog.search's own priority
-        # fix (CHAOS-3388): incidental substring noise must never crowd the
-        # real acronym match for a named project out of the returned page.
-        alias_matches.sort(key=_label_sort_key)
-        matched.sort(key=_label_sort_key)
-        return (alias_matches + matched)[:limit]
+        # page boundary never reaches the caller at all. The rank-then-truncate
+        # step is the production function itself, imported rather than
+        # re-implemented: a hand-mirrored copy is exactly how a fake drifts
+        # from its producer and starts passing tests the live path fails.
+        return merge_search_candidates(
+            alias_hits=alias_matches,
+            substring_hits=matched,
+            preferred_kinds=preferred_kinds,
+            limit=limit,
+        )
 
     async def organization_repository_ids(
         self, org_id: str, *, limit: int

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -154,18 +154,29 @@ class SeededCatalog:
             # scan over the *same* seeded org-scoped entities, so a test can
             # exercise acronym/parenthetical-alias matching through this fake
             # without a live ClickHouse.
-            matched_ids = {(entity.kind, entity.canonical_id) for entity in matched}
+            #
+            # CHAOS-3422 codex review, medium: this pass ran *independently*
+            # of the substring pass in production and did not here -- it used
+            # to skip any entity the substring pass had already matched. An
+            # entity that matches both ways ("ACR Platform" for the query
+            # "acr") is therefore an alias hit in production and was a
+            # substring hit in the fake, so the fake ranked it one tier lower
+            # than the live path would. Deduplication belongs to
+            # ``merge_search_candidates``, which resolves the overlap in
+            # alias's favour; the two passes must stay independent here for
+            # it to see the overlap at all.
+            seen_alias: set[tuple[EntityKind, str]] = set()
             for owner, entity in self.entities:
                 if (
                     owner == org_id
                     and entity.kind in kinds
                     and entity.kind in {EntityKind.PROJECT, EntityKind.TEAM}
-                    and (entity.kind, entity.canonical_id) not in matched_ids
+                    and (entity.kind, entity.canonical_id) not in seen_alias
                 ):
                     forms = alias_forms(entity.label)
                     if needle in forms.literal_aliases or needle in forms.acronyms:
                         alias_matches.append(entity)
-                        matched_ids.add((entity.kind, entity.canonical_id))
+                        seen_alias.add((entity.kind, entity.canonical_id))
         # ORDER BY lowerUTF8(label), canonical_id ... LIMIT n — the ordering and
         # the truncation both happen in SQL, so an exact label sorted past the
         # page boundary never reaches the caller at all. The rank-then-truncate

--- a/tests/api/dev/test_chaos_3259_status_evidence_projection.py
+++ b/tests/api/dev/test_chaos_3259_status_evidence_projection.py
@@ -283,8 +283,9 @@ class _FakeAuthorizedEntityCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
-        del org_id, query, kinds, limit, include_alias_matches
+        del org_id, query, kinds, limit, include_alias_matches, preferred_kinds
         return []
 
 

--- a/tests/api/dev/test_chaos_3297_s2_round9_disclosure_trigger.py
+++ b/tests/api/dev/test_chaos_3297_s2_round9_disclosure_trigger.py
@@ -206,8 +206,9 @@ class _FakeAuthorizedEntityCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
-        del org_id, query, kinds, limit, include_alias_matches
+        del org_id, query, kinds, limit, include_alias_matches, preferred_kinds
         return []
 
 

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -97,6 +97,7 @@ class LimitRecordingCatalog(SeededCatalog):
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         self.search_limits.append((len(kinds), limit))
         return await super().search(
@@ -105,6 +106,7 @@ class LimitRecordingCatalog(SeededCatalog):
             kinds,
             limit=limit,
             include_alias_matches=include_alias_matches,
+            preferred_kinds=preferred_kinds,
         )
 
 
@@ -123,6 +125,7 @@ class CrossTenantLeakingCatalog(SeededCatalog):
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         if len(kinds) == 1:
             return await super().search(
@@ -131,6 +134,7 @@ class CrossTenantLeakingCatalog(SeededCatalog):
                 kinds,
                 limit=limit,
                 include_alias_matches=include_alias_matches,
+                preferred_kinds=preferred_kinds,
             )
         needle = query.casefold()
         matched = [
@@ -157,6 +161,7 @@ class MultiKindFailingCatalog(SeededCatalog):
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         if len(kinds) > 1:
             raise RuntimeError("catalog unavailable for the fallback search")
@@ -166,6 +171,7 @@ class MultiKindFailingCatalog(SeededCatalog):
             kinds,
             limit=limit,
             include_alias_matches=include_alias_matches,
+            preferred_kinds=preferred_kinds,
         )
 
 

--- a/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
+++ b/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
@@ -475,7 +475,27 @@ async def test_the_seeded_catalog_agrees_with_the_production_catalog(
 
     Both sides are driven from the *same* rows, through the same WHERE
     semantics, so the comparison cannot be satisfied by two different inputs.
-    Repository search is deliberately outside this oracle: production enriches
+
+    **What this oracle cannot catch, stated so the green tick is not read as
+    more than it is.** ``SeededCatalog`` imports the production
+    ``merge_search_candidates`` rather than re-implementing it, so a defect
+    *inside* that function is invisible here: both sides call it and agree on
+    the same wrong answer. Two independent reviewers reproduced exactly that
+    — planting the CHAOS-3388 alias-tier defect leaves all twelve cases below
+    green. That is the deliberate trade for killing the input-construction
+    drift this test exists to kill, and it is only safe because the ranking
+    itself is pinned by *hardcoded* expectations elsewhere, which do die on
+    that mutation: ``test_the_oracle_rows_rank_the_way_the_contract_says``
+    (drives the real catalog), plus
+    ``test_inside_the_preferred_kind_alias_precision_still_decides`` and
+    ``test_merging_without_a_preference_keeps_the_chaos_3388_order`` (call the
+    helper directly). Delete those and this oracle does not cover for them.
+
+    So: this test covers how each side *builds the input* — SQL WHERE
+    semantics, parameter binding, alias eligibility, org scoping. It does not
+    cover the ranking.
+
+    Repository search is deliberately outside it too: production enriches
     repository labels through ``resolve_scope_display_names``, which the fake
     does not model at all — a pre-existing divergence this ticket does not
     close, and pretending otherwise here would be the false confidence the

--- a/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
+++ b/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
@@ -1,0 +1,439 @@
+"""CHAOS-3422: a typed mention's kind must rank its own kind first.
+
+The live repro (run ``acdc0a67-8312-43e0-8b59-0aafc0f10a68``, main @
+``c255e4932``): *"What's the status of the ACR project…"* — CHAOS-3388's
+acronym matcher correctly finds the one real project, and the clarification
+then lists it **5th of 5**, behind four irrelevant issue substring hits.
+
+Two kind-blind ranking seams produced that, and each has its own test here:
+
+* ``ClickHouseAuthorizedEntityCatalog.search`` merges alias hits ahead of
+  substring hits and truncates to ``limit`` — precision-ranked, kind-blind.
+* ``ScopeResolutionService.search`` then re-sorts the whole page into one
+  alphabetical order by label, which discards even that alias-first rank.
+  ``[CHAOS-2911] Harden ACR runtime client boundary`` casefolds to a ``[``
+  that sorts ahead of ``dev health agent context runtime…``.
+
+The fix ranks, it never filters. Filtering to the mention's kind would gut
+CHAOS-3366's own premise — its live case is "the Go workers project" where
+the catalog holds only *issues*, so a kind filter returns zero candidates and
+regresses that ticket back to a bare not-found. Both directions are pinned
+below.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2 import PublicOutcome, ResolutionOutcome
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_catalog import merge_search_candidates
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ScopeRequestCache,
+    ScopeResolutionService,
+    ScopeSearchRequest,
+)
+from dev_health_ops.api.dev.subject_preflight import (
+    NOT_FOUND_FALLBACK_LIMIT,
+    PreflightDecision,
+    SubjectPreflight,
+)
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ORG_ID,
+    SeededCatalog,
+    fixed_now,
+    request_for,
+    sequential_ids,
+    versions,
+)
+
+#: The production catalog row the live repro named, verbatim from the
+#: CHAOS-3388 fixture that was read out of ClickHouse ``projects`` — not a
+#: hand-authored stand-in.
+ACR_PROJECT = AuthorizedEntity(
+    kind=EntityKind.PROJECT,
+    canonical_id="60997592-f9f4-462b-87c3-ef82671df270",
+    label="Dev Health Agent Context Runtime (Context Fabric)",
+    repository_id=None,
+)
+
+#: The literal repro question from the live incident report.
+ACR_QUESTION = "What's the status of the ACR Project and what is blocking it?"
+
+#: The four incidental substring hits the live clarification actually listed
+#: ahead of the project. Every label casefolds to a leading ``[``, which sorts
+#: ahead of any letter — this is the exact shape that buried the project.
+ACR_SUBSTRING_ISSUES = tuple(
+    AuthorizedEntity(
+        kind=EntityKind.ISSUE,
+        canonical_id=f"linear:CHAOS-{number}",
+        label=label,
+        repository_id=None,
+    )
+    for number, label in (
+        (2911, "[CHAOS-2911] Harden ACR runtime client boundary"),
+        (2912, "[CHAOS-2912] ACR runtime deploy stack"),
+        (2913, "[CHAOS-2913] ACR context budget guard"),
+        (2914, "[CHAOS-2914] ACR evidence adapter"),
+    )
+)
+
+
+def go_workers_issues(count: int) -> list[AuthorizedEntity]:
+    """CHAOS-3366's live case: work items titled ``Go workers…``, no project."""
+
+    return [
+        AuthorizedEntity(
+            kind=EntityKind.ISSUE,
+            canonical_id=f"linear:CHAOS-{3000 + index}",
+            label=f"Go workers: stage {index:02d}",
+            repository_id=None,
+        )
+        for index in range(count)
+    ]
+
+
+def _preflight(entities: Any) -> SubjectPreflight:
+    mint = sequential_ids()
+    return SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog(entities), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+
+async def _run(preflight: SubjectPreflight, request: Any) -> Any:
+    return await preflight.run(
+        request=request,
+        org_id=ORG_ID,
+        permission_fingerprint="permissions_01",
+        authorized_scope=request.scope,
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+    )
+
+
+def _candidates(result: Any) -> tuple[Any, ...]:
+    assert result.answer is not None
+    return result.answer.frame.clarification_candidates
+
+
+# ---------------------------------------------------------------------------
+# RED -- the ticket's own repro
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_typed_project_mention_ranks_the_real_project_first() -> None:
+    """The acceptance case: the only real project must lead, not trail.
+
+    Asserts the *position*, not membership. CHAOS-3388 already pins that the
+    acronym match survives the bound; surviving it in last place is what this
+    ticket reports, so an ``in candidates`` assertion here could not fail.
+    """
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ACR_PROJECT)]
+            + [(ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES]
+        ),
+        request_for(ACR_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.diagnostic == "unresolved_close_matches"
+    candidates = _candidates(result)
+    assert [candidate.entity_ref.display_label for candidate in candidates] == [
+        ACR_PROJECT.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_same_kind_candidate_is_ranked_before_the_bound_truncates() -> None:
+    """Ranking after truncation is cosmetic: the project must not be dropped.
+
+    Six alias hits for one five-slot page. Every team's acronym is ``acr`` and
+    every team label sorts ahead of the project's, so a kind-blind page keeps
+    five teams and loses the one project outright — the user asked for a
+    project and is offered five things that are not one. Reordering whatever
+    happens to survive cannot fix this; the preference has to be applied
+    before the catalog's own ``[:limit]``.
+    """
+
+    teams = [
+        AuthorizedEntity(
+            kind=EntityKind.TEAM,
+            canonical_id=f"team-acr-{index}",
+            label=f"A{index} Core Runtime",
+            repository_id=None,
+        )
+        for index in range(NOT_FOUND_FALLBACK_LIMIT)
+    ]
+    result = await _run(
+        _preflight([(ORG_ID, ACR_PROJECT)] + [(ORG_ID, team) for team in teams]),
+        request_for(ACR_QUESTION),
+    )
+
+    candidates = _candidates(result)
+    assert len(candidates) == NOT_FOUND_FALLBACK_LIMIT, "the cap is unchanged"
+    assert candidates[0].entity_ref.display_label == ACR_PROJECT.label
+    assert candidates[0].entity_ref.entity_id == ACR_PROJECT.canonical_id
+
+
+# ---------------------------------------------------------------------------
+# The preference ranks; it must never filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_typed_mention_still_gets_other_kind_close_matches() -> None:
+    """CHAOS-3366's own live case, unchanged: typed project, only issues exist.
+
+    A kind *filter* would return nothing here and regress this question to a
+    bare ``not_found``. The whole offer, its count and its kinds, must be
+    exactly what CHAOS-3366 landed.
+    """
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ASK_DEV_PROJECT)]
+            + [(ORG_ID, issue) for issue in go_workers_issues(23)]
+        ),
+        request_for('What is the status of the "Go workers" project?'),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.diagnostic == "unresolved_close_matches"
+    candidates = _candidates(result)
+    assert len(candidates) == NOT_FOUND_FALLBACK_LIMIT
+    assert {candidate.entity_ref.entity_kind.value for candidate in candidates} == {
+        "issue"
+    }
+    assert [candidate.entity_ref.display_label for candidate in candidates] == [
+        issue.label for issue in go_workers_issues(NOT_FOUND_FALLBACK_LIMIT)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_nonsense_typed_name_still_offers_nothing() -> None:
+    """Preferring a kind must not invent a candidate of that kind."""
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT), (ORG_ID, ACR_PROJECT)]),
+        request_for("What is the status of the Zebra Project?"),
+    )
+
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+    assert result.answer is not None
+    assert not result.answer.frame.clarification_candidates
+
+
+# ---------------------------------------------------------------------------
+# Untyped mentions keep today's behaviour exactly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_untyped_bare_name_never_reaches_the_close_match_fallback() -> None:
+    """An untyped bare name carries ``PROJECT`` as a *declared default*.
+
+    ``question_interpreter._add_untyped_mentions`` stamps that kind on a span
+    the user never typed a kind for, so preferring it would be inventing a
+    user intent. The structural reason it cannot happen is that
+    ``blocking_ids`` excludes every untyped mention, so the terminating
+    mention — the only one the fallback ever searches for — is always typed.
+    This pins the untyped run end to end, so a change that let an untyped
+    mention terminate would surface here rather than silently acquiring a
+    project preference.
+    """
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ACR_PROJECT)]
+            + [(ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES]
+        ),
+        request_for("How is ACR doing?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.answer is None
+
+
+@pytest.mark.asyncio
+async def test_an_untyped_span_beside_a_typed_one_ranks_only_the_typed_kind() -> None:
+    """A typed mention terminates; the untyped span's default never ranks.
+
+    "the ACR Project" types ``project``; "Nightfall" is a bare name typed only
+    by the declared default. The offer must be ranked for the *typed*
+    mention's kind — the same ordering as the single-mention repro above.
+    """
+
+    result = await _run(
+        _preflight(
+            [(ORG_ID, ACR_PROJECT)]
+            + [(ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES]
+        ),
+        request_for("What is the status of the ACR Project, and how is Nightfall?"),
+    )
+
+    assert result.outcome is PublicOutcome.NEEDS_CLARIFICATION
+    assert result.diagnostic == "unresolved_close_matches"
+    candidates = _candidates(result)
+    assert candidates[0].entity_ref.display_label == ACR_PROJECT.label
+
+
+# ---------------------------------------------------------------------------
+# The search seam itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_without_a_preference_is_byte_for_byte_todays_ordering() -> None:
+    """Every existing caller passes no preference and must be untouched."""
+
+    entities = [(ORG_ID, ACR_PROJECT)] + [
+        (ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES
+    ]
+    service = ScopeResolutionService(SeededCatalog(entities), cache=ScopeRequestCache())
+
+    result = await service.search(
+        ORG_ID,
+        "permissions_01",
+        ScopeSearchRequest(
+            query="acr",
+            kinds=(EntityKind.ISSUE, EntityKind.PROJECT),
+            limit=NOT_FOUND_FALLBACK_LIMIT,
+            include_alias_matches=True,
+        ),
+    )
+
+    assert [candidate.label for candidate in result.candidates] == [
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
+        ACR_PROJECT.label,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_preference_and_no_preference_do_not_share_a_cache_entry() -> None:
+    """Same query, same kinds, same limit — different answers.
+
+    A shared cache key would let whichever request ran first silently answer
+    the other's call, which is the defect CHAOS-3388 already documented for
+    ``include_alias_matches``.
+    """
+
+    entities = [(ORG_ID, ACR_PROJECT)] + [
+        (ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES
+    ]
+    service = ScopeResolutionService(SeededCatalog(entities), cache=ScopeRequestCache())
+    kwargs: dict[str, Any] = {
+        "query": "acr",
+        "kinds": (EntityKind.ISSUE, EntityKind.PROJECT),
+        "limit": NOT_FOUND_FALLBACK_LIMIT,
+        "include_alias_matches": True,
+    }
+
+    unpreferred = await service.search(
+        ORG_ID, "permissions_01", ScopeSearchRequest(**kwargs)
+    )
+    preferred = await service.search(
+        ORG_ID,
+        "permissions_01",
+        ScopeSearchRequest(preferred_kinds=frozenset({EntityKind.PROJECT}), **kwargs),
+    )
+
+    assert unpreferred.candidates[0].label != preferred.candidates[0].label
+    assert preferred.candidates[0].label == ACR_PROJECT.label
+
+
+def test_a_preference_outside_the_searched_kinds_is_a_caller_defect() -> None:
+    """The preference is a ranking over the searched page, not a widening."""
+
+    with pytest.raises(ValueError, match="preferred"):
+        ScopeSearchRequest(
+            query="acr",
+            kinds=(EntityKind.ISSUE,),
+            preferred_kinds=frozenset({EntityKind.PROJECT}),
+        )
+
+
+def test_inside_the_preferred_kind_alias_precision_still_decides() -> None:
+    """CHAOS-3388's second key survives underneath CHAOS-3422's first one.
+
+    ``Aardvark ACR Rites`` sorts ahead of the real project by label and holds
+    ``ACR`` only as an incidental substring; the real project matches by
+    acronym. Both are projects, so the kind key cannot separate them and the
+    precision key must. Asserted at ``merge_search_candidates`` because
+    that is the only layer holding the alias/substring distinction: an
+    ``AuthorizedEntity`` carries no match provenance downstream of it.
+    """
+
+    aardvark = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-aardvark-rites",
+        label="Aardvark ACR Rites",
+        repository_id=None,
+    )
+    ranked = merge_search_candidates(
+        alias_hits=[ACR_PROJECT],
+        substring_hits=[aardvark, *ACR_SUBSTRING_ISSUES],
+        preferred_kinds=frozenset({EntityKind.PROJECT}),
+        limit=NOT_FOUND_FALLBACK_LIMIT,
+    )
+
+    assert [entity.label for entity in ranked] == [
+        ACR_PROJECT.label,
+        aardvark.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES[:3]),
+    ]
+
+
+def test_merging_without_a_preference_keeps_the_chaos_3388_order() -> None:
+    """No preference must be byte-for-byte alias-then-substring, by label."""
+
+    aardvark = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-aardvark-rites",
+        label="Aardvark ACR Rites",
+        repository_id=None,
+    )
+    ranked = merge_search_candidates(
+        alias_hits=[ACR_PROJECT],
+        substring_hits=[aardvark, *ACR_SUBSTRING_ISSUES],
+        preferred_kinds=frozenset(),
+        limit=NOT_FOUND_FALLBACK_LIMIT,
+    )
+
+    assert [entity.label for entity in ranked] == [
+        ACR_PROJECT.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_close_match_entry_still_never_commits() -> None:
+    """Ranking must not turn a sole leading candidate into a pick."""
+
+    result = await _run(
+        _preflight([(ORG_ID, ACR_PROJECT)]),
+        request_for(ACR_QUESTION),
+    )
+
+    assert result.committed_resolution is None
+    latest = result.ledger.latest_by_mention()
+    outcomes = {entry.outcome for entry in latest.values()}
+    assert ResolutionOutcome.EXACT_MATCH not in outcomes
+    assert ResolutionOutcome.AMBIGUOUS_CANDIDATES in outcomes

--- a/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
+++ b/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
@@ -29,7 +29,10 @@ import pytest
 
 from dev_health_ops.api.dev.contracts_v2 import PublicOutcome, ResolutionOutcome
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
-from dev_health_ops.api.dev.scope_catalog import merge_search_candidates
+from dev_health_ops.api.dev.scope_catalog import (
+    ClickHouseAuthorizedEntityCatalog,
+    merge_search_candidates,
+)
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
     EntityKind,
@@ -357,6 +360,89 @@ async def test_a_preference_and_no_preference_do_not_share_a_cache_entry() -> No
 
     assert unpreferred.candidates[0].label != preferred.candidates[0].label
     assert preferred.candidates[0].label == ACR_PROJECT.label
+
+
+@pytest.mark.asyncio
+async def test_the_seeded_catalog_agrees_with_the_production_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A differential oracle over the two search implementations.
+
+    Every preflight scenario in this module reaches ``merge_search_candidates``
+    through ``SeededCatalog``, so the fake is a second implementation of the
+    production catalog's search and the only question that matters is whether
+    they agree. Codex review, medium: they did not — the fake skipped the
+    alias pass for any entity the substring pass had already matched, so
+    ``Zeta Runtime (ACR)`` was an alias hit in production and a substring hit
+    in the fake, one rank lower. Both are driven from the *same* rows here,
+    with the production side's ``query_dicts`` returning exactly what the fake
+    is seeded with, so the comparison cannot be satisfied by two different
+    inputs.
+    """
+
+    rows = [
+        AuthorizedEntity(
+            kind=EntityKind.PROJECT,
+            canonical_id="project-zeta",
+            label="Zeta Runtime (ACR)",
+        ),
+        AuthorizedEntity(
+            kind=EntityKind.PROJECT,
+            canonical_id="project-aardvark",
+            label="Aardvark ACR Notes",
+        ),
+        AuthorizedEntity(
+            kind=EntityKind.PROJECT,
+            canonical_id="project-agile",
+            label="Agile Core Runway",
+        ),
+    ]
+
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM projects FINAL" not in sql:
+            return []
+        if "lowerUTF8(name)" in sql:  # the alias roster scan
+            return [
+                {"canonical_id": row.canonical_id, "label": row.label} for row in rows
+            ]
+        return [  # the substring pass
+            {"canonical_id": row.canonical_id, "label": row.label}
+            for row in rows
+            if "acr" in row.label.casefold()
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+
+    for preferred in (frozenset(), frozenset({EntityKind.PROJECT})):
+        production = await ClickHouseAuthorizedEntityCatalog(object()).search(
+            ORG_ID,
+            "acr",
+            (EntityKind.PROJECT,),
+            limit=NOT_FOUND_FALLBACK_LIMIT,
+            include_alias_matches=True,
+            preferred_kinds=preferred,
+        )
+        seeded = await SeededCatalog([(ORG_ID, row) for row in rows]).search(
+            ORG_ID,
+            "acr",
+            (EntityKind.PROJECT,),
+            limit=NOT_FOUND_FALLBACK_LIMIT,
+            include_alias_matches=True,
+            preferred_kinds=preferred,
+        )
+        assert seeded == production, f"the fake diverges for preferred={preferred}"
+
+    # And the agreed-upon answer is the right one, so agreeing on a wrong
+    # order could not satisfy this test either.
+    assert [entity.canonical_id for entity in seeded] == [
+        "project-agile",  # alias only, sorts first inside the alias tier
+        "project-zeta",  # alias AND substring -- still an alias hit
+        "project-aardvark",  # substring only
+    ]
 
 
 def test_a_preference_outside_the_searched_kinds_is_a_caller_defect() -> None:

--- a/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
+++ b/tests/api/dev/test_chaos_3422_kind_ranked_close_matches.py
@@ -5,12 +5,12 @@ The live repro (run ``acdc0a67-8312-43e0-8b59-0aafc0f10a68``, main @
 acronym matcher correctly finds the one real project, and the clarification
 then lists it **5th of 5**, behind four irrelevant issue substring hits.
 
-Two kind-blind ranking seams produced that, and each has its own test here:
+Two kind-blind seams produced that, and each has its own test here:
 
-* ``ClickHouseAuthorizedEntityCatalog.search`` merges alias hits ahead of
-  substring hits and truncates to ``limit`` — precision-ranked, kind-blind.
-* ``ScopeResolutionService.search`` then re-sorts the whole page into one
-  alphabetical order by label, which discards even that alias-first rank.
+* ``ClickHouseAuthorizedEntityCatalog.search`` merged alias hits ahead of
+  substring hits and truncated to ``limit`` — precision-ranked, kind-blind.
+* ``ScopeResolutionService.search`` then re-sorted the whole page into one
+  alphabetical order by label, discarding even that alias-first rank.
   ``[CHAOS-2911] Harden ACR runtime client boundary`` casefolds to a ``[``
   that sorts ahead of ``dev health agent context runtime…``.
 
@@ -304,8 +304,16 @@ async def test_an_untyped_span_beside_a_typed_one_ranks_only_the_typed_kind() ->
 
 
 @pytest.mark.asyncio
-async def test_search_without_a_preference_is_byte_for_byte_todays_ordering() -> None:
-    """Every existing caller passes no preference and must be untouched."""
+async def test_search_without_a_preference_keeps_the_catalogs_own_rank() -> None:
+    """No preference must leave the catalog's ranking exactly as it arrived.
+
+    Codex review round 3, confirmed: the service used to re-sort every page by
+    label, which discarded CHAOS-3388's alias precedence as well as this
+    ticket's kind key — the acronym-matched project arrived first from the
+    catalog and left the service last. Preserving the order is only visible
+    for the one caller that enables alias matching; with substring hits alone
+    the catalog's order already *is* label order.
+    """
 
     entities = [(ORG_ID, ACR_PROJECT)] + [
         (ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES
@@ -324,8 +332,8 @@ async def test_search_without_a_preference_is_byte_for_byte_todays_ordering() ->
     )
 
     assert [candidate.label for candidate in result.candidates] == [
-        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
         ACR_PROJECT.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
     ]
 
 
@@ -335,10 +343,19 @@ async def test_a_preference_and_no_preference_do_not_share_a_cache_entry() -> No
 
     A shared cache key would let whichever request ran first silently answer
     the other's call, which is the defect CHAOS-3388 already documented for
-    ``include_alias_matches``.
+    ``include_alias_matches``. The seeded rows must be a case where the two
+    genuinely differ, or the test would pass with the cache keys collided:
+    ``Aardvark ACR Notes`` is a project matching only by substring, so it
+    trails the acronym hit either way, while the *issues* lead the page
+    without a preference and trail both projects with one.
     """
 
-    entities = [(ORG_ID, ACR_PROJECT)] + [
+    aardvark = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-aardvark",
+        label="Aardvark ACR Notes",
+    )
+    entities = [(ORG_ID, ACR_PROJECT), (ORG_ID, aardvark)] + [
         (ORG_ID, issue) for issue in ACR_SUBSTRING_ISSUES
     ]
     service = ScopeResolutionService(SeededCatalog(entities), cache=ScopeRequestCache())
@@ -358,13 +375,93 @@ async def test_a_preference_and_no_preference_do_not_share_a_cache_entry() -> No
         ScopeSearchRequest(preferred_kinds=frozenset({EntityKind.PROJECT}), **kwargs),
     )
 
-    assert unpreferred.candidates[0].label != preferred.candidates[0].label
-    assert preferred.candidates[0].label == ACR_PROJECT.label
+    assert [candidate.label for candidate in unpreferred.candidates] == [
+        ACR_PROJECT.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES),
+    ]
+    assert [candidate.label for candidate in preferred.candidates] == [
+        ACR_PROJECT.label,
+        aardvark.label,
+        *(issue.label for issue in ACR_SUBSTRING_ISSUES[:3]),
+    ]
+
+
+#: Rows the oracle below drives through both search implementations. Chosen so
+#: every tier boundary is crossed: alias-only, alias *and* substring, and
+#: substring-only, with the substring-only label sorting first so a lost alias
+#: rank is visible as a reordering rather than hidden by the alphabet.
+_ORACLE_ROWS = (
+    AuthorizedEntity(
+        kind=EntityKind.PROJECT, canonical_id="project-zeta", label="Zeta Runtime (ACR)"
+    ),
+    AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-aardvark",
+        label="Aardvark ACR Notes",
+    ),
+    AuthorizedEntity(
+        kind=EntityKind.PROJECT, canonical_id="project-agile", label="Agile Core Runway"
+    ),
+    AuthorizedEntity(
+        kind=EntityKind.TEAM, canonical_id="team-acr", label="Analytics Core Reporting"
+    ),
+    AuthorizedEntity(
+        kind=EntityKind.TEAM, canonical_id="team-beta", label="Beta ACR Guild"
+    ),
+)
+
+
+def _oracle_query_dicts(rows: tuple[AuthorizedEntity, ...]) -> Any:
+    """``query_dicts`` over ``rows``, mirroring each production query's WHERE.
+
+    The roster scan and the substring pass are told apart by their *parameters*
+    -- only the substring pass binds ``query`` -- not by matching SQL text.
+    Codex review round 3, confirmed: the first version keyed on the substring
+    ``lowerUTF8(name)``, which the project substring SQL also contains
+    (``scope_catalog`` line 402), so both production queries were handed the
+    unfiltered roster and the two sides were never driven from equal inputs.
+    It passed anyway, by luck, because the extra row was an alias hit too.
+    """
+
+    kind_by_table = {
+        "FROM projects FINAL": EntityKind.PROJECT,
+        "FROM teams FINAL": EntityKind.TEAM,
+    }
+
+    async def query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        kind = next(
+            (kind for table, kind in kind_by_table.items() if table in sql), None
+        )
+        if kind is None:
+            return []
+        matching = [row for row in rows if row.kind is kind]
+        if "query" in params:  # the substring pass
+            needle = params["query"].casefold()
+            matching = [
+                row
+                for row in matching
+                if needle == row.canonical_id.casefold()
+                or needle in row.label.casefold()
+            ]
+        return [
+            {"canonical_id": row.canonical_id, "label": row.label} for row in matching
+        ]
+
+    return query_dicts
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query", ["acr", "runtime", "project-zeta", "nothing-matches-this"]
+)
+@pytest.mark.parametrize(
+    "preferred",
+    [frozenset(), frozenset({EntityKind.PROJECT}), frozenset({EntityKind.TEAM})],
+)
 async def test_the_seeded_catalog_agrees_with_the_production_catalog(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, query: str, preferred: frozenset[EntityKind]
 ) -> None:
     """A differential oracle over the two search implementations.
 
@@ -374,74 +471,142 @@ async def test_the_seeded_catalog_agrees_with_the_production_catalog(
     they agree. Codex review, medium: they did not — the fake skipped the
     alias pass for any entity the substring pass had already matched, so
     ``Zeta Runtime (ACR)`` was an alias hit in production and a substring hit
-    in the fake, one rank lower. Both are driven from the *same* rows here,
-    with the production side's ``query_dicts`` returning exactly what the fake
-    is seeded with, so the comparison cannot be satisfied by two different
-    inputs.
+    in the fake, one rank lower.
+
+    Both sides are driven from the *same* rows, through the same WHERE
+    semantics, so the comparison cannot be satisfied by two different inputs.
+    Repository search is deliberately outside this oracle: production enriches
+    repository labels through ``resolve_scope_display_names``, which the fake
+    does not model at all — a pre-existing divergence this ticket does not
+    close, and pretending otherwise here would be the false confidence the
+    oracle exists to remove.
     """
 
-    rows = [
-        AuthorizedEntity(
-            kind=EntityKind.PROJECT,
-            canonical_id="project-zeta",
-            label="Zeta Runtime (ACR)",
-        ),
-        AuthorizedEntity(
-            kind=EntityKind.PROJECT,
-            canonical_id="project-aardvark",
-            label="Aardvark ACR Notes",
-        ),
-        AuthorizedEntity(
-            kind=EntityKind.PROJECT,
-            canonical_id="project-agile",
-            label="Agile Core Runway",
-        ),
-    ]
-
-    async def fake_query_dicts(
-        _client: object, sql: str, params: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        if "FROM projects FINAL" not in sql:
-            return []
-        if "lowerUTF8(name)" in sql:  # the alias roster scan
-            return [
-                {"canonical_id": row.canonical_id, "label": row.label} for row in rows
-            ]
-        return [  # the substring pass
-            {"canonical_id": row.canonical_id, "label": row.label}
-            for row in rows
-            if "acr" in row.label.casefold()
-        ]
-
     monkeypatch.setattr(
-        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+        "dev_health_ops.api.dev.scope_catalog.query_dicts",
+        _oracle_query_dicts(_ORACLE_ROWS),
+    )
+    kinds = (EntityKind.PROJECT, EntityKind.TEAM)
+
+    production = await ClickHouseAuthorizedEntityCatalog(object()).search(
+        ORG_ID,
+        query,
+        kinds,
+        limit=NOT_FOUND_FALLBACK_LIMIT,
+        include_alias_matches=True,
+        preferred_kinds=preferred,
+    )
+    seeded = await SeededCatalog([(ORG_ID, row) for row in _ORACLE_ROWS]).search(
+        ORG_ID,
+        query,
+        kinds,
+        limit=NOT_FOUND_FALLBACK_LIMIT,
+        include_alias_matches=True,
+        preferred_kinds=preferred,
     )
 
-    for preferred in (frozenset(), frozenset({EntityKind.PROJECT})):
-        production = await ClickHouseAuthorizedEntityCatalog(object()).search(
-            ORG_ID,
-            "acr",
-            (EntityKind.PROJECT,),
-            limit=NOT_FOUND_FALLBACK_LIMIT,
-            include_alias_matches=True,
-            preferred_kinds=preferred,
-        )
-        seeded = await SeededCatalog([(ORG_ID, row) for row in rows]).search(
-            ORG_ID,
-            "acr",
-            (EntityKind.PROJECT,),
-            limit=NOT_FOUND_FALLBACK_LIMIT,
-            include_alias_matches=True,
-            preferred_kinds=preferred,
-        )
-        assert seeded == production, f"the fake diverges for preferred={preferred}"
+    assert seeded == production, f"the fake diverges for {query!r}/{preferred}"
 
-    # And the agreed-upon answer is the right one, so agreeing on a wrong
-    # order could not satisfy this test either.
-    assert [entity.canonical_id for entity in seeded] == [
-        "project-agile",  # alias only, sorts first inside the alias tier
-        "project-zeta",  # alias AND substring -- still an alias hit
+
+@pytest.mark.asyncio
+async def test_the_oracle_rows_rank_the_way_the_contract_says(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agreeing on a *wrong* order must not satisfy the oracle above."""
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts",
+        _oracle_query_dicts(_ORACLE_ROWS),
+    )
+
+    result = await ClickHouseAuthorizedEntityCatalog(object()).search(
+        ORG_ID,
+        "acr",
+        (EntityKind.PROJECT, EntityKind.TEAM),
+        limit=NOT_FOUND_FALLBACK_LIMIT,
+        include_alias_matches=True,
+        preferred_kinds=frozenset({EntityKind.PROJECT}),
+    )
+
+    assert [entity.canonical_id for entity in result] == [
+        # Preferred kind first: alias hits by label, then the substring-only one.
+        "project-agile",  # "Agile Core Runway" -> acronym "acr"
+        "project-zeta",  # alias AND substring -- still ranked as an alias hit
         "project-aardvark",  # substring only
+        # Then the other kind, same two keys.
+        "team-acr",  # "Analytics Core Reporting" -> acronym "acr"
+        "team-beta",  # substring only
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_service_ranks_even_when_the_catalog_ignores_the_hint() -> None:
+    """``preferred_kinds`` is a hint to the catalog and a guarantee at the service.
+
+    ``AuthorizedEntityCatalog`` is a Protocol, and ``preferred_kinds`` reaches
+    it with a default of ``frozenset()`` — so an implementation that simply
+    ignores the argument is a valid one, and would silently return a
+    kind-blind page. Depending on every implementation to honour a ranking
+    hint is the kind of unstated assumption that only shows up in production,
+    so the service re-applies the key over whatever it is handed. Without
+    this, that re-application has no witness at all: the real catalog already
+    ranks, so removing it changes nothing any other test can see.
+    """
+
+    class RankIgnoringCatalog(SeededCatalog):
+        async def search(
+            self,
+            org_id: str,
+            query: str,
+            kinds: tuple[EntityKind, ...],
+            *,
+            limit: int,
+            include_alias_matches: bool = False,
+            preferred_kinds: frozenset[EntityKind] = frozenset(),
+        ) -> list[AuthorizedEntity]:
+            return await super().search(
+                org_id,
+                query,
+                kinds,
+                limit=limit,
+                include_alias_matches=include_alias_matches,
+            )
+
+    # A plain substring match on both sides, so nothing but the kind key can
+    # move the project: its label sorts last, and the catalog here ignores the
+    # hint that would otherwise have raised it.
+    project = AuthorizedEntity(
+        kind=EntityKind.PROJECT,
+        canonical_id="project-zulu",
+        label="Zulu Runtime Program",
+    )
+    issues = [
+        AuthorizedEntity(
+            kind=EntityKind.ISSUE,
+            canonical_id=f"linear:CHAOS-{2911 + index}",
+            label=f"{index} runtime task",
+        )
+        for index in range(4)
+    ]
+    service = ScopeResolutionService(
+        RankIgnoringCatalog([(ORG_ID, entity) for entity in [project, *issues]]),
+        cache=ScopeRequestCache(),
+    )
+
+    result = await service.search(
+        ORG_ID,
+        "permissions_01",
+        ScopeSearchRequest(
+            query="runtime",
+            kinds=(EntityKind.ISSUE, EntityKind.PROJECT),
+            limit=NOT_FOUND_FALLBACK_LIMIT,
+            preferred_kinds=frozenset({EntityKind.PROJECT}),
+        ),
+    )
+
+    assert [candidate.canonical_id for candidate in result.candidates] == [
+        project.canonical_id,
+        *(issue.canonical_id for issue in issues),
     ]
 
 

--- a/tests/api/dev/test_scope_catalog.py
+++ b/tests/api/dev/test_scope_catalog.py
@@ -99,6 +99,101 @@ async def test_search_queries_only_requested_approved_tables(
     assert all("org_id = {org_id:String}" in sql for sql in sqls)
 
 
+#: The live shape CHAOS-3422 reports, reduced to what the ranking can see: a
+#: page bound of five, five work items whose titles hold the query as an
+#: incidental substring and casefold ahead of the one real project, and that
+#: project. Kind-blind, the project sorts sixth and is truncated off the page
+#: entirely — the user asked for a project and is offered five things that are
+#: not one.
+_PREFERRED_KIND_PROJECT_ROW = {
+    "canonical_id": "60997592-f9f4-462b-87c3-ef82671df270",
+    "label": "Zulu Agent Context Runtime",
+}
+_PREFERRED_KIND_ISSUE_ROWS = [
+    {"canonical_id": f"linear:CHAOS-{2911 + index}", "label": f"{index} runtime task"}
+    for index in range(5)
+]
+
+
+def _runtime_rows() -> Any:
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        assert params["org_id"] == "org-a"
+        if "FROM work_items FINAL" in sql:
+            return list(_PREFERRED_KIND_ISSUE_ROWS)
+        if "FROM projects FINAL" in sql:
+            return [dict(_PREFERRED_KIND_PROJECT_ROW)]
+        return []
+
+    return fake_query_dicts
+
+
+@pytest.mark.asyncio
+async def test_the_production_search_ranks_the_preferred_kind_before_its_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3422 at the real catalog, not at a stand-in for it.
+
+    Codex review, confirmed by mutation: every other CHAOS-3422 test drives
+    ``SeededCatalog``, which calls ``merge_search_candidates`` itself — so
+    dropping ``preferred_kinds`` at *this* call site left the whole suite
+    green while the live clarification regressed. The first shape written for
+    this test could not fail either: with the project arriving as an *alias*
+    hit, CHAOS-3388's own alias-first key already put it first, so removing
+    the kind key changed nothing. The project matches by plain substring here,
+    which is the only shape where the kind key is the deciding one.
+    """
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", _runtime_rows()
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    result = await catalog.search(
+        "org-a",
+        "runtime",
+        (EntityKind.PROJECT, EntityKind.ISSUE),
+        limit=5,
+        preferred_kinds=frozenset({EntityKind.PROJECT}),
+    )
+
+    assert len(result) == 5, "the page bound is unchanged"
+    assert result[0].kind is EntityKind.PROJECT
+    assert result[0].canonical_id == _PREFERRED_KIND_PROJECT_ROW["canonical_id"]
+    assert [entity.kind for entity in result[1:]] == [EntityKind.ISSUE] * 4, (
+        "ranking must not filter the other kinds off the page"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_production_search_without_a_preference_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same rows, no preference: today's label-ordered page, verbatim.
+
+    Also the before/after witness for the ticket — with no kind key the real
+    project is not merely ranked last, it is off the page.
+    """
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", _runtime_rows()
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    result = await catalog.search(
+        "org-a",
+        "runtime",
+        (EntityKind.PROJECT, EntityKind.ISSUE),
+        limit=5,
+    )
+
+    assert [entity.kind for entity in result] == [EntityKind.ISSUE] * 5
+    assert [entity.label for entity in result] == [
+        row["label"] for row in _PREFERRED_KIND_ISSUE_ROWS
+    ]
+
+
 def test_catalog_rejects_supporting_evidence_kind() -> None:
     with pytest.raises(ValueError, match="not catalog-searchable"):
         ClickHouseAuthorizedEntityCatalog._query_for(

--- a/tests/api/dev/test_scope_catalog.py
+++ b/tests/api/dev/test_scope_catalog.py
@@ -194,6 +194,110 @@ async def test_the_production_search_without_a_preference_is_unchanged(
     ]
 
 
+@pytest.mark.asyncio
+async def test_an_entity_matching_both_ways_is_ranked_as_the_alias_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The alias and substring passes are independent, and alias wins.
+
+    CHAOS-3422 codex review, medium: the seeded test double used to skip any
+    entity the substring pass had already matched, so an entity that matches
+    *both* ways ranked one tier lower in the fake than in production. This
+    pins production's own semantics — the behaviour the fake now has to
+    mirror — so the divergence cannot re-open silently on this side either.
+    """
+
+    # "Zeta Runtime (ACR)" matches BOTH ways: its parenthetical is the literal
+    # alias "acr", and its label also contains "acr" outright. The substring-
+    # only entity sorts ahead of it by label, so the alias tier is the only
+    # thing that can put the both-ways entity first.
+    both_ways = {"canonical_id": "project-zeta", "label": "Zeta Runtime (ACR)"}
+    substring_only = {"canonical_id": "project-aardvark", "label": "Aardvark ACR Notes"}
+
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM projects FINAL" not in sql:
+            return []
+        return [dict(both_ways), dict(substring_only)]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    result = await catalog.search(
+        "org-a",
+        "acr",
+        (EntityKind.PROJECT,),
+        limit=5,
+        include_alias_matches=True,
+    )
+
+    assert [entity.canonical_id for entity in result] == [
+        both_ways["canonical_id"],
+        substring_only["canonical_id"],
+    ]
+    assert len(result) == 2, "one entity, matched twice, is offered once"
+
+
+@pytest.mark.asyncio
+async def test_the_per_kind_sql_cap_can_only_drop_an_already_full_same_kind_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3422 codex review, refuted-with-evidence — pinned, not fixed.
+
+    Each kind's SQL applies ``LIMIT`` before ``merge_search_candidates`` ranks
+    anything, so a same-kind entity *can* be dropped before the kind key is
+    ever read. That cannot bury the user's kind behind another one, which is
+    what this ticket is about: the per-kind cap equals the page bound, so a
+    same-kind entity is only lost once ``limit`` same-kind entities already
+    matched — and then every slot on the page is already that kind. Six
+    projects and five issues below; the page is five projects.
+
+    That the sixth project is unreachable is the ``NOT_FOUND_FALLBACK_LIMIT``
+    cap doing its documented job, unchanged by this ticket. Asserted so the
+    semantics are a decision on the record rather than an accident.
+    """
+
+    projects = [
+        {"canonical_id": f"project-{index}", "label": f"{index} Runtime Program"}
+        for index in range(6)
+    ]
+    issues = [
+        {"canonical_id": f"linear:CHAOS-{index}", "label": f"{index} runtime task"}
+        for index in range(5)
+    ]
+
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        limit = params["limit"]
+        if "FROM projects FINAL" in sql:
+            return [dict(row) for row in projects[:limit]]
+        if "FROM work_items FINAL" in sql:
+            return [dict(row) for row in issues[:limit]]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    result = await catalog.search(
+        "org-a",
+        "runtime",
+        (EntityKind.PROJECT, EntityKind.ISSUE),
+        limit=5,
+        preferred_kinds=frozenset({EntityKind.PROJECT}),
+    )
+
+    assert [entity.kind for entity in result] == [EntityKind.PROJECT] * 5
+    assert [entity.canonical_id for entity in result] == [
+        row["canonical_id"] for row in projects[:5]
+    ]
+
+
 def test_catalog_rejects_supporting_evidence_kind() -> None:
     with pytest.raises(ValueError, match="not catalog-searchable"):
         ClickHouseAuthorizedEntityCatalog._query_for(

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -104,6 +104,7 @@ class FakeCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         self.search_calls += 1
         return [

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -7,6 +7,7 @@ import pytest
 
 from dev_health_ops.api.dev import scope_service as scope_service_module
 from dev_health_ops.api.dev.contracts import DevScope, DevTimeRange, DirectScope
+from dev_health_ops.api.dev.scope_catalog import merge_search_candidates
 from dev_health_ops.api.dev.scope_service import (
     AuthorizedEntity,
     EntityKind,
@@ -107,11 +108,21 @@ class FakeCatalog:
         preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         self.search_calls += 1
-        return [
-            entity
-            for entity in self.entities
-            if entity.kind in kinds and query.casefold() in entity.label.casefold()
-        ][:limit]
+        # Ranked and truncated by the production helper: every catalog query
+        # applies its ORDER BY in SQL, and since CHAOS-3422 the service
+        # preserves the order it is handed rather than re-sorting it, so a
+        # double returning rows in seeded order would pin an order the real
+        # catalog never emits.
+        return merge_search_candidates(
+            alias_hits=(),
+            substring_hits=[
+                entity
+                for entity in self.entities
+                if entity.kind in kinds and query.casefold() in entity.label.casefold()
+            ],
+            preferred_kinds=preferred_kinds,
+            limit=limit,
+        )
 
     async def organization_repository_ids(
         self, org_id: str, *, limit: int

--- a/tests/api/graphql/test_dev_scope_search.py
+++ b/tests/api/graphql/test_dev_scope_search.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev.scope_catalog import merge_search_candidates
 from dev_health_ops.api.dev.scope_service import AuthorizedEntity, EntityKind
 from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.resolvers import dev_entitlement
@@ -49,10 +50,19 @@ class FakeCatalog:
         assert query == "ask"
         assert kinds == (EntityKind.ISSUE, EntityKind.PROJECT)
         assert limit == 25
-        return [
-            AuthorizedEntity(EntityKind.PROJECT, "project-z", "Ask Dev"),
-            AuthorizedEntity(EntityKind.ISSUE, "issue-a", "ask dev"),
-        ]
+        # Ranked and truncated by the production helper, not by hand: the
+        # service now preserves the catalog's order instead of re-sorting it
+        # (CHAOS-3422), so a double that returned rows in seeded order would
+        # be asserting an order the real catalog never emits.
+        return merge_search_candidates(
+            alias_hits=(),
+            substring_hits=[
+                AuthorizedEntity(EntityKind.PROJECT, "project-z", "Ask Dev"),
+                AuthorizedEntity(EntityKind.ISSUE, "issue-a", "ask dev"),
+            ],
+            preferred_kinds=preferred_kinds,
+            limit=limit,
+        )
 
     async def exact(self, *_args: Any, **_kwargs: Any) -> list[AuthorizedEntity]:
         raise AssertionError("GraphQL scope search must use the shared search service")

--- a/tests/api/graphql/test_dev_scope_search.py
+++ b/tests/api/graphql/test_dev_scope_search.py
@@ -42,6 +42,7 @@ class FakeCatalog:
         *,
         limit: int,
         include_alias_matches: bool = False,
+        preferred_kinds: frozenset[EntityKind] = frozenset(),
     ) -> list[AuthorizedEntity]:
         type(self).calls += 1
         assert org_id == ORG_ID


### PR DESCRIPTION
## What this fixes

A typed mention states a kind, and the Ask Dev closest-matches clarification ignored it. Live repro (run `acdc0a67-8312-43e0-8b59-0aafc0f10a68`): *"What's the status of the ACR project…"* found the one real project by acronym and listed it **5th of 5**, behind four issues whose titles merely contain "acr".

Two truncation points on that path both ordered the page by label alone:

1. `ClickHouseAuthorizedEntityCatalog.search` — `(alias + substring)[:limit]`, precision-ranked (CHAOS-3388) but kind-blind.
2. `ScopeResolutionService.search` — re-sorted the whole page alphabetically, discarding even that alias-first rank. `[CHAOS-2911] Harden ACR…` casefolds to a `[` that sorts ahead of `dev health agent context runtime…`.

## The approach: rank, never filter

`ScopeSearchRequest.preferred_kinds` moves same-kind candidates ahead of every other kind **before each bound applies**. Sort key: named kind → alias-over-substring → label/kind/id.

Filtering was rejected on evidence. CHAOS-3366's founding case is "the Go workers project", where the catalog holds only *issues* — a kind filter returns zero candidates there and regresses that ticket to a bare not-found. A regression test pins exactly that.

Empty `preferred_kinds` is today's behaviour byte-for-byte, which is every caller except the two that enable alias matching.

## Before / after (clarification candidates)

| Scenario | Before | After |
| --- | --- | --- |
| Ticket repro: 1 project + 4 ACR issues | 4 issues, then project (5th) | project, then 4 issues |
| 1 project + 5 acronym-matching teams, bound 5 | project **off the page** | project, then 4 teams |
| CHAOS-3366 Go-workers (typed project, only issues) | 5 issue candidates | unchanged |

Caps, clarification copy/keys, diagnostics and every enum value are untouched. No new outcome; no widened alias auto-commit.

## Untyped mentions

Not gated defensively — traced. `blocking_ids` structurally excludes untyped ids, so the terminating mention is always typed and an untyped bare name never reaches this seam. That matters because untyped names are minted with `requested_entity_kind=PROJECT` as a *declared default*. Pinned end-to-end both ways.

## Review

Three adversarial rounds plus a scoped confirm-or-refute pass on the last commit. Findings accepted and fixed:

- The production catalog's own `merge_search_candidates` call site had no witness — dropping `preferred_kinds` there left all 2413 tests green. Now covered.
- The seeded test double hid production input-shape divergence (it skipped the alias pass for anything the substring pass matched). Fixed, plus a differential oracle driving both implementations from the same rows.
- The service re-sort still erased CHAOS-3388's alias precedence. Fixed: the search path now dedupes without reordering.
- The oracle's SQL discriminator false-passed (it keyed on `lowerUTF8(name)`, which the project substring SQL also contains). Now discriminated by query parameters.

One finding **refuted with evidence and pinned by test** rather than "fixed": the per-kind SQL `LIMIT` precedes ranking, but the per-kind cap equals the page bound, so a same-kind entity is only lost once `limit` same-kind entities already matched — and then the page is entirely that kind. Asserted with 6 projects + 5 issues at a bound of 5.

Two of my own fixes were themselves non-discriminating tests, caught by re-running the mutation rather than by re-reading them.

## Verification

Seven clause mutations, all killed, each restore digest-verified. One survived after a later fix (the real catalog already ranks), so rather than leave an unwitnessed clause there is now a catalog double that ignores the ranking hint — the `AuthorizedEntityCatalog` Protocol takes `preferred_kinds` with a default, so an implementation ignoring it is valid.

Known residual, disclosed rather than papered over: repository search is outside the differential oracle, because production enriches repository labels via `resolve_scope_display_names` and the fake models none of it. Pre-existing; including it would manufacture confidence the oracle exists to remove.

## Gate

`ci/local_validate.sh` on the rebased tree (`d05a20616`, base `7063b83ad`):

| Stage | Result |
| --- | --- |
| ruff format --check | pass |
| ruff check | pass |
| mypy | pass |
| ch-scratch-create | pass |
| ch-migrate | pass |
| unit suite | 3 failed, **12463 passed**, 247 skipped, 1 xfailed |

All three failures are in `tests/tooling/test_local_validate_lock.py`, tracked as CHAOS-3468 machine-class:

- `test_two_concurrent_invocations_serialize_not_both_run`
- `test_high_concurrency_stress_no_double_acquire`
- `test_reclaim_is_compare_and_delete_under_widened_window`

They cannot be caused by this change: `git diff origin/main..HEAD -- tests/tooling/ ci/` is **empty** — both that test file and `ci/local_validate.sh` are byte-identical to `origin/main`. The same ids also fail **standalone**, with no gate running and no lock held.

### Root cause found while gating (belongs to CHAOS-3468, not to this PR)

The file deadlocks on a serial-`communicate()` pipe bug in the test harness, not on a lock defect:

```python
proc_a = _spawn_probe(...)   # both spawned concurrently, both stdout=PIPE
proc_b = _spawn_probe(...)
out_a = proc_a.communicate(timeout=960)[0]   # drains A only
out_b = proc_b.communicate(timeout=960)[0]   # B undrained until A exits
```

The undrained child fills its 16KB pipe buffer and blocks on write *while holding the lock*, so the other probe polls for a lock its holder can never release. Sampled stacks confirm it: one probe in `putchar → __swbuf` (full pipe), the other in the bash poll loop.

Measured cost: the file alone takes **995s (16:35)** standalone and the failing tests burn their `communicate(timeout=960)` budgets. Raising `wait_secs` 60 → 900 never fixed the bug — it bought the deadlock 15 minutes before failing anyway. The suggested fix (for that ticket) is to drain both children concurrently, or `stdout=tempfile` per probe.
