### PR TITLE
fix(ci): repair the two Go workflow reds on the feature branch

### DIFF
--- a/internal/domaingrants/roles.go
+++ b/internal/domaingrants/roles.go
@@ -266,6 +266,20 @@ var acknowledgedBlindSpots = []AcknowledgedBlindSpot{
 			"TestScheduledMaterializerRoleBoundary proves the domain/coordinator split.",
 	},
 	{
+		Role: RoleDomain, Table: "sync_run_unit_effect_snapshots", Privilege: PrivInsert,
+		Why: "providersync/prepared_route_snapshot.go:304 executes insertPreparedRouteSnapshotSQL " +
+			"on a pgx.Tx the mutate closure receives as a PARAMETER -- mutateGenerationJournalTx " +
+			"(generation_journal.go:407) begins it from PostgresRepository.Pool -- so pool taint " +
+			"stops at the closure boundary and the site is invisible to this analysis, the same " +
+			"wiring hop as the sync_run_units INSERT above. That pool IS the domain pool: " +
+			"cmd/dev-health-worker/provider_sync.go:467 constructs the repository with " +
+			"pools.Domain. The privilege is exercised, not over-declared: " +
+			"TestPostgresPreparedRouteSnapshotRunsUnderTheRestrictedDomainRole prepares a snapshot " +
+			"through a pool logged in as the restricted domain role, which fails if the INSERT " +
+			"grant is absent. The SELECT and DELETE on this table run straight off the pool and " +
+			"are traced normally; only the INSERT sits behind the transaction boundary.",
+	},
+	{
 		Role: RoleCoordinator, Table: "feature_flags", Privilege: PrivUpdate,
 		Why: "scheduler/sync/materializer.go locks canonical_incident_ingestion with SELECT FOR " +
 			"UPDATE inside the coordinator occurrence transaction; no feature row is mutated.",

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -355,6 +355,16 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 		"CREATE TABLE public.integration_credentials (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
+		// Migration 0088 (#1529) added this table to domainPosture's manifest,
+		// so the CheckDomainAuthorization readiness call each test in this
+		// package makes fails closed on its absence — the
+		// table has to exist here even though this fixture never writes to it,
+		// exactly as it has to exist in a deployment before domain workers
+		// start. ApplyPinnedMigrations' domain GRANT for it is guarded by
+		// `IF to_regclass(...) IS NOT NULL`, so without this CREATE the role
+		// silently receives no grant and readiness reports the opaque
+		// "PostgreSQL readiness check failed".
+		"CREATE TABLE public.sync_run_unit_effect_snapshots (sync_run_unit_id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_watermarks (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.sync_configurations (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.organizations (id bigint PRIMARY KEY)",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -94,6 +94,49 @@ _LICENSE_TYPES_SOURCE = _source("dev_health_ops/licensing/types.py")
 _LICENSE_REGISTRY_SOURCE = _source("dev_health_ops/licensing/registry.py")
 _FEATURE_POLICY_SOURCE = _source("dev_health_ops/licensing/feature_policy.py")
 
+# The ClickHouse metrics sink package, for the direct work-item destination
+# projection oracle. Every one of these is a real production source; the list
+# is long because the target is a package __init__ that composes fourteen
+# mixins, and each one has to be in sys.modules before that __init__ runs
+# (see _target_clickhouse_metrics_sink).
+_CLICKHOUSE_DEDUP_SOURCE = _source("dev_health_ops/clickhouse_dedup.py")
+_METRICS_SCHEMAS_SOURCE = _source("dev_health_ops/metrics/schemas.py")
+_WORK_ITEM_MODELS_SOURCE = _source("dev_health_ops/models/work_items.py")
+_AI_ATTRIBUTION_MODELS_SOURCE = _source("dev_health_ops/models/ai_attribution.py")
+_AI_WORKFLOW_MODELS_SOURCE = _source("dev_health_ops/models/ai_workflow.py")
+_AI_GOVERNANCE_MODELS_SOURCE = _source("dev_health_ops/audit/ai_governance/models.py")
+_RECOMMENDATION_SNAPSHOT_SOURCE = _source("dev_health_ops/recommendations/snapshot.py")
+_CLICKHOUSE_MIGRATIONS_SOURCE = _source(
+    "dev_health_ops/migrations/clickhouse/__init__.py"
+)
+_METRICS_SINK_BASE_SOURCE = _source("dev_health_ops/metrics/sinks/base.py")
+_METRICS_SINK_FACTORY_SOURCE = _source("dev_health_ops/metrics/sinks/factory.py")
+_CLICKHOUSE_SINK_PACKAGE = "dev_health_ops/metrics/sinks/clickhouse"
+_CLICKHOUSE_INSERT_SOURCE = _source(f"{_CLICKHOUSE_SINK_PACKAGE}/_insert.py")
+_CLICKHOUSE_CONNECTION_SOURCE = _source(f"{_CLICKHOUSE_SINK_PACKAGE}/connection.py")
+_CLICKHOUSE_CORE_SOURCE = _source(f"{_CLICKHOUSE_SINK_PACKAGE}/core.py")
+_CLICKHOUSE_MIXIN_SOURCES: tuple[tuple[str, Path], ...] = tuple(
+    (
+        f"dev_health_ops.metrics.sinks.clickhouse.{module}",
+        _source(f"{_CLICKHOUSE_SINK_PACKAGE}/{module}.py"),
+    )
+    for module in (
+        "ai_attribution",
+        "ai_governance",
+        "ai_impact",
+        "ai_workflow",
+        "ci",
+        "compounding_risk",
+        "dora",
+        "investment",
+        "llm_tokens",
+        "recommendations",
+        "wellbeing",
+        "work_graph",
+    )
+)
+_CLICKHOUSE_SINK_SOURCE = _source(f"{_CLICKHOUSE_SINK_PACKAGE}/__init__.py")
+
 _SAFE_SOURCE_MODULES: dict[str, Path] = {
     "dev_health_ops.sync.budget_types": _BUDGET_TYPES_SOURCE,
     "dev_health_ops.sync.datasets": _DATASETS_SOURCE,
@@ -769,6 +812,75 @@ def _target_fetch_utils() -> None:
     _install_module("dev_health_ops.utils", {"BATCH_SIZE": 1000})
 
 
+def _target_clickhouse_metrics_sink() -> None:
+    """Compose the real ClickHouseMetricsSink without the application stack.
+
+    The target here is the sink package's own __init__, so the oracle built on
+    it constructs the SAME class production constructs -- not a local
+    re-composition of two mixins that a future mixin override could silently
+    diverge from.
+
+    Two things make a plain ``import dev_health_ops.metrics.sinks.clickhouse``
+    impossible under the go-quality interpreter, and both are package
+    __init__ side effects rather than anything the sink itself needs:
+
+      * ``metrics/sinks/__init__.py`` imports ``sinks.base``, which imports
+        ``models.work_items``, which runs ``models/__init__.py``, which
+        imports ``licensing/__init__.py``, which imports ``licensing/gating.py``,
+        which imports **fastapi** -- the whole HTTP API stack, pulled in to
+        write a row to ClickHouse. That is the CI failure this target closes
+        (ModuleNotFoundError: No module named 'fastapi').
+      * ``clickhouse/core.py`` imports **clickhouse_connect** at module level
+        for its connect path. The sink under test never connects: the oracle
+        injects a recording client. Only that name is stubbed, and it is
+        stubbed to fail loudly rather than silently return a mock, so an
+        oracle that ever reached the real connect path would say so.
+
+    Everything else below is loaded from its real source, in dependency order,
+    because ``__init__`` needs each submodule already resolved (its parent
+    package stub has an empty __path__, so the import system finds submodules
+    only through sys.modules). No projection logic is stubbed: the column
+    lists, the coercions, ClickHouseCore._insert_rows' asdict/org_id/datetime
+    handling and each mixin's writer are the shipped code.
+    """
+    _install_module("clickhouse_connect", {"get_client": _unsupported_dependency})
+    _load_source_module("dev_health_ops.clickhouse_dedup", _CLICKHOUSE_DEDUP_SOURCE)
+    _load_source_module("dev_health_ops.metrics.schemas", _METRICS_SCHEMAS_SOURCE)
+    _load_source_module(
+        "dev_health_ops.metrics.testops_schemas", _TESTOPS_SCHEMAS_SOURCE
+    )
+    _load_source_module("dev_health_ops.models.work_items", _WORK_ITEM_MODELS_SOURCE)
+    _load_source_module(
+        "dev_health_ops.models.ai_attribution", _AI_ATTRIBUTION_MODELS_SOURCE
+    )
+    _load_source_module("dev_health_ops.models.ai_workflow", _AI_WORKFLOW_MODELS_SOURCE)
+    _load_source_module(
+        "dev_health_ops.audit.ai_governance.models", _AI_GOVERNANCE_MODELS_SOURCE
+    )
+    _load_source_module(
+        "dev_health_ops.recommendations.snapshot", _RECOMMENDATION_SNAPSHOT_SOURCE
+    )
+    _load_source_module(
+        "dev_health_ops.migrations.clickhouse", _CLICKHOUSE_MIGRATIONS_SOURCE
+    )
+    _load_source_module("dev_health_ops.metrics.sinks.base", _METRICS_SINK_BASE_SOURCE)
+    _load_source_module(
+        "dev_health_ops.metrics.sinks.factory", _METRICS_SINK_FACTORY_SOURCE
+    )
+    _load_source_module(
+        "dev_health_ops.metrics.sinks.clickhouse._insert", _CLICKHOUSE_INSERT_SOURCE
+    )
+    _load_source_module(
+        "dev_health_ops.metrics.sinks.clickhouse.connection",
+        _CLICKHOUSE_CONNECTION_SOURCE,
+    )
+    _load_source_module(
+        "dev_health_ops.metrics.sinks.clickhouse.core", _CLICKHOUSE_CORE_SOURCE
+    )
+    for module_name, module_source in _CLICKHOUSE_MIXIN_SOURCES:
+        _load_source_module(module_name, module_source)
+
+
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
     _FETCH_UTILS_SOURCE: (
         "dev_health_ops.processors.fetch_utils",
@@ -890,6 +1002,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
         _FEATURE_POLICY_SOURCE,
         _target_feature_policy,
     ),
+    _CLICKHOUSE_SINK_SOURCE: (
+        "dev_health_ops.metrics.sinks.clickhouse",
+        _CLICKHOUSE_SINK_SOURCE,
+        _target_clickhouse_metrics_sink,
+    ),
 }
 
 
@@ -920,12 +1037,17 @@ def _install_namespace() -> None:
     for name in (
         "dev_health_ops",
         "dev_health_ops.analytics",
+        "dev_health_ops.audit",
+        "dev_health_ops.audit.ai_governance",
         "dev_health_ops.connectors",
         "dev_health_ops.credentials",
         "dev_health_ops.licensing",
+        "dev_health_ops.migrations",
         "dev_health_ops.models",
         "dev_health_ops.metrics",
         "dev_health_ops.metrics.sinks",
+        "dev_health_ops.metrics.sinks.clickhouse",
+        "dev_health_ops.recommendations",
         "dev_health_ops.parsers",
         "dev_health_ops.processors",
         "dev_health_ops.providers",

--- a/internal/providersync/testdata/python_work_item_sink_oracle.py
+++ b/internal/providersync/testdata/python_work_item_sink_oracle.py
@@ -19,6 +19,15 @@ write method. The captured column list and value matrix are therefore produced
 by the real writer -- not by re-reading its source, and not by a hand-authored
 fixture that could agree with a stale reading of it.
 
+The sink is reached through python_oracle_loader, not through a plain
+``import dev_health_ops.metrics.sinks.clickhouse``. Both are the same
+production module; the plain import additionally runs three package __init__
+files on the way in, and one of them (``models/__init__`` ->
+``licensing/__init__`` -> ``licensing/gating``) imports fastapi, which the
+go-quality interpreter deliberately does not have. The loader executes the
+same sources with those unrelated initializers skipped -- see
+_target_clickhouse_metrics_sink. Nothing about the writer is stubbed.
+
 Values are type-tagged on the way out (the same wire format
 python_generic_row_oracle.py uses) so the Go comparison cannot collapse an int
 to a float or a UUID to a string.
@@ -29,21 +38,42 @@ Usage: python_work_item_sink_oracle.py <cases.json>
 from __future__ import annotations
 
 import json
+import pathlib
 import sys
 from datetime import date, datetime, timezone
 from typing import Any
 from uuid import UUID
 
-from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.models.ai_attribution import AIAttributionRecord
-from dev_health_ops.models.work_items import (
-    Sprint,
-    WorkItem,
-    WorkItemDependency,
-    WorkItemInteractionEvent,
-    WorkItemReopenEvent,
-    WorkItemStatusTransition,
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from internal.providersync.testdata.python_oracle_loader import (  # noqa: E402
+    ROOT as _LOADER_ROOT,
 )
+from internal.providersync.testdata.python_oracle_loader import (  # noqa: E402
+    load_live_module,
+)
+
+_SINK_MODULE = load_live_module(
+    _LOADER_ROOT
+    / "src"
+    / "dev_health_ops"
+    / "metrics"
+    / "sinks"
+    / "clickhouse"
+    / "__init__.py"
+)
+ClickHouseMetricsSink = _SINK_MODULE.ClickHouseMetricsSink
+AIAttributionRecord = sys.modules[
+    "dev_health_ops.models.ai_attribution"
+].AIAttributionRecord
+_WORK_ITEM_MODELS = sys.modules["dev_health_ops.models.work_items"]
+Sprint = _WORK_ITEM_MODELS.Sprint
+WorkItem = _WORK_ITEM_MODELS.WorkItem
+WorkItemDependency = _WORK_ITEM_MODELS.WorkItemDependency
+WorkItemInteractionEvent = _WORK_ITEM_MODELS.WorkItemInteractionEvent
+WorkItemReopenEvent = _WORK_ITEM_MODELS.WorkItemReopenEvent
+WorkItemStatusTransition = _WORK_ITEM_MODELS.WorkItemStatusTransition
 
 
 class _RecordingClient:

--- a/internal/storage/postgres/venue_posture_coverage_test.go
+++ b/internal/storage/postgres/venue_posture_coverage_test.go
@@ -1,0 +1,275 @@
+package postgres
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This guard exists because of a defect that reached CI three times over: an
+// integration venue that builds its schema BY HAND, a posture manifest that
+// grows a table, and nothing connecting the two until a container run fails
+// with CheckDomainAuthorization's deliberately opaque "PostgreSQL readiness
+// check failed".
+//
+// The concrete instance: #1529 added sync_run_unit_effect_snapshots to
+// domainPosture (migration 0088) and a matching domain GRANT in
+// riverstore.ApplyPinnedMigrations. That GRANT is guarded by
+// `IF to_regclass(...) IS NOT NULL`, so in a venue that never CREATEs the
+// table the grant is silently skipped, the readiness check fails closed, and
+// the error names neither the table nor the venue. Three tests in two packages
+// went red for one missing CREATE.
+//
+// The fix for that instance was two CREATE TABLE lines. This test is the fix
+// for the CLASS: it fails at the next posture addition, in the fast unit lane
+// with the table and package named, instead of at the next container run with
+// an opaque readiness error. It needs no Docker on purpose -- a guard that
+// only runs where the original failure ran would be no earlier than the
+// failure it replaces.
+//
+// It is deliberately a SOURCE analysis rather than a runtime one. A runtime
+// version could only re-discover what CheckDomainAuthorization already
+// discovers, at the same moment, in the same job.
+
+// venuePackagesWithoutSchema is the ONLY place a package that calls
+// CheckDomainAuthorization may be exempt from the coverage requirement below,
+// and every entry needs a real reason. The default for such a package is "it
+// builds a venue and that venue must be complete"; discovery finding no
+// CREATE TABLE in it is treated as a possible relocation of the DDL (which
+// would silently un-cover the venue), not as self-evidently fine.
+//
+// A stale entry -- one naming a package that discovery no longer classifies
+// this way -- FAILS, for the same reason INTEGRATION_DENYLIST entries do in
+// ci/check_go.sh: an exemption list that drifts unnoticed is how the next
+// gap gets pre-approved.
+// It is empty today, and that is a real result rather than a placeholder:
+// every package discovery enrols does build a venue. internal/domaingrants was
+// the one candidate for an entry -- grant_surface_test.go names
+// CheckDomainAuthorization and starts no database -- but it names it inside a
+// message string, and discovery matches parsed CALL sites, so it is never
+// enrolled and needs no exemption.
+var venuePackagesWithoutSchema = map[string]string{}
+
+var createTablePattern = regexp.MustCompile(
+	`(?i)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?public\.([a-z0-9_]+)`,
+)
+
+// TestHandBuiltVenuesCreateEveryDomainPostureTable requires every package that
+// gates a test on CheckDomainAuthorization to create every table
+// domainPosture() declares. Discovery is repo-wide and inclusive: a venue
+// added tomorrow is covered the day it is written, without anyone remembering
+// to add it here.
+func TestHandBuiltVenuesCreateEveryDomainPostureTable(t *testing.T) {
+	root := repositoryRoot(t)
+	required := requiredPostureTables()
+	if len(required) == 0 {
+		t.Fatal("domainPosture() declared no tables -- the extraction below is " +
+			"reading the wrong thing, not a genuinely empty manifest")
+	}
+
+	packages := discoverDomainAuthorizationPackages(t, root)
+	if len(packages) == 0 {
+		t.Fatal("no package calls CheckDomainAuthorization from a test -- discovery " +
+			"is broken (this repository has several), and a guard that silently " +
+			"checks nothing reads exactly like a guard that passes")
+	}
+
+	exempt := map[string]bool{}
+	for _, pkg := range packages {
+		created := createdTables(t, filepath.Join(root, pkg))
+		if len(created) == 0 {
+			reason, allowed := venuePackagesWithoutSchema[pkg]
+			if !allowed {
+				t.Errorf("%s gates a test on CheckDomainAuthorization but creates no "+
+					"tables of its own. Either its venue DDL moved (which un-covers it "+
+					"from this guard -- point the guard at wherever it went) or it "+
+					"genuinely has no venue, in which case add it to "+
+					"venuePackagesWithoutSchema with the reason.", pkg)
+				continue
+			}
+			exempt[pkg] = true
+			t.Logf("%s: no venue schema, exempt (%s)", pkg, reason)
+			continue
+		}
+		var missing []string
+		for _, table := range required {
+			if !created[table] {
+				missing = append(missing, table)
+			}
+		}
+		if len(missing) > 0 {
+			t.Errorf("%s builds a venue by hand but never creates %v, which "+
+				"domainPosture() requires. CheckDomainAuthorization fails closed on a "+
+				"missing table, and ApplyPinnedMigrations' domain GRANT for it is "+
+				"guarded by `IF to_regclass(...) IS NOT NULL`, so the venue reports the "+
+				"opaque \"PostgreSQL readiness check failed\" instead. Add a CREATE "+
+				"TABLE for each to this package's fixture.", pkg, missing)
+			continue
+		}
+		t.Logf("%s: covers all %d required tables", pkg, len(required))
+	}
+
+	for pkg := range venuePackagesWithoutSchema {
+		if !exempt[pkg] {
+			t.Errorf("venuePackagesWithoutSchema names %q, which discovery did not "+
+				"classify as a CheckDomainAuthorization package without schema -- a "+
+				"stale exemption suppressing nothing, or a misspelled path", pkg)
+		}
+	}
+}
+
+// requiredPostureTables is every table the domain role's readiness check
+// touches: the RequiredTables manifest plus the tables behind its
+// column-scoped privileges, which must equally exist for
+// has_table_privilege() to answer at all. It reads domainPosture() directly
+// rather than restating it -- a second hand-maintained list here would
+// reintroduce the drift this guard exists to catch, one level up.
+func requiredPostureTables() []string {
+	posture := domainPosture()
+	unique := map[string]bool{}
+	for _, table := range posture.RequiredTables {
+		unique[table.TableName] = true
+	}
+	for _, column := range posture.ColumnScoped {
+		unique[column.TableName] = true
+	}
+	tables := make([]string, 0, len(unique))
+	for table := range unique {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	return tables
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	// internal/storage/postgres -> repository root.
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolved repository root %s has no go.mod: %v", root, err)
+	}
+	return root
+}
+
+// discoverDomainAuthorizationPackages returns every repository-relative
+// directory holding a _test.go file that CALLS CheckDomainAuthorization. The
+// match is on the parsed identifier, not on the file text, so naming the
+// function in a comment or a doc string does not enrol a package that never
+// runs the check.
+func discoverDomainAuthorizationPackages(t *testing.T, root string) []string {
+	t.Helper()
+	found := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "node_modules", ".venv", "site", "docs":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		if !callsDomainAuthorization(t, path) {
+			return nil
+		}
+		relative, relErr := filepath.Rel(root, filepath.Dir(path))
+		if relErr != nil {
+			return relErr
+		}
+		found[filepath.ToSlash(relative)] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	packages := make([]string, 0, len(found))
+	for pkg := range found {
+		packages = append(packages, pkg)
+	}
+	sort.Strings(packages)
+	return packages
+}
+
+func callsDomainAuthorization(t *testing.T, path string) bool {
+	t.Helper()
+	// Parsing WITHOUT comments is what makes this a call-site match: a file
+	// that only discusses the check in prose never reaches ast.Ident.
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	called := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch function := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if function.Sel.Name == "CheckDomainAuthorization" {
+				called = true
+			}
+		case *ast.Ident:
+			if function.Name == "CheckDomainAuthorization" {
+				called = true
+			}
+		}
+		return !called
+	})
+	return called
+}
+
+// createdTables collects the tables a package's tests create, reading only
+// STRING LITERALS. A regex over raw file text would count a table named in a
+// comment as created -- which is precisely the direction that must never be
+// wrong here, since a false "created" reading silently exempts a real gap.
+func createdTables(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := map[string]bool{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			literal, ok := node.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+			text, unquoteErr := strconv.Unquote(literal.Value)
+			if unquoteErr != nil {
+				// A raw string with an embedded backtick cannot occur in Go, so
+				// this only fires on a literal this walk should not see at all.
+				return true
+			}
+			for _, match := range createTablePattern.FindAllStringSubmatch(text, -1) {
+				created[strings.ToLower(match[1])] = true
+			}
+			return true
+		})
+	}
+	return created
+}

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -675,6 +675,16 @@ func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) err
 		// eda2d6b91) — created but never granted to the domain role here.
 		"CREATE TABLE public.worker_job_routes (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
+		// Migration 0088 (#1529) added this table to domainPosture's manifest,
+		// so the CheckDomainAuthorization readiness call each test in this
+		// package makes fails closed on its absence — the
+		// table has to exist here even though this fixture never writes to it,
+		// exactly as it has to exist in a deployment before domain workers
+		// start. ApplyPinnedMigrations' domain GRANT for it is guarded by
+		// `IF to_regclass(...) IS NOT NULL`, so without this CREATE the role
+		// silently receives no grant and readiness reports the opaque
+		// "PostgreSQL readiness check failed".
+		"CREATE TABLE public.sync_run_unit_effect_snapshots (sync_run_unit_id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_watermarks (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.worker_job_completion_fences (completion_key text PRIMARY KEY)",


### PR DESCRIPTION
Both failure groups from workflow_dispatch run 31128957169 (the feature branch's first real CI since the Actions outage). Each was reproduced locally as an observed red before the fix, and observed green after.

## Group 1 — go-storage-integration (3 tests, one cause)

`TestPostgresOperatorAuthenticationBackendAndAudit`, `TestMutationReconcilerActiveActive`, `TestKernelMutationPostgresTransactionFence` all failed with the opaque `domain authorization: PostgreSQL readiness check failed`.

Root cause, proven rather than pattern-matched: `DiagnoseRolePosture` against the live venue returns exactly one gap — `sync_run_unit_effect_snapshots: table does not exist`. #1529 added that table to `domainPosture()`'s required-table manifest (migration 0088) plus a domain `GRANT` in `riverstore.ApplyPinnedMigrations`; that GRANT is guarded by `IF to_regclass(...) IS NOT NULL`, so in the two venues that build their schema by hand (`createOperatorIntegrationSchema`, `createKernelIntegrationFixture` — the latter shared by the active/active suite) the table never existed, no grant was issued, and `CheckDomainAuthorization` failed closed.

Fix: both fixtures create the table. This is the same ordering constraint the deployment has (0088 before domain workers start), not a weakening — the readiness check is unchanged and still fails closed.

Bisect: the posture row arrives with #1529 (`f715dcd8c`), so the red predates #1535/#1537 on this branch; it is in-branch, not environmental.

## Group 2 — go-quality (`TestDirectAdapterProjectionsMatchTheLivePythonSink`)

`ModuleNotFoundError: No module named 'fastapi'`. The oracle imported the sink with a plain `import dev_health_ops.metrics.sinks.clickhouse`, which runs three package `__init__` files the sink does not need; one chain (`metrics/sinks/__init__` → `sinks.base` → `models.work_items` → `models/__init__` → `licensing/__init__` → `licensing/gating`) imports fastapi. go-quality's interpreter is Python 3.13 plus the pinned `ci/requirements-live-python-oracles.txt` closure installed `--no-deps`; fastapi is not in it, and neither is `clickhouse_connect`, which `clickhouse/core.py` imports at module level — so extending the requirements file would have needed fastapi + starlette + pydantic-tree + clickhouse_connect and would only have moved the failure one import further in the meantime.

Fix: reach the same production module through `python_oracle_loader`, which exists for exactly this (its allowlist already bypasses `licensing/__init__` for the feature-policy oracle). The new `_target_clickhouse_metrics_sink` preloads every real source the sink package composes and stubs exactly one name — `clickhouse_connect`, whose only use is the connect path this oracle never takes, stubbed to raise rather than silently no-op. The load target is the package `__init__` itself, so the oracle still constructs the production `ClickHouseMetricsSink`, not a local re-composition of two mixins.

No production code changed, no projection logic stubbed, and the test still runs (not skips) under `ci/check_go.sh live-python-oracles`.

## Verification

- Group 1 red → green: the three tests run exactly as CI runs them (`GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=30m`), then the two full packages: `ok internal/joboperator`, `ok internal/syncreconciler`.
- Group 2 red reproduced under a CI-parity interpreter (3.13.14 + the pinned requirements, `--no-deps`): identical fastapi traceback. After the fix all 7 destination subtests PASS.
- Mutation checks that the oracle still executes live production code, on both insert paths: reordering two columns in `work_graph.write_work_items` fails `work_items`/`work_items_multi_row`; reversing the value loop in `ClickHouseCore._insert_rows` fails the destinations that write through it. Both reverted.
- `ci/check_go.sh fast` (fmt, vet, test, live-python-oracles, build, contract, integration-vet, integration-coverage) exits 0 with that interpreter on PATH; `ruff format --check`, `ruff check` and mypy clean.

Note, unrelated to this PR and non-gating: the grant-surface advisory reports `UNACKNOWLEDGED posture row without evidence: domain: sync_run_unit_effect_snapshots INSERT`, which arrived with #1529.