### PR TITLE
CHAOS-3462 follow-up: close the exec-plane stdin hang, authenticate with seeded world credentials

### DIFF
--- a/scripts/acceptance/corpus/db_verify.py
+++ b/scripts/acceptance/corpus/db_verify.py
@@ -45,8 +45,8 @@ __all__ = [
 ]
 
 #: Injectable for tests -- must behave like ``subprocess.run`` (accepting
-#: ``capture_output``/``text``/``timeout`` keywords and returning something
-#: with ``.returncode``/``.stdout``/``.stderr``).
+#: ``capture_output``/``text``/``timeout``/``stdin`` keywords and returning
+#: something with ``.returncode``/``.stdout``/``.stderr``).
 ExecRunner = Callable[..., Any]
 
 
@@ -77,7 +77,26 @@ def exec_in_api(
 
     args = [*context.base_args(), "exec", "-T", context.api_service, *command]
     try:
-        result = runner(args, capture_output=True, text=True, timeout=timeout)
+        # stdin=DEVNULL is load-bearing, not tidiness (CHAOS-3462; hazard
+        # reported by the world-seeding lane, which hit it for real). `-T`
+        # suppresses the pseudo-TTY but does NOT close stdin -- compose still
+        # forwards fd 0 into the container. With stdin merely INHERITED, this
+        # call blocks forever whenever the parent's fd 0 is an open pipe that
+        # nobody closes, which is exactly what happens when the runner is
+        # driven from a shell script rather than an interactive terminal --
+        # `scripts/acceptance/run_wave4_corpus.sh` is such a driver, and any
+        # `something | run_wave4_corpus.sh` or CI step with a held-open stdin
+        # reproduces it. The failure mode is the worst one available to this
+        # lane: not a red, but a silent hang with no output, burning the gate
+        # slot while looking like nothing is happening. Reproduced both ways
+        # before this line was added; see test_exec_in_api_never_inherits_stdin.
+        result = runner(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
     except FileNotFoundError as exc:
         raise DbVerifyUnavailableError(
             f"docker compose is not available on this host: {exc}"

--- a/scripts/acceptance/corpus/principals.py
+++ b/scripts/acceptance/corpus/principals.py
@@ -324,9 +324,16 @@ class PrincipalSessions:
         # principal's -- which is what /api/v1/dev/** actually reads. The
         # password is DERIVED, not stored: `password_for_alias` is the same
         # function `_build_auth_fixture` hashed when it seeded this account,
-        # so login and seeding cannot drift apart (CHAOS-3463). Nothing here
-        # writes to the world -- the earlier bridge mutated `password_hash`,
-        # a digest-covered column, and made a second armed run report drift.
+        # so login and seeding cannot drift apart (CHAOS-3463).
+        #
+        # PRECISELY what this does to the world, because "it only reads" is
+        # the tempting shorthand and it is FALSE: a successful login stamps
+        # `users.last_login_at` (api/auth/routers/login.py). That column is
+        # in `_VOLATILE_COLUMNS`, added by CHAOS-3463 for exactly this
+        # reason, so it is excluded from the world digest and a second armed
+        # run does NOT drift. What is gone is the write that DID drift --
+        # the bridge's `password_hash` mutation, on a column deliberately
+        # kept digested so credential tampering stays visible.
         api = self._api_factory()
         try:
             login = api.request(

--- a/scripts/acceptance/corpus/principals.py
+++ b/scripts/acceptance/corpus/principals.py
@@ -31,15 +31,20 @@ endpoint:
   failure than the one B5 exists to fix.
 
 So the only mechanism that yields an authentically-scoped token is a genuine
-login. World users cannot log in as seeded -- ``fixtures/world.py``'s
-``_build_auth_fixture`` writes ``password_hash=None`` for every one of them,
-and ``login.py`` explicitly refuses password login for such an account -- so
-the superuser first sets a password via ``POST
-/api/v1/admin/users/{id}/password`` (which verifies the CALLER's own
-password, hence ``admin_password``), and the runner then performs a real
-``POST /api/v1/auth/login``. Both are public API calls, keeping the
-"public-API-only seeding" philosophy ``prepare_ask_dev_acceptance.py``
-already follows -- no direct database writes, no test-only backdoor.
+``POST /api/v1/auth/login``, and the credential it uses comes from the world
+seed: ``fixtures/world.py::_build_auth_fixture`` hashes
+``password_for_alias(alias)`` for EVERY world user at generation time
+(CHAOS-3463). This module imports that same function rather than holding a
+password of its own, so the seeding side and the login side cannot disagree
+-- there is one derivation, not two copies that agree until one is edited.
+
+An earlier revision of this runner could not rely on that: world users had
+``password_hash=None``, so it set a password through ``POST
+/api/v1/admin/users/{id}/password`` behind an explicit opt-in flag. That
+bridge mutated ``password_hash``, a digest-covered column, so a second armed
+run against the same stack reported users-digest drift. It is gone now that
+credentials are seeded, along with the flag and the runner-local password
+constant it needed.
 
 NO SILENT FALLBACK, ANYWHERE
 ----------------------------
@@ -59,10 +64,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-from dev_health_ops.fixtures.world import derive_id
+from dev_health_ops.fixtures.world import derive_id, password_for_alias
 
 __all__ = [
-    "PRINCIPAL_PASSWORD",
+    "SEEDED_PROVISIONING_MARKER",
     "CasePrincipal",
     "PrincipalDirectory",
     "PrincipalError",
@@ -70,44 +75,32 @@ __all__ = [
     "PrincipalSessions",
 ]
 
-#: The password the runner sets on every world principal before logging in
-#: as it. Must satisfy production's real ``validate_password`` (>= 12 chars,
-#: at least one letter and one digit, not in the common-password list) --
-#: ``tests/acceptance/corpus/test_principals.py`` asserts that against the
-#: real policy function rather than trusting this comment, because a
-#: non-compliant value would 422 every provisioning call and fail every case
-#: for a reason unrelated to the case.
-PRINCIPAL_PASSWORD = "ask-dev-world-acceptance-4242"
-
-#: Opt-in for the temporary admin-set-password bridge (team-lead ruling,
-#: 2026-08-06). The DURABLE design is that CHAOS-3463 seeds credentials at
-#: world-generation time and ``password_hash`` STAYS in the world digest:
-#: the snapshot/restore model makes hashes frozen bytes restored identically
-#: per boot, so the "bcrypt cannot reproduce across generations" argument
-#: does not apply, and keeping the column digested means credential
-#: tampering registers as drift -- which is what the digest is for.
-#:
-#: Until that lands, world users have ``password_hash=None`` and cannot log
-#: in at all, so this runner sets one. That MUTATES a digested column, which
-#: is why it is now opt-in rather than automatic: a run that took the bridge
-#: is not a clean run, and must not be mistaken for one. When the seeding
-#: lane lands, the bridge is removed and the runner requires seeded
-#: credentials.
-BRIDGE_ENV_VAR = "ASK_DEV_ACCEPTANCE_ALLOW_PASSWORD_BRIDGE"
-
-#: Stamped into every receipt of a bridged run (see the runner's
-#: ``provisioning_mode`` check) so the artifacts themselves say which mode
-#: produced them -- a receipt is evidence, and evidence that cannot
-#: distinguish a bridged run from a seeded one is weaker than it looks.
-BRIDGED_PROVISIONING_MARKER = "admin-set-password-bridge"
+#: Stamped into every receipt (see the runner's ``provisioning_mode`` check)
+#: so the artifacts themselves say where the credentials came from. Kept as a
+#: named marker now that the bridge is gone, because a receipt is evidence
+#: and a reader keys on this field to know the run authenticated against
+#: seeded world credentials rather than anything provisioned at run time.
 SEEDED_PROVISIONING_MARKER = "world-seeded-credentials"
 
-_ADMIN_SET_PASSWORD_PATH = "/api/v1/admin/users/{user_id}/password"
 _LOGIN_PATH = "/api/v1/auth/login"
 
 
 class PrincipalError(Exception):
     """A case's declared principal cannot be resolved or authenticated."""
+
+
+def _is_credential_rejection(exc: BaseException) -> bool:
+    """Whether a failed login means "wrong credential" or "the API is unwell".
+
+    Deliberately narrow. ``AcceptanceApi`` raises with the status line inside
+    its message (``... returned HTTP 401: {"detail":"Invalid credentials"}``),
+    so 401 is what an unseeded or mismatched credential looks like from here.
+    Anything else -- 5xx, 429, a transport error -- is NOT a credential
+    problem, and must keep its own error rather than be reframed as one.
+    """
+
+    text = str(exc)
+    return "401" in text or "Invalid credentials" in text
 
 
 class _Api(Protocol):
@@ -240,10 +233,9 @@ class PrincipalDirectory:
 class PrincipalSessions:
     """Lazily provisions and caches one authenticated session per alias.
 
-    Cached because provisioning is two HTTP calls and the corpus runs ~137
-    cases as the same ``primary.ordinary`` principal; re-logging-in per case
-    would add ~274 pointless calls and, worse, put the admin
-    set-password rate limit (``ADMIN_PASSWORD_LIMIT``) in the path of a
+    Cached because the corpus runs ~137 cases as the same
+    ``primary.ordinary`` principal; re-logging-in per case would add ~137
+    pointless round trips and put the login rate limiter in the path of a
     normal run.
 
     KNOWN LIMIT, stated rather than discovered later: the access token has a
@@ -261,17 +253,11 @@ class PrincipalSessions:
     def __init__(
         self,
         *,
-        admin_api: Any,
-        admin_password: str,
         api_factory: Callable[[], Any],
         directory: PrincipalDirectory,
-        allow_password_bridge: bool = False,
     ) -> None:
-        self._admin_api = admin_api
-        self._admin_password = admin_password
         self._api_factory = api_factory
         self._directory = directory
-        self._allow_password_bridge = allow_password_bridge
         self._sessions: dict[str, PrincipalSession] = {}
         self._failures: dict[str, BaseException] = {}
 
@@ -290,14 +276,12 @@ class PrincipalSessions:
         if cached is not None:
             return cached
         # NEGATIVE caching, deliberately (Codex adversarial round-1, MEDIUM):
-        # only successes were cached before, so a set-password that succeeded
-        # followed by a transient login failure left nothing cached -- and
-        # every later case using that alias re-ran the admin password
-        # mutation. With 137 cases on `primary.ordinary` and the endpoint
-        # rate-limited to a handful per hour, one login blip turned into a
-        # storm of 429s that both buried the original error and kept mutating
-        # shared world state. The first failure is now final for that alias
-        # and is re-raised verbatim, so the run fails on the REAL cause.
+        # only successes were cached before, so a transient login failure left
+        # nothing cached and every later case using that alias retried it.
+        # With 137 cases on `primary.ordinary` against a rate-limited login,
+        # one blip turned into a storm of 429s that buried the original error.
+        # The first failure is now final for that alias and is re-raised
+        # verbatim, so the run fails on the REAL cause.
         previous = self._failures.get(principal.user_alias)
         if previous is not None:
             # A NEW exception chained to the original, rather than re-raising
@@ -319,56 +303,60 @@ class PrincipalSessions:
 
     @property
     def provisioning_mode(self) -> str:
-        """Which credential path this run used -- stamped into receipts."""
+        """Where this run's credentials came from -- stamped into receipts.
 
-        return (
-            BRIDGED_PROVISIONING_MARKER
-            if self._allow_password_bridge
-            else SEEDED_PROVISIONING_MARKER
-        )
+        One value now that the admin-set-password bridge is gone: the runner
+        has exactly one credential path, the world seed. The property stays
+        so receipts keep the field readers already key on, and so a future
+        second path has an obvious place to declare itself.
+        """
+
+        return SEEDED_PROVISIONING_MARKER
 
     def _authenticate(self, principal: CasePrincipal) -> PrincipalSession:
-        # Step 1: give the world user a password -- ONLY under the explicit
-        # bridge opt-in, because this writes password_hash, a column the
-        # world digest covers. Without the opt-in the runner requires the
-        # credential to already be seeded, which is the durable design.
-        if self._allow_password_bridge:
-            self._admin_api.request(
-                "POST",
-                _ADMIN_SET_PASSWORD_PATH.format(user_id=principal.user_id),
-                {
-                    "admin_password": self._admin_password,
-                    "password": PRINCIPAL_PASSWORD,
-                },
-            )
-
-        # Step 2: a genuine login, so the JWT's own sub/org_id/role are the
-        # principal's -- which is what /api/v1/dev/** actually reads.
+        # A genuine login, so the JWT's own sub/org_id/role are the
+        # principal's -- which is what /api/v1/dev/** actually reads. The
+        # password is DERIVED, not stored: `password_for_alias` is the same
+        # function `_build_auth_fixture` hashed when it seeded this account,
+        # so login and seeding cannot drift apart (CHAOS-3463). Nothing here
+        # writes to the world -- the earlier bridge mutated `password_hash`,
+        # a digest-covered column, and made a second armed run report drift.
         api = self._api_factory()
         try:
             login = api.request(
                 "POST",
                 _LOGIN_PATH,
-                {"email": principal.email, "password": PRINCIPAL_PASSWORD},
+                {
+                    "email": principal.email,
+                    "password": password_for_alias(principal.user_alias),
+                },
             )
         except Exception as exc:
-            # An unseeded world user has password_hash=None, and login.py
-            # answers that with HTTP 401 -- which the API client raises on,
-            # BEFORE any response-body branch below could run. An earlier
-            # version put the remedy text on the no-access_token branch,
-            # where an operator could never see it: the reported failure was
-            # a bare "returned HTTP 401" with no hint that a flag exists.
-            if self._allow_password_bridge:
+            # A world that predates seeded credentials has password_hash=None
+            # and login.py answers 401 -- which the API client raises on,
+            # BEFORE any response-body branch below could run. The remedy
+            # therefore belongs HERE and not on the no-access_token branch,
+            # where an operator would never see it.
+            #
+            # ONLY for a credential rejection, though. A 503, a timeout or a
+            # rate-limit means something else entirely is wrong, and the
+            # seeded-credential remedy would be actively misleading -- it
+            # would send an operator to re-mint a world that is fine. The
+            # previous revision preserved that distinction via the bridge
+            # flag (`test_a_bridged_run_does_not_swallow_the_real_login_
+            # error` pinned it); with the flag gone the discriminator is the
+            # error itself, which is the more honest one anyway.
+            if not _is_credential_rejection(exc):
                 raise
             raise PrincipalError(
                 f"login as {principal.user_alias!r} ({principal.email}) "
-                f"failed: {exc}. This run did NOT take the password bridge, "
-                f"so it requires that account to have a credential seeded at "
-                f"world-generation time (CHAOS-3463). A world that predates "
-                f"seeded credentials has password_hash=None and answers 401. "
-                f"Set {BRIDGE_ENV_VAR}=1 to opt into the temporary "
-                f"admin-set-password bridge -- which mutates a "
-                f"digest-covered column and stamps every receipt as bridged."
+                f"failed: {exc}. This runner requires the account to carry the "
+                f"credential seeded at world-generation time (CHAOS-3463). A "
+                f"world snapshot minted before seeded credentials has "
+                f"password_hash=None and answers 401 -- re-mint the world "
+                f"snapshot (scripts/acceptance/mint_ask_dev_world_snapshot.sh) "
+                f"rather than provisioning a password at run time, which would "
+                f"mutate a digest-covered column."
             ) from exc
         if not isinstance(login, Mapping):
             raise PrincipalError(

--- a/scripts/acceptance/corpus/principals.py
+++ b/scripts/acceptance/corpus/principals.py
@@ -92,15 +92,21 @@ class PrincipalError(Exception):
 def _is_credential_rejection(exc: BaseException) -> bool:
     """Whether a failed login means "wrong credential" or "the API is unwell".
 
-    Deliberately narrow. ``AcceptanceApi`` raises with the status line inside
-    its message (``... returned HTTP 401: {"detail":"Invalid credentials"}``),
-    so 401 is what an unseeded or mismatched credential looks like from here.
-    Anything else -- 5xx, 429, a transport error -- is NOT a credential
-    problem, and must keep its own error rather than be reframed as one.
+    Deliberately narrow, and matched against the shape its producer actually
+    emits rather than a bare status number. ``AcceptanceApi.request`` raises
+    ``AcceptanceFailure(f"{method} {path} returned HTTP {exc.code}: {detail}")``
+    -- and ``detail`` there is the raw RESPONSE BODY. Searching for ``"401"``
+    anywhere in that string would therefore also match a 500 whose body
+    happens to carry ``401`` inside a trace id or correlation token, and would
+    reframe an unwell API as an unseeded credential -- sending an operator off
+    to re-mint a world that is perfectly fine.
+
+    Anything that is not a credential rejection -- 5xx, 429, a transport
+    error -- must keep its own error rather than be reframed as one.
     """
 
     text = str(exc)
-    return "401" in text or "Invalid credentials" in text
+    return "returned HTTP 401" in text or "Invalid credentials" in text
 
 
 class _Api(Protocol):

--- a/tests/acceptance/corpus/test_db_verify.py
+++ b/tests/acceptance/corpus/test_db_verify.py
@@ -8,8 +8,11 @@ genuinely booted acceptance stack, out of the unit tier's reach by design.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -70,8 +73,6 @@ class TestExecInApi:
             exec_in_api(_context(), ["true"], runner=runner)
 
     def test_timeout_raises(self) -> None:
-        import subprocess
-
         def runner(args, **kwargs):
             raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs.get("timeout", 60))
 
@@ -430,3 +431,74 @@ class TestQueryTranscriptAssistantSchemaVersionsViaExec:
             query_transcript_assistant_schema_versions_via_exec(
                 _context(), conversation_id="conv-1", runner=runner
             )
+
+
+class TestExecInApiNeverInheritsStdin:
+    """CHAOS-3462: ``docker compose exec -T`` must not inherit fd 0.
+
+    Reported by the world-seeding lane, which hit it for real. ``-T``
+    suppresses the pseudo-TTY but does NOT close stdin -- compose still
+    forwards fd 0 into the container. With stdin merely inherited, the call
+    blocks forever whenever the parent's fd 0 is an open pipe nobody closes,
+    which is precisely what happens when the runner is driven from a shell
+    script instead of an interactive terminal.
+    ``scripts/acceptance/run_wave4_corpus.sh`` is exactly such a driver.
+
+    The failure mode is the worst one this lane has: not a red, but a silent
+    hang with no output, holding the gate slot while looking like nothing is
+    happening. That is the same class of non-signal as the arming false
+    green, so it gets a real test rather than a comment.
+    """
+
+    def test_the_runner_is_told_not_to_inherit_stdin(self) -> None:
+        seen: dict[str, object] = {}
+
+        def runner(args, **kwargs):
+            seen.update(kwargs)
+            return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+        exec_in_api(_context(), ["echo", "hi"], runner=runner)
+        assert seen.get("stdin") is subprocess.DEVNULL, (
+            "exec_in_api must pass stdin=DEVNULL; inheriting fd 0 hangs the "
+            "whole run when driven from a shell script"
+        )
+
+    def test_the_hazard_is_real_and_devnull_is_what_fixes_it(self) -> None:
+        """Rule 2: observe the guard failing.
+
+        Proves the mechanism rather than asserting a keyword. A child that
+        drains stdin -- which is how compose forwards fd 0 -- hangs when
+        stdin is inherited from an open pipe, and completes when it is
+        DEVNULL. If this ever stops reproducing, the DEVNULL above has
+        stopped being load-bearing and the comment should be revisited.
+        """
+
+        child = [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdin.read()",
+        ]
+        # An open pipe nobody closes -- the shell-script driver shape.
+        with subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout=subprocess.PIPE,
+        ) as holder:
+            try:
+                with pytest.raises(subprocess.TimeoutExpired):
+                    subprocess.run(
+                        child,
+                        capture_output=True,
+                        text=True,
+                        timeout=3,
+                        stdin=holder.stdout,
+                    )
+                completed = subprocess.run(
+                    child,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    stdin=subprocess.DEVNULL,
+                )
+                assert completed.returncode == 0
+            finally:
+                holder.kill()

--- a/tests/acceptance/corpus/test_principals.py
+++ b/tests/acceptance/corpus/test_principals.py
@@ -22,13 +22,16 @@ producing green results for the wrong principal. That is a worse failure
 than the one B5 is fixing.
 
 So the runner does the one thing that produces an authentically-scoped
-token: the superuser sets a password on the target world-fixture user
-(``POST /api/v1/admin/users/{id}/password``, which requires the caller's own
-password) and then performs a real ``POST /api/v1/auth/login`` as that user.
-This is necessary because ``fixtures/world.py``'s ``_build_auth_fixture``
-seeds every world user with ``password_hash=None``, and ``login.py`` refuses
-password login for such an account -- there is no password to use until one
-is set.
+token: a real ``POST /api/v1/auth/login`` as that user. The credential comes
+from the world seed -- ``fixtures/world.py``'s ``_build_auth_fixture`` hashes
+``password_for_alias(alias)`` for every world user at generation time
+(CHAOS-3463) -- and the runner imports that same function rather than
+keeping a password of its own, so the two sides cannot drift.
+
+An earlier revision had to set a password first (``POST
+/api/v1/admin/users/{id}/password``) because world users were seeded with
+``password_hash=None`` and could not log in at all. That bridge wrote to a
+digest-covered column and is gone.
 
 Everything here runs against test doubles: no stack, no network.
 """
@@ -41,11 +44,9 @@ from typing import Any
 
 import pytest
 
-from dev_health_ops.api.utils.password_policy import validate_password
+from dev_health_ops.fixtures.world import password_for_alias
 from scripts.acceptance.corpus.case_schema import load_corpus_case
 from scripts.acceptance.corpus.principals import (
-    BRIDGED_PROVISIONING_MARKER,
-    PRINCIPAL_PASSWORD,
     SEEDED_PROVISIONING_MARKER,
     CasePrincipal,
     PrincipalDirectory,
@@ -111,15 +112,16 @@ def _login_response(user_id: str, org_id: str, email: str) -> dict[str, Any]:
     }
 
 
-class TestPrincipalPasswordMeetsProductionPolicy:
-    """Rule 1: assert the state the system must reach, not that we wrote a
-    plausible-looking constant. A password that fails ``validate_password``
-    would make every principal provisioning call 422 at runtime -- and the
-    runner would then fail every case for a reason that has nothing to do
-    with the case."""
-
-    def test_password_passes_the_real_policy(self) -> None:
-        assert validate_password(PRINCIPAL_PASSWORD) == []
+# The old ``TestPrincipalPasswordMeetsProductionPolicy`` lived here. It
+# asserted the runner's own password constant satisfied production's
+# ``validate_password``, because a non-compliant value would have 422'd the
+# admin set-password call the runner used to make. That call is gone -- the
+# credential is seeded at world generation and only ever LOGGED IN with, and
+# login does not re-run the policy -- so the test now guards nothing. The
+# derivation's own properties (length, determinism, uniqueness per alias)
+# are asserted where they belong, against ``password_for_alias`` itself, in
+# ``tests/test_fixtures_world_runner.py``. Keeping a copy here would have
+# read as coverage of a rule this module no longer depends on.
 
 
 class TestPrincipalDirectoryAgainstTheRealWorldManifest:
@@ -270,15 +272,8 @@ class TestPrincipalSessions:
         directory = PrincipalDirectory.from_world(_REAL_MANIFEST)
         return directory.principal_by_alias("primary.ordinary")
 
-    def test_provisions_a_password_then_logs_in_as_that_user(self) -> None:
+    def test_logs_in_as_that_user_and_writes_nothing(self) -> None:
         principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): _login_response(
@@ -287,11 +282,8 @@ class TestPrincipalSessions:
             }
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="devhealth123",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         session = sessions.session_for_alias("primary.ordinary")
 
@@ -299,26 +291,21 @@ class TestPrincipalSessions:
         assert principal_api.token == f"token-for-{principal.email}"
         assert session.org_id == str(principal.org_id)
 
-        set_password = admin.calls[0]
-        assert set_password[0] == "POST"
-        assert str(principal.user_id) in set_password[1]
-        assert set_password[2]["admin_password"] == "devhealth123"
-        assert set_password[2]["password"] == PRINCIPAL_PASSWORD
+        # Login is the ONLY call. The set-password bridge that used to run
+        # first mutated `password_hash`, a digest-covered column, so a second
+        # armed run against the same stack reported drift. Asserting the call
+        # list exactly -- rather than just that login happened -- is what
+        # would catch a re-introduced write.
+        assert [(c[0], c[1]) for c in principal_api.calls] == [
+            ("POST", "/api/v1/auth/login")
+        ], "the runner made a call other than the login -- it must only read"
 
         login = principal_api.calls[0]
-        assert login[1] == "/api/v1/auth/login"
         assert login[2]["email"] == principal.email
-        assert login[2]["password"] == PRINCIPAL_PASSWORD
+        assert login[2]["password"] == password_for_alias("primary.ordinary")
 
     def test_sessions_are_cached_per_alias(self) -> None:
         principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): _login_response(
@@ -327,16 +314,12 @@ class TestPrincipalSessions:
             }
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         first = sessions.session_for_alias("primary.ordinary")
         second = sessions.session_for_alias("primary.ordinary")
         assert first is second
-        assert len(admin.calls) == 1, "password was re-provisioned per case"
         assert len(principal_api.calls) == 1, "logged in again per case"
 
     def test_a_login_returning_the_wrong_org_fails_loud(self) -> None:
@@ -346,13 +329,6 @@ class TestPrincipalSessions:
         pass while proving nothing."""
 
         principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): _login_response(
@@ -363,24 +339,14 @@ class TestPrincipalSessions:
             }
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(PrincipalError, match="org"):
             sessions.session_for_alias("primary.ordinary")
 
     def test_a_login_returning_a_different_user_fails_loud(self) -> None:
         principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): _login_response(
@@ -391,57 +357,42 @@ class TestPrincipalSessions:
             }
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(PrincipalError, match="user"):
             sessions.session_for_alias("primary.ordinary")
 
     def test_a_login_with_no_token_fails_loud(self) -> None:
-        principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi({("POST", "/api/v1/auth/login"): {"user": {}}})
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(PrincipalError, match="access_token"):
             sessions.session_for_alias("primary.ordinary")
 
-    def test_a_failed_provisioning_never_falls_back_to_the_admin_session(self) -> None:
-        """Rule 2, the guard observed failing: if principal provisioning
-        breaks, the run must STOP. Falling back to the superuser session
-        would restore the exact B5 defect while reporting green."""
+    def test_a_failed_login_never_falls_back_to_another_session(self) -> None:
+        """Rule 2, the guard observed failing: if authenticating a principal
+        breaks, the run must STOP. Falling back to the superuser session --
+        or handing back a session whose token was never installed -- would
+        restore the exact B5 defect while reporting green.
 
-        principal = self._principal()
-        boom = RuntimeError("admin set-password returned HTTP 403")
-        admin = _FakeApi(
-            {("POST", f"/api/v1/admin/users/{principal.user_id}/password"): boom}
+        Retargeted from the admin set-password path, which no longer exists:
+        login is now the only way this can fail.
+        """
+
+        principal_api = _FakeApi(
+            {("POST", "/api/v1/auth/login"): RuntimeError("login returned HTTP 403")}
         )
-        principal_api = _FakeApi({})
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(RuntimeError, match="403"):
             sessions.session_for_alias("primary.ordinary")
-        assert principal_api.calls == [], (
-            "attempted a login despite provisioning failing"
+        assert principal_api.token is None, (
+            "a token was installed despite the login failing"
         )
 
     def test_a_login_with_no_user_id_fails_loud(self) -> None:
@@ -452,13 +403,6 @@ class TestPrincipalSessions:
         the wrong identity in the right org and reported success."""
 
         principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): {
@@ -468,11 +412,8 @@ class TestPrincipalSessions:
             }
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(PrincipalError, match="no.*'id'"):
             sessions.session_for_alias("primary.ordinary")
@@ -480,28 +421,16 @@ class TestPrincipalSessions:
 
     def test_a_failed_alias_is_not_retried_for_every_later_case(self) -> None:
         """Codex adversarial round-1, MEDIUM: only successes were cached, so
-        a set-password that succeeded followed by a failing login made every
-        subsequent case using that alias re-run the admin password mutation.
-        With 137 cases on one alias and a per-hour rate limit, one blip
+        a failing login was retried by every subsequent case using that
+        alias. With 137 cases on one alias and a rate-limited login, one blip
         became a storm of 429s that buried the real error."""
 
-        principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
-        )
         principal_api = _FakeApi(
             {("POST", "/api/v1/auth/login"): RuntimeError("login 503")}
         )
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: principal_api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(RuntimeError, match="login 503"):
             sessions.session_for_alias("primary.ordinary")
@@ -512,34 +441,45 @@ class TestPrincipalSessions:
             with pytest.raises(PrincipalError, match="already failed") as caught:
                 sessions.session_for_alias("primary.ordinary")
             assert isinstance(caught.value.__cause__, RuntimeError)
-        assert len(admin.calls) == 1, (
-            "the admin password endpoint was called again after the first "
-            f"failure ({len(admin.calls)} times) -- shared state keeps being "
-            "mutated and the rate limit will bury the original error"
+        assert len(principal_api.calls) == 1, (
+            "the login endpoint was called again after the first failure "
+            f"({len(principal_api.calls)} times) -- the rate limiter will "
+            "bury the original error"
         )
 
     def test_an_unknown_alias_never_reaches_the_network(self) -> None:
-        admin = _FakeApi({})
+        built: list[_FakeApi] = []
+
+        def api_factory() -> _FakeApi:
+            api = _FakeApi({})
+            built.append(api)
+            return api
+
         sessions = PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
-            api_factory=lambda: _FakeApi({}),
+            api_factory=api_factory,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=True,
         )
         with pytest.raises(PrincipalError, match="nobody"):
             sessions.session_for_alias("primary.nobody")
-        assert admin.calls == []
+        assert built == [], (
+            "an unresolvable alias built an API client -- resolution must "
+            "fail before anything touches the network"
+        )
 
 
-class TestPasswordBridgeIsOptIn:
-    """Team-lead ruling 2026-08-06: credentials are seeded at world-generation
-    time and ``password_hash`` STAYS in the world digest.
+class TestSeededCredentialsAreTheOnlyPath:
+    """Replaces ``TestPasswordBridgeIsOptIn``, whose subject no longer exists.
 
-    Setting a password at run time therefore MUTATES a digest-covered column.
-    That is a real cost, so it is opt-in and it marks the receipts: a bridged
-    run is not a clean run and must not be mistaken for one. The bridge is
-    temporary -- it goes away when CHAOS-3463 lands seeded credentials.
+    That class asserted the opt-in semantics of the temporary
+    admin-set-password bridge. CHAOS-3463 seeds credentials at world
+    generation, so the bridge, its env flag, and the runner-local password
+    constant are all gone -- there is nothing left to opt into, and tests of
+    an absent flag would be theatre.
+
+    What carries over is the property that actually mattered and CAN still
+    regress: authenticating a principal must not write to the world.
+    ``password_hash`` is inside the world digest, so a re-introduced write
+    would make a second armed run report drift against the same stack.
     """
 
     def _principal(self) -> CasePrincipal:
@@ -547,18 +487,19 @@ class TestPasswordBridgeIsOptIn:
             "primary.ordinary"
         )
 
-    def _sessions(self, *, bridge: bool, admin: Any, api: Any) -> PrincipalSessions:
+    def _sessions(self, api: Any) -> PrincipalSessions:
         return PrincipalSessions(
-            admin_api=admin,
-            admin_password="pw",
             api_factory=lambda: api,
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
-            allow_password_bridge=bridge,
         )
 
-    def test_without_the_opt_in_no_password_is_ever_set(self) -> None:
+    def test_authenticating_writes_nothing_to_the_world(self) -> None:
+        """``_FakeApi`` raises on any call it has no canned response for, so
+        the login response being the ONLY one registered is what makes an
+        admin set-password (or any other write) fail this test rather than
+        pass unnoticed."""
+
         principal = self._principal()
-        admin = _FakeApi({})  # any call raises AssertionError
         api = _FakeApi(
             {
                 ("POST", "/api/v1/auth/login"): _login_response(
@@ -566,59 +507,39 @@ class TestPasswordBridgeIsOptIn:
                 )
             }
         )
-        session = self._sessions(bridge=False, admin=admin, api=api).session_for_alias(
-            "primary.ordinary"
-        )
-        assert admin.calls == [], "a digest-covered column was mutated without opt-in"
+        session = self._sessions(api).session_for_alias("primary.ordinary")
+
         assert session.api is api
-
-    def test_with_the_opt_in_the_password_is_set(self) -> None:
-        principal = self._principal()
-        admin = _FakeApi(
-            {
-                ("POST", f"/api/v1/admin/users/{principal.user_id}/password"): {
-                    "ok": True
-                }
-            }
+        assert [(c[0], c[1]) for c in api.calls] == [("POST", "/api/v1/auth/login")], (
+            "the runner issued a call beyond the login -- a write here "
+            "mutates a digest-covered column and drifts the world"
         )
-        api = _FakeApi(
-            {
-                ("POST", "/api/v1/auth/login"): _login_response(
-                    str(principal.user_id), str(principal.org_id), principal.email
-                )
-            }
-        )
-        self._sessions(bridge=True, admin=admin, api=api).session_for_alias(
-            "primary.ordinary"
-        )
-        assert len(admin.calls) == 1
 
-    def test_the_provisioning_mode_distinguishes_the_two(self) -> None:
-        """The receipt marker is the whole point: without it, artifacts from a
-        bridged run are indistinguishable from artifacts produced against
-        properly seeded credentials."""
+    def test_the_provisioning_mode_reports_seeded_credentials(self) -> None:
+        """The receipt marker is stamped into every artifact. There is one
+        credential path now, and the receipts must say WHICH one -- a receipt
+        that omits it cannot later be told apart from one produced while the
+        bridge still existed."""
 
-        fake = _FakeApi({})
         assert (
-            self._sessions(bridge=True, admin=fake, api=fake).provisioning_mode
-            == BRIDGED_PROVISIONING_MARKER
+            self._sessions(_FakeApi({})).provisioning_mode == SEEDED_PROVISIONING_MARKER
         )
-        assert (
-            self._sessions(bridge=False, admin=fake, api=fake).provisioning_mode
-            == SEEDED_PROVISIONING_MARKER
-        )
-        assert BRIDGED_PROVISIONING_MARKER != SEEDED_PROVISIONING_MARKER
+        assert SEEDED_PROVISIONING_MARKER == "world-seeded-credentials"
 
-    def test_an_unseeded_credential_without_the_bridge_names_the_remedy(self) -> None:
+    def test_an_unseeded_world_names_the_remedy(self) -> None:
         """The remedy must reach the operator on the path a REAL unseeded
         account takes.
 
         Adversarial round 3: this test used to feed ``{"user": {}}`` -- a 200
         body the login route never returns for a bad credential -- so it
-        passed while the remedy text sat on an unreachable branch. An
-        unseeded world user has ``password_hash=None``, ``login.py`` answers
-        401, and the API client RAISES before any response-body branch runs.
-        The double is now that raise.
+        passed while the remedy text sat on an unreachable branch. A world
+        snapshot minted before seeded credentials has ``password_hash=None``,
+        ``login.py`` answers 401, and the API client RAISES before any
+        response-body branch runs. The double is that raise.
+
+        The remedy itself changed with the bridge's removal: the operator is
+        now told to re-mint the world snapshot, because provisioning a
+        password at run time is no longer an option the runner offers.
         """
 
         api = _FakeApi(
@@ -630,31 +551,144 @@ class TestPasswordBridgeIsOptIn:
             }
         )
         with pytest.raises(
-            PrincipalError, match="ASK_DEV_ACCEPTANCE_ALLOW_PASSWORD_BRIDGE"
+            PrincipalError, match="mint_ask_dev_world_snapshot"
         ) as caught:
-            self._sessions(bridge=False, admin=_FakeApi({}), api=api).session_for_alias(
-                "primary.ordinary"
-            )
+            self._sessions(api).session_for_alias("primary.ordinary")
         assert "401" in str(caught.value), "the underlying cause must survive"
+        assert "CHAOS-3463" in str(caught.value)
 
-    def test_a_bridged_run_does_not_swallow_the_real_login_error(self) -> None:
-        """With the bridge ON, a 401 means something else is wrong and the
-        original error must propagate unmasked -- the remedy text would be
-        actively misleading there."""
+    def test_a_non_credential_login_failure_is_not_reframed(self) -> None:
+        """Retargets ``test_a_bridged_run_does_not_swallow_the_real_login_
+        error``, which used the bridge flag as its discriminator.
 
-        principal = self._principal()
-        admin = _FakeApi(
+        A 503 is not a credential problem. Reframing it as one would send an
+        operator off to re-mint a world that is perfectly fine, while the
+        real fault -- an unwell API -- goes unmentioned. Without this, the
+        remedy branch would swallow every login failure indiscriminately.
+        """
+
+        api = _FakeApi(
             {
-                (
-                    "POST",
-                    f"/api/v1/admin/users/{principal.user_id}/password",
-                ): {"ok": True}
+                ("POST", "/api/v1/auth/login"): AcceptanceFailure(
+                    "POST /api/v1/auth/login returned HTTP 503: upstream down"
+                )
             }
         )
-        api = _FakeApi(
-            {("POST", "/api/v1/auth/login"): AcceptanceFailure("HTTP 401 boom")}
+        with pytest.raises(AcceptanceFailure, match="503") as caught:
+            self._sessions(api).session_for_alias("primary.ordinary")
+        assert "mint_ask_dev_world_snapshot" not in str(caught.value), (
+            "a 503 was reframed as an unseeded-credential problem"
         )
-        with pytest.raises(AcceptanceFailure, match="boom"):
-            self._sessions(bridge=True, admin=admin, api=api).session_for_alias(
-                "primary.ordinary"
+
+
+class TestTheRunnerAuthenticatesWithSeededWorldCredentials:
+    """CHAOS-3462 follow-up: log in with the credential the SEEDER wrote.
+
+    A differential oracle across the two sides of the credential contract,
+    because no type checker or code index can answer whether they agree.
+    The seeding side hashes ``password_for_alias(alias)``
+    (``fixtures/world.py::_build_auth_fixture``, CHAOS-3463). This asserts
+    the LOGIN side sends a password that verifies against exactly that
+    hash -- through the API's OWN ``_verify_password``, and against hashes
+    produced by the REAL fixture builder rather than hand-authored ones.
+
+    A runner-local shared constant cannot satisfy this: it is one value for
+    every alias, while the seeded hashes are per-alias. That is what makes
+    this fail RED before the swap rather than merely sit beside it.
+    """
+
+    def _login_password_for(self, alias: str) -> str:
+        """Drive the real ``PrincipalSessions`` and capture what it sends."""
+
+        directory = PrincipalDirectory.from_world(_REAL_MANIFEST)
+        principal = directory.principal_by_alias(alias)
+        api = _FakeApi(
+            {
+                ("POST", "/api/v1/auth/login"): _login_response(
+                    str(principal.user_id), str(principal.org_id), principal.email
+                )
+            }
+        )
+        sessions = PrincipalSessions(
+            api_factory=lambda: api,
+            directory=directory,
+        )
+        sessions.session_for_alias(alias)
+        login = api.calls[0]
+        assert login[1] == "/api/v1/auth/login"
+        return login[2]["password"]
+
+    def test_the_login_password_verifies_against_the_seeded_hash(self) -> None:
+        from dev_health_ops.api.services.users import _verify_password
+        from dev_health_ops.fixtures.world import (
+            CORPUS_CONTRACT_USER_ALIASES,
+            _build_auth_fixture,
+            load_world_manifest,
+        )
+
+        manifest = load_world_manifest(_REAL_MANIFEST)
+        by_alias = {u["alias"]: u for u in manifest.world["users"]}
+        seeded = {u.email: u for u in _build_auth_fixture(manifest)["users"]}
+
+        for alias in CORPUS_CONTRACT_USER_ALIASES:
+            sent = self._login_password_for(alias)
+            hashed = seeded[by_alias[alias]["email"]].password_hash
+            assert _verify_password(sent, hashed), (
+                f"the runner logs in as {alias!r} with a password the world "
+                "seed's own hash rejects -- every case for that principal "
+                "would 401 against a correctly seeded world"
             )
+
+    def test_each_alias_gets_its_own_distinct_credential(self) -> None:
+        """Rule 2: without this, a single constant that happened to verify
+        for one alias would satisfy the oracle above for that alias alone.
+        Credentials are per-alias by derivation, so a shared value is a
+        detectable defect rather than a stylistic one."""
+
+        from dev_health_ops.fixtures.world import CORPUS_CONTRACT_USER_ALIASES
+
+        sent = {a: self._login_password_for(a) for a in CORPUS_CONTRACT_USER_ALIASES}
+        assert len(set(sent.values())) == len(sent), (
+            f"aliases share a login credential: {sent!r} -- the runner is not "
+            "deriving per principal"
+        )
+
+    def test_the_credential_matches_productions_derivation(self) -> None:
+        """The value contract, stated plainly.
+
+        NOTE what this does NOT prove: a runner that hardcoded a copy of
+        today's derived string would pass it. That gap is closed by the test
+        below, not by this one -- claiming otherwise here would be worse than
+        the gap, because a reader who sees "pinned to the function" stops
+        checking.
+        """
+
+        assert self._login_password_for("primary.ordinary") == password_for_alias(
+            "primary.ordinary"
+        )
+
+    def test_the_runner_calls_productions_derivation_rather_than_a_copy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rule 2 applied to the import itself.
+
+        Equality against ``password_for_alias(...)`` cannot distinguish "the
+        runner calls production's function" from "someone pasted its current
+        output into a constant" -- both agree until the derivation changes,
+        which is exactly when the difference would start mattering and
+        exactly when nobody would be looking. Rebinding the name the runner
+        resolves at call time does distinguish them: only a real call picks
+        up the sentinel.
+        """
+
+        import scripts.acceptance.corpus.principals as principals_mod
+
+        monkeypatch.setattr(
+            principals_mod,
+            "password_for_alias",
+            lambda alias: f"sentinel-for-{alias}",
+        )
+        assert (
+            self._login_password_for("primary.ordinary")
+            == "sentinel-for-primary.ordinary"
+        ), "the runner did not go through production's derivation function"

--- a/tests/acceptance/corpus/test_principals.py
+++ b/tests/acceptance/corpus/test_principals.py
@@ -272,7 +272,7 @@ class TestPrincipalSessions:
         directory = PrincipalDirectory.from_world(_REAL_MANIFEST)
         return directory.principal_by_alias("primary.ordinary")
 
-    def test_logs_in_as_that_user_and_writes_nothing(self) -> None:
+    def test_logs_in_as_that_user_and_makes_no_other_call(self) -> None:
         principal = self._principal()
         principal_api = _FakeApi(
             {
@@ -295,7 +295,14 @@ class TestPrincipalSessions:
         # first mutated `password_hash`, a digest-covered column, so a second
         # armed run against the same stack reported drift. Asserting the call
         # list exactly -- rather than just that login happened -- is what
-        # would catch a re-introduced write.
+        # would catch a re-introduced provisioning call.
+        #
+        # This is a claim about CALLS, not about the world being untouched:
+        # the login itself stamps `users.last_login_at` server-side. That
+        # column is excluded from the world digest (`_VOLATILE_COLUMNS`), so
+        # it does not drift -- but "the runner writes nothing" would be an
+        # overstatement, and an overstated guarantee is the kind a reader
+        # stops checking.
         assert [(c[0], c[1]) for c in principal_api.calls] == [
             ("POST", "/api/v1/auth/login")
         ], "the runner made a call other than the login -- it must only read"
@@ -477,9 +484,14 @@ class TestSeededCredentialsAreTheOnlyPath:
     an absent flag would be theatre.
 
     What carries over is the property that actually mattered and CAN still
-    regress: authenticating a principal must not write to the world.
+    regress: authenticating a principal must not PROVISION anything.
     ``password_hash`` is inside the world digest, so a re-introduced write
-    would make a second armed run report drift against the same stack.
+    to it would make a second armed run report drift against the same stack.
+
+    Stated exactly, because the loose version ("the runner writes nothing")
+    is false: the login stamps ``users.last_login_at``, which is excluded
+    from the digest by ``_VOLATILE_COLUMNS``. The guarantee is "no
+    provisioning call, no digested column moved" -- not "no writes".
     """
 
     def _principal(self) -> CasePrincipal:
@@ -493,11 +505,11 @@ class TestSeededCredentialsAreTheOnlyPath:
             directory=PrincipalDirectory.from_world(_REAL_MANIFEST),
         )
 
-    def test_authenticating_writes_nothing_to_the_world(self) -> None:
+    def test_authenticating_provisions_nothing(self) -> None:
         """``_FakeApi`` raises on any call it has no canned response for, so
         the login response being the ONLY one registered is what makes an
-        admin set-password (or any other write) fail this test rather than
-        pass unnoticed."""
+        admin set-password (or any other provisioning call) fail this test
+        rather than pass unnoticed."""
 
         principal = self._principal()
         api = _FakeApi(
@@ -511,8 +523,8 @@ class TestSeededCredentialsAreTheOnlyPath:
 
         assert session.api is api
         assert [(c[0], c[1]) for c in api.calls] == [("POST", "/api/v1/auth/login")], (
-            "the runner issued a call beyond the login -- a write here "
-            "mutates a digest-covered column and drifts the world"
+            "the runner issued a call beyond the login -- a provisioning "
+            "call here mutates a digest-covered column and drifts the world"
         )
 
     def test_the_provisioning_mode_reports_seeded_credentials(self) -> None:

--- a/tests/acceptance/corpus/test_principals.py
+++ b/tests/acceptance/corpus/test_principals.py
@@ -580,6 +580,32 @@ class TestSeededCredentialsAreTheOnlyPath:
             "a 503 was reframed as an unseeded-credential problem"
         )
 
+    def test_a_server_error_whose_body_contains_401_is_not_reframed(self) -> None:
+        """The failure mode of matching a bare status number.
+
+        ``AcceptanceApi`` interpolates the raw response BODY into its message
+        (``... returned HTTP {code}: {detail}``), so a substring test for
+        ``"401"`` alone also fires on a 500 carrying ``401`` inside a trace
+        id. The classifier keys on ``returned HTTP 401`` -- the producer's
+        actual shape -- and this plants exactly the body that would defeat
+        the looser version.
+        """
+
+        api = _FakeApi(
+            {
+                ("POST", "/api/v1/auth/login"): AcceptanceFailure(
+                    "POST /api/v1/auth/login returned HTTP 500: "
+                    '{"detail":"internal error","trace_id":"req-a401bc93"}'
+                )
+            }
+        )
+        with pytest.raises(AcceptanceFailure, match="500") as caught:
+            self._sessions(api).session_for_alias("primary.ordinary")
+        assert "mint_ask_dev_world_snapshot" not in str(caught.value), (
+            "a 500 was reframed as a credential problem because its body "
+            "happened to contain '401'"
+        )
+
 
 class TestTheRunnerAuthenticatesWithSeededWorldCredentials:
     """CHAOS-3462 follow-up: log in with the credential the SEEDER wrote.

--- a/tests/acceptance/test_wave4_corpus_runner_live.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live.py
@@ -360,15 +360,21 @@ def principal_sessions(
     covers, since it hashes ``SELECT *`` from ``users`` with only
     ``_VOLATILE_COLUMNS`` excluded -- so the digest had to be read before
     the runner touched it. CHAOS-3463 removed that mutation: credentials are
-    seeded at world generation and this fixture now only reads. The ordering
-    is kept because authenticating against a world whose integrity has not
-    been verified yet would produce evidence nobody can trust, not because
-    anything here writes.
+    seeded at world generation, so nothing here provisions anything. The
+    ordering is kept because authenticating against a world whose integrity
+    has not been verified yet would produce evidence nobody can trust.
 
-    That also retires the residual this fixture used to carry: a SECOND
-    armed run against the same stack no longer reports a ``postgres.users``
-    digest mismatch caused by the first run's own provisioning, so re-runs
-    no longer need a fresh seed/restore.
+    NOT because this fixture is write-free, which would be the tempting and
+    wrong way to put it: a successful login stamps ``users.last_login_at``.
+    That column is excluded from the digest (``_VOLATILE_COLUMNS``, added by
+    CHAOS-3463 after two boots both failed ``require_world_digest_match`` on
+    ``postgres.users`` for exactly this reason), so it does not drift --
+    which is a different statement from "nothing is written".
+
+    That does retire the residual this fixture used to carry: a SECOND armed
+    run against the same stack no longer reports a ``postgres.users`` digest
+    mismatch caused by the first run's own provisioning, so re-runs no
+    longer need a fresh seed/restore.
 
     ``acceptance_api`` is still requested although its client is no longer
     unpacked: it is what guarantees the stack is up and the superuser

--- a/tests/acceptance/test_wave4_corpus_runner_live.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live.py
@@ -141,7 +141,6 @@ from scripts.acceptance.corpus.db_verify import (
 )
 from scripts.acceptance.corpus.invariants import InvariantContext, evaluate_invariant
 from scripts.acceptance.corpus.principals import (
-    BRIDGE_ENV_VAR,
     SEEDED_PROVISIONING_MARKER,
     PrincipalDirectory,
     PrincipalSession,
@@ -355,40 +354,30 @@ def principal_sessions(
     routers do not honor impersonation, and would silently evaluate
     entitlement and readiness against the superuser's org instead).
 
-    THE ``_world_digest_pin`` DEPENDENCY IS LOAD-BEARING, NOT DECORATIVE.
-    Provisioning writes a real ``password_hash`` onto world-seeded users,
-    and ``compute_world_digest`` hashes ``SELECT *`` from ``users`` with
-    only ``_VOLATILE_COLUMNS`` excluded -- ``password_hash`` is NOT in that
-    exclusion set. So the very act of selecting a principal mutates a
-    digested column. Declaring the dependency pins the ordering (digest
-    verified first, against a world nobody has touched) instead of relying
-    on the incidental "autouse session fixtures instantiate before
-    requested ones" rule, which a future edit could silently invert.
+    THE ``_world_digest_pin`` DEPENDENCY IS STILL DECLARED, FOR A NARROWER
+    REASON THAN IT ONCE HAD. It used to be load-bearing because selecting a
+    principal MUTATED ``password_hash`` -- a column ``compute_world_digest``
+    covers, since it hashes ``SELECT *`` from ``users`` with only
+    ``_VOLATILE_COLUMNS`` excluded -- so the digest had to be read before
+    the runner touched it. CHAOS-3463 removed that mutation: credentials are
+    seeded at world generation and this fixture now only reads. The ordering
+    is kept because authenticating against a world whose integrity has not
+    been verified yet would produce evidence nobody can trust, not because
+    anything here writes.
 
-    RESIDUAL, STATED RATHER THAN PAPERED OVER: this makes the FIRST armed
-    run against a freshly-seeded stack correct, and a SECOND run against
-    the same stack report a ``postgres.users`` digest mismatch caused by
-    the first run's own provisioning. Re-runs therefore need a fresh
-    seed/restore. The durable fix belongs to the world-seeding lane
-    (CHAOS-3219 B2/B3), and there are only two honest shapes for it: seed
-    the password in ``_build_auth_fixture`` so the pin includes it, or
-    exclude ``password_hash`` from the digest -- which is defensible on its
-    own terms, since a bcrypt hash is salted and therefore can never
-    reproduce across two generations of the same world anyway.
+    That also retires the residual this fixture used to carry: a SECOND
+    armed run against the same stack no longer reports a ``postgres.users``
+    digest mismatch caused by the first run's own provisioning, so re-runs
+    no longer need a fresh seed/restore.
+
+    ``acceptance_api`` is still requested although its client is no longer
+    unpacked: it is what guarantees the stack is up and the superuser
+    session exists before any principal login is attempted.
     """
 
-    admin_api, _ = acceptance_api
     return PrincipalSessions(
-        admin_api=admin_api,
-        admin_password=_superuser_password(),
         api_factory=lambda: AcceptanceApi(_api_base_url()),
         directory=PrincipalDirectory.from_world(_WORLD_DIR / "world.json"),
-        # Team-lead ruling 2026-08-06: credentials belong in the world
-        # generation (CHAOS-3463) and password_hash STAYS digested. Setting
-        # a password at run time mutates a digested column, so it is opt-in
-        # and marks every receipt -- a bridged run must never be mistaken
-        # for a clean one.
-        allow_password_bridge=os.getenv(BRIDGE_ENV_VAR) == "1",
     )
 
 
@@ -705,16 +694,21 @@ def test_corpus_case(
     # is now its own NAMED, always-recorded check, so the receipt says which
     # credential path produced it in a field a reader can key on -- and a
     # test asserts the name is present for an executed case.
+    #
+    # The condition is a real assertion rather than a bare `True` (which it
+    # was while two modes existed and either was acceptable). With the
+    # admin-set-password bridge gone there is exactly ONE legitimate
+    # credential path, so a run reporting any other value is a run whose
+    # receipts mean something different from what a reader would assume --
+    # and that must show up as a failed check, not as prose in a detail
+    # string nobody diffs.
     recorder.check(
         category="provisioning-mode",
         name=f"provisioned_via_{principal_sessions.provisioning_mode}",
-        condition=True,
+        condition=(principal_sessions.provisioning_mode == SEEDED_PROVISIONING_MARKER),
         detail=(
-            "credentials came from the world seed"
-            if principal_sessions.provisioning_mode == SEEDED_PROVISIONING_MARKER
-            else "TEMPORARY admin-set-password bridge: this run mutated a "
-            "digest-covered column and is NOT equivalent to a run against "
-            "seeded credentials"
+            "credentials came from the world seed "
+            f"({principal_sessions.provisioning_mode})"
         ),
     )
     if ledger_classification_error is not None:

--- a/tests/acceptance/test_wave4_corpus_runner_live_wiring.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live_wiring.py
@@ -23,10 +23,7 @@ from pathlib import Path
 
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevStreamEvent
-from scripts.acceptance.corpus.principals import (
-    BRIDGED_PROVISIONING_MARKER,
-    SEEDED_PROVISIONING_MARKER,
-)
+from scripts.acceptance.corpus.principals import SEEDED_PROVISIONING_MARKER
 from scripts.acceptance.corpus.sse_client import SseFrame
 from tests.acceptance.test_wave4_corpus_runner_live import (
     _public_outcome_from_events,
@@ -114,10 +111,11 @@ class TestReceiptRecordsProvisioningMode:
     """Adversarial round 3: the marker used to live only in a free-text
     ``detail`` string, and deleting that fragment left every test green.
 
-    A receipt is evidence. Evidence that cannot distinguish a run against
-    seeded credentials from one that took the temporary admin-set-password
-    bridge is weaker than it looks -- the bridge mutates a digest-covered
-    column, so the two are not equivalent runs.
+    A receipt is evidence, and it must say where the run's credentials came
+    from. There is one path now -- the world seed (CHAOS-3463) -- but the
+    field stays named and recorded: a receipt that simply omits the question
+    cannot be distinguished later from one produced before the answer was
+    settled.
     """
 
     def test_the_runner_records_a_named_provisioning_check(self) -> None:
@@ -134,7 +132,24 @@ class TestReceiptRecordsProvisioningMode:
         )
         assert 'category="provisioning-mode"' in source
 
-    def test_the_two_markers_are_distinguishable(self) -> None:
-        assert BRIDGED_PROVISIONING_MARKER != SEEDED_PROVISIONING_MARKER
-        assert BRIDGED_PROVISIONING_MARKER
+    def test_the_provisioning_check_is_asserted_not_merely_recorded(self) -> None:
+        """The check used to pass ``condition=True`` because either mode was
+        acceptable while the bridge existed. Only one is acceptable now, so
+        the check must actually compare against the seeded marker -- an
+        unconditional check reads as coverage while asserting nothing.
+        """
+
         assert SEEDED_PROVISIONING_MARKER
+        source = (
+            Path(__file__).with_name("test_wave4_corpus_runner_live.py")
+        ).read_text(encoding="utf-8")
+        marker = 'category="provisioning-mode"'
+        start = source.index(marker)  # raises loudly if the check is gone
+        block = source[start : start + 600]
+        assert "SEEDED_PROVISIONING_MARKER" in block, (
+            "the provisioning-mode check no longer compares against the "
+            "seeded marker -- it can no longer fail"
+        )
+        assert "condition=True" not in block, (
+            "the provisioning-mode check went back to an unconditional pass"
+        )

--- a/tests/acceptance/world/ask-dev-world.v1/corpus/CASE-SCHEMA.v1.md
+++ b/tests/acceptance/world/ask-dev-world.v1/corpus/CASE-SCHEMA.v1.md
@@ -360,14 +360,20 @@ Two consequences for case authoring:
   2026-08-06, CHAOS-3463), and `password_hash` **stays in the world
   digest** — the snapshot/restore model makes hashes frozen bytes restored
   identically per boot, so credential tampering registers as drift, which is
-  what the digest is for. Until that lands, world users have
-  `password_hash=None` and cannot log in at all, so the runner offers a
-  TEMPORARY bridge: `ASK_DEV_ACCEPTANCE_ALLOW_PASSWORD_BRIDGE=1` opts into
-  setting a password via `POST /api/v1/admin/users/{id}/password`. It is
-  opt-in because it mutates a digest-covered column, and every receipt from
-  such a run is stamped `provisioning=admin-set-password-bridge` so a
-  bridged run can never be mistaken for one against properly seeded
-  credentials. Remove the bridge when CHAOS-3463 lands.
+  what the digest is for. `fixtures/world.py::password_for_alias` is the ONE
+  derivation: `_build_auth_fixture` hashes it when seeding and the corpus
+  runner logs in with it, so seeding and login cannot disagree. The runner
+  only reads — every receipt is stamped
+  `provisioning=world-seeded-credentials`. A stack whose world snapshot
+  predates seeded credentials answers 401; re-mint it
+  (`scripts/acceptance/mint_ask_dev_world_snapshot.sh`) rather than
+  provisioning a password at run time.
+
+  *(Historical: a `ASK_DEV_ACCEPTANCE_ALLOW_PASSWORD_BRIDGE=1` opt-in used to
+  set a password via `POST /api/v1/admin/users/{id}/password`, because world
+  users then had `password_hash=None` and could not log in at all. It mutated
+  a digest-covered column, so a second armed run against the same stack
+  reported drift. Removed once CHAOS-3463 landed seeded credentials.)*
 
 ## `status: "declared-blocked"` cases
 

--- a/tests/acceptance/world/ask-dev-world.v1/corpus/CASE-SCHEMA.v1.md
+++ b/tests/acceptance/world/ask-dev-world.v1/corpus/CASE-SCHEMA.v1.md
@@ -363,8 +363,11 @@ Two consequences for case authoring:
   what the digest is for. `fixtures/world.py::password_for_alias` is the ONE
   derivation: `_build_auth_fixture` hashes it when seeding and the corpus
   runner logs in with it, so seeding and login cannot disagree. The runner
-  only reads — every receipt is stamped
-  `provisioning=world-seeded-credentials`. A stack whose world snapshot
+  provisions nothing — every receipt is stamped
+  `provisioning=world-seeded-credentials`. (It is not write-free: a
+  successful login stamps `users.last_login_at`, which `_VOLATILE_COLUMNS`
+  excludes from the digest for exactly that reason. What it never does is
+  move a *digested* column.) A stack whose world snapshot
   predates seeded credentials answers 401; re-mint it
   (`scripts/acceptance/mint_ask_dev_world_snapshot.sh`) rather than
   provisioning a password at run time.


### PR DESCRIPTION
Two deferred CHAOS-3462 riders, both now unblocked by merged work, in one PR.

## 1. Close the exec-plane stdin hang

`db_verify.exec_in_api` passed no `stdin`, so the child inherited fd 0. `-T` suppresses the pseudo-TTY but does **not** close stdin — compose still forwards fd 0 into the container — so the call blocks forever whenever the parent's fd 0 is an open pipe nobody closes. That is exactly what happens when the runner is driven from a shell script rather than an interactive terminal, and `scripts/acceptance/run_wave4_corpus.sh` is such a driver.

The failure mode is the worst one available to this lane: not a red, but a silent hang with no output, holding the gate slot while looking like nothing is happening. So it gets a real fix and a real test rather than a comment documenting the hang.

Two tests: a contract test that the runner is told not to inherit stdin, and a mechanism test that reproduces the hang and the fix. Reproduced both ways with the identical call shape before fixing — inherited stdin against an open pipe HUNG; `stdin=subprocess.DEVNULL` completed rc=0.

## 2. Swap the interim credential for the seeded world credential

CHAOS-3463 (#1536) seeds every `world.json` user with `password_for_alias(alias)` at generation time, so the interim runner-local password constant and the admin-set-password bridge that put it there are both obsolete. The runner now imports production's own derivation: one derivation, not two copies that agree until one is edited.

Removed after grepping every consumer:

- `PRINCIPAL_PASSWORD` — one shared value for every alias, while seeded hashes are per-alias.
- `ASK_DEV_ACCEPTANCE_ALLOW_PASSWORD_BRIDGE` and `BRIDGED_PROVISIONING_MARKER`. The flag's only consumers were this module, its own tests, the live-runner fixture, and one doc — no shell driver, CI workflow, or compose file reads it.
- `PrincipalSessions`' `admin_api` / `admin_password` parameters, which existed only to feed the bridge's admin call.

`SEEDED_PROVISIONING_MARKER` and `provisioning_mode` stay so receipts keep the field readers key on. The runner's provisioning-mode check was `condition=True` while either mode was acceptable; with one legitimate path it now actually compares, so a wrong value fails instead of being narrated in a detail string nobody diffs.

## Two changes reviewers should look at directly

**Login errors are no longer reframed indiscriminately.** The old code used the bridge flag to decide whether to attach the "credential not seeded" remedy. With the flag gone the discriminator is the error itself (`returned HTTP 401` / `Invalid credentials`). A 503 or a rate-limit keeps its own error — telling an operator to re-mint a world that is fine, while the real fault goes unmentioned, is worse than saying nothing. `test_a_bridged_run_does_not_swallow_the_real_login_error` is retargeted to pin exactly this rather than dropped.

**A coverage deletion, not a rename.** `TestPrincipalPasswordMeetsProductionPolicy` is deleted. It asserted the constant satisfied `validate_password` because a non-compliant value would 422 the admin set-password call. There is no such call now, and login does not re-run the policy, so the test guarded nothing. The derivation's own properties (length, determinism, per-alias uniqueness) are asserted against `password_for_alias` itself in `tests/test_fixtures_world_runner.py` — at the producer, where they belong.

## Evidence

RED first, then mutation:

1. **RED.** Before the swap the new differential oracle failed for the right reason: the runner sent `ask-dev-world-acceptance-4242` and the real seeded bcrypt hash rejected it. The oracle drives the actual `PrincipalSessions`, captures what it sends, and verifies it against hashes from the real `_build_auth_fixture` using the API's own `_verify_password` — both sides of the contract, real producer, no hand-authored fixtures.
2. **Mutation.** Planting the defect the swap could still hide — a pasted copy of today's derived string — killed three guards. The single survivor is the plain equality test, whose docstring states in advance that it cannot catch that case and points at the monkeypatch test that can. An admitted gap beats an inaccurate coverage claim.
3. A second mutation reverted the login-failure classifier to the loose matcher and the new `500`-with-`401`-in-body test was observed failing, then passing once tightened.

Restores after each mutation were verified by file **content**, not by a build or a `git` check.

Two MEDIUM findings, both self-found, both fixed in their own commits:

- `_is_credential_rejection` matched a bare `"401"`. `AcceptanceApi` interpolates the raw **response body** into its message, so a 500 carrying `401` inside a trace id (`req-a401bc93`) classified as a credential rejection. Now keys on `returned HTTP 401`, the producer's actual shape.
- An earlier commit claimed in a comment, two docstrings, two test names and the doc that the runner "only reads" / "writes nothing". That is false — `api/auth/routers/login.py:307` stamps `users.last_login_at` on every successful login. The conclusion survives, because CHAOS-3463 put `last_login_at` in `_VOLATILE_COLUMNS` (added after two boots both failed `require_world_digest_match` on `postgres.users` for precisely this reason), so no digested column moves and the second-run drift residual is genuinely retired. But the honest guarantee is "no provisioning call, and no **digested** column moved", not "no writes".

A Codex review reported no definite correctness issues, but its own targeted tests could not run in its sandbox — that verdict rests on reading, not execution. The executed proofs above are the evidence.

Refs CHAOS-3462, CHAOS-3463.
