### PR TITLE
CHAOS-3123: Go parity for three derived work-item destinations (PR-A)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -146,6 +146,21 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: '**/go.sum'
 
+      # The derived work-item integration tests migrate their throwaway
+      # ClickHouse container with the project's REAL migration chain
+      # (internal/testsupport/chschema), which shells out to Python. This job
+      # previously installed no Python dependencies at all, so that helper died
+      # with ModuleNotFoundError. The closure is pinned and installed with
+      # --no-deps for the same reason go-quality's is: an undeclared dependency
+      # must fail loudly rather than drift to latest.
+      - name: Set up Python 3.13.14 for the ClickHouse migration chain
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13.14'
+
+      - name: Install locked ClickHouse migration dependencies
+        run: python -m pip install --no-deps -r ci/requirements-clickhouse-migrations.txt
+
       - name: Run isolated storage integration suite
         run: bash ci/check_go.sh integration
 

--- a/ci/requirements-clickhouse-migrations.txt
+++ b/ci/requirements-clickhouse-migrations.txt
@@ -1,0 +1,62 @@
+# Exact Python 3.13 closure from uv.lock for RUNNING THE REAL ClickHouse
+# migration chain from a Go integration test (internal/testsupport/chschema).
+#
+# Separate from requirements-live-python-oracles.txt on purpose. That file
+# serves go-quality, whose oracle loader STUBS the heavy modules before
+# importing production code, so it needs neither FastAPI nor a ClickHouse
+# client. chschema does the opposite by design: it executes the project's real
+# migration entrypoint, so it drags the entrypoint's true import closure --
+# which reaches dev_health_ops.models -> licensing -> fastapi and nacl -- plus a
+# live ClickHouse client. Merging the two files would put that weight on a job
+# that does not need it, and would hide which job needs what.
+#
+# CI installs this with --no-deps, so every transitive is listed explicitly and
+# an undeclared dependency fails loudly instead of silently drifting to latest.
+#
+# Versions are from uv.lock, NOT from a fresh resolve. That distinction is not
+# cosmetic: resolving these packages latest-first yields
+# clickhouse-connect 1.6.0 (lock: 0.15.1) and fastapi 0.141.1, and the latter
+# violates pyproject's own `fastapi>=0.136.1,<0.137` constraint. A CI job that
+# installed the resolved set would be testing against dependencies the project
+# forbids.
+
+# --- shared with the live-oracle closure ---
+annotated-types==0.7.0
+anyio==4.13.0
+certifi==2026.4.22
+defusedxml==0.7.1
+gitdb==4.0.12
+GitPython==3.1.54
+greenlet==3.5.0
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.15
+pydantic==2.13.4
+pydantic-core==2.46.4
+PyYAML==6.0.3
+smmap==5.0.3
+SQLAlchemy==2.0.49
+typing-extensions==4.15.0
+typing-inspection==0.4.2
+
+# --- additionally required to import the migration entrypoint ---
+# dev_health_ops.metrics.sinks -> models -> licensing.gating imports FastAPI,
+# and licensing.validator imports nacl. Both are on the import path of the
+# migration runner even though a migration performs no HTTP and verifies no
+# signature.
+annotated-doc==0.0.4
+fastapi==0.136.3
+starlette==1.3.1
+pynacl==1.6.2
+cffi==2.0.0
+pycparser==3.0
+
+# --- ClickHouse client used to APPLY the migrations ---
+clickhouse-connect==0.15.1
+lz4==4.4.5
+urllib3==2.7.0
+zstandard==0.25.0
+# pytz is required by clickhouse-connect 0.15.1's tzutil at IMPORT time; the
+# --no-deps install is what surfaced it.
+pytz==2026.2

--- a/internal/jobs/providerunit/deterministic_terminal_category_test.go
+++ b/internal/jobs/providerunit/deterministic_terminal_category_test.go
@@ -1,0 +1,90 @@
+package providerunit
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/providersync"
+)
+
+// The signature contract of deterministicTerminalCategory, pinned as a table so
+// that adding, removing or renaming a mapping is a deliberate edit to this list
+// rather than a silent change in how a whole class of units terminalizes.
+//
+// Both directions matter. A missing entry burns every retry and then records
+// the generic exhausted category, hiding the real cause; a spurious entry
+// terminalizes a fault a retry would have cleared.
+func TestDeterministicTerminalCategoryContract(t *testing.T) {
+	deterministic := []struct {
+		name     string
+		err      error
+		category string
+	}{
+		{
+			name:     "repository identity ambiguous",
+			err:      providersync.ErrRepositoryIdentityAmbiguous,
+			category: RepositoryIdentityCategory,
+		},
+		{
+			// Reached when a readback finds a stored row that disagrees with
+			// the replayed effect, when the effect is recovery-blocked, or when
+			// the committer has no readback. All three are decided by already
+			// persisted state, so every later attempt reaches the same verdict.
+			name:     "effect recovery ambiguous",
+			err:      providersync.ErrEffectRecoveryAmbiguous,
+			category: EffectRecoveryAmbiguousCategory,
+		},
+	}
+	for _, testCase := range deterministic {
+		t.Run(testCase.name, func(t *testing.T) {
+			category, ok := deterministicTerminalCategory(testCase.err)
+			if !ok || category != testCase.category {
+				t.Fatalf("bare error: got (%q, %v), want (%q, true)",
+					category, ok, testCase.category)
+			}
+			// Executors return wrapped errors, so matching MUST go through
+			// errors.Is. An equality check would pass the bare case above and
+			// silently fail in production.
+			wrapped := fmt.Errorf("executing route: %w", testCase.err)
+			category, ok = deterministicTerminalCategory(wrapped)
+			if !ok || category != testCase.category {
+				t.Fatalf("wrapped error: got (%q, %v), want (%q, true)",
+					category, ok, testCase.category)
+			}
+		})
+	}
+
+	// The categories must stay distinguishable from each other and from the
+	// exhausted fallback: collapsing two of them would make the alert that
+	// fires on one of them fire on both.
+	seen := map[string]string{}
+	for _, testCase := range deterministic {
+		if previous, duplicate := seen[testCase.category]; duplicate {
+			t.Errorf("category %q is shared by %q and %q",
+				testCase.category, previous, testCase.name)
+		}
+		seen[testCase.category] = testCase.name
+	}
+	for category := range seen {
+		if category == "provider_unit_exhausted" ||
+			category == GitHubFilesInventoryFailureCategory ||
+			category == RouteReconciliationCategory {
+			t.Errorf("deterministic category %q collides with a non-deterministic one", category)
+		}
+	}
+
+	// Anything not listed must keep the ordinary bounded-retry path. A mapper
+	// that returned true for an arbitrary error would terminalize transient
+	// faults, which is the failure this half of the contract exists to catch.
+	for _, err := range []error{
+		errors.New("connection reset by peer"),
+		providersync.ErrInvalidConfiguration,
+		fmt.Errorf("wrapped: %w", errors.New("timeout")),
+	} {
+		if category, ok := deterministicTerminalCategory(err); ok {
+			t.Errorf("deterministicTerminalCategory(%v) = (%q, true), want retryable",
+				err, category)
+		}
+	}
+}

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -40,12 +40,33 @@ const RepositoryIdentityCategory = "repository_identity_ambiguous"
 // never established.
 const GitHubFilesInventoryFailureCategory = "github_files_inventory_failed"
 
+// EffectRecoveryAmbiguousCategory records a unit whose effect recovery cannot
+// be reconciled: a readback found a stored row that disagrees with the effect
+// being replayed, the effect was marked recovery-blocked, or the committer had
+// no readback to consult (effect_committer.go:128,158,163).
+//
+// Every one of those is decided by state already durably persisted, so a later
+// attempt re-reads the same rows and reaches the same verdict. Retrying burns
+// the remaining attempts and then buries the real cause under the generic
+// provider_unit_exhausted category, which is exactly the outcome that makes a
+// wedged effect hard to find.
+const EffectRecoveryAmbiguousCategory = "effect_recovery_ambiguous"
+
 // deterministicTerminalCategory maps executor failures that no retry can clear
 // onto their own durable category. Anything not listed keeps the ordinary
 // bounded-retry path.
+//
+// This is ADAPTER-INDEPENDENT: it reclassifies ErrEffectRecoveryAmbiguous for
+// every route that reaches the shared committer, not only the three derived
+// destinations this lane adds. That is intended -- the error means the same
+// thing wherever it comes from -- but it does change the recorded category and
+// the retry count for existing adapters that previously exhausted instead.
 func deterministicTerminalCategory(err error) (string, bool) {
 	if errors.Is(err, providersync.ErrRepositoryIdentityAmbiguous) {
 		return RepositoryIdentityCategory, true
+	}
+	if errors.Is(err, providersync.ErrEffectRecoveryAmbiguous) {
+		return EffectRecoveryAmbiguousCategory, true
 	}
 	return "", false
 }

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -258,6 +258,11 @@ unestimated_count, backlog_size, ratio, computed_at, org_id)`)
 	if err != nil {
 		return err
 	}
+	// Abort is a no-op once Send succeeds, so this only fires on an early
+	// return -- an Append error, a lease loss, or a Day parse failure. Without
+	// it those paths leak the prepared batch's connection, exactly as every
+	// sibling adapter in this package already guards against.
+	defer batch.Abort()
 	for _, row := range rows {
 		day, err := row.Day.time()
 		if err != nil {
@@ -381,6 +386,11 @@ is_primary, confidence, evidence, computed_at)`)
 	if err != nil {
 		return err
 	}
+	// Abort is a no-op once Send succeeds, so this only fires on an early
+	// return -- an Append error, a lease loss, or a Day parse failure. Without
+	// it those paths leak the prepared batch's connection, exactly as every
+	// sibling adapter in this package already guards against.
+	defer batch.Abort()
 	for _, row := range rows {
 		if err := batch.Append(
 			identity.OrgID, githubWorkItemDerivedRepoID(row.RepoID), row.WorkItemID,
@@ -491,6 +501,11 @@ items_touched, computed_at, avg_wip, org_id)`)
 	if err != nil {
 		return err
 	}
+	// Abort is a no-op once Send succeeds, so this only fires on an early
+	// return -- an Append error, a lease loss, or a Day parse failure. Without
+	// it those paths leak the prepared batch's connection, exactly as every
+	// sibling adapter in this package already guards against.
+	defer batch.Abort()
 	for _, row := range rows {
 		day, err := row.Day.time()
 		if err != nil {

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -550,6 +550,38 @@ GROUP BY org_id, provider, work_scope_id, team_id, status, day`,
 	return compareGitHubWorkItemStateDurationVersion(expected, actual, found, identity.OrgID), nil
 }
 
+// githubWorkItemDerivedVersionOrder is the THREE-WAY version comparison every
+// comparator in this file must apply BEFORE looking at any value column.
+//
+// A two-way `!Equal -> Absent` is not merely incomplete, it wedges. Consider a
+// byte-identical recompute where only computed_at moved -- the steady state for
+// work_item_team_attributions, whose producer is called once per backfill day
+// and re-emits identical rows. Persisted carries the NEWER stamp, the effect
+// being inspected carries the older one, and every value column agrees. Under
+// `!Equal -> Absent` that reads Absent, the committer rewrites the OLDER
+// generation, argMax (or RMT) keeps the newer one, the next readback answers
+// Absent again, and the loop never terminates. On plain-MergeTree
+// state_durations each iteration also APPENDS a row.
+//
+// Order matters as much as the three-way itself:
+//   - persisted OLDER than the effect: our write never landed, so value
+//     differences are EXPECTED and must not be reported as a conflict.
+//   - persisted NEWER: a later generation already superseded this key.
+//     Rewriting would regress it, and we cannot prove our write landed.
+//   - persisted EQUAL: same generation, so any value disagreement is a real
+//     contradiction rather than a version difference.
+//
+// This mirrors compareRepositoryVersion (github_repository_effects_clickhouse.go).
+func githubWorkItemDerivedVersionOrder(actual, expected time.Time) (EffectInspection, bool) {
+	switch {
+	case actual.Before(expected):
+		return EffectAbsent, true
+	case actual.After(expected):
+		return EffectConflict, true
+	}
+	return EffectExact, false
+}
+
 // The three comparators below all test `found != 1` FIRST. Reaching an
 // absent/stale branch before the duplicate check is what turns duplicates plus
 // a stale row into an infinite rewrite loop.
@@ -566,7 +598,17 @@ func compareGitHubEstimateCoverageVersion(
 		// would rewrite and duplicate again.
 		return EffectConflict
 	}
-	if actual.OrgID != orgID || actual.Day != expected.Day ||
+	// Tenancy is not a version question: a foreign tenant's row is a
+	// contradiction at ANY version.
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if verdict, decided := githubWorkItemDerivedVersionOrder(
+		actual.ComputedAt, githubWorkItemDerivedMillis(expected.ComputedAt),
+	); decided {
+		return verdict
+	}
+	if actual.Day != expected.Day ||
 		actual.Provider != expected.Provider ||
 		actual.WorkScopeID != expected.WorkScopeID ||
 		!githubWorkItemDerivedStringPointerEqual(actual.TeamID, expected.TeamID) ||
@@ -576,9 +618,6 @@ func compareGitHubEstimateCoverageVersion(
 		actual.BacklogSize != expected.BacklogSize ||
 		!githubWorkItemDerivedFloatPointerEqual(actual.Ratio, expected.Ratio) {
 		return EffectConflict
-	}
-	if !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {
-		return EffectAbsent
 	}
 	return EffectExact
 }
@@ -592,7 +631,15 @@ func compareGitHubWorkItemTeamAttributionVersion(
 		}
 		return EffectConflict
 	}
-	if actual.OrgID != orgID || actual.WorkItemID != expected.WorkItemID ||
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if verdict, decided := githubWorkItemDerivedVersionOrder(
+		actual.ComputedAt, githubWorkItemDerivedMillis(expected.ComputedAt),
+	); decided {
+		return verdict
+	}
+	if actual.WorkItemID != expected.WorkItemID ||
 		actual.Provider != expected.Provider ||
 		githubWorkItemDerivedRepoID(actual.RepoID) != githubWorkItemDerivedRepoID(expected.RepoID) ||
 		!githubWorkItemDerivedStringPointerEqual(actual.TeamID, expected.TeamID) ||
@@ -600,9 +647,6 @@ func compareGitHubWorkItemTeamAttributionVersion(
 		actual.Source != expected.Source || actual.IsPrimary != expected.IsPrimary ||
 		actual.Confidence != expected.Confidence || actual.Evidence != expected.Evidence {
 		return EffectConflict
-	}
-	if !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {
-		return EffectAbsent
 	}
 	return EffectExact
 }
@@ -619,14 +663,19 @@ func compareGitHubWorkItemStateDurationVersion(
 		// never a reason to rewrite.
 		return EffectConflict
 	}
-	if actual.OrgID != orgID || actual.TeamName != expected.TeamName ||
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if verdict, decided := githubWorkItemDerivedVersionOrder(
+		actual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),
+	); decided {
+		return verdict
+	}
+	if actual.TeamName != expected.TeamName ||
 		actual.DurationHours != expected.DurationHours ||
 		actual.ItemsTouched != expected.ItemsTouched ||
 		actual.AvgWIP != expected.AvgWIP {
 		return EffectConflict
-	}
-	if !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {
-		return EffectAbsent
 	}
 	return EffectExact
 }

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -140,7 +140,19 @@ func githubWorkItemDerivedSeconds(value time.Time) time.Time {
 }
 
 // githubWorkItemDerivedSortingKeyDedupe collapses rows that share a full
-// ClickHouse sorting key, keeping the LAST occurrence.
+// ClickHouse sorting key, keeping the HIGHEST version and breaking ties by
+// order (last occurrence wins).
+//
+// Version first, not order first, because the destination is a
+// ReplacingMergeTree keyed on computed_at: the server resolves a collision by
+// VERSION and ignores insertion order entirely. Ordering alone is correct only
+// while every row in a batch shares one computed_at -- true today, enforced by
+// nothing. The day a batch carries mixed versions, an order-only dedup names a
+// row the server discards, the readback compares against a row that is not
+// there, and recovery wedges at Conflict permanently.
+//
+// The tie-break stays LAST-wins so the equal-version behaviour, which is the
+// case every real batch takes today, is unchanged.
 //
 // This is a PERSISTENCE-layer decision, not a compute-layer one, so it does
 // not touch the D16 mirroring of the builders: Python writes every row and
@@ -154,19 +166,33 @@ func githubWorkItemDerivedSeconds(value time.Time) time.Time {
 // differently -- collapse to one stored row, `found` is 1, the team_name
 // mismatch reads as Conflict, and recovery is wedged permanently.
 func githubWorkItemDerivedSortingKeyDedupe[T any](
-	rows []T, key func(T) string,
+	rows []T, key func(T) string, version func(T) time.Time,
 ) []T {
-	lastIndex := make(map[string]int, len(rows))
+	winner := make(map[string]int, len(rows))
 	for index, row := range rows {
-		lastIndex[key(row)] = index
+		current, exists := winner[key(row)]
+		// `!Before` keeps the LATER index on an exact tie, which is the
+		// last-wins tie-break.
+		if !exists || !version(row).Before(version(rows[current])) {
+			winner[key(row)] = index
+		}
 	}
 	result := make([]T, 0, len(rows))
 	for index, row := range rows {
-		if lastIndex[key(row)] == index {
+		if winner[key(row)] == index {
 			result = append(result, row)
 		}
 	}
 	return result
+}
+
+// githubTeamAttributionVersion is the ReplacingMergeTree version column for
+// work_item_team_attributions, read through the same stored-precision
+// truncation the write and the comparison use. Comparing raw stamps here while
+// storing truncated ones would let two rows that are one version after
+// truncation be ordered by digits the column cannot hold.
+func githubTeamAttributionVersion(row githubWorkItemTeamAttributionRow) time.Time {
+	return githubWorkItemDerivedMillis(row.ComputedAt)
 }
 
 // githubWorkItemDerivedUniqueSortingKeys reports whether every row already
@@ -346,7 +372,9 @@ func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) WriteGitHubWorkItemE
 	// destinations: the resolver emits one candidate per ownership fact, so two
 	// facts naming the same team differently produce two rows with an identical
 	// sorting key that differ only in team_name.
-	rows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)
+	rows = githubWorkItemDerivedSortingKeyDedupe(
+		rows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,
+	)
 	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions
 (org_id, repo_id, work_item_id, provider, team_id, team_name, source,
 is_primary, confidence, evidence, computed_at)`)
@@ -389,7 +417,9 @@ func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) InspectGitHubWorkIte
 	}
 	// The expectation must name the row the WRITE will actually leave behind,
 	// or the readback compares against a row storage discarded.
-	rows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)
+	rows = githubWorkItemDerivedSortingKeyDedupe(
+		rows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,
+	)
 	return inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {
 		return sink.inspect(ctx, identity, row)
 	})

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -121,17 +121,22 @@ func inspectGitHubWorkItemDerivedRows[T any](
 // green integration tests over this exact defect because every fixture used a
 // zero-nanosecond instant.
 //
-// The three tables do NOT share a precision: estimate coverage and team
-// attributions are DateTime64(3) (milliseconds), while state durations is a
-// plain DateTime (SECONDS). Truncating everything to milliseconds would leave
-// the state-durations verdict permanently Absent for any computed_at with a
-// sub-second component.
+// The builder now quantizes at its own stamping sites, so for rows this process
+// built these are NO-OPS. They stay because this boundary must hold for rows it
+// did NOT build: a replayed effect is decoded from a persisted snapshot, and a
+// snapshot written by an older build (or by any future producer that forgets)
+// still has to compare against what the column can store. Truncation is
+// idempotent, so applying it twice costs nothing and removing it would make the
+// adapter trust its input.
+//
+// The precision constants live with the builders, next to the destination whose
+// column decides them, so the two layers cannot drift into disagreeing.
 func githubWorkItemDerivedMillis(value time.Time) time.Time {
-	return value.UTC().Truncate(time.Millisecond)
+	return githubWorkItemDerivedStamp(value, githubEstimateCoverageStampPrecision)
 }
 
 func githubWorkItemDerivedSeconds(value time.Time) time.Time {
-	return value.UTC().Truncate(time.Second)
+	return githubWorkItemDerivedStamp(value, githubStateDurationStampPrecision)
 }
 
 // githubWorkItemDerivedSortingKeyDedupe collapses rows that share a full

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -111,6 +112,95 @@ func inspectGitHubWorkItemDerivedRows[T any](
 	return verdict, nil
 }
 
+// Stored-precision truncation. A version column can only hold what its type
+// can represent, so the comparator MUST compare the expected value as it would
+// be STORED, not as it was stamped. Otherwise a computed_at carrying
+// sub-precision digits is written, quantized by the server, read back
+// different, and the version verdict is Absent forever -- replay can never
+// answer Exact and the committer rewrites on every recovery. #1537 shipped 13
+// green integration tests over this exact defect because every fixture used a
+// zero-nanosecond instant.
+//
+// The three tables do NOT share a precision: estimate coverage and team
+// attributions are DateTime64(3) (milliseconds), while state durations is a
+// plain DateTime (SECONDS). Truncating everything to milliseconds would leave
+// the state-durations verdict permanently Absent for any computed_at with a
+// sub-second component.
+func githubWorkItemDerivedMillis(value time.Time) time.Time {
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func githubWorkItemDerivedSeconds(value time.Time) time.Time {
+	return value.UTC().Truncate(time.Second)
+}
+
+// githubWorkItemDerivedSortingKeyDedupe collapses rows that share a full
+// ClickHouse sorting key, keeping the LAST occurrence.
+//
+// This is a PERSISTENCE-layer decision, not a compute-layer one, so it does
+// not touch the D16 mirroring of the builders: Python writes every row and
+// lets ReplacingMergeTree pick a winner among equal versions, which is not
+// deterministic. Deduplicating before the write makes the stored outcome
+// deterministic AND lets the expectation name the same winner, instead of the
+// readback comparing against a row the storage silently discarded.
+//
+// Without this, two attribution candidates that differ only in team_name --
+// which the resolver genuinely produces when two ownership facts name one team
+// differently -- collapse to one stored row, `found` is 1, the team_name
+// mismatch reads as Conflict, and recovery is wedged permanently.
+func githubWorkItemDerivedSortingKeyDedupe[T any](
+	rows []T, key func(T) string,
+) []T {
+	lastIndex := make(map[string]int, len(rows))
+	for index, row := range rows {
+		lastIndex[key(row)] = index
+	}
+	result := make([]T, 0, len(rows))
+	for index, row := range rows {
+		if lastIndex[key(row)] == index {
+			result = append(result, row)
+		}
+	}
+	return result
+}
+
+// githubWorkItemDerivedUniqueSortingKeys reports whether every row already
+// occupies a distinct sorting key. The two map-derived destinations are unique
+// BY CONSTRUCTION; asserting it here makes that impossibility measured rather
+// than assumed, so it fails loudly the day a builder starts emitting a
+// collision instead of wedging a readback in production.
+func githubWorkItemDerivedUniqueSortingKeys[T any](rows []T, key func(T) string) bool {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		identifier := key(row)
+		if _, duplicate := seen[identifier]; duplicate {
+			return false
+		}
+		seen[identifier] = struct{}{}
+	}
+	return true
+}
+
+func githubEstimateCoverageSortingKey(row githubEstimateCoverageMetricsDailyRow) string {
+	return strings.Join([]string{
+		string(row.Day), row.Provider, row.WorkScopeID,
+		githubWorkItemDerivedNullableString(row.TeamID),
+	}, "\x00")
+}
+
+func githubStateDurationSortingKey(row githubWorkItemStateDurationDailyRow) string {
+	return strings.Join([]string{
+		string(row.Day), row.Provider, row.WorkScopeID, row.TeamID, row.Status,
+	}, "\x00")
+}
+
+func githubTeamAttributionSortingKey(row githubWorkItemTeamAttributionRow) string {
+	return strings.Join([]string{
+		githubWorkItemDerivedRepoID(row.RepoID).String(), row.WorkItemID,
+		githubWorkItemDerivedNullableString(row.TeamID), row.Source,
+	}, "\x00")
+}
+
 func (sink GitHubEstimateCoverageClickHouseEffects) WriteGitHubWorkItemEffect(
 	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
 ) error {
@@ -126,6 +216,11 @@ func (sink GitHubEstimateCoverageClickHouseEffects) WriteGitHubWorkItemEffect(
 	if len(rows) == 0 {
 		return nil
 	}
+	// Map-derived, so one row per sorting key by construction. Measured, not
+	// assumed: a collision would collapse under RMT and wedge the readback.
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubEstimateCoverageSortingKey) {
+		return ErrInvalidConfiguration
+	}
 	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO estimate_coverage_metrics_daily
 (day, provider, work_scope_id, team_id, team_name, estimated_count,
 unestimated_count, backlog_size, ratio, computed_at, org_id)`)
@@ -140,7 +235,8 @@ unestimated_count, backlog_size, ratio, computed_at, org_id)`)
 		if err := batch.Append(
 			day, row.Provider, row.WorkScopeID, row.TeamID, row.TeamName,
 			uint32(row.EstimatedCount), uint32(row.UnestimatedCount),
-			uint32(row.BacklogSize), row.Ratio, row.ComputedAt, identity.OrgID,
+			uint32(row.BacklogSize), row.Ratio,
+			githubWorkItemDerivedMillis(row.ComputedAt), identity.OrgID,
 		); err != nil {
 			return err
 		}
@@ -241,6 +337,11 @@ func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) WriteGitHubWorkItemE
 	if len(rows) == 0 {
 		return nil
 	}
+	// Collisions are GENUINELY REACHABLE here, unlike the two map-derived
+	// destinations: the resolver emits one candidate per ownership fact, so two
+	// facts naming the same team differently produce two rows with an identical
+	// sorting key that differ only in team_name.
+	rows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)
 	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions
 (org_id, repo_id, work_item_id, provider, team_id, team_name, source,
 is_primary, confidence, evidence, computed_at)`)
@@ -251,7 +352,8 @@ is_primary, confidence, evidence, computed_at)`)
 		if err := batch.Append(
 			identity.OrgID, githubWorkItemDerivedRepoID(row.RepoID), row.WorkItemID,
 			row.Provider, row.TeamID, row.TeamName, row.Source,
-			uint8(row.IsPrimary), row.Confidence, row.Evidence, row.ComputedAt,
+			uint8(row.IsPrimary), row.Confidence, row.Evidence,
+			githubWorkItemDerivedMillis(row.ComputedAt),
 		); err != nil {
 			return err
 		}
@@ -280,6 +382,9 @@ func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) InspectGitHubWorkIte
 	if sink.Conn == nil {
 		return EffectConflict, ErrInvalidConfiguration
 	}
+	// The expectation must name the row the WRITE will actually leave behind,
+	// or the readback compares against a row storage discarded.
+	rows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)
 	return inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {
 		return sink.inspect(ctx, identity, row)
 	})
@@ -342,6 +447,9 @@ func (sink GitHubWorkItemStateDurationsClickHouseEffects) WriteGitHubWorkItemEff
 	if len(rows) == 0 {
 		return nil
 	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubStateDurationSortingKey) {
+		return ErrInvalidConfiguration
+	}
 	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_state_durations_daily
 (day, provider, work_scope_id, team_id, team_name, status, duration_hours,
 items_touched, computed_at, avg_wip, org_id)`)
@@ -356,7 +464,7 @@ items_touched, computed_at, avg_wip, org_id)`)
 		if err := batch.Append(
 			day, row.Provider, row.WorkScopeID, row.TeamID, row.TeamName,
 			row.Status, row.DurationHours, uint32(row.ItemsTouched),
-			row.ComputedAt, row.AvgWIP, identity.OrgID,
+			githubWorkItemDerivedSeconds(row.ComputedAt), row.AvgWIP, identity.OrgID,
 		); err != nil {
 			return err
 		}
@@ -469,7 +577,7 @@ func compareGitHubEstimateCoverageVersion(
 		!githubWorkItemDerivedFloatPointerEqual(actual.Ratio, expected.Ratio) {
 		return EffectConflict
 	}
-	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+	if !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {
 		return EffectAbsent
 	}
 	return EffectExact
@@ -493,7 +601,7 @@ func compareGitHubWorkItemTeamAttributionVersion(
 		actual.Confidence != expected.Confidence || actual.Evidence != expected.Evidence {
 		return EffectConflict
 	}
-	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+	if !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {
 		return EffectAbsent
 	}
 	return EffectExact
@@ -517,7 +625,7 @@ func compareGitHubWorkItemStateDurationVersion(
 		actual.AvgWIP != expected.AvgWIP {
 		return EffectConflict
 	}
-	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+	if !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {
 		return EffectAbsent
 	}
 	return EffectExact

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -1,0 +1,561 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// ClickHouse effect adapters for the three derived destinations this lane
+// owns. They deliberately do NOT share one readback shape, because the three
+// tables do not share one engine:
+//
+//   - estimate_coverage_metrics_daily is ReplacingMergeTree(computed_at)
+//     PARTITION BY toYYYYMM(day) (migration 063). FINAL collapses duplicate
+//     versions, but ONLY WITHIN A PARTITION -- so the WHERE must pin `day`,
+//     which fully determines toYYYYMM(day) and prunes to exactly one
+//     partition. A readback keyed on the sorting key without `day` returned
+//     found=2 across a month boundary on PR #1535; that class is closed here
+//     by construction, not by hoping.
+//   - work_item_state_durations_daily is PLAIN MergeTree. Migration 055
+//     converted the two work-item rollups to ReplacingMergeTree and
+//     explicitly declined to convert this one, on the grounds that its
+//     readers already deduplicate with argMax(metric, computed_at). FINAL on
+//     a non-Replacing engine is a NO-OP: it would silently return every
+//     appended version. So this readback groups by the natural key and takes
+//     argMax over computed_at, which is what production readers do.
+//   - work_item_team_attributions is ReplacingMergeTree(computed_at) with NO
+//     PARTITION BY clause (migration 051). One partition means FINAL
+//     deduplicates globally and no partition fence exists to add. That
+//     asymmetry is asserted by the integration tests rather than assumed.
+//
+// All three comparators test `found != 1` BEFORE looking at the scanned row.
+// Checking an absent/stale branch first turns "duplicates plus a stale row"
+// into an infinite rewrite loop -- the second blocking finding on #1535.
+
+// GitHubEstimateCoverageClickHouseEffects writes and verifies
+// estimate_coverage_metrics_daily.
+type GitHubEstimateCoverageClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+// GitHubWorkItemTeamAttributionsClickHouseEffects writes and verifies
+// work_item_team_attributions.
+type GitHubWorkItemTeamAttributionsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+// GitHubWorkItemStateDurationsClickHouseEffects writes and verifies
+// work_item_state_durations_daily.
+type GitHubWorkItemStateDurationsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+// validateGitHubWorkItemDerivedEffect re-derives the typed rows from the
+// frozen effect and refuses anything whose destination, tenancy or recovery
+// posture does not match the identity. Decoding from effect.Rows rather than
+// from a builder result is deliberate: recovery replays a persisted manifest
+// that no builder run produced.
+func validateGitHubWorkItemDerivedEffect[T any](
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+	destination string,
+) ([]T, error) {
+	if identity.Destination != destination || effect.Destination != destination ||
+		effect.Recovery != EffectReadbackRequired || identity.OrgID == "" ||
+		identity.RowCount != len(effect.Rows) {
+		return nil, ErrInvalidConfiguration
+	}
+	rows := make([]T, 0, len(effect.Rows))
+	for _, raw := range effect.Rows {
+		var row T
+		if err := json.Unmarshal(raw, &row); err != nil {
+			return nil, ErrInvalidConfiguration
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// inspectGitHubWorkItemDerivedRows returns the WEAKEST verdict across rows:
+// any conflict wins, then any absence. A batch is only exact when every row
+// in it reads back exactly, because the committer rewrites the whole batch.
+func inspectGitHubWorkItemDerivedRows[T any](
+	rows []T,
+	inspect func(T) (EffectInspection, error),
+) (EffectInspection, error) {
+	verdict := EffectExact
+	for _, row := range rows {
+		inspection, err := inspect(row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectConflict:
+			return EffectConflict, nil
+		case EffectAbsent:
+			verdict = EffectAbsent
+		case EffectExact:
+		default:
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	return verdict, nil
+}
+
+func (sink GitHubEstimateCoverageClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubEstimateCoverageMetricsDailyRow](
+		identity, effect, githubEstimateCoverageDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO estimate_coverage_metrics_daily
+(day, provider, work_scope_id, team_id, team_name, estimated_count,
+unestimated_count, backlog_size, ratio, computed_at, org_id)`)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		day, err := row.Day.time()
+		if err != nil {
+			return err
+		}
+		if err := batch.Append(
+			day, row.Provider, row.WorkScopeID, row.TeamID, row.TeamName,
+			uint32(row.EstimatedCount), uint32(row.UnestimatedCount),
+			uint32(row.BacklogSize), row.Ratio, row.ComputedAt, identity.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubEstimateCoverageClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubEstimateCoverageMetricsDailyRow](
+		identity, effect, githubEstimateCoverageDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubEstimateCoverageMetricsDailyRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubEstimateCoverageClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubEstimateCoverageMetricsDailyRow,
+) (EffectInspection, error) {
+	day, err := expected.Day.time()
+	if err != nil {
+		return EffectConflict, err
+	}
+	// `day = ?` is doing double duty: it is part of the sorting key AND it
+	// fully determines toYYYYMM(day), so FINAL is evaluated inside exactly one
+	// partition. Dropping it would reintroduce the #1535 cross-partition
+	// found=2. ifNull(team_id, '') mirrors the table's own sorting-key
+	// expression so a NULL team never falls outside the fence.
+	scan, err := sink.Conn.Query(ctx, `SELECT day, provider, work_scope_id, team_id,
+team_name, estimated_count, unestimated_count, backlog_size, ratio, computed_at, org_id
+FROM estimate_coverage_metrics_daily FINAL
+WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?
+AND ifNull(team_id, '') = ?`,
+		identity.OrgID, day, expected.Provider, expected.WorkScopeID,
+		githubWorkItemDerivedNullableString(expected.TeamID))
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	var actual githubEstimateCoverageMetricsDailyRow
+	found := 0
+	for scan.Next() {
+		var actualDay time.Time
+		// The three counters are UInt32; the driver refuses to scan an
+		// unsigned column into a Go int, which would make every readback fail
+		// as a transport error rather than ever returning a verdict.
+		var estimated, unestimated, backlog uint32
+		if err := scan.Scan(
+			&actualDay, &actual.Provider, &actual.WorkScopeID, &actual.TeamID,
+			&actual.TeamName, &estimated, &unestimated, &backlog, &actual.Ratio,
+			&actual.ComputedAt, &actual.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.Day = newGitHubWorkItemDerivedDay(actualDay)
+		actual.EstimatedCount = int(estimated)
+		actual.UnestimatedCount = int(unestimated)
+		actual.BacklogSize = int(backlog)
+		found++
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubEstimateCoverageVersion(expected, actual, found, identity.OrgID), nil
+}
+
+func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemTeamAttributionRow](
+		identity, effect, githubTeamAttributionsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions
+(org_id, repo_id, work_item_id, provider, team_id, team_name, source,
+is_primary, confidence, evidence, computed_at)`)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := batch.Append(
+			identity.OrgID, githubWorkItemDerivedRepoID(row.RepoID), row.WorkItemID,
+			row.Provider, row.TeamID, row.TeamName, row.Source,
+			uint8(row.IsPrimary), row.Confidence, row.Evidence, row.ComputedAt,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemTeamAttributionRow](
+		identity, effect, githubTeamAttributionsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubWorkItemTeamAttributionRow,
+) (EffectInspection, error) {
+	// This table has NO PARTITION BY, so it is a single partition and FINAL
+	// deduplicates across the whole table. There is no partition key to fence
+	// and adding a day predicate would be meaningless here -- the fence is the
+	// full sorting key.
+	scan, err := sink.Conn.Query(ctx, `SELECT org_id, repo_id, work_item_id, provider,
+team_id, team_name, source, is_primary, confidence, evidence, computed_at
+FROM work_item_team_attributions FINAL
+WHERE org_id = ? AND repo_id = ? AND work_item_id = ?
+AND ifNull(team_id, '') = ? AND source = ?`,
+		identity.OrgID, githubWorkItemDerivedRepoID(expected.RepoID), expected.WorkItemID,
+		githubWorkItemDerivedNullableString(expected.TeamID), expected.Source)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	var actual githubWorkItemTeamAttributionRow
+	found := 0
+	for scan.Next() {
+		var repoID uuid.UUID
+		var isPrimary uint8
+		if err := scan.Scan(
+			&actual.OrgID, &repoID, &actual.WorkItemID, &actual.Provider,
+			&actual.TeamID, &actual.TeamName, &actual.Source, &isPrimary,
+			&actual.Confidence, &actual.Evidence, &actual.ComputedAt,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.RepoID = &repoID
+		actual.IsPrimary = int(isPrimary)
+		found++
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubWorkItemTeamAttributionVersion(expected, actual, found, identity.OrgID), nil
+}
+
+func (sink GitHubWorkItemStateDurationsClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemStateDurationDailyRow](
+		identity, effect, githubStateDurationsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_state_durations_daily
+(day, provider, work_scope_id, team_id, team_name, status, duration_hours,
+items_touched, computed_at, avg_wip, org_id)`)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		day, err := row.Day.time()
+		if err != nil {
+			return err
+		}
+		if err := batch.Append(
+			day, row.Provider, row.WorkScopeID, row.TeamID, row.TeamName,
+			row.Status, row.DurationHours, uint32(row.ItemsTouched),
+			row.ComputedAt, row.AvgWIP, identity.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubWorkItemStateDurationsClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context, identity GitHubWorkItemEffectIdentity, effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemStateDurationDailyRow](
+		identity, effect, githubStateDurationsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemStateDurationDailyRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubWorkItemStateDurationsClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubWorkItemStateDurationDailyRow,
+) (EffectInspection, error) {
+	day, err := expected.Day.time()
+	if err != nil {
+		return EffectConflict, err
+	}
+	// PLAIN MergeTree: FINAL is a no-op here and would return every appended
+	// version, so a re-run would read found=N and rewrite forever. argMax over
+	// computed_at is what production readers do (migration 055 declined to
+	// convert this table precisely because its readers already dedupe this
+	// way). GROUP BY collapses to at most one row, so `found` still
+	// distinguishes absent from present -- and `day` still prunes the
+	// toYYYYMM(day) partition even though the engine is not Replacing.
+	scan, err := sink.Conn.Query(ctx, `SELECT
+argMax(team_name, computed_at), argMax(duration_hours, computed_at),
+argMax(items_touched, computed_at), max(computed_at), argMax(avg_wip, computed_at)
+FROM work_item_state_durations_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?
+AND team_id = ? AND status = ?
+GROUP BY org_id, provider, work_scope_id, team_id, status, day`,
+		identity.OrgID, day, expected.Provider, expected.WorkScopeID,
+		expected.TeamID, expected.Status)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	actual := githubWorkItemStateDurationDailyRow{
+		Day: expected.Day, Provider: expected.Provider,
+		WorkScopeID: expected.WorkScopeID, TeamID: expected.TeamID,
+		Status: expected.Status, OrgID: identity.OrgID,
+	}
+	found := 0
+	for scan.Next() {
+		var itemsTouched uint32
+		if err := scan.Scan(
+			&actual.TeamName, &actual.DurationHours, &itemsTouched,
+			&actual.ComputedAt, &actual.AvgWIP,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.ItemsTouched = int(itemsTouched)
+		found++
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubWorkItemStateDurationVersion(expected, actual, found, identity.OrgID), nil
+}
+
+// The three comparators below all test `found != 1` FIRST. Reaching an
+// absent/stale branch before the duplicate check is what turns duplicates plus
+// a stale row into an infinite rewrite loop.
+
+func compareGitHubEstimateCoverageVersion(
+	expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,
+) EffectInspection {
+	if found != 1 {
+		if found == 0 {
+			return EffectAbsent
+		}
+		// More than one row survived FINAL inside a single partition: the
+		// fence is wrong, not the data. Never report this as absent, which
+		// would rewrite and duplicate again.
+		return EffectConflict
+	}
+	if actual.OrgID != orgID || actual.Day != expected.Day ||
+		actual.Provider != expected.Provider ||
+		actual.WorkScopeID != expected.WorkScopeID ||
+		!githubWorkItemDerivedStringPointerEqual(actual.TeamID, expected.TeamID) ||
+		!githubWorkItemDerivedStringPointerEqual(actual.TeamName, expected.TeamName) ||
+		actual.EstimatedCount != expected.EstimatedCount ||
+		actual.UnestimatedCount != expected.UnestimatedCount ||
+		actual.BacklogSize != expected.BacklogSize ||
+		!githubWorkItemDerivedFloatPointerEqual(actual.Ratio, expected.Ratio) {
+		return EffectConflict
+	}
+	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+		return EffectAbsent
+	}
+	return EffectExact
+}
+
+func compareGitHubWorkItemTeamAttributionVersion(
+	expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,
+) EffectInspection {
+	if found != 1 {
+		if found == 0 {
+			return EffectAbsent
+		}
+		return EffectConflict
+	}
+	if actual.OrgID != orgID || actual.WorkItemID != expected.WorkItemID ||
+		actual.Provider != expected.Provider ||
+		githubWorkItemDerivedRepoID(actual.RepoID) != githubWorkItemDerivedRepoID(expected.RepoID) ||
+		!githubWorkItemDerivedStringPointerEqual(actual.TeamID, expected.TeamID) ||
+		!githubWorkItemDerivedStringPointerEqual(actual.TeamName, expected.TeamName) ||
+		actual.Source != expected.Source || actual.IsPrimary != expected.IsPrimary ||
+		actual.Confidence != expected.Confidence || actual.Evidence != expected.Evidence {
+		return EffectConflict
+	}
+	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+		return EffectAbsent
+	}
+	return EffectExact
+}
+
+func compareGitHubWorkItemStateDurationVersion(
+	expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,
+) EffectInspection {
+	if found != 1 {
+		if found == 0 {
+			return EffectAbsent
+		}
+		// GROUP BY the full natural key can only produce one row, so more than
+		// one means the grouping no longer matches the key -- a wiring defect,
+		// never a reason to rewrite.
+		return EffectConflict
+	}
+	if actual.OrgID != orgID || actual.TeamName != expected.TeamName ||
+		actual.DurationHours != expected.DurationHours ||
+		actual.ItemsTouched != expected.ItemsTouched ||
+		actual.AvgWIP != expected.AvgWIP {
+		return EffectConflict
+	}
+	if !actual.ComputedAt.Equal(expected.ComputedAt) {
+		return EffectAbsent
+	}
+	return EffectExact
+}
+
+// time parses the calendar day back into the UTC midnight instant the driver
+// binds to a ClickHouse Date column.
+func (day githubWorkItemDerivedDay) time() (time.Time, error) {
+	return time.ParseInLocation("2006-01-02", string(day), time.UTC)
+}
+
+// githubWorkItemDerivedRepoID mirrors what the Python sink persists for an
+// item with no repo: work_item_team_attributions.repo_id is a NON-nullable
+// UUID column, so a missing repo becomes the nil UUID rather than NULL.
+func githubWorkItemDerivedRepoID(value *uuid.UUID) uuid.UUID {
+	if value == nil {
+		return uuid.Nil
+	}
+	return *value
+}
+
+func githubWorkItemDerivedNullableString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func githubWorkItemDerivedStringPointerEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func githubWorkItemDerivedFloatPointerEqual(left, right *float64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}

--- a/internal/providersync/github_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/github_work_item_derived_effects_integration_test.go
@@ -602,3 +602,120 @@ WHERE org_id = ? AND work_item_id = ?`, githubDerivedIntegrationOrg, "acme/api#3
 		t.Fatalf("foreign tenant: inspection = %v, err = %v, want EffectAbsent", inspection, err)
 	}
 }
+
+// Each readback fences the FULL sorting key, and until now every readback test
+// wrote a single row per natural key -- so dropping any one fence still
+// selected exactly that row, `found` stayed 1, and the verdict stayed Exact.
+// Four mutations that neutralise a fence therefore SURVIVED while reading as
+// covered.
+//
+// The missing ingredient is a SIBLING row: one that differs from the expected
+// row only in the fenced column, so it is a distinct sorting key that the
+// fence is the only thing excluding. With the fence intact both rows read back
+// Exact; with it dropped the query matches both, found becomes 2, and the
+// comparator answers Conflict.
+//
+// These are written as separate top-level tests per table because the three
+// tables do not share an engine and each fence fails for its own reason.
+func TestGitHubEstimateCoverageReadbackFencesTeamID(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubEstimateCoverageClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	stamp := time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC)
+	ratio := 0.5
+	row := func(teamID, teamName string) githubEstimateCoverageMetricsDailyRow {
+		id, name := teamID, teamName
+		return githubEstimateCoverageMetricsDailyRow{
+			Day: "2026-08-04", Provider: "github", WorkScopeID: "acme/api",
+			TeamID: &id, TeamName: &name,
+			EstimatedCount: 1, UnestimatedCount: 1, BacklogSize: 2, Ratio: &ratio,
+			ComputedAt: stamp, OrgID: githubDerivedIntegrationOrg,
+		}
+	}
+	// Same day, provider and work_scope_id; ONLY team_id differs, which is the
+	// last component of this table's sorting key.
+	rows := []githubEstimateCoverageMetricsDailyRow{row("t1", "Team One"), row("t2", "Team Two")}
+	effect := githubDerivedIntegrationEffect(t, githubEstimateCoverageDestination, rows)
+	identity := githubDerivedIntegrationIdentity(githubEstimateCoverageDestination, len(rows))
+
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectExact {
+		t.Fatalf("two teams on one (day, provider, work_scope_id): inspection = %v, err = %v, "+
+			"want EffectExact -- a readback that does not fence ifNull(team_id,'') sees both "+
+			"rows and answers found=2", inspection, err)
+	}
+}
+
+func TestGitHubWorkItemTeamAttributionsReadbackFencesTeamID(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubWorkItemTeamAttributionsClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	stamp := time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC)
+	row := func(teamID, teamName string) githubWorkItemTeamAttributionRow {
+		id, name := teamID, teamName
+		return githubWorkItemTeamAttributionRow{
+			WorkItemID: "acme/api#1", Provider: "github", Source: "assignee_membership",
+			IsPrimary: 1, Confidence: "high", Evidence: "assignee_membership=" + teamID,
+			ComputedAt: stamp, RepoID: &repoID, TeamID: &id, TeamName: &name,
+			OrgID: githubDerivedIntegrationOrg,
+		}
+	}
+	// One work item legitimately carries several attribution candidates that
+	// differ only in team_id -- two members of different teams assigned to it.
+	rows := []githubWorkItemTeamAttributionRow{row("t1", "Team One"), row("t2", "Team Two")}
+	effect := githubDerivedIntegrationEffect(t, githubTeamAttributionsDestination, rows)
+	identity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(rows))
+
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectExact {
+		t.Fatalf("two teams on one (repo_id, work_item_id, source): inspection = %v, err = %v, "+
+			"want EffectExact -- a readback that does not fence ifNull(team_id,'') compares "+
+			"against a sibling candidate's row", inspection, err)
+	}
+}
+
+func TestGitHubWorkItemStateDurationsReadbackFencesDay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubWorkItemStateDurationsClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	stamp := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	row := func(day githubWorkItemDerivedDay, hours float64) githubWorkItemStateDurationDailyRow {
+		return githubWorkItemStateDurationDailyRow{
+			Day: day, Provider: "github", WorkScopeID: "acme/api",
+			TeamID: "t1", TeamName: "Team One", Status: "in_progress",
+			DurationHours: hours, ItemsTouched: 1, ComputedAt: stamp,
+			AvgWIP: hours / 24.0, OrgID: githubDerivedIntegrationOrg,
+		}
+	}
+	// `day` is in this table's GROUP BY, so without the day fence the query
+	// returns one group PER DAY for the same natural key. Two days inside ONE
+	// month, so this is about the grouping and not about partition pruning.
+	rows := []githubWorkItemStateDurationDailyRow{
+		row("2026-08-04", 3), row("2026-08-05", 5),
+	}
+	effect := githubDerivedIntegrationEffect(t, githubStateDurationsDestination, rows)
+	identity := githubDerivedIntegrationIdentity(githubStateDurationsDestination, len(rows))
+
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectExact {
+		t.Fatalf("two days on one natural key: inspection = %v, err = %v, want EffectExact -- "+
+			"a readback that does not fence `day` groups both days and answers found=2",
+			inspection, err)
+	}
+}

--- a/internal/providersync/github_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/github_work_item_derived_effects_integration_test.go
@@ -4,9 +4,11 @@ package providersync
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
 
@@ -105,6 +107,70 @@ func githubDerivedIntegrationConn(t *testing.T, ctx context.Context) driver.Conn
 	return conn
 }
 
+// TestGitHubDerivedTablesPartitionExpressionsAreDerivableFromTheSortingKey is
+// the precondition every partition-fenced readback in this package rests on,
+// and it reads the LIVE schema via SHOW CREATE TABLE rather than trusting the
+// migration file we believe produced it.
+//
+// The rule (cross-lane finding, measured on a real container): fencing a
+// readback on the partition key is only safe when the partition expression is
+// DERIVABLE from the sorting key, so a given key can occupy exactly one
+// partition. If a table partitioned on a column outside its sorting key, the
+// fence would be actively WRONG under the default server setting: FINAL merges
+// across partitions to a single winner, the fence filters that winner out, a
+// correctly superseded row reads Absent, and the committer rewrites forever.
+//
+// All three tables here satisfy the rule -- the two partitioned ones carry
+// `day` in their sorting keys, and the third has no PARTITION BY at all -- but
+// that is a fact to VERIFY, not to assume, because it is the migration
+// authors' choice and not ours.
+func TestGitHubDerivedTablesPartitionExpressionsAreDerivableFromTheSortingKey(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+
+	for _, tt := range []struct {
+		table           string
+		wantPartitioned bool
+	}{
+		{"estimate_coverage_metrics_daily", true},
+		{"work_item_state_durations_daily", true},
+		{"work_item_team_attributions", false},
+	} {
+		t.Run(tt.table, func(t *testing.T) {
+			var ddl string
+			if err := conn.QueryRow(ctx, "SHOW CREATE TABLE "+tt.table).Scan(&ddl); err != nil {
+				t.Fatal(err)
+			}
+			partitioned := strings.Contains(ddl, "PARTITION BY")
+			if partitioned != tt.wantPartitioned {
+				t.Fatalf("%s: PARTITION BY present = %v, want %v -- the readback shape "+
+					"chosen for this table assumes otherwise\nDDL: %s",
+					tt.table, partitioned, tt.wantPartitioned, ddl)
+			}
+			if !partitioned {
+				return
+			}
+			if !strings.Contains(ddl, "PARTITION BY toYYYYMM(day)") {
+				t.Fatalf("%s: partition expression is not toYYYYMM(day); a fence on `day` "+
+					"may no longer pin one partition\nDDL: %s", tt.table, ddl)
+			}
+			orderBy := ddl[strings.Index(ddl, "ORDER BY"):]
+			if end := strings.Index(orderBy, "\nSETTINGS"); end > 0 {
+				orderBy = orderBy[:end]
+			}
+			// `day` must be IN the sorting key, so toYYYYMM(day) is derivable
+			// from it and one key cannot span two partitions.
+			if !strings.Contains(orderBy, "day") {
+				t.Fatalf("%s: `day` is NOT in the sorting key, so toYYYYMM(day) is not "+
+					"derivable from it and fencing the readback on day is UNSAFE "+
+					"under the default do_not_merge_across_partitions_select_final=0"+
+					"\nORDER BY: %s", tt.table, orderBy)
+			}
+		})
+	}
+}
+
 func githubDerivedIntegrationLease() providerfoundation.LeaseGuard {
 	return providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
 }
@@ -192,6 +258,24 @@ WHERE org_id = ? AND provider = ? AND work_scope_id = ? AND ifNull(team_id, '') 
 	if unfenced != 2 {
 		t.Fatalf("fence precondition: unfenced count = %d, want 2 -- the two rows must "+
 			"straddle a month boundary or this test proves nothing about partitioning", unfenced)
+	}
+
+	// BOTH SETTINGS. Under the DEFAULT (0) the server may merge across
+	// partitions when evaluating FINAL, so a #1535-class fence defect presents
+	// as a FALSE CONFLICT (the wrong month's row wins the merge and is
+	// compared) rather than as found=2. A test asserting only the found=2
+	// symptom therefore passes on a default server while the bug is live.
+	// Running the real readback under both settings pins the verdict rather
+	// than the symptom: with `day` in the sorting key the answer must be
+	// Exact either way.
+	for _, merge := range []int{0, 1} {
+		settingCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+			"do_not_merge_across_partitions_select_final": merge,
+		}))
+		if inspection, err := sink.InspectGitHubWorkItemEffect(settingCtx, identity, effect); err != nil || inspection != EffectExact {
+			t.Fatalf("do_not_merge_across_partitions_select_final=%d: inspection = %v, err = %v, want EffectExact",
+				merge, inspection, err)
+		}
 	}
 
 	// A stale persisted version must read as Absent so the writer replaces it.

--- a/internal/providersync/github_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/github_work_item_derived_effects_integration_test.go
@@ -14,68 +14,30 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 )
 
-// The DDL below is these three tables AS PRODUCTION HAS THEM after the
-// migrations that shaped them: 001 (create) and 002 (avg_wip) for state
-// durations, 051 for team attributions, 063 for estimate coverage, 024/027 for
-// org_id and org_id-first sorting keys. It runs against a throwaway container,
-// never a developer's database and never the ask-dev acceptance stack.
+// This file authors NO DDL. The three tables come from the real migration
+// chain (src/dev_health_ops/migrations/clickhouse), applied by chschema through
+// the project's own canonical entrypoint.
 //
-// The engines are the whole point of this file and are NOT simplified:
+// The previous hand-typed CREATE TABLE constants were a second, unversioned
+// copy of the schema, and the SHOW CREATE TABLE test below could only ever
+// confirm what those constants declared. They had already drifted: the
+// work_item_team_attributions copy carried the PRE-053 enums, missing the
+// `issue_project` and `manual_fallback` source values and the `manual` and
+// `none` confidence values that the production resolver genuinely emits. The
+// unassigned fixture in this file had been written as confidence "low" -- a
+// value the resolver never produces -- which is exactly what kept the stale
+// enum from failing anything.
+//
+// The engines remain the whole point of this file, and now they are the
+// migrations' engines rather than our restatement of them:
 //   - estimate coverage is ReplacingMergeTree PARTITION BY toYYYYMM(day)
 //   - state durations is PLAIN MergeTree, also partitioned, where FINAL does
 //     nothing at all
 //   - team attributions is ReplacingMergeTree with NO PARTITION BY
-const (
-	githubEstimateCoverageDDL = `CREATE TABLE estimate_coverage_metrics_daily (
-  day Date,
-  provider String,
-  work_scope_id String,
-  team_id Nullable(String),
-  team_name Nullable(String),
-  estimated_count UInt32,
-  unestimated_count UInt32,
-  backlog_size UInt32,
-  ratio Nullable(Float64),
-  computed_at DateTime64(3, 'UTC'),
-  org_id String DEFAULT ''
-) ENGINE = ReplacingMergeTree(computed_at)
-PARTITION BY toYYYYMM(day)
-ORDER BY (org_id, day, provider, work_scope_id, ifNull(team_id, ''))`
-
-	githubStateDurationsDDL = `CREATE TABLE work_item_state_durations_daily (
-  day Date,
-  provider LowCardinality(String),
-  work_scope_id LowCardinality(String),
-  team_id LowCardinality(String),
-  team_name String,
-  status LowCardinality(String),
-  duration_hours Float64,
-  items_touched UInt32,
-  computed_at DateTime('UTC'),
-  avg_wip Float64 DEFAULT 0.0,
-  org_id String DEFAULT ''
-) ENGINE = MergeTree
-PARTITION BY toYYYYMM(day)
-ORDER BY (org_id, provider, work_scope_id, team_id, status, day)`
-
-	githubTeamAttributionsDDL = `CREATE TABLE work_item_team_attributions (
-  org_id String,
-  repo_id UUID,
-  work_item_id String,
-  provider String,
-  team_id Nullable(String),
-  team_name Nullable(String),
-  source Enum8('native_team' = 1, 'linked_issue' = 2, 'project_ownership' = 3, 'repo_ownership' = 4, 'assignee_membership' = 5, 'unassigned' = 6),
-  is_primary UInt8,
-  confidence Enum8('high' = 1, 'medium' = 2, 'low' = 3),
-  evidence String,
-  computed_at DateTime64(3, 'UTC')
-) ENGINE = ReplacingMergeTree(computed_at)
-ORDER BY (org_id, repo_id, work_item_id, ifNull(team_id, ''), source)`
-)
 
 const githubDerivedIntegrationOrg = "org-acme"
 
@@ -92,25 +54,146 @@ func githubDerivedIntegrationConn(t *testing.T, ctx context.Context) driver.Conn
 			t.Errorf("terminate ClickHouse: %v", err)
 		}
 	})
+	// Migrate BEFORE opening the Go connection, so a failure to apply the real
+	// chain surfaces as a migration failure rather than as a confusing "table
+	// does not exist" from the first query.
+	chschema.Apply(ctx, t, instance)
 	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = conn.Close() })
-	for _, statement := range []string{
-		githubEstimateCoverageDDL, githubStateDurationsDDL, githubTeamAttributionsDDL,
-	} {
-		if err := conn.Exec(ctx, statement); err != nil {
-			t.Fatal(err)
-		}
-	}
 	return conn
 }
 
+// githubWorkItemDerivedEmittableSources and ...Confidences are every value the
+// production resolver can put in these two enum columns
+// (github_work_items_derivation_context.go:327,404,462,491,510,561 and
+// confidenceForPrimary). "low" is deliberately ABSENT: the resolver never emits
+// it, and the fixture in this file that used to claim it was written to fit a
+// stale hand-typed enum rather than to describe anything production produces.
+var (
+	githubWorkItemDerivedEmittableSources = []string{
+		"native_team", "issue_project", "project_ownership", "repo_ownership",
+		"assignee_membership", "linked_issue", "manual_fallback", "unassigned",
+	}
+	githubWorkItemDerivedEmittableConfidences = []string{
+		"high", "medium", "manual", "none",
+	}
+)
+
+// TestGitHubWorkItemTeamAttributionEnumsAcceptEveryResolverValue closes the
+// drift class directly, rather than trusting that sourcing the schema from the
+// migrations happens to keep it closed.
+//
+// The hand-typed DDL this file used to create carried the PRE-053 enums, so
+// `issue_project`, `manual_fallback`, `manual` and `none` -- all genuinely
+// reachable resolver outputs -- would have been REJECTED with
+// UNKNOWN_ELEMENT_OF_ENUM by the real column. Nothing failed, because no
+// fixture ever used one.
+//
+// This asserts against the enum the MIGRATION CHAIN produced, and the value
+// list comes from the producer, so it fails if either side moves: a new
+// resolver source without a migration, or a migration that narrows an enum.
+func TestGitHubWorkItemTeamAttributionEnumsAcceptEveryResolverValue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+
+	for _, tt := range []struct {
+		column string
+		values []string
+	}{
+		{"source", githubWorkItemDerivedEmittableSources},
+		{"confidence", githubWorkItemDerivedEmittableConfidences},
+	} {
+		t.Run(tt.column, func(t *testing.T) {
+			var columnType string
+			if err := conn.QueryRow(ctx,
+				"SELECT type FROM system.columns WHERE table = 'work_item_team_attributions' "+
+					"AND name = ? AND database = currentDatabase()", tt.column,
+			).Scan(&columnType); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(columnType, "Enum") {
+				t.Fatalf("%s is %s, not an Enum -- this guard assumes an enum and would "+
+					"otherwise pass vacuously", tt.column, columnType)
+			}
+			for _, value := range tt.values {
+				// Match the quoted enum element, not a bare substring: 'none'
+				// must not be satisfied by a hypothetical 'none_given'.
+				if !strings.Contains(columnType, "'"+value+"'") {
+					t.Errorf("the resolver can emit %s=%q but the migrated column cannot "+
+						"store it, so a real row would be rejected with "+
+						"UNKNOWN_ELEMENT_OF_ENUM\ncolumn type: %s",
+						tt.column, value, columnType)
+				}
+			}
+		})
+	}
+}
+
+// githubDerivedSortingKeyColumns extracts the sorting key's top-level entries
+// from a SHOW CREATE TABLE body.
+//
+// A substring test is NOT good enough here: `strings.Contains(orderBy, "day")`
+// is satisfied by a column named `birthday`, by `toYYYYMM(day)` appearing in
+// the PARTITION BY clause the slice may still include, and by a column named
+// `day_bucket` -- none of which put `day` itself in the key. The whole point of
+// the assertion is that the partition expression is derivable from the sorting
+// key, so it has to compare real key entries.
+func githubDerivedSortingKeyColumns(t *testing.T, ddl string) []string {
+	t.Helper()
+	marker := "\nORDER BY "
+	start := strings.Index(ddl, marker)
+	if start < 0 {
+		t.Fatalf("no ORDER BY clause in DDL:\n%s", ddl)
+	}
+	clause := ddl[start+len(marker):]
+	if end := strings.IndexAny(clause, "\n"); end >= 0 {
+		clause = clause[:end]
+	}
+	clause = strings.TrimSpace(clause)
+	// A single-column key has no parentheses; a tuple key does.
+	if strings.HasPrefix(clause, "(") && strings.HasSuffix(clause, ")") {
+		clause = clause[1 : len(clause)-1]
+	}
+	var columns []string
+	depth, current := 0, strings.Builder{}
+	flush := func() {
+		if value := strings.TrimSpace(current.String()); value != "" {
+			columns = append(columns, value)
+		}
+		current.Reset()
+	}
+	for _, symbol := range clause {
+		switch {
+		case symbol == '(':
+			depth++
+			current.WriteRune(symbol)
+		case symbol == ')':
+			depth--
+			current.WriteRune(symbol)
+		case symbol == ',' && depth == 0:
+			// Only a top-level comma separates key entries; a comma inside
+			// ifNull(team_id, '') does not.
+			flush()
+		default:
+			current.WriteRune(symbol)
+		}
+	}
+	flush()
+	return columns
+}
+
 // TestGitHubDerivedTablesPartitionExpressionsAreDerivableFromTheSortingKey is
-// the precondition every partition-fenced readback in this package rests on,
-// and it reads the LIVE schema via SHOW CREATE TABLE rather than trusting the
-// migration file we believe produced it.
+// the precondition every partition-fenced readback in this package rests on.
+//
+// It is only meaningful because the schema now comes from the real migration
+// chain. While the tables were created from hand-typed constants in this file,
+// reading them back via SHOW CREATE TABLE proved nothing beyond "ClickHouse
+// stored what we just typed" -- the assertion and the input had the same
+// author.
 //
 // The rule (cross-lane finding, measured on a real container): fencing a
 // readback on the partition key is only safe when the partition expression is
@@ -155,17 +238,21 @@ func TestGitHubDerivedTablesPartitionExpressionsAreDerivableFromTheSortingKey(t 
 				t.Fatalf("%s: partition expression is not toYYYYMM(day); a fence on `day` "+
 					"may no longer pin one partition\nDDL: %s", tt.table, ddl)
 			}
-			orderBy := ddl[strings.Index(ddl, "ORDER BY"):]
-			if end := strings.Index(orderBy, "\nSETTINGS"); end > 0 {
-				orderBy = orderBy[:end]
-			}
 			// `day` must be IN the sorting key, so toYYYYMM(day) is derivable
 			// from it and one key cannot span two partitions.
-			if !strings.Contains(orderBy, "day") {
-				t.Fatalf("%s: `day` is NOT in the sorting key, so toYYYYMM(day) is not "+
-					"derivable from it and fencing the readback on day is UNSAFE "+
+			columns := githubDerivedSortingKeyColumns(t, ddl)
+			present := false
+			for _, column := range columns {
+				if column == "day" {
+					present = true
+					break
+				}
+			}
+			if !present {
+				t.Fatalf("%s: `day` is NOT a column of the sorting key, so toYYYYMM(day) "+
+					"is not derivable from it and fencing the readback on day is UNSAFE "+
 					"under the default do_not_merge_across_partitions_select_final=0"+
-					"\nORDER BY: %s", tt.table, orderBy)
+					"\nsorting key columns: %q", tt.table, columns)
 			}
 		})
 	}
@@ -418,9 +505,16 @@ func TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse(t *testing.
 		OrgID: githubDerivedIntegrationOrg,
 	}
 	// The unassigned shape this table persists: NULL team, nil repo.
+	//
+	// Confidence is "none", which is what the production resolver actually
+	// emits for this candidate (derivation_context.go:462). It was "low"
+	// before -- a value the resolver never produces -- because "none" only
+	// entered the enum in migration 053 and would have been REJECTED by the
+	// hand-typed DDL this file used to create. The fixture was shaped to fit
+	// the stale copy of the schema instead of the schema failing.
 	unassigned := githubWorkItemTeamAttributionRow{
 		WorkItemID: "acme/api#2", Provider: "github", Source: "unassigned",
-		IsPrimary: 1, Confidence: "low", Evidence: "no_candidate",
+		IsPrimary: 1, Confidence: "none", Evidence: "no_candidate",
 		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC),
 		RepoID:     nil, TeamID: nil, TeamName: nil,
 		OrgID: githubDerivedIntegrationOrg,

--- a/internal/providersync/github_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/github_work_item_derived_effects_integration_test.go
@@ -1,0 +1,383 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// The DDL below is these three tables AS PRODUCTION HAS THEM after the
+// migrations that shaped them: 001 (create) and 002 (avg_wip) for state
+// durations, 051 for team attributions, 063 for estimate coverage, 024/027 for
+// org_id and org_id-first sorting keys. It runs against a throwaway container,
+// never a developer's database and never the ask-dev acceptance stack.
+//
+// The engines are the whole point of this file and are NOT simplified:
+//   - estimate coverage is ReplacingMergeTree PARTITION BY toYYYYMM(day)
+//   - state durations is PLAIN MergeTree, also partitioned, where FINAL does
+//     nothing at all
+//   - team attributions is ReplacingMergeTree with NO PARTITION BY
+const (
+	githubEstimateCoverageDDL = `CREATE TABLE estimate_coverage_metrics_daily (
+  day Date,
+  provider String,
+  work_scope_id String,
+  team_id Nullable(String),
+  team_name Nullable(String),
+  estimated_count UInt32,
+  unestimated_count UInt32,
+  backlog_size UInt32,
+  ratio Nullable(Float64),
+  computed_at DateTime64(3, 'UTC'),
+  org_id String DEFAULT ''
+) ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, day, provider, work_scope_id, ifNull(team_id, ''))`
+
+	githubStateDurationsDDL = `CREATE TABLE work_item_state_durations_daily (
+  day Date,
+  provider LowCardinality(String),
+  work_scope_id LowCardinality(String),
+  team_id LowCardinality(String),
+  team_name String,
+  status LowCardinality(String),
+  duration_hours Float64,
+  items_touched UInt32,
+  computed_at DateTime('UTC'),
+  avg_wip Float64 DEFAULT 0.0,
+  org_id String DEFAULT ''
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, provider, work_scope_id, team_id, status, day)`
+
+	githubTeamAttributionsDDL = `CREATE TABLE work_item_team_attributions (
+  org_id String,
+  repo_id UUID,
+  work_item_id String,
+  provider String,
+  team_id Nullable(String),
+  team_name Nullable(String),
+  source Enum8('native_team' = 1, 'linked_issue' = 2, 'project_ownership' = 3, 'repo_ownership' = 4, 'assignee_membership' = 5, 'unassigned' = 6),
+  is_primary UInt8,
+  confidence Enum8('high' = 1, 'medium' = 2, 'low' = 3),
+  evidence String,
+  computed_at DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(computed_at)
+ORDER BY (org_id, repo_id, work_item_id, ifNull(team_id, ''), source)`
+)
+
+const githubDerivedIntegrationOrg = "org-acme"
+
+func githubDerivedIntegrationConn(t *testing.T, ctx context.Context) driver.Conn {
+	t.Helper()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	for _, statement := range []string{
+		githubEstimateCoverageDDL, githubStateDurationsDDL, githubTeamAttributionsDDL,
+	} {
+		if err := conn.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return conn
+}
+
+func githubDerivedIntegrationLease() providerfoundation.LeaseGuard {
+	return providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+}
+
+func githubDerivedIntegrationEffect(t *testing.T, destination string, rows any) EffectBatch {
+	t.Helper()
+	encoded, err := marshalGitHubWorkItemDerivedRows(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := BuildEffectBatch(destination, EffectReadbackRequired, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func githubDerivedIntegrationIdentity(destination string, rowCount int) GitHubWorkItemEffectIdentity {
+	return GitHubWorkItemEffectIdentity{
+		OrgID: githubDerivedIntegrationOrg, Provider: "github", Dataset: "work-items",
+		Generation: "gen-1", Destination: destination, RowCount: rowCount,
+	}
+}
+
+// TestGitHubEstimateCoverageReadbackAgainstRealClickHouse proves the partition
+// fence with data rather than by reading the SQL. The two rows share EVERY
+// sorting-key column except `day`, and their days fall in DIFFERENT MONTHS --
+// so they live in different toYYYYMM partitions. FINAL collapses versions only
+// within a partition, which is exactly why a readback that omits `day` sees
+// both and answers found=2. This is the shape that blocked #1535.
+func TestGitHubEstimateCoverageReadbackAgainstRealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubEstimateCoverageClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	teamID, teamName := "t1", "Team One"
+	ratio := 0.5
+	july := githubEstimateCoverageMetricsDailyRow{
+		Day: "2026-07-31", Provider: "github", WorkScopeID: "acme/api",
+		TeamID: &teamID, TeamName: &teamName, EstimatedCount: 1, UnestimatedCount: 1,
+		BacklogSize: 2, Ratio: &ratio,
+		ComputedAt: time.Date(2026, 8, 1, 0, 30, 0, 0, time.UTC),
+		OrgID:      githubDerivedIntegrationOrg,
+	}
+	august := july
+	august.Day = "2026-08-01"
+	august.ComputedAt = time.Date(2026, 8, 2, 0, 30, 0, 0, time.UTC)
+
+	both := []githubEstimateCoverageMetricsDailyRow{july, august}
+	effect := githubDerivedIntegrationEffect(t, githubEstimateCoverageDestination, both)
+	identity := githubDerivedIntegrationIdentity(githubEstimateCoverageDestination, len(both))
+
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	// SNAPSHOT REPLAY: re-inspecting the very same effect must answer Exact,
+	// not Absent. An adapter that answered Absent here would rewrite on every
+	// recovery replay and duplicate the rows it was verifying.
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("snapshot replay: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+	// And replaying the WRITE must stay Exact too: the RMT version column is
+	// computed_at, so re-writing identical rows collapses rather than doubles.
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("write replay: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+
+	// THE FENCE ITSELF: with both months present, a query that keeps every
+	// sorting-key column EXCEPT day returns two rows. That is the state the
+	// production readback must never be in, and it is measured here rather
+	// than asserted from the SQL text.
+	var unfenced uint64
+	if err := conn.QueryRow(ctx, `SELECT count() FROM estimate_coverage_metrics_daily FINAL
+WHERE org_id = ? AND provider = ? AND work_scope_id = ? AND ifNull(team_id, '') = ?`,
+		githubDerivedIntegrationOrg, "github", "acme/api", teamID).Scan(&unfenced); err != nil {
+		t.Fatal(err)
+	}
+	if unfenced != 2 {
+		t.Fatalf("fence precondition: unfenced count = %d, want 2 -- the two rows must "+
+			"straddle a month boundary or this test proves nothing about partitioning", unfenced)
+	}
+
+	// A stale persisted version must read as Absent so the writer replaces it.
+	stale := august
+	stale.ComputedAt = august.ComputedAt.Add(time.Hour)
+	staleEffect := githubDerivedIntegrationEffect(t, githubEstimateCoverageDestination,
+		[]githubEstimateCoverageMetricsDailyRow{stale})
+	staleIdentity := githubDerivedIntegrationIdentity(githubEstimateCoverageDestination, 1)
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, staleIdentity, staleEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("newer expected version: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+
+	// A foreign tenant must never satisfy the check.
+	foreign := githubDerivedIntegrationIdentity(githubEstimateCoverageDestination, len(both))
+	foreign.OrgID = "org-other"
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, foreign, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign tenant: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+}
+
+// TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse proves the
+// argMax dedup against a DUPLICATE-PART fixture. The table is plain MergeTree,
+// so two inserts of the same natural key genuinely coexist as two rows and
+// FINAL would not remove them -- only argMax over computed_at picks the
+// current version. Writing twice with different computed_at values is what
+// creates that state; asserting the SQL shape would not.
+func TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubWorkItemStateDurationsClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	older := githubWorkItemStateDurationDailyRow{
+		Day: "2026-08-04", Provider: "github", WorkScopeID: "acme/api",
+		TeamID: "unassigned", TeamName: "Unassigned", Status: "in_progress",
+		DurationHours: 6, ItemsTouched: 1,
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		AvgWIP:     0.25, OrgID: githubDerivedIntegrationOrg,
+	}
+	newer := older
+	newer.DurationHours = 18
+	newer.ItemsTouched = 2
+	newer.AvgWIP = 0.75
+	newer.ComputedAt = time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
+
+	olderEffect := githubDerivedIntegrationEffect(t, githubStateDurationsDestination,
+		[]githubWorkItemStateDurationDailyRow{older})
+	newerEffect := githubDerivedIntegrationEffect(t, githubStateDurationsDestination,
+		[]githubWorkItemStateDurationDailyRow{newer})
+	identity := githubDerivedIntegrationIdentity(githubStateDurationsDestination, 1)
+
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, olderEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, olderEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("snapshot replay of the only version: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, newerEffect); err != nil {
+		t.Fatal(err)
+	}
+
+	// A SECOND STATUS under the same (org, provider, scope, team, day). Without
+	// it, dropping `status` from the readback's GROUP BY merges nothing and the
+	// grouping key is untestable -- which is exactly how that mutation first
+	// survived.
+	otherStatus := newer
+	otherStatus.Status = "todo"
+	otherStatus.DurationHours = 6
+	otherStatus.ItemsTouched = 1
+	otherStatus.AvgWIP = 0.25
+	otherStatusEffect := githubDerivedIntegrationEffect(t, githubStateDurationsDestination,
+		[]githubWorkItemStateDurationDailyRow{otherStatus})
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, otherStatusEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, otherStatusEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("second status: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+
+	// DUPLICATE-PART PRECONDITION: both versions must genuinely be present.
+	// FINAL is a no-op on plain MergeTree, so if this is not 2 the fixture is
+	// not exercising what the argMax exists for.
+	var raw uint64
+	if err := conn.QueryRow(ctx, `SELECT count() FROM work_item_state_durations_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ? AND team_id = ? AND status = ?`,
+		githubDerivedIntegrationOrg, time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+		"github", "acme/api", "unassigned", "in_progress").Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw != 2 {
+		t.Fatalf("duplicate-part precondition: raw row count = %d, want 2 -- plain "+
+			"MergeTree must retain both appended versions or this proves nothing "+
+			"about argMax", raw)
+	}
+
+	// argMax must report the NEWER version as current...
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, newerEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("newer version after duplicate append: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+	// ...and replaying the SUPERSEDED effect must CONFLICT, not read as
+	// absent. My first version of this test asserted Absent and the real
+	// server disagreed, which was the test being wrong rather than the
+	// comparator: "absent" tells the committer to write, and writing a stale
+	// generation back over fresher data is a silent regression. The table
+	// currently serves duration_hours=18; an effect claiming 6 is not a
+	// missing row, it is a contradicting one, and it must fail loudly.
+	//
+	// The normal ordering -- persisted OLDER than the effect being written --
+	// is the Absent case, and the estimate-coverage test covers it. Only the
+	// reverse, a replay of a stale generation, reaches here.
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, olderEffect); err != nil || inspection != EffectConflict {
+		t.Fatalf("superseded version: inspection = %v, err = %v, want EffectConflict", inspection, err)
+	}
+
+	foreign := githubDerivedIntegrationIdentity(githubStateDurationsDestination, 1)
+	foreign.OrgID = "org-other"
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, foreign, newerEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign tenant: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+}
+
+// TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse covers the
+// unpartitioned ReplacingMergeTree, where FINAL deduplicates globally and there
+// is no partition key to fence. It also pins the nil-repo case: repo_id is a
+// NON-nullable UUID column, so an item with no repo persists as the nil UUID
+// and must not be confused with a real one.
+func TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubWorkItemTeamAttributionsClickHouseEffects{Conn: conn, Lease: githubDerivedIntegrationLease()}
+
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	teamID, teamName := "t1", "Team One"
+	withRepo := githubWorkItemTeamAttributionRow{
+		WorkItemID: "acme/api#1", Provider: "github", Source: "repo_ownership",
+		IsPrimary: 1, Confidence: "high", Evidence: "repo:acme/api",
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		RepoID:     &repoID, TeamID: &teamID, TeamName: &teamName,
+		OrgID: githubDerivedIntegrationOrg,
+	}
+	// The unassigned shape this table persists: NULL team, nil repo.
+	unassigned := githubWorkItemTeamAttributionRow{
+		WorkItemID: "acme/api#2", Provider: "github", Source: "unassigned",
+		IsPrimary: 1, Confidence: "low", Evidence: "no_candidate",
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		RepoID:     nil, TeamID: nil, TeamName: nil,
+		OrgID: githubDerivedIntegrationOrg,
+	}
+
+	rows := []githubWorkItemTeamAttributionRow{withRepo, unassigned}
+	effect := githubDerivedIntegrationEffect(t, githubTeamAttributionsDestination, rows)
+	identity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(rows))
+
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	// SNAPSHOT REPLAY, including the NULL-team row: a comparator that mapped
+	// NULL to "" on one side only would answer Absent here and rewrite forever.
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("snapshot replay: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("write replay: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+
+	// A different SOURCE for the same work item is a DIFFERENT row, not a new
+	// version of the same one: source is part of the sorting key.
+	otherSource := withRepo
+	otherSource.Source = "assignee_membership"
+	otherEffect := githubDerivedIntegrationEffect(t, githubTeamAttributionsDestination,
+		[]githubWorkItemTeamAttributionRow{otherSource})
+	otherIdentity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, 1)
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, otherIdentity, otherEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("different source: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+
+	foreign := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(rows))
+	foreign.OrgID = "org-other"
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, foreign, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("foreign tenant: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+}

--- a/internal/providersync/github_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/github_work_item_derived_effects_integration_test.go
@@ -213,12 +213,12 @@ func TestGitHubEstimateCoverageReadbackAgainstRealClickHouse(t *testing.T) {
 		Day: "2026-07-31", Provider: "github", WorkScopeID: "acme/api",
 		TeamID: &teamID, TeamName: &teamName, EstimatedCount: 1, UnestimatedCount: 1,
 		BacklogSize: 2, Ratio: &ratio,
-		ComputedAt: time.Date(2026, 8, 1, 0, 30, 0, 0, time.UTC),
+		ComputedAt: time.Date(2026, 8, 1, 0, 30, 0, 123456789, time.UTC),
 		OrgID:      githubDerivedIntegrationOrg,
 	}
 	august := july
 	august.Day = "2026-08-01"
-	august.ComputedAt = time.Date(2026, 8, 2, 0, 30, 0, 0, time.UTC)
+	august.ComputedAt = time.Date(2026, 8, 2, 0, 30, 0, 987654321, time.UTC)
 
 	both := []githubEstimateCoverageMetricsDailyRow{july, august}
 	effect := githubDerivedIntegrationEffect(t, githubEstimateCoverageDestination, both)
@@ -312,14 +312,14 @@ func TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse(t *testing.T)
 		Day: "2026-08-04", Provider: "github", WorkScopeID: "acme/api",
 		TeamID: "unassigned", TeamName: "Unassigned", Status: "in_progress",
 		DurationHours: 6, ItemsTouched: 1,
-		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC),
 		AvgWIP:     0.25, OrgID: githubDerivedIntegrationOrg,
 	}
 	newer := older
 	newer.DurationHours = 18
 	newer.ItemsTouched = 2
 	newer.AvgWIP = 0.75
-	newer.ComputedAt = time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
+	newer.ComputedAt = time.Date(2026, 8, 6, 0, 30, 0, 987654321, time.UTC)
 
 	olderEffect := githubDerivedIntegrationEffect(t, githubStateDurationsDestination,
 		[]githubWorkItemStateDurationDailyRow{older})
@@ -413,7 +413,7 @@ func TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse(t *testing.
 	withRepo := githubWorkItemTeamAttributionRow{
 		WorkItemID: "acme/api#1", Provider: "github", Source: "repo_ownership",
 		IsPrimary: 1, Confidence: "high", Evidence: "repo:acme/api",
-		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC),
 		RepoID:     &repoID, TeamID: &teamID, TeamName: &teamName,
 		OrgID: githubDerivedIntegrationOrg,
 	}
@@ -421,7 +421,7 @@ func TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse(t *testing.
 	unassigned := githubWorkItemTeamAttributionRow{
 		WorkItemID: "acme/api#2", Provider: "github", Source: "unassigned",
 		IsPrimary: 1, Confidence: "low", Evidence: "no_candidate",
-		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC),
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC),
 		RepoID:     nil, TeamID: nil, TeamName: nil,
 		OrgID: githubDerivedIntegrationOrg,
 	}
@@ -457,6 +457,49 @@ func TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse(t *testing.
 	otherIdentity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, 1)
 	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, otherIdentity, otherEffect); err != nil || inspection != EffectAbsent {
 		t.Fatalf("different source: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+
+	// SAME-SORTING-KEY COLLAPSE. Two candidates for one item that differ ONLY
+	// in team_name -- the exact shape the resolver produces when two ownership
+	// facts name one team differently -- share a full sorting key, so
+	// ReplacingMergeTree stores ONE row. Without deterministic dedup on both
+	// the write and the expectation, found==1, the team_name mismatch reads as
+	// Conflict, and recovery is wedged permanently rather than transiently.
+	collidingA := withRepo
+	collidingA.WorkItemID = "acme/api#3"
+	collidingA.TeamName = stringPointer("Team One")
+	collidingB := collidingA
+	collidingB.TeamName = stringPointer("Team Uno")
+	colliding := []githubWorkItemTeamAttributionRow{collidingA, collidingB}
+	if githubTeamAttributionSortingKey(collidingA) != githubTeamAttributionSortingKey(collidingB) {
+		t.Fatal("collision precondition: the two rows must share a sorting key, " +
+			"otherwise this case proves nothing about RMT collapse")
+	}
+	collidingEffect := githubDerivedIntegrationEffect(t, githubTeamAttributionsDestination, colliding)
+	collidingIdentity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(colliding))
+	if err := sink.WriteGitHubWorkItemEffect(ctx, collidingIdentity, collidingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, collidingIdentity, collidingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("colliding sorting keys: inspection = %v, err = %v, want EffectExact "+
+			"(a permanent Conflict here is the wedged-recovery defect)", inspection, err)
+	}
+	// Replay must stay Exact, which is what proves the dedup is deterministic
+	// rather than accidentally agreeing once.
+	if err := sink.WriteGitHubWorkItemEffect(ctx, collidingIdentity, collidingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, collidingIdentity, collidingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("colliding sorting keys on replay: inspection = %v, err = %v, want EffectExact", inspection, err)
+	}
+	var stored uint64
+	if err := conn.QueryRow(ctx, `SELECT count() FROM work_item_team_attributions FINAL
+WHERE org_id = ? AND work_item_id = ?`, githubDerivedIntegrationOrg, "acme/api#3").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != 1 {
+		t.Fatalf("colliding sorting keys: stored row count = %d, want 1 -- the two "+
+			"rows must genuinely collapse or this case is not exercising the defect", stored)
 	}
 
 	foreign := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(rows))

--- a/internal/providersync/github_work_item_derived_effects_test.go
+++ b/internal/providersync/github_work_item_derived_effects_test.go
@@ -1,0 +1,320 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// These are fast, synthetic-data unit tests of the three comparators' own
+// logic. Each clause gets a case that exercises ONLY that clause, so a
+// mutation to any one of them is caught by a case isolating it rather than by
+// coincidence from a case exercising several at once.
+//
+// The ordering property matters most: `found != 1` must be tested BEFORE
+// anything reads the scanned row. If a stale-version branch ran first, a table
+// holding duplicates PLUS a stale row would answer "absent", the committer
+// would rewrite, and the rewrite would add another duplicate -- an infinite
+// loop, and the second blocking finding on PR #1535.
+
+var (
+	githubDerivedEffectComputedAt = time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	githubDerivedEffectStaleAt    = time.Date(2026, 8, 4, 0, 30, 0, 0, time.UTC)
+)
+
+func githubDerivedEffectCoverageRow() githubEstimateCoverageMetricsDailyRow {
+	teamID, teamName := "t1", "Team One"
+	ratio := 0.5
+	return githubEstimateCoverageMetricsDailyRow{
+		Day: "2026-08-04", Provider: "github", WorkScopeID: "acme/api",
+		TeamID: &teamID, TeamName: &teamName, EstimatedCount: 1,
+		UnestimatedCount: 1, BacklogSize: 2, Ratio: &ratio,
+		ComputedAt: githubDerivedEffectComputedAt, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubEstimateCoverageVersionClauseCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*githubEstimateCoverageMetricsDailyRow)
+		found  int
+		want   EffectInspection
+	}{
+		{"identical single row is exact", nil, 1, EffectExact},
+		{"absent when nothing read back", nil, 0, EffectAbsent},
+		{
+			// The load-bearing ordering case: duplicates AND a stale version.
+			// A comparator that checked staleness first would answer Absent
+			// and rewrite forever.
+			name:   "duplicates with a stale version conflict, never absent",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  2, want: EffectConflict,
+		},
+		{"duplicates alone conflict", nil, 2, EffectConflict},
+		{
+			name:   "older version reads as absent so the writer replaces it",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  1, want: EffectAbsent,
+		},
+		{
+			name:   "different estimated_count conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.EstimatedCount = 9 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different unestimated_count conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.UnestimatedCount = 9 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different backlog_size conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.BacklogSize = 9 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different day conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.Day = "2026-08-05" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different work_scope_id conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.WorkScopeID = "other/repo" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different provider conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.Provider = "gitlab" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			// A NULL ratio and a 0.0 ratio are different persisted facts: the
+			// null arm is what an all-zero backlog produces.
+			name:   "null ratio against a present ratio conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.Ratio = nil },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name: "different ratio value conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) {
+				other := 0.75
+				row.Ratio = &other
+			},
+			found: 1, want: EffectConflict,
+		},
+		{
+			name:   "null team_id against a present team_id conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.TeamID = nil },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different team_name conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.TeamName = stringPointer("Team Uno") },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "foreign tenant conflicts",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.OrgID = "org-other" },
+			found:  1, want: EffectConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := githubDerivedEffectCoverageRow()
+			actual := githubDerivedEffectCoverageRow()
+			if tt.mutate != nil {
+				tt.mutate(&actual)
+			}
+			got := compareGitHubEstimateCoverageVersion(expected, actual, tt.found, "org-acme")
+			if got != tt.want {
+				t.Fatalf("compareGitHubEstimateCoverageVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func githubDerivedEffectStateDurationRow() githubWorkItemStateDurationDailyRow {
+	return githubWorkItemStateDurationDailyRow{
+		Day: "2026-08-04", Provider: "github", WorkScopeID: "acme/api",
+		TeamID: "unassigned", TeamName: "Unassigned", Status: "in_progress",
+		DurationHours: 18, ItemsTouched: 2,
+		ComputedAt: githubDerivedEffectComputedAt, AvgWIP: 0.75, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubWorkItemStateDurationVersionClauseCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*githubWorkItemStateDurationDailyRow)
+		found  int
+		want   EffectInspection
+	}{
+		{"identical grouped row is exact", nil, 1, EffectExact},
+		{"absent when the group is empty", nil, 0, EffectAbsent},
+		{
+			// GROUP BY the full natural key cannot return two rows, so this is
+			// a wiring defect. It must never be answered with a rewrite.
+			name:   "more than one group conflicts even when stale",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  2, want: EffectConflict,
+		},
+		{
+			name:   "older argMax version reads as absent",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  1, want: EffectAbsent,
+		},
+		{
+			name:   "different duration_hours conflicts",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.DurationHours = 17 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different items_touched conflicts",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.ItemsTouched = 1 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			// avg_wip is a stored column (migration 002), not a view over
+			// duration_hours, so it has to be compared in its own right.
+			name:   "different avg_wip conflicts",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.AvgWIP = 0.5 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different team_name conflicts",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.TeamName = "Other" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "foreign tenant conflicts",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.OrgID = "org-other" },
+			found:  1, want: EffectConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := githubDerivedEffectStateDurationRow()
+			actual := githubDerivedEffectStateDurationRow()
+			if tt.mutate != nil {
+				tt.mutate(&actual)
+			}
+			got := compareGitHubWorkItemStateDurationVersion(expected, actual, tt.found, "org-acme")
+			if got != tt.want {
+				t.Fatalf("compareGitHubWorkItemStateDurationVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func githubDerivedEffectAttributionRow() githubWorkItemTeamAttributionRow {
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	teamID, teamName := "t1", "Team One"
+	return githubWorkItemTeamAttributionRow{
+		WorkItemID: "acme/api#1", Provider: "github", Source: "repo_ownership",
+		IsPrimary: 1, Confidence: "high", Evidence: "repo:acme/api",
+		ComputedAt: githubDerivedEffectComputedAt, RepoID: &repoID,
+		TeamID: &teamID, TeamName: &teamName, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*githubWorkItemTeamAttributionRow)
+		found  int
+		want   EffectInspection
+	}{
+		{"identical single row is exact", nil, 1, EffectExact},
+		{"absent when nothing read back", nil, 0, EffectAbsent},
+		{
+			// This table has no PARTITION BY, so FINAL deduplicates globally
+			// and two survivors mean the sorting-key fence is wrong.
+			name:   "duplicates with a stale version conflict, never absent",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  2, want: EffectConflict,
+		},
+		{
+			name:   "older version reads as absent",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.ComputedAt = githubDerivedEffectStaleAt },
+			found:  1, want: EffectAbsent,
+		},
+		{
+			name:   "different source conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.Source = "assignee_membership" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different is_primary conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.IsPrimary = 0 },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different confidence conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.Confidence = "low" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different evidence conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.Evidence = "other" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			// A null team_id is the persisted shape for an unassigned
+			// candidate on THIS table, unlike the coverage rollup which
+			// normalises it to "unassigned". Confusing the two must conflict.
+			name:   "null team_id against a present team_id conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.TeamID = nil },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different team_name conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.TeamName = stringPointer("Team Uno") },
+			found:  1, want: EffectConflict,
+		},
+		{
+			// repo_id is a NON-nullable UUID column, so a missing repo
+			// persists as the nil UUID -- which must not read as equal to a
+			// real repo id.
+			name:   "nil repo_id against a real repo_id conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.RepoID = nil },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "different work_item_id conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.WorkItemID = "acme/api#2" },
+			found:  1, want: EffectConflict,
+		},
+		{
+			name:   "foreign tenant conflicts",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.OrgID = "org-other" },
+			found:  1, want: EffectConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := githubDerivedEffectAttributionRow()
+			actual := githubDerivedEffectAttributionRow()
+			if tt.mutate != nil {
+				tt.mutate(&actual)
+			}
+			got := compareGitHubWorkItemTeamAttributionVersion(expected, actual, tt.found, "org-acme")
+			if got != tt.want {
+				t.Fatalf("compareGitHubWorkItemTeamAttributionVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGitHubWorkItemDerivedAdaptersSatisfyTheCompositeInterface keeps the three
+// adapters wired to the dispatcher's contract. Without it they would compile
+// as unreferenced exported types and could drift out of the interface silently.
+func TestGitHubWorkItemDerivedAdaptersSatisfyTheCompositeInterface(t *testing.T) {
+	var adapters = []GitHubWorkItemEffectAdapter{
+		GitHubEstimateCoverageClickHouseEffects{},
+		GitHubWorkItemTeamAttributionsClickHouseEffects{},
+		GitHubWorkItemStateDurationsClickHouseEffects{},
+	}
+	if len(adapters) != 3 {
+		t.Fatalf("expected three derived adapters, got %d", len(adapters))
+	}
+}

--- a/internal/providersync/github_work_item_derived_effects_test.go
+++ b/internal/providersync/github_work_item_derived_effects_test.go
@@ -21,6 +21,7 @@ import (
 var (
 	githubDerivedEffectComputedAt = time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
 	githubDerivedEffectStaleAt    = time.Date(2026, 8, 4, 0, 30, 0, 0, time.UTC)
+	githubDerivedEffectNewerAt    = time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
 )
 
 func githubDerivedEffectCoverageRow() githubEstimateCoverageMetricsDailyRow {
@@ -43,6 +44,17 @@ func TestCompareGitHubEstimateCoverageVersionClauseCoverage(t *testing.T) {
 	}{
 		{"identical single row is exact", nil, 1, EffectExact},
 		{"absent when nothing read back", nil, 0, EffectAbsent},
+		{
+			// THE WEDGE CASE. A byte-identical recompute where only computed_at
+			// moved -- the steady state for a producer re-run per backfill day.
+			// Values all agree and the persisted stamp is NEWER. A two-way
+			// `!Equal -> Absent` answers Absent here, the committer rewrites the
+			// OLDER generation, the store keeps the newer one, and the readback
+			// answers Absent forever. It must be Conflict.
+			name:   "newer persisted version with identical values conflicts, never absent",
+			mutate: func(row *githubEstimateCoverageMetricsDailyRow) { row.ComputedAt = githubDerivedEffectNewerAt },
+			found:  1, want: EffectConflict,
+		},
 		{
 			// The load-bearing ordering case: duplicates AND a stale version.
 			// A comparator that checked staleness first would answer Absent
@@ -152,6 +164,17 @@ func TestCompareGitHubWorkItemStateDurationVersionClauseCoverage(t *testing.T) {
 		{"identical grouped row is exact", nil, 1, EffectExact},
 		{"absent when the group is empty", nil, 0, EffectAbsent},
 		{
+			// THE WEDGE CASE. A byte-identical recompute where only computed_at
+			// moved -- the steady state for a producer re-run per backfill day.
+			// Values all agree and the persisted stamp is NEWER. A two-way
+			// `!Equal -> Absent` answers Absent here, the committer rewrites the
+			// OLDER generation, the store keeps the newer one, and the readback
+			// answers Absent forever. It must be Conflict.
+			name:   "newer persisted version with identical values conflicts, never absent",
+			mutate: func(row *githubWorkItemStateDurationDailyRow) { row.ComputedAt = githubDerivedEffectNewerAt },
+			found:  1, want: EffectConflict,
+		},
+		{
 			// GROUP BY the full natural key cannot return two rows, so this is
 			// a wiring defect. It must never be answered with a rewrite.
 			name:   "more than one group conflicts even when stale",
@@ -226,6 +249,17 @@ func TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage(t *testing.T)
 	}{
 		{"identical single row is exact", nil, 1, EffectExact},
 		{"absent when nothing read back", nil, 0, EffectAbsent},
+		{
+			// THE WEDGE CASE. A byte-identical recompute where only computed_at
+			// moved -- the steady state for a producer re-run per backfill day.
+			// Values all agree and the persisted stamp is NEWER. A two-way
+			// `!Equal -> Absent` answers Absent here, the committer rewrites the
+			// OLDER generation, the store keeps the newer one, and the readback
+			// answers Absent forever. It must be Conflict.
+			name:   "newer persisted version with identical values conflicts, never absent",
+			mutate: func(row *githubWorkItemTeamAttributionRow) { row.ComputedAt = githubDerivedEffectNewerAt },
+			found:  1, want: EffectConflict,
+		},
 		{
 			// This table has no PARTITION BY, so FINAL deduplicates globally
 			// and two survivors mean the sorting-key fence is wrong.

--- a/internal/providersync/github_work_item_derived_surfaces.go
+++ b/internal/providersync/github_work_item_derived_surfaces.go
@@ -1,0 +1,579 @@
+package providersync
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// This file ports three of the nine Python-derived work-item destinations:
+// estimate_coverage_metrics_daily, work_item_team_attributions, and
+// work_item_state_durations_daily. The remaining three derived destinations
+// this lane owns (issue_type_metrics_daily and the two investment surfaces)
+// are computed inline inside job_work_items.py and depend on two config-driven
+// engines that have no Go port yet; they land separately.
+//
+// Per D16 these builders mirror Python bug-for-bug. Every divergence a reader
+// might mistake for a defect is called out at its site with the Python line it
+// mirrors, and every one of them is pinned by an oracle case rather than
+// corrected here.
+
+// githubWorkItemDerivedDay is a calendar day, not an instant. The daily
+// destinations persist a ClickHouse Date, and the generic oracle comparator
+// tags a value carrying oracleDate() as "date" so it can never compare equal
+// to a same-looking plain string.
+type githubWorkItemDerivedDay string
+
+func newGitHubWorkItemDerivedDay(value time.Time) githubWorkItemDerivedDay {
+	return githubWorkItemDerivedDay(value.UTC().Format("2006-01-02"))
+}
+
+func (day githubWorkItemDerivedDay) oracleDate() string { return string(day) }
+
+// githubEstimateCoverageMetricsDailyRow mirrors
+// EstimateCoverageMetricsDailyRecord (metrics/schemas.py).
+type githubEstimateCoverageMetricsDailyRow struct {
+	Day              githubWorkItemDerivedDay `json:"day"`
+	Provider         string                   `json:"provider"`
+	WorkScopeID      string                   `json:"work_scope_id"`
+	TeamID           *string                  `json:"team_id"`
+	TeamName         *string                  `json:"team_name"`
+	EstimatedCount   int                      `json:"estimated_count"`
+	UnestimatedCount int                      `json:"unestimated_count"`
+	BacklogSize      int                      `json:"backlog_size"`
+	Ratio            *float64                 `json:"ratio"`
+	ComputedAt       time.Time                `json:"computed_at"`
+	OrgID            string                   `json:"org_id"`
+}
+
+// githubWorkItemTeamAttributionRow mirrors WorkItemTeamAttributionRecord.
+type githubWorkItemTeamAttributionRow struct {
+	WorkItemID string     `json:"work_item_id"`
+	Provider   string     `json:"provider"`
+	Source     string     `json:"source"`
+	IsPrimary  int        `json:"is_primary"`
+	Confidence string     `json:"confidence"`
+	Evidence   string     `json:"evidence"`
+	ComputedAt time.Time  `json:"computed_at"`
+	RepoID     *uuid.UUID `json:"repo_id"`
+	TeamID     *string    `json:"team_id"`
+	TeamName   *string    `json:"team_name"`
+	OrgID      string     `json:"org_id"`
+}
+
+// githubWorkItemStateDurationDailyRow mirrors
+// WorkItemStateDurationDailyRecord.
+type githubWorkItemStateDurationDailyRow struct {
+	Day           githubWorkItemDerivedDay `json:"day"`
+	Provider      string                   `json:"provider"`
+	WorkScopeID   string                   `json:"work_scope_id"`
+	TeamID        string                   `json:"team_id"`
+	TeamName      string                   `json:"team_name"`
+	Status        string                   `json:"status"`
+	DurationHours float64                  `json:"duration_hours"`
+	ItemsTouched  int                      `json:"items_touched"`
+	ComputedAt    time.Time                `json:"computed_at"`
+	AvgWIP        float64                  `json:"avg_wip"`
+	OrgID         string                   `json:"org_id"`
+}
+
+type githubWorkItemDerivedSurfaces struct {
+	EstimateCoverage []githubEstimateCoverageMetricsDailyRow
+	TeamAttributions []githubWorkItemTeamAttributionRow
+	StateDurations   []githubWorkItemStateDurationDailyRow
+}
+
+const (
+	githubEstimateCoverageDestination = "estimate_coverage_metrics_daily"
+	githubTeamAttributionsDestination = "work_item_team_attributions"
+	githubStateDurationsDestination   = "work_item_state_durations_daily"
+)
+
+// githubWorkItemDerivedSurfaceDestinations is the exact set this builder
+// speaks for. It is a strict subset of githubWorkItemDerivedDestinations; the
+// route's deriver seam requires every derived key to be present, so a caller
+// assembling the full map must combine this with the other derived builders.
+var githubWorkItemDerivedSurfaceDestinations = []string{
+	githubEstimateCoverageDestination,
+	githubStateDurationsDestination,
+	githubTeamAttributionsDestination,
+}
+
+const (
+	githubWorkItemUnassignedTeamID   = "unassigned"
+	githubWorkItemUnassignedTeamName = "Unassigned"
+)
+
+// buildGitHubWorkItemDerivedSurfaces is deliberately pure: the caller loads
+// the shared derivation context once and reuses it across backfill days. It
+// registers and activates nothing.
+func buildGitHubWorkItemDerivedSurfaces(
+	claim Claim,
+	rows githubWorkItemRows,
+	day time.Time,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) (githubWorkItemDerivedSurfaces, error) {
+	if claim.Validate() != nil || claim.Provider != "github" ||
+		!isWorkItemFamilyDataset(claim.Dataset) || day.IsZero() || computedAt.IsZero() {
+		return githubWorkItemDerivedSurfaces{}, ErrInvalidConfiguration
+	}
+	dayUTC := time.Date(
+		day.UTC().Year(), day.UTC().Month(), day.UTC().Day(), 0, 0, 0, 0, time.UTC,
+	)
+	end := dayUTC.AddDate(0, 0, 1)
+	computedAt = computedAt.UTC()
+
+	coverage, err := buildGitHubEstimateCoverageMetricsDaily(
+		claim, rows, dayUTC, end, computedAt, derived,
+	)
+	if err != nil {
+		return githubWorkItemDerivedSurfaces{}, err
+	}
+	attributions, err := buildGitHubWorkItemTeamAttributions(
+		claim, rows, computedAt, derived,
+	)
+	if err != nil {
+		return githubWorkItemDerivedSurfaces{}, err
+	}
+	durations, err := buildGitHubWorkItemStateDurationsDaily(
+		claim, rows, dayUTC, end, computedAt, derived,
+	)
+	if err != nil {
+		return githubWorkItemDerivedSurfaces{}, err
+	}
+	return githubWorkItemDerivedSurfaces{
+		EstimateCoverage: coverage,
+		TeamAttributions: attributions,
+		StateDurations:   durations,
+	}, nil
+}
+
+type githubEstimateCoverageKey struct {
+	provider, workScopeID, teamID string
+}
+
+type githubEstimateCoverageBucket struct {
+	teamName                         string
+	estimatedCount, unestimatedCount int
+}
+
+// buildGitHubEstimateCoverageMetricsDaily mirrors
+// compute_estimate_coverage_metrics_daily (compute_work_items.py:1116).
+func buildGitHubEstimateCoverageMetricsDaily(
+	claim Claim,
+	rows githubWorkItemRows,
+	dayUTC, end, computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) ([]githubEstimateCoverageMetricsDailyRow, error) {
+	buckets := make(map[githubEstimateCoverageKey]*githubEstimateCoverageBucket)
+	order := make([]githubEstimateCoverageKey, 0, len(rows.WorkItems))
+
+	for _, item := range rows.WorkItems {
+		if err := assertGitHubWorkItemDerivedTenancy(claim, item); err != nil {
+			return nil, err
+		}
+		createdAt := item.CreatedAt.UTC()
+		terminalAt := earliestGitHubWorkItemDerivedTime(item.CompletedAt, item.ClosedAt)
+		if !createdAt.Before(end) {
+			continue
+		}
+		subject := githubWorkItemDerivationSubjectFromRow(item)
+		teamID, teamName, _ := derived.resolve(subject)
+		key := githubEstimateCoverageKey{
+			provider:    item.Provider,
+			workScopeID: workItemDerivationScope(subject),
+			teamID:      normalizeGitHubWorkItemDerivedTeamID(teamID),
+		}
+		bucket := buckets[key]
+		if bucket == nil {
+			// Python creates the bucket BEFORE the terminal-item skip below, so
+			// an item that reached a terminal state before the window end still
+			// materialises an all-zero group (backlog_size 0, ratio None). D16:
+			// pinned by the terminal_only_group oracle case, not corrected. The
+			// team_name recorded here is the FIRST contributing item's — later
+			// items resolving a different name do not overwrite it, which is the
+			// opposite of the state-duration builder's last-wins rule below.
+			bucket = &githubEstimateCoverageBucket{
+				teamName: normalizeGitHubWorkItemDerivedTeamName(teamName),
+			}
+			buckets[key] = bucket
+			order = append(order, key)
+		}
+		if terminalAt != nil && terminalAt.Before(end) {
+			continue
+		}
+		if item.StoryPoints == nil {
+			bucket.unestimatedCount++
+			continue
+		}
+		bucket.estimatedCount++
+	}
+
+	// Python sorts by (provider, work_scope_id, str(team_id or "")). team_id is
+	// already normalised to a non-empty string by this point, so the `or ""`
+	// arm is unreachable here; sorting on the normalised value matches.
+	sort.SliceStable(order, func(left, right int) bool {
+		return githubEstimateCoverageKeyLess(order[left], order[right])
+	})
+
+	result := make([]githubEstimateCoverageMetricsDailyRow, 0, len(order))
+	for _, key := range order {
+		bucket := buckets[key]
+		backlogSize := bucket.estimatedCount + bucket.unestimatedCount
+		var ratio *float64
+		if backlogSize != 0 {
+			value := float64(bucket.estimatedCount) / float64(backlogSize)
+			ratio = &value
+		}
+		teamID := key.teamID
+		teamName := bucket.teamName
+		result = append(result, githubEstimateCoverageMetricsDailyRow{
+			Day:              newGitHubWorkItemDerivedDay(dayUTC),
+			Provider:         key.provider,
+			WorkScopeID:      key.workScopeID,
+			TeamID:           &teamID,
+			TeamName:         &teamName,
+			EstimatedCount:   bucket.estimatedCount,
+			UnestimatedCount: bucket.unestimatedCount,
+			BacklogSize:      backlogSize,
+			Ratio:            ratio,
+			ComputedAt:       computedAt,
+			OrgID:            claim.OrgID,
+		})
+	}
+	return result, nil
+}
+
+func githubEstimateCoverageKeyLess(left, right githubEstimateCoverageKey) bool {
+	if left.provider != right.provider {
+		return left.provider < right.provider
+	}
+	if left.workScopeID != right.workScopeID {
+		return left.workScopeID < right.workScopeID
+	}
+	return left.teamID < right.teamID
+}
+
+// buildGitHubWorkItemTeamAttributions mirrors
+// compute_work_item_team_attributions (compute_work_items.py:1189).
+//
+// D16: the Python composite calls this inside its `for d in days` loop while
+// the function itself takes no day, so a multi-day backfill recomputes and
+// rewrites byte-identical rows once per day. This builder reproduces the
+// per-call result exactly; the repetition is a property of the caller and is
+// pinned at the route seam, not smoothed over here.
+func buildGitHubWorkItemTeamAttributions(
+	claim Claim,
+	rows githubWorkItemRows,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) ([]githubWorkItemTeamAttributionRow, error) {
+	result := make([]githubWorkItemTeamAttributionRow, 0, len(rows.WorkItems))
+	for _, item := range rows.WorkItems {
+		if err := assertGitHubWorkItemDerivedTenancy(claim, item); err != nil {
+			return nil, err
+		}
+		_, _, candidates := derived.resolve(githubWorkItemDerivationSubjectFromRow(item))
+		for _, candidate := range candidates {
+			// Python emits candidate.team_id / team_name UNNORMALISED here --
+			// unlike every other derived surface, which routes them through
+			// normalize_team_id. A null team_id therefore persists as NULL in
+			// this table while the same resolution persists as "unassigned" in
+			// estimate coverage. D16: mirrored, pinned by the
+			// unassigned_candidate oracle case.
+			result = append(result, githubWorkItemTeamAttributionRow{
+				WorkItemID: item.WorkItemID,
+				Provider:   item.Provider,
+				Source:     candidate.Source,
+				IsPrimary:  candidate.IsPrimary,
+				Confidence: candidate.Confidence,
+				Evidence:   candidate.Evidence,
+				ComputedAt: computedAt,
+				RepoID:     item.RepoID,
+				TeamID:     candidate.TeamID,
+				TeamName:   candidate.TeamName,
+				OrgID:      item.OrgID,
+			})
+		}
+	}
+	return result, nil
+}
+
+type githubStateDurationKey struct {
+	provider, workScopeID, teamID, status string
+}
+
+type githubStateDurationTeamKey struct {
+	provider, workScopeID, teamID string
+}
+
+type githubWorkItemStatusSegment struct {
+	status     string
+	start, end time.Time
+}
+
+// buildGitHubWorkItemStateDurationsDaily mirrors
+// compute_work_item_state_durations_daily
+// (compute_work_item_state_durations.py:108).
+func buildGitHubWorkItemStateDurationsDaily(
+	claim Claim,
+	rows githubWorkItemRows,
+	dayUTC, end, computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) ([]githubWorkItemStateDurationDailyRow, error) {
+	transitionsByItem := make(map[string][]githubWorkItemTransitionRow)
+	for _, transition := range rows.StatusTransitions {
+		if transition.OrgID != claim.OrgID {
+			return nil, ErrInvalidConfiguration
+		}
+		transitionsByItem[transition.WorkItemID] = append(
+			transitionsByItem[transition.WorkItemID], transition,
+		)
+	}
+
+	totals := make(map[githubStateDurationKey]float64)
+	itemsSeen := make(map[githubStateDurationKey]map[string]struct{})
+	teamNames := make(map[githubStateDurationTeamKey]string)
+	order := make([]githubStateDurationKey, 0, len(rows.WorkItems))
+
+	for _, item := range rows.WorkItems {
+		if err := assertGitHubWorkItemDerivedTenancy(claim, item); err != nil {
+			return nil, err
+		}
+		itemTransitions := transitionsByItem[item.WorkItemID]
+		if len(itemTransitions) == 0 {
+			// Python: an item with no transition history contributes no rows,
+			// and -- because this `continue` precedes the team_name write below
+			// -- also never registers its team name.
+			continue
+		}
+		subject := githubWorkItemDerivationSubjectFromRow(item)
+		teamIDValue, teamNameValue, _ := derived.resolve(subject)
+		teamID := normalizeGitHubWorkItemDerivedTeamID(teamIDValue)
+		teamName := normalizeGitHubWorkItemDerivedTeamName(teamNameValue)
+		workScopeID := workItemDerivationScope(subject)
+		// Last contributing item wins, in work-item iteration order. The
+		// estimate-coverage builder above deliberately keeps the FIRST instead;
+		// the two rules disagree in Python and must not be shared.
+		teamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName
+
+		for _, segment := range githubWorkItemStatusSegments(item, itemTransitions, computedAt) {
+			overlapStart := segment.start
+			if dayUTC.After(overlapStart) {
+				overlapStart = dayUTC
+			}
+			overlapEnd := segment.end
+			if end.Before(overlapEnd) {
+				overlapEnd = end
+			}
+			if !overlapEnd.After(overlapStart) {
+				continue
+			}
+			hours := overlapEnd.Sub(overlapStart).Seconds() / 3600.0
+			key := githubStateDurationKey{
+				provider: item.Provider, workScopeID: workScopeID,
+				teamID: teamID, status: segment.status,
+			}
+			if _, exists := totals[key]; !exists {
+				order = append(order, key)
+			}
+			totals[key] += hours
+			if itemsSeen[key] == nil {
+				itemsSeen[key] = make(map[string]struct{})
+			}
+			itemsSeen[key][item.WorkItemID] = struct{}{}
+		}
+	}
+
+	sort.SliceStable(order, func(left, right int) bool {
+		return githubStateDurationKeyLess(order[left], order[right])
+	})
+
+	result := make([]githubWorkItemStateDurationDailyRow, 0, len(order))
+	for _, key := range order {
+		totalHours := totals[key]
+		result = append(result, githubWorkItemStateDurationDailyRow{
+			Day:           newGitHubWorkItemDerivedDay(dayUTC),
+			Provider:      key.provider,
+			WorkScopeID:   key.workScopeID,
+			TeamID:        key.teamID,
+			TeamName:      teamNames[githubStateDurationTeamKey{key.provider, key.workScopeID, key.teamID}],
+			Status:        key.status,
+			DurationHours: totalHours,
+			ItemsTouched:  len(itemsSeen[key]),
+			ComputedAt:    computedAt,
+			// Python divides the whole-day total by a fixed 24, not by the
+			// number of hours the window actually covers, so a partial-day
+			// window understates avg_wip. Mirrored.
+			AvgWIP: totalHours / 24.0,
+			OrgID:  claim.OrgID,
+		})
+	}
+	return result, nil
+}
+
+func githubStateDurationKeyLess(left, right githubStateDurationKey) bool {
+	if left.provider != right.provider {
+		return left.provider < right.provider
+	}
+	if left.workScopeID != right.workScopeID {
+		return left.workScopeID < right.workScopeID
+	}
+	if left.teamID != right.teamID {
+		return left.teamID < right.teamID
+	}
+	return left.status < right.status
+}
+
+// githubWorkItemStatusSegments mirrors _segment_statuses
+// (compute_work_item_state_durations.py:56).
+func githubWorkItemStatusSegments(
+	item githubWorkItemRow,
+	transitions []githubWorkItemTransitionRow,
+	computedAt time.Time,
+) []githubWorkItemStatusSegment {
+	if len(transitions) == 0 {
+		return nil
+	}
+	ordered := make([]githubWorkItemTransitionRow, len(transitions))
+	copy(ordered, transitions)
+	// Python's sorted() is stable, so transitions sharing an occurred_at keep
+	// their input order. sort.Slice is NOT stable and would reorder them.
+	sort.SliceStable(ordered, func(left, right int) bool {
+		return ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())
+	})
+
+	endOfItem := computedAt.UTC()
+	if item.CompletedAt != nil {
+		endOfItem = item.CompletedAt.UTC()
+	}
+	currentStatus := ordered[0].FromStatus
+	if currentStatus == "" {
+		currentStatus = item.Status
+	}
+	currentStart := item.CreatedAt.UTC()
+
+	segments := make([]githubWorkItemStatusSegment, 0, len(ordered)+1)
+	for _, transition := range ordered {
+		occurredAt := transition.OccurredAt.UTC()
+		if !occurredAt.After(currentStart) {
+			// A transition at or before the current segment start rewrites the
+			// open segment rather than closing one, so a pre-creation
+			// transition silently moves the item's start backwards.
+			currentStatus = transition.ToStatus
+			currentStart = occurredAt
+			continue
+		}
+		segments = append(segments, githubWorkItemStatusSegment{
+			status: currentStatus, start: currentStart, end: occurredAt,
+		})
+		currentStatus = transition.ToStatus
+		currentStart = occurredAt
+	}
+	if endOfItem.After(currentStart) {
+		segments = append(segments, githubWorkItemStatusSegment{
+			status: currentStatus, start: currentStart, end: endOfItem,
+		})
+	}
+	result := make([]githubWorkItemStatusSegment, 0, len(segments))
+	for _, segment := range segments {
+		if segment.end.After(segment.start) {
+			result = append(result, segment)
+		}
+	}
+	return result
+}
+
+// derivedRows encodes this builder's three destinations for the route's
+// deriver seam. It speaks only for the destinations it owns: the caller
+// merges this with the other derived builders' maps.
+func (surfaces githubWorkItemDerivedSurfaces) derivedRows() (map[string][]json.RawMessage, error) {
+	values := map[string]any{
+		githubEstimateCoverageDestination: surfaces.EstimateCoverage,
+		githubStateDurationsDestination:   surfaces.StateDurations,
+		githubTeamAttributionsDestination: surfaces.TeamAttributions,
+	}
+	result := make(map[string][]json.RawMessage, len(values))
+	for _, destination := range githubWorkItemDerivedSurfaceDestinations {
+		rows, owned := values[destination]
+		if !owned {
+			return nil, ErrInvalidConfiguration
+		}
+		encoded, err := marshalGitHubWorkItemDerivedRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		result[destination] = encoded
+	}
+	if len(result) != len(values) {
+		return nil, ErrInvalidConfiguration
+	}
+	return result, nil
+}
+
+func marshalGitHubWorkItemDerivedRows(rows any) ([]json.RawMessage, error) {
+	encoded, err := json.Marshal(rows)
+	if err != nil {
+		return nil, err
+	}
+	var result []json.RawMessage
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		return nil, fmt.Errorf("%w: derived rows", ErrEffectRecoveryUnsafe)
+	}
+	if result == nil {
+		// A nil Go slice marshals to `null`, which round-trips back to nil. The
+		// deriver seam distinguishes "evaluated, produced nothing" from
+		// "missing destination" by key presence, so the value must be an empty
+		// slice, never a nil one.
+		result = []json.RawMessage{}
+	}
+	return result, nil
+}
+
+func assertGitHubWorkItemDerivedTenancy(claim Claim, item githubWorkItemRow) error {
+	if item.OrgID != claim.OrgID || item.Provider != claim.Provider ||
+		item.CreatedAt.IsZero() {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+// earliestGitHubWorkItemDerivedTime mirrors _earliest_utc: the earliest
+// non-null of the two, or nil when both are nil.
+func earliestGitHubWorkItemDerivedTime(values ...*time.Time) *time.Time {
+	var earliest *time.Time
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		candidate := value.UTC()
+		if earliest == nil || candidate.Before(*earliest) {
+			earliest = &candidate
+		}
+	}
+	return earliest
+}
+
+// normalizeGitHubWorkItemDerivedTeamID mirrors normalize_team_id
+// (providers/teams.py:36): None/blank becomes "unassigned", otherwise the
+// value is stripped.
+func normalizeGitHubWorkItemDerivedTeamID(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return githubWorkItemUnassignedTeamID
+	}
+	return strings.TrimSpace(*value)
+}
+
+// normalizeGitHubWorkItemDerivedTeamName mirrors normalize_team_name
+// (providers/teams.py:43).
+func normalizeGitHubWorkItemDerivedTeamName(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return githubWorkItemUnassignedTeamName
+	}
+	return strings.TrimSpace(*value)
+}

--- a/internal/providersync/github_work_item_derived_surfaces.go
+++ b/internal/providersync/github_work_item_derived_surfaces.go
@@ -301,8 +301,13 @@ func githubEstimateCoverageKeyLess(left, right githubEstimateCoverageKey) bool {
 // D16: the Python composite calls this inside its `for d in days` loop while
 // the function itself takes no day, so a multi-day backfill recomputes and
 // rewrites byte-identical rows once per day. This builder reproduces the
-// per-call result exactly; the repetition is a property of the caller and is
-// pinned at the route seam, not smoothed over here.
+// per-call result exactly; the repetition is a property of the CALLER, not of
+// this function, and is tracked as CHAOS-3494.
+//
+// It is NOT pinned here, and no oracle case covers it: proving it needs a
+// multi-day driver, which arrives with the deriver that owns the day loop.
+// Claiming a pin at a seam this PR does not contain would read as coverage
+// that does not exist.
 func buildGitHubWorkItemTeamAttributions(
 	claim Claim,
 	rows githubWorkItemRows,
@@ -577,6 +582,25 @@ func marshalGitHubWorkItemDerivedRows(rows any) ([]json.RawMessage, error) {
 	return result, nil
 }
 
+// assertGitHubWorkItemDerivedTenancy refuses a row that does not belong to the
+// claim, and a row whose created_at is missing.
+//
+// It is called BEFORE each builder's own window/terminal skips, deliberately.
+// A foreign-tenant row that happens to fall outside the window would otherwise
+// be silently skipped rather than refused, so whether a cross-tenant leak
+// raises would depend on the row's dates -- the check would hold only for the
+// rows that were going to be counted anyway, which is the opposite of a
+// tenancy fence. Asserting first makes the guarantee unconditional.
+//
+// DIVERGENCE FROM PYTHON, at-site: the CreatedAt.IsZero() clause hard-fails,
+// while Python accepts datetime(1,1,1) and carries it through. Go cannot
+// distinguish "absent" from "zero instant" -- time.Time's zero value IS
+// 0001-01-01 -- and every consumer here does date arithmetic against
+// created_at, so a zero would silently place the item before every window
+// rather than announce itself. Refusing is the safer half of the divergence
+// and it is a REJECTION, never a wrong number. No oracle case covers it,
+// because constructing one would require Python to accept an input this
+// function rejects; it is asserted by the unit test instead.
 func assertGitHubWorkItemDerivedTenancy(claim Claim, item githubWorkItemRow) error {
 	if item.OrgID != claim.OrgID || item.Provider != claim.Provider ||
 		item.CreatedAt.IsZero() {

--- a/internal/providersync/github_work_item_derived_surfaces.go
+++ b/internal/providersync/github_work_item_derived_surfaces.go
@@ -108,6 +108,40 @@ const (
 	githubWorkItemUnassignedTeamName = "Unassigned"
 )
 
+// Stored-precision quantization for computed_at, applied HERE at the builder
+// rather than only at the adapter boundary. The production feed is time.Now()
+// (complete_route.go:118), which carries nanoseconds; no destination column can
+// hold them. A stamp emitted at a precision the column cannot store is written,
+// quantized by the server, read back different, and the replay verdict is
+// Absent forever, so the committer rewrites on every recovery.
+//
+// The three destinations do NOT share a precision, so this cannot be one
+// constant: estimate coverage and team attributions are DateTime64(3), while
+// state durations is a plain DateTime (SECONDS). Each builder quantizes at its
+// own stamping site, next to the destination whose column decides the rule.
+//
+// DIVERGENCE FROM PYTHON (deliberate, D16 does not apply -- this is a
+// persistence contract, not a computed value): Python passes computed_at
+// through raw and lets the ClickHouse sink quantize on insert, because nothing
+// in Python ever compares a stamped value against a stored one. The Go
+// committer does exactly that on replay, so it must stamp what will be stored.
+// Every oracle case uses a whole-second ComputedAt, where the two are
+// identical; the divergence is only reachable with sub-precision digits.
+const (
+	githubEstimateCoverageStampPrecision = time.Millisecond
+	githubTeamAttributionStampPrecision  = time.Millisecond
+	githubStateDurationStampPrecision    = time.Second
+)
+
+// githubWorkItemDerivedStamp quantizes a stamp to what its column can store.
+// It is applied ONLY where computed_at is written into a row -- never to the
+// value the compute reads. An open item's final state segment ends at
+// computed_at, so truncating the arithmetic input would shorten duration_hours
+// against Python by up to a second.
+func githubWorkItemDerivedStamp(value time.Time, precision time.Duration) time.Time {
+	return value.UTC().Truncate(precision)
+}
+
 // buildGitHubWorkItemDerivedSurfaces is deliberately pure: the caller loads
 // the shared derivation context once and reuses it across backfill days. It
 // registers and activates nothing.
@@ -242,8 +276,10 @@ func buildGitHubEstimateCoverageMetricsDaily(
 			UnestimatedCount: bucket.unestimatedCount,
 			BacklogSize:      backlogSize,
 			Ratio:            ratio,
-			ComputedAt:       computedAt,
-			OrgID:            claim.OrgID,
+			ComputedAt: githubWorkItemDerivedStamp(
+				computedAt, githubEstimateCoverageStampPrecision,
+			),
+			OrgID: claim.OrgID,
 		})
 	}
 	return result, nil
@@ -293,11 +329,13 @@ func buildGitHubWorkItemTeamAttributions(
 				IsPrimary:  candidate.IsPrimary,
 				Confidence: candidate.Confidence,
 				Evidence:   candidate.Evidence,
-				ComputedAt: computedAt,
-				RepoID:     item.RepoID,
-				TeamID:     candidate.TeamID,
-				TeamName:   candidate.TeamName,
-				OrgID:      item.OrgID,
+				ComputedAt: githubWorkItemDerivedStamp(
+					computedAt, githubTeamAttributionStampPrecision,
+				),
+				RepoID:   item.RepoID,
+				TeamID:   candidate.TeamID,
+				TeamName: candidate.TeamName,
+				OrgID:    item.OrgID,
 			})
 		}
 	}
@@ -406,7 +444,11 @@ func buildGitHubWorkItemStateDurationsDaily(
 			Status:        key.status,
 			DurationHours: totalHours,
 			ItemsTouched:  len(itemsSeen[key]),
-			ComputedAt:    computedAt,
+			// The RAW computedAt above is what githubWorkItemStatusSegments
+			// used as the open segment's end; only the stamp is quantized.
+			ComputedAt: githubWorkItemDerivedStamp(
+				computedAt, githubStateDurationStampPrecision,
+			),
 			// Python divides the whole-day total by a fixed 24, not by the
 			// number of hours the window actually covers, so a partial-day
 			// window understates avg_wip. Mirrored.

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -442,6 +442,85 @@ func githubDerivedOracleCases() []oracleCase {
 			},
 		},
 		{
+			// M7 -- from_status FALLBACK. The first transition carries an EMPTY
+			// from_status, so both sides must fall back to the ITEM's status
+			// (compute_work_item_state_durations.py:86,
+			// githubWorkItemStatusSegments). The item's status is deliberately
+			// NOT "todo": with "todo" the fallback and the decoder default are
+			// the same value and the arm stays unmeasured.
+			ID: "from_status_empty_falls_back_to_item_status",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#60", map[string]any{
+						"status": "in_review",
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#60", "2026-08-04T06:00:00Z", "", "done"),
+				},
+			},
+		},
+		{
+			// M7 -- EMPTY-STRING team_id, which is NOT the same as NULL. A fact
+			// carrying a blank team id makes the attribution row persist "" while
+			// the coverage rollup normalises the same resolution to "unassigned".
+			// Only the unassigned_candidate case covers the NULL side.
+			ID: "empty_string_team_id_is_not_null",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Teams": []any{}, "Projects": []any{}, "Members": []any{},
+					"ManualFallbacks": []any{},
+					"Repos": []any{
+						githubDerivedOracleRepoFact(
+							"44444444-4444-4444-8444-444444444444", "acme/blank-team", "", "",
+						),
+					},
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#61", map[string]any{
+						"repo_id": "44444444-4444-4444-8444-444444444444",
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#61", "2026-08-04T05:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
+			// M7 -- EQUALITY BOUNDARIES, all three in one case because they share
+			// a window. #62 reaches a terminal state EXACTLY at the window end
+			// (terminalAt == end, so `terminalAt.Before(end)` is false and the
+			// item is NOT skipped). #63 is created EXACTLY at the window end
+			// (createdAt == end, so `!createdAt.Before(end)` holds and it IS
+			// skipped). #64's only segment ends exactly where it starts once
+			// clipped, so overlapEnd == overlapStart and it contributes nothing.
+			ID: "equality_boundaries_at_window_edges",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-06T00:30:00Z", "AsOf": "2026-08-06T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#62", map[string]any{
+						"story_points": 3, "completed_at": "2026-08-05T00:00:00Z",
+					}),
+					githubDerivedOracleItem("acme/api#63", map[string]any{
+						"created_at": "2026-08-05T00:00:00Z",
+					}),
+					githubDerivedOracleItem("acme/api#64", nil),
+				},
+				"Transitions": []any{
+					// Ends exactly at the window start, so after clipping the
+					// segment has zero length.
+					githubDerivedOracleTransition("acme/api#64", "2026-08-04T00:00:00Z", "todo", "done"),
+				},
+			},
+		},
+		{
 			// TIMEZONE: the window is UTC, and this case is chosen so the
 			// local and UTC calendar dates DISAGREE. 2026-08-04T23:30:00Z is
 			// still 2026-08-04 in UTC but already 2026-08-05 at +02:00, and
@@ -508,8 +587,15 @@ func TestGitHubWorkItemStateDurationsMatchLivePythonProduction(t *testing.T) {
 
 // The column structs below are the Go half of the column-oriented comparison.
 // They are STRUCTS, not maps, on purpose: typedEncode walks a struct's fields
-// exhaustively, so a field the production row declares and this projection
-// forgets is a compile-time or comparison failure, never a silent narrowing.
+// exhaustively, so every field this projection declares is compared.
+//
+// A field this projection FORGETS is caught as a COMPARISON failure, not a
+// compile-time one -- Go never requires a struct field to be used, so omitting
+// one compiles cleanly. What catches it is the OTHER side: the Python pair
+// reflects its field set from the production dataclass, so a field the record
+// declares and this struct omits appears in the Python row and not in the Go
+// row, and the comparison fails on the missing key. The guarantee rests on the
+// Python-side reflection, not on the Go type.
 
 type githubEstimateCoverageColumns struct {
 	Day              []githubWorkItemDerivedDay `json:"day"`

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -240,6 +240,53 @@ func githubDerivedOracleCases() []oracleCase {
 			},
 		},
 		{
+			// POPULATED-FACT class, and the only case that reaches the team
+			// and membership fact tables at all. One item resolves through
+			// assignee_membership (a Members fact matching its assignee), the
+			// other through issue_project (a Teams fact matching its
+			// project_key) -- two different sources, two different team ids,
+			// both at "high" confidence, sharing one work_scope_id. The
+			// repo-ownership case above covers a third source; project
+			// ownership, manual fallback and linked-issue inheritance remain
+			// the resolver pair's business, not these three destinations'.
+			//
+			// The Python pair asserts the production loader actually issued
+			// all four fact queries, so a case that silently stopped feeding
+			// facts fails rather than quietly narrowing to the empty class.
+			ID: "populated_facts_membership_and_project",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Projects": []any{}, "Repos": []any{}, "ManualFallbacks": []any{},
+					"Teams": []any{map[string]any{
+						"TeamID": "platform", "TeamName": "Platform",
+						"ProjectKeys": []any{"PLAT"},
+					}},
+					"Members": []any{map[string]any{
+						"Provider": "github", "TeamID": "payments",
+						"TeamName": "Payments", "MemberID": "m1",
+						"RawProviderUserID": "octocat", "RawEmail": "octo@example.com",
+						"IdentityFacets": []any{"octocat"},
+						"IsPrimary":      1, "Specificity": 50, "Priority": 20,
+						"UpdatedAt": "2026-07-01T00:00:00Z",
+					}},
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#20", map[string]any{
+						"assignees": []any{"octocat"}, "story_points": 8,
+					}),
+					githubDerivedOracleItem("acme/api#21", map[string]any{
+						"project_key": "PLAT",
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#20", "2026-08-04T03:00:00Z", "todo", "in_progress"),
+					githubDerivedOracleTransition("acme/api#21", "2026-08-04T09:00:00Z", "todo", "review"),
+				},
+			},
+		},
+		{
 			// TIMEZONE: the window is UTC, and this case is chosen so the
 			// local and UTC calendar dates DISAGREE. 2026-08-04T23:30:00Z is
 			// still 2026-08-04 in UTC but already 2026-08-05 at +02:00, and
@@ -521,6 +568,14 @@ func githubDerivedOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemR
 	if value, ok := raw["story_points"].(int); ok {
 		points := float64(value)
 		row.StoryPoints = &points
+	}
+	if value, ok := raw["project_key"].(string); ok {
+		row.ProjectKey = stringPointer(value)
+	}
+	if values, ok := raw["assignees"].([]any); ok {
+		for _, value := range values {
+			row.Assignees = append(row.Assignees, value.(string))
+		}
 	}
 	if value, ok := raw["repo_id"].(string); ok {
 		parsed, err := uuid.Parse(value)

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -287,6 +287,48 @@ func githubDerivedOracleCases() []oracleCase {
 			},
 		},
 		{
+			// LINKED-ISSUE DONOR class. The donor appears ONLY in `Donors`, never
+			// in `WorkItems`, so it can reach the resolver by exactly one route:
+			// the donor list both sides decode from this key. If either side
+			// stopped reading it -- or read a different key -- the donor would
+			// vanish for that side alone, #31 would fall back to "unassigned"
+			// there, and every column would diverge at once.
+			//
+			// #31 carries no repo, assignee, project_key or native_team_key, so
+			// its own cascade resolves to nothing and `baseNative` is false,
+			// which is what lets the inherited candidate through. The donor
+			// resolves through repo_ownership, an allowed donor source.
+			ID: "linked_issue_donor_inheritance",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Teams": []any{}, "Projects": []any{}, "Members": []any{},
+					"ManualFallbacks": []any{},
+					"Repos": []any{
+						githubDerivedOracleRepoFact(
+							"33333333-3333-4333-8333-333333333333", "acme/donor-repo",
+							"t9", "Team Nine",
+						),
+					},
+				},
+				"Donors": []any{
+					githubDerivedOracleItem("acme/api#30", map[string]any{
+						"repo_id": "33333333-3333-4333-8333-333333333333",
+					}),
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#31", nil),
+				},
+				"Dependencies": []any{
+					githubDerivedOracleDependency("acme/api#31", "acme/api#30", "relates_to"),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#31", "2026-08-04T07:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
 			// TIMEZONE: the window is UTC, and this case is chosen so the
 			// local and UTC calendar dates DISAGREE. 2026-08-04T23:30:00Z is
 			// still 2026-08-04 in UTC but already 2026-08-05 at +02:00, and
@@ -496,6 +538,11 @@ func buildGitHubDerivedOracleSurfaces(
 			rows.StatusTransitions, githubDerivedOracleGoTransition(t, raw.(map[string]any)),
 		)
 	}
+	for _, raw := range githubDerivedOracleList(input, "Dependencies") {
+		rows.Dependencies = append(
+			rows.Dependencies, githubDerivedOracleGoDependency(t, raw.(map[string]any)),
+		)
+	}
 	// Facts decode from the SAME case JSON the Python pair reads, so neither
 	// side can be handed a fact set the other never saw. An empty fact set
 	// still goes through the real context constructor: the resolver's
@@ -510,11 +557,50 @@ func buildGitHubDerivedOracleSurfaces(
 		t.Fatal(err)
 	}
 	derived := newGitHubWorkItemDerivationContext(facts)
+	// The linked-issue index is built here, not left nil, because production
+	// builds it too (loadGitHubWorkItemDerivationContext). Leaving it nil made
+	// the donor arm dead on the Go side while the Python pair wired a live
+	// resolver from the same case -- the two agreed only because no case
+	// supplied a donor, so the whole class sat unproven on both sides.
+	//
+	// The merge order mirrors production exactly: donors first, then the fresh
+	// rows, so a work item present in both lists resolves from its FRESH
+	// version. Donors decode with the SAME work-item decoder as WorkItems,
+	// which is why `Donors` carries the work-item shape rather than the
+	// PascalCase fact shape -- Python's `_work_item` reads this key too, and it
+	// requires `created_at`, a field the Go facts-side subject type does not
+	// even carry.
+	subjects := make(
+		map[string]githubWorkItemDerivationSubject,
+		len(rows.WorkItems)+len(githubDerivedOracleList(input, "Donors")),
+	)
+	for _, raw := range githubDerivedOracleList(input, "Donors") {
+		donor := githubWorkItemDerivationSubjectFromRow(
+			githubDerivedOracleGoItem(t, raw.(map[string]any)),
+		)
+		subjects[donor.WorkItemID] = donor
+	}
+	for _, row := range rows.WorkItems {
+		subject := githubWorkItemDerivationSubjectFromRow(row)
+		subjects[subject.WorkItemID] = subject
+	}
+	derived.linkedIssue = derived.buildLinkedIssueIndex(subjects, rows.Dependencies)
 	surfaces, err := buildGitHubWorkItemDerivedSurfaces(claim, rows, day, computedAt, derived)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return surfaces
+}
+
+// githubDerivedOracleList reads an OPTIONAL top-level case list. Most cases
+// carry no donors or dependencies, and a missing key must decode as empty
+// rather than panicking on a nil type assertion.
+func githubDerivedOracleList(input map[string]any, key string) []any {
+	values, ok := input[key].([]any)
+	if !ok {
+		return nil
+	}
+	return values
 }
 
 func githubDerivedOracleEmptyFacts() map[string]any {
@@ -541,6 +627,34 @@ func githubDerivedOracleTransition(id, occurredAt, from, to string) map[string]a
 	return map[string]any{
 		"work_item_id": id, "provider": "github", "occurred_at": occurredAt,
 		"from_status": from, "to_status": to, "org_id": githubDerivedOracleOrg,
+	}
+}
+
+// Dependencies are top-level beside WorkItems and Transitions because they are
+// ROWS -- the sync's own output -- not attribution facts. Python's `_dependency`
+// reads this exact shape.
+func githubDerivedOracleDependency(source, target, relationship string) map[string]any {
+	return map[string]any{
+		"source_work_item_id": source, "target_work_item_id": target,
+		"relationship_type": relationship, "relationship_type_raw": relationship,
+		"relationship_semantics_version": "canonical-blocks.v2",
+		"last_synced":                    "2026-08-04T00:00:00Z",
+		"org_id":                         githubDerivedOracleOrg,
+	}
+}
+
+func githubDerivedOracleGoDependency(
+	t *testing.T, raw map[string]any,
+) githubWorkItemDependencyRow {
+	t.Helper()
+	return githubWorkItemDependencyRow{
+		SourceWorkItemID:             raw["source_work_item_id"].(string),
+		TargetWorkItemID:             raw["target_work_item_id"].(string),
+		RelationshipType:             raw["relationship_type"].(string),
+		RelationshipTypeRaw:          githubDerivedOracleString(raw, "relationship_type_raw", ""),
+		RelationshipSemanticsVersion: githubDerivedOracleString(raw, "relationship_semantics_version", "canonical-blocks.v2"),
+		LastSynced:                   githubDerivedOracleTime(t, raw["last_synced"].(string)),
+		OrgID:                        raw["org_id"].(string),
 	}
 }
 

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -287,6 +287,62 @@ func githubDerivedOracleCases() []oracleCase {
 			},
 		},
 		{
+			// PRE-EXISTING DIVERGENCE (not introduced by this lane): Python's
+			// project-key resolver STRIPS the lookup value
+			// (providers/teams.py:88, `work_scope_id.strip()`), and the Go
+			// issue_project candidate looked it up raw. An item whose scope
+			// carries surrounding whitespace resolves to a team in Python and
+			// to nothing in Go.
+			ID: "issue_project_scope_needs_trimming",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Projects": []any{}, "Repos": []any{}, "Members": []any{},
+					"ManualFallbacks": []any{},
+					"Teams": []any{map[string]any{
+						"TeamID": "platform", "TeamName": "Platform",
+						"ProjectKeys": []any{"PLAT"},
+					}},
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#50", map[string]any{
+						"project_id": " PLAT ",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// PRE-EXISTING DIVERGENCE (not introduced by this lane): Python
+			// builds its match sets by DROPPING falsy values
+			// (compute_work_items.py:304-309), so a rule with a blank scope_id
+			// matches nothing. Go compared the blank scope_id against
+			// stringValue(nil) == "", so the rule matched EVERY item with a
+			// null repo -- a blank config row silently attributing the whole
+			// tenant to one team.
+			ID: "manual_fallback_blank_scope_id_matches_nothing",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Teams": []any{}, "Projects": []any{}, "Repos": []any{},
+					"Members": []any{},
+					"ManualFallbacks": []any{map[string]any{
+						"Provider": "github", "ScopeType": "repo", "ScopeID": "",
+						"TeamID": "catchall", "TeamName": "Catch All",
+						"Reason": "blank scope", "Priority": 100,
+					}},
+				},
+				"WorkItems": []any{
+					// No repo_id at all, which is what the blank rule used to
+					// collide with on the Go side.
+					githubDerivedOracleItem("acme/api#51", nil),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
 			// SORTING-KEY COLLISION class. Two members of the SAME team are
 			// assigned to one issue, so the resolver emits two
 			// assignee_membership candidates that agree on team_id and differ

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -1,0 +1,577 @@
+package providersync
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The three derived surfaces this file proves share one case shape, because in
+// production they share one resolver cascade and one work-item list. Each pair
+// selects its own destination's rows from the same case, so a case that
+// exercises a team-resolution edge exercises it for all three at once rather
+// than three fixtures drifting apart.
+//
+// Cases are COLUMN-ORIENTED on both sides: the Python pair transposes its
+// record list into one key per production field, so row ORDER is compared (a
+// reordering diverges every column at once) and the field set is reflected
+// from the production dataclass rather than hand-listed.
+
+const (
+	githubDerivedOracleOrg   = "org-acme"
+	githubDerivedOracleScope = "acme/api"
+)
+
+func githubDerivedOracleCases() []oracleCase {
+	return []oracleCase{
+		{
+			// Baseline: one estimated, one unestimated, both still open at the
+			// window end, so both land in the backlog and the ratio is a real
+			// fraction rather than the null-on-empty arm.
+			ID: "open_backlog_mixed_estimates",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#1", map[string]any{"story_points": 3}),
+					githubDerivedOracleItem("acme/api#2", nil),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// D16 PIN: the coverage bucket is created BEFORE the terminal-item
+			// skip, so an item completed before the window end still
+			// materialises an all-zero group with a NULL ratio. Removing that
+			// ordering in Go would drop this row entirely.
+			ID: "terminal_only_group",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#3", map[string]any{
+						"story_points": 5, "completed_at": "2026-08-02T09:00:00Z",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// closed_at alone (no completed_at) must count as terminal via the
+			// earliest-of-the-two rule, and an item created after the window
+			// end must not appear at all.
+			ID: "closed_only_and_future_creation",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-06T00:30:00Z", "AsOf": "2026-08-06T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#4", map[string]any{
+						"closed_at": "2026-08-03T09:00:00Z", "story_points": 2,
+					}),
+					githubDerivedOracleItem("acme/api#5", map[string]any{
+						"created_at": "2026-08-05T09:00:00Z",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// D16 PIN: with no attribution fact of any kind the resolver yields
+			// a single "unassigned" candidate whose team_id and team_name are
+			// NULL. The coverage rollup normalises the same resolution to
+			// "unassigned"/"Unassigned"; the attribution row does not. Both
+			// pairs read this one case, so the asymmetry is asserted, not
+			// assumed.
+			ID: "unassigned_candidate",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#6", map[string]any{
+						"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// Two statuses inside one day, split by a mid-day transition. The
+			// day boundary must clip the pre-window part of the first segment
+			// rather than counting it.
+			ID: "state_split_across_one_day",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#7", nil),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#7", "2026-08-04T06:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
+			// A transition at or before the segment start rewrites the open
+			// segment instead of closing one, so a pre-creation transition
+			// moves the item's start backwards. Also covers the stable-sort
+			// requirement: two transitions share an occurred_at, and Python's
+			// sorted() keeps their input order.
+			ID: "pre_creation_and_tied_transitions",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#8", nil),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#8", "2026-07-30T00:00:00Z", "todo", "in_progress"),
+					githubDerivedOracleTransition("acme/api#8", "2026-08-04T08:00:00Z", "in_progress", "review"),
+					githubDerivedOracleTransition("acme/api#8", "2026-08-04T08:00:00Z", "review", "done"),
+				},
+			},
+		},
+		{
+			// An item with transitions but no overlap with the window, beside
+			// an item with no transitions at all -- the latter contributes no
+			// state-duration row AND never registers its team name, because
+			// Python's `continue` precedes the team-name write.
+			ID: "no_transitions_and_no_overlap",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#9", nil),
+					githubDerivedOracleItem("acme/api#10", map[string]any{
+						"completed_at": "2026-08-02T00:00:00Z",
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#10", "2026-08-01T06:00:00Z", "todo", "done"),
+				},
+			},
+		},
+		{
+			// A transition occurring EXACTLY at the segment start takes the
+			// rewrite arm, not the close arm: `tr_at <= current_start`. Without
+			// this case a Go `Before` reads identically to Python's `<=`,
+			// because no other case puts a transition on the boundary.
+			ID: "transition_exactly_at_creation",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#12", nil),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#12", "2026-08-01T00:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
+			// TWO items land in the SAME (provider, scope, team, status) key,
+			// so items_touched must be a DISTINCT count of work-item ids rather
+			// than a count of contributing segments. Every other case has one
+			// item per key, where the two are indistinguishable.
+			ID: "two_items_share_one_state_key",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#13", nil),
+					githubDerivedOracleItem("acme/api#14", nil),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#13", "2026-08-04T04:00:00Z", "todo", "in_progress"),
+					githubDerivedOracleTransition("acme/api#14", "2026-08-04T10:00:00Z", "todo", "in_progress"),
+					// One item re-enters a status it already held today, so the
+					// same item contributes TWO segments to one key.
+					githubDerivedOracleTransition("acme/api#13", "2026-08-04T14:00:00Z", "in_progress", "todo"),
+					githubDerivedOracleTransition("acme/api#13", "2026-08-04T18:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
+			// The ONLY case that puts two items in one group under DIFFERENT
+			// team names: same work_scope_id (project_id), same resolved
+			// team_id, but two repo-ownership facts naming that team
+			// differently. Without it, first-writer-wins and last-writer-wins
+			// are indistinguishable -- and Python uses OPPOSITE rules in the
+			// two builders (coverage keeps the first, state durations keep the
+			// last), so both rules would sit unasserted.
+			ID: "one_group_two_team_names",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Teams": []any{}, "Projects": []any{}, "Members": []any{},
+					"ManualFallbacks": []any{},
+					"Repos": []any{
+						githubDerivedOracleRepoFact(
+							"11111111-1111-4111-8111-111111111111", "acme/api-a", "t1", "Team One",
+						),
+						githubDerivedOracleRepoFact(
+							"22222222-2222-4222-8222-222222222222", "acme/api-b", "t1", "Team Uno",
+						),
+					},
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#15", map[string]any{
+						"repo_id": "11111111-1111-4111-8111-111111111111",
+					}),
+					githubDerivedOracleItem("acme/api#16", map[string]any{
+						"repo_id": "22222222-2222-4222-8222-222222222222",
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#15", "2026-08-04T04:00:00Z", "todo", "in_progress"),
+					githubDerivedOracleTransition("acme/api#16", "2026-08-04T05:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
+			// TIMEZONE: the window is UTC, and this case is chosen so the
+			// local and UTC calendar dates DISAGREE. 2026-08-04T23:30:00Z is
+			// still 2026-08-04 in UTC but already 2026-08-05 at +02:00, and
+			// 2026-08-04T00:30:00Z is 2026-08-03 at -05:00. A builder that
+			// bucketed on a local date would put these on the wrong day.
+			ID: "utc_window_disagrees_with_local_date",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#11", nil),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#11", "2026-08-04T00:30:00Z", "todo", "in_progress"),
+					githubDerivedOracleTransition("acme/api#11", "2026-08-04T23:30:00Z", "in_progress", "done"),
+				},
+			},
+		},
+	}
+}
+
+func TestGitHubEstimateCoverageMatchesLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/estimate-coverage",
+		githubDerivedOracleCases(),
+		func(t *testing.T, input map[string]any) githubEstimateCoverageColumns {
+			t.Helper()
+			surfaces := buildGitHubDerivedOracleSurfaces(t, input)
+			return newGitHubEstimateCoverageColumns(surfaces.EstimateCoverage)
+		},
+		nil,
+	)
+}
+
+func TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/team-attributions",
+		githubDerivedOracleCases(),
+		func(t *testing.T, input map[string]any) githubTeamAttributionColumns {
+			t.Helper()
+			surfaces := buildGitHubDerivedOracleSurfaces(t, input)
+			return newGitHubTeamAttributionColumns(surfaces.TeamAttributions)
+		},
+		nil,
+	)
+}
+
+func TestGitHubWorkItemStateDurationsMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/state-durations",
+		githubDerivedOracleCases(),
+		func(t *testing.T, input map[string]any) githubStateDurationColumns {
+			t.Helper()
+			surfaces := buildGitHubDerivedOracleSurfaces(t, input)
+			return newGitHubStateDurationColumns(surfaces.StateDurations)
+		},
+		nil,
+	)
+}
+
+// The column structs below are the Go half of the column-oriented comparison.
+// They are STRUCTS, not maps, on purpose: typedEncode walks a struct's fields
+// exhaustively, so a field the production row declares and this projection
+// forgets is a compile-time or comparison failure, never a silent narrowing.
+
+type githubEstimateCoverageColumns struct {
+	Day              []githubWorkItemDerivedDay `json:"day"`
+	Provider         []string                   `json:"provider"`
+	WorkScopeID      []string                   `json:"work_scope_id"`
+	TeamID           []*string                  `json:"team_id"`
+	TeamName         []*string                  `json:"team_name"`
+	EstimatedCount   []int                      `json:"estimated_count"`
+	UnestimatedCount []int                      `json:"unestimated_count"`
+	BacklogSize      []int                      `json:"backlog_size"`
+	Ratio            []*float64                 `json:"ratio"`
+	ComputedAt       []time.Time                `json:"computed_at"`
+	OrgID            []string                   `json:"org_id"`
+}
+
+func newGitHubEstimateCoverageColumns(
+	rows []githubEstimateCoverageMetricsDailyRow,
+) githubEstimateCoverageColumns {
+	columns := githubEstimateCoverageColumns{
+		Day: []githubWorkItemDerivedDay{}, Provider: []string{},
+		WorkScopeID: []string{}, TeamID: []*string{}, TeamName: []*string{},
+		EstimatedCount: []int{}, UnestimatedCount: []int{}, BacklogSize: []int{},
+		Ratio: []*float64{}, ComputedAt: []time.Time{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.Day = append(columns.Day, row.Day)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.WorkScopeID = append(columns.WorkScopeID, row.WorkScopeID)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.EstimatedCount = append(columns.EstimatedCount, row.EstimatedCount)
+		columns.UnestimatedCount = append(columns.UnestimatedCount, row.UnestimatedCount)
+		columns.BacklogSize = append(columns.BacklogSize, row.BacklogSize)
+		columns.Ratio = append(columns.Ratio, row.Ratio)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+type githubTeamAttributionColumns struct {
+	WorkItemID []string     `json:"work_item_id"`
+	Provider   []string     `json:"provider"`
+	Source     []string     `json:"source"`
+	IsPrimary  []int        `json:"is_primary"`
+	Confidence []string     `json:"confidence"`
+	Evidence   []string     `json:"evidence"`
+	ComputedAt []time.Time  `json:"computed_at"`
+	RepoID     []*uuid.UUID `json:"repo_id"`
+	TeamID     []*string    `json:"team_id"`
+	TeamName   []*string    `json:"team_name"`
+	OrgID      []string     `json:"org_id"`
+}
+
+func newGitHubTeamAttributionColumns(
+	rows []githubWorkItemTeamAttributionRow,
+) githubTeamAttributionColumns {
+	columns := githubTeamAttributionColumns{
+		WorkItemID: []string{}, Provider: []string{}, Source: []string{},
+		IsPrimary: []int{}, Confidence: []string{}, Evidence: []string{},
+		ComputedAt: []time.Time{}, RepoID: []*uuid.UUID{}, TeamID: []*string{},
+		TeamName: []*string{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.WorkItemID = append(columns.WorkItemID, row.WorkItemID)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.Source = append(columns.Source, row.Source)
+		columns.IsPrimary = append(columns.IsPrimary, row.IsPrimary)
+		columns.Confidence = append(columns.Confidence, row.Confidence)
+		columns.Evidence = append(columns.Evidence, row.Evidence)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.RepoID = append(columns.RepoID, row.RepoID)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+type githubStateDurationColumns struct {
+	Day           []githubWorkItemDerivedDay `json:"day"`
+	Provider      []string                   `json:"provider"`
+	WorkScopeID   []string                   `json:"work_scope_id"`
+	TeamID        []string                   `json:"team_id"`
+	TeamName      []string                   `json:"team_name"`
+	Status        []string                   `json:"status"`
+	DurationHours []float64                  `json:"duration_hours"`
+	ItemsTouched  []int                      `json:"items_touched"`
+	ComputedAt    []time.Time                `json:"computed_at"`
+	AvgWIP        []float64                  `json:"avg_wip"`
+	OrgID         []string                   `json:"org_id"`
+}
+
+func newGitHubStateDurationColumns(
+	rows []githubWorkItemStateDurationDailyRow,
+) githubStateDurationColumns {
+	columns := githubStateDurationColumns{
+		Day: []githubWorkItemDerivedDay{}, Provider: []string{},
+		WorkScopeID: []string{}, TeamID: []string{}, TeamName: []string{},
+		Status: []string{}, DurationHours: []float64{}, ItemsTouched: []int{},
+		ComputedAt: []time.Time{}, AvgWIP: []float64{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.Day = append(columns.Day, row.Day)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.WorkScopeID = append(columns.WorkScopeID, row.WorkScopeID)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.Status = append(columns.Status, row.Status)
+		columns.DurationHours = append(columns.DurationHours, row.DurationHours)
+		columns.ItemsTouched = append(columns.ItemsTouched, row.ItemsTouched)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.AvgWIP = append(columns.AvgWIP, row.AvgWIP)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+func buildGitHubDerivedOracleSurfaces(
+	t *testing.T, input map[string]any,
+) githubWorkItemDerivedSurfaces {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["OrgID"].(string)
+	day, err := time.Parse("2006-01-02", input["Day"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	computedAt, err := time.Parse(time.RFC3339Nano, input["ComputedAt"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := githubWorkItemRows{}
+	for _, raw := range input["WorkItems"].([]any) {
+		rows.WorkItems = append(rows.WorkItems, githubDerivedOracleGoItem(t, raw.(map[string]any)))
+	}
+	for _, raw := range input["Transitions"].([]any) {
+		rows.StatusTransitions = append(
+			rows.StatusTransitions, githubDerivedOracleGoTransition(t, raw.(map[string]any)),
+		)
+	}
+	// Facts decode from the SAME case JSON the Python pair reads, so neither
+	// side can be handed a fact set the other never saw. An empty fact set
+	// still goes through the real context constructor: the resolver's
+	// unassigned fallback is production behaviour, not a shortcut this test
+	// may take on Python's behalf.
+	encodedFacts, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var facts githubWorkItemDerivationFacts
+	if err := json.Unmarshal(encodedFacts, &facts); err != nil {
+		t.Fatal(err)
+	}
+	derived := newGitHubWorkItemDerivationContext(facts)
+	surfaces, err := buildGitHubWorkItemDerivedSurfaces(claim, rows, day, computedAt, derived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return surfaces
+}
+
+func githubDerivedOracleEmptyFacts() map[string]any {
+	return map[string]any{
+		"Teams": []any{}, "Projects": []any{}, "Repos": []any{},
+		"Members": []any{}, "ManualFallbacks": []any{},
+	}
+}
+
+func githubDerivedOracleItem(id string, overrides map[string]any) map[string]any {
+	item := map[string]any{
+		"work_item_id": id, "provider": "github", "title": id,
+		"project_id": githubDerivedOracleScope,
+		"created_at": "2026-08-01T00:00:00Z", "updated_at": "2026-08-04T00:00:00Z",
+		"org_id": githubDerivedOracleOrg,
+	}
+	for key, value := range overrides {
+		item[key] = value
+	}
+	return item
+}
+
+func githubDerivedOracleTransition(id, occurredAt, from, to string) map[string]any {
+	return map[string]any{
+		"work_item_id": id, "provider": "github", "occurred_at": occurredAt,
+		"from_status": from, "to_status": to, "org_id": githubDerivedOracleOrg,
+	}
+}
+
+func githubDerivedOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemRow {
+	t.Helper()
+	row := githubWorkItemRow{
+		WorkItemID: raw["work_item_id"].(string),
+		Provider:   raw["provider"].(string),
+		Title:      raw["title"].(string),
+		Type:       "issue",
+		Status:     githubDerivedOracleString(raw, "status", "todo"),
+		ProjectID:  stringPointer(raw["project_id"].(string)),
+		CreatedAt:  githubDerivedOracleTime(t, raw["created_at"].(string)),
+		UpdatedAt:  githubDerivedOracleTime(t, raw["updated_at"].(string)),
+		OrgID:      raw["org_id"].(string),
+	}
+	if value, ok := raw["completed_at"].(string); ok {
+		parsed := githubDerivedOracleTime(t, value)
+		row.CompletedAt = &parsed
+	}
+	if value, ok := raw["closed_at"].(string); ok {
+		parsed := githubDerivedOracleTime(t, value)
+		row.ClosedAt = &parsed
+	}
+	if value, ok := raw["story_points"].(int); ok {
+		points := float64(value)
+		row.StoryPoints = &points
+	}
+	if value, ok := raw["repo_id"].(string); ok {
+		parsed, err := uuid.Parse(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row.RepoID = &parsed
+	}
+	return row
+}
+
+func githubDerivedOracleGoTransition(
+	t *testing.T, raw map[string]any,
+) githubWorkItemTransitionRow {
+	t.Helper()
+	return githubWorkItemTransitionRow{
+		WorkItemID: raw["work_item_id"].(string),
+		Provider:   raw["provider"].(string),
+		OccurredAt: githubDerivedOracleTime(t, raw["occurred_at"].(string)),
+		FromStatus: raw["from_status"].(string),
+		ToStatus:   raw["to_status"].(string),
+		OrgID:      raw["org_id"].(string),
+	}
+}
+
+func githubDerivedOracleString(raw map[string]any, key, fallback string) string {
+	if value, ok := raw[key].(string); ok && value != "" {
+		return value
+	}
+	return fallback
+}
+
+func githubDerivedOracleTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed.UTC()
+}
+
+// The two facts MUST carry different repo_full_name values. With the same
+// full name both facts match BOTH items (the resolver indexes by name as well
+// as by id), every item then sees both candidates, and the primary resolution
+// picks the same one for each -- which is exactly why the first version of
+// this case left the first-writer/last-writer mutants alive.
+func githubDerivedOracleRepoFact(repoID, repoFullName, teamID, teamName string) map[string]any {
+	return map[string]any{
+		"Provider": "github", "TeamID": teamID, "TeamName": teamName,
+		"RepoID": repoID, "RepoFullName": repoFullName,
+		"IsPrimary": 1, "Specificity": 100, "Priority": 10,
+		"UpdatedAt": "2026-07-01T00:00:00Z",
+	}
+}

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -287,6 +287,63 @@ func githubDerivedOracleCases() []oracleCase {
 			},
 		},
 		{
+			// SORTING-KEY COLLISION class. Two members of the SAME team are
+			// assigned to one issue, so the resolver emits two
+			// assignee_membership candidates that agree on team_id and differ
+			// only in the member behind them. Candidate dedup compares evidence
+			// and the evidence embeds member_id
+			// (github_work_items_derivation_context.go:328), so it cannot
+			// collapse them -- and the attribution table's sorting key
+			// (org_id, repo_id, work_item_id, ifNull(team_id,''), source)
+			// contains none of the fields they differ in. Two rows therefore
+			// land on ONE sorting key, differing in team_name, is_primary and
+			// evidence.
+			//
+			// This is the input class the write-side dedup exists for. Every
+			// other case has one candidate per (source, team_id), where a dedup
+			// that collapses correctly and one that does nothing at all are
+			// indistinguishable.
+			//
+			// The two facts carry DIFFERENT TeamName for one TeamID on purpose:
+			// with equal names the surviving row would look the same whichever
+			// of the two won, so which row survives would sit unasserted.
+			ID: "two_assignees_one_team_collide_on_sorting_key",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": map[string]any{
+					"Teams": []any{}, "Projects": []any{}, "Repos": []any{},
+					"ManualFallbacks": []any{},
+					"Members": []any{
+						map[string]any{
+							"Provider": "github", "TeamID": "payments",
+							"TeamName": "Payments", "MemberID": "m1",
+							"RawProviderUserID": "octocat", "RawEmail": "octo@example.com",
+							"IdentityFacets": []any{"octocat"},
+							"IsPrimary":      1, "Specificity": 50, "Priority": 20,
+							"UpdatedAt": "2026-07-01T00:00:00Z",
+						},
+						map[string]any{
+							"Provider": "github", "TeamID": "payments",
+							"TeamName": "Payments Squad", "MemberID": "m2",
+							"RawProviderUserID": "hubcat", "RawEmail": "hub@example.com",
+							"IdentityFacets": []any{"hubcat"},
+							"IsPrimary":      0, "Specificity": 50, "Priority": 20,
+							"UpdatedAt": "2026-07-01T00:00:00Z",
+						},
+					},
+				},
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#40", map[string]any{
+						"assignees": []any{"octocat", "hubcat"},
+					}),
+				},
+				"Transitions": []any{
+					githubDerivedOracleTransition("acme/api#40", "2026-08-04T09:00:00Z", "todo", "in_progress"),
+				},
+			},
+		},
+		{
 			// LINKED-ISSUE DONOR class. The donor appears ONLY in `Donors`, never
 			// in `WorkItems`, so it can reach the resolver by exactly one route:
 			// the donor list both sides decode from this key. If either side

--- a/internal/providersync/github_work_item_derived_surfaces_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_test.go
@@ -1,6 +1,7 @@
 package providersync
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -248,6 +249,191 @@ func TestGitHubTeamAttributionDedupeTieBreaksByOrder(t *testing.T) {
 	)
 	if len(deduped) != 1 || deduped[0].Evidence != "assignee_membership=m2" {
 		t.Fatalf("equal versions must keep the LAST row, got %+v", deduped)
+	}
+}
+
+// inspectGitHubWorkItemDerivedRows had no test at all, so the precedence it
+// encodes -- conflict beats absent beats exact -- was unasserted while every
+// batch readback in the package depends on it.
+//
+// The precedence is not cosmetic. The committer treats Absent as "write this",
+// so a batch containing one CONFLICTING row that reported Absent would be
+// rewritten straight over data that disagrees with it. Both orders are tested
+// because a verdict that wins only when it arrives first is not precedence, and
+// the natural mutant (swap the two arms) is invisible to a single ordering.
+func TestInspectGitHubWorkItemDerivedRowsTakesTheWeakestVerdict(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		inspections []EffectInspection
+		want        EffectInspection
+	}{
+		{"empty batch is exact", nil, EffectExact},
+		{"all exact", []EffectInspection{EffectExact, EffectExact}, EffectExact},
+		{"one absent", []EffectInspection{EffectExact, EffectAbsent}, EffectAbsent},
+		{"absent then exact", []EffectInspection{EffectAbsent, EffectExact}, EffectAbsent},
+		{"one conflict", []EffectInspection{EffectExact, EffectConflict}, EffectConflict},
+		{
+			"conflict BEFORE absent",
+			[]EffectInspection{EffectConflict, EffectAbsent}, EffectConflict,
+		},
+		{
+			// The ordering that catches an inverted precedence: absent is seen
+			// first and must NOT win.
+			"absent BEFORE conflict",
+			[]EffectInspection{EffectAbsent, EffectConflict}, EffectConflict,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			index := 0
+			got, err := inspectGitHubWorkItemDerivedRows(
+				tt.inspections,
+				func(inspection EffectInspection) (EffectInspection, error) {
+					index++
+					return inspection, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("verdict = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("inspection error is a conflict", func(t *testing.T) {
+		got, err := inspectGitHubWorkItemDerivedRows(
+			[]EffectInspection{EffectExact},
+			func(EffectInspection) (EffectInspection, error) {
+				return EffectExact, ErrInvalidConfiguration
+			},
+		)
+		if !errors.Is(err, ErrInvalidConfiguration) || got != EffectConflict {
+			t.Fatalf("got (%v, %v), want (EffectConflict, ErrInvalidConfiguration)", got, err)
+		}
+	})
+
+	t.Run("unknown verdict is rejected", func(t *testing.T) {
+		got, err := inspectGitHubWorkItemDerivedRows(
+			[]EffectInspection{EffectExact},
+			func(EffectInspection) (EffectInspection, error) {
+				return EffectInspection("not-a-verdict"), nil
+			},
+		)
+		if !errors.Is(err, ErrInvalidConfiguration) || got != EffectConflict {
+			t.Fatalf("got (%v, %v), want (EffectConflict, ErrInvalidConfiguration)", got, err)
+		}
+	})
+}
+
+// assertGitHubWorkItemDerivedTenancy has THREE clauses and, before this test,
+// deleting its entire body survived every test in the package: no fixture
+// carried a foreign org, a foreign provider or a zero created_at, so the fence
+// guarded nothing that was ever exercised.
+//
+// Each clause is mutated independently. A single "wrong row is rejected" case
+// would be satisfied by any one clause surviving, which is exactly how a
+// compound predicate keeps a dead clause hidden.
+func TestAssertGitHubWorkItemDerivedTenancyRejectsEachClause(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	valid := githubWorkItemRow{
+		WorkItemID: "acme/api#1", Provider: claim.Provider, Title: "t", Type: "issue",
+		Status: "todo", ProjectID: stringPointer("acme/api"),
+		CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+		OrgID:     claim.OrgID,
+	}
+	if err := assertGitHubWorkItemDerivedTenancy(claim, valid); err != nil {
+		t.Fatalf("the valid row must pass, else every case below is vacuous: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(githubWorkItemRow) githubWorkItemRow
+	}{
+		{"foreign org", func(row githubWorkItemRow) githubWorkItemRow {
+			row.OrgID = "org-other"
+			return row
+		}},
+		{"empty org", func(row githubWorkItemRow) githubWorkItemRow {
+			row.OrgID = ""
+			return row
+		}},
+		{"foreign provider", func(row githubWorkItemRow) githubWorkItemRow {
+			row.Provider = "gitlab"
+			return row
+		}},
+		{
+			// Go's zero time.Time IS 0001-01-01, so "absent" and "the zero
+			// instant" are the same value. Python accepts datetime(1,1,1);
+			// this port refuses it rather than silently sorting the item
+			// before every window.
+			"zero created_at",
+			func(row githubWorkItemRow) githubWorkItemRow {
+				row.CreatedAt = time.Time{}
+				return row
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := assertGitHubWorkItemDerivedTenancy(claim, tt.mutate(valid)); !errors.Is(
+				err, ErrInvalidConfiguration,
+			) {
+				t.Errorf("got %v, want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+// The assertion must run BEFORE the window and terminal skips, or a
+// foreign-tenant row that falls outside the window is silently skipped instead
+// of refused -- making the tenancy guarantee depend on the row's dates.
+//
+// Every builder is checked, because each has its own skip and each could
+// regress independently. The row is placed OUTSIDE the day window on purpose:
+// with an in-window row all three would raise even if the assertion sat after
+// the skip, and the ordering would stay unmeasured.
+func TestGitHubWorkItemDerivedBuildersAssertTenancyBeforeSkipping(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	day := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	computedAt := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	foreign := githubWorkItemRow{
+		WorkItemID: "acme/api#99", Provider: "github", Title: "t", Type: "issue",
+		Status: "todo", ProjectID: stringPointer("acme/api"),
+		// Created AFTER the window ends, so every builder's own skip would
+		// drop it before ever looking at the tenant.
+		CreatedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		OrgID:     "org-other",
+	}
+	rows := githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{foreign},
+		StatusTransitions: []githubWorkItemTransitionRow{{
+			WorkItemID: "acme/api#99", Provider: "github",
+			OccurredAt: time.Date(2026, 9, 1, 6, 0, 0, 0, time.UTC),
+			FromStatus: "todo", ToStatus: "in_progress", OrgID: claim.OrgID,
+		}},
+	}
+	derived := newGitHubWorkItemDerivationContext(githubWorkItemDerivationFacts{})
+	if _, err := buildGitHubWorkItemDerivedSurfaces(
+		claim, rows, day, computedAt, derived,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("composite: got %v, want ErrInvalidConfiguration", err)
+	}
+	if _, err := buildGitHubEstimateCoverageMetricsDaily(
+		claim, rows, day, day.AddDate(0, 0, 1), computedAt, derived,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Errorf("estimate coverage: got %v, want ErrInvalidConfiguration", err)
+	}
+	if _, err := buildGitHubWorkItemTeamAttributions(
+		claim, rows, computedAt, derived,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Errorf("team attributions: got %v, want ErrInvalidConfiguration", err)
+	}
+	if _, err := buildGitHubWorkItemStateDurationsDaily(
+		claim, rows, day, day.AddDate(0, 0, 1), computedAt, derived,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Errorf("state durations: got %v, want ErrInvalidConfiguration", err)
 	}
 }
 

--- a/internal/providersync/github_work_item_derived_surfaces_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_test.go
@@ -74,6 +74,183 @@ func TestGitHubWorkItemDerivedSurfacesQuantizeStampsAtBuilderEntry(t *testing.T)
 	}
 }
 
+// githubWorkItemDerivedCollisionFixture is the Go twin of the
+// two_assignees_one_team_collide_on_sorting_key oracle case: two members of ONE
+// team assigned to one issue. It is built from the REAL derivation context and
+// the REAL builder, so if the resolver ever stops emitting two candidates here
+// the collision tests below fail rather than quietly becoming vacuous.
+func githubWorkItemDerivedCollisionFixture(
+	t *testing.T, computedAt time.Time,
+) githubWorkItemDerivedSurfaces {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	facts := githubWorkItemDerivationFacts{
+		Members: []githubWorkItemDerivationMemberFact{
+			{
+				Provider: "github", TeamID: "payments", TeamName: "Payments",
+				MemberID: "m1", RawProviderUserID: stringPointer("octocat"),
+				IdentityFacets: []string{"octocat"},
+				IsPrimary:      1, Specificity: 50, Priority: 20,
+				UpdatedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				Provider: "github", TeamID: "payments", TeamName: "Payments Squad",
+				MemberID: "m2", RawProviderUserID: stringPointer("hubcat"),
+				IdentityFacets: []string{"hubcat"},
+				IsPrimary:      0, Specificity: 50, Priority: 20,
+				UpdatedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	rows := githubWorkItemRows{WorkItems: []githubWorkItemRow{{
+		WorkItemID: "acme/api#40", Provider: "github", Title: "t", Type: "issue",
+		Status: "todo", ProjectID: stringPointer("acme/api"),
+		Assignees: []string{"octocat", "hubcat"},
+		CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+		OrgID:     claim.OrgID,
+	}}}
+	surfaces, err := buildGitHubWorkItemDerivedSurfaces(
+		claim, rows, time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC), computedAt,
+		newGitHubWorkItemDerivationContext(facts),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return surfaces
+}
+
+// The dedup's whole reason to exist is a real builder output that collides.
+// The predecessor's B2 work asserted the dedup in the abstract without ever
+// showing the resolver produces a collision, which leaves "the dedup collapses
+// it" and "there was nothing to collapse" indistinguishable. This asserts the
+// COLLISION first, then the collapse.
+func TestGitHubTeamAttributionCollisionIsRealAndCollapses(t *testing.T) {
+	computedAt := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	surfaces := githubWorkItemDerivedCollisionFixture(t, computedAt)
+
+	rows := surfaces.TeamAttributions
+	byKey := map[string][]githubWorkItemTeamAttributionRow{}
+	for _, row := range rows {
+		byKey[githubTeamAttributionSortingKey(row)] = append(
+			byKey[githubTeamAttributionSortingKey(row)], row,
+		)
+	}
+	var collided []githubWorkItemTeamAttributionRow
+	for _, group := range byKey {
+		if len(group) > 1 {
+			collided = group
+		}
+	}
+	if len(collided) != 2 {
+		t.Fatalf("fixture produced no sorting-key collision (%d rows, %d keys); "+
+			"the dedup tests below would be vacuous", len(rows), len(byKey))
+	}
+	// They must differ in fields the sorting key does NOT carry -- otherwise
+	// the collision is harmless and proves nothing about which row survives.
+	if collided[0].TeamName == nil || collided[1].TeamName == nil ||
+		*collided[0].TeamName == *collided[1].TeamName {
+		t.Errorf("collided rows must differ in team_name, got %v / %v",
+			collided[0].TeamName, collided[1].TeamName)
+	}
+	if collided[0].Evidence == collided[1].Evidence {
+		t.Errorf("collided rows must differ in evidence, got %q twice",
+			collided[0].Evidence)
+	}
+
+	deduped := githubWorkItemDerivedSortingKeyDedupe(
+		rows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,
+	)
+	if len(deduped) != len(byKey) {
+		t.Fatalf("dedup left %d rows for %d distinct sorting keys", len(deduped), len(byKey))
+	}
+	// Name the survivor. "The count dropped" would also pass if the dedup kept
+	// an arbitrary row, and the readback expectation has to match the row the
+	// server actually stores.
+	var survivor *githubWorkItemTeamAttributionRow
+	for index, row := range deduped {
+		if githubTeamAttributionSortingKey(row) == githubTeamAttributionSortingKey(collided[0]) {
+			survivor = &deduped[index]
+		}
+	}
+	if survivor == nil {
+		t.Fatal("dedup dropped the collided sorting key entirely")
+	}
+	if survivor.Evidence != collided[1].Evidence {
+		t.Errorf("dedup kept evidence %q, want the LAST occurrence %q",
+			survivor.Evidence, collided[1].Evidence)
+	}
+}
+
+// Last-wins is only correct while every row in a batch shares one computed_at.
+// That is true today and nothing enforces it: the dedup picks the row the
+// server would NOT keep the moment a batch carries mixed versions, because
+// ReplacingMergeTree resolves by version, not by insertion order. The
+// expectation would then name a row the storage discards, and the readback
+// wedges at Conflict forever.
+//
+// Ordering is still the TIE-break, so the equal-version behaviour the
+// collision test above pins is unchanged.
+func TestGitHubTeamAttributionDedupePrefersHighestVersion(t *testing.T) {
+	older := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 5, 6, 0, 0, 0, time.UTC)
+	teamID := "payments"
+	row := func(evidence string, computedAt time.Time) githubWorkItemTeamAttributionRow {
+		return githubWorkItemTeamAttributionRow{
+			WorkItemID: "acme/api#40", Provider: "github",
+			Source: "assignee_membership", IsPrimary: 1, Confidence: "high",
+			Evidence: evidence, ComputedAt: computedAt, TeamID: &teamID,
+			OrgID: "org-acme",
+		}
+	}
+	// The NEWER row is FIRST, so index order and version order disagree.
+	rows := []githubWorkItemTeamAttributionRow{
+		row("assignee_membership=m1", newer),
+		row("assignee_membership=m2", older),
+	}
+	if githubTeamAttributionSortingKey(rows[0]) != githubTeamAttributionSortingKey(rows[1]) {
+		t.Fatal("fixture rows must share a sorting key")
+	}
+	deduped := githubWorkItemDerivedSortingKeyDedupe(
+		rows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,
+	)
+	if len(deduped) != 1 {
+		t.Fatalf("dedup left %d rows, want 1", len(deduped))
+	}
+	if !deduped[0].ComputedAt.Equal(newer) {
+		t.Errorf("dedup kept computed_at %v, want the HIGHEST version %v",
+			deduped[0].ComputedAt, newer)
+	}
+	if deduped[0].Evidence != "assignee_membership=m1" {
+		t.Errorf("dedup kept %q, want the highest-version row", deduped[0].Evidence)
+	}
+}
+
+// Equal versions must still fall back to ordering, which is what the stored
+// outcome depends on when a batch shares one computed_at -- the case every
+// real batch takes today.
+func TestGitHubTeamAttributionDedupeTieBreaksByOrder(t *testing.T) {
+	stamp := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	teamID := "payments"
+	row := func(evidence string) githubWorkItemTeamAttributionRow {
+		return githubWorkItemTeamAttributionRow{
+			WorkItemID: "acme/api#40", Provider: "github",
+			Source: "assignee_membership", IsPrimary: 1, Confidence: "high",
+			Evidence: evidence, ComputedAt: stamp, TeamID: &teamID,
+			OrgID: "org-acme",
+		}
+	}
+	deduped := githubWorkItemDerivedSortingKeyDedupe(
+		[]githubWorkItemTeamAttributionRow{
+			row("assignee_membership=m1"), row("assignee_membership=m2"),
+		},
+		githubTeamAttributionSortingKey, githubTeamAttributionVersion,
+	)
+	if len(deduped) != 1 || deduped[0].Evidence != "assignee_membership=m2" {
+		t.Fatalf("equal versions must keep the LAST row, got %+v", deduped)
+	}
+}
+
 // Quantizing the STAMP must not quantize the value the compute uses. An open
 // item's final segment ends at computed_at, so truncating the arithmetic input
 // to seconds would shorten duration_hours by up to a second against Python,

--- a/internal/providersync/github_work_item_derived_surfaces_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_test.go
@@ -1,0 +1,121 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+)
+
+// The production feed for computed_at is time.Now() (complete_route.go:118),
+// which carries NANOSECONDS. None of the three destinations can store them:
+// estimate coverage and team attributions are DateTime64(3) and state
+// durations is a plain DateTime. A stamp the builder emits at a precision the
+// column cannot hold is written, quantized by the server, read back different,
+// and the replay verdict is Absent forever.
+//
+// Every oracle case uses a whole-second ComputedAt, so the oracle pairs cannot
+// see this: it needs a fixture that actually carries sub-precision digits.
+func TestGitHubWorkItemDerivedSurfacesQuantizeStampsAtBuilderEntry(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	day := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	// 123456789ns is chosen so the millisecond and the second truncation
+	// disagree with each other AND with the raw value: a builder that
+	// quantized everything to one precision fails this, not just a builder
+	// that quantizes nothing.
+	computedAt := time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC)
+	wantMillis := time.Date(2026, 8, 5, 0, 30, 0, 123000000, time.UTC)
+	wantSeconds := time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+
+	item := githubWorkItemRow{
+		WorkItemID: "acme/api#1", Provider: "github", Title: "t", Type: "issue",
+		Status: "todo", ProjectID: stringPointer("acme/api"),
+		CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+		OrgID:     claim.OrgID,
+	}
+	rows := githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{item},
+		StatusTransitions: []githubWorkItemTransitionRow{{
+			WorkItemID: "acme/api#1", Provider: "github",
+			OccurredAt: time.Date(2026, 8, 4, 6, 0, 0, 0, time.UTC),
+			FromStatus: "todo", ToStatus: "in_progress", OrgID: claim.OrgID,
+		}},
+	}
+	surfaces, err := buildGitHubWorkItemDerivedSurfaces(
+		claim, rows, day, computedAt, newGitHubWorkItemDerivationContext(
+			githubWorkItemDerivationFacts{},
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(surfaces.EstimateCoverage) == 0 || len(surfaces.TeamAttributions) == 0 ||
+		len(surfaces.StateDurations) == 0 {
+		t.Fatalf("fixture produced no rows on some surface: %d/%d/%d",
+			len(surfaces.EstimateCoverage), len(surfaces.TeamAttributions),
+			len(surfaces.StateDurations))
+	}
+	for _, row := range surfaces.EstimateCoverage {
+		if !row.ComputedAt.Equal(wantMillis) {
+			t.Errorf("estimate coverage computed_at = %v, want %v (DateTime64(3))",
+				row.ComputedAt, wantMillis)
+		}
+	}
+	for _, row := range surfaces.TeamAttributions {
+		if !row.ComputedAt.Equal(wantMillis) {
+			t.Errorf("team attribution computed_at = %v, want %v (DateTime64(3))",
+				row.ComputedAt, wantMillis)
+		}
+	}
+	for _, row := range surfaces.StateDurations {
+		if !row.ComputedAt.Equal(wantSeconds) {
+			t.Errorf("state duration computed_at = %v, want %v (plain DateTime)",
+				row.ComputedAt, wantSeconds)
+		}
+	}
+}
+
+// Quantizing the STAMP must not quantize the value the compute uses. An open
+// item's final segment ends at computed_at, so truncating the arithmetic input
+// to seconds would shorten duration_hours by up to a second against Python,
+// which passes computed_at through raw. This asserts the segment math still
+// sees the FULL-precision instant while the stamp is quantized.
+func TestGitHubWorkItemStateDurationsKeepFullPrecisionSegmentEnd(t *testing.T) {
+	claim := githubWorkItemOracleClaim()
+	day := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	// Sits INSIDE the window so the open segment's end is computed_at itself
+	// rather than the window end, which is what exposes the truncation.
+	computedAt := time.Date(2026, 8, 4, 12, 0, 0, 500000000, time.UTC)
+	rows := githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{{
+			WorkItemID: "acme/api#1", Provider: "github", Title: "t", Type: "issue",
+			Status: "todo", ProjectID: stringPointer("acme/api"),
+			CreatedAt: time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+			OrgID:     claim.OrgID,
+		}},
+		StatusTransitions: []githubWorkItemTransitionRow{{
+			WorkItemID: "acme/api#1", Provider: "github",
+			OccurredAt: time.Date(2026, 8, 4, 6, 0, 0, 0, time.UTC),
+			FromStatus: "todo", ToStatus: "in_progress", OrgID: claim.OrgID,
+		}},
+	}
+	surfaces, err := buildGitHubWorkItemDerivedSurfaces(
+		claim, rows, day, computedAt, newGitHubWorkItemDerivationContext(
+			githubWorkItemDerivationFacts{},
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total float64
+	for _, row := range surfaces.StateDurations {
+		total += row.DurationHours
+	}
+	// 00:00 -> 12:00:00.5 == 12.0001388...h. A seconds-truncated segment end
+	// would give exactly 12.
+	want := 12.0 + 0.5/3600.0
+	if diff := total - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("total duration_hours = %.12f, want %.12f (full-precision segment end)",
+			total, want)
+	}
+}

--- a/internal/providersync/github_work_items_derivation_context.go
+++ b/internal/providersync/github_work_items_derivation_context.go
@@ -354,8 +354,21 @@ func githubWorkItemDerivationCandidateFromFact(
 	if teamName == "" {
 		teamName = teamID
 	}
+	// An ownership row's team_id is passed through RAW by Python, so a blank
+	// team id persists as "" on work_item_team_attributions -- NOT as NULL.
+	// githubWorkItemDerivationStringPointer maps "" to nil, which made Go write
+	// NULL where Python writes "", and in a Nullable(String) column those are
+	// different values. The two daily rollups normalise both to "unassigned",
+	// so the attribution table is the only surface that can see it. Pinned by
+	// the empty_string_team_id_is_not_null oracle case.
+	//
+	// Only this FACT-derived path is corrected, because only it is measured.
+	// The native_team, issue_project, manual_fallback and linked_issue
+	// candidates still route through the nil-on-empty helper: a blank team id
+	// is not reachable there from any oracle case in this PR, and changing
+	// them would be an unmeasured claim.
 	return githubWorkItemDerivationCandidate{
-		Source: source, TeamID: githubWorkItemDerivationStringPointer(teamID), TeamName: githubWorkItemDerivationStringPointer(teamName),
+		Source: source, TeamID: &teamID, TeamName: &teamName,
 		Confidence: confidenceForPrimary(isPrimary), Evidence: evidence,
 		IsPrimary: isPrimary, Specificity: specificity, Priority: priority,
 		UpdatedAt: normalizedDerivationTime(updatedAt),

--- a/internal/providersync/github_work_items_derivation_context.go
+++ b/internal/providersync/github_work_items_derivation_context.go
@@ -502,7 +502,12 @@ func (derived githubWorkItemDerivationContext) issueProjectCandidate(
 		keys = append(keys, *subject.ProjectKey)
 	}
 	for _, key := range keys {
-		team, exists := derived.projectKeyTeams[key]
+		// Python looks the key up STRIPPED (providers/teams.py:88,
+		// `work_scope_id.strip()`) but reports the RAW key in its evidence, so
+		// the trim belongs on the lookup alone. Trimming the evidence too
+		// would swap one divergence for another; both halves are pinned by the
+		// issue_project_scope_needs_trimming oracle case.
+		team, exists := derived.projectKeyTeams[strings.TrimSpace(key)]
 		if !exists {
 			continue
 		}
@@ -539,11 +544,29 @@ func (derived githubWorkItemDerivationContext) manualCandidates(
 		matched := false
 		switch rule.ScopeType {
 		case "repo":
-			matched = scopeID == githubWorkItemDerivationStringValue(subject.RepoID) || scopeID == githubWorkItemDerivationStringValue(subject.ProjectID)
+			// Python compares against a SET built by dropping falsy values
+			// (compute_work_items.py:304-309), so a blank scope_id matches
+			// nothing. Comparing directly against stringValue(nil) == ""
+			// instead made a blank rule match EVERY item with a null repo --
+			// one empty config row silently attributing the whole tenant to
+			// one team. githubWorkItemDerivationScopeMatch reproduces the set
+			// semantics: empty candidates are dropped and an empty scope_id
+			// can never match.
+			matched = githubWorkItemDerivationScopeMatch(scopeID,
+				githubWorkItemDerivationStringValue(subject.RepoID),
+				githubWorkItemDerivationStringValue(subject.ProjectID))
 		case "project":
-			matched = scopeID == githubWorkItemDerivationStringValue(subject.ProjectID) || scopeID == githubWorkItemDerivationStringValue(subject.ProjectKey) || scopeID == workItemDerivationScope(subject)
+			matched = githubWorkItemDerivationScopeMatch(scopeID,
+				githubWorkItemDerivationStringValue(subject.ProjectID),
+				githubWorkItemDerivationStringValue(subject.ProjectKey),
+				workItemDerivationScope(subject))
 		case "member":
 			for _, assignee := range subject.Assignees {
+				// Python's member_ids drops falsy assignees, so a blank
+				// assignee cannot be matched by a blank rule either.
+				if scopeID == "" || assignee == "" {
+					continue
+				}
 				matched = matched || normalizeDerivationIdentity(scopeID) == normalizeDerivationIdentity(assignee)
 			}
 		case "issue_key_prefix":
@@ -564,6 +587,21 @@ func (derived githubWorkItemDerivationContext) manualCandidates(
 		})
 	}
 	return result
+}
+
+// githubWorkItemDerivationScopeMatch mirrors Python's `scope_id in {...}`
+// where the set is built by dropping falsy values: an empty scope_id matches
+// nothing, and an empty candidate is not a member.
+func githubWorkItemDerivationScopeMatch(scopeID string, candidates ...string) bool {
+	if scopeID == "" {
+		return false
+	}
+	for _, candidate := range candidates {
+		if candidate != "" && strings.TrimSpace(candidate) == scopeID {
+			return true
+		}
+	}
+	return false
 }
 
 func githubWorkItemIssueKeyPrefix(workItemID string) string {

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -478,7 +478,7 @@
           "integration",
           "-count=1",
           "-run",
-          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "^TestGitHubEstimateCoverageReadbackFencesTeamID$|^TestGitHubWorkItemTeamAttributionsReadbackFencesTeamID$|^TestGitHubWorkItemStateDurationsReadbackFencesDay$",
           "./internal/providersync/"
         ]
       ]
@@ -497,7 +497,7 @@
           "integration",
           "-count=1",
           "-run",
-          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "^TestGitHubEstimateCoverageReadbackFencesTeamID$|^TestGitHubWorkItemTeamAttributionsReadbackFencesTeamID$|^TestGitHubWorkItemStateDurationsReadbackFencesDay$",
           "./internal/providersync/"
         ]
       ]
@@ -516,7 +516,7 @@
           "integration",
           "-count=1",
           "-run",
-          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "^TestGitHubEstimateCoverageReadbackFencesTeamID$|^TestGitHubWorkItemTeamAttributionsReadbackFencesTeamID$|^TestGitHubWorkItemStateDurationsReadbackFencesDay$",
           "./internal/providersync/"
         ]
       ]
@@ -538,7 +538,8 @@
           "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
           "./internal/providersync/"
         ]
-      ]
+      ],
+      "expected_survivor_reason": "UNREACHABLE while the fences hold, and measured as such rather than assumed. This readback's WHERE pins the COMPLETE sorting key (org_id, day, provider, work_scope_id, ifNull(team_id,'')), so FINAL can return at most one row and found>1 is not producible by any input -- which is why moving the duplicate check below the comparison changes nothing observable. The branch is defensive depth for the case where a fence regresses, and every fence that would make it reachable has its OWN mutation: E2 (partition/day), E10 (team_id), and for the sibling tables E11 and E12. Input class: a batch whose expected row shares its full sorting key with a second stored row -- unconstructible against this schema, verified by the sibling-row tests, which write exactly such a sibling differing in one fenced column and still read found=1."
     },
     {
       "id": "E14-batch-verdict-conflict-outranks-absent",

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -336,6 +336,82 @@
      "./internal/providersync/"
     ]
    ]
+  },
+  {
+   "id": "E6-coverage-compares-at-stored-millisecond-precision",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}\n\treturn EffectExact\n}\n\nfunc compareGitHubWorkItemTeamAttributionVersion(",
+   "replace": "\tif !actual.ComputedAt.Equal(expected.ComputedAt) {\n\t\treturn EffectAbsent\n\t}\n\treturn EffectExact\n}\n\nfunc compareGitHubWorkItemTeamAttributionVersion(",
+   "rationale": "estimate_coverage_metrics_daily.computed_at is DateTime64(3): a sub-millisecond stamp quantizes on write, so an untruncated expectation can NEVER equal the stored value and replay answers Absent forever. #1537 shipped 13 green integration tests over this because every fixture had ns=0.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E7-state-durations-compares-at-stored-second-precision",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}",
+   "replace": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}",
+   "rationale": "work_item_state_durations_daily.computed_at is a plain DateTime -- SECONDS, not milliseconds. Truncating to milliseconds like the other two tables leaves any sub-second stamp permanently unequal to the stored value.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E8-attribution-dedupes-colliding-sorting-keys-on-write",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)\n\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
+   "replace": "\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
+   "rationale": "two candidates differing only in team_name share a full sorting key and collapse under RMT to ONE row; without deterministic dedup the readback finds 1 row whose team_name matches only one of the two expectations, reads Conflict, and wedges recovery permanently",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E9-attribution-dedupes-the-expectation-too",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)\n\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
+   "replace": "\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
+   "rationale": "deduping only the write is not enough: the expectation must name the row the write actually leaves behind, or the readback compares against a row storage discarded",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
+    ]
+   ]
   }
  ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -1,0 +1,184 @@
+{
+ "schema_version": 1,
+ "name": "github work-item derived surfaces (coverage, team attributions, state durations)",
+ "build": [
+  "go",
+  "test",
+  "-run",
+  "^$",
+  "./internal/providersync/"
+ ],
+ "mutations": [
+  {
+   "id": "R1-coverage-bucket-created-before-terminal-skip",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
+   "replace": "\t\tif terminalAt != nil && terminalAt.Before(end) {\n\t\t\tcontinue\n\t\t}\n\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
+   "rationale": "Python creates the coverage bucket BEFORE skipping terminal items, so an item that reached a terminal state before the window end still materialises an all-zero group with a NULL ratio. Hoisting the skip is the 'obvious fix' a porter would make and it silently drops rows.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R2-coverage-team-name-first-writer-wins",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}",
+   "replace": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}\n\t\tbucket.teamName = normalizeGitHubWorkItemDerivedTeamName(teamName)",
+   "rationale": "coverage keeps the FIRST contributing item's team name for a group; state durations keep the LAST. The two Python rules are opposite and must not be shared or swapped.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R3-avg-wip-divides-by-fixed-24",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "AvgWIP: totalHours / 24.0,",
+   "replace": "AvgWIP: totalHours / 12.0,",
+   "rationale": "Python divides the day total by a fixed 24 regardless of how much of the day the window covers.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R4-transition-sort-is-stable",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\tsort.SliceStable(ordered, func(left, right int) bool {\n\t\treturn ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
+   "replace": "\tsort.Slice(ordered, func(left, right int) bool {\n\t\treturn !ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
+   "rationale": "Python's sorted() is stable, so transitions sharing an occurred_at keep input order. sort.Slice is not stable and would reorder them.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R5-transition-at-segment-start-rewrites",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\tif !occurredAt.After(currentStart) {",
+   "replace": "\t\tif occurredAt.Before(currentStart) {",
+   "rationale": "mirrors Python's `tr_at <= current_start` rewrite arm rather than a strict `<`",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ],
+   "expected_survivor_reason": "Provably equivalent, not merely unobserved. The two forms differ ONLY at exact equality, and at equality the close arm emits a segment whose end equals its start, which githubWorkItemStatusSegments' own `segment.end.After(segment.start)` filter removes before returning. Both arms therefore leave identical state (current_status = to_status, current_start = occurredAt) and identical output. The transition_exactly_at_creation case forces the boundary so this is measured on the exact input class that distinguishes them, not assumed from cases that never reach it."
+  },
+  {
+   "id": "R6-attribution-team-id-unnormalised",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\t\t\tTeamID:     candidate.TeamID,",
+   "replace": "\t\t\t\tTeamID:     stringPointer(normalizeGitHubWorkItemDerivedTeamID(candidate.TeamID)),",
+   "rationale": "attribution rows persist the RAW candidate team id, so a null stays NULL here while the same resolution becomes 'unassigned' in the coverage rollup",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R7-nil-story-points-is-unestimated",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\tif item.StoryPoints == nil {",
+   "replace": "\t\tif item.StoryPoints != nil {",
+   "rationale": "a null story_points counts as UNestimated; inverting the test swaps both counters and the ratio",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R8-item-created-after-window-skipped",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\tif !createdAt.Before(end) {",
+   "replace": "\t\tif createdAt.Before(end) && false {",
+   "rationale": "an item created at or after the window end contributes nothing, not even a group",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R9b-items-touched-map-records-the-item-id",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\t\titemsSeen[key][item.WorkItemID] = struct{}{}",
+   "replace": "\t\t\titemsSeen[key][\"\"] = struct{}{}",
+   "rationale": "items_touched is a DISTINCT count of work-item ids for the key, not a count of contributing segments; one item can contribute several segments to one key",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "R10-state-duration-team-name-last-writer-wins",
+   "file": "internal/providersync/github_work_item_derived_surfaces.go",
+   "find": "\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName",
+   "replace": "\t\tif _, seen := teamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}]; !seen {\n\t\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName\n\t\t}",
+   "rationale": "state durations keep the LAST contributing item's team name, the opposite of the coverage rollup's first-wins rule",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+     "./internal/providersync/"
+    ]
+   ]
+  }
+ ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -194,6 +194,16 @@
      "-run",
      "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
      "./internal/providersync/"
+    ],
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
     ]
    ]
   },
@@ -210,6 +220,16 @@
      "-count=1",
      "-run",
      "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ],
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
      "./internal/providersync/"
     ]
    ]
@@ -228,6 +248,16 @@
      "-run",
      "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
      "./internal/providersync/"
+    ],
+    [
+     "go",
+     "test",
+     "-tags",
+     "integration",
+     "-count=1",
+     "-run",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+     "./internal/providersync/"
     ]
    ]
   },
@@ -241,43 +271,49 @@
     [
      "go",
      "test",
+     "-tags",
+     "integration",
      "-count=1",
      "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
      "./internal/providersync/"
     ]
    ]
   },
   {
-   "id": "E3-state-durations-dedupe-with-argmax-not-any",
+   "id": "E3-state-durations-argmax-takes-the-newest-version",
    "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
    "find": "argMax(items_touched, computed_at), max(computed_at), argMax(avg_wip, computed_at)",
-   "replace": "any(items_touched), max(computed_at), any(avg_wip)",
-   "rationale": "work_item_state_durations_daily is PLAIN MergeTree where FINAL is a no-op; any() over appended versions can return an older value than max(computed_at) reports, so the readback would confirm a row it never wrote",
+   "replace": "argMin(items_touched, computed_at), max(computed_at), argMin(avg_wip, computed_at)",
+   "rationale": "work_item_state_durations_daily is PLAIN MergeTree where FINAL is a no-op, so the readback must take the NEWEST version by computed_at. argMin takes the oldest -- the deterministic inverse. An earlier form used any(), which is nondeterministic and survived by happening to return the newest row; a mutation whose verdict depends on which part the server reads first measures nothing reliable.",
    "proof": [
     [
      "go",
      "test",
+     "-tags",
+     "integration",
      "-count=1",
      "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
      "./internal/providersync/"
     ]
    ]
   },
   {
-   "id": "E4-state-durations-group-by-is-the-natural-key",
+   "id": "E4-state-durations-status-is-part-of-the-fence",
    "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "GROUP BY org_id, provider, work_scope_id, team_id, status, day",
-   "replace": "GROUP BY org_id, provider, work_scope_id, team_id, day",
-   "rationale": "dropping status from the grouping merges two statuses' argMax into one row, so a per-status effect would verify against a blended value",
+   "find": "AND team_id = ? AND status = ?",
+   "replace": "AND team_id = ? AND (status = ? OR 1 = 1)",
+   "rationale": "status must be part of the readback fence: two statuses share one (org, provider, work_scope_id, team_id, day) key, so a readback that does not pin status aggregates both and verifies an effect against a blended row. The first form of this mutation removed status from the GROUP BY instead and SURVIVED -- correctly, because the WHERE already pins every grouping column, which makes the GROUP BY list redundant and that mutation genuinely equivalent. Mutating the fence tests the property the grouping only restates.",
    "proof": [
     [
      "go",
      "test",
+     "-tags",
+     "integration",
      "-count=1",
      "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
      "./internal/providersync/"
     ]
    ]
@@ -292,9 +328,11 @@
     [
      "go",
      "test",
+     "-tags",
+     "integration",
      "-count=1",
      "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
      "./internal/providersync/"
     ]
    ]

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -1,468 +1,561 @@
 {
- "schema_version": 1,
- "name": "github work-item derived surfaces (coverage, team attributions, state durations)",
- "build": [
-  "go",
-  "test",
-  "-run",
-  "^$",
-  "./internal/providersync/"
- ],
- "mutations": [
-  {
-   "id": "R1-coverage-bucket-created-before-terminal-skip",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
-   "replace": "\t\tif terminalAt != nil && terminalAt.Before(end) {\n\t\t\tcontinue\n\t\t}\n\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
-   "rationale": "Python creates the coverage bucket BEFORE skipping terminal items, so an item that reached a terminal state before the window end still materialises an all-zero group with a NULL ratio. Hoisting the skip is the 'obvious fix' a porter would make and it silently drops rows.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R2-coverage-team-name-first-writer-wins",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}",
-   "replace": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}\n\t\tbucket.teamName = normalizeGitHubWorkItemDerivedTeamName(teamName)",
-   "rationale": "coverage keeps the FIRST contributing item's team name for a group; state durations keep the LAST. The two Python rules are opposite and must not be shared or swapped.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R3-avg-wip-divides-by-fixed-24",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "AvgWIP: totalHours / 24.0,",
-   "replace": "AvgWIP: totalHours / 12.0,",
-   "rationale": "Python divides the day total by a fixed 24 regardless of how much of the day the window covers.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R4-transition-sort-is-stable",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\tsort.SliceStable(ordered, func(left, right int) bool {\n\t\treturn ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
-   "replace": "\tsort.Slice(ordered, func(left, right int) bool {\n\t\treturn !ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
-   "rationale": "Python's sorted() is stable, so transitions sharing an occurred_at keep input order. sort.Slice is not stable and would reorder them.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R5-transition-at-segment-start-rewrites",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\tif !occurredAt.After(currentStart) {",
-   "replace": "\t\tif occurredAt.Before(currentStart) {",
-   "rationale": "mirrors Python's `tr_at <= current_start` rewrite arm rather than a strict `<`",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ],
-   "expected_survivor_reason": "Provably equivalent, not merely unobserved. The two forms differ ONLY at exact equality, and at equality the close arm emits a segment whose end equals its start, which githubWorkItemStatusSegments' own `segment.end.After(segment.start)` filter removes before returning. Both arms therefore leave identical state (current_status = to_status, current_start = occurredAt) and identical output. The transition_exactly_at_creation case forces the boundary so this is measured on the exact input class that distinguishes them, not assumed from cases that never reach it."
-  },
-  {
-   "id": "R6-attribution-team-id-unnormalised",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\t\t\tTeamID:     candidate.TeamID,",
-   "replace": "\t\t\t\tTeamID:     stringPointer(normalizeGitHubWorkItemDerivedTeamID(candidate.TeamID)),",
-   "rationale": "attribution rows persist the RAW candidate team id, so a null stays NULL here while the same resolution becomes 'unassigned' in the coverage rollup",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R7-nil-story-points-is-unestimated",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\tif item.StoryPoints == nil {",
-   "replace": "\t\tif item.StoryPoints != nil {",
-   "rationale": "a null story_points counts as UNestimated; inverting the test swaps both counters and the ratio",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R8-item-created-after-window-skipped",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\tif !createdAt.Before(end) {",
-   "replace": "\t\tif createdAt.Before(end) && false {",
-   "rationale": "an item created at or after the window end contributes nothing, not even a group",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R9b-items-touched-map-records-the-item-id",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\t\titemsSeen[key][item.WorkItemID] = struct{}{}",
-   "replace": "\t\t\titemsSeen[key][\"\"] = struct{}{}",
-   "rationale": "items_touched is a DISTINCT count of work-item ids for the key, not a count of contributing segments; one item can contribute several segments to one key",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "R10-state-duration-team-name-last-writer-wins",
-   "file": "internal/providersync/github_work_item_derived_surfaces.go",
-   "find": "\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName",
-   "replace": "\t\tif _, seen := teamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}]; !seen {\n\t\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName\n\t\t}",
-   "rationale": "state durations keep the LAST contributing item's team name, the opposite of the coverage rollup's first-wins rule",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E1-coverage-duplicates-are-a-conflict-not-an-absence",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "replace": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ],
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E1-attribution-duplicates-are-a-conflict-not-an-absence",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "replace": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ],
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E1-state-durations-duplicates-are-a-conflict-not-an-absence",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "replace": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
-   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ],
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E2-coverage-partition-fence-is-in-the-readback",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
-   "replace": "WHERE org_id = ? AND (day = ? OR 1 = 1) AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
-   "rationale": "estimate_coverage_metrics_daily is PARTITION BY toYYYYMM(day); FINAL only dedupes within a partition, so dropping `day` lets two months' versions of one key both survive (predicate neutralised rather than deleted, so the mutant builds and is actually measured)",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E3-state-durations-argmax-takes-the-newest-version",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "argMax(items_touched, computed_at), max(computed_at), argMax(avg_wip, computed_at)",
-   "replace": "argMin(items_touched, computed_at), max(computed_at), argMin(avg_wip, computed_at)",
-   "rationale": "work_item_state_durations_daily is PLAIN MergeTree where FINAL is a no-op, so the readback must take the NEWEST version by computed_at. argMin takes the oldest -- the deterministic inverse. An earlier form used any(), which is nondeterministic and survived by happening to return the newest row; a mutation whose verdict depends on which part the server reads first measures nothing reliable.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E4-state-durations-status-is-part-of-the-fence",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "AND team_id = ? AND status = ?",
-   "replace": "AND team_id = ? AND (status = ? OR 1 = 1)",
-   "rationale": "status must be part of the readback fence: two statuses share one (org, provider, work_scope_id, team_id, day) key, so a readback that does not pin status aggregates both and verifies an effect against a blended row. The first form of this mutation removed status from the GROUP BY instead and SURVIVED -- correctly, because the WHERE already pins every grouping column, which makes the GROUP BY list redundant and that mutation genuinely equivalent. Mutating the fence tests the property the grouping only restates.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E5-attribution-tenant-fence-in-the-readback",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "WHERE org_id = ? AND repo_id = ? AND work_item_id = ?",
-   "replace": "WHERE org_id != '' AND repo_id = ? AND work_item_id = ?",
-   "rationale": "every ClickHouse readback must fence org_id; without it a foreign tenant's row for the same work item can satisfy the check",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E6-coverage-compares-at-stored-millisecond-precision",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}\n\treturn EffectExact\n}\n\nfunc compareGitHubWorkItemTeamAttributionVersion(",
-   "replace": "\tif !actual.ComputedAt.Equal(expected.ComputedAt) {\n\t\treturn EffectAbsent\n\t}\n\treturn EffectExact\n}\n\nfunc compareGitHubWorkItemTeamAttributionVersion(",
-   "rationale": "estimate_coverage_metrics_daily.computed_at is DateTime64(3): a sub-millisecond stamp quantizes on write, so an untruncated expectation can NEVER equal the stored value and replay answers Absent forever. #1537 shipped 13 green integration tests over this because every fixture had ns=0.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E7-state-durations-compares-at-stored-second-precision",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}",
-   "replace": "\tif !actual.ComputedAt.Equal(githubWorkItemDerivedMillis(expected.ComputedAt)) {\n\t\treturn EffectAbsent\n\t}",
-   "rationale": "work_item_state_durations_daily.computed_at is a plain DateTime -- SECONDS, not milliseconds. Truncating to milliseconds like the other two tables leaves any sub-second stamp permanently unequal to the stored value.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E8-attribution-dedupes-colliding-sorting-keys-on-write",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)\n\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
-   "replace": "\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
-   "rationale": "two candidates differing only in team_name share a full sorting key and collapse under RMT to ONE row; without deterministic dedup the readback finds 1 row whose team_name matches only one of the two expectations, reads Conflict, and wedges recovery permanently",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "E9-attribution-dedupes-the-expectation-too",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(rows, githubTeamAttributionSortingKey)\n\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
-   "replace": "\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
-   "rationale": "deduping only the write is not enough: the expectation must name the row the write actually leaves behind, or the readback compares against a row storage discarded",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-tags",
-     "integration",
-     "-count=1",
-     "-run",
-     "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "B1a-newer-persisted-version-conflicts",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\tcase actual.After(expected):\n\t\treturn EffectConflict, true",
-   "replace": "\tcase actual.After(expected):\n\t\treturn EffectAbsent, true",
-   "rationale": "a NEWER persisted version must CONFLICT. Answering Absent makes the committer rewrite an older generation that the store then discards, so the next readback answers Absent again -- an unterminating rewrite loop, and on plain-MergeTree state_durations each pass also appends a row. This is the branch a two-way `!Equal -> Absent` comparator lacks entirely.",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "B1b-older-persisted-version-is-absent-not-conflict",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\tcase actual.Before(expected):\n\t\treturn EffectAbsent, true",
-   "replace": "\tcase actual.Before(expected):\n\t\treturn EffectConflict, true",
-   "rationale": "an OLDER persisted version means our write never landed, which is the normal pre-write state; reporting Conflict there would refuse to write instead of writing",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ]
-   ]
-  },
-  {
-   "id": "B1c-version-order-precedes-value-comparison",
-   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
-   "find": "\tif verdict, decided := githubWorkItemDerivedVersionOrder(\n\t\tactual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),\n\t); decided {\n\t\treturn verdict\n\t}\n\tif actual.TeamName != expected.TeamName ||",
-   "replace": "\tif actual.TeamName != expected.TeamName ||",
-   "rationale": "version ordering must run BEFORE any value comparison: with an older persisted row the values legitimately differ, and comparing them first reports Conflict where Absent is correct",
-   "proof": [
-    [
-     "go",
-     "test",
-     "-count=1",
-     "-run",
-     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
-     "./internal/providersync/"
-    ]
-   ]
-  }
- ]
+  "schema_version": 1,
+  "name": "github work-item derived surfaces (coverage, team attributions, state durations)",
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
+  "mutations": [
+    {
+      "id": "R1-coverage-bucket-created-before-terminal-skip",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
+      "replace": "\t\tif terminalAt != nil && terminalAt.Before(end) {\n\t\t\tcontinue\n\t\t}\n\t\tbucket := buckets[key]\n\t\tif bucket == nil {",
+      "rationale": "Python creates the coverage bucket BEFORE skipping terminal items, so an item that reached a terminal state before the window end still materialises an all-zero group with a NULL ratio. Hoisting the skip is the 'obvious fix' a porter would make and it silently drops rows.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R2-coverage-team-name-first-writer-wins",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}",
+      "replace": "\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}\n\t\tbucket.teamName = normalizeGitHubWorkItemDerivedTeamName(teamName)",
+      "rationale": "coverage keeps the FIRST contributing item's team name for a group; state durations keep the LAST. The two Python rules are opposite and must not be shared or swapped.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R3-avg-wip-divides-by-fixed-24",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "AvgWIP: totalHours / 24.0,",
+      "replace": "AvgWIP: totalHours / 12.0,",
+      "rationale": "Python divides the day total by a fixed 24 regardless of how much of the day the window covers.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R4-transition-sort-is-stable",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\tsort.SliceStable(ordered, func(left, right int) bool {\n\t\treturn ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
+      "replace": "\tsort.Slice(ordered, func(left, right int) bool {\n\t\treturn !ordered[left].OccurredAt.UTC().Before(ordered[right].OccurredAt.UTC())\n\t})",
+      "rationale": "Python's sorted() is stable, so transitions sharing an occurred_at keep input order. sort.Slice is not stable and would reorder them.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R5-transition-at-segment-start-rewrites",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\tif !occurredAt.After(currentStart) {",
+      "replace": "\t\tif occurredAt.Before(currentStart) {",
+      "rationale": "mirrors Python's `tr_at <= current_start` rewrite arm rather than a strict `<`",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ],
+      "expected_survivor_reason": "Provably equivalent, not merely unobserved. The two forms differ ONLY at exact equality, and at equality the close arm emits a segment whose end equals its start, which githubWorkItemStatusSegments' own `segment.end.After(segment.start)` filter removes before returning. Both arms therefore leave identical state (current_status = to_status, current_start = occurredAt) and identical output. The transition_exactly_at_creation case forces the boundary so this is measured on the exact input class that distinguishes them, not assumed from cases that never reach it."
+    },
+    {
+      "id": "R6-attribution-team-id-unnormalised",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\t\t\tTeamID:   candidate.TeamID,",
+      "replace": "\t\t\t\tTeamID:   stringPointer(normalizeGitHubWorkItemDerivedTeamID(candidate.TeamID)),",
+      "rationale": "attribution rows persist the RAW candidate team id, so a null stays NULL here while the same resolution becomes 'unassigned' in the coverage rollup",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R7-nil-story-points-is-unestimated",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\tif item.StoryPoints == nil {",
+      "replace": "\t\tif item.StoryPoints != nil {",
+      "rationale": "a null story_points counts as UNestimated; inverting the test swaps both counters and the ratio",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R8-item-created-after-window-skipped",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\tif !createdAt.Before(end) {",
+      "replace": "\t\tif createdAt.Before(end) && false {",
+      "rationale": "an item created at or after the window end contributes nothing, not even a group",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R9b-items-touched-map-records-the-item-id",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\t\titemsSeen[key][item.WorkItemID] = struct{}{}",
+      "replace": "\t\t\titemsSeen[key][\"\"] = struct{}{}",
+      "rationale": "items_touched is a DISTINCT count of work-item ids for the key, not a count of contributing segments; one item can contribute several segments to one key",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "R10-state-duration-team-name-last-writer-wins",
+      "file": "internal/providersync/github_work_item_derived_surfaces.go",
+      "find": "\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName",
+      "replace": "\t\tif _, seen := teamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}]; !seen {\n\t\t\tteamNames[githubStateDurationTeamKey{item.Provider, workScopeID, teamID}] = teamName\n\t\t}",
+      "rationale": "state durations keep the LAST contributing item's team name, the opposite of the coverage rollup's first-wins rule",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageMatchesLivePythonProduction$|^TestGitHubWorkItemTeamAttributionsMatchLivePythonProduction$|^TestGitHubWorkItemStateDurationsMatchLivePythonProduction$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E1-coverage-duplicates-are-a-conflict-not-an-absence",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "replace": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E1-attribution-duplicates-are-a-conflict-not-an-absence",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "replace": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E1-state-durations-duplicates-are-a-conflict-not-an-absence",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "replace": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+      "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ],
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E2-coverage-partition-fence-is-in-the-readback",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
+      "replace": "WHERE org_id = ? AND (day = ? OR 1 = 1) AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
+      "rationale": "estimate_coverage_metrics_daily is PARTITION BY toYYYYMM(day); FINAL only dedupes within a partition, so dropping `day` lets two months' versions of one key both survive (predicate neutralised rather than deleted, so the mutant builds and is actually measured)",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E3-state-durations-argmax-takes-the-newest-version",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "argMax(items_touched, computed_at), max(computed_at), argMax(avg_wip, computed_at)",
+      "replace": "argMin(items_touched, computed_at), max(computed_at), argMin(avg_wip, computed_at)",
+      "rationale": "work_item_state_durations_daily is PLAIN MergeTree where FINAL is a no-op, so the readback must take the NEWEST version by computed_at. argMin takes the oldest -- the deterministic inverse. An earlier form used any(), which is nondeterministic and survived by happening to return the newest row; a mutation whose verdict depends on which part the server reads first measures nothing reliable.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E4-state-durations-status-is-part-of-the-fence",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "AND team_id = ? AND status = ?",
+      "replace": "AND team_id = ? AND (status = ? OR 1 = 1)",
+      "rationale": "status must be part of the readback fence: two statuses share one (org, provider, work_scope_id, team_id, day) key, so a readback that does not pin status aggregates both and verifies an effect against a blended row. The first form of this mutation removed status from the GROUP BY instead and SURVIVED -- correctly, because the WHERE already pins every grouping column, which makes the GROUP BY list redundant and that mutation genuinely equivalent. Mutating the fence tests the property the grouping only restates.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E5-attribution-tenant-fence-in-the-readback",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND repo_id = ? AND work_item_id = ?",
+      "replace": "WHERE (org_id = ? OR 1 = 1) AND repo_id = ? AND work_item_id = ?",
+      "rationale": "every ClickHouse readback must fence org_id; without it a foreign tenant's row for the same work item can satisfy the check. The predicate is NEUTRALISED in place rather than replaced by `org_id != ''`: that earlier form deleted a placeholder, shifted every later binding by one, and died on a binding/type error before the query ever ran -- and ANY failure scores KILLED, so it measured nothing about tenancy. Arity is preserved and the parentheses keep the neutralisation confined to the tenancy clause (AND binds tighter than OR, so an unparenthesised form would also erase the repo_id and work_item_id fences)",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E6-coverage-compares-at-stored-millisecond-precision",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\t\tactual.ComputedAt, githubWorkItemDerivedMillis(expected.ComputedAt),\n\t); decided {\n\t\treturn verdict\n\t}\n\tif actual.Day != expected.Day ||",
+      "replace": "\t\tactual.ComputedAt, expected.ComputedAt,\n\t); decided {\n\t\treturn verdict\n\t}\n\tif actual.Day != expected.Day ||",
+      "rationale": "estimate_coverage_metrics_daily stores computed_at as DateTime64(3), so the expectation MUST be truncated to milliseconds before it is ordered against the stored value; comparing the raw stamp makes a sub-millisecond computed_at order as newer-than-stored forever and the verdict never reaches Exact. NOTE: this entry previously searched for an `actual.ComputedAt.Equal(...)` form that the three-way version ordering (B1) had already replaced, so it matched NOTHING and was INVALID -- it was reported as KILLED while measuring nothing. Re-pointed at the live comparison.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E7-state-durations-compares-at-stored-second-precision",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\t\tactual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),",
+      "replace": "\t\tactual.ComputedAt, githubWorkItemDerivedMillis(expected.ComputedAt),",
+      "rationale": "work_item_state_durations_daily is a PLAIN DateTime (seconds); truncating the expectation to milliseconds instead leaves any sub-second computed_at permanently unequal to the stored value. Same INVALID history as E6: the old find targeted a pre-B1 `Equal(...)` form and matched nothing.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E8-attribution-dedupes-colliding-sorting-keys-on-write",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(\n\t\trows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,\n\t)\n\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
+      "replace": "\tbatch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO work_item_team_attributions",
+      "rationale": "two candidates differing only in team_name share a full sorting key and collapse under RMT to ONE row; without deterministic dedup the readback finds 1 row whose team_name matches only one of the two expectations, reads Conflict, and wedges recovery permanently",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E9-attribution-dedupes-the-expectation-too",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\trows = githubWorkItemDerivedSortingKeyDedupe(\n\t\trows, githubTeamAttributionSortingKey, githubTeamAttributionVersion,\n\t)\n\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
+      "replace": "\treturn inspectGitHubWorkItemDerivedRows(rows, func(row githubWorkItemTeamAttributionRow) (EffectInspection, error) {",
+      "rationale": "deduping only the write is not enough: the expectation must name the row the write actually leaves behind, or the readback compares against a row storage discarded",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "B1a-newer-persisted-version-conflicts",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\tcase actual.After(expected):\n\t\treturn EffectConflict, true",
+      "replace": "\tcase actual.After(expected):\n\t\treturn EffectAbsent, true",
+      "rationale": "a NEWER persisted version must CONFLICT. Answering Absent makes the committer rewrite an older generation that the store then discards, so the next readback answers Absent again -- an unterminating rewrite loop, and on plain-MergeTree state_durations each pass also appends a row. This is the branch a two-way `!Equal -> Absent` comparator lacks entirely.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "B1b-older-persisted-version-is-absent-not-conflict",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\tcase actual.Before(expected):\n\t\treturn EffectAbsent, true",
+      "replace": "\tcase actual.Before(expected):\n\t\treturn EffectConflict, true",
+      "rationale": "an OLDER persisted version means our write never landed, which is the normal pre-write state; reporting Conflict there would refuse to write instead of writing",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "B1c-version-order-precedes-value-comparison",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\tif verdict, decided := githubWorkItemDerivedVersionOrder(\n\t\tactual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),\n\t); decided {\n\t\treturn verdict\n\t}\n\tif actual.TeamName != expected.TeamName ||",
+      "replace": "\tif actual.TeamName != expected.TeamName ||",
+      "rationale": "version ordering must run BEFORE any value comparison: with an older persisted row the values legitimately differ, and comparing them first reports Conflict where Absent is correct",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E10-coverage-team-id-fence-in-the-readback",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "FROM estimate_coverage_metrics_daily FINAL\nWHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
+      "replace": "FROM estimate_coverage_metrics_daily FINAL\nWHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?\nAND (ifNull(team_id, '') = ? OR 1 = 1)",
+      "rationale": "ifNull(team_id,'') is the last component of this table's sorting key, and the readback must fence it or two teams' rows for one (day, provider, work_scope_id) both satisfy the query and found becomes 2. The ifNull wrapper specifically mirrors the table's own key expression: a NULL team_id must match the stored empty-string form, not compare NULL-to-NULL. Neutralised in place, so arity and every binding are preserved.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E11-attribution-team-id-fence-in-the-readback",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "FROM work_item_team_attributions FINAL\nWHERE org_id = ? AND repo_id = ? AND work_item_id = ?\nAND ifNull(team_id, '') = ? AND source = ?",
+      "replace": "FROM work_item_team_attributions FINAL\nWHERE org_id = ? AND repo_id = ? AND work_item_id = ?\nAND (ifNull(team_id, '') = ? OR 1 = 1) AND source = ?",
+      "rationale": "the same sorting-key component on the other RMT table. One work item legitimately carries several attribution rows differing only in team_id, so dropping this fence makes the readback match a sibling candidate's row and compare the wrong one.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E12-state-durations-day-fence-in-the-readback",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "FROM work_item_state_durations_daily\nWHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?",
+      "replace": "FROM work_item_state_durations_daily\nWHERE org_id = ? AND (day = ? OR 1 = 1) AND provider = ? AND work_scope_id = ?",
+      "rationale": "day is in this table's GROUP BY, so without the day fence the query returns one group PER DAY for the same natural key. found becomes >1 and the comparator can no longer identify the row it is verifying. Unlike the two RMT tables this is not a partition question -- it is a plain MergeTree and the grouping itself is what breaks.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E13-coverage-duplicate-check-precedes-the-comparison",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}\n\t\t// More than one row survived FINAL inside a single partition: the\n\t\t// fence is wrong, not the data. Never report this as absent, which\n\t\t// would rewrite and duplicate again.\n\t\treturn EffectConflict\n\t}",
+      "replace": "\tif found == 0 {\n\t\treturn EffectAbsent\n\t}",
+      "rationale": "MOVES THE DUPLICATE CHECK BELOW THE COMPARISON rather than deleting the concept: found==0 still answers Absent, but found>1 now falls through and the comparator judges whichever row the scan happened to leave in `actual`. When duplicates carry matching values that yields Exact, and when they carry a stale row it yields Absent -- which instructs the committer to rewrite, duplicating again. This is the ordering the file's header comment claims and nothing measured.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags",
+          "integration",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageReadbackAgainstRealClickHouse$|^TestGitHubWorkItemStateDurationsReadbackAgainstRealClickHouse$|^TestGitHubWorkItemTeamAttributionsReadbackAgainstRealClickHouse$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E14-batch-verdict-conflict-outranks-absent",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\t\tcase EffectConflict:\n\t\t\treturn EffectConflict, nil\n\t\tcase EffectAbsent:\n\t\t\tverdict = EffectAbsent",
+      "replace": "\t\tcase EffectConflict:\n\t\t\tverdict = EffectConflict\n\t\tcase EffectAbsent:\n\t\t\treturn EffectAbsent, nil",
+      "rationale": "inverts the batch verdict precedence. The committer treats Absent as 'write this', so a batch holding one CONFLICTING row that reports Absent is rewritten straight over data that disagrees with it. The mutant only shows up when absent is seen BEFORE conflict, which is why the killing test asserts both orders.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestInspectGitHubWorkItemDerivedRowsTakesTheWeakestVerdict$",
+          "./internal/providersync/"
+        ]
+      ]
+    }
+  ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -412,6 +412,57 @@
      "./internal/providersync/"
     ]
    ]
+  },
+  {
+   "id": "B1a-newer-persisted-version-conflicts",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\tcase actual.After(expected):\n\t\treturn EffectConflict, true",
+   "replace": "\tcase actual.After(expected):\n\t\treturn EffectAbsent, true",
+   "rationale": "a NEWER persisted version must CONFLICT. Answering Absent makes the committer rewrite an older generation that the store then discards, so the next readback answers Absent again -- an unterminating rewrite loop, and on plain-MergeTree state_durations each pass also appends a row. This is the branch a two-way `!Equal -> Absent` comparator lacks entirely.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "B1b-older-persisted-version-is-absent-not-conflict",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\tcase actual.Before(expected):\n\t\treturn EffectAbsent, true",
+   "replace": "\tcase actual.Before(expected):\n\t\treturn EffectConflict, true",
+   "rationale": "an OLDER persisted version means our write never landed, which is the normal pre-write state; reporting Conflict there would refuse to write instead of writing",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "B1c-version-order-precedes-value-comparison",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "\tif verdict, decided := githubWorkItemDerivedVersionOrder(\n\t\tactual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),\n\t); decided {\n\t\treturn verdict\n\t}\n\tif actual.TeamName != expected.TeamName ||",
+   "replace": "\tif actual.TeamName != expected.TeamName ||",
+   "rationale": "version ordering must run BEFORE any value comparison: with an older persisted row the values legitimately differ, and comparing them first reports Conflict where Absent is correct",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
   }
  ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -179,6 +179,125 @@
      "./internal/providersync/"
     ]
    ]
+  },
+  {
+   "id": "E1-coverage-duplicates-are-a-conflict-not-an-absence",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "replace": "expected, actual githubEstimateCoverageMetricsDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E1-attribution-duplicates-are-a-conflict-not-an-absence",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "replace": "expected, actual githubWorkItemTeamAttributionRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E1-state-durations-duplicates-are-a-conflict-not-an-absence",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found == 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "replace": "expected, actual githubWorkItemStateDurationDailyRow, found int, orgID string,\n) EffectInspection {\n\tif found != 1 {\n\t\tif found >= 0 {\n\t\t\treturn EffectAbsent\n\t\t}",
+   "rationale": "duplicates must CONFLICT, never read as absent: answering absent makes the committer rewrite, and the rewrite adds another duplicate -- the infinite rewrite loop that was the second blocking finding on #1535. This collapses the duplicate arm into the absent arm for ONE comparator at a time.",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E2-coverage-partition-fence-is-in-the-readback",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "WHERE org_id = ? AND day = ? AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
+   "replace": "WHERE org_id = ? AND (day = ? OR 1 = 1) AND provider = ? AND work_scope_id = ?\nAND ifNull(team_id, '') = ?",
+   "rationale": "estimate_coverage_metrics_daily is PARTITION BY toYYYYMM(day); FINAL only dedupes within a partition, so dropping `day` lets two months' versions of one key both survive (predicate neutralised rather than deleted, so the mutant builds and is actually measured)",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E3-state-durations-dedupe-with-argmax-not-any",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "argMax(items_touched, computed_at), max(computed_at), argMax(avg_wip, computed_at)",
+   "replace": "any(items_touched), max(computed_at), any(avg_wip)",
+   "rationale": "work_item_state_durations_daily is PLAIN MergeTree where FINAL is a no-op; any() over appended versions can return an older value than max(computed_at) reports, so the readback would confirm a row it never wrote",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E4-state-durations-group-by-is-the-natural-key",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "GROUP BY org_id, provider, work_scope_id, team_id, status, day",
+   "replace": "GROUP BY org_id, provider, work_scope_id, team_id, day",
+   "rationale": "dropping status from the grouping merges two statuses' argMax into one row, so a per-status effect would verify against a blended value",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
+  },
+  {
+   "id": "E5-attribution-tenant-fence-in-the-readback",
+   "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+   "find": "WHERE org_id = ? AND repo_id = ? AND work_item_id = ?",
+   "replace": "WHERE org_id != '' AND repo_id = ? AND work_item_id = ?",
+   "rationale": "every ClickHouse readback must fence org_id; without it a foreign tenant's row for the same work item can satisfy the check",
+   "proof": [
+    [
+     "go",
+     "test",
+     "-count=1",
+     "-run",
+     "^TestCompareGitHubEstimateCoverageVersionClauseCoverage$|^TestCompareGitHubWorkItemStateDurationVersionClauseCoverage$|^TestCompareGitHubWorkItemTeamAttributionVersionClauseCoverage$",
+     "./internal/providersync/"
+    ]
+   ]
   }
  ]
 }

--- a/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
@@ -1,0 +1,357 @@
+"""Shared live-production wiring for the derived work-item destination pairs.
+
+Three destinations are covered here -- estimate_coverage_metrics_daily,
+work_item_team_attributions and work_item_state_durations_daily. All three
+resolve a work item's team through the SAME production cascade
+(``resolve_team_attribution``, the project-key resolver, the linked-issue donor
+index and the ClickHouse-loaded attribution context), so building that cascade
+once per case and letting each pair call its own production function keeps the
+three comparisons consistent by construction rather than by three copies of the
+same wiring agreeing by luck.
+
+Nothing about the compared values is reimplemented. The team resolvers, the
+attribution context, the linked-issue donor index and all three compute
+functions are the live production functions. Only the ClickHouse transport
+under ``ClickHouseDataLoader`` is faked, exactly as the derivation-context pair
+does, and its SQL and row mapping stay live.
+
+LANE NOTE (derived-lane): the metric-triplet lane's
+``_github_work_item_metrics_helpers`` carries a near-identical copy of the case
+decoders, the fake query client and ``columns``. That duplication is
+deliberate and temporary -- that lane is unmerged and its files may still move,
+so importing from it would couple this lane to an unreviewed head. Whichever
+lands second collapses the two modules into one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import pathlib
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.metrics.compute_work_item_state_durations import (
+        compute_work_item_state_durations_daily,
+    )
+    from dev_health_ops.metrics.compute_work_items import (
+        build_linked_issue_team_resolver,
+        compute_estimate_coverage_metrics_daily,
+        compute_work_item_team_attributions,
+    )
+    from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
+    from dev_health_ops.models.work_items import (
+        WorkItem,
+        WorkItemDependency,
+        WorkItemStatusTransition,
+    )
+    from dev_health_ops.providers.teams import build_project_key_resolver
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+SCHEMA_SOURCE = REPO_ROOT / "src/dev_health_ops/metrics/schemas.py"
+
+# Every record dataclass in this family defaults org_id to "" and relies on the
+# ClickHouse sink to inject the tenant from sink context at insert time
+# (sinks/clickhouse/core.py). The Go port has no sink-level context to inject
+# from, so it stamps the frozen claim's OrgID at compute time. The persisted
+# value is compared for real by the ClickHouse readback integration test, not
+# here. Declared in one place so the three pairs cannot drift in their reason.
+ORG_ID_EXCLUSION = (
+    "the Python compute functions never set org_id: the record dataclasses "
+    "default it to '' and the ClickHouse sink injects the tenant from sink "
+    "context at insert time. The Go port stamps the frozen claim's OrgID at "
+    "compute time instead, and the persisted value is proved equal by the "
+    "ClickHouse readback integration test rather than by this comparison."
+)
+
+
+def parse_time(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def _required_time(value: Any) -> datetime:
+    parsed = parse_time(value)
+    if parsed is None:
+        raise ValueError("a required timestamp was null in the oracle case")
+    return parsed
+
+
+def _work_item(raw: dict[str, Any]) -> WorkItem:
+    repo_id = raw.get("repo_id")
+    story_points = raw.get("story_points")
+    return WorkItem(
+        work_item_id=str(raw["work_item_id"]),
+        provider=raw["provider"],
+        title=str(raw.get("title") or raw["work_item_id"]),
+        type=raw.get("type") or "issue",
+        status=raw.get("status") or "todo",
+        status_raw=raw.get("status_raw"),
+        repo_id=uuid.UUID(repo_id) if repo_id else None,
+        native_team_key=raw.get("native_team_key"),
+        project_key=raw.get("project_key"),
+        project_id=raw.get("project_id"),
+        project_name=raw.get("project_name"),
+        assignees=list(raw.get("assignees") or []),
+        created_at=_required_time(raw["created_at"]),
+        updated_at=_required_time(raw.get("updated_at") or raw["created_at"]),
+        started_at=parse_time(raw.get("started_at")),
+        completed_at=parse_time(raw.get("completed_at")),
+        closed_at=parse_time(raw.get("closed_at")),
+        labels=list(raw.get("labels") or []),
+        story_points=None if story_points is None else float(story_points),
+        org_id=str(raw.get("org_id") or ""),
+    )
+
+
+def _transition(raw: dict[str, Any]) -> WorkItemStatusTransition:
+    return WorkItemStatusTransition(
+        work_item_id=str(raw["work_item_id"]),
+        provider=raw["provider"],
+        occurred_at=_required_time(raw["occurred_at"]),
+        from_status_raw=raw.get("from_status_raw"),
+        to_status_raw=raw.get("to_status_raw"),
+        from_status=raw.get("from_status") or "todo",
+        to_status=raw["to_status"],
+        actor=raw.get("actor"),
+        org_id=str(raw.get("org_id") or ""),
+    )
+
+
+def _dependency(raw: dict[str, Any]) -> WorkItemDependency:
+    return WorkItemDependency(
+        source_work_item_id=str(raw["source_work_item_id"]),
+        target_work_item_id=str(raw["target_work_item_id"]),
+        relationship_type=str(raw["relationship_type"]),
+        relationship_type_raw=str(raw.get("relationship_type_raw") or ""),
+        relationship_semantics_version=str(
+            raw.get("relationship_semantics_version") or "canonical-blocks.v2"
+        ),
+        last_synced=_required_time(raw.get("last_synced") or "1970-01-01T00:00:00Z"),
+        org_id=str(raw.get("org_id") or ""),
+    )
+
+
+def _loader_row(raw: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    row: dict[str, Any] = {}
+    for field in fields:
+        raw_key = {
+            "team_id": "TeamID",
+            "project_id": "ProjectID",
+            "repo_id": "RepoID",
+            "member_id": "MemberID",
+            "raw_provider_user_id": "RawProviderUserID",
+            "scope_id": "ScopeID",
+        }.get(field, "".join(part.title() for part in field.split("_")))
+        value = raw.get(raw_key)
+        row[field] = parse_time(value) if field == "updated_at" and value else value
+    return row
+
+
+_PROJECT_FIELDS = (
+    "provider",
+    "team_id",
+    "team_name",
+    "project_id",
+    "project_key",
+    "is_primary",
+    "specificity",
+    "priority",
+    "updated_at",
+)
+_REPO_FIELDS = (
+    "provider",
+    "team_id",
+    "team_name",
+    "repo_id",
+    "repo_full_name",
+    "is_primary",
+    "specificity",
+    "priority",
+    "updated_at",
+)
+_MEMBER_FIELDS = (
+    "provider",
+    "team_id",
+    "team_name",
+    "member_id",
+    "raw_provider_user_id",
+    "raw_email",
+    "identity_facets",
+    "is_primary",
+    "specificity",
+    "priority",
+    "updated_at",
+)
+_MANUAL_FIELDS = (
+    "provider",
+    "scope_type",
+    "scope_id",
+    "team_id",
+    "team_name",
+    "reason",
+    "priority",
+)
+
+
+class _ContextQueryClient:
+    """Fake ClickHouse boundary; production loader SQL and mapping stay live."""
+
+    def __init__(self, facts: dict[str, Any], *, org_id: str, as_of: datetime) -> None:
+        self.facts = facts
+        self.org_id = org_id
+        self.as_of = as_of
+        self.seen: set[str] = set()
+
+    def query_dicts(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        if (
+            params.get("org_id") != self.org_id
+            or "o.org_id = {org_id:String}" not in query
+        ):
+            raise AssertionError("team attribution query lost its tenant fence")
+        if params.get("as_of") != self.as_of.replace(tzinfo=None):
+            raise AssertionError("team attribution query lost its exact as-of value")
+        if "team_project_ownership" in query:
+            self.seen.add("projects")
+            return [
+                _loader_row(raw, _PROJECT_FIELDS)
+                for raw in self.facts.get("Projects") or []
+            ]
+        if "team_repo_ownership" in query:
+            self.seen.add("repos")
+            return [
+                _loader_row(raw, _REPO_FIELDS) for raw in self.facts.get("Repos") or []
+            ]
+        if "team_memberships" in query:
+            self.seen.add("members")
+            return [
+                _loader_row(raw, _MEMBER_FIELDS)
+                for raw in self.facts.get("Members") or []
+            ]
+        if "manual_attribution_fallbacks" in query:
+            self.seen.add("manual")
+            return [
+                _loader_row(raw, _MANUAL_FIELDS)
+                for raw in self.facts.get("ManualFallbacks") or []
+            ]
+        raise AssertionError(f"unexpected team-attribution query: {query}")
+
+
+class DerivedCase:
+    """One decoded case plus the live production resolver cascade it needs."""
+
+    def __init__(self, case: dict[str, Any]) -> None:
+        facts = case.get("Facts") or {}
+        self.org_id = str(case.get("OrgID") or "")
+        self.as_of = _required_time(case.get("AsOf") or case["ComputedAt"])
+        self.computed_at = _required_time(case["ComputedAt"])
+        self.day = date.fromisoformat(str(case["Day"]))
+        self.work_items = [_work_item(raw) for raw in case.get("WorkItems") or []]
+        self.transitions = [_transition(raw) for raw in case.get("Transitions") or []]
+        dependencies = [_dependency(raw) for raw in case.get("Dependencies") or []]
+
+        # Donor subjects are the previously persisted work items an inheritable
+        # dependency edge can point at. job_work_items.py builds the resolver
+        # from `donor_by_id.values()`, a merge of fetched donors with the
+        # freshly synced rows where fresh wins, and
+        # loadGitHubWorkItemDerivationContext merges the same two sets the same
+        # way -- so this must too. Passing only `work_items` would make
+        # cross-provider inheritance untestable; passing both lists unmerged
+        # would double-count a row present in each.
+        donor_subjects: dict[str, WorkItem] = {}
+        for raw in case.get("Donors") or []:
+            donor = _work_item(raw)
+            donor_subjects[donor.work_item_id] = donor
+        for item in self.work_items:
+            donor_subjects[item.work_item_id] = item
+
+        teams = [
+            {
+                "id": str(raw.get("TeamID") or ""),
+                "name": str(raw.get("TeamName") or raw.get("TeamID") or ""),
+                "project_keys": list(raw.get("ProjectKeys") or []),
+            }
+            for raw in facts.get("Teams") or []
+        ]
+        self.project_key_resolver = build_project_key_resolver(teams)
+        query_client = _ContextQueryClient(facts, org_id=self.org_id, as_of=self.as_of)
+        self.attribution_context = asyncio.run(
+            ClickHouseDataLoader(
+                query_client, org_id=self.org_id
+            ).load_team_attribution_context(as_of=self.as_of)
+        )
+        if query_client.seen != {"projects", "repos", "members", "manual"}:
+            raise AssertionError(
+                "production team-attribution loader coverage incomplete: "
+                f"{query_client.seen}"
+            )
+        self.linked_issue_resolver = build_linked_issue_team_resolver(
+            work_items=list(donor_subjects.values()),
+            dependencies=dependencies,
+            project_key_resolver=self.project_key_resolver,
+            attribution_context=self.attribution_context,
+        )
+
+    def _resolver_kwargs(self) -> dict[str, Any]:
+        return {
+            "project_key_resolver": self.project_key_resolver,
+            "linked_issue_resolver": self.linked_issue_resolver,
+            "attribution_context": self.attribution_context,
+        }
+
+    def estimate_coverage(self) -> list[Any]:
+        return compute_estimate_coverage_metrics_daily(
+            day=self.day,
+            work_items=self.work_items,
+            computed_at=self.computed_at,
+            **self._resolver_kwargs(),
+        )
+
+    def team_attributions(self) -> list[Any]:
+        return compute_work_item_team_attributions(
+            work_items=self.work_items,
+            computed_at=self.computed_at,
+            **self._resolver_kwargs(),
+        )
+
+    def state_durations(self) -> list[Any]:
+        return compute_work_item_state_durations_daily(
+            day=self.day,
+            work_items=self.work_items,
+            transitions=self.transitions,
+            computed_at=self.computed_at,
+            **self._resolver_kwargs(),
+        )
+
+
+def columns(records: list[Any], fields: frozenset[str]) -> dict[str, list[Any]]:
+    """Transpose an ordered record list into one column per production field.
+
+    The generic comparator needs a top-level object per case; column lists keep
+    the production ORDER comparable (a reordering shows up as every column
+    diverging at once) while `fields` coming from the production dataclass keeps
+    the shape exhaustive when a field is added or removed upstream.
+    """
+    return {
+        field: [_json_safe(getattr(record, field)) for record in records]
+        for field in sorted(fields)
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    return value

--- a/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
@@ -124,7 +124,13 @@ def _transition(raw: dict[str, Any]) -> WorkItemStatusTransition:
         occurred_at=_required_time(raw["occurred_at"]),
         from_status_raw=raw.get("from_status_raw"),
         to_status_raw=raw.get("to_status_raw"),
-        from_status=raw.get("from_status") or "todo",
+        # `or "todo"` would coerce an explicit "" to "todo" and MASK the
+        # from_status fallback production Python actually has
+        # (compute_work_item_state_durations.py:86 uses
+        # `first.from_status if first.from_status else item.status`). Absent
+        # key still defaults to "todo"; an explicit "" is passed through so the
+        # fallback can be exercised on both sides.
+        from_status=("todo" if "from_status" not in raw else raw["from_status"]),
         to_status=raw["to_status"],
         actor=raw.get("actor"),
         org_id=str(raw.get("org_id") or ""),

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_estimate-coverage.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_estimate-coverage.py
@@ -1,0 +1,40 @@
+"""Live Python oracle for the daily estimate-coverage rollup.
+
+Compared surface: every field ``EstimateCoverageMetricsDailyRecord`` declares,
+reflected from the production dataclass rather than listed here, so a field
+added or removed upstream breaks this comparison instead of silently narrowing
+it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "EstimateCoverageMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).estimate_coverage()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/estimate-coverage",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_state-durations.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_state-durations.py
@@ -1,0 +1,39 @@
+"""Live Python oracle for the daily time-in-state rollup.
+
+Compared surface: every field ``WorkItemStateDurationDailyRecord`` declares,
+including ``avg_wip``, which Python computes as the day total divided by a
+fixed 24 regardless of how much of the day the window actually covers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemStateDurationDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).state_durations()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/state-durations",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions.py
@@ -1,0 +1,48 @@
+"""Live Python oracle for the per-item team attribution candidate rows.
+
+Compared surface: every field ``WorkItemTeamAttributionRecord`` declares.
+Unlike the daily rollups this record carries the UNNORMALISED candidate team
+id and name straight from ``resolve_team_attribution`` -- a null team_id stays
+null here while the same resolution becomes "unassigned" in the coverage
+rollup. That asymmetry is Python's, and the ``unassigned_candidate`` case
+exists to pin it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemTeamAttributionRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).team_attributions()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/team-attributions",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        # NO org_id exclusion here, unlike the two daily rollups. This record is
+        # the one member of the family Python populates itself
+        # (compute_work_item_team_attributions copies item.org_id rather than
+        # leaving the dataclass default for the sink to fill), so org_id is a
+        # genuinely comparable value on both sides and excluding it would hide
+        # a real tenant-stamping divergence behind a reason that is simply
+        # untrue for this pair. Proved by running the pair: it emits
+        # org_id="org-acme", not "".
+    )
+)

--- a/internal/testsupport/chschema/chschema.go
+++ b/internal/testsupport/chschema/chschema.go
@@ -1,0 +1,128 @@
+// Package chschema applies the REAL ClickHouse migration chain to a throwaway
+// test container.
+//
+// It exists because hand-typed DDL in a Go test is not a schema: it is a
+// SECOND, unversioned copy of one, and the test that reads it back can only
+// ever confirm what the test itself declared. The derived work-item tables
+// caught this concretely -- the hand-typed work_item_team_attributions carried
+// the PRE-053 enums, missing the `issue_project` and `manual_fallback` source
+// values and the `manual` and `none` confidence values that the production
+// resolver actually emits (derivation_context.go:462,510,561). Every test over
+// that table was green while an insert of a genuinely reachable row would have
+// been rejected by the real column, and one fixture had been quietly written to
+// `low` to stay inside the stale enum.
+//
+// So no DDL is authored here. The chain under
+// src/dev_health_ops/migrations/clickhouse is applied through the project's own
+// canonical migration entrypoint -- the same call the `migrate clickhouse
+// upgrade` CLI makes -- which covers BOTH the .sql migrations and the .py ones
+// (027 and 055 rebuild tables through a shadow-table swap that no static SQL
+// extractor could reproduce).
+package chschema
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// applyScript runs the canonical migration entrypoint. force=true bypasses the
+// AUTO_RUN_MIGRATIONS opt-out exactly as the CLI does, so a developer's ambient
+// environment cannot turn this into a silent no-op that leaves a test asserting
+// against an empty database.
+const applyScript = `
+import sys
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+sink = ClickHouseMetricsSink(dsn=sys.argv[1])
+try:
+    sink.ensure_schema(force=True)
+finally:
+    sink.close()
+print("CHSCHEMA_APPLIED")
+`
+
+// Apply migrates the container to the current head of the real chain.
+//
+// It FAILS the test rather than skipping when Python is unavailable. A skip
+// here would silently drop every schema-dependent assertion in the calling
+// package while the package still reported ok, which is precisely the
+// unmeasured-but-green shape this helper was written to remove.
+func Apply(ctx context.Context, t *testing.T, instance *containers.Instance) {
+	t.Helper()
+	dsn, err := containers.ClickHouseHTTPDSN(ctx, instance)
+	if err != nil {
+		t.Fatalf("chschema: %v", err)
+	}
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("chschema: %v", err)
+	}
+	python, err := pythonBinary(root)
+	if err != nil {
+		t.Fatalf("chschema: %v", err)
+	}
+	command := exec.CommandContext(ctx, python, "-c", applyScript, dsn)
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PYTHONPATH="+filepath.Join(root, "src")+string(os.PathListSeparator)+os.Getenv("PYTHONPATH"),
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("chschema: applying the real migration chain failed: %v\n%s", err, output)
+	}
+	// The runner can exit 0 having done nothing if the entrypoint ever stops
+	// raising on failure, so require the positive marker rather than trusting
+	// the exit code alone.
+	if !strings.Contains(string(output), "CHSCHEMA_APPLIED") {
+		t.Fatalf("chschema: migration runner produced no completion marker:\n%s", output)
+	}
+}
+
+// repoRoot walks up from THIS file, not from the test's working directory, so
+// the answer does not depend on which package invoked the helper.
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("cannot locate the chschema source file")
+	}
+	directory := filepath.Dir(file)
+	for {
+		migrations := filepath.Join(directory, "src", "dev_health_ops", "migrations", "clickhouse")
+		if info, err := os.Stat(migrations); err == nil && info.IsDir() {
+			return directory, nil
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			return "", fmt.Errorf("no src/dev_health_ops/migrations/clickhouse above %s", filepath.Dir(file))
+		}
+		directory = parent
+	}
+}
+
+// pythonBinary prefers the checked-out virtualenv, which is what the live
+// Python oracle gate already relies on, then an explicit override, then PATH.
+func pythonBinary(root string) (string, error) {
+	if override := os.Getenv("DEV_HEALTH_PYTHON"); override != "" {
+		return override, nil
+	}
+	venv := filepath.Join(root, ".venv", "bin", "python")
+	if _, err := os.Stat(venv); err == nil {
+		return venv, nil
+	}
+	found, err := exec.LookPath("python3")
+	if err != nil {
+		return "", fmt.Errorf(
+			"no Python to run the migration chain: %s does not exist, "+
+				"DEV_HEALTH_PYTHON is unset, and python3 is not on PATH", venv,
+		)
+	}
+	return found, nil
+}

--- a/internal/testsupport/chschema/chschema.go
+++ b/internal/testsupport/chschema/chschema.go
@@ -18,6 +18,12 @@
 // upgrade` CLI makes -- which covers BOTH the .sql migrations and the .py ones
 // (027 and 055 rebuild tables through a shadow-table swap that no static SQL
 // extractor could reproduce).
+//
+// SHARED, and table-agnostic by construction: Apply takes no table list and
+// migrates the database to the chain's head, so any package needing real
+// tables gets all of them at once. It was written for three derived work-item
+// destinations, but nothing about it is specific to them -- adopters need only
+// call Apply instead of executing their own CREATE TABLE text.
 package chschema
 
 import (

--- a/internal/testsupport/containers/harness.go
+++ b/internal/testsupport/containers/harness.go
@@ -67,13 +67,52 @@ func StartPostgres(ctx context.Context) (*Instance, error) {
 	return &Instance{Container: container, URI: uri.String()}, nil
 }
 
+// ClickHouse test credentials, exported so a helper that must address the
+// container over a DIFFERENT protocol than Instance.URI can build its own DSN
+// instead of re-declaring these and drifting from them.
+const (
+	ClickHouseUser     = "worker_test"
+	ClickHousePassword = "worker_test_password"
+	ClickHouseDatabase = "worker_test"
+	// ClickHouseHTTPPort is exposed alongside the native port. Instance.URI
+	// addresses the NATIVE protocol, which the Go driver speaks; the Python
+	// migration runner is an HTTP client and needs this one.
+	ClickHouseHTTPPort = "8123/tcp"
+)
+
+// ClickHouseHTTPDSN returns a clickhouse:// DSN addressed at the container's
+// mapped HTTP port. The scheme must stay clickhouse:// -- the Python sink
+// factory rejects http:// outright ("Only ClickHouse is supported", CHAOS-641)
+// -- while the PORT must be the HTTP one, because that client speaks HTTP and
+// not the native protocol Instance.URI points at.
+func ClickHouseHTTPDSN(ctx context.Context, instance *Instance) (string, error) {
+	if instance == nil || instance.Container == nil {
+		return "", fmt.Errorf("clickhouse HTTP DSN: no container")
+	}
+	host, err := instance.Container.Host(ctx)
+	if err != nil {
+		return "", fmt.Errorf("clickhouse HTTP DSN host: %w", err)
+	}
+	mapped, err := instance.Container.MappedPort(ctx, ClickHouseHTTPPort)
+	if err != nil {
+		return "", fmt.Errorf("clickhouse HTTP DSN port: %w", err)
+	}
+	uri := url.URL{
+		Scheme: "clickhouse",
+		User:   url.UserPassword(ClickHouseUser, ClickHousePassword),
+		Host:   host + ":" + mapped.Port(),
+		Path:   ClickHouseDatabase,
+	}
+	return uri.String(), nil
+}
+
 func StartClickHouse(ctx context.Context) (*Instance, error) {
 	const (
-		user     = "worker_test"
-		password = "worker_test_password"
-		database = "worker_test"
+		user     = ClickHouseUser
+		password = ClickHousePassword
+		database = ClickHouseDatabase
 		port     = "9000/tcp"
-		httpPort = "8123/tcp"
+		httpPort = ClickHouseHTTPPort
 	)
 	container, host, mappedPort, err := start(ctx, testcontainers.ContainerRequest{
 		Image:        ClickHouseImage,


### PR DESCRIPTION
Ports three of the nine Python-derived GitHub work-item destinations to Go: `estimate_coverage_metrics_daily`, `work_item_team_attributions`, `work_item_state_durations_daily`. Builders, ClickHouse effect adapters, differential oracles, and real-server readback evidence.

**Targets `feat/go-worker-runtime-migration` only — never `main`. No route activation:** all five work-item aliases remain `route_ready: false` / `go_executor: none`, `contracts/` and `deploy/` are byte-identical to base, and migration 0066 is untouched.

**CI note:** GitHub Actions is in a major outage, so this rides a later amend-push for CI, same as #1535/#1537. Local evidence is the bar for now; every exit code below was captured unpiped.

## Scope

`workItemRouteDestinations()` is 16; `githubWorkItemDerivedDestinations` is 9, so 7 are direct. The metric-triplet lane (#1535) owns 3 derived destinations; this PR owns 3 of the remaining 6. The last 3 (`issue_type_metrics_daily` and both investment surfaces) are computed inline in `job_work_items.py` on top of two config-driven engines with no Go port, and follow as PR-B (engines) and PR-C (destinations).

## Pinned Python defects (D16 — mirrored bug-for-bug, not fixed)

Each is mirrored in Go and pinned by an oracle case. None is fixed here — a port is not the place to change Python behaviour.

1. **CHAOS-3491** — the estimate-coverage bucket is created **before** its own terminal-item skip, so an item that reached a terminal state before the window end still materialises an all-zero group with a NULL ratio.
2. **CHAOS-3492** — coverage keeps the **first** contributing item's `team_name` for a group; state durations keep the **last**. Opposite rules for the same concept, deliberately not sharing a helper.
3. **CHAOS-3492** — attribution rows persist the **raw** candidate team id, so a null stays NULL there while the same resolution becomes `"unassigned"` in the coverage rollup. Ticketed together with 2 as one team-id/team-name consistency issue.
4. **CHAOS-3493** — `avg_wip` divides by a fixed 24 regardless of how much of the day the window covers.
5. **CHAOS-3494** — `compute_work_item_team_attributions` takes no `day` while its caller loops over days, so a backfill rewrites byte-identical rows once per day.

**CHAOS-3495** (reported separately) is not mirrored here but bears directly on this PR's comparator contract: backfills recompute **all** data in range rather than only what is missing, so a re-run whose rows are byte-identical except for `computed_at` is the *steady state*, not an edge case. That is exactly the input the three-way version ordering added in this PR exists to survive — under the previous two-way `!Equal → Absent` it produced an unterminating rewrite loop. The interaction is worth keeping in view when 3494 and 3495 are scheduled: fixing either changes how often the version-only-difference path is taken, and it is the path all thirteen sibling adapters inherit from this contract.

## Evidence

**Differential oracles.** Three pairs that EXECUTE the real production compute functions through the real project-key resolver, linked-issue donor index and `ClickHouseDataLoader` attribution context; only the ClickHouse transport is faked, and the pair fails if the production loader did not issue all four fact queries. Compared field sets are reflected from the production dataclasses, never hand-listed. Comparison is column-oriented, so row order diverges visibly.

Proven input classes: empty-fact, repo-ownership, and membership/project. Project ownership, manual fallback and linked-issue inheritance are **not** claimed here — they belong to the derivation-context pair.

**`org_id` is deliberately NOT excluded on the team-attributions pair.** That producer populates `org_id` itself, so excluding it would hide a real tenant-stamping divergence behind a reason that is untrue for that pair. It stays excluded on the two daily rollups, where Python genuinely leaves it to the sink.

**Mutations: 29 measured — 26 KILLED, 2 SURVIVED_DECLARED, 1 SURVIVED_UNDECLARED, 0 INVALID, 0 BASELINE_FAILED.** `verify` reports a clean tree after every run. `--assert-all-killed` does NOT exit 0, and that is deliberate: **E8** is left an UNDECLARED survivor. Removing the write-side dedup survives only because ClickHouse's equal-version tie-break happens to coincide with the row the expectation names — undefined behaviour is not equivalence, and declaring it as one to turn the flag green would be exactly the false coverage this gate exists to prevent. Every other survivor carries a measured reason. The TWO declared survivors each carry a measured reason. `R5` is provably equivalent: the two forms differ only at exact equality, where the zero-length-segment filter erases the difference — measured with a case that forces that exact boundary. `E13` is UNREACHABLE rather than equivalent: that readback's `WHERE` pins the complete sorting key, so `FINAL` returns at most one row and `found > 1` cannot be constructed against this schema — the sibling-row tests are the evidence, writing exactly such a sibling and still reading `found = 1`. Its branch is defensive depth for a regressed fence, and every fence that would make it reachable has its own mutation (`E2`, `E10`, `E11`, `E12`), all killed.

**Correction to this PR's earlier claim.** A previous revision of this body reported `17 measured — 16 KILLED … 0 INVALID`. That was wrong. `E6` and `E7` searched for an `actual.ComputedAt.Equal(...)` form that the three-way version ordering had already replaced, so they matched **nothing** and were scored as KILLED while measuring nothing at all. INVALID is not KILLED. Both are re-pointed at the live comparison and re-measured here, and the plan is now validated by asserting every `find` string occurs exactly once in its target file before a run — a mutant that cannot apply is the one failure mode that reads as coverage from every direction.

**Three readback shapes, because the three tables do not share an engine.** Coverage is RMT partitioned by `toYYYYMM(day)`; state durations is **plain** MergeTree where `FINAL` is a no-op and dedup must be `argMax` over the natural key; team attributions is RMT with no `PARTITION BY`. All three test `found != 1` **first** — reaching an absent/stale branch before the duplicate check turns duplicates-plus-a-stale-row into an infinite rewrite loop.

**Partition-fence precondition is verified, not assumed.** Per the cross-lane finding, a partition predicate is only safe when the partition expression is derivable from the sorting key. A test reads `SHOW CREATE TABLE` from the live server and fails if a partitioned table's `day` ever leaves the sorting key. That assertion is only meaningful because the tables are now created by the **real migration chain** (`internal/testsupport/chschema` applies `src/dev_health_ops/migrations/clickhouse` through the project's own canonical entrypoint, covering the `.py` migrations that rebuild tables via a shadow-table swap). While the DDL was hand-typed in the test file, reading it back proved only that ClickHouse stored what we had just typed — the assertion and the input had the same author. The membership test is a real top-level column-list check, not `strings.Contains(orderBy, "day")`, which a column named `birthday` satisfies. The month-boundary readback runs under **both** values of `do_not_merge_across_partitions_select_final`, because under the default the defect presents as a false Conflict rather than as `found=2`.

## Things caught by running things, not reading them

- Oracle tests `t.Skip` unless `DEV_HEALTH_LIVE_PYTHON_ORACLES=1`, and `go test` prints `ok` for an all-skipped package — this scored 5 mutants as false survivors before it was caught. The real protection is not a `--- SKIP` string match: when the oracle env is absent the baseline **and** the mutant both skip, the mutant is therefore scored **SURVIVED**, and `--assert-all-killed` exits non-zero because it has no declared survivor reason. The gate fails closed on an unmeasured run rather than depending on parsing test output.
- Replaying a **superseded** effect returns Conflict, not Absent: "absent" instructs the committer to write, and writing a stale generation over fresher data is a silent regression. My test asserted Absent; the server was right.
- One mutation used `any()`, which is nondeterministic and survived by happening to return the newest row — replaced with `argMin`, the deterministic inverse.
- One mutation removed `status` from a `GROUP BY` and survived **correctly**, because the `WHERE` already pins every grouping column. Rather than declare the equivalence, it was repointed at the fence itself.
- Two plan entries went INVALID (non-building mutants, which measure nothing while reading as coverage) and were rewritten to neutralise predicates rather than orphan bindings.

**Schema drift the hand-typed DDL was hiding.** The test file's copy of
`work_item_team_attributions` carried the **pre-053** enums, missing the `issue_project` and
`manual_fallback` source values and the `manual` and `none` confidence values — all of which the
production resolver genuinely emits. Measured, not argued: inserting `confidence='none'` or
`source='issue_project'` into the old hand-typed DDL fails with `UNKNOWN_ELEMENT_OF_ENUM` (code
691), and the same insert succeeds against the migrated schema. The unassigned fixture had been
written as confidence `"low"` — a value the resolver never produces — which is precisely why
nothing ever failed. A second drift surfaced by the same comparison:
`work_item_state_durations_daily.org_id` is `DEFAULT 'default'` in the real chain, not `DEFAULT ''`.
A new guard checks every value the resolver can emit against the enum the migration produced, so it
fails if either side moves.

**`computed_at` is now quantized at the BUILDER, per destination.** The production feed is
`time.Now()` with nanoseconds and no destination column can hold them, so a stamp emitted at
unstorable precision is written, quantized by the server, read back different, and the replay
verdict is `Absent` forever. Estimate coverage and team attributions quantize to milliseconds,
state durations to seconds. Only the **stamping sites** quantize: `computed_at` is also the open
state segment's end, so quantizing the arithmetic would shorten `duration_hours` against Python by
up to a second. This matters more than it looks given CHAOS-3495 — because backfills recompute the
whole range, a re-run differing only in `computed_at` is the **steady state**, so an already-quantized
stamp is what keeps ordinary operation answering `Exact` instead of rewriting on every pass.

**Precondition: single writer.** The builder-side `computed_at` stamping and the version-aware
write-side dedup are both valid only under one writer per (org, destination, day). Two concurrent
writers stamping independent `time.Now()` values can interleave versions such that the row a writer
expects is not the row `ReplacingMergeTree` keeps. Nothing in this PR enforces that; the activation
layer does, and no route here is activated (`route_ready: false` / `go_executor: none` unchanged).

**`ErrEffectRecoveryAmbiguous` now terminalizes deterministically, for ALL adapters.** A readback
conflict, a recovery-blocked effect and a missing readback are each decided by already-persisted
state, so every retry reaches the same verdict; they previously burned all attempts and then
recorded the generic `provider_unit_exhausted`. `deterministicTerminalCategory` is shared, so this
changes the recorded category and retry count for every route reaching the committer, not only
these three destinations. That is intended.

## Gates

`ci/check_go.sh fast` exit 0 with `=== CRITICAL (0) ===` · `ci/check_go.sh live-python-oracles` exit 0 (requires a proof marker per checked-in pair, so it proves the three new pairs executed) · `go build` / `go vet` / `go vet -tags integration` / gofmt / ruff clean · full `internal/providersync` suite green · integration tests green on a throwaway testcontainer.

## Review notes

- The two `oracle_compare_test.go` edits are byte-duplicates of what #1535 introduces and are marked `LANE NOTE`; merge order puts this second, so they get dropped at that rebase.
- The three adapters share two helpers and live in one sectioned file, each with its own integration test.
- Pre-existing and unrelated: an advisory `ACKNOWLEDGEMENT` row for `sync_run_unit_effect_snapshots INSERT`, which arrived with #1529 and gates nothing.


