### PR TITLE
feat(providersync): ClickHouse effect adapters for the 7 direct github work-item destinations (CHAOS-3123)

### DIFF
--- a/internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go
+++ b/internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go
@@ -1,0 +1,420 @@
+package providersync
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+)
+
+// GitHubAIAttributionClickHouseAdapter mirrors write_ai_attribution
+// (metrics/sinks/clickhouse/ai_attribution.py:103) and its _to_row projection.
+//
+// ai_attribution is the only work-item destination that is PARTITIONED
+// (PARTITION BY toYYYYMM(observed_at)) and the only one whose partition
+// expression is absent from its sorting key
+// (org_id, provider, subject_type, repo_id, subject_id, source).
+//
+// That is the PR #1535 shape, and the obvious response -- fence the readback on
+// toYYYYMM(observed_at) too -- was measured to be WRONG here. Measurement, on
+// the container this suite uses, of two rows sharing a sorting key either side
+// of a month boundary:
+//
+//	FINAL, default do_not_merge_across_partitions_select_final=0 -> 1 row
+//	FINAL, do_not_merge_across_partitions_select_final=1         -> 2 rows
+//	no FINAL                                                     -> 2 rows
+//
+// Under the default, FINAL merges ACROSS partitions: the sorting key has one
+// current row, the greatest computed_at, and the older observed_at row is
+// superseded rather than co-resident. Adding a partition predicate then filters
+// that single winner out and the readback answers Absent for a row that was
+// written and correctly superseded -- an endless replay, which is worse than
+// the duplicate it was meant to prevent.
+//
+// Fencing the sorting key alone and letting found > 1 answer Conflict fixes the
+// wrong answer but leaves the VERDICT settings-dependent: under
+// do_not_merge_across_partitions_select_final=1 a correctly superseded row comes
+// back as two rows and becomes a permanent Conflict, on a server knob this code
+// does not control.
+//
+// So this readback does not use FINAL at all. It resolves the winning row
+// explicitly with `ORDER BY computed_at DESC ... LIMIT 1 BY <sorting key>`,
+// which reproduces the ReplacingMergeTree rule (greatest version wins) as a
+// plain query. Measured on the same two-rows-across-a-month-boundary fixture:
+//
+//	LIMIT 1 BY, default knob -> 1 row (the later computed_at)
+//	LIMIT 1 BY, knob = 1     -> 1 row (the later computed_at)
+//	FINAL,      knob = 1     -> 2 rows
+//
+// LIMIT 1 BY rather than per-column argMax(col, computed_at) on purpose: it
+// takes one whole ROW, so a tie on computed_at cannot blend columns from two
+// different rows the way independent per-column argMax calls could. The
+// record_id tiebreaker makes the choice deterministic when versions do tie.
+//
+// The other six direct destinations keep FINAL: they are unpartitioned, and the
+// knob only governs cross-partition merging, so their verdicts are already
+// settings-independent.
+type GitHubAIAttributionClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubAIAttributionInsert = `INSERT INTO ai_attribution (record_id, org_id, provider, subject_type, subject_id, repo_id, kind, source, confidence, actor, evidence, observed_at, ingested_at, superseded_by, computed_at)`
+
+const gitHubAIAttributionSelectBase = `SELECT record_id, org_id, provider, subject_type, subject_id, repo_id, kind, source, confidence, actor, evidence, observed_at, ingested_at, superseded_by, computed_at FROM ai_attribution WHERE org_id = ? AND provider = ? AND subject_type = ? AND subject_id = ? AND source = ?`
+
+// gitHubAIAttributionSelectResolve collapses the matched rows to the single
+// current one, replacing FINAL. It must be appended AFTER the repo_id clause.
+const gitHubAIAttributionSelectResolve = ` ORDER BY computed_at DESC, record_id DESC LIMIT 1 BY org_id, provider, subject_type, repo_id, subject_id, source`
+
+type aiAttributionStoredRow struct {
+	RecordID     uuid.UUID
+	OrgID        uuid.UUID
+	Provider     string
+	SubjectType  string
+	SubjectID    string
+	RepoID       *uuid.UUID
+	Kind         string
+	Source       string
+	Confidence   float32
+	Actor        *string
+	Evidence     string
+	ObservedAt   time.Time
+	IngestedAt   time.Time
+	SupersededBy *uuid.UUID
+	ComputedAt   time.Time
+}
+
+// projectAIAttribution applies the coercions _to_row applies.
+//
+// One deliberate, declared divergence: Python stamps `computed_at` from
+// wall-clock inside _to_row, which no retry can reproduce. computed_at is the
+// ReplacingMergeTree version column, so a wall-clock stamp would make every
+// replay of a recovery snapshot write a strictly newer version and the readback
+// could never answer Exact for a replayed effect. Go stamps the unit's
+// normalizedAt, which already reaches this adapter as IngestedAt. The column
+// keeps its meaning (when this unit computed the row) and gains determinism.
+//
+// PRECONDITION -- SINGLE WRITER PER TABLE PER ORG, as for the other direct
+// destinations: sound only while Python's writers are stopped before Go's
+// start. See githubWorkItemRow.LastSynced for the full statement; the
+// activation layer owns enforcement.
+func projectAIAttribution(row githubAIAttributionRow) (aiAttributionStoredRow, error) {
+	evidence, err := pythonEvidenceJSON(row.Evidence)
+	if err != nil {
+		return aiAttributionStoredRow{}, err
+	}
+	return aiAttributionStoredRow{
+		RecordID: row.RecordID, OrgID: row.OrgID, Provider: row.Provider,
+		SubjectType: row.SubjectType, SubjectID: row.SubjectID,
+		RepoID: row.RepoID, Kind: row.Kind, Source: row.Source,
+		Confidence: float32(row.Confidence), Actor: row.Actor,
+		Evidence: evidence, ObservedAt: clickHouseMillis(row.ObservedAt),
+		IngestedAt: clickHouseMillis(row.IngestedAt), SupersededBy: row.SupersededBy,
+		ComputedAt: clickHouseMillis(row.IngestedAt),
+	}, nil
+}
+
+func (adapter GitHubAIAttributionClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubAIAttributionRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "ai_attribution", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	stored, err := projectAIAttributionRows(rows, identity)
+	if err != nil {
+		return err
+	}
+	if len(stored) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubAIAttributionInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range stored {
+		if err := batch.Append(
+			row.RecordID, row.OrgID, row.Provider, row.SubjectType, row.SubjectID,
+			row.RepoID, row.Kind, row.Source, row.Confidence, row.Actor,
+			row.Evidence, row.ObservedAt, row.IngestedAt, row.SupersededBy,
+			row.ComputedAt,
+		); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubAIAttributionClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubAIAttributionRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "ai_attribution", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	stored, err := projectAIAttributionRows(rows, identity)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if len(stored) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(stored, func(expected aiAttributionStoredRow) (EffectInspection, error) {
+		query := gitHubAIAttributionSelectBase
+		arguments := []any{
+			expected.OrgID, expected.Provider, expected.SubjectType,
+			expected.SubjectID, expected.Source,
+		}
+		// repo_id is a Nullable key column (allow_nullable_key=1). `= NULL` is
+		// never true, so a NULL repo_id needs the IS NULL form or the readback
+		// would report a written row as absent and rewrite it forever.
+		if expected.RepoID == nil {
+			query += ` AND repo_id IS NULL`
+		} else {
+			query += ` AND repo_id = ?`
+			arguments = append(arguments, *expected.RepoID)
+		}
+		query += gitHubAIAttributionSelectResolve
+		result, err := adapter.Conn.Query(ctx, query, arguments...)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual aiAttributionStoredRow
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.RecordID, &actual.OrgID, &actual.Provider,
+				&actual.SubjectType, &actual.SubjectID, &actual.RepoID,
+				&actual.Kind, &actual.Source, &actual.Confidence, &actual.Actor,
+				&actual.Evidence, &actual.ObservedAt, &actual.IngestedAt,
+				&actual.SupersededBy, &actual.ComputedAt,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.ComputedAt, expected.ComputedAt); final {
+			return verdict, nil
+		}
+		if actual.RecordID != expected.RecordID || actual.OrgID != expected.OrgID ||
+			actual.Provider != expected.Provider ||
+			actual.SubjectType != expected.SubjectType ||
+			actual.SubjectID != expected.SubjectID ||
+			!uuidPointersEqual(actual.RepoID, expected.RepoID) ||
+			actual.Kind != expected.Kind || actual.Source != expected.Source ||
+			actual.Confidence != expected.Confidence ||
+			!stringPointersEqual(actual.Actor, expected.Actor) ||
+			actual.Evidence != expected.Evidence ||
+			!actual.ObservedAt.Equal(expected.ObservedAt) ||
+			!actual.IngestedAt.Equal(expected.IngestedAt) ||
+			!uuidPointersEqual(actual.SupersededBy, expected.SupersededBy) {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+func projectAIAttributionRows(
+	rows []githubAIAttributionRow,
+	identity GitHubWorkItemEffectIdentity,
+) ([]aiAttributionStoredRow, error) {
+	// ai_attribution.org_id is a UUID column while the claim carries the tenant
+	// as a string; compare through the parsed form so a differently-formatted
+	// but equal UUID is not read as a cross-tenant row.
+	tenant, err := uuid.Parse(identity.OrgID)
+	if err != nil {
+		return nil, ErrInvalidConfiguration
+	}
+	stored := make([]aiAttributionStoredRow, 0, len(rows))
+	for _, row := range rows {
+		if row.OrgID != tenant {
+			return nil, ErrInvalidConfiguration
+		}
+		projected, err := projectAIAttribution(row)
+		if err != nil {
+			return nil, err
+		}
+		stored = append(stored, projected)
+	}
+	// Same-key collision inside one batch, same reasoning and same measured
+	// keep-last rule as the other six destinations (see dedupeBySortingKey).
+	// Reachable here whenever one pull request yields two signals from the same
+	// source, since `source` is part of the key but the signal index is not.
+	return dedupeBySortingKey(stored, aiAttributionSortingKey), nil
+}
+
+func aiAttributionSortingKey(row aiAttributionStoredRow) string {
+	repoID := "null"
+	if row.RepoID != nil {
+		repoID = row.RepoID.String()
+	}
+	return strings.Join([]string{
+		row.OrgID.String(), row.Provider, row.SubjectType, repoID,
+		row.SubjectID, row.Source,
+	}, workItemKeySeparator)
+}
+
+// -----------------------------------------------------------------------------
+// evidence encoding
+// -----------------------------------------------------------------------------
+
+// pythonEvidenceKeyOrder pins the insertion order of every evidence shape the
+// Python detectors build, because `json.dumps` serialises a dict in insertion
+// order while Go's encoding/json sorts map keys. Two of these five shapes
+// disagree with alphabetical order (bot_author and pr_body), so marshalling the
+// map directly would store bytes Python never writes.
+//
+// Keyed by the sorted key set so lookup does not depend on Go's map ordering.
+var pythonEvidenceKeyOrder = map[string][]string{
+	"label":                                 {"label"},
+	"app_slug|known_ai_bot|login|user_type": {"login", "user_type", "app_slug", "known_ai_bot"},
+	"trailer_key|trailer_value":             {"trailer_key", "trailer_value"},
+	"branch|matched_pattern":                {"branch", "matched_pattern"},
+	"matched_pattern|matched_text":          {"matched_text", "matched_pattern"},
+}
+
+// pythonEvidenceJSON renders evidence exactly as
+// `json.dumps(evidence, default=str)` does: insertion order, ", " and ": "
+// separators, and ensure_ascii escaping.
+//
+// It fails closed on an unknown key set rather than falling back to sorted
+// order. A silent fallback would store a subtly different string for a shape
+// nobody had reviewed, and no test asserting decoded evidence could see it.
+func pythonEvidenceJSON(evidence map[string]any) (string, error) {
+	if evidence == nil {
+		return "", ErrInvalidConfiguration
+	}
+	keys := make([]string, 0, len(evidence))
+	for key := range evidence {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	order, known := pythonEvidenceKeyOrder[strings.Join(keys, "|")]
+	if !known || len(order) != len(evidence) {
+		return "", ErrInvalidConfiguration
+	}
+	var builder strings.Builder
+	builder.WriteByte('{')
+	for index, key := range order {
+		value, present := evidence[key]
+		if !present {
+			return "", ErrInvalidConfiguration
+		}
+		if index > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(pythonJSONString(key))
+		builder.WriteString(": ")
+		encoded, err := pythonJSONValue(value)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(encoded)
+	}
+	builder.WriteByte('}')
+	return builder.String(), nil
+}
+
+// pythonJSONValue encodes the value types the evidence detectors actually
+// produce. Anything else is refused: `default=str` would stringify it on the
+// Python side in a form this code has not been shown to reproduce, and guessing
+// is how a parity break gets stored.
+func pythonJSONValue(value any) (string, error) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return pythonJSONString(typed), nil
+	case *string:
+		if typed == nil {
+			return "null", nil
+		}
+		return pythonJSONString(*typed), nil
+	case bool:
+		if typed {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", ErrInvalidConfiguration
+	}
+}
+
+// pythonJSONString mirrors CPython's json encoder for str: it escapes the two
+// mandatory characters and the short-form control codes, emits \uXXXX for the
+// remaining control codes, and — because ensure_ascii defaults to True —
+// escapes every non-ASCII rune, using a surrogate pair above the BMP. It does
+// NOT escape <, > or &, which Go's encoding/json would.
+func pythonJSONString(value string) string {
+	var builder strings.Builder
+	builder.WriteByte('"')
+	for _, runeValue := range value {
+		switch runeValue {
+		case '"':
+			builder.WriteString(`\"`)
+		case '\\':
+			builder.WriteString(`\\`)
+		case '\n':
+			builder.WriteString(`\n`)
+		case '\r':
+			builder.WriteString(`\r`)
+		case '\t':
+			builder.WriteString(`\t`)
+		case '\b':
+			builder.WriteString(`\b`)
+		case '\f':
+			builder.WriteString(`\f`)
+		default:
+			switch {
+			case runeValue < 0x20:
+				builder.WriteString(pythonJSONEscape(uint16(runeValue)))
+			case runeValue < 0x7f:
+				builder.WriteRune(runeValue)
+			case runeValue <= 0xffff:
+				builder.WriteString(pythonJSONEscape(uint16(runeValue)))
+			default:
+				high, low := utf16SurrogatePair(runeValue)
+				builder.WriteString(pythonJSONEscape(high))
+				builder.WriteString(pythonJSONEscape(low))
+			}
+		}
+	}
+	builder.WriteByte('"')
+	return builder.String()
+}
+
+func pythonJSONEscape(value uint16) string {
+	hex := strconv.FormatUint(uint64(value), 16)
+	return `\u` + strings.Repeat("0", 4-len(hex)) + hex
+}
+
+func utf16SurrogatePair(value rune) (uint16, uint16) {
+	value -= 0x10000
+	return uint16(0xd800 + (value >> 10)), uint16(0xdc00 + (value & 0x3ff))
+}
+
+var _ GitHubWorkItemEffectAdapter = GitHubAIAttributionClickHouseAdapter{}

--- a/internal/providersync/github_work_items_direct_effects_clickhouse.go
+++ b/internal/providersync/github_work_items_direct_effects_clickhouse.go
@@ -1,0 +1,1214 @@
+package providersync
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+)
+
+// Concrete ClickHouse adapters for the six direct fact surfaces the Python
+// composite work-item unit writes through metrics/sinks/clickhouse/work_graph.py.
+// The seventh direct surface, ai_attribution, lives beside its own Python
+// producer in github_work_items_ai_attribution_effects_clickhouse.go because it
+// is the only partitioned destination and the only one with a JSON-encoded
+// column.
+//
+// Every column list below is the Python sink's own column list, in the Python
+// sink's own order, including its omissions. Under D16 an omission is behavior:
+// `work_items` never writes description/priority_raw/service_class/due_at and
+// `work_item_transitions` never writes provider, even though all five columns
+// exist on the tables. Writing them here would diverge from the running system
+// on a whole-row ReplacingMergeTree replacement.
+
+// workItemReadbackVerdict folds a readback row count into a comparator answer.
+//
+// HONEST SCOPE: the `> 1` arm is defense-in-depth, NOT the duplicate protection.
+// Every readback here fences the destination's full sorting key and then
+// collapses (FINAL for the six unpartitioned tables, LIMIT 1 BY for
+// ai_attribution), so more than one row cannot come back and this arm is
+// unreachable in all seven adapters. It is kept because a future change to a
+// WHERE clause or a collapse strategy would make it reachable again, and
+// answering Absent there would rewrite forever -- the rewrite adds a row and
+// cannot remove the duplicate that produced the verdict. Conflict is the only
+// answer that terminates.
+//
+// The real same-key protection is dedupeBySortingKey, which collapses
+// collisions inside the batch BEFORE they reach the write or the expected set.
+// That is what a duplicate actually hits.
+//
+// The arms below are mutually exclusive, so their ORDER is not load-bearing:
+// exactly one of {>1, <1, ==1} holds for every integer, making a swap
+// equivalent over the whole input domain.
+//
+// The boolean reports whether the verdict is final; false means "exactly one
+// row was found, the caller must now compare it".
+func workItemReadbackVerdict(found int) (EffectInspection, bool) {
+	switch {
+	case found > 1:
+		return EffectConflict, true
+	case found < 1:
+		return EffectAbsent, true
+	default:
+		return EffectExact, false
+	}
+}
+
+// workItemVersionVerdict compares the ReplacingMergeTree version column before
+// any field comparison. An older stored row means our write has not landed yet
+// (replay); a newer one means somebody else owns the key (ambiguous).
+func workItemVersionVerdict(actual, expected time.Time) (EffectInspection, bool) {
+	switch {
+	case actual.IsZero():
+		return EffectAbsent, true
+	case actual.UTC().Before(expected.UTC()):
+		return EffectAbsent, true
+	case actual.UTC().After(expected.UTC()):
+		return EffectConflict, true
+	default:
+		return EffectExact, false
+	}
+}
+
+// emptyEffectInspection mirrors the Python sink's `if not rows: return`. A
+// destination that produced no rows was still evaluated; it has nothing to read
+// back, so it reports Absent and the committer treats it as nothing to commit.
+func emptyEffectInspection() EffectInspection { return EffectAbsent }
+
+func workItemAdapterGuard(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+	destination string,
+	conn driver.Conn,
+	rowCount int,
+) error {
+	if ctx == nil || identity.Destination != destination ||
+		effect.Destination != destination || identity.OrgID == "" ||
+		identity.RowCount != len(effect.Rows) {
+		return ErrInvalidConfiguration
+	}
+	if rowCount > 0 && conn == nil {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// work_items
+// -----------------------------------------------------------------------------
+
+// GitHubWorkItemsClickHouseAdapter mirrors write_work_items
+// (metrics/sinks/clickhouse/work_graph.py:656).
+type GitHubWorkItemsClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubWorkItemsInsert = `INSERT INTO work_items (repo_id, work_item_id, provider, title, type, status, status_raw, project_key, project_id, native_team_key, project_name, assignees, reporter, created_at, updated_at, started_at, completed_at, closed_at, labels, story_points, sprint_id, sprint_name, parent_id, epic_id, url, last_synced, org_id, source_id)`
+
+const gitHubWorkItemsSelect = `SELECT repo_id, work_item_id, provider, title, type, status, status_raw, project_key, project_id, native_team_key, project_name, assignees, reporter, created_at, updated_at, started_at, completed_at, closed_at, labels, story_points, sprint_id, sprint_name, parent_id, epic_id, url, last_synced, org_id, source_id FROM work_items FINAL WHERE org_id = ? AND repo_id = ? AND work_item_id = ?`
+
+// workItemStoredRow is the stored projection of the columns this unit owns. It
+// is deliberately not githubWorkItemRow: the semantic row carries fields this
+// unit never writes, and comparing those would assert ownership Python does not
+// take.
+type workItemStoredRow struct {
+	RepoID        uuid.UUID
+	WorkItemID    string
+	Provider      string
+	Title         string
+	Type          string
+	Status        string
+	StatusRaw     string
+	ProjectKey    string
+	ProjectID     string
+	NativeTeamKey string
+	ProjectName   string
+	Assignees     []string
+	Reporter      string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	StartedAt     *time.Time
+	CompletedAt   *time.Time
+	ClosedAt      *time.Time
+	Labels        []string
+	StoryPoints   *float64
+	SprintID      string
+	SprintName    string
+	ParentID      string
+	EpicID        string
+	URL           string
+	LastSynced    time.Time
+	OrgID         string
+	SourceID      *uuid.UUID
+}
+
+// projectWorkItem applies exactly the coercions write_work_items applies.
+func projectWorkItem(row githubWorkItemRow) workItemStoredRow {
+	repoID := uuid.Nil
+	if row.RepoID != nil {
+		repoID = *row.RepoID
+	}
+	assignees, labels := row.Assignees, row.Labels
+	if assignees == nil {
+		assignees = []string{}
+	}
+	if labels == nil {
+		labels = []string{}
+	}
+	return workItemStoredRow{
+		RepoID: repoID, WorkItemID: row.WorkItemID, Provider: row.Provider,
+		Title: row.Title, Type: row.Type, Status: row.Status,
+		StatusRaw:     derefString(row.StatusRaw),
+		ProjectKey:    derefString(row.ProjectKey),
+		ProjectID:     derefString(row.ProjectID),
+		NativeTeamKey: derefString(row.NativeTeamKey),
+		ProjectName:   derefString(row.ProjectName),
+		Assignees:     assignees, Reporter: derefString(row.Reporter),
+		CreatedAt: clickHouseMillis(row.CreatedAt), UpdatedAt: clickHouseMillis(row.UpdatedAt),
+		StartedAt: utcPointer(row.StartedAt), CompletedAt: utcPointer(row.CompletedAt),
+		ClosedAt: utcPointer(row.ClosedAt), Labels: labels,
+		StoryPoints: row.StoryPoints, SprintID: derefString(row.SprintID),
+		SprintName: derefString(row.SprintName), ParentID: derefString(row.ParentID),
+		EpicID: derefString(row.EpicID), URL: derefString(row.URL),
+		LastSynced: clickHouseMillis(row.LastSynced), OrgID: row.OrgID,
+		// source_id is NULL for native sync; only the external-ingest sink
+		// stamps it (CHAOS-2698 D1), and this unit is never that writer.
+		SourceID: nil,
+	}
+}
+
+func (adapter GitHubWorkItemsClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubWorkItemRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_items", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemSortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubWorkItemsInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(projectWorkItem(row).values()...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubWorkItemsClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubWorkItemRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_items", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemSortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubWorkItemRow) (EffectInspection, error) {
+		expected := projectWorkItem(row)
+		result, err := adapter.Conn.Query(
+			ctx, gitHubWorkItemsSelect,
+			expected.OrgID, expected.RepoID, expected.WorkItemID,
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual workItemStoredRow
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.RepoID, &actual.WorkItemID, &actual.Provider, &actual.Title,
+				&actual.Type, &actual.Status, &actual.StatusRaw, &actual.ProjectKey,
+				&actual.ProjectID, &actual.NativeTeamKey, &actual.ProjectName,
+				&actual.Assignees, &actual.Reporter, &actual.CreatedAt,
+				&actual.UpdatedAt, &actual.StartedAt, &actual.CompletedAt,
+				&actual.ClosedAt, &actual.Labels, &actual.StoryPoints,
+				&actual.SprintID, &actual.SprintName, &actual.ParentID,
+				&actual.EpicID, &actual.URL, &actual.LastSynced, &actual.OrgID,
+				&actual.SourceID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, expected.LastSynced); final {
+			return verdict, nil
+		}
+		return workItemStoredRowsEqual(expected, actual), nil
+	})
+}
+
+func workItemStoredRowsEqual(expected, actual workItemStoredRow) EffectInspection {
+	if expected.RepoID != actual.RepoID ||
+		expected.WorkItemID != actual.WorkItemID ||
+		expected.Provider != actual.Provider || expected.Title != actual.Title ||
+		expected.Type != actual.Type || expected.Status != actual.Status ||
+		expected.StatusRaw != actual.StatusRaw ||
+		expected.ProjectKey != actual.ProjectKey ||
+		expected.ProjectID != actual.ProjectID ||
+		expected.NativeTeamKey != actual.NativeTeamKey ||
+		expected.ProjectName != actual.ProjectName ||
+		!stringSlicesEqual(expected.Assignees, actual.Assignees) ||
+		expected.Reporter != actual.Reporter ||
+		!expected.CreatedAt.Equal(actual.CreatedAt) ||
+		!expected.UpdatedAt.Equal(actual.UpdatedAt) ||
+		!timePointersEqual(expected.StartedAt, actual.StartedAt) ||
+		!timePointersEqual(expected.CompletedAt, actual.CompletedAt) ||
+		!timePointersEqual(expected.ClosedAt, actual.ClosedAt) ||
+		!stringSlicesEqual(expected.Labels, actual.Labels) ||
+		!float64PointersEqual(expected.StoryPoints, actual.StoryPoints) ||
+		expected.SprintID != actual.SprintID ||
+		expected.SprintName != actual.SprintName ||
+		expected.ParentID != actual.ParentID || expected.EpicID != actual.EpicID ||
+		expected.URL != actual.URL || expected.OrgID != actual.OrgID ||
+		!uuidPointersEqual(expected.SourceID, actual.SourceID) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+// -----------------------------------------------------------------------------
+// work_item_transitions
+// -----------------------------------------------------------------------------
+
+// GitHubWorkItemTransitionsClickHouseAdapter mirrors write_work_item_transitions
+// (metrics/sinks/clickhouse/work_graph.py:744). Note the absent `provider`
+// column: the Python sink builds no provider value for this table, so the stored
+// row carries the column default.
+type GitHubWorkItemTransitionsClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubWorkItemTransitionsInsert = `INSERT INTO work_item_transitions (repo_id, work_item_id, occurred_at, from_status, to_status, from_status_raw, to_status_raw, actor, last_synced, org_id, source_id)`
+
+const gitHubWorkItemTransitionsSelect = `SELECT repo_id, work_item_id, occurred_at, from_status, to_status, from_status_raw, to_status_raw, actor, last_synced, org_id, source_id FROM work_item_transitions FINAL WHERE org_id = ? AND repo_id = ? AND work_item_id = ? AND occurred_at = toDateTime64(?, 3, 'UTC')`
+
+type workItemTransitionStoredRow struct {
+	RepoID        uuid.UUID
+	WorkItemID    string
+	OccurredAt    time.Time
+	FromStatus    string
+	ToStatus      string
+	FromStatusRaw string
+	ToStatusRaw   string
+	Actor         string
+	LastSynced    time.Time
+	OrgID         string
+	SourceID      *uuid.UUID
+}
+
+func projectWorkItemTransition(row githubWorkItemTransitionRow) workItemTransitionStoredRow {
+	return workItemTransitionStoredRow{
+		// The semantic transition row carries no repo_id, so Python's
+		// `if repo_id_val: ... else uuid.UUID(int=0)` always takes the else
+		// branch for this unit.
+		RepoID: uuid.Nil, WorkItemID: row.WorkItemID,
+		OccurredAt: clickHouseMillis(row.OccurredAt), FromStatus: row.FromStatus,
+		ToStatus:      row.ToStatus,
+		FromStatusRaw: derefString(row.FromStatusRaw),
+		ToStatusRaw:   derefString(row.ToStatusRaw),
+		Actor:         derefString(row.Actor),
+		LastSynced:    clickHouseMillis(row.LastSynced), OrgID: row.OrgID, SourceID: nil,
+	}
+}
+
+func (adapter GitHubWorkItemTransitionsClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubWorkItemTransitionRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_transitions", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemTransitionSortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubWorkItemTransitionsInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(projectWorkItemTransition(row).values()...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubWorkItemTransitionsClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubWorkItemTransitionRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_transitions", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemTransitionSortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubWorkItemTransitionRow) (EffectInspection, error) {
+		expected := projectWorkItemTransition(row)
+		result, err := adapter.Conn.Query(
+			ctx, gitHubWorkItemTransitionsSelect,
+			expected.OrgID, expected.RepoID, expected.WorkItemID,
+			clickHouseMillisParam(expected.OccurredAt),
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual workItemTransitionStoredRow
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.RepoID, &actual.WorkItemID, &actual.OccurredAt,
+				&actual.FromStatus, &actual.ToStatus, &actual.FromStatusRaw,
+				&actual.ToStatusRaw, &actual.Actor, &actual.LastSynced,
+				&actual.OrgID, &actual.SourceID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, expected.LastSynced); final {
+			return verdict, nil
+		}
+		if expected.RepoID != actual.RepoID ||
+			expected.WorkItemID != actual.WorkItemID ||
+			!expected.OccurredAt.Equal(actual.OccurredAt) ||
+			expected.FromStatus != actual.FromStatus ||
+			expected.ToStatus != actual.ToStatus ||
+			expected.FromStatusRaw != actual.FromStatusRaw ||
+			expected.ToStatusRaw != actual.ToStatusRaw ||
+			expected.Actor != actual.Actor || expected.OrgID != actual.OrgID ||
+			!uuidPointersEqual(expected.SourceID, actual.SourceID) {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+// -----------------------------------------------------------------------------
+// work_item_dependencies
+// -----------------------------------------------------------------------------
+
+// GitHubWorkItemDependenciesClickHouseAdapter mirrors
+// write_work_item_dependencies (metrics/sinks/clickhouse/work_graph.py:334),
+// which routes through core._insert_rows: dataclass fields pass through
+// unchanged apart from datetime normalisation, so the Nullable columns keep
+// their NULLs rather than collapsing to "".
+type GitHubWorkItemDependenciesClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubWorkItemDependenciesInsert = `INSERT INTO work_item_dependencies (source_work_item_id, target_work_item_id, relationship_type, relationship_type_raw, relationship_semantics_version, last_synced, org_id, source_id)`
+
+const gitHubWorkItemDependenciesSelect = `SELECT source_work_item_id, target_work_item_id, relationship_type, relationship_type_raw, relationship_semantics_version, last_synced, org_id, source_id FROM work_item_dependencies FINAL WHERE org_id = ? AND source_work_item_id = ? AND target_work_item_id = ? AND relationship_type = ?`
+
+func (adapter GitHubWorkItemDependenciesClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubWorkItemDependencyRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_dependencies", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemDependencySortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubWorkItemDependenciesInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(workItemDependencyValues(row)...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubWorkItemDependenciesClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubWorkItemDependencyRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_dependencies", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemDependencySortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubWorkItemDependencyRow) (EffectInspection, error) {
+		result, err := adapter.Conn.Query(
+			ctx, gitHubWorkItemDependenciesSelect,
+			row.OrgID, row.SourceWorkItemID, row.TargetWorkItemID, row.RelationshipType,
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual githubWorkItemDependencyRow
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.SourceWorkItemID, &actual.TargetWorkItemID,
+				&actual.RelationshipType, &actual.RelationshipTypeRaw,
+				&actual.RelationshipSemanticsVersion, &actual.LastSynced,
+				&actual.OrgID, &actual.SourceID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, clickHouseMillis(row.LastSynced)); final {
+			return verdict, nil
+		}
+		if actual.SourceWorkItemID != row.SourceWorkItemID ||
+			actual.TargetWorkItemID != row.TargetWorkItemID ||
+			actual.RelationshipType != row.RelationshipType ||
+			actual.RelationshipTypeRaw != row.RelationshipTypeRaw ||
+			actual.RelationshipSemanticsVersion != row.RelationshipSemanticsVersion ||
+			actual.OrgID != row.OrgID ||
+			!uuidPointersEqual(actual.SourceID, row.SourceID) {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+// -----------------------------------------------------------------------------
+// work_item_reopen_events
+// -----------------------------------------------------------------------------
+
+// GitHubWorkItemReopenEventsClickHouseAdapter mirrors
+// write_work_item_reopen_events (metrics/sinks/clickhouse/work_graph.py:352).
+type GitHubWorkItemReopenEventsClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubWorkItemReopenEventsInsert = `INSERT INTO work_item_reopen_events (work_item_id, occurred_at, from_status, to_status, from_status_raw, to_status_raw, actor, last_synced, org_id)`
+
+const gitHubWorkItemReopenEventsSelect = `SELECT work_item_id, occurred_at, from_status, to_status, from_status_raw, to_status_raw, actor, last_synced, org_id FROM work_item_reopen_events FINAL WHERE org_id = ? AND work_item_id = ? AND occurred_at = toDateTime64(?, 3, 'UTC')`
+
+func (adapter GitHubWorkItemReopenEventsClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubWorkItemReopenRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_reopen_events", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemReopenSortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubWorkItemReopenEventsInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(workItemReopenValues(row)...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubWorkItemReopenEventsClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubWorkItemReopenRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_reopen_events", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemReopenSortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubWorkItemReopenRow) (EffectInspection, error) {
+		result, err := adapter.Conn.Query(
+			ctx, gitHubWorkItemReopenEventsSelect,
+			row.OrgID, row.WorkItemID, clickHouseMillisParam(row.OccurredAt),
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual githubWorkItemReopenRow
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.WorkItemID, &actual.OccurredAt, &actual.FromStatus,
+				&actual.ToStatus, &actual.FromStatusRaw, &actual.ToStatusRaw,
+				&actual.Actor, &actual.LastSynced, &actual.OrgID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, clickHouseMillis(row.LastSynced)); final {
+			return verdict, nil
+		}
+		if actual.WorkItemID != row.WorkItemID ||
+			!actual.OccurredAt.Equal(clickHouseMillis(row.OccurredAt)) ||
+			actual.FromStatus != row.FromStatus || actual.ToStatus != row.ToStatus ||
+			!stringPointersEqual(actual.FromStatusRaw, row.FromStatusRaw) ||
+			!stringPointersEqual(actual.ToStatusRaw, row.ToStatusRaw) ||
+			!stringPointersEqual(actual.Actor, row.Actor) ||
+			actual.OrgID != row.OrgID {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+// -----------------------------------------------------------------------------
+// work_item_interactions
+// -----------------------------------------------------------------------------
+
+// GitHubWorkItemInteractionsClickHouseAdapter mirrors
+// write_work_item_interactions (metrics/sinks/clickhouse/work_graph.py:373).
+type GitHubWorkItemInteractionsClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubWorkItemInteractionsInsert = `INSERT INTO work_item_interactions (work_item_id, provider, interaction_type, occurred_at, actor, body_length, last_synced, org_id)`
+
+const gitHubWorkItemInteractionsSelect = `SELECT work_item_id, provider, interaction_type, occurred_at, actor, body_length, last_synced, org_id FROM work_item_interactions FINAL WHERE org_id = ? AND work_item_id = ? AND occurred_at = toDateTime64(?, 3, 'UTC') AND interaction_type = ?`
+
+func (adapter GitHubWorkItemInteractionsClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubWorkItemInteractionRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_interactions", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		// body_length is UInt32; a negative length cannot round-trip and must
+		// never reach the driver as a silent wrap.
+		if row.OrgID != identity.OrgID || row.BodyLength < 0 {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemInteractionSortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubWorkItemInteractionsInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(workItemInteractionValues(row)...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubWorkItemInteractionsClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubWorkItemInteractionRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "work_item_interactions", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID || row.BodyLength < 0 {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, workItemInteractionSortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubWorkItemInteractionRow) (EffectInspection, error) {
+		result, err := adapter.Conn.Query(
+			ctx, gitHubWorkItemInteractionsSelect,
+			row.OrgID, row.WorkItemID, clickHouseMillisParam(row.OccurredAt), row.InteractionType,
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual githubWorkItemInteractionRow
+		var actualBodyLength uint32
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.WorkItemID, &actual.Provider, &actual.InteractionType,
+				&actual.OccurredAt, &actual.Actor, &actualBodyLength,
+				&actual.LastSynced, &actual.OrgID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, clickHouseMillis(row.LastSynced)); final {
+			return verdict, nil
+		}
+		if actual.WorkItemID != row.WorkItemID || actual.Provider != row.Provider ||
+			actual.InteractionType != row.InteractionType ||
+			!actual.OccurredAt.Equal(clickHouseMillis(row.OccurredAt)) ||
+			!stringPointersEqual(actual.Actor, row.Actor) ||
+			actualBodyLength != uint32(row.BodyLength) ||
+			actual.OrgID != row.OrgID {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+// -----------------------------------------------------------------------------
+// sprints
+// -----------------------------------------------------------------------------
+
+// GitHubSprintsClickHouseAdapter mirrors write_sprints
+// (metrics/sinks/clickhouse/work_graph.py:393), including its pre-insert
+// `replace(native_team_key or "")`: the column is a non-nullable String, so a
+// missing native team key is stored as the empty string, not NULL.
+type GitHubSprintsClickHouseAdapter struct{ Conn driver.Conn }
+
+const gitHubSprintsInsert = `INSERT INTO sprints (provider, sprint_id, native_team_key, name, state, started_at, ended_at, completed_at, last_synced, org_id)`
+
+const gitHubSprintsSelect = `SELECT provider, sprint_id, native_team_key, name, state, started_at, ended_at, completed_at, last_synced, org_id FROM sprints FINAL WHERE org_id = ? AND provider = ? AND sprint_id = ?`
+
+func (adapter GitHubSprintsClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := decodeEffectRows[githubSprintRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "sprints", adapter.Conn, len(rows),
+	); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, sprintSortingKey)
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := adapter.Conn.PrepareBatch(ctx, gitHubSprintsInsert)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(sprintValues(row)...); err != nil {
+			return err
+		}
+	}
+	return batch.Send()
+}
+
+func (adapter GitHubSprintsClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := decodeEffectRows[githubSprintRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := workItemAdapterGuard(
+		ctx, identity, effect, "sprints", adapter.Conn, len(rows),
+	); err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range rows {
+		if row.OrgID != identity.OrgID {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	rows = dedupeBySortingKey(rows, sprintSortingKey)
+	if len(rows) == 0 {
+		return emptyEffectInspection(), nil
+	}
+	return foldWorkItemInspections(rows, func(row githubSprintRow) (EffectInspection, error) {
+		result, err := adapter.Conn.Query(
+			ctx, gitHubSprintsSelect, row.OrgID, row.Provider, row.SprintID,
+		)
+		if err != nil {
+			return EffectConflict, err
+		}
+		defer result.Close()
+		var actual githubSprintRow
+		var actualNativeTeamKey string
+		found := 0
+		for result.Next() {
+			if err := result.Scan(
+				&actual.Provider, &actual.SprintID, &actualNativeTeamKey,
+				&actual.Name, &actual.State, &actual.StartedAt, &actual.EndedAt,
+				&actual.CompletedAt, &actual.LastSynced, &actual.OrgID,
+			); err != nil {
+				return EffectConflict, err
+			}
+			found++
+		}
+		if err := result.Err(); err != nil {
+			return EffectConflict, err
+		}
+		if verdict, final := workItemReadbackVerdict(found); final {
+			return verdict, nil
+		}
+		if verdict, final := workItemVersionVerdict(actual.LastSynced, clickHouseMillis(row.LastSynced)); final {
+			return verdict, nil
+		}
+		if actual.Provider != row.Provider || actual.SprintID != row.SprintID ||
+			actualNativeTeamKey != derefString(row.NativeTeamKey) ||
+			!stringPointersEqual(actual.Name, row.Name) ||
+			!stringPointersEqual(actual.State, row.State) ||
+			!timePointersEqual(actual.StartedAt, utcPointer(row.StartedAt)) ||
+			!timePointersEqual(actual.EndedAt, utcPointer(row.EndedAt)) ||
+			!timePointersEqual(actual.CompletedAt, utcPointer(row.CompletedAt)) ||
+			actual.OrgID != row.OrgID {
+			return EffectConflict, nil
+		}
+		return EffectExact, nil
+	})
+}
+
+// -----------------------------------------------------------------------------
+// shared folding and value helpers
+// -----------------------------------------------------------------------------
+
+// foldWorkItemInspections reduces per-row verdicts to one batch verdict. A
+// mixed batch is a conflict rather than a replay: replaying it would rewrite
+// the rows that already landed, and the committer cannot express "replay these
+// three of five".
+func foldWorkItemInspections[T any](
+	rows []T,
+	inspect func(T) (EffectInspection, error),
+) (EffectInspection, error) {
+	exact, absent := 0, 0
+	for _, row := range rows {
+		inspection, err := inspect(row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(rows):
+		return EffectExact, nil
+	case absent == len(rows):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func utcPointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	utc := clickHouseMillis(*value)
+	return &utc
+}
+
+// clickHouseMillis renders an instant at the precision every destination column
+// here actually stores, DateTime64(3).
+//
+// The projection is the answer to "what will ClickHouse hold after this write",
+// so it must round-trip: an untruncated expectation compares .123456789 against
+// a stored .123, the version verdict reads Absent for a row that landed, and
+// the committer rewrites it every pass. The route truncates normalizedAt at
+// entry as well; this makes the adapter correct for ANY caller rather than only
+// a well-behaved one, since a sub-millisecond expectation is never satisfiable.
+func clickHouseMillis(value time.Time) time.Time {
+	return value.UTC().Truncate(workItemColumnPrecision)
+}
+
+// workItemColumnPrecision is the stored precision EVERY timestamp column across
+// these seven destinations currently has: DateTime64(3), milliseconds.
+//
+// It is a single constant rather than a per-destination table because the seven
+// tables agree today -- but that agreement is an assumption about the schema,
+// not a property of it, and the assumption is load-bearing in both directions:
+// truncating coarser than the column stores makes the comparator reject a row
+// it wrote, and truncating finer leaves a value the column cannot hold, which
+// is the same permanent-Absent rewrite loop either way.
+//
+// So it is ASSERTED, not assumed:
+// TestWorkItemTimestampColumnsAllHaveTheAssumedPrecision reads the real
+// migrated schema and fails if any timestamp column disagrees. A sibling lane
+// hit exactly this shape one table over -- a version column that was plain
+// DateTime (seconds) while the shared helper truncated to milliseconds -- so if
+// that test ever fails, the fix is to make the truncation per-destination
+// rather than to widen the constant.
+const workItemColumnPrecision = time.Millisecond
+
+// clickHouseMillisParam renders an instant for use as an EQUALITY PARAMETER
+// against a DateTime64(3) column.
+//
+// A bound time.Time does not work: measured against a real server, a row whose
+// stored occurred_at scans back Equal() to the expectation still matched ZERO
+// rows under `occurred_at = ?`, because the driver binds the parameter without
+// the sub-second component. The readback then reports Absent for a row that is
+// present and the committer rewrites it forever.
+//
+// Every fixture in this suite previously used a whole second, so the truncated
+// parameter happened to equal the stored value and the defect was invisible.
+//
+// The value is formatted to millisecond precision and interpreted explicitly as
+// UTC, which keeps the predicate independent of the server timezone; the column
+// itself is naive DateTime64(3). The column stays bare on the left-hand side so
+// the primary-key index can still prune.
+func clickHouseMillisParam(value time.Time) string {
+	return clickHouseMillis(value).Format("2006-01-02 15:04:05.000")
+}
+
+func float64PointersEqual(left, right *float64) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func uuidPointersEqual(left, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+var _ GitHubWorkItemEffectAdapter = GitHubWorkItemsClickHouseAdapter{}
+var _ GitHubWorkItemEffectAdapter = GitHubWorkItemTransitionsClickHouseAdapter{}
+var _ GitHubWorkItemEffectAdapter = GitHubWorkItemDependenciesClickHouseAdapter{}
+var _ GitHubWorkItemEffectAdapter = GitHubWorkItemReopenEventsClickHouseAdapter{}
+var _ GitHubWorkItemEffectAdapter = GitHubWorkItemInteractionsClickHouseAdapter{}
+var _ GitHubWorkItemEffectAdapter = GitHubSprintsClickHouseAdapter{}
+
+// -----------------------------------------------------------------------------
+// ordered insert values
+// -----------------------------------------------------------------------------
+//
+// One definition of each destination's value order, used by the writer above
+// AND by the differential oracle that compares it against the real Python
+// sink's insert matrix. Duplicating the order in the test would let the two
+// drift together and agree while both were wrong.
+
+func (row workItemStoredRow) values() []any {
+	return []any{
+		row.RepoID, row.WorkItemID, row.Provider, row.Title, row.Type,
+		row.Status, row.StatusRaw, row.ProjectKey, row.ProjectID,
+		row.NativeTeamKey, row.ProjectName, row.Assignees, row.Reporter,
+		row.CreatedAt, row.UpdatedAt, row.StartedAt, row.CompletedAt,
+		row.ClosedAt, row.Labels, row.StoryPoints, row.SprintID, row.SprintName,
+		row.ParentID, row.EpicID, row.URL, row.LastSynced, row.OrgID,
+		row.SourceID,
+	}
+}
+
+func (row workItemTransitionStoredRow) values() []any {
+	return []any{
+		row.RepoID, row.WorkItemID, row.OccurredAt, row.FromStatus, row.ToStatus,
+		row.FromStatusRaw, row.ToStatusRaw, row.Actor, row.LastSynced, row.OrgID,
+		row.SourceID,
+	}
+}
+
+func workItemDependencyValues(row githubWorkItemDependencyRow) []any {
+	return []any{
+		row.SourceWorkItemID, row.TargetWorkItemID, row.RelationshipType,
+		row.RelationshipTypeRaw, row.RelationshipSemanticsVersion,
+		clickHouseMillis(row.LastSynced), row.OrgID, row.SourceID,
+	}
+}
+
+func workItemReopenValues(row githubWorkItemReopenRow) []any {
+	return []any{
+		row.WorkItemID, clickHouseMillis(row.OccurredAt), row.FromStatus, row.ToStatus,
+		row.FromStatusRaw, row.ToStatusRaw, row.Actor, clickHouseMillis(row.LastSynced),
+		row.OrgID,
+	}
+}
+
+func workItemInteractionValues(row githubWorkItemInteractionRow) []any {
+	return []any{
+		row.WorkItemID, row.Provider, row.InteractionType, clickHouseMillis(row.OccurredAt),
+		row.Actor, uint32(row.BodyLength), clickHouseMillis(row.LastSynced), row.OrgID,
+	}
+}
+
+func sprintValues(row githubSprintRow) []any {
+	return []any{
+		row.Provider, row.SprintID, derefString(row.NativeTeamKey), row.Name,
+		row.State, utcPointer(row.StartedAt), utcPointer(row.EndedAt),
+		utcPointer(row.CompletedAt), clickHouseMillis(row.LastSynced), row.OrgID,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// same-key collision inside one batch
+// -----------------------------------------------------------------------------
+
+// dedupeBySortingKey collapses rows that share a destination's ReplacingMergeTree
+// sorting key, keeping the LAST occurrence in the batch's order.
+//
+// Why this exists: a single batch can legitimately carry two rows at one sorting
+// key. Two issue events in the same second produce two transitions at the same
+// (org_id, repo_id, work_item_id, occurred_at); the parse-failure fallback to the
+// item's createdAt makes it reachable deterministically; and
+// github_work_items_projects_v2.go:574 concatenates the repository and
+// projects-v2 transition slices with no dedup of its own.
+//
+// Without this, ClickHouse collapses the pair on write, the readback finds ONE
+// row, and the comparator sees a field mismatch against whichever expectation
+// lost -- a permanent Conflict, which reaches the committer as
+// ErrEffectRecoveryAmbiguous and wedges the unit with no way to self-heal.
+// Python does not fail there: its sink hands both rows to ClickHouse and simply
+// loses one. Turning that silent loss into a hard stop would be an undeclared
+// D16 liveness divergence, so the port mirrors the loss.
+//
+// keep-LAST is not a guess. Measured against a real ReplacingMergeTree with two
+// rows at one key and EQUAL versions:
+//
+//	one INSERT block, payloads (A, B) -> retains B, raw count 1
+//	one INSERT block, payloads (B, A) -> retains A, raw count 1
+//	two INSERT blocks, A then B       -> FINAL retains B, raw count 2
+//
+// The reversed-order control rules out "greatest value wins": it is the last row
+// in insertion order that survives. Keeping the last occurrence therefore makes
+// the expected set agree with what the table actually holds.
+func dedupeBySortingKey[T any](rows []T, key func(T) string) []T {
+	if len(rows) < 2 {
+		return rows
+	}
+	position := make(map[string]int, len(rows))
+	deduped := make([]T, 0, len(rows))
+	for _, row := range rows {
+		identity := key(row)
+		if index, seen := position[identity]; seen {
+			deduped[index] = row // last occurrence wins, as the engine does
+			continue
+		}
+		position[identity] = len(deduped)
+		deduped = append(deduped, row)
+	}
+	return deduped
+}
+
+// The sorting key of each destination, rendered as a comparable string. Unit
+// separators keep two different field splits from colliding into one identity.
+const workItemKeySeparator = "\x1f"
+
+func workItemSortingKey(row githubWorkItemRow) string {
+	repoID := uuid.Nil
+	if row.RepoID != nil {
+		repoID = *row.RepoID
+	}
+	return strings.Join([]string{row.OrgID, repoID.String(), row.WorkItemID}, workItemKeySeparator)
+}
+
+func workItemTransitionSortingKey(row githubWorkItemTransitionRow) string {
+	// repo_id is always the nil UUID for this unit; see projectWorkItemTransition.
+	return strings.Join([]string{
+		row.OrgID, uuid.Nil.String(), row.WorkItemID,
+		clickHouseMillis(row.OccurredAt).Format(time.RFC3339Nano),
+	}, workItemKeySeparator)
+}
+
+func workItemDependencySortingKey(row githubWorkItemDependencyRow) string {
+	return strings.Join([]string{
+		row.OrgID, row.SourceWorkItemID, row.TargetWorkItemID, row.RelationshipType,
+	}, workItemKeySeparator)
+}
+
+func workItemReopenSortingKey(row githubWorkItemReopenRow) string {
+	return strings.Join([]string{
+		row.OrgID, row.WorkItemID,
+		clickHouseMillis(row.OccurredAt).Format(time.RFC3339Nano),
+	}, workItemKeySeparator)
+}
+
+func workItemInteractionSortingKey(row githubWorkItemInteractionRow) string {
+	return strings.Join([]string{
+		row.OrgID, row.WorkItemID,
+		clickHouseMillis(row.OccurredAt).Format(time.RFC3339Nano), row.InteractionType,
+	}, workItemKeySeparator)
+}
+
+func sprintSortingKey(row githubSprintRow) string {
+	return strings.Join([]string{row.OrgID, row.Provider, row.SprintID}, workItemKeySeparator)
+}

--- a/internal/providersync/github_work_items_direct_effects_integration_test.go
+++ b/internal/providersync/github_work_items_direct_effects_integration_test.go
@@ -1,0 +1,896 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// DDL transcribed from `SHOW CREATE TABLE` on a schema built by the real
+// migration chain (src/dev_health_ops/migrations/clickhouse, including the .py
+// migrations 027/042/044/061 that a .sql-only replay would miss). The column
+// DEFAULTs are part of the transcription on purpose: `org_id String DEFAULT
+// 'default'` and `relationship_semantics_version String DEFAULT 'legacy.v1'`
+// are what an omitted column actually stores, and a test that dropped them
+// would silently diverge from production on exactly the omission cases these
+// adapters mirror.
+const (
+	workItemsDDL = `
+CREATE TABLE work_items (
+  repo_id UUID, work_item_id String, provider String, title String,
+  description Nullable(String), type String, status String, status_raw String,
+  project_key String, project_id String, native_team_key String,
+  project_name String, assignees Array(String), reporter String,
+  created_at DateTime64(3), updated_at DateTime64(3),
+  started_at Nullable(DateTime64(3)), completed_at Nullable(DateTime64(3)),
+  closed_at Nullable(DateTime64(3)), labels Array(String),
+  story_points Nullable(Float64), sprint_id String, sprint_name String,
+  parent_id String, epic_id String, url String, last_synced DateTime64(3),
+  priority_raw Nullable(String), service_class Nullable(String),
+  due_at Nullable(DateTime64(3)), org_id String DEFAULT 'default',
+  source_id Nullable(UUID) DEFAULT NULL
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, work_item_id)`
+
+	workItemTransitionsDDL = `
+CREATE TABLE work_item_transitions (
+  repo_id UUID, work_item_id String, occurred_at DateTime64(3),
+  provider String, from_status String, to_status String,
+  from_status_raw String, to_status_raw String, actor String,
+  last_synced DateTime64(3), org_id String DEFAULT 'default',
+  source_id Nullable(UUID) DEFAULT NULL
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, work_item_id, occurred_at)`
+
+	workItemDependenciesDDL = `
+CREATE TABLE work_item_dependencies (
+  source_work_item_id String, target_work_item_id String,
+  relationship_type String, relationship_type_raw String,
+  last_synced DateTime64(3), org_id String DEFAULT 'default',
+  source_id Nullable(UUID) DEFAULT NULL,
+  relationship_semantics_version String DEFAULT 'legacy.v1'
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, source_work_item_id, target_work_item_id, relationship_type)`
+
+	workItemReopenEventsDDL = `
+CREATE TABLE work_item_reopen_events (
+  work_item_id String, occurred_at DateTime64(3), from_status String,
+  to_status String, from_status_raw Nullable(String),
+  to_status_raw Nullable(String), actor Nullable(String),
+  last_synced DateTime64(3), org_id String DEFAULT 'default'
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, work_item_id, occurred_at)`
+
+	workItemInteractionsDDL = `
+CREATE TABLE work_item_interactions (
+  work_item_id String, provider String, interaction_type String,
+  occurred_at DateTime64(3), actor Nullable(String), body_length UInt32,
+  last_synced DateTime64(3), org_id String DEFAULT 'default'
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, work_item_id, occurred_at, interaction_type)`
+
+	sprintsDDL = `
+CREATE TABLE sprints (
+  provider String, sprint_id String, native_team_key String,
+  name Nullable(String), state Nullable(String),
+  started_at Nullable(DateTime64(3)), ended_at Nullable(DateTime64(3)),
+  completed_at Nullable(DateTime64(3)), last_synced DateTime64(3),
+  org_id String DEFAULT 'default'
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, provider, sprint_id)`
+
+	aiAttributionDDL = `
+CREATE TABLE ai_attribution (
+  record_id UUID, org_id UUID, provider LowCardinality(String),
+  subject_type LowCardinality(String), subject_id String,
+  repo_id Nullable(UUID), kind LowCardinality(String),
+  source LowCardinality(String), confidence Float32, actor Nullable(String),
+  evidence String, observed_at DateTime64(3, 'UTC'),
+  ingested_at DateTime64(3, 'UTC'), superseded_by Nullable(UUID),
+  computed_at DateTime64(3, 'UTC') DEFAULT now64()
+) ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, provider, subject_type, repo_id, subject_id, source)
+SETTINGS allow_nullable_key = 1`
+)
+
+// A negative-offset zone where the local date disagrees with the UTC date, so
+// any accidental local-time formatting shows up as a wrong day rather than
+// passing by coincidence.
+var workItemTestZone = time.FixedZone("test-west", -7*60*60)
+
+func newWorkItemEffectsConn(t *testing.T, ddl ...string) (context.Context, driver.Conn) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatalf("start ClickHouse: %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatalf("open ClickHouse: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	for _, statement := range ddl {
+		if err := conn.Exec(ctx, statement); err != nil {
+			t.Fatalf("apply DDL: %v", err)
+		}
+	}
+	return ctx, conn
+}
+
+func workItemEffect(t *testing.T, destination string, rows ...any) (GitHubWorkItemEffectIdentity, EffectBatch) {
+	t.Helper()
+	claim := nativeTestClaim("github", "work-items")
+	encoded := make([]json.RawMessage, 0, len(rows))
+	for _, row := range rows {
+		raw, err := json.Marshal(row)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded = append(encoded, raw)
+	}
+	effect, err := BuildEffectBatch(destination, EffectReadbackRequired, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return GitHubWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: "github", Dataset: "work-items",
+		Generation: claim.GenerationKey(), Destination: destination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}, effect
+}
+
+func workItemTestOrgID(t *testing.T) string {
+	t.Helper()
+	return nativeTestClaim("github", "work-items").OrgID
+}
+
+// ai_attribution.org_id is a UUID column, unlike the String org_id every other
+// direct destination carries, so its rows can only exist for a tenant whose id
+// parses as a UUID -- which is why normalizeGitHubPullRequestBundle already
+// refuses the row otherwise. The shared test claim's "org-acme" cannot be used
+// here, and substituting it would fail at the driver rather than prove anything.
+const aiAttributionTestOrgID = "6f1c2d3e-4a5b-4c6d-8e9f-0a1b2c3d4e5f"
+
+func aiAttributionEffect(t *testing.T, row githubAIAttributionRow) (GitHubWorkItemEffectIdentity, EffectBatch) {
+	t.Helper()
+	identity, effect := workItemEffect(t, "ai_attribution", row)
+	identity.OrgID = row.OrgID.String()
+	return identity, effect
+}
+
+// -----------------------------------------------------------------------------
+// The contract every direct adapter owes the recovery lane
+// -----------------------------------------------------------------------------
+
+// Per the #1529 binding contract item 9 the snapshot supplies expected effects,
+// not write receipts, so a recovered worker re-runs the adapter over the very
+// same payload. Inspect must answer Exact for that replay: an Absent would
+// rewrite forever and a Conflict would hard-stop the unit.
+//
+// This is the test the whole "carry the write stamp in the effect row" design
+// exists to make passable -- a wall-clock stamp would write a strictly newer
+// version on every replay and could never answer Exact.
+func TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed(t *testing.T) {
+	orgID := workItemTestOrgID(t)
+	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	for _, testCase := range directAdapterCases(orgID, observed) {
+		t.Run(testCase.destination, func(t *testing.T) {
+			ctx, conn := newWorkItemEffectsConn(t, testCase.ddl)
+			adapter := testCase.adapter(conn)
+			identity, effect := workItemEffect(t, testCase.destination, testCase.row)
+
+			if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+				t.Fatalf("before write: inspection=%s err=%v, want absent", inspection, err)
+			}
+			if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after write: inspection=%s err=%v, want exact", inspection, err)
+			}
+
+			// The replay: identical payload, exactly as the snapshot stores it.
+			if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+				t.Fatalf("replay write: %v", err)
+			}
+			if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after replay: inspection=%s err=%v, want exact", inspection, err)
+			}
+		})
+	}
+}
+
+// A row written under one tenant must never satisfy another tenant's readback,
+// even at an identical natural key. org_id leads every sorting key here, so a
+// dropped predicate is easy to write and invisible without this.
+func TestDirectAdaptersReadbackExcludesOtherTenantsAtTheSameKey(t *testing.T) {
+	orgID := workItemTestOrgID(t)
+	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	for _, testCase := range directAdapterCases(orgID, observed) {
+		if testCase.foreignRow == nil {
+			continue
+		}
+		t.Run(testCase.destination, func(t *testing.T) {
+			ctx, conn := newWorkItemEffectsConn(t, testCase.ddl)
+			adapter := testCase.adapter(conn)
+
+			foreignIdentity, foreignEffect := workItemEffect(t, testCase.destination, testCase.foreignRow)
+			foreignIdentity.OrgID = testCase.foreignOrgID
+			if err := adapter.WriteGitHubWorkItemEffect(ctx, foreignIdentity, foreignEffect); err != nil {
+				t.Fatalf("write foreign tenant row: %v", err)
+			}
+
+			identity, effect := workItemEffect(t, testCase.destination, testCase.row)
+			if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+				t.Fatalf("another tenant's row leaked: inspection=%s err=%v, want absent", inspection, err)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ai_attribution: the partitioned destination (PR #1535)
+// -----------------------------------------------------------------------------
+
+// ai_attribution partitions on toYYYYMM(observed_at) while its sorting key
+// (org_id, provider, subject_type, repo_id, subject_id, source) does not carry
+// observed_at, so one sorting key observed either side of a month boundary is
+// the PR #1535 shape.
+//
+// What the fix turned out to be is not what it looked like. Measured here:
+// with ClickHouse's default do_not_merge_across_partitions_select_final=0,
+// FINAL merges ACROSS partitions, so the sorting key has exactly ONE current
+// row -- the greatest computed_at -- and the earlier observed_at row is
+// superseded, not co-resident. Fencing the readback on the partition would
+// filter that single winner out and answer Absent for a row that was written
+// and correctly superseded, which replays forever.
+//
+// So the readback fences the sorting key only and lets found > 1 answer
+// Conflict. This test pins both halves: the winner is retrievable and compares
+// Exact, and the superseded row answers Conflict rather than Absent.
+//
+// The two instants are chosen so a UTC-07:00 reading puts both in the SAME
+// local month while UTC puts them in different months, so a partition
+// expression evaluated in local time would not reproduce the boundary at all.
+// Run under BOTH values of do_not_merge_across_partitions_select_final. That
+// knob is a server setting this code does not control, and it is exactly what
+// made the FINAL-based readback's verdict unstable: with the knob on, a
+// correctly superseded row came back as two rows and became a permanent
+// Conflict. Asserting only the default would leave that failure mode untested.
+func TestAIAttributionReadbackResolvesTheSupersededRowAcrossAMonthBoundary(t *testing.T) {
+	for _, crossPartitionMerge := range []int{0, 1} {
+		t.Run(fmt.Sprintf("do_not_merge_across_partitions_select_final=%d", crossPartitionMerge), func(t *testing.T) {
+			aiAttributionSupersededRowCase(t, crossPartitionMerge)
+		})
+	}
+}
+
+func aiAttributionSupersededRowCase(t *testing.T, crossPartitionMerge int) {
+	t.Helper()
+	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(map[string]any{
+		"do_not_merge_across_partitions_select_final": crossPartitionMerge,
+	}))
+	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
+	orgID := aiAttributionTestOrgID
+
+	august := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+	september := time.Date(2026, 9, 1, 1, 30, 0, 0, time.UTC)
+	if august.In(workItemTestZone).Month() != september.In(workItemTestZone).Month() {
+		t.Fatalf("fixture no longer exercises the boundary: %s vs %s local",
+			august.In(workItemTestZone), september.In(workItemTestZone))
+	}
+	if august.Month() == september.Month() {
+		t.Fatal("fixture no longer spans two UTC months")
+	}
+
+	augustRow := aiAttributionTestRow(t, orgID, august)
+	septemberRow := aiAttributionTestRow(t, orgID, september)
+
+	augustIdentity, augustEffect := aiAttributionEffect(t, augustRow)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, augustIdentity, augustEffect); err != nil {
+		t.Fatalf("write august row: %v", err)
+	}
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, augustIdentity, augustEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("august before supersede: inspection=%s err=%v, want exact", inspection, err)
+	}
+
+	septemberIdentity, septemberEffect := aiAttributionEffect(t, septemberRow)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, septemberIdentity, septemberEffect); err != nil {
+		t.Fatalf("write september row: %v", err)
+	}
+
+	// Both rows are on disk; only one is current.
+	var stored uint64
+	if err := conn.QueryRow(ctx,
+		`SELECT count() FROM ai_attribution WHERE org_id = ?`, uuid.MustParse(orgID),
+	).Scan(&stored); err != nil {
+		t.Fatalf("count stored rows: %v", err)
+	}
+	if stored != 2 {
+		t.Fatalf("expected both months on disk, got %d", stored)
+	}
+
+	// The later computed_at wins globally, across the partition boundary.
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, septemberIdentity, septemberEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("september: inspection=%s err=%v, want exact", inspection, err)
+	}
+	// And the superseded row must say Conflict -- NOT Absent, which would make
+	// the committer rewrite it on every pass forever.
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, augustIdentity, augustEffect); err != nil || inspection != EffectConflict {
+		t.Fatalf("superseded august row: inspection=%s err=%v, want conflict", inspection, err)
+	}
+}
+
+// The stored evidence column must hold Python's exact bytes, not Go's default
+// map marshalling. Asserting the decoded map would pass while the stored string
+// differed in key order, spacing, and escaping.
+func TestAIAttributionStoresPythonEvidenceBytes(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
+	orgID := aiAttributionTestOrgID
+	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	row := aiAttributionTestRow(t, orgID, observed)
+	row.Evidence = map[string]any{
+		"login": "copilot[bot]", "user_type": "Bot",
+		"app_slug": "github-copilot", "known_ai_bot": true,
+	}
+	identity, effect := aiAttributionEffect(t, row)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stored string
+	if err := conn.QueryRow(ctx,
+		`SELECT evidence FROM ai_attribution FINAL WHERE org_id = ?`, uuid.MustParse(orgID),
+	).Scan(&stored); err != nil {
+		t.Fatalf("read evidence: %v", err)
+	}
+	const want = `{"login": "copilot[bot]", "user_type": "Bot", "app_slug": "github-copilot", "known_ai_bot": true}`
+	if stored != want {
+		t.Fatalf("stored evidence bytes\n got=%s\nwant=%s", stored, want)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// version semantics
+// -----------------------------------------------------------------------------
+
+// A stored row older than ours has not been overwritten by us yet and must
+// replay; a stored row newer than ours belongs to somebody else and must not be
+// silently clobbered. Both directions are asserted against a real
+// ReplacingMergeTree rather than against the comparator in isolation.
+func TestWorkItemsReadbackDistinguishesStaleFromOverwritten(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+	adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
+	orgID := workItemTestOrgID(t)
+	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	current := workItemTestRow(orgID, now)
+	previous := workItemTestRow(orgID, now.Add(-time.Hour))
+	previous.Title = "older title"
+
+	previousIdentity, previousEffect := workItemEffect(t, "work_items", previous)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, previousIdentity, previousEffect); err != nil {
+		t.Fatalf("write previous: %v", err)
+	}
+	currentIdentity, currentEffect := workItemEffect(t, "work_items", current)
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, currentIdentity, currentEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale stored row: inspection=%s err=%v, want absent", inspection, err)
+	}
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, currentIdentity, currentEffect); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, currentIdentity, currentEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("winning row: inspection=%s err=%v, want exact", inspection, err)
+	}
+	// Now the stored row is newer than what the older effect expects.
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, previousIdentity, previousEffect); err != nil || inspection != EffectConflict {
+		t.Fatalf("overwritten row: inspection=%s err=%v, want conflict", inspection, err)
+	}
+}
+
+// A batch where some rows landed and others did not cannot be replayed without
+// rewriting the ones that did, so the committer must be told Conflict.
+func TestWorkItemsPartlyLandedBatchIsAConflict(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+	adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
+	orgID := workItemTestOrgID(t)
+	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	landed := workItemTestRow(orgID, now)
+	missing := workItemTestRow(orgID, now)
+	missing.WorkItemID = "gh:acme/api#999"
+
+	landedIdentity, landedEffect := workItemEffect(t, "work_items", landed)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, landedIdentity, landedEffect); err != nil {
+		t.Fatalf("write landed row: %v", err)
+	}
+	bothIdentity, bothEffect := workItemEffect(t, "work_items", landed, missing)
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, bothIdentity, bothEffect); err != nil || inspection != EffectConflict {
+		t.Fatalf("mixed batch: inspection=%s err=%v, want conflict", inspection, err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// D16 omissions, observed in storage rather than in the SQL string
+// -----------------------------------------------------------------------------
+
+// write_work_items never writes description/priority_raw/service_class/due_at
+// and write_work_item_transitions never writes provider. A ReplacingMergeTree
+// replaces whole rows, so a Go adapter that "helpfully" filled these in would
+// store values the running Python system never stores. Asserting the stored
+// columns proves the omission reached the table, which reading the INSERT
+// string cannot.
+func TestDirectAdaptersLeaveThePythonOmittedColumnsAtTheirDefaults(t *testing.T) {
+	orgID := workItemTestOrgID(t)
+	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	t.Run("work_items", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+		adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
+		row := workItemTestRow(orgID, now)
+		// The semantic row carries all four; the sink still must not write them.
+		row.Description = stringPointer("body text")
+		row.PriorityRaw = stringPointer("p1")
+		row.ServiceClass = stringPointer("expedite")
+		due := now.Add(48 * time.Hour)
+		row.DueAt = &due
+
+		identity, effect := workItemEffect(t, "work_items", row)
+		if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var description, priorityRaw, serviceClass *string
+		var dueAt *time.Time
+		if err := conn.QueryRow(ctx,
+			`SELECT description, priority_raw, service_class, due_at FROM work_items FINAL WHERE org_id = ?`,
+			orgID,
+		).Scan(&description, &priorityRaw, &serviceClass, &dueAt); err != nil {
+			t.Fatalf("read omitted columns: %v", err)
+		}
+		if description != nil || priorityRaw != nil || serviceClass != nil || dueAt != nil {
+			t.Fatalf("this unit wrote a column write_work_items omits: description=%v priority_raw=%v service_class=%v due_at=%v",
+				description, priorityRaw, serviceClass, dueAt)
+		}
+	})
+
+	t.Run("work_item_transitions", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemTransitionsDDL)
+		adapter := GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
+		row := workItemTransitionTestRow(orgID, now)
+		row.Provider = "github"
+
+		identity, effect := workItemEffect(t, "work_item_transitions", row)
+		if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var provider string
+		if err := conn.QueryRow(ctx,
+			`SELECT provider FROM work_item_transitions FINAL WHERE org_id = ?`, orgID,
+		).Scan(&provider); err != nil {
+			t.Fatalf("read provider: %v", err)
+		}
+		if provider != "" {
+			t.Fatalf("this unit wrote provider=%q, which write_work_item_transitions omits", provider)
+		}
+	})
+}
+
+// -----------------------------------------------------------------------------
+// fixtures
+// -----------------------------------------------------------------------------
+
+type directAdapterCase struct {
+	destination  string
+	ddl          string
+	adapter      func(driver.Conn) GitHubWorkItemEffectAdapter
+	row          any
+	foreignRow   any
+	foreignOrgID string
+}
+
+const foreignTenantOrgID = "11111111-2222-3333-4444-555555555555"
+
+func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
+	foreignWorkItem := workItemTestRow(foreignTenantOrgID, now)
+	foreignTransition := workItemTransitionTestRow(foreignTenantOrgID, now)
+	foreignDependency := workItemDependencyTestRow(foreignTenantOrgID, now)
+	foreignReopen := workItemReopenTestRow(foreignTenantOrgID, now)
+	foreignInteraction := workItemInteractionTestRow(foreignTenantOrgID, now)
+	foreignSprint := sprintTestRow(foreignTenantOrgID, now)
+	return []directAdapterCase{
+		{
+			destination: "work_items", ddl: workItemsDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubWorkItemsClickHouseAdapter{Conn: conn}
+			},
+			row: workItemTestRow(orgID, now), foreignRow: foreignWorkItem,
+			foreignOrgID: foreignTenantOrgID,
+		},
+		{
+			destination: "work_item_transitions", ddl: workItemTransitionsDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
+			},
+			row: workItemTransitionTestRow(orgID, now), foreignRow: foreignTransition,
+			foreignOrgID: foreignTenantOrgID,
+		},
+		{
+			destination: "work_item_dependencies", ddl: workItemDependenciesDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn}
+			},
+			row: workItemDependencyTestRow(orgID, now), foreignRow: foreignDependency,
+			foreignOrgID: foreignTenantOrgID,
+		},
+		{
+			destination: "work_item_reopen_events", ddl: workItemReopenEventsDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn}
+			},
+			row: workItemReopenTestRow(orgID, now), foreignRow: foreignReopen,
+			foreignOrgID: foreignTenantOrgID,
+		},
+		{
+			destination: "work_item_interactions", ddl: workItemInteractionsDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn}
+			},
+			row: workItemInteractionTestRow(orgID, now), foreignRow: foreignInteraction,
+			foreignOrgID: foreignTenantOrgID,
+		},
+		{
+			destination: "sprints", ddl: sprintsDDL,
+			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
+				return GitHubSprintsClickHouseAdapter{Conn: conn}
+			},
+			row: sprintTestRow(orgID, now), foreignRow: foreignSprint,
+			foreignOrgID: foreignTenantOrgID,
+		},
+	}
+}
+
+func workItemTestRow(orgID string, now time.Time) githubWorkItemRow {
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	return githubWorkItemRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github", Title: "Repair path",
+		Type: "issue", Status: "doing", StatusRaw: stringPointer("open"),
+		RepoID: &repoID, ProjectID: stringPointer("acme/api"),
+		Assignees: []string{"dev"}, Reporter: stringPointer("reporter"),
+		CreatedAt: now.Add(-72 * time.Hour), UpdatedAt: now.Add(-time.Hour),
+		Labels: []string{"bug"}, URL: stringPointer("https://github.com/acme/api/issues/42"),
+		OrgID: orgID, LastSynced: now,
+	}
+}
+
+func workItemTransitionTestRow(orgID string, now time.Time) githubWorkItemTransitionRow {
+	return githubWorkItemTransitionRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github",
+		OccurredAt: now.Add(-2 * time.Hour), FromStatus: "todo", ToStatus: "doing",
+		ToStatusRaw: stringPointer("doing"), OrgID: orgID, LastSynced: now,
+	}
+}
+
+func workItemDependencyTestRow(orgID string, now time.Time) githubWorkItemDependencyRow {
+	return githubWorkItemDependencyRow{
+		SourceWorkItemID: "gh:acme/api#42", TargetWorkItemID: "gh:acme/api#7",
+		RelationshipType: "blocks", RelationshipTypeRaw: "blocks",
+		RelationshipSemanticsVersion: "canonical-blocks.v2",
+		LastSynced:                   now, OrgID: orgID,
+	}
+}
+
+func workItemReopenTestRow(orgID string, now time.Time) githubWorkItemReopenRow {
+	return githubWorkItemReopenRow{
+		WorkItemID: "gh:acme/api#42", OccurredAt: now.Add(-3 * time.Hour),
+		FromStatus: "done", ToStatus: "doing", LastSynced: now, OrgID: orgID,
+	}
+}
+
+func workItemInteractionTestRow(orgID string, now time.Time) githubWorkItemInteractionRow {
+	return githubWorkItemInteractionRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github",
+		InteractionType: "comment", OccurredAt: now.Add(-4 * time.Hour),
+		Actor: stringPointer("dev"), BodyLength: 128, LastSynced: now, OrgID: orgID,
+	}
+}
+
+func sprintTestRow(orgID string, now time.Time) githubSprintRow {
+	started := now.Add(-240 * time.Hour)
+	return githubSprintRow{
+		Provider: "github", SprintID: "gh:acme/api/milestone/3",
+		Name: stringPointer("Sprint 3"), State: stringPointer("open"),
+		StartedAt: &started, LastSynced: now, OrgID: orgID,
+	}
+}
+
+func aiAttributionTestRow(t *testing.T, orgID string, observed time.Time) githubAIAttributionRow {
+	t.Helper()
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	return githubAIAttributionRow{
+		RecordID: uuid.MustParse("9f8b7c6d-5e4f-4a3b-8c1d-2e3f4a5b6c7d"),
+		OrgID:    uuid.MustParse(orgID), Provider: "github",
+		SubjectType: "pull_request", SubjectID: "17", RepoID: &repoID,
+		Kind: "ai_assisted", Source: "commit_trailer", Confidence: 0.85,
+		Actor:      stringPointer("claude"),
+		Evidence:   map[string]any{"label": "ai-generated"},
+		ObservedAt: observed, IngestedAt: observed.Add(time.Minute),
+	}
+}
+
+// The replay contract, for the one adapter directAdapterCases cannot carry
+// because its tenant column is a UUID rather than a String.
+func TestAIAttributionAnswersExactWhenARecoverySnapshotIsReplayed(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
+	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+	identity, effect := aiAttributionEffect(t, aiAttributionTestRow(t, aiAttributionTestOrgID, observed))
+
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write: inspection=%s err=%v, want absent", inspection, err)
+	}
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("after write: inspection=%s err=%v, want exact", inspection, err)
+	}
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay: inspection=%s err=%v, want exact", inspection, err)
+	}
+}
+
+// A row belonging to another tenant must not satisfy this tenant's readback
+// even at an identical subject key and partition.
+func TestAIAttributionReadbackExcludesOtherTenants(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
+	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	foreign := aiAttributionTestRow(t, "8a7b6c5d-4e3f-4a2b-9c8d-7e6f5a4b3c2d", observed)
+	foreignIdentity, foreignEffect := aiAttributionEffect(t, foreign)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, foreignIdentity, foreignEffect); err != nil {
+		t.Fatalf("write foreign tenant row: %v", err)
+	}
+	identity, effect := aiAttributionEffect(t, aiAttributionTestRow(t, aiAttributionTestOrgID, observed))
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("another tenant's row leaked: inspection=%s err=%v, want absent", inspection, err)
+	}
+}
+
+// A batch carrying two rows at one sorting key is constructible in production:
+// two issue events in the same second yield two transitions at the same
+// (org_id, repo_id, work_item_id, occurred_at); the parse-failure fallback to
+// the item's createdAt makes it reachable deterministically; and
+// github_work_items_projects_v2.go concatenates the repository and projects-v2
+// transition slices without dedup.
+//
+// ClickHouse collapses such a pair on write. Without dedup the readback finds
+// ONE row, the comparator sees a field mismatch against whichever expectation
+// lost, and the verdict is a permanent Conflict -- which reaches the committer
+// as ErrEffectRecoveryAmbiguous and wedges the unit with no way to self-heal.
+// Python does not fail there; it silently loses one row. This asserts the port
+// mirrors that loss rather than converting it into a hard stop.
+func TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch(t *testing.T) {
+	orgID := workItemTestOrgID(t)
+	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
+
+	t.Run("work_item_transitions", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemTransitionsDDL)
+		adapter := GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
+		first := workItemTransitionTestRow(orgID, now)
+		second := workItemTransitionTestRow(orgID, now)
+		second.ToStatus = "done" // same key, different payload
+		assertCollapsesToTheLastRow(t, ctx, conn, adapter,
+			"work_item_transitions", first, second,
+			`SELECT to_status FROM work_item_transitions FINAL WHERE org_id = ?`, orgID, "done")
+	})
+
+	t.Run("work_item_reopen_events", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemReopenEventsDDL)
+		adapter := GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn}
+		first := workItemReopenTestRow(orgID, now)
+		second := workItemReopenTestRow(orgID, now)
+		second.ToStatus = "reopened"
+		assertCollapsesToTheLastRow(t, ctx, conn, adapter,
+			"work_item_reopen_events", first, second,
+			`SELECT to_status FROM work_item_reopen_events FINAL WHERE org_id = ?`, orgID, "reopened")
+	})
+
+	t.Run("work_item_interactions", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemInteractionsDDL)
+		adapter := GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn}
+		first := workItemInteractionTestRow(orgID, now)
+		second := workItemInteractionTestRow(orgID, now)
+		second.BodyLength = 999
+		assertCollapsesToTheLastRow(t, ctx, conn, adapter,
+			"work_item_interactions", first, second,
+			`SELECT toString(body_length) FROM work_item_interactions FINAL WHERE org_id = ?`, orgID, "999")
+	})
+
+	t.Run("work_item_dependencies", func(t *testing.T) {
+		ctx, conn := newWorkItemEffectsConn(t, workItemDependenciesDDL)
+		adapter := GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn}
+		first := workItemDependencyTestRow(orgID, now)
+		second := workItemDependencyTestRow(orgID, now)
+		second.RelationshipTypeRaw = "is blocked by"
+		assertCollapsesToTheLastRow(t, ctx, conn, adapter,
+			"work_item_dependencies", first, second,
+			`SELECT relationship_type_raw FROM work_item_dependencies FINAL WHERE org_id = ?`,
+			orgID, "is blocked by")
+	})
+}
+
+func assertCollapsesToTheLastRow(
+	t *testing.T,
+	ctx context.Context,
+	conn driver.Conn,
+	adapter GitHubWorkItemEffectAdapter,
+	destination string,
+	first, second any,
+	probe string,
+	orgID string,
+	wantStored string,
+) {
+	t.Helper()
+	identity, effect := workItemEffect(t, destination, first, second)
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatalf("write colliding batch: %v", err)
+	}
+	// Exactly one row survives, and it is the LAST of the pair -- matching what
+	// the engine retains for equal versions.
+	var stored string
+	if err := conn.QueryRow(ctx, probe, orgID).Scan(&stored); err != nil {
+		t.Fatalf("probe stored row: %v", err)
+	}
+	if stored != wantStored {
+		t.Fatalf("stored row is %q, want the last of the colliding pair (%q)", stored, wantStored)
+	}
+	// And the verdict must be Exact, not the permanent Conflict that an
+	// un-deduped expected set would produce.
+	inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect)
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("colliding batch: inspection=%s err=%v, want exact", inspection, err)
+	}
+	// Replay must remain Exact too.
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatalf("replay colliding batch: %v", err)
+	}
+	if inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("colliding batch replay: inspection=%s err=%v, want exact", inspection, err)
+	}
+}
+
+// Every timestamp column these adapters write must actually store the precision
+// the truncation assumes. Read from the real schema rather than restated here,
+// so a migration that changes one column's precision fails this test instead of
+// silently producing a verdict that can never be Exact.
+//
+// Both directions are fatal, which is why this asserts equality rather than
+// "at least milliseconds": truncating coarser than the column stores makes the
+// comparator reject a row it just wrote, and truncating finer leaves a value the
+// column cannot hold. A sibling lane hit the second shape one table over, where
+// a version column was plain DateTime (seconds) and a shared millisecond helper
+// left the verdict permanently Absent.
+func TestWorkItemTimestampColumnsAllHaveTheAssumedPrecision(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t,
+		workItemsDDL, workItemTransitionsDDL, workItemDependenciesDDL,
+		workItemReopenEventsDDL, workItemInteractionsDDL, sprintsDDL,
+		aiAttributionDDL)
+
+	// The version column of each destination is called out separately: it is the
+	// one the comparator orders on, so a precision mismatch there decides
+	// rewrite-vs-done rather than merely comparing a field.
+	versionColumns := map[string]string{
+		"work_items": "last_synced", "work_item_transitions": "last_synced",
+		"work_item_dependencies": "last_synced", "work_item_reopen_events": "last_synced",
+		"work_item_interactions": "last_synced", "sprints": "last_synced",
+		"ai_attribution": "computed_at",
+	}
+
+	rows, err := conn.Query(ctx,
+		`SELECT table, name, type FROM system.columns
+		 WHERE database = currentDatabase() AND table IN (?, ?, ?, ?, ?, ?, ?)
+		   AND (type LIKE 'DateTime%' OR type LIKE 'Nullable(DateTime%')`,
+		"work_items", "work_item_transitions", "work_item_dependencies",
+		"work_item_reopen_events", "work_item_interactions", "sprints",
+		"ai_attribution")
+	if err != nil {
+		t.Fatalf("read column types: %v", err)
+	}
+	defer rows.Close()
+
+	seenVersionColumns := map[string]bool{}
+	inspected := 0
+	for rows.Next() {
+		var table, name, columnType string
+		if err := rows.Scan(&table, &name, &columnType); err != nil {
+			t.Fatal(err)
+		}
+		inspected++
+		if versionColumns[table] == name {
+			seenVersionColumns[table] = true
+		}
+		precision, err := clickHouseColumnPrecision(columnType)
+		if err != nil {
+			t.Fatalf("%s.%s: %v", table, name, err)
+		}
+		if precision != workItemColumnPrecision {
+			t.Fatalf("%s.%s stores %s (type %q) but the adapters truncate to %s -- "+
+				"make the truncation per-destination rather than widening the constant",
+				table, name, precision, columnType, workItemColumnPrecision)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	// A query that matched nothing would pass every assertion above.
+	if inspected == 0 {
+		t.Fatal("no timestamp columns were inspected, so this test asserted nothing")
+	}
+	for table, column := range versionColumns {
+		if !seenVersionColumns[table] {
+			t.Fatalf("the version column %s.%s was never inspected -- it is the column "+
+				"the comparator orders on, so leaving it uncovered is the whole risk",
+				table, column)
+		}
+	}
+}
+
+// clickHouseColumnPrecision maps a ClickHouse date/time column type to the
+// smallest interval it can represent. Plain DateTime is seconds; DateTime64(N)
+// is 10^-N seconds. An unrecognised type is an error, never a default, because
+// a silently-assumed precision is the defect this exists to catch.
+func clickHouseColumnPrecision(columnType string) (time.Duration, error) {
+	inner := strings.TrimSuffix(strings.TrimPrefix(columnType, "Nullable("), ")")
+	if strings.HasPrefix(inner, "DateTime64(") {
+		digits := strings.TrimPrefix(inner, "DateTime64(")
+		digits = strings.SplitN(digits, ",", 2)[0]
+		digits = strings.TrimSpace(strings.TrimSuffix(digits, ")"))
+		scale, err := strconv.Atoi(digits)
+		if err != nil {
+			return 0, fmt.Errorf("unparsable DateTime64 scale in %q", columnType)
+		}
+		precision := time.Second
+		for i := 0; i < scale; i++ {
+			precision /= 10
+		}
+		if precision <= 0 {
+			return 0, fmt.Errorf("scale %d in %q is finer than Go can express", scale, columnType)
+		}
+		return precision, nil
+	}
+	if strings.HasPrefix(inner, "DateTime") {
+		return time.Second, nil
+	}
+	return 0, fmt.Errorf("not a date/time column type: %q", columnType)
+}

--- a/internal/providersync/github_work_items_direct_effects_test.go
+++ b/internal/providersync/github_work_items_direct_effects_test.go
@@ -1,0 +1,571 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+)
+
+// The evidence column is a String, so Go and Python agree only if they produce
+// the same BYTES. Decoding both sides and comparing the decoded maps would pass
+// while the stored strings differ in key order, separator spacing, or non-ASCII
+// escaping -- which is exactly the class of divergence this encoder exists to
+// prevent. Every case therefore executes the real CPython json.dumps and
+// compares the raw string.
+func TestPythonEvidenceJSONMatchesRealJSONDumpsByteForByte(t *testing.T) {
+	python := pythonExecutable(t)
+	cases := []struct {
+		name     string
+		evidence map[string]any
+		// pythonLiteral is the dict literal in the same INSERTION ORDER the
+		// Python detector builds it, because that order is what json.dumps
+		// serialises and what the stored bytes therefore contain.
+		pythonLiteral string
+	}{
+		{
+			name:          "label",
+			evidence:      map[string]any{"label": "ai-generated"},
+			pythonLiteral: `{"label": "ai-generated"}`,
+		},
+		{
+			// _ai_detection.detect_from_author builds login, user_type,
+			// app_slug, known_ai_bot -- NOT alphabetical order. Marshalling the
+			// Go map directly would sort these and store different bytes.
+			name: "bot author disagrees with alphabetical order",
+			evidence: map[string]any{
+				"login": "copilot[bot]", "user_type": "Bot",
+				"app_slug": "github-copilot", "known_ai_bot": true,
+			},
+			pythonLiteral: `{"login": "copilot[bot]", "user_type": "Bot", "app_slug": "github-copilot", "known_ai_bot": True}`,
+		},
+		{
+			name: "commit trailer",
+			evidence: map[string]any{
+				"trailer_key": "Co-authored-by", "trailer_value": "Claude <noreply@anthropic.com>",
+			},
+			pythonLiteral: `{"trailer_key": "Co-authored-by", "trailer_value": "Claude <noreply@anthropic.com>"}`,
+		},
+		{
+			name: "branch",
+			evidence: map[string]any{
+				"branch": "feat/ai-thing", "matched_pattern": `(?i)\bai\b`,
+			},
+			pythonLiteral: `{"branch": "feat/ai-thing", "matched_pattern": "(?i)\\bai\\b"}`,
+		},
+		{
+			// detect_from_pr_body builds matched_text first; alphabetical order
+			// would put matched_pattern first.
+			name: "pr body disagrees with alphabetical order",
+			evidence: map[string]any{
+				"matched_text": "Generated with Claude", "matched_pattern": "Generated with",
+			},
+			pythonLiteral: `{"matched_text": "Generated with Claude", "matched_pattern": "Generated with"}`,
+		},
+		{
+			// Python's json.dumps defaults to ensure_ascii=True and does NOT
+			// escape <, > or &; Go's encoding/json does the opposite on both
+			// counts. A PR title carrying either is ordinary, not exotic.
+			name: "non-ascii and html characters",
+			evidence: map[string]any{
+				"label": "ai-généré <tag> & more … 🤖",
+			},
+			pythonLiteral: `{"label": "ai-g\u00e9n\u00e9r\u00e9 <tag> & more \u2026 \U0001F916"}`,
+		},
+		{
+			name:          "control characters and quotes",
+			evidence:      map[string]any{"label": "line\nbreak\t\"quoted\"\\slash\x01"},
+			pythonLiteral: `{"label": "line\nbreak\t\"quoted\"\\slash\x01"}`,
+		},
+		{
+			name: "null actor value",
+			evidence: map[string]any{
+				"login": "someone", "user_type": (*string)(nil),
+				"app_slug": (*string)(nil), "known_ai_bot": false,
+			},
+			pythonLiteral: `{"login": "someone", "user_type": None, "app_slug": None, "known_ai_bot": False}`,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			goEncoded, err := pythonEvidenceJSON(testCase.evidence)
+			if err != nil {
+				t.Fatalf("pythonEvidenceJSON: %v", err)
+			}
+			// Ask CPython what it stores for the same dict, in the same order.
+			script := "import json,sys; sys.stdout.write(json.dumps(" +
+				testCase.pythonLiteral + ", default=str))"
+			output, err := exec.Command(python, "-c", script).CombinedOutput()
+			if err != nil {
+				t.Fatalf("execute python json.dumps: %v: %s", err, output)
+			}
+			if string(output) != goEncoded {
+				t.Fatalf("stored evidence bytes diverge from Python\npython=%s\ngo    =%s",
+					output, goEncoded)
+			}
+		})
+	}
+}
+
+// A shape the encoder has not been shown must not be guessed at. Falling back
+// to Go's sorted-key marshalling would store bytes nobody reviewed, and a test
+// that decoded the evidence before comparing could never see it.
+func TestPythonEvidenceJSONFailsClosedOnUnknownShape(t *testing.T) {
+	t.Parallel()
+	unknown := []map[string]any{
+		{"surprise": "value"},
+		{"label": "x", "extra": "y"},
+		{},
+		nil,
+	}
+	for _, evidence := range unknown {
+		if encoded, err := pythonEvidenceJSON(evidence); err == nil {
+			t.Fatalf("unknown evidence shape %v encoded as %q instead of failing", evidence, encoded)
+		}
+	}
+}
+
+// A value type the encoder cannot reproduce must be refused rather than passed
+// to Python's `default=str`, whose output this code has not been shown.
+func TestPythonEvidenceJSONFailsClosedOnUnreproducibleValueType(t *testing.T) {
+	t.Parallel()
+	if _, err := pythonEvidenceJSON(map[string]any{"label": 42}); err == nil {
+		t.Fatal("integer evidence value encoded instead of failing closed")
+	}
+	if _, err := pythonEvidenceJSON(map[string]any{"label": []string{"a"}}); err == nil {
+		t.Fatal("slice evidence value encoded instead of failing closed")
+	}
+}
+
+// The committer replays Absent and hard-stops Conflict, so a duplicated key
+// answering Absent would be rewritten forever. This pins that mapping.
+//
+// Note the honest scope: this arm is unreachable in all seven adapters today
+// (the readbacks fence the full sorting key and collapse), so it is
+// defense-in-depth against a future WHERE/collapse change, not the live
+// duplicate protection. The live protection is dedupeBySortingKey, covered by
+// TestDedupeBySortingKeyKeepsTheRowClickHouseRetains and the same-key
+// integration cases.
+func TestWorkItemReadbackVerdictResolvesDuplicatesBeforeAbsence(t *testing.T) {
+	t.Parallel()
+	if verdict, final := workItemReadbackVerdict(2); !final || verdict != EffectConflict {
+		t.Fatalf("two rows: verdict=%s final=%v, want conflict/final", verdict, final)
+	}
+	if verdict, final := workItemReadbackVerdict(9); !final || verdict != EffectConflict {
+		t.Fatalf("nine rows: verdict=%s final=%v, want conflict/final", verdict, final)
+	}
+	if verdict, final := workItemReadbackVerdict(0); !final || verdict != EffectAbsent {
+		t.Fatalf("no rows: verdict=%s final=%v, want absent/final", verdict, final)
+	}
+	if _, final := workItemReadbackVerdict(1); final {
+		t.Fatal("exactly one row must not be final -- the caller still has to compare it")
+	}
+}
+
+func TestWorkItemVersionVerdictSeparatesStaleFromOverwritten(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if verdict, final := workItemVersionVerdict(time.Time{}, now); !final || verdict != EffectAbsent {
+		t.Fatalf("zero version: verdict=%s final=%v", verdict, final)
+	}
+	if verdict, final := workItemVersionVerdict(now.Add(-time.Hour), now); !final || verdict != EffectAbsent {
+		t.Fatalf("older stored version must replay: verdict=%s final=%v", verdict, final)
+	}
+	if verdict, final := workItemVersionVerdict(now.Add(time.Hour), now); !final || verdict != EffectConflict {
+		t.Fatalf("newer stored version must not replay: verdict=%s final=%v", verdict, final)
+	}
+	if _, final := workItemVersionVerdict(now, now); final {
+		t.Fatal("equal versions must fall through to field comparison")
+	}
+	// A stored version in a different zone but the same instant is the same
+	// version; comparing wall-clock fields rather than instants would call it
+	// a conflict and hard-stop the unit.
+	zoned := now.In(time.FixedZone("west", -7*60*60))
+	if _, final := workItemVersionVerdict(zoned, now); final {
+		t.Fatal("same instant in another zone must compare equal")
+	}
+}
+
+// A partly-landed batch cannot be expressed to the committer: replaying it
+// would rewrite the rows that already landed. Conflict is the only safe answer.
+func TestFoldWorkItemInspectionsTreatsMixedBatchAsConflict(t *testing.T) {
+	t.Parallel()
+	verdicts := []EffectInspection{EffectExact, EffectAbsent}
+	index := 0
+	folded, err := foldWorkItemInspections([]int{0, 1}, func(int) (EffectInspection, error) {
+		verdict := verdicts[index]
+		index++
+		return verdict, nil
+	})
+	if err != nil || folded != EffectConflict {
+		t.Fatalf("mixed batch folded to %s (err=%v), want conflict", folded, err)
+	}
+}
+
+// work_items omits description/priority_raw/service_class/due_at and
+// work_item_transitions omits provider. Those omissions are the running Python
+// system's behavior (D16), and a ReplacingMergeTree replaces whole rows, so
+// writing them would diverge from what production stores. This pins the column
+// lists against a well-meaning "the table has the column, fill it in" edit.
+func TestDirectAdapterColumnListsMirrorThePythonSinkOmissions(t *testing.T) {
+	t.Parallel()
+	for _, absent := range []string{"description", "priority_raw", "service_class", "due_at"} {
+		if containsColumn(gitHubWorkItemsInsert, absent) {
+			t.Fatalf("work_items insert writes %q, which write_work_items does not", absent)
+		}
+		if containsColumn(gitHubWorkItemsSelect, absent) {
+			t.Fatalf("work_items readback compares %q, a column this unit does not own", absent)
+		}
+	}
+	if containsColumn(gitHubWorkItemTransitionsInsert, "provider") {
+		t.Fatal("work_item_transitions insert writes provider, which write_work_item_transitions does not")
+	}
+}
+
+// Every readback must fence the tenant. A missing org_id predicate on a table
+// whose sorting key leads with org_id reads another tenant's row as ours.
+func TestEveryDirectReadbackFencesOrgID(t *testing.T) {
+	t.Parallel()
+	selects := map[string]string{
+		"work_items":              gitHubWorkItemsSelect,
+		"work_item_transitions":   gitHubWorkItemTransitionsSelect,
+		"work_item_dependencies":  gitHubWorkItemDependenciesSelect,
+		"work_item_reopen_events": gitHubWorkItemReopenEventsSelect,
+		"work_item_interactions":  gitHubWorkItemInteractionsSelect,
+		"sprints":                 gitHubSprintsSelect,
+		"ai_attribution":          gitHubAIAttributionSelectBase,
+	}
+	for destination, query := range selects {
+		if !containsColumn(query, "org_id = ?") {
+			t.Fatalf("%s readback does not fence org_id: %s", destination, query)
+		}
+		// Every readback must resolve ReplacingMergeTree versions somehow. The
+		// six unpartitioned destinations use FINAL; ai_attribution resolves the
+		// winner explicitly because FINAL's answer there depends on a server
+		// knob (see below).
+		resolves := containsColumn(query, "FINAL") ||
+			containsColumn(gitHubAIAttributionSelectResolve, "LIMIT 1 BY") &&
+				destination == "ai_attribution"
+		if !resolves {
+			t.Fatalf("%s readback does not resolve ReplacingMergeTree versions: %s", destination, query)
+		}
+	}
+	// ai_attribution is the only PARTITIONED destination and its partition
+	// expression is not in its sorting key. It deliberately does NOT fence the
+	// partition: measured against a real ClickHouse, the default
+	// do_not_merge_across_partitions_select_final=0 makes FINAL merge ACROSS
+	// partitions, so the sorting key has exactly one current row and a partition
+	// predicate would filter that winner out -- answering Absent for a correctly
+	// superseded row, which replays forever. `found > 1` carries the duplicate
+	// protection instead and is correct under both settings.
+	//
+	// Pinned here so the fence cannot be reintroduced as an "obvious fix" for
+	// PR #1535 without confronting the measurement that rejected it.
+	if containsColumn(gitHubAIAttributionSelectBase, "toYYYYMM") {
+		t.Fatal("ai_attribution readback reintroduced a partition fence; see the " +
+			"measurement recorded in github_work_items_ai_attribution_effects_clickhouse.go")
+	}
+	// It must also not use FINAL: FINAL's row count for a superseded row across
+	// a month boundary depends on do_not_merge_across_partitions_select_final,
+	// a server knob this code does not control, which would make the verdict
+	// settings-dependent. The winner is resolved explicitly instead.
+	if containsColumn(gitHubAIAttributionSelectBase, "FINAL") {
+		t.Fatal("ai_attribution readback uses FINAL, making its verdict depend on " +
+			"do_not_merge_across_partitions_select_final")
+	}
+	if !containsColumn(gitHubAIAttributionSelectResolve, "LIMIT 1 BY org_id, provider, subject_type, repo_id, subject_id, source") {
+		t.Fatal("ai_attribution readback no longer resolves one row per sorting key")
+	}
+	if !containsColumn(gitHubAIAttributionSelectResolve, "ORDER BY computed_at DESC") {
+		t.Fatal("ai_attribution readback no longer resolves by the RMT version column")
+	}
+}
+
+func containsColumn(query, needle string) bool {
+	return len(query) >= len(needle) && indexOf(query, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for index := 0; index+len(needle) <= len(haystack); index++ {
+		if haystack[index:index+len(needle)] == needle {
+			return index
+		}
+	}
+	return -1
+}
+
+// The dispatcher must refuse an effect aimed at a different destination even
+// when the payload decodes cleanly, or a mis-wired slot would write one
+// surface's rows into another's table.
+func TestDirectAdaptersRejectForeignDestination(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "work-items")
+	startedAt := time.Now().UTC()
+	row := githubSprintRow{
+		Provider: "github", SprintID: "1", Name: stringPointer("s"),
+		State: stringPointer("open"), StartedAt: &startedAt,
+		LastSynced: startedAt, OrgID: claim.OrgID,
+	}
+	encoded, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := BuildEffectBatch("sprints", EffectReadbackRequired, []json.RawMessage{encoded})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := GitHubWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: "github", Dataset: "work-items",
+		Generation: claim.GenerationKey(), Destination: "work_items",
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	if err := (GitHubWorkItemsClickHouseAdapter{Conn: unreachableConn{t: t}}).WriteGitHubWorkItemEffect(
+		t.Context(), identity, effect,
+	); err == nil {
+		t.Fatal("work_items adapter accepted a sprints effect")
+	}
+}
+
+// body_length is UInt32. A negative Go int would wrap to an enormous unsigned
+// value rather than error, so it must be refused before it reaches the driver.
+func TestDirectAdaptersRejectNegativeBodyLength(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	row := githubWorkItemInteractionRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github",
+		InteractionType: "comment", OccurredAt: now, BodyLength: -1,
+		LastSynced: now, OrgID: nativeTestClaim("github", "work-items").OrgID,
+	}
+	identity, effect := directAdapterTestEffect(t, "work_item_interactions", row)
+	adapter := GitHubWorkItemInteractionsClickHouseAdapter{Conn: unreachableConn{t: t}}
+	if err := adapter.WriteGitHubWorkItemEffect(t.Context(), identity, effect); err == nil {
+		t.Fatal("a negative body_length reached the write path")
+	}
+	if _, err := adapter.InspectGitHubWorkItemEffect(t.Context(), identity, effect); err == nil {
+		t.Fatal("a negative body_length reached the readback path")
+	}
+}
+
+// A row carrying another tenant's org_id must be refused before any I/O, not
+// filtered later by the readback -- by then it has already been written.
+func TestDirectAdaptersRejectCrossTenantRowsBeforeIO(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	row := githubWorkItemRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github", Title: "t",
+		Type: "issue", Status: "doing", RepoID: &repoID,
+		Assignees: []string{}, Labels: []string{},
+		CreatedAt: now, UpdatedAt: now, LastSynced: now,
+		OrgID: "some-other-tenant",
+	}
+	identity, effect := directAdapterTestEffect(t, "work_items", row)
+	// A non-nil connection that fails the test if reached: with a nil Conn the
+	// guard under test could be deleted and this would still pass.
+	adapter := GitHubWorkItemsClickHouseAdapter{Conn: unreachableConn{t: t}}
+	if err := adapter.WriteGitHubWorkItemEffect(t.Context(), identity, effect); err == nil {
+		t.Fatal("a cross-tenant row reached the write path")
+	}
+}
+
+func directAdapterTestEffect(t *testing.T, destination string, row any) (GitHubWorkItemEffectIdentity, EffectBatch) {
+	t.Helper()
+	claim := nativeTestClaim("github", "work-items")
+	encoded, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := BuildEffectBatch(destination, EffectReadbackRequired, []json.RawMessage{encoded})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return GitHubWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: "github", Dataset: "work-items",
+		Generation: claim.GenerationKey(), Destination: destination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}, effect
+}
+
+// unreachableConn is a driver.Conn that fails the test if the adapter reaches
+// it. A nil Conn cannot serve this purpose: workItemAdapterGuard rejects a nil
+// connection whenever there are rows, so a nil-Conn test passes even when the
+// guard it claims to exercise has been deleted. (Found by mutations M13/M14/M15
+// surviving against exactly that shape.)
+type unreachableConn struct {
+	t *testing.T
+}
+
+func (c unreachableConn) reached(method string) {
+	c.t.Helper()
+	c.t.Fatalf("adapter reached ClickHouse via %s -- the row should have been "+
+		"refused before any I/O", method)
+}
+
+func (c unreachableConn) Contributors() []string { c.reached("Contributors"); return nil }
+func (c unreachableConn) ServerVersion() (*chdriver.ServerVersion, error) {
+	c.reached("ServerVersion")
+	return nil, nil
+}
+func (c unreachableConn) Select(context.Context, any, string, ...any) error {
+	c.reached("Select")
+	return nil
+}
+func (c unreachableConn) Query(context.Context, string, ...any) (chdriver.Rows, error) {
+	c.reached("Query")
+	return nil, nil
+}
+func (c unreachableConn) QueryRow(context.Context, string, ...any) chdriver.Row {
+	c.reached("QueryRow")
+	return nil
+}
+func (c unreachableConn) PrepareBatch(context.Context, string, ...chdriver.PrepareBatchOption) (chdriver.Batch, error) {
+	c.reached("PrepareBatch")
+	return nil, nil
+}
+func (c unreachableConn) Exec(context.Context, string, ...any) error { c.reached("Exec"); return nil }
+func (c unreachableConn) AsyncInsert(context.Context, string, bool, ...any) error {
+	c.reached("AsyncInsert")
+	return nil
+}
+func (c unreachableConn) Ping(context.Context) error { c.reached("Ping"); return nil }
+func (c unreachableConn) Stats() chdriver.Stats      { c.reached("Stats"); return chdriver.Stats{} }
+func (c unreachableConn) Close() error               { return nil }
+
+var _ chdriver.Conn = unreachableConn{}
+
+// The previous foreign-destination test could not see the destination guard at
+// all: it sent a sprints ROW, which fails decodeEffectRows' DisallowUnknownFields
+// before the guard is ever consulted, so deleting the guard left it green
+// (mutation M14 survived against exactly that shape).
+//
+// This sends a payload that decodes cleanly as a work_items row but is labelled
+// for another destination. Now only the guard can stop it, and if it does not,
+// the adapter reaches the connection and unreachableConn fails the test.
+func TestDirectAdaptersRejectMislabelledDestinationThatStillDecodes(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "work-items")
+	now := time.Now().UTC()
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	row := githubWorkItemRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github", Title: "t",
+		Type: "issue", Status: "doing", RepoID: &repoID,
+		Assignees: []string{}, Labels: []string{},
+		CreatedAt: now, UpdatedAt: now, LastSynced: now, OrgID: claim.OrgID,
+	}
+	encoded, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Valid work_items rows, but the batch is labelled for another destination.
+	effect, err := BuildEffectBatch("sprints", EffectReadbackRequired, []json.RawMessage{encoded})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := GitHubWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: "github", Dataset: "work-items",
+		Generation: claim.GenerationKey(), Destination: "work_items",
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	adapter := GitHubWorkItemsClickHouseAdapter{Conn: unreachableConn{t: t}}
+	if err := adapter.WriteGitHubWorkItemEffect(t.Context(), identity, effect); err == nil {
+		t.Fatal("adapter accepted an effect labelled for another destination")
+	}
+	if _, err := adapter.InspectGitHubWorkItemEffect(t.Context(), identity, effect); err == nil {
+		t.Fatal("readback accepted an effect labelled for another destination")
+	}
+}
+
+// dedupeBySortingKey must keep the row ClickHouse itself retains. Measured
+// against a real ReplacingMergeTree with two rows at one key and EQUAL
+// versions: one INSERT block (A,B) retains B; the reversed block (B,A) retains
+// A -- so it is the LAST row in insertion order, not the greatest value. The
+// reversed case is the control that rules out "max wins"; without it, keeping
+// the last row would be indistinguishable from keeping the larger one.
+func TestDedupeBySortingKeyKeepsTheRowClickHouseRetains(t *testing.T) {
+	t.Parallel()
+	type row struct{ key, payload string }
+	identity := func(r row) string { return r.key }
+
+	forward := dedupeBySortingKey([]row{{"k", "A"}, {"k", "B"}}, identity)
+	if len(forward) != 1 || forward[0].payload != "B" {
+		t.Fatalf("(A,B) deduped to %+v, want one row carrying B", forward)
+	}
+	reversed := dedupeBySortingKey([]row{{"k", "B"}, {"k", "A"}}, identity)
+	if len(reversed) != 1 || reversed[0].payload != "A" {
+		t.Fatalf("(B,A) deduped to %+v, want one row carrying A -- keeping the "+
+			"greatest value instead of the last would pass the forward case alone", reversed)
+	}
+	// Distinct keys must survive untouched, and in order.
+	distinct := dedupeBySortingKey([]row{{"a", "1"}, {"b", "2"}, {"a", "3"}}, identity)
+	if len(distinct) != 2 || distinct[0].payload != "3" || distinct[1].payload != "2" {
+		t.Fatalf("mixed batch deduped to %+v, want [a=3 b=2] preserving first-seen order", distinct)
+	}
+}
+
+// The sorting keys must not collide across different field splits: two rows
+// whose concatenated fields are equal but whose field boundaries differ are
+// different rows and must not be deduped into one.
+func TestSortingKeysDoNotCollideAcrossFieldBoundaries(t *testing.T) {
+	t.Parallel()
+	left := githubWorkItemDependencyRow{
+		OrgID: "org", SourceWorkItemID: "a", TargetWorkItemID: "bc",
+		RelationshipType: "blocks",
+	}
+	right := githubWorkItemDependencyRow{
+		OrgID: "org", SourceWorkItemID: "ab", TargetWorkItemID: "c",
+		RelationshipType: "blocks",
+	}
+	if workItemDependencySortingKey(left) == workItemDependencySortingKey(right) {
+		t.Fatal("two distinct dependency rows share a sorting key -- the separator " +
+			"is not doing its job and one row would be silently dropped")
+	}
+}
+
+// The LIMIT 1 BY key is a hard-coded string, so nothing but this test stops it
+// drifting from the table it is supposed to mirror. A key that lost a column
+// would collapse rows that are genuinely distinct; one that gained a column
+// would stop collapsing rows that must collapse. Both are silent.
+//
+// The expectation is PARSED from the migration that owns the table
+// (044_ai_attribution_repo_id_dedup_key.sql, which added repo_id to the dedup
+// key) rather than restated here, so a future migration that changes the key
+// fails this test instead of quietly disagreeing with the readback.
+func TestAIAttributionResolveKeyMatchesTheMigrationSortingKey(t *testing.T) {
+	t.Parallel()
+	_, currentFile, _, _ := runtime.Caller(0)
+	migration := filepath.Join(filepath.Dir(currentFile), "..", "..",
+		"src", "dev_health_ops", "migrations", "clickhouse",
+		"044_ai_attribution_repo_id_dedup_key.sql")
+	source, err := os.ReadFile(migration)
+	if err != nil {
+		t.Fatalf("read the migration that owns ai_attribution's sorting key: %v", err)
+	}
+	var orderBy string
+	for _, line := range strings.Split(string(source), "\n") {
+		// The effective statement only; the file also discusses the OLD key in
+		// comments, and matching one of those would assert against the very
+		// key this migration replaced.
+		if strings.HasPrefix(line, "ORDER BY (") {
+			orderBy = strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(line), "ORDER BY ("), ")")
+			break
+		}
+	}
+	if orderBy == "" {
+		t.Fatal("no effective ORDER BY found in the migration -- the parse is " +
+			"stale, so this test would otherwise assert nothing")
+	}
+	want := " ORDER BY computed_at DESC, record_id DESC LIMIT 1 BY " + orderBy
+	if gitHubAIAttributionSelectResolve != want {
+		t.Fatalf("resolve clause disagrees with the migration's sorting key\n"+
+			"migration=%s\nresolve  =%s", want, gitHubAIAttributionSelectResolve)
+	}
+}

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -442,6 +442,7 @@ func normalizeGitHubProjectV2Item(
 			FromStatusRaw: nullableString(fromRaw), ToStatusRaw: nullableString(toRaw),
 			FromStatus: githubProjectV2Status(fromRaw, nil, ""),
 			ToStatus:   githubProjectV2Status(toRaw, nil, ""), Actor: actor, OrgID: claim.OrgID,
+			LastSynced: normalizedAt.UTC(),
 		}
 		if err := transition.validate(claim); err != nil {
 			return githubWorkItemRow{}, nil, false, err
@@ -496,7 +497,7 @@ func normalizeGitHubProjectV2Item(
 		RepoID: nil, ProjectID: stringPointer(projectScopeID), Assignees: assignees,
 		Reporter: reporter, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC(),
 		ClosedAt: closedAt, Labels: labels, StoryPoints: storyPoints, URL: content.URL,
-		OrgID: claim.OrgID,
+		OrgID: claim.OrgID, LastSynced: normalizedAt.UTC(),
 	}
 	if statusRaw == "" {
 		row.StatusRaw = nullableString(state)

--- a/internal/providersync/github_work_items_projects_v2_oracle_test.go
+++ b/internal/providersync/github_work_items_projects_v2_oracle_test.go
@@ -42,7 +42,7 @@ func TestGitHubProjectV2WorkItemMatchesLivePythonProductionRow(t *testing.T) {
 				t.Fatal("Go normalizer skipped issue")
 			}
 			return row
-		}, nil,
+		}, githubWorkItemWriteStampGoOnly,
 	)
 }
 
@@ -61,7 +61,7 @@ func TestGitHubProjectV2DraftIssueMatchesLivePythonProductionRow(t *testing.T) {
 				t.Fatal("Go normalizer skipped draft issue")
 			}
 			return row
-		}, nil,
+		}, githubWorkItemWriteStampGoOnly,
 	)
 }
 
@@ -77,7 +77,7 @@ func TestGitHubProjectV2TransitionMatchesLivePythonProductionRow(t *testing.T) {
 				t.Fatalf("emitted=%t transitions=%+v", emitted, transitions)
 			}
 			return transitions[input["transition_index"].(int)]
-		}, nil,
+		}, githubWorkItemWriteStampGoOnly,
 	)
 }
 

--- a/internal/providersync/github_work_items_route.go
+++ b/internal/providersync/github_work_items_route.go
@@ -201,6 +201,15 @@ func (handler GitHubWorkItemsRouteHandler) Collect(
 		client.Lease == nil || normalizedAt.IsZero() {
 		return CompleteRouteBatch{}, ErrInvalidConfiguration
 	}
+	// Every destination column that receives normalizedAt is DateTime64(3), so
+	// the nanoseconds a wall-clock now() carries cannot survive a round trip.
+	// Truncating here rather than only inside REST.Collect (which truncates its
+	// own by-value copy, leaving the PR-bundle and projects-v2 paths below
+	// untouched) keeps the effect payload equal to what ClickHouse stores --
+	// otherwise the readback compares .123456789 against a stored .123, answers
+	// Absent for a row that landed, and the committer rewrites it on every
+	// recovery pass forever. Same fix, same reason, as github_blame_route.go.
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
 	if handler.Deriver == nil {
 		return CompleteRouteBatch{}, ErrGitHubWorkItemsDerivationsUnavailable
 	}

--- a/internal/providersync/github_work_items_route_test.go
+++ b/internal/providersync/github_work_items_route_test.go
@@ -122,7 +122,7 @@ func TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage(t *te
 		Title: "project wins", Type: "issue", Status: "done",
 		ProjectID: stringPointer("ghprojv2:acme#3"),
 		Assignees: []string{}, Labels: []string{}, OrgID: claim.OrgID,
-		CreatedAt: normalizedAt, UpdatedAt: normalizedAt,
+		CreatedAt: normalizedAt, UpdatedAt: normalizedAt, LastSynced: normalizedAt,
 	}
 	projects := &githubWorkItemsRouteProjectPolicy{result: GitHubProjectV2FetchResult{
 		Rows: githubWorkItemRows{
@@ -130,7 +130,7 @@ func TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage(t *te
 			StatusTransitions: []githubWorkItemTransitionRow{{
 				WorkItemID: projectRow.WorkItemID, Provider: "github",
 				OccurredAt: normalizedAt, FromStatus: "todo", ToStatus: "done",
-				OrgID: claim.OrgID,
+				OrgID: claim.OrgID, LastSynced: normalizedAt,
 			}},
 		},
 		Evidence: FetchEvidence{Provider: "github", Dataset: "projects-v2", Requests: 3, Pages: 2, Records: 2},
@@ -802,4 +802,108 @@ func githubWorkItemsIncompleteError(t *testing.T, err error) *GitHubWorkItemsRou
 		t.Fatalf("error type=%T", err)
 	}
 	return routeErr
+}
+
+// The route must truncate normalizedAt to the precision its destination columns
+// can hold. REST.Collect truncates only its own by-value copy, so without the
+// route-entry truncation the PR-bundle and projects-v2 paths carry a wall-clock
+// instant's sub-millisecond component into DateTime64(3) columns; the stored
+// value then never equals the expectation, the readback answers Absent for a
+// row that landed, and the committer rewrites it on every recovery pass.
+//
+// Asserted on the EFFECT PAYLOAD rather than on a stored row, because that is
+// what the recovery snapshot persists and replays: an untruncated payload is
+// unsatisfiable no matter what the adapter later does.
+func TestGitHubWorkItemsRouteTruncatesTimestampsToTheColumnPrecision(t *testing.T) {
+	// Deliberately sub-millisecond: 123.456789ms. A whole-millisecond fixture
+	// would pass with or without the truncation.
+	normalizedAt := time.Date(2026, 8, 4, 12, 0, 0, 123456789, time.UTC)
+	batch := githubWorkItemsRouteCollectForTruncation(t, normalizedAt)
+
+	for _, destination := range []string{"work_items", "work_item_transitions"} {
+		effect := githubWorkItemsRouteEffect(t, batch, destination)
+		if len(effect.Rows) == 0 {
+			t.Fatalf("%s produced no rows, so this test would assert nothing", destination)
+		}
+		for index, raw := range effect.Rows {
+			var fields map[string]any
+			if err := json.Unmarshal(raw, &fields); err != nil {
+				t.Fatal(err)
+			}
+			for name, value := range fields {
+				text, isText := value.(string)
+				if !isText {
+					continue
+				}
+				stamp, err := time.Parse(time.RFC3339Nano, text)
+				if err != nil {
+					continue // not a timestamp field
+				}
+				if stamp.Truncate(time.Millisecond) != stamp {
+					t.Fatalf("%s row %d field %q carries sub-millisecond precision (%s) "+
+						"that DateTime64(3) cannot store", destination, index, name,
+						stamp.Format(time.RFC3339Nano))
+				}
+			}
+		}
+	}
+}
+
+// githubWorkItemsRouteCollectForTruncation drives the real route with the same
+// fixtures as the composition test, parameterised on normalizedAt.
+func githubWorkItemsRouteCollectForTruncation(t *testing.T, normalizedAt time.Time) CompleteRouteBatch {
+	t.Helper()
+	claim := githubWorkItemsRESTClaim()
+	claim.DatasetOptions["fetch_milestones"] = false
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": "acme", "project_number": 3},
+	}}
+	fixtures := githubWorkItemsRESTFixtures()
+	delete(fixtures, "/repos/acme/api/milestones")
+	doer := &githubWorkItemsRouteDoer{
+		t:              t,
+		rest:           &githubWorkItemsRESTDoer{t: t, replies: fixtures},
+		graphqlReplies: []string{`{"data":{"repository":{"pr0":{"number":52,"comments":{"nodes":[{"databaseId":9007199254740993,"body":"social","createdAt":"2026-07-23T00:00:00Z","author":{"login":"reviewer"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"timelineItems":{"nodes":[{"__typename":"ClosedEvent","createdAt":"2026-07-24T00:00:00Z","actor":{"login":"closer"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`},
+	}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	// The Projects policy is a stub, so these rows bypass the real normalizer
+	// (which stamps the route's already-truncated normalizedAt). Stamping them
+	// at millisecond precision here mirrors what normalizeGitHubProjectV2Item
+	// would produce, leaving the route's OWN path as the only thing this test
+	// can be measuring.
+	stamped := normalizedAt.UTC().Truncate(time.Millisecond)
+	projectRow := githubWorkItemRow{
+		WorkItemID: "gh:Acme/API-Renamed#42", Provider: "github",
+		Title: "project wins", Type: "issue", Status: "done",
+		ProjectID: stringPointer("ghprojv2:acme#3"),
+		Assignees: []string{}, Labels: []string{}, OrgID: claim.OrgID,
+		CreatedAt: stamped, UpdatedAt: stamped, LastSynced: stamped,
+	}
+	projects := &githubWorkItemsRouteProjectPolicy{result: GitHubProjectV2FetchResult{
+		Rows: githubWorkItemRows{
+			WorkItems: []githubWorkItemRow{projectRow},
+			StatusTransitions: []githubWorkItemTransitionRow{{
+				WorkItemID: projectRow.WorkItemID, Provider: "github",
+				OccurredAt: stamped, FromStatus: "todo", ToStatus: "done",
+				OrgID: claim.OrgID, LastSynced: stamped,
+			}},
+		},
+		Evidence: FetchEvidence{Provider: "github", Dataset: "projects-v2", Requests: 3, Pages: 2, Records: 2},
+		Usage: GitHubProjectV2Usage{
+			Transport: "graphql", RouteFamily: "work_item_prs",
+			Dimension: BudgetGraphQLCost, RequestCount: 3,
+		},
+		Targets: 1,
+	}}
+	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
+	handler := GitHubWorkItemsRouteHandler{Projects: projects, Deriver: deriver}
+	batch, err := handler.Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return batch
 }

--- a/internal/providersync/github_work_items_rows.go
+++ b/internal/providersync/github_work_items_rows.go
@@ -50,6 +50,24 @@ type githubWorkItemRow struct {
 	ServiceClass  *string    `json:"service_class"`
 	DueAt         *time.Time `json:"due_at"`
 	OrgID         string     `json:"org_id"`
+	// PRECONDITION -- SINGLE WRITER PER TABLE PER ORG. Carrying a deterministic
+	// normalizedAt as the version is only sound while Python's writers are
+	// stopped before Go's start. Under coexistence dual-writing the two would
+	// interleave versions on one key, and Python's wall-clock stamp would
+	// out-version any normalizedAt Go had written. Dual writing is out of scope
+	// BY DESIGN: activation is an atomic alias flip, and a rollback that
+	// re-enables Python correctly out-versions Go's rows for the same reason.
+	// The ACTIVATION LAYER must enforce single-writer; this row cannot. The
+	// same precondition covers the record_id divergence (Python assigns uuid4,
+	// Go derives a stable retry identifier).
+	//
+	// LastSynced is the ReplacingMergeTree version column for `work_items`.
+	// Python stamps it from wall-clock inside the sink writer, which cannot be
+	// reproduced by a retry; carrying the unit's normalizedAt in the effect row
+	// instead keeps the payload — and therefore a recovery-snapshot replay of
+	// it — byte-identical across attempts. Mirrors the four sibling direct rows
+	// that already carry LastSynced.
+	LastSynced time.Time `json:"last_synced"`
 }
 
 type githubWorkItemTransitionRow struct {
@@ -62,6 +80,8 @@ type githubWorkItemTransitionRow struct {
 	ToStatus      string    `json:"to_status"`
 	Actor         *string   `json:"actor"`
 	OrgID         string    `json:"org_id"`
+	// LastSynced: see githubWorkItemRow.LastSynced.
+	LastSynced time.Time `json:"last_synced"`
 }
 
 type githubWorkItemDependencyRow struct {
@@ -271,7 +291,7 @@ func normalizeGitHubIssueWorkItem(
 		ProjectID: &projectID, Assignees: assignees, Reporter: reporter,
 		CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC(), ClosedAt: closedAt,
 		Labels: labels, URL: url, PriorityRaw: priority, ServiceClass: serviceClass,
-		OrgID: claim.OrgID,
+		OrgID: claim.OrgID, LastSynced: normalizedAt.UTC(),
 	}
 	if closedAt != nil {
 		copy := closedAt.UTC()
@@ -492,6 +512,7 @@ func normalizeGitHubPullRequestBundle(
 		CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC(), StartedAt: &startedAt,
 		ClosedAt: closedAt, Labels: labels, URL: urlValue,
 		PriorityRaw: priority, ServiceClass: serviceClass, OrgID: claim.OrgID,
+		LastSynced: normalizedAt.UTC(),
 	}
 	if mergedAt != nil {
 		completed := mergedAt.UTC()
@@ -622,6 +643,7 @@ func normalizeGitHubWorkItemEvents(
 				WorkItemID: workItemID, Provider: "github", OccurredAt: transitionAt,
 				ToStatusRaw: nullableString(toRaw), FromStatus: previous,
 				ToStatus: toStatus, OrgID: claim.OrgID,
+				LastSynced: normalizedAt.UTC(),
 			}
 			if err := transition.validate(claim); err != nil {
 				return nil, nil, err
@@ -1206,7 +1228,8 @@ func (row githubWorkItemRow) validate(claim Claim) error {
 	if row.Provider != "github" || row.OrgID == "" || row.OrgID != claim.OrgID ||
 		row.WorkItemID == "" || row.RepoID == nil || *row.RepoID == uuid.Nil ||
 		row.Title == "" || row.Type == "" || row.Status == "" ||
-		row.CreatedAt.IsZero() || row.UpdatedAt.IsZero() || row.Assignees == nil || row.Labels == nil {
+		row.CreatedAt.IsZero() || row.UpdatedAt.IsZero() || row.Assignees == nil ||
+		row.Labels == nil || row.LastSynced.IsZero() {
 		return providerfoundation.ErrInvalidScope
 	}
 	return nil
@@ -1223,7 +1246,8 @@ func (row githubSprintRow) validate(claim Claim) error {
 
 func (row githubWorkItemTransitionRow) validate(claim Claim) error {
 	if row.WorkItemID == "" || row.Provider != "github" || row.OccurredAt.IsZero() ||
-		row.FromStatus == "" || row.ToStatus == "" || row.OrgID == "" || row.OrgID != claim.OrgID {
+		row.FromStatus == "" || row.ToStatus == "" || row.OrgID == "" ||
+		row.OrgID != claim.OrgID || row.LastSynced.IsZero() {
 		return providerfoundation.ErrInvalidScope
 	}
 	return nil

--- a/internal/providersync/github_work_items_rows_generic_oracle_test.go
+++ b/internal/providersync/github_work_items_rows_generic_oracle_test.go
@@ -72,8 +72,25 @@ func TestGitHubIssueWorkItemMatchesLivePythonProductionRow(t *testing.T) {
 			},
 		},
 		buildGitHubIssueWorkItemOracleRow,
-		nil,
+		githubWorkItemWriteStampGoOnly,
 	)
+}
+
+// githubWorkItemWriteStampGoOnly declares the one field the Go work-item and
+// transition rows carry that the Python semantic row structurally cannot.
+//
+// Python's WorkItem/WorkItemStatusTransition dataclasses have no last_synced:
+// the sink stamps that column from wall-clock at insert time
+// (metrics/sinks/clickhouse/work_graph.py:661 and :749). Go carries the unit's
+// normalizedAt in the row instead, so the effect payload — and therefore a
+// recovery-snapshot replay of it — is byte-identical across attempts, which a
+// wall-clock stamp can never be. The stored column keeps its meaning; only its
+// determinism changes.
+var githubWorkItemWriteStampGoOnly = map[string]string{
+	"last_synced": "Python's semantic row has no last_synced at all -- its sink " +
+		"stamps the column from wall-clock at insert time, which no retry can " +
+		"reproduce. Go carries the unit's normalizedAt in the row so a recovery " +
+		"snapshot replays to identical bytes and the readback can answer Exact.",
 }
 
 func TestGitHubSprintMatchesLivePythonProductionRow(t *testing.T) {

--- a/internal/providersync/github_work_items_semantic_oracle_test.go
+++ b/internal/providersync/github_work_items_semantic_oracle_test.go
@@ -29,7 +29,7 @@ func TestGitHubPullRequestWorkItemMatchesLivePythonProductionRow(t *testing.T) {
 			}, []any{}),
 		}},
 		buildGitHubPullRequestWorkItemOracleRow,
-		nil,
+		githubWorkItemWriteStampGoOnly,
 	)
 }
 
@@ -68,7 +68,7 @@ func TestGitHubWorkItemStatusTransitionMatchesLivePythonProductionRow(t *testing
 			{ID: "issue_labeled_in_progress", Input: issueInput},
 		},
 		buildGitHubStatusTransitionOracleRow,
-		nil,
+		githubWorkItemWriteStampGoOnly,
 	)
 }
 

--- a/internal/providersync/github_work_items_sink_oracle_test.go
+++ b/internal/providersync/github_work_items_sink_oracle_test.go
@@ -1,0 +1,396 @@
+package providersync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The per-destination differential for the effects layer.
+//
+// The existing oracle_pairs cover the SEMANTIC row -- what the provider
+// normalises. They stop before the sink, so nothing until now compared the
+// INSERT PROJECTION: which columns this unit writes, in what order, with which
+// coercions. That projection is where a port silently diverges, because every
+// omission and every `or ""` is invisible to a row-level comparison.
+//
+// testdata/python_work_item_sink_oracle.py executes the real production sink
+// (ClickHouseMetricsSink, constructed with a recording client) and reports the
+// column list and value matrix it would have inserted. This test runs the Go
+// adapter's projection over the same row and compares both, with types
+// preserved on the wire so an int cannot pass as a float or a UUID as a string.
+func TestDirectAdapterProjectionsMatchTheLivePythonSink(t *testing.T) {
+	python := pythonExecutable(t)
+	// A negative-offset evening: the local date and the UTC date disagree, so
+	// any accidental local-time coercion on either side shows up as a wrong day
+	// rather than passing by coincidence.
+	normalizedAt := time.Date(2026, 8, 31, 23, 30, 0, 0, time.UTC)
+	orgID := "org-acme"
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+
+	// Every value in a positionally-indistinguishable group is DISTINCT on
+	// purpose. work_items writes eight consecutive String columns
+	// (status_raw, project_key, project_id, native_team_key, project_name,
+	// reporter, sprint_id, sprint_name, parent_id, epic_id, url) and five
+	// consecutive timestamps; if any two carried the same value a transposition
+	// of those columns would compare equal and the oracle would pass while the
+	// projection was wrong.
+	storyPoints := 100000.0 // integral on purpose: repr() vs 'g' disagree here
+	workItem := githubWorkItemRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github", Title: "Repair path",
+		Type: "issue", Status: "doing", StatusRaw: stringPointer("open"),
+		ProjectKey:    stringPointer("project-key-value"),
+		NativeTeamKey: stringPointer("native-team-key-value"),
+		ProjectName:   stringPointer("project-name-value"),
+		SprintID:      stringPointer("sprint-id-value"),
+		SprintName:    stringPointer("sprint-name-value"),
+		ParentID:      stringPointer("parent-id-value"),
+		EpicID:        stringPointer("epic-id-value"),
+		StoryPoints:   &storyPoints,
+		// Set on purpose: write_work_items must NOT carry these four to the
+		// table, and a projection that "helpfully" added them diverges here.
+		Description: stringPointer("body"), PriorityRaw: stringPointer("p1"),
+		ServiceClass: stringPointer("expedite"),
+		RepoID:       &repoID, ProjectID: stringPointer("acme/api"),
+		Assignees: []string{"dev", "second-assignee"},
+		Reporter:  stringPointer("reporter"),
+		CreatedAt: normalizedAt.Add(-72 * time.Hour),
+		UpdatedAt: normalizedAt.Add(-71 * time.Hour),
+		Labels:    []string{"bug", "p1", "third-label"},
+		URL:       stringPointer("https://github.com/acme/api/issues/42"),
+		OrgID:     orgID, LastSynced: normalizedAt,
+	}
+	dueAt := normalizedAt.Add(48 * time.Hour)
+	workItem.DueAt = &dueAt
+	startedAtItem := normalizedAt.Add(-70 * time.Hour)
+	completedAtItem := normalizedAt.Add(-69 * time.Hour)
+	closedAtItem := normalizedAt.Add(-68 * time.Hour)
+	workItem.StartedAt = &startedAtItem
+	workItem.CompletedAt = &completedAtItem
+	workItem.ClosedAt = &closedAtItem
+
+	transition := githubWorkItemTransitionRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github",
+		OccurredAt: normalizedAt.Add(-2 * time.Hour), FromStatus: "todo",
+		ToStatus: "doing", ToStatusRaw: stringPointer("doing"),
+		OrgID: orgID, LastSynced: normalizedAt,
+	}
+	dependency := githubWorkItemDependencyRow{
+		SourceWorkItemID: "gh:acme/api#42", TargetWorkItemID: "gh:acme/api#7",
+		RelationshipType: "blocks", RelationshipTypeRaw: "blocks",
+		RelationshipSemanticsVersion: "canonical-blocks.v2",
+		LastSynced:                   normalizedAt, OrgID: orgID,
+	}
+	reopen := githubWorkItemReopenRow{
+		WorkItemID: "gh:acme/api#42", OccurredAt: normalizedAt.Add(-3 * time.Hour),
+		FromStatus: "done", ToStatus: "doing", LastSynced: normalizedAt,
+		OrgID: orgID,
+	}
+	interaction := githubWorkItemInteractionRow{
+		WorkItemID: "gh:acme/api#42", Provider: "github",
+		InteractionType: "comment", OccurredAt: normalizedAt.Add(-4 * time.Hour),
+		Actor: stringPointer("dev"), BodyLength: 128, LastSynced: normalizedAt,
+		OrgID: orgID,
+	}
+	startedAt := normalizedAt.Add(-240 * time.Hour)
+	endedAt := normalizedAt.Add(-239 * time.Hour)
+	completedAt := normalizedAt.Add(-238 * time.Hour)
+	sprint := githubSprintRow{
+		Provider: "github", SprintID: "gh:acme/api/milestone/3",
+		Name: stringPointer("Sprint 3"), State: stringPointer("open"),
+		NativeTeamKey: stringPointer("sprint-team-key"),
+		StartedAt:     &startedAt, EndedAt: &endedAt, CompletedAt: &completedAt,
+		LastSynced: normalizedAt, OrgID: orgID,
+	}
+
+	// A second, DIFFERENT work item so the multi-row case can catch a
+	// projection that is right for one row and wrong for the next (a captured
+	// loop variable, a shared buffer, a per-batch value hoisted by mistake).
+	secondItem := workItem
+	secondItem.WorkItemID = "gh:acme/api#43"
+	secondItem.Title = "Second item"
+	secondItem.Status = "todo"
+	secondItem.Assignees = []string{"other"}
+	secondItem.Labels = []string{}
+	secondPoints := 0.5
+	secondItem.StoryPoints = &secondPoints
+
+	cases := []struct {
+		id          string
+		destination string
+		sourceRows  []any
+		columns     string
+		rows        [][]any
+	}{
+		{"work_items", "work_items", []any{workItem}, gitHubWorkItemsInsert,
+			[][]any{projectWorkItem(workItem).values()}},
+		{"work_items_multi_row", "work_items", []any{workItem, secondItem}, gitHubWorkItemsInsert,
+			[][]any{projectWorkItem(workItem).values(), projectWorkItem(secondItem).values()}},
+		{"work_item_transitions", "work_item_transitions", []any{transition}, gitHubWorkItemTransitionsInsert,
+			[][]any{projectWorkItemTransition(transition).values()}},
+		{"work_item_dependencies", "work_item_dependencies", []any{dependency}, gitHubWorkItemDependenciesInsert,
+			[][]any{workItemDependencyValues(dependency)}},
+		{"work_item_reopen_events", "work_item_reopen_events", []any{reopen}, gitHubWorkItemReopenEventsInsert,
+			[][]any{workItemReopenValues(reopen)}},
+		{"work_item_interactions", "work_item_interactions", []any{interaction}, gitHubWorkItemInteractionsInsert,
+			[][]any{workItemInteractionValues(interaction)}},
+		{"sprints", "sprints", []any{sprint}, gitHubSprintsInsert,
+			[][]any{sprintValues(sprint)}},
+	}
+
+	payload := make([]map[string]any, 0, len(cases))
+	for _, testCase := range cases {
+		rows := make([]map[string]any, 0, len(testCase.sourceRows))
+		for _, source := range testCase.sourceRows {
+			encoded, err := json.Marshal(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var row map[string]any
+			if err := json.Unmarshal(encoded, &row); err != nil {
+				t.Fatal(err)
+			}
+			rows = append(rows, row)
+		}
+		payload = append(payload, map[string]any{
+			"id": testCase.id, "destination": testCase.destination,
+			"org_id": orgID, "rows": rows,
+		})
+	}
+
+	_, currentFile, _, _ := runtime.Caller(0)
+	packageDir := filepath.Dir(currentFile)
+	casesFile := filepath.Join(t.TempDir(), "sink-cases.json")
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(casesFile, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command(
+		python,
+		filepath.Join(packageDir, "testdata", "python_work_item_sink_oracle.py"),
+		casesFile,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute Python sink oracle: %v: %s", err, output)
+	}
+	var decoded struct {
+		Cases []struct {
+			ID          string              `json:"id"`
+			Table       string              `json:"table"`
+			ColumnNames []string            `json:"column_names"`
+			Rows        [][]json.RawMessage `json:"rows"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(output, &decoded); err != nil {
+		t.Fatalf("decode Python sink oracle output: %v: %s", err, output)
+	}
+	if len(decoded.Cases) != len(cases) {
+		t.Fatalf("oracle returned %d cases, expected %d -- a missing case would "+
+			"silently drop a destination from this comparison",
+			len(decoded.Cases), len(cases))
+	}
+
+	byID := map[string]int{}
+	for index, testCase := range cases {
+		byID[testCase.id] = index
+	}
+	for _, result := range decoded.Cases {
+		index, known := byID[result.ID]
+		if !known {
+			t.Fatalf("oracle returned unknown case %q", result.ID)
+		}
+		testCase := cases[index]
+		t.Run(result.ID, func(t *testing.T) {
+			goColumns := insertColumns(t, testCase.columns)
+			if strings.Join(goColumns, ",") != strings.Join(result.ColumnNames, ",") {
+				t.Fatalf("column list diverges from the live Python sink\npython=%v\ngo    =%v",
+					result.ColumnNames, goColumns)
+			}
+			if len(result.Rows) != len(testCase.rows) {
+				t.Fatalf("row count diverges: python=%d go=%d",
+					len(result.Rows), len(testCase.rows))
+			}
+			for rowIndex, pythonRow := range result.Rows {
+				compareSinkRow(t, result.ID, rowIndex, result.ColumnNames,
+					pythonRow, testCase.rows[rowIndex])
+			}
+		})
+	}
+}
+
+func compareSinkRow(
+	t *testing.T,
+	caseID string,
+	rowIndex int,
+	columns []string,
+	pythonRow []json.RawMessage,
+	goRow []any,
+) {
+	t.Helper()
+	if len(pythonRow) != len(goRow) {
+		t.Fatalf("row %d value count diverges: python=%d go=%d", rowIndex,
+			len(pythonRow), len(goRow))
+	}
+	for position, pythonValue := range pythonRow {
+		column := columns[position]
+		goRendered, err := renderSinkValue(goRow[position])
+		if err != nil {
+			t.Fatalf("row %d column %q: %v", rowIndex, column, err)
+		}
+		pythonRendered := renderPythonSinkValue(t, pythonValue)
+		// last_synced on the two shape-A destinations is the one column Python
+		// stamps from wall-clock inside the writer, so its value is
+		// unreproducible by construction. Everything about it except the
+		// instant is still compared: it must be present, in this position, and
+		// a datetime on both sides.
+		if column == "last_synced" && (strings.HasPrefix(caseID, "work_items") || caseID == "work_item_transitions") {
+			if !strings.HasPrefix(pythonRendered, "datetime:") ||
+				!strings.HasPrefix(goRendered, "datetime:") {
+				t.Fatalf("row %d column %q: expected a datetime on both sides, python=%s go=%s",
+					rowIndex, column, pythonRendered, goRendered)
+			}
+			continue
+		}
+		if pythonRendered != goRendered {
+			t.Fatalf("row %d column %q diverges\npython=%s\ngo    =%s",
+				rowIndex, column, pythonRendered, goRendered)
+		}
+	}
+}
+
+// insertColumns extracts the column list from an INSERT statement so the
+// comparison uses the very string the writer executes, not a second copy of it.
+func insertColumns(t *testing.T, statement string) []string {
+	t.Helper()
+	open := strings.Index(statement, "(")
+	close := strings.LastIndex(statement, ")")
+	if open < 0 || close < open {
+		t.Fatalf("cannot parse column list from %q", statement)
+	}
+	parts := strings.Split(statement[open+1:close], ",")
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		columns = append(columns, strings.TrimSpace(part))
+	}
+	return columns
+}
+
+// renderSinkValue renders a Go insert value in the oracle's type-tagged shape.
+// Unknown types are refused rather than formatted with %v, which would let a
+// type change pass as long as its text happened to match.
+func renderSinkValue(value any) (string, error) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return "str:" + typed, nil
+	case bool:
+		return "bool:" + strconv.FormatBool(typed), nil
+	case int:
+		return "int:" + strconv.Itoa(typed), nil
+	case uint32:
+		return "int:" + strconv.FormatUint(uint64(typed), 10), nil
+	case float64:
+		return canonicalFloat(typed), nil
+	case *float64:
+		if typed == nil {
+			return "null", nil
+		}
+		return canonicalFloat(*typed), nil
+	case *string:
+		if typed == nil {
+			return "null", nil
+		}
+		return "str:" + *typed, nil
+	case []string:
+		return "list:[" + strings.Join(typed, ",") + "]", nil
+	case time.Time:
+		return "datetime:" + typed.UTC().Format(time.RFC3339Nano), nil
+	case *time.Time:
+		if typed == nil {
+			return "null", nil
+		}
+		return "datetime:" + typed.UTC().Format(time.RFC3339Nano), nil
+	case uuid.UUID:
+		return "uuid:" + typed.String(), nil
+	case *uuid.UUID:
+		if typed == nil {
+			return "null", nil
+		}
+		return "uuid:" + typed.String(), nil
+	default:
+		return "", fmt.Errorf("unrenderable Go insert value type %T", value)
+	}
+}
+
+// canonicalFloat renders a float in a form that round-trips exactly and does
+// not depend on either language's default formatting. Python's repr() and Go's
+// 'g' verb disagree on integral values (repr(100000.0) is "100000.0", 'g' is
+// "100000"), so comparing the two languages' text would report a divergence
+// where the numbers are equal. The hex form is exact and unambiguous.
+func canonicalFloat(value float64) string {
+	return "float:" + strconv.FormatFloat(value, 'x', -1, 64)
+}
+
+func renderPythonSinkValue(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "null" {
+		return "null"
+	}
+	var list []struct {
+		Tag   string `json:"t"`
+		Value string `json:"v"`
+	}
+	if err := json.Unmarshal(raw, &list); err == nil {
+		items := make([]string, 0, len(list))
+		for _, item := range list {
+			items = append(items, item.Value)
+		}
+		return "list:[" + strings.Join(items, ",") + "]"
+	}
+	var tagged struct {
+		Tag   string `json:"t"`
+		Value string `json:"v"`
+	}
+	if err := json.Unmarshal(raw, &tagged); err != nil {
+		t.Fatalf("decode python value %s: %v", raw, err)
+	}
+	switch tagged.Tag {
+	case "str":
+		return "str:" + tagged.Value
+	case "bool":
+		return "bool:" + tagged.Value
+	case "int":
+		return "int:" + tagged.Value
+	case "float":
+		parsed, err := strconv.ParseFloat(tagged.Value, 64)
+		if err != nil {
+			t.Fatalf("parse python float %q: %v", tagged.Value, err)
+		}
+		return canonicalFloat(parsed)
+	case "uuid":
+		return "uuid:" + tagged.Value
+	case "datetime":
+		parsed, err := time.Parse(time.RFC3339Nano, tagged.Value)
+		if err != nil {
+			t.Fatalf("parse python datetime %q: %v", tagged.Value, err)
+		}
+		return "datetime:" + parsed.UTC().Format(time.RFC3339Nano)
+	default:
+		t.Fatalf("unknown python value tag %q", tagged.Tag)
+		return ""
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_direct_effects.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_direct_effects.json
@@ -1,0 +1,454 @@
+{
+  "schema_version": 1,
+  "name": "github work-item direct destination ClickHouse adapters (7 surfaces)",
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
+  "mutations": [
+    {
+      "id": "M01-workitems-writes-a-column-python-omits",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "url, last_synced, org_id, source_id)`",
+      "replace": "url, last_synced, org_id, source_id, description)`",
+      "rationale": "write_work_items omits description/priority_raw/service_class/due_at; a ReplacingMergeTree replaces whole rows, so writing one diverges from the running system",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdapterProjectionsMatchTheLivePythonSink)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M02-transitions-writes-provider",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "INSERT INTO work_item_transitions (repo_id, work_item_id, occurred_at,",
+      "replace": "INSERT INTO work_item_transitions (provider, repo_id, work_item_id, occurred_at,",
+      "rationale": "write_work_item_transitions builds no provider value; the column keeps its default",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdapterProjectionsMatchTheLivePythonSink)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M03-missing-optional-string-becomes-a-sentinel",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "func derefString(value *string) string {\n\tif value == nil {\n\t\treturn \"\"\n\t}",
+      "replace": "func derefString(value *string) string {\n\tif value == nil {\n\t\treturn \"unknown\"\n\t}",
+      "rationale": "Python stores the empty string for a missing optional, never a sentinel",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdapterProjectionsMatchTheLivePythonSink)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M04-same-key-collision-is-not-deduped",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tif len(rows) < 2 {\n\t\treturn rows\n\t}",
+      "replace": "\tif len(rows) >= 0 {\n\t\treturn rows\n\t}",
+      "rationale": "two rows at one sorting key must collapse keep-last before the write and the expected set; leaving them wedges the unit on a permanent Conflict",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDedupeBySortingKeyKeepsTheRowClickHouseRetains)$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M05-dedup-keeps-the-first-row-instead-of-the-last",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\t\t\tdeduped[index] = row // last occurrence wins, as the engine does",
+      "replace": "\t\t\t_ = index // keep the first occurrence",
+      "rationale": "ClickHouse retains the LAST row of a colliding pair at equal versions (measured, with a reversed-order control); keeping the first makes the expected set disagree with the table",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDedupeBySortingKeyKeepsTheRowClickHouseRetains)$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M06-stale-stored-version-hard-stops-instead-of-replaying",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tcase actual.UTC().Before(expected.UTC()):\n\t\treturn EffectAbsent, true",
+      "replace": "\tcase actual.UTC().Before(expected.UTC()):\n\t\treturn EffectConflict, true",
+      "rationale": "an older stored version means our write has not landed; it must replay, not wedge",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestWorkItemVersionVerdictSeparatesStaleFromOverwritten)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M07-newer-stored-version-is-silently-clobbered",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tcase actual.UTC().After(expected.UTC()):\n\t\treturn EffectConflict, true",
+      "replace": "\tcase actual.UTC().After(expected.UTC()):\n\t\treturn EffectAbsent, true",
+      "rationale": "a newer stored version belongs to another writer and must not be overwritten silently",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestWorkItemVersionVerdictSeparatesStaleFromOverwritten)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M08-partly-landed-batch-reports-exact",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tcase exact == len(rows):\n\t\treturn EffectExact, nil",
+      "replace": "\tcase exact >= 0:\n\t\treturn EffectExact, nil",
+      "rationale": "a batch where only some rows landed cannot be replayed without rewriting the ones that did",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestFoldWorkItemInspectionsTreatsMixedBatchAsConflict)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M09-timestamp-not-truncated-to-the-column-precision",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "func clickHouseMillis(value time.Time) time.Time {\n\treturn value.UTC().Truncate(time.Millisecond)\n}",
+      "replace": "func clickHouseMillis(value time.Time) time.Time {\n\treturn value.UTC()\n}",
+      "rationale": "DateTime64(3) cannot hold the nanoseconds a wall-clock now() carries; an untruncated expectation is never satisfiable and replays forever",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M10-timestamp-parameter-drops-sub-second-precision",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "return clickHouseMillis(value).Format(\"2006-01-02 15:04:05.000\")",
+      "replace": "return clickHouseMillis(value).Format(\"2006-01-02 15:04:05\")",
+      "rationale": "the equality parameter must carry millisecond precision. A bound time.Time was measured NOT to compare equal to a stored DateTime64(3) at all; a second-precision string is the same defect one step later -- the readback finds nothing and rewrites a row that is present",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M21-timestamp-parameter-loses-its-explicit-UTC-interpretation",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "AND occurred_at = toDateTime64(?, 3, 'UTC') AND interaction_type = ?`",
+      "replace": "AND occurred_at = toDateTime64(?, 3) AND interaction_type = ?`",
+      "rationale": "the explicit UTC argument removes the dependence on the server timezone when parsing the parameter string",
+      "expected_survivor_reason": "EQUIVALENT ON A UTC-CONFIGURED SERVER, which is the only venue this suite has: measured `SELECT timezone()` on the test container returns UTC, so toDateTime64(?,3) and toDateTime64(?,3,'UTC') parse the parameter identically and no assertion can separate them here. The argument is retained because the column is a NAIVE DateTime64(3) whose parameter parsing would otherwise follow the server timezone, so the mutation stops being equivalent on any non-UTC server -- a venue this lane cannot provision. Declared rather than deleted so the gap is visible: the input class covered is UTC servers only.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M11-route-does-not-truncate-normalizedAt",
+      "file": "internal/providersync/github_work_items_route.go",
+      "find": "\tnormalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)",
+      "replace": "\tnormalizedAt = normalizedAt.UTC()",
+      "rationale": "REST.Collect truncates only its own by-value copy, so without the route-entry truncation the PR-bundle and projects-v2 paths carry sub-millisecond precision into DateTime64(3) columns. Proven at the EFFECT PAYLOAD, which is what the recovery snapshot replays; the adapter integration tests build rows directly and never exercise the route, which is why this mutation first SURVIVED",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemsRouteTruncatesTimestampsToTheColumnPrecision)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M12-evidence-key-order-sorted-not-python-insertion-order",
+      "file": "internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go",
+      "find": "\"app_slug|known_ai_bot|login|user_type\": {\"login\", \"user_type\", \"app_slug\", \"known_ai_bot\"},",
+      "replace": "\"app_slug|known_ai_bot|login|user_type\": {\"app_slug\", \"known_ai_bot\", \"login\", \"user_type\"},",
+      "rationale": "json.dumps serialises a dict in insertion order; sorting stores bytes Python never writes",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestPythonEvidenceJSONMatchesRealJSONDumpsByteForByte)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M13-evidence-separator-is-not-json-dumps-default",
+      "file": "internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go",
+      "find": "builder.WriteString(\": \")",
+      "replace": "builder.WriteString(\":\")",
+      "rationale": "json.dumps defaults to ', ' and ': ' separators",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestPythonEvidenceJSONMatchesRealJSONDumpsByteForByte)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M14-unknown-evidence-shape-guesses-instead-of-failing-closed",
+      "file": "internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go",
+      "find": "\tif !known || len(order) != len(evidence) {\n\t\treturn \"\", ErrInvalidConfiguration\n\t}",
+      "replace": "\tif !known {\n\t\torder = keys\n\t}",
+      "rationale": "an unreviewed evidence shape must not be stored in a guessed encoding",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestPythonEvidenceJSONFailsClosedOnUnknownShape)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M15-non-ascii-not-escaped-like-ensure-ascii",
+      "file": "internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go",
+      "find": "\t\t\tcase runeValue <= 0xffff:\n\t\t\t\tbuilder.WriteString(pythonJSONEscape(uint16(runeValue)))",
+      "replace": "\t\t\tcase runeValue <= 0xffff:\n\t\t\t\tbuilder.WriteRune(runeValue)",
+      "rationale": "json.dumps defaults to ensure_ascii=True",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestPythonEvidenceJSONMatchesRealJSONDumpsByteForByte)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M16-negative-body-length-reaches-a-uint32-column",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "if row.OrgID != identity.OrgID || row.BodyLength < 0 {\n\t\t\treturn ErrInvalidConfiguration",
+      "replace": "if row.OrgID != identity.OrgID {\n\t\t\treturn ErrInvalidConfiguration",
+      "rationale": "a negative Go int wraps to an enormous unsigned value rather than erroring",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdaptersRejectNegativeBodyLength)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M17-effect-for-another-destination-is-accepted",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "if ctx == nil || identity.Destination != destination ||\n\t\teffect.Destination != destination || identity.OrgID == \"\" ||",
+      "replace": "if ctx == nil || identity.OrgID == \"\" ||",
+      "rationale": "a mis-wired slot would write one surface's rows into another's table",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdaptersRejectMislabelledDestinationThatStillDecodes)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M18-cross-tenant-row-is-written",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tfor _, row := range rows {\n\t\tif row.OrgID != identity.OrgID {\n\t\t\treturn ErrInvalidConfiguration\n\t\t}\n\t}\n\trows = dedupeBySortingKey(rows, workItemSortingKey)",
+      "replace": "\trows = dedupeBySortingKey(rows, workItemSortingKey)",
+      "rationale": "a row from another tenant must be refused before any I/O",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestDirectAdaptersRejectCrossTenantRowsBeforeIO)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M19-ai-attribution-readback-reverts-to-FINAL",
+      "file": "internal/providersync/github_work_items_ai_attribution_effects_clickhouse.go",
+      "find": "const gitHubAIAttributionSelectResolve = ` ORDER BY computed_at DESC, record_id DESC LIMIT 1 BY org_id, provider, subject_type, repo_id, subject_id, source`",
+      "replace": "const gitHubAIAttributionSelectResolve = ``",
+      "rationale": "FINAL's answer for a superseded row across a month boundary depends on do_not_merge_across_partitions_select_final, a server knob this code does not control",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestEveryDirectReadbackFencesOrgID)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M20-readback-order-of-the-duplicate-arm",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tcase found > 1:\n\t\treturn EffectConflict, true\n\tcase found < 1:\n\t\treturn EffectAbsent, true",
+      "replace": "\tcase found < 1:\n\t\treturn EffectAbsent, true\n\tcase found > 1:\n\t\treturn EffectConflict, true",
+      "rationale": "records that the ORDER of the two arms is not load-bearing",
+      "expected_survivor_reason": "EQUIVALENT BY PROOF over the whole input domain, not by sampling: the two arms switch on the integer `found`, and exactly one of {found>1, found<1, found==1} holds for every integer, so the arms are disjoint and no ordering can change any outcome. Recorded rather than deleted because the ordering reads as significant and a future reader would otherwise re-derive it. The reachable same-key protection is dedupeBySortingKey, covered by M04/M05.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestWorkItemReadbackVerdictResolvesDuplicatesBeforeAbsence)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M22-equal-version-short-circuits-the-field-comparison",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tdefault:\n\t\treturn EffectExact, false\n\t}\n}\n\n// emptyEffectInspection",
+      "replace": "\tdefault:\n\t\treturn EffectExact, true\n\t}\n}\n\n// emptyEffectInspection",
+      "rationale": "the equal-version branch must FALL THROUGH to the field comparison. Returning final Exact there declares a row correct on the strength of its version alone, so a row whose fields differ but whose version matches reads as done and is never rewritten. This is the third arm of the three-way ordering and the only one that does not decide the verdict by itself",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestWorkItemVersionVerdictSeparatesStaleFromOverwritten)$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-timeout",
+          "20m",
+          "-run",
+          "^(TestWorkItemsReadbackDistinguishesStaleFromOverwritten|TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M23-zero-stored-version-is-not-treated-as-absent",
+      "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
+      "find": "\tcase actual.IsZero():\n\t\treturn EffectAbsent, true",
+      "replace": "\tcase actual.IsZero():\n\t\treturn EffectExact, true",
+      "rationale": "a zero stored version means no row was read; calling that Exact marks an effect committed that never landed",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestWorkItemVersionVerdictSeparatesStaleFromOverwritten)$",
+          "./internal/providersync/"
+        ]
+      ]
+    }
+  ]
+}

--- a/internal/providersync/testdata/python_work_item_sink_oracle.py
+++ b/internal/providersync/testdata/python_work_item_sink_oracle.py
@@ -1,0 +1,224 @@
+"""Capture what the REAL Python work-item sink would insert, without a database.
+
+Note on one Python branch this oracle cannot exercise: write_work_item_transitions
+falls back to ``datetime.now(timezone.utc)`` when ``occurred_at`` is falsy. That
+branch is unreachable from Go, because githubWorkItemTransitionRow.validate
+rejects a zero OccurredAt before any effect is built, so no Go-produced case can
+reach it. It is therefore left uncompared deliberately rather than overlooked --
+covering it would mean asserting behaviour the port can never produce.
+
+Every direct work-item destination is written by
+``metrics/sinks/clickhouse/work_graph.py`` (six of seven) or
+``metrics/sinks/clickhouse/ai_attribution.py`` (ai_attribution), reached from the
+composite unit in ``metrics/job_work_items.py``. Those sinks end in
+``self.client.insert(table, matrix, column_names=...)``.
+
+``ClickHouseMetricsSink.__init__`` accepts an injected client, so this oracle
+constructs the production sink with a recording stub and calls the production
+write method. The captured column list and value matrix are therefore produced
+by the real writer -- not by re-reading its source, and not by a hand-authored
+fixture that could agree with a stale reading of it.
+
+Values are type-tagged on the way out (the same wire format
+python_generic_row_oracle.py uses) so the Go comparison cannot collapse an int
+to a float or a UUID to a string.
+
+Usage: python_work_item_sink_oracle.py <cases.json>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
+from dev_health_ops.models.work_items import (
+    Sprint,
+    WorkItem,
+    WorkItemDependency,
+    WorkItemInteractionEvent,
+    WorkItemReopenEvent,
+    WorkItemStatusTransition,
+)
+
+
+class _RecordingClient:
+    """Stub that records insert calls instead of performing them."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def insert(
+        self, table: str, matrix: Any, column_names: Any = None, **_: Any
+    ) -> None:
+        self.calls.append(
+            {
+                "table": table,
+                "column_names": list(column_names or []),
+                "matrix": [list(row) for row in matrix],
+            }
+        )
+
+    def close(self) -> None:  # pragma: no cover - never reached in this oracle
+        pass
+
+
+def _encode(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return {"t": "bool", "v": "true" if value else "false"}
+    if isinstance(value, int):
+        return {"t": "int", "v": str(value)}
+    if isinstance(value, float):
+        return {"t": "float", "v": repr(value)}
+    if isinstance(value, str):
+        return {"t": "str", "v": value}
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return {
+            "t": "datetime",
+            "v": value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+    if isinstance(value, UUID):
+        return {"t": "uuid", "v": str(value).lower()}
+    if isinstance(value, date):
+        return {"t": "date", "v": value.isoformat()}
+    if isinstance(value, (list, tuple)):
+        return [_encode(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _encode(item) for key, item in value.items()}
+    raise TypeError(f"unencodable value type {type(value)!r}")
+
+
+def _parse_datetime(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(text)
+
+
+_DATETIME_FIELDS = {
+    "created_at",
+    "updated_at",
+    "started_at",
+    "completed_at",
+    "closed_at",
+    "due_at",
+    "occurred_at",
+    "ended_at",
+    "last_synced",
+    "observed_at",
+    "ingested_at",
+}
+_UUID_FIELDS = {"repo_id", "org_id", "source_id", "record_id", "superseded_by"}
+
+# The case file crosses the language boundary as JSON, and JSON has one number
+# type. Go's json.Marshal writes a float64 of 100000.0 as ``100000``, which
+# json.load then reads back as a Python *int* -- so an integral float arrives
+# here with its type quietly collapsed, and the sink (which passes story_points
+# through untouched) would insert an int where production inserts a float.
+#
+# Restoring the declared type here keeps the comparison about the production
+# code rather than about the transport. It is the same int/float collapse the
+# comparison itself is careful to avoid on the way out.
+_FLOAT_FIELDS = {"story_points", "confidence"}
+
+
+def _coerce(model: Any, row: dict[str, Any], uuid_fields: set[str]) -> Any:
+    import dataclasses
+
+    names = {field.name for field in dataclasses.fields(model)}
+    kwargs: dict[str, Any] = {}
+    for key, value in row.items():
+        if key not in names:
+            # The Go row carries fields the Python dataclass does not have
+            # (notably last_synced on WorkItem/WorkItemStatusTransition, whose
+            # sinks stamp it from wall-clock). Dropping them here is what makes
+            # this a comparison of the PYTHON writer's own output.
+            continue
+        if value is not None and key in _DATETIME_FIELDS:
+            value = _parse_datetime(value)
+        if value is not None and key in uuid_fields:
+            value = UUID(str(value))
+        if value is not None and key in _FLOAT_FIELDS:
+            value = float(value)
+        kwargs[key] = value
+    return model(**kwargs)
+
+
+_MODELS = {
+    "work_items": (WorkItem, "write_work_items", {"repo_id", "source_id"}),
+    "work_item_transitions": (
+        WorkItemStatusTransition,
+        "write_work_item_transitions",
+        {"repo_id", "source_id"},
+    ),
+    "work_item_dependencies": (
+        WorkItemDependency,
+        "write_work_item_dependencies",
+        {"source_id"},
+    ),
+    "work_item_reopen_events": (
+        WorkItemReopenEvent,
+        "write_work_item_reopen_events",
+        set(),
+    ),
+    "work_item_interactions": (
+        WorkItemInteractionEvent,
+        "write_work_item_interactions",
+        set(),
+    ),
+    "sprints": (Sprint, "write_sprints", set()),
+}
+
+
+def main() -> int:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        cases = json.load(handle)
+
+    results = []
+    for case in cases:
+        destination = case["destination"]
+        client = _RecordingClient()
+        sink = ClickHouseMetricsSink("clickhouse://stub/stub", client=client)
+        sink.org_id = case.get("org_id") or ""
+
+        payload = case["rows"] if "rows" in case else [case["row"]]
+        if destination == "ai_attribution":
+            records = [_coerce(AIAttributionRecord, r, _UUID_FIELDS) for r in payload]
+            sink.write_ai_attribution(records)
+        else:
+            model, method, uuid_fields = _MODELS[destination]
+            rows = [_coerce(model, r, uuid_fields) for r in payload]
+            getattr(sink, method)(rows)
+
+        if len(client.calls) != 1:
+            raise SystemExit(
+                f"case {case['id']}: the production sink made {len(client.calls)} "
+                "insert calls; this oracle can only speak for exactly one"
+            )
+        call = client.calls[0]
+        results.append(
+            {
+                "id": case["id"],
+                "table": call["table"],
+                "column_names": call["column_names"],
+                # Every row, not just the first: a multi-row batch is the shape
+                # production actually writes, and a projection that is correct
+                # for one row can still mis-handle the second.
+                "rows": [[_encode(value) for value in row] for row in call["matrix"]],
+            }
+        )
+
+    json.dump({"cases": results}, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the seven **direct** destination adapters for the GitHub work-items composite route (CHAOS-3123, layer 2). Feature-only: targets `feat/go-worker-runtime-migration`, never `main`.

Draft: merge order is #1535 → this / derived-lane in readiness order, and an adversarial review round runs before ready. **GitHub Actions is in a major outage, so no CI has registered on this branch** — the evidence below is local, and CI will be re-triggered by amend-push once Actions recovers (same as #1535).

## Scope

`GitHubWorkItemEffectAdapter` implementations for the seven direct fact surfaces:

`work_items`, `work_item_transitions`, `work_item_dependencies`, `work_item_reopen_events`, `work_item_interactions`, `sprints`, `ai_attribution`

`BuildGitHubWorkItemEffects` enumerates 16 destinations; the other 9 are derived-lane's and are disjoint. **Nothing is activated**: no route registered, no alias flipped, no `contracts/provider-matrix` change. `GitHubWorkItemClickHouseEffects.complete()` still requires derived-lane's 9, so no composed sink is constructed yet — that is layer 4.

## Mirroring the real Python producer (D16)

The composite unit is `metrics/job_work_items.py`, which writes through the **metrics sink** — `metrics/sinks/clickhouse/work_graph.py` (6 of 7) and `metrics/sinks/clickhouse/ai_attribution.py`. `storage/clickhouse.py` is the *API-ingest* path (`api/ingest/persist.py`) and diverges; porting from it would have mis-ported three destinations.

Every column list is the sink's own list, in its order, **including its omissions**, which are behavior under D16 on a whole-row ReplacingMergeTree replacement:

- `work_items` never writes `description`, `priority_raw`, `service_class`, `due_at`
- `work_item_transitions` never writes `provider`

Both omissions are confirmed by executing the real sink (below), not by reading it, and are pinned by tests that assert the **stored** columns.

## Differential oracles — Python executed, not digested

1. **Projection differential** (`testdata/python_work_item_sink_oracle.py`, new): constructs the production `ClickHouseMetricsSink` with a recording client and calls the real `write_*` methods, capturing the actual column list and insert matrix. Compared against Go with types preserved on the wire (type-tagged; no JSON int/float collapse). All 6 non-AI destinations match exactly. The existing `oracle_pairs` stop at the semantic row — nothing before this compared the insert projection.
2. **Evidence-byte differential**: 8 cases against real CPython `json.dumps`. Go's default map marshalling diverges on three independent axes — separator spacing, key order (`bot_author` and `pr_body` disagree with sorted keys), and HTML/non-ASCII escaping. The encoder reproduces `json.dumps` exactly and **fails closed** on an unrecognised evidence shape rather than guessing.

## Timestamp precision (found in review — two distinct defects)

Both were invisible because every fixture used a whole second, the class of test that cannot fail.

1. **Nanoseconds never reached the column.** `executor.now()` is untruncated and `REST.Collect` truncates only its own by-value copy, so the PR-bundle and projects-v2 paths carried nanoseconds into a `DateTime64(3)` column. The stored `.123` then never equalled the expected `.123456789`, the version verdict read Absent for a row that landed, and the committer rewrote it on **every** recovery pass — `Exact` was unreachable in production. Fixed at the route entry (as `github_blame_route.go` does) *and* in the projections, so the adapter is correct for any caller, not only a well-behaved one.
2. **A bound `time.Time` does not compare equal to a stored `DateTime64(3)`.** Measured: a row whose stored `occurred_at` scans back `Equal()` to the expectation still matched **zero** rows under `occurred_at = ?`. The three readbacks keyed on a timestamp now bind through `toDateTime64(?, 3, 'UTC')`, which matches, keeps the key column bare so the index can prune, and is independent of the server timezone by construction.

Fixtures now carry non-zero nanoseconds throughout; reverting either fix fails the replay suite.

## Same-key collisions inside one batch (found in review)

A batch can legitimately carry two rows at one sorting key — two issue events in the same second, the parse-failure fallback to the item's `createdAt`, and the projects-v2 concatenation that has no dedup of its own. ClickHouse collapses the pair on write, so the readback found ONE row, the comparator saw a field mismatch against whichever expectation lost, and the verdict was a permanent Conflict that wedged the unit with no way to self-heal. Python does not fail there — it silently loses one row — so the port was converting a silent loss into a hard stop, an undeclared D16 liveness divergence.

Both the write batch and the expected set are now deduped by sorting key, keep-last. **Keep-last is measured, not assumed:** against a real ReplacingMergeTree with equal versions, one INSERT block of (A,B) retains B and the reversed (B,A) retains A — the reversed case being the control that rules out "greatest value wins". Same-key integration cases cover transitions, reopen_events, interactions and dependencies.

## ReplacingMergeTree readback correctness

Readbacks fence `org_id` and resolve versions.

**Honest scope on `found > 1`:** it is defense-in-depth, **not** the duplicate protection. Every readback fences the full sorting key and then collapses, so more than one row cannot come back and the arm is unreachable in all seven adapters today. It is kept against a future WHERE/collapse change. The live same-key protection is the batch dedup above.

`ai_attribution` is the only partitioned destination, and its partition expression (`toYYYYMM(observed_at)`) is **not** in its sorting key. Measured, rather than assumed:

| query | `do_not_merge_across_partitions_select_final` | rows |
| --- | --- | --- |
| `FINAL` | 0 (default) | 1 |
| `FINAL` | 1 | 2 |
| `LIMIT 1 BY` | 0 | 1 |
| `LIMIT 1 BY` | 1 | 1 |

So the intuitive fix — fencing `toYYYYMM(observed_at)` — is **wrong**: under the default, `FINAL` merges across partitions to one winner and the predicate filters that winner out, answering Absent for a correctly superseded row (endless replay). And `FINAL` alone leaves the verdict dependent on a server knob we do not control.

This readback therefore uses no `FINAL`; it resolves the winner explicitly with `ORDER BY computed_at DESC, record_id DESC LIMIT 1 BY <sorting key>`, which is correct under **both** settings. `LIMIT 1 BY` rather than per-column `argMax` so a tie on `computed_at` cannot blend columns from two different rows. The integration test runs under both knob values, and reverting to `FINAL` fails the knob=1 variant — the guard is observed failing, not merely present. The other six destinations keep `FINAL`: they are unpartitioned, so the knob cannot affect them.

## Recovery-snapshot replay

Per #1529 contract item 9 the snapshot supplies expected effects, not write receipts, so a recovered worker re-runs the adapter over the identical payload and `Inspect` must answer `Exact`. A wall-clock version stamp never could — it writes a strictly newer version on every replay. The write stamp therefore lives in the effect row: `githubWorkItemRow` and `githubWorkItemTransitionRow` gained `LastSynced` from the unit's `normalizedAt` (5 construction sites), mirroring the four sibling direct rows that already do this. `ai_attribution` stamps `computed_at` from `IngestedAt` for the same reason — a declared divergence from Python's wall-clock, documented in the source. Declared in 6 oracle pairs as a Go-only field with a written reason.

## Evidence

- `gofmt` / `go build` / `go vet` / `go vet -tags integration`: clean
- `ci/check_go.sh live-python-oracles`: **exit 0**; every checked-in oracle pair recorded its `executed` proof
- Unit suite green, including the 8-case CPython differential **verified executing, not skipped**
- Integration (testcontainers ClickHouse): **13 tests / 14 executions**, exit 0 — replay for all 7 adapters, cross-tenant isolation, stale-vs-overwritten versions, mixed-batch conflict, stored-column omissions, month-boundary supersede under both knob settings
- Mutations: the plan is checked in at `internal/providersync/testdata/mutation-plans/github_work_items_direct_effects.json` (20 mutations) and run through the repo's shared harness with `--assert-all-killed`, so the table is reproducible rather than reported

The one declared survivor is equivalent **by proof over the whole input domain**, not by sampling: it swaps two arms of a `switch` on the integer `found`, and exactly one of `{>1, <1, ==1}` holds for every integer, so the arms are disjoint and no ordering can change any outcome. It is recorded rather than deleted because the ordering reads as significant. The reachable same-key protection is the batch dedup, covered by its own mutations.

The mutation runs earned their cost by finding four real defects, three in the tests themselves: three guard tests were green via a nil `driver.Conn` (which the adapter guard rejects independently) rather than via the guard they named, and a fourth sent a payload that failed decoding before the guard was consulted. All are now structured so only the guard under test can produce the pass.

## Known gaps (stated, not papered over)

1. **Integration DDL is transcribed** from `SHOW CREATE TABLE` on a migrated instance rather than derived from the migration chain at test time. It matches today and includes the column `DEFAULT`s, but can drift if a future migration alters these 7 tables. This is the pre-existing repo-wide pattern (every existing `*_effects_integration_test.go` does the same); deriving schema from the migration chain is a follow-up, not lane scope.
2. **The projection differential covers the 6 non-AI destinations.** `ai_attribution`'s writer is covered at the byte level for `evidence` and end-to-end in ClickHouse, but is not in the column/value comparison, because `_to_row` stamps a wall-clock `computed_at` and builds from `AIAttributionRecord` rather than the shared dataclass path.
3. **Composition is not wired** — the full sink needs derived-lane's 9 adapters before `complete()` returns true. Layer 4.

## Precondition: single writer per table per org

The deterministic version stamps are sound only while Python's writers are stopped before Go's start. Coexistence dual-writing is out of scope **by design**: activation is an atomic alias flip, and a rollback that re-enables Python correctly out-versions Go's rows (wall-clock beats any prior `normalizedAt`). **The activation layer must enforce single-writer; these adapters cannot.** Recorded here and at the stamping sites in source. The same precondition covers the `record_id` divergence (Python assigns uuid4, Go derives a stable retry identifier).

## Constraints

Migration `0066` untouched; no new migrations. `contracts/`, `deploy/`, `migrations/` and `src/dev_health_ops/migrations/` are byte-identical to base. No route activation, no alias activation, no matrix change. Not run through `local_validate` (machine-wide single-flight); targeted gates used instead.
