### PR TITLE
CHAOS-3362: stop feeding the argMax proof program through a here-document

### DIFF
--- a/ci/local_validate.sh
+++ b/ci/local_validate.sh
@@ -480,6 +480,17 @@ release_lock() {
   fi
 }
 
+# Temp dir holding the argMax proof program (CHAOS-3362). Empty until
+# ch_argmax_proof() creates it; declared here, ABOVE the trap, so the EXIT
+# handler can reference it under `set -u` even on the earliest `die`.
+ARGMAX_PROOF_TMPDIR=""
+cleanup_argmax_tmpdir() {
+  if [ -n "${ARGMAX_PROOF_TMPDIR:-}" ] && [ -d "${ARGMAX_PROOF_TMPDIR}" ]; then
+    rm -rf "${ARGMAX_PROOF_TMPDIR}"
+  fi
+  ARGMAX_PROOF_TMPDIR=""
+}
+
 # Single EXIT trap for the whole script (trap does not stack — a second `trap ...
 # EXIT` would silently replace this one, which is why ch_create_scratch() below
 # does NOT set its own trap and instead relies on this handler calling
@@ -495,6 +506,11 @@ release_lock() {
 # rather than a wedged mutex for the whole host.
 on_exit() {
   release_lock
+  # Second: a local `rm -rf` of our own mktemp -d, which cannot block on anything
+  # external, so it is safe to run before the unbounded docker exec below. This
+  # is what stops a SIGINT/SIGTERM mid-argMax-stage from leaking the temp dir the
+  # stage's own inline cleanup would otherwise have removed.
+  cleanup_argmax_tmpdir
   cleanup_scratch
 }
 trap on_exit EXIT
@@ -744,22 +760,45 @@ ch_migrate() {
   return 0
 }
 
-ch_argmax_proof() {
-  # The high-value, CI-uncovered data-layer check. CI's unit tier runs
-  # `-m "not clickhouse"`, and the only mock-based loader test merely string-matches
-  # 'argMax'. Here we build a real ClickHouseDataLoader against the (migrated, empty)
-  # scratch db and AWAIT load_team_attribution_context, forcing ClickHouse to parse +
-  # EXECUTE every argMax(...,(updated_at,valid_from)) / GROUP BY block. A tuple-arg or
-  # column mistake throws here; an empty scratch legitimately returns zero candidates
-  # (still execution proof).
-  #
-  # NOTE: the broader `pytest -m clickhouse` suite (flow-matrix-live, recommendations,
-  # resolver EXPLAIN, RMT-dedup-live) needs a SEEDED ClickHouse and is NOT part of this
-  # gate (CI does not run it either). To run it by hand: create a scratch db, point
-  # CLICKHOUSE_URI at it, `dev-hops fixtures generate`, then `pytest -m clickhouse`.
-  SCRATCH_DB="${SCRATCH_DB}" CLICKHOUSE_URI="${SCRATCH_URI}" DATABASE_URI="${SCRATCH_URI}" OTEL_ENABLED=false PYTHONPATH=src \
-    "${PROXY_OFF[@]}" "${PYBIN}" - <<'PYEOF'
-import asyncio, os, sys
+# The argMax proof PROGRAM, held as a shell string rather than a here-document.
+#
+# WHY NOT A HERE-DOCUMENT (CHAOS-3362 — this is the whole fix, do not "simplify"
+# it back). Bash delivers a here-document by writing it into a pipe and only
+# THEN forking the command that reads it, so the writing shell briefly holds
+# both ends of that pipe itself. If the document does not fit in the pipe
+# buffer, the write can never complete: nothing is reading, and because the
+# writer owns the read end it cannot even get EPIPE. It blocks forever.
+#
+# That is not theoretical here. Measured on this host, `cat >/dev/null <<EOF`:
+#
+#     400 bytes -> completes in 0.3s
+#     512 bytes -> BLOCKS (killed at 5s)
+#    1024 bytes -> BLOCKS
+#    4000 bytes -> BLOCKS
+#
+# while `lsof` reports the same pipes with the nominal 16384-byte capacity.
+# Nominal is not actual: macOS hands out a small pipe buffer and defers
+# expansion under kernel pipe-memory pressure, and a host running many
+# concurrent agent sessions sits in that state persistently. So "the program is
+# small, the pipe is fine" is not a defense at any size worth writing.
+#
+# This program is 1269 bytes, i.e. permanently over the line. That is the real
+# mechanism behind CHAOS-3362's "gate hangs entering the argMax stage": the
+# stage never reached ClickHouse and never even exec'd Python — the forensics on
+# that ticket found the writer subshell in write() on 1802 of 1808 samples with
+# fd 3 and fd 4 both on the same pipe, and no Python child at all. The argMax
+# attribution was pointing at the wrong subsystem the whole time. Same class as
+# CHAOS-3468 (lock-test probes blocking in write() at ~370 bytes of output).
+#
+# The fix is to remove the pipe, not to shrink the program: the text below is
+# written to a private temp file with the `printf` BUILTIN (in-process, no pipe,
+# no fork) and Python is handed that path.
+#
+# CONSTRAINT: this is a single-quoted shell string, so the program text must
+# contain NO single-quote character. tests/tooling/test_local_validate_heredocs.py
+# enforces that, that it is valid Python, and that no here-document anywhere in
+# this script grows back over the measured threshold.
+ARGMAX_PROOF_PY='import asyncio, os, sys
 from datetime import datetime, timezone
 
 uri = os.environ["CLICKHOUSE_URI"]
@@ -776,6 +815,14 @@ async def main() -> int:
     ctx = await loader.load_team_attribution_context(as_of=datetime.now(timezone.utc))
     # Reaching here means the real engine parsed + executed every argMax/GROUP BY
     # block in load_team_attribution_context without a SYNTAX/TYPE error.
+    #
+    # ...unless nothing was awaited. Dropping the await above leaves a coroutine
+    # that is never run: no query reaches ClickHouse, Python exits 0, and this
+    # stage prints OK. Measured, not imagined -- the only visible trace was
+    # "candidate buckets: coroutine" and a RuntimeWarning nobody reads. This
+    # stage exists to prove the engine executed, so refuse to claim it did.
+    if asyncio.iscoroutine(ctx):
+        raise AssertionError("load_team_attribution_context was never awaited - no query reached ClickHouse")
     print(f"   argMax live-exec OK — context loaded (candidate buckets: {type(ctx).__name__})")
     sink.close()
     return 0
@@ -787,7 +834,46 @@ except SystemExit:
 except Exception as exc:  # noqa: BLE001 — surface the real engine error verbatim
     print(f"   argMax live-exec FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
     raise SystemExit(1)
-PYEOF
+'
+
+ch_argmax_proof() {
+  # The high-value, CI-uncovered data-layer check. CI's unit tier runs
+  # `-m "not clickhouse"`, and the only mock-based loader test merely string-matches
+  # 'argMax'. Here we build a real ClickHouseDataLoader against the (migrated, empty)
+  # scratch db and AWAIT load_team_attribution_context, forcing ClickHouse to parse +
+  # EXECUTE every argMax(...,(updated_at,valid_from)) / GROUP BY block. A tuple-arg or
+  # column mistake throws here; an empty scratch legitimately returns zero candidates
+  # (still execution proof).
+  #
+  # NOTE: the broader `pytest -m clickhouse` suite (flow-matrix-live, recommendations,
+  # resolver EXPLAIN, RMT-dedup-live) needs a SEEDED ClickHouse and is NOT part of this
+  # gate (CI does not run it either). To run it by hand: create a scratch db, point
+  # CLICKHOUSE_URI at it, `dev-hops fixtures generate`, then `pytest -m clickhouse`.
+  local rc
+  # A private DIRECTORY, not a bare temp file: `python <script>` puts the
+  # script's directory on sys.path[0] (where `python -` put the CWD). An empty
+  # dir of our own is the closest safe equivalent — a shared /tmp on sys.path
+  # would let any stray /tmp/*.py shadow a real module. PYTHONPATH=src below is
+  # what makes dev_health_ops importable either way.
+  ARGMAX_PROOF_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/local-validate-argmax.XXXXXX")" || {
+    printf '   %s could not create a temp dir for the argMax proof program.\n' "$(c_red 'FAILED:')" >&2
+    return 1
+  }
+  # `printf` is a BUILTIN writing straight to the redirected file: no pipe, no
+  # fork, nothing that can block. Using `cat >file <<EOF` here would reintroduce
+  # exactly the here-document pipe this whole change exists to remove.
+  if ! printf '%s' "${ARGMAX_PROOF_PY}" >"${ARGMAX_PROOF_TMPDIR}/argmax_proof.py"; then
+    printf '   %s could not write the argMax proof program to %s.\n' "$(c_red 'FAILED:')" "${ARGMAX_PROOF_TMPDIR}" >&2
+    cleanup_argmax_tmpdir
+    return 1
+  fi
+  SCRATCH_DB="${SCRATCH_DB}" CLICKHOUSE_URI="${SCRATCH_URI}" DATABASE_URI="${SCRATCH_URI}" OTEL_ENABLED=false PYTHONPATH=src \
+    "${PROXY_OFF[@]}" "${PYBIN}" "${ARGMAX_PROOF_TMPDIR}/argmax_proof.py"
+  rc=$?
+  # Capture rc FIRST: the cleanup below must never become the return value, or a
+  # real argMax mismatch would be reported as a pass.
+  cleanup_argmax_tmpdir
+  return "${rc}"
 }
 
 # Provision the isolated scratch db + apply THIS branch's migrations BEFORE the

--- a/tests/tooling/test_local_validate_heredocs.py
+++ b/tests/tooling/test_local_validate_heredocs.py
@@ -1,0 +1,177 @@
+"""Regression coverage for the CHAOS-3362 here-document pipe wedge.
+
+``ci/local_validate.sh`` used to feed its argMax proof program to Python as a
+1269-byte here-document. Bash delivers a here-document by writing it into a pipe
+and only THEN forking the reader, so the writing shell transiently holds both
+ends. If the document does not fit in the pipe buffer the write never completes
+-- nothing is draining, and the writer owning the read end cannot even receive
+EPIPE. The gate hung there forever, before ClickHouse or Python were ever
+reached (CHAOS-3362 forensics: writer subshell in ``write()`` on 1802 of 1808
+samples, fd 3 and fd 4 both on the same pipe, no Python child).
+
+Measured on the affected host with ``cat >/dev/null <<EOF``::
+
+     400 bytes -> completes in 0.3s
+     512 bytes -> BLOCKS
+    1024 bytes -> BLOCKS
+    4000 bytes -> BLOCKS
+
+``lsof`` reports those same pipes with the nominal 16384-byte capacity. Nominal
+is not actual: macOS hands out a small pipe buffer and defers expansion under
+kernel pipe-memory pressure, which a host running many concurrent agent sessions
+sits in persistently. So "the here-document is small, the pipe is fine" is not a
+defense at any size worth writing, which is why the budget below is 400 bytes --
+the largest size actually measured to complete -- and not a comfortable-looking
+round number derived from the nominal capacity.
+
+Same class as CHAOS-3468 (lock-test probes blocking in ``write()`` at ~370 bytes
+of output) and CHAOS-3348 (``ci/check_go.sh``, since converted away from the
+here-string seam it used -- see ``test_check_go_integration_coverage.py``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ci" / "local_validate.sh"
+
+# Largest here-document size measured to complete on the affected host. Anything
+# at or above this has been measured to block forever there.
+_HEREDOC_BUDGET_BYTES = 400
+
+# `cmd <<EOF`, `cmd <<'EOF'`, `cmd <<-"EOF"`. The negative lookahead keeps
+# here-STRINGS (`<<<`) out: their content is a runtime expansion, not literal
+# text this scanner could size.
+_HEREDOC_START = re.compile(r"<<-?\s*(?!<)([\"']?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def _heredocs(text: str) -> list[tuple[int, str, bytes]]:
+    """Every here-document in ``text`` as ``(line_number, delimiter, body)``."""
+
+    lines = text.split("\n")
+    found: list[tuple[int, str, bytes]] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        # Whole-line comments are prose, not redirections -- this very repo's
+        # scripts document the hazard by quoting `cat >file <<EOF` in a comment.
+        if line.lstrip().startswith("#"):
+            index += 1
+            continue
+        match = _HEREDOC_START.search(line)
+        if match is None:
+            index += 1
+            continue
+        delimiter = match.group(2)
+        body: list[str] = []
+        cursor = index + 1
+        while cursor < len(lines) and lines[cursor].strip() != delimiter:
+            body.append(lines[cursor])
+            cursor += 1
+        # An unterminated here-document means this scanner mis-parsed the
+        # script. Fail loudly: silently swallowing the rest of the file would
+        # make every later here-document invisible to the budget check.
+        assert cursor < len(lines), (
+            f"unterminated here-document <<{delimiter} opened at line"
+            f" {index + 1}; the scanner in this test needs fixing"
+        )
+        found.append((index + 1, delimiter, ("\n".join(body) + "\n").encode("utf-8")))
+        index = cursor + 1
+    return found
+
+
+def _argmax_program(text: str) -> str:
+    match = re.search(r"^ARGMAX_PROOF_PY='(.*?)'\n", text, re.S | re.M)
+    assert match is not None, (
+        "ARGMAX_PROOF_PY assignment not found in ci/local_validate.sh. Either the"
+        " argMax proof program was renamed, or -- the case this test exists for --"
+        " it was converted back into a here-document. Do not delete this test to"
+        " make it pass; see the module docstring."
+    )
+    return match.group(1)
+
+
+def test_local_validate_has_no_heredoc_over_the_measured_pipe_budget() -> None:
+    """No here-document in the gate script may exceed the measured budget.
+
+    Guards the whole class, not just the one call site that wedged: any stage
+    that grows a here-document past ~400 bytes reintroduces the same hang.
+    """
+
+    assert SCRIPT.is_file(), f"gate script missing at {SCRIPT}"
+    text = SCRIPT.read_text(encoding="utf-8")
+    # The scan must have something to scan: an empty/renamed script would
+    # otherwise sail through with zero findings and read as coverage.
+    assert len(text) > 10_000, f"{SCRIPT} is unexpectedly small ({len(text)} bytes)"
+
+    oversized = [
+        (line, delimiter, len(body))
+        for line, delimiter, body in _heredocs(text)
+        if len(body) >= _HEREDOC_BUDGET_BYTES
+    ]
+    assert not oversized, (
+        "here-document(s) at or above the measured pipe budget of "
+        f"{_HEREDOC_BUDGET_BYTES} bytes: {oversized}. Bash writes a here-document"
+        " into a pipe it also holds the read end of, so this hangs the gate"
+        " forever on hosts with a small effective pipe buffer (CHAOS-3362)."
+        " Write the payload to a temp file with the printf BUILTIN instead --"
+        " `cat >file <<EOF` is the same pipe and does NOT fix it."
+    )
+
+
+def test_argmax_proof_program_is_valid_python() -> None:
+    """The program is now shell-string data, so nothing else type-checks it."""
+
+    compile(
+        _argmax_program(SCRIPT.read_text(encoding="utf-8")), "argmax_proof.py", "exec"
+    )
+
+
+def test_argmax_proof_program_awaits_the_loader_call() -> None:
+    """The loader call must be AWAITED, not merely present in the text.
+
+    Found by adversarial review and then reproduced: delete the ``await`` and
+    the program builds a coroutine it never runs. No query reaches ClickHouse,
+    Python exits 0, and the stage prints ``argMax live-exec OK -- context
+    loaded (candidate buckets: coroutine)``. Measured directly against the real
+    engine: the stage returned 0 with the ClickHouse query never executed. A
+    stage that reports success without measuring anything is worse than a
+    missing stage, because the green reads as proof.
+
+    Checked through the AST rather than by searching for the substring
+    ``await``: the substring appears elsewhere in the program, so a text match
+    would keep passing with the await moved or removed from THIS call.
+    """
+
+    tree = ast.parse(_argmax_program(SCRIPT.read_text(encoding="utf-8")))
+    awaited = {
+        node.value.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Await)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+    }
+    assert "load_team_attribution_context" in awaited, (
+        "the argMax proof program does not AWAIT load_team_attribution_context."
+        f" Awaited method calls found: {sorted(awaited) or 'none'}. Without the"
+        " await the coroutine never runs, ClickHouse is never queried, and the"
+        " stage reports OK anyway."
+    )
+
+
+def test_argmax_proof_program_contains_no_single_quote() -> None:
+    """A single quote would silently truncate the single-quoted shell string.
+
+    Bash would end the assignment early and try to execute the remainder as
+    commands, so this is a syntax break rather than a subtle bug -- but it is
+    cheap to catch here rather than in the middle of a gate run.
+    """
+
+    program = _argmax_program(SCRIPT.read_text(encoding="utf-8"))
+    assert "'" not in program, (
+        "ARGMAX_PROOF_PY is a single-quoted shell string; the Python program"
+        " inside it must not contain a single-quote character"
+    )


### PR DESCRIPTION
The gate did not hang in argMax, or in ClickHouse, or in Python. It hung in bash. Fixes CHAOS-3362.

## Root cause

`ch_argmax_proof()` fed its 1269-byte program to the interpreter as a here-document. Bash delivers a here-document by writing it into a pipe and only THEN forking the reader, so the writing shell transiently holds both ends. When the document does not fit the pipe buffer that write can never complete: nothing is draining it, and the writer owning the read end cannot even receive EPIPE.

Measured on the affected host with the ticket's own repro, `cat >/dev/null <<EOF`, `timeout 5`:

```
   400 bytes -> ok, 0.30s
   512 bytes -> WEDGED
   600 bytes -> WEDGED
  1024 bytes -> WEDGED
  1269 bytes -> WEDGED
  4000 bytes -> WEDGED
```

The effective pipe capacity is **at most 512 bytes** — worse than the 1024 recorded on the ticket — while `lsof` reports those same pipes with the nominal 16384. Nominal is not actual: macOS hands out a small pipe buffer and defers expansion under kernel pipe-memory pressure, which a host running many concurrent agent sessions sits in persistently. That is why every "the program is small, the pipe is fine" argument has been wrong.

Reproduced against the real stage before changing it: lines 760-790 extracted verbatim with `PYBIN` stubbed to `/usr/bin/true` wedge at `timeout 10`, and the statement after the here-document never runs. No interpreter is ever exec'd, matching the ticket's forensics (writer subshell in `write()` on 1802 of 1808 samples, fd 3 and fd 4 both on the same pipe, no Python child). The stage name had been pointing at the wrong subsystem for three days.

Hosted CI runners have normal pipe buffers, so this has never been a CI failure — it is a developer-machine wedge, which is exactly why it survived so long misattributed to ClickHouse.

## The fix

The program is now a shell string written to a private `mktemp -d` with the `printf` **builtin** — in-process, no pipe, no fork — and Python is handed the path. `ci/local_validate.sh` now contains **zero** here-documents.

`cat >file <<EOF` would NOT have fixed this: the pipe is the here-document mechanism itself, not something the reader introduces, which is exactly why the ticket's repro uses `cat`.

A private directory rather than a bare temp file, because `python <script>` puts the script's directory on `sys.path[0]` where `python -` put the CWD; an empty directory of our own is the closest safe equivalent, and a shared `/tmp` on `sys.path` would let a stray `/tmp/*.py` shadow a real module. The stage's return code is captured BEFORE cleanup so a real argMax mismatch can never be reported as a pass, and the existing single EXIT trap removes the directory if a signal lands mid-stage.

## Deviation from the old program, called out explicitly

The program text is otherwise carried over unchanged, with **one deliberate addition**: it now raises if `ctx` is a coroutine.

Adversarial review raised that as a hypothesis and it reproduced exactly. With the `await` deleted, no query reaches ClickHouse, Python exits 0, and the stage printed:

```
argMax live-exec OK — context loaded (candidate buckets: coroutine)
rc 0        <- ClickHouse never queried
3 passed    <- the guard did not notice
```

A stage whose whole purpose is proving the engine executed must not report success when it did not. Closed at both levels: the program raises and the stage fails loudly, and the guard now asserts through the **AST** rather than by substring search — the word `await` appears elsewhere in the program, so a text match would keep passing with the await removed from *this* call. Both guards were observed failing against the planted defect before being accepted, then the defect was reverted and both observed passing again.

## Class guard

`tests/tooling/test_local_validate_heredocs.py` guards the class rather than the one call site: every here-document in the gate script is budgeted at 400 bytes, the largest size measured to complete. It fails on the pre-fix script and passes on this one. Its scanner treats an unterminated here-document as a mis-parse and fails loudly, rather than silently swallowing the rest of the file and rendering every later here-document invisible to the budget.

## Gate

`bash ci/local_validate.sh` on merged main + this diff — **GATE PASSED**, exit 0:

```
✔ lint: ruff format --check
✔ lint: ruff check
✔ typecheck: mypy
✔ ch-scratch-create
✔ ch-migrate (upgrade + status --check)
✔ unit suite (FULL, not subset)   12769 passed, 249 skipped, 1 xfailed in 155.40s
✔ argMax live-exec proof (real engine)
   argMax live-exec OK — context loaded (candidate buckets: TeamAttributionContext)
```

**Zero tolerated failures used** — not the known-16, not `test_budget_guard_cooldown`, not any CHAOS-3468-class lock id. The argMax stage completed in seconds instead of never.

## Negative control

The **shipped** `ch_argmax_proof` and `run_stage` extracted verbatim (not reimplemented), run against a dedicated scratch db; dev `default` untouched, db dropped after.

- unmutated: `argMax live-exec OK — context loaded`, rc 0
- with `argMax(o.project_key, (o.updated_at, o.valid_from))` cut down to `argMax(o.project_key)` in the loader:

```
argMax live-exec FAILED: DatabaseError: Code: 42. DB::Exception:
Aggregate function argMax requires two arguments. (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)
SUMMARY
   FAIL  argMax live-exec proof (real engine)
GATE FAILED. first failing stage: argMax live-exec proof (real engine)
```

rc 1. The hang was not traded for a silent skip. Restore verified by sha256 **and** by re-running the positive control afterwards — a clean `git status` alone would not have proved behaviour came back.

## Scope

`ci/check_go.sh` (CHAOS-3348) is deliberately untouched and confirmed unnecessary: it contains no `<<` of any kind, its here-string seam having already been converted away and covered by `tests/tooling/test_check_go_integration_coverage.py`.

Two latent same-class instances outside this script — `ci/run_tests.sh:10` (800-byte `usage()`) and six `run_python - <<'PY'` documents in `ci/run_live_backend_e2e.sh` — are tracked in CHAOS-3489, not fixed here.

Closes CHAOS-3362.
