### PR TITLE
CHAOS-3450 follow-up: give a create_all schema 0049's dispatch fence triggers

### DIFF
--- a/src/dev_health_ops/models/integrations.py
+++ b/src/dev_health_ops/models/integrations.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Any
 
 from sqlalchemy import (
+    DDL,
     JSON,
     BigInteger,
     Boolean,
@@ -17,6 +18,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -544,3 +546,187 @@ class SyncDispatchTransportRoute(Base):
             name="ck_sync_dispatch_transport_routes_pause_timestamp",
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Sync dispatch transport fence: the PostgreSQL arm of migration 0049.
+#
+# `ck_sync_dispatch_outbox_claim_route_coherence` is declared above, so
+# `Base.metadata.create_all` installs it -- but the BEFORE INSERT OR UPDATE
+# trigger that makes the constraint SATISFIABLE for a writer that sets only
+# `claim_token`/`claim_expires_at` (a pre-0049 Celery worker, and every
+# claim path that predates the route columns) lived ONLY in migration 0049.
+# A database built by `create_all` therefore got the constraint without the
+# trigger that fills the pair it demands, and any legacy-shaped claim write
+# died on a CheckViolation that a migrated database never produces. That is
+# exactly what `test_real_postgres_migration_trigger_keeps_legacy_celery_-
+# worker_compatible` hit the moment CHAOS-3450 (#1523) first let the
+# Postgres-gated suites actually execute (CHAOS-3465 follow-up).
+#
+# Registered the same way `models/dev_persistence.py` registers the payload
+# contract triggers whose PostgreSQL arm ships as migration 0080: the DDL is
+# duplicated here rather than imported from the migration, because a
+# migration is frozen against the schema it shipped and must not follow this
+# module's drift.
+#
+# PostgreSQL only -- 0049 has no SQLite arm, and the SQLite unit fixtures
+# never exercise a claim write that omits the route pair. Production
+# databases are built by Alembic, never by `create_all`, so this changes no
+# deployed schema; it only stops `create_all` from producing a schema that
+# is strictly stricter than the one production runs.
+#
+# The DROP and CREATE are separate DDL objects (and separate `event.listen`
+# registrations) because asyncpg prepares each statement individually and
+# rejects multiple commands in one `execute()` -- see the same note in
+# `models/dev_persistence.py`.
+# ---------------------------------------------------------------------------
+
+SYNC_DISPATCH_ROUTE_GENERATION_FUNCTION_POSTGRESQL = """
+CREATE OR REPLACE FUNCTION enforce_sync_dispatch_route_generation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.generation < OLD.generation THEN
+        RAISE EXCEPTION 'sync dispatch route generation cannot decrease';
+    END IF;
+    IF (
+        NEW.transport IS DISTINCT FROM OLD.transport
+        OR NEW.paused IS DISTINCT FROM OLD.paused
+        OR NEW.paused_at IS DISTINCT FROM OLD.paused_at
+        OR NEW.rollback_transport IS DISTINCT FROM OLD.rollback_transport
+    ) AND NEW.generation <= OLD.generation THEN
+        RAISE EXCEPTION
+            'sync dispatch route state change requires generation increase';
+    END IF;
+    RETURN NEW;
+END;
+$$
+"""
+
+SYNC_DISPATCH_ROUTE_GENERATION_TRIGGER_DROP_POSTGRESQL = """
+DROP TRIGGER IF EXISTS trg_sync_dispatch_route_generation
+ON sync_dispatch_transport_routes
+"""
+
+SYNC_DISPATCH_ROUTE_GENERATION_TRIGGER_CREATE_POSTGRESQL = """
+CREATE TRIGGER trg_sync_dispatch_route_generation
+BEFORE UPDATE ON sync_dispatch_transport_routes
+FOR EACH ROW
+EXECUTE FUNCTION enforce_sync_dispatch_route_generation()
+"""
+
+SYNC_DISPATCH_OUTBOX_FENCE_FUNCTION_POSTGRESQL = """
+CREATE OR REPLACE FUNCTION enforce_sync_dispatch_outbox_route_fence()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    active_transport text;
+    active_generation bigint;
+BEGIN
+    IF (NEW.claim_token IS NULL) <> (NEW.claim_expires_at IS NULL) THEN
+        RAISE EXCEPTION
+            'sync dispatch claim token and expiry must change together';
+    END IF;
+
+    IF NEW.claim_token IS NOT NULL
+       AND (
+           NEW.claim_transport IS NULL
+           OR NEW.claim_route_generation IS NULL
+       ) THEN
+        SELECT transport, generation
+        INTO active_transport, active_generation
+        FROM sync_dispatch_transport_routes
+        WHERE kind = NEW.kind
+          AND transport = 'celery'
+          AND paused = FALSE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'sync dispatch kind has no active celery route';
+        END IF;
+        NEW.claim_transport := active_transport;
+        NEW.claim_route_generation := active_generation;
+    END IF;
+
+    IF NEW.status = 'dispatched'
+       AND NEW.last_error IS DISTINCT FROM 'feature_disabled' THEN
+        NEW.dispatched_transport := COALESCE(
+            NEW.dispatched_transport,
+            NEW.claim_transport,
+            OLD.claim_transport
+        );
+        NEW.dispatched_route_generation := COALESCE(
+            NEW.dispatched_route_generation,
+            NEW.claim_route_generation,
+            OLD.claim_route_generation
+        );
+    ELSE
+        NEW.dispatched_transport := NULL;
+        NEW.dispatched_route_generation := NULL;
+        NEW.transport_job_id := NULL;
+    END IF;
+
+    IF NEW.claim_token IS NULL THEN
+        NEW.claim_transport := NULL;
+        NEW.claim_route_generation := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$
+"""
+
+SYNC_DISPATCH_OUTBOX_FENCE_TRIGGER_DROP_POSTGRESQL = """
+DROP TRIGGER IF EXISTS trg_sync_dispatch_outbox_route_fence
+ON sync_dispatch_outbox
+"""
+
+SYNC_DISPATCH_OUTBOX_FENCE_TRIGGER_CREATE_POSTGRESQL = """
+CREATE TRIGGER trg_sync_dispatch_outbox_route_fence
+BEFORE INSERT OR UPDATE ON sync_dispatch_outbox
+FOR EACH ROW
+EXECUTE FUNCTION enforce_sync_dispatch_outbox_route_fence()
+"""
+
+event.listen(
+    SyncDispatchTransportRoute.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_ROUTE_GENERATION_FUNCTION_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)
+event.listen(
+    SyncDispatchTransportRoute.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_ROUTE_GENERATION_TRIGGER_DROP_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)
+event.listen(
+    SyncDispatchTransportRoute.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_ROUTE_GENERATION_TRIGGER_CREATE_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)
+event.listen(
+    SyncDispatchOutbox.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_OUTBOX_FENCE_FUNCTION_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)
+event.listen(
+    SyncDispatchOutbox.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_OUTBOX_FENCE_TRIGGER_DROP_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)
+event.listen(
+    SyncDispatchOutbox.__table__,
+    "after_create",
+    DDL(SYNC_DISPATCH_OUTBOX_FENCE_TRIGGER_CREATE_POSTGRESQL).execute_if(
+        dialect="postgresql"
+    ),
+)

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -900,6 +900,15 @@ def test_backoff_seconds_sequence_is_capped():
     reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
 )
 def test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible():
+    """A writer that sets only the pre-0049 lease columns still commits.
+
+    The trigger under test is ``trg_sync_dispatch_outbox_route_fence``. It
+    reaches production as migration 0049 and reaches the ``create_all``
+    schema this test builds through the ``after_create`` DDL registrations
+    in ``models/integrations.py`` -- same statement text, two install
+    paths. Naming only the migration would be a claim this test cannot
+    make, because ``create_all`` never runs one.
+    """
     engine = create_engine(sync_postgres_test_url())
     Base.metadata.create_all(engine)
     run_id = None


### PR DESCRIPTION
## The suspect is exonerated; the cause is a create_all-vs-Alembic schema split

Main's Tests workflow has been red on **exactly one** test — see run
[31128956838](https://github.com/full-chaos/dev-health-ops/actions/runs/31128956838),
coverage job, Postgres tier, 12810 passed / 1 failed:

```
tests/test_dispatch_outbox.py::test_real_postgres_migration_trigger_keeps_legacy_celery_worker_compatible
sqlalchemy.exc.IntegrityError: (psycopg2.errors.CheckViolation)
new row for relation "sync_dispatch_outbox"
violates check constraint "ck_sync_dispatch_outbox_claim_route_coherence"
```

The prime suspect was #1526 (CHAOS-3465), the most recent merge in the dispatch-outbox
domain and one that landed un-CI-validated during the GitHub outage. **It is not the
cause**, and the evidence is CI's own logs rather than a reading of the diff:

| coverage job | commit | relationship to #1526 | failing tests |
|---|---|---|---|
| 92712256918 | `34ac4d640` | after | this one, alone |
| 92667755399 | `b759c7bfb` | after | this one, alone |
| 92623892798 | `c894beef7` | **before** | this one, alone |
| 92616532279 | `e317395b9` | **before** | this one + 8 more |

#1526's own Postgres test creates a throwaway database and drops it, so it cannot
reach the shared `test_db` at all. Full exoneration is recorded on CHAOS-3465
(comment `95dc7d4b-2b21-4236-92be-5da7cd97b5e5`) so that ticket's session knows its
merge is clean.

The test has **never** passed. #1523 (CHAOS-3450) fixed the sync-driver coercion and so
let the Postgres-gated suites execute for the first time; it cleared eight of the nine
failures above. This one survived because it is not a driver problem.

### Root cause

Migration `0049_add_sync_dispatch_transport_fence` ships **two** things:

1. the CHECK `ck_sync_dispatch_outbox_claim_route_coherence` — a claim is all-four-columns
   or none; and
2. the `BEFORE INSERT OR UPDATE` trigger `trg_sync_dispatch_outbox_route_fence`, which
   backfills `claim_transport`/`claim_route_generation` from the active Celery route when
   a writer sets only `claim_token`/`claim_expires_at`.

The CHECK is declared on the model, so `Base.metadata.create_all` installs it. **The
trigger was never registered on the metadata.** A `create_all`-built database therefore
receives the constraint *without* the trigger that makes it satisfiable — a schema
strictly **stricter** than the one production runs.

The test builds its schema with `create_all`, then simulates a pre-0049 Celery worker
writing only the two original lease columns. On a migrated database the trigger fills the
pair; on a `create_all` database nothing does, and the CHECK rejects the row.

### Production impact: none

Production and every deployed environment are built by Alembic, so the fence is present
there. No real retry path — #1526's surplus phase included — writes a violating row. The
only unconditional `Base.metadata.create_all` outside tests is
`SQLAlchemyStore.ensure_tables`, and every `ensure_tables()` call site in `src/` is on
`ClickHouseMetricsSink`, not that store. The gap is confined to `create_all` schemas:
tests and local scratch databases.

## The fix

`models/integrations.py` registers 0049's PostgreSQL DDL — both trigger functions and both
triggers — as `after_create` listeners on `SyncDispatchOutbox.__table__` and
`SyncDispatchTransportRoute.__table__`.

This is the pattern the repo already uses: `models/dev_persistence.py` registers the
payload-contract triggers the same way, and ships their PostgreSQL arm as migration 0080,
with the comment *"Registered via `event.listen(<table>, "after_create", DDL(...))` so
`Base.metadata.create_all` … installs the … arm automatically."* 0049 did the migration
half and skipped the metadata half.

Details that are deliberate, not incidental:

- **Statement text is duplicated, not imported from the migration.** A migration is frozen
  against the schema it shipped and must not follow this module's drift. 0080/`dev_persistence`
  make the same call.
- **DROP and CREATE are separate `DDL` objects and separate `event.listen` registrations**,
  because asyncpg prepares each statement individually and rejects multiple commands in one
  `execute()` — the same note already stands in `models/dev_persistence.py`.
- **PostgreSQL only.** 0049 has no SQLite arm, and the SQLite unit fixtures never exercise a
  claim write that omits the route pair.
- **No migration is edited and no deployed schema changes.**

`tests/test_dispatch_outbox.py` gets a docstring and nothing else. The test's name calls this
the "migration" trigger — a claim the test cannot make, since it builds its schema with
`create_all`, which never runs a migration. The docstring now names both install paths. No
assertion is touched; the test is the RED and stays exactly as strict.

## Verification

RED-first, against a scratch `postgres:17.4` on a non-conflicting port, with the database
dropped and recreated before each direction (never the dev stack's live Postgres):

| | result |
|---|---|
| the exact test, **pre-fix** | **1 failed** — same `CheckViolation`, same DETAIL row shape as CI |
| `tests/test_dispatch_outbox.py`, **post-fix** | **30 passed** |
| full Postgres-gated set — 11 files, incl. `tests/test_chaos_3465_budget_surplus_retry.py`, `test_sync_watermarks.py`, `test_sync_planner.py`, `test_sync_reconciler.py`, `tests/api/…` | **251 passed** |
| SQLite side, `-k "dispatch or outbox or transport_route"` | **395 passed, 8 skipped** |
| `ruff check` / `ruff format --check` / `mypy` on both files | clean |

The local gate cannot exercise this test — there is no Postgres tier locally, which is
precisely why the defect reached main. **This PR's own coverage job is the real proof**;
its result is reported in a comment below.

Refs CHAOS-3450, CHAOS-3039, CHAOS-3465
