### PR TITLE
CHAOS-3123: Go port of the legacy investment classifier (PR-B, engine 1 of 2)

### DIFF
--- a/internal/providersync/capabilities_test.go
+++ b/internal/providersync/capabilities_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -77,15 +79,82 @@ type registryEntry struct {
 func pythonExecutable(t *testing.T) string {
 	t.Helper()
 	requireLivePythonOracles(t)
+	resolved := ""
 	if configured := os.Getenv("PYTHON"); configured != "" {
-		return configured
+		resolved = configured
+	} else if path, err := exec.LookPath("python3"); err == nil {
+		resolved = path
 	}
-	if path, err := exec.LookPath("python3"); err == nil {
-		return path
+	if resolved == "" {
+		t.Fatal("python3 is required for the cross-language dataset registry freshness check")
 	}
-	t.Fatal("python3 is required for the cross-language dataset registry freshness check")
-	return ""
+	assertPythonProducerIsThisWorktree(t, resolved)
+	return resolved
 }
+
+// assertPythonProducerIsThisWorktree fails unless the interpreter about to be
+// executed resolves `dev_health_ops` INSIDE this checkout.
+//
+// Every live-Python oracle in this package compares Go against "the real
+// production function". WHICH production function that is depends entirely on
+// sys.path, and nothing here previously checked it. On a machine with more than
+// one worktree -- the normal case for this repo -- an ambient interpreter (a
+// pyenv virtualenv editable-installed against a DIFFERENT checkout, say)
+// silently supplies another worktree's `dev_health_ops`, while the oracle pairs,
+// which resolve their own paths from `__file__`, keep reading THIS worktree's
+// config and testdata. The comparison then runs half against one checkout and
+// half against another, and reports a clean pass.
+//
+// That was reproduced directly on this machine, not hypothesised: with
+// PYTHONPATH unset, the investment classifier came from
+// ops-worktrees/chaos-3219-compose-env while its config came from here, and the
+// whole suite went green.
+//
+// ci/check_go.sh sets PYTHONPATH="${ROOT}/src" and is therefore safe, but a bare
+// `go test` with the opt-in env vars is not -- and a green run is exactly the
+// output that stops anyone looking. This turns that silent mis-measurement into
+// a hard failure naming both paths.
+//
+// find_spec LOCATES the package without executing it, so this can neither be
+// affected by nor disturb the stub namespace python_oracle_loader.py installs.
+func assertPythonProducerIsThisWorktree(t *testing.T, python string) {
+	t.Helper()
+	pythonProducerOnce.Do(func() {
+		output, err := exec.Command(python, "-c",
+			"import importlib.util;s=importlib.util.find_spec('dev_health_ops');"+
+				"print(s.origin if s else '')").CombinedOutput()
+		pythonProducerOrigin = strings.TrimSpace(string(output))
+		pythonProducerErr = err
+	})
+	if pythonProducerErr != nil {
+		t.Fatalf("cannot determine which dev_health_ops %s would import: %v: %s",
+			python, pythonProducerErr, pythonProducerOrigin)
+	}
+	if pythonProducerOrigin == "" {
+		t.Fatalf("%s cannot import dev_health_ops at all -- the live-Python oracles "+
+			"would compare against nothing. Set PYTHONPATH to this worktree's src/, "+
+			"or run through ci/check_go.sh, which does it for you", python)
+	}
+	_, currentFile, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filepath.Dir(filepath.Dir(currentFile)))
+	if !strings.HasPrefix(pythonProducerOrigin, root+string(filepath.Separator)) {
+		t.Fatalf("live-Python oracle producer is NOT in this worktree:\n"+
+			"  interpreter    %s\n"+
+			"  dev_health_ops %s\n"+
+			"  this worktree  %s\n"+
+			"Every oracle here would compare Go against ANOTHER checkout's Python "+
+			"while reading this one's config and testdata -- a mixed-source "+
+			"comparison that passes. Set PYTHONPATH=%s/src (ci/check_go.sh does it "+
+			"for you), or point PYTHON at this worktree's .venv.",
+			python, pythonProducerOrigin, root, root)
+	}
+}
+
+var (
+	pythonProducerOnce   sync.Once
+	pythonProducerOrigin string
+	pythonProducerErr    error
+)
 
 func TestCapabilityCostWatermarkAndFlagsAreExact(t *testing.T) {
 	t.Parallel()

--- a/internal/providersync/investment_classifier.go
+++ b/internal/providersync/investment_classifier.go
@@ -66,16 +66,31 @@ import (
 //     InvestmentClassification, whose Python annotation is `str` and is not
 //     enforced. Go's *string cannot hold it, so this refuses rather than
 //     silently coerce to "7".
-//  2. Two or more rules whose `priority` values are all non-numeric but
-//     mutually comparable (`priority: "a"` everywhere). Python's sort succeeds;
-//     this refuses. A single rule with a non-numeric priority is MIRRORED --
-//     sorted() never calls the comparator for one element, so Python does not
-//     raise there either.
-//  3. A document yaml.v3's parser rejects outright but PyYAML accepts.
+//  2. Two or more rules whose priorities share ONE orderable non-numeric Python
+//     type -- every rule `priority: "a"`-style strings, or every rule a list.
+//     Python's sort succeeds lexicographically; this orders only numbers, so it
+//     refuses rather than impose an order Python would not produce. A single
+//     rule with such a priority is MIRRORED, since sorted() never calls the
+//     comparator for one element. A MIXED config (`1` and `"a"`), or any null
+//     or mapping priority, is a mirrored TypeError instead -- Python really
+//     does raise there.
+//  3. A leading-zero integer priority, which PyYAML's YAML 1.1 resolver reads
+//     as octal and yaml.v3's 1.2 reads as decimal. Both engines sort; neither
+//     order is the mirror.
+//  4. A merge key whose anchor chain refers back to its own mapping.
 //
-// All three are Go-erroring-where-Python-proceeds, which is the loud/safe
+// All four are Go-erroring-where-Python-proceeds, which is the loud/safe
 // direction: the job fails visibly rather than emitting a row Python would not
-// have. None of the three occurs in the checked-in config.
+// have. None of them occurs in the checked-in config, and each is pinned by the
+// analytics/investment/declared_divergence oracle pair -- which asserts the
+// divergence STILL EXISTS, so making the engines agree without deleting the
+// declaration fails the build rather than leaving a stale note behind.
+//
+// One residual is NOT a declared divergence because no instance of it is known:
+// the two YAML PARSERS could in principle disagree at the syntax level. Every
+// candidate tried lands the same way on both (a tab indent is rejected by
+// both), and this is recorded as a risk rather than a claim precisely because
+// there is nothing to pin.
 
 const (
 	legacyDefaultInvestmentArea = "product"
@@ -239,6 +254,11 @@ func NewInvestmentClassifier(configPath string) (*InvestmentClassifier, error) {
 		// when decoding into a typed value, and this decodes into a Node.
 		return nil, fmt.Errorf("investment config %s: %w", configPath, err)
 	}
+	if err := investmentExpandMergeKeys(
+		&root, map[*yaml.Node]bool{}, map[*yaml.Node]bool{},
+	); err != nil {
+		return nil, err
+	}
 	investmentApplyPyYAMLBooleans(&root)
 	document := investmentDocumentBody(&root)
 	if document == nil || document.Tag == yamlNullTag {
@@ -325,35 +345,92 @@ func investmentResolvePriorities(rules []investmentRule) error {
 	if len(rules) < 2 {
 		return nil
 	}
+	// Python's `<` is defined WITHIN a type, not across types, so what decides
+	// between "sorted() raises" and "sorted() succeeds and we cannot reproduce
+	// its order" is whether every key shares one orderable Python type. Both
+	// halves are measured: sorted(["b","a"]) and sorted([[2],[1]]) succeed,
+	// while sorted([1,"a"]), sorted([None,None]) and sorted([{},{}]) all raise.
+	// Collapsing that into "not a number means Python raises" would have this
+	// port CLAIM a mirrored TypeError for an all-string config Python sorts
+	// happily -- a false mirror, which is worse than an admitted divergence.
+	groups := map[string]bool{}
+	ambiguous := false
 	for _, rule := range rules {
-		switch rule.priorityKind {
-		case investmentPriorityNotComparable:
+		if rule.priorityKind == investmentPriorityUnorderable {
 			return investmentTypeError(
 				"'<' not supported between instances of 'int' and '%s': a rule's "+
-					"priority is not a number and there is more than one rule to order",
+					"priority is of a type Python cannot order at all, and there is "+
+					"more than one rule to order",
 				investmentPythonTypeName(rule.priority))
-		case investmentPriorityAmbiguous:
-			return investmentUnrepresentable(
-				"priority %q is octal to PyYAML's YAML 1.1 resolver and decimal to "+
-					"yaml.v3's 1.2 one, so no ordering here is the mirror",
-				investmentResolveAlias(rule.priority).Value)
 		}
+		if rule.priorityKind == investmentPriorityAmbiguousNumeric {
+			ambiguous = true
+		}
+		groups[investmentPriorityPythonType(rule.priorityKind)] = true
+	}
+	if len(groups) > 1 {
+		return investmentTypeError(
+			"'<' not supported between instances of %s: the rules mix priority "+
+				"types, and Python compares only within one",
+			investmentSortedQuoted(groups))
+	}
+	if groups["str"] || groups["list"] {
+		return investmentUnrepresentable(
+			"every rule's priority is a %s, which Python orders lexicographically; "+
+				"this port orders only numbers, so it refuses rather than impose an "+
+				"order Python would not produce", investmentSortedQuoted(groups))
+	}
+	if ambiguous {
+		return investmentUnrepresentable(
+			"a priority is written with a leading zero, which is octal to PyYAML's " +
+				"YAML 1.1 resolver and decimal to yaml.v3's 1.2 one, so no ordering " +
+				"here is the mirror")
 	}
 	return nil
+}
+
+func investmentSortedQuoted(values map[string]bool) string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, "'"+name+"'")
+	}
+	sort.Strings(names)
+	return strings.Join(names, " and ")
 }
 
 // investmentPriorityKind is how `x.get("priority", 100)` behaves as a sort key.
 type investmentPriorityKind int
 
 const (
-	// Python compares it fine and both resolvers agree on its value.
+	// An int, float or bool: Python orders them together (bool IS an int), and
+	// both YAML resolvers agree on the value.
 	investmentPriorityNumeric investmentPriorityKind = iota
-	// Python raises on the first comparison (null, a string, a container).
-	investmentPriorityNotComparable
-	// Both engines sort, but they would sort DIFFERENTLY -- a declared
-	// divergence rather than a mirrored raise, and so refused separately.
-	investmentPriorityAmbiguous
+	// An int literal the two resolvers read differently (a leading zero is
+	// octal to PyYAML, decimal to yaml.v3). Both engines sort; they would sort
+	// DIFFERENTLY, so this is a declared divergence, not a mirrored raise.
+	investmentPriorityAmbiguousNumeric
+	// A string. Python orders these lexicographically among themselves.
+	investmentPriorityString
+	// A sequence. Python orders these lexicographically among themselves too.
+	investmentPrioritySequence
+	// null or a mapping: Python raises on the first comparison, even against
+	// another value of the same type (`None < None` and `{} < {}` both raise).
+	investmentPriorityUnorderable
 )
+
+// investmentPriorityPythonType names the Python type whose ordering applies, so
+// two kinds that share one type (a plain int and an ambiguous one) group
+// together and a mixed config is detected as mixed.
+func investmentPriorityPythonType(kind investmentPriorityKind) string {
+	switch kind {
+	case investmentPriorityString:
+		return "str"
+	case investmentPrioritySequence:
+		return "list"
+	default:
+		return "int"
+	}
+}
 
 // investmentPrioritySortKey returns the numeric sort key and how Python would
 // treat it. bool counts as numeric because Python's bool IS an int subclass, so
@@ -363,10 +440,19 @@ func investmentPrioritySortKey(node *yaml.Node) (float64, investmentPriorityKind
 		return legacyDefaultRulePriority, investmentPriorityNumeric
 	}
 	node = investmentResolveAlias(node)
-	if node == nil || node.Kind != yaml.ScalarNode {
-		return 0, investmentPriorityNotComparable
+	if node == nil {
+		return 0, investmentPriorityUnorderable
+	}
+	if node.Kind == yaml.SequenceNode {
+		return 0, investmentPrioritySequence
+	}
+	if node.Kind != yaml.ScalarNode {
+		// A mapping: Python cannot order two of them either.
+		return 0, investmentPriorityUnorderable
 	}
 	switch node.Tag {
+	case yamlStrTag:
+		return 0, investmentPriorityString
 	case yamlIntTag:
 		// A leading zero is the one integer literal the two resolvers read
 		// differently: PyYAML's YAML 1.1 makes `010` OCTAL (8), yaml.v3's 1.2
@@ -375,15 +461,16 @@ func investmentPrioritySortKey(node *yaml.Node) (float64, investmentPriorityKind
 		// one.
 		digits := strings.TrimLeft(node.Value, "-+")
 		if len(digits) > 1 && digits[0] == '0' {
-			return 0, investmentPriorityAmbiguous
+			return 0, investmentPriorityAmbiguousNumeric
 		}
 	case yamlFloatTag, yamlBoolTag:
 	default:
-		return 0, investmentPriorityNotComparable
+		// A null, or a scalar carrying some other tag (a plain timestamp, say).
+		return 0, investmentPriorityUnorderable
 	}
 	var number float64
 	if err := node.Decode(&number); err != nil {
-		return 0, investmentPriorityNotComparable
+		return 0, investmentPriorityUnorderable
 	}
 	return number, investmentPriorityNumeric
 }
@@ -738,6 +825,124 @@ func investmentTruthy(node *yaml.Node) bool {
 		}
 	default:
 		return true
+	}
+}
+
+// investmentExpandMergeKeys resolves YAML merge keys (`<<: *anchor`) into the
+// mapping that carries them, as PyYAML's constructor does before the classifier
+// ever sees a dict.
+//
+// Without this the node walk treats `<<` as an ordinary key and never finds the
+// merged criteria -- and the direction is fail-open, which is why it is fixed
+// rather than declared. A rule written as
+//
+//	match:
+//	  <<: *shared_labels
+//
+// has, to this port, a match block with NO criteria, and a match block with no
+// criteria reaches `_matches`'s final `return True` and MATCHES EVERY ARTIFACT.
+// Python matches only the artifacts carrying the merged labels. Pinned by two
+// cases over one file that differ only in whether those labels are present.
+//
+// The precedence rules are PyYAML's, measured rather than assumed:
+//
+//   - an EXPLICIT key beats a merged one wherever it appears in the mapping,
+//     including after the `<<`;
+//   - for `<<: [*a, *b]`, the FIRST source wins a key both define;
+//   - a source that itself carries a `<<` is expanded first.
+func investmentExpandMergeKeys(node *yaml.Node, done, active map[*yaml.Node]bool) error {
+	node = investmentResolveAlias(node)
+	if node == nil || done[node] {
+		return nil
+	}
+	if active[node] {
+		// `a: &x {<<: *x}`. PyYAML recurses until it dies; refusing is the
+		// loud direction and no config can need this.
+		return investmentUnrepresentable("a merge key refers to its own mapping")
+	}
+	active[node] = true
+	defer func() {
+		delete(active, node)
+		done[node] = true
+	}()
+	for _, child := range node.Content {
+		if err := investmentExpandMergeKeys(child, done, active); err != nil {
+			return err
+		}
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var explicit []*yaml.Node
+	var merges []*yaml.Node
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		key, value := node.Content[index], node.Content[index+1]
+		if key.Tag == "!!merge" || key.Value == "<<" {
+			merges = append(merges, value)
+			continue
+		}
+		explicit = append(explicit, key, value)
+	}
+	if len(merges) == 0 {
+		return nil
+	}
+	claimed := make(map[string]bool, len(explicit)/2)
+	for index := 0; index < len(explicit); index += 2 {
+		claimed[explicit[index].Value] = true
+	}
+	for _, merge := range merges {
+		sources, err := investmentMergeSources(merge)
+		if err != nil {
+			return err
+		}
+		for _, source := range sources {
+			if err := investmentExpandMergeKeys(source, done, active); err != nil {
+				return err
+			}
+			for index := 0; index+1 < len(source.Content); index += 2 {
+				key, value := source.Content[index], source.Content[index+1]
+				if claimed[key.Value] {
+					continue
+				}
+				claimed[key.Value] = true
+				explicit = append(explicit, key, value)
+			}
+		}
+	}
+	node.Content = explicit
+	return nil
+}
+
+// investmentMergeSources flattens a merge value into the mappings it names.
+// PyYAML accepts one mapping or a sequence of mappings and raises
+// ConstructorError for anything else.
+func investmentMergeSources(node *yaml.Node) ([]*yaml.Node, error) {
+	node = investmentResolveAlias(node)
+	if node == nil {
+		return nil, investmentMergeTypeError()
+	}
+	if node.Kind == yaml.MappingNode {
+		return []*yaml.Node{node}, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, investmentMergeTypeError()
+	}
+	sources := make([]*yaml.Node, 0, len(node.Content))
+	for _, entry := range node.Content {
+		entry = investmentResolveAlias(entry)
+		if entry == nil || entry.Kind != yaml.MappingNode {
+			return nil, investmentMergeTypeError()
+		}
+		sources = append(sources, entry)
+	}
+	return sources, nil
+}
+
+func investmentMergeTypeError() error {
+	return &InvestmentConfigError{
+		PythonException: "ConstructorError",
+		Detail: "expected a mapping or a list of mappings for merging, " +
+			"but found another node",
 	}
 }
 

--- a/internal/providersync/investment_classifier.go
+++ b/internal/providersync/investment_classifier.go
@@ -23,8 +23,59 @@ import (
 //
 // Per D16 this mirrors Python bug-for-bug. Four of the 44 rules in the checked-in
 // config are UNREACHABLE from the work-item call site, and that is reproduced
-// rather than corrected; see investmentClassifierUnreachableRules in the tests,
-// which fails if a future config edit revives one.
+// rather than corrected; see investment_classifier_reachability_test.go, which
+// DERIVES that dead set by execution and fails if a future config edit revives
+// one.
+//
+// # Why the config is decoded as yaml.Node and not into typed structs
+//
+// Python reads the file with `yaml.safe_load` into plain dicts, and every
+// lookup is `d.get(key, default)`. That makes an EXPLICIT NULL and an ABSENT
+// KEY two different things everywhere: `priority:` yields None (and blows up
+// the sort), while an absent `priority` yields 100; `match:` yields None (and
+// blows up `_matches`), while an absent `match` yields {} and matches
+// everything. A typed decode -- including one using pointers per field --
+// collapses those two into each other, because yaml.v3 decodes an explicit
+// null into the same nil a missing key leaves behind. The first version of this
+// port did exactly that, and the result was a classifier that returned a
+// plausible product/general/0.0/legacy_default (or, worse, FIRED a rule whose
+// `match:` was null) for eight config shapes on which Python raises. That is
+// fail-open in the one direction D16 says is unacceptable: during Python/Go
+// coexistence both engines read the SAME file, so a Go engine that invents an
+// answer where Python refuses silently writes rows Python would never have
+// written.
+//
+// So the document is walked as yaml.Nodes, where "absent", "present and null"
+// and "present with a value" are three distinguishable states, and every shape
+// on which Python raises returns an *InvestmentConfigError naming the exception
+// class Python raises for it. Those classes are MEASURED, not inferred: the
+// refusal oracle pair (testdata/oracle_pairs/analytics_investment_refusal.py)
+// executes the real Python classifier against the same files and compares the
+// exception type name against what this file produces.
+//
+// # Declared divergences (Go refuses where Python proceeds)
+//
+// Node-walking removed the two divergences an earlier typed decode had -- a
+// duplicate mapping key (PyYAML keeps the LAST, yaml.v3's typed decoder
+// rejects the document) and a bare-string `component:`/`label:` (Python does
+// substring containment / character iteration) are both mirrored exactly now,
+// each pinned by its own oracle case. What remains, and is NOT mirrored:
+//
+//  1. A non-string scalar where Python would yield a non-string VALUE:
+//     `id: 7`, `investment_area: true`. Python puts the int/bool straight into
+//     InvestmentClassification, whose Python annotation is `str` and is not
+//     enforced. Go's *string cannot hold it, so this refuses rather than
+//     silently coerce to "7".
+//  2. Two or more rules whose `priority` values are all non-numeric but
+//     mutually comparable (`priority: "a"` everywhere). Python's sort succeeds;
+//     this refuses. A single rule with a non-numeric priority is MIRRORED --
+//     sorted() never calls the comparator for one element, so Python does not
+//     raise there either.
+//  3. A document yaml.v3's parser rejects outright but PyYAML accepts.
+//
+// All three are Go-erroring-where-Python-proceeds, which is the loud/safe
+// direction: the job fails visibly rather than emitting a row Python would not
+// have. None of the three occurs in the checked-in config.
 
 const (
 	legacyDefaultInvestmentArea = "product"
@@ -37,36 +88,97 @@ const (
 	legacyUnnamedRuleID       = "legacy_rule"
 )
 
+// YAML resolved tags this file distinguishes. Compared as strings rather than
+// re-derived per call site so a typo cannot silently make a branch dead.
+const (
+	yamlNullTag  = "!!null"
+	yamlBoolTag  = "!!bool"
+	yamlIntTag   = "!!int"
+	yamlFloatTag = "!!float"
+	yamlStrTag   = "!!str"
+	yamlSeqTag   = "!!seq"
+	yamlMapTag   = "!!map"
+)
+
+// InvestmentConfigError is returned for every config/artifact combination on
+// which the Python classifier RAISES, plus the small declared set on which
+// Python proceeds and this port refuses rather than emit a value it cannot
+// represent (see the file comment).
+//
+// PythonException names the exception CLASS Python raises -- "AttributeError"
+// or "TypeError" -- and is the value the refusal oracle compares, so a Go
+// refusal for the wrong reason cannot pass as agreement. It is EMPTY for the
+// declared divergences, which is the type-level marker that Python does not
+// raise there at all.
+type InvestmentConfigError struct {
+	PythonException string
+	Detail          string
+}
+
+func (err *InvestmentConfigError) Error() string {
+	if err.PythonException == "" {
+		return fmt.Sprintf(
+			"investment config: declared divergence, Python proceeds but this port "+
+				"refuses: %s", err.Detail)
+	}
+	return fmt.Sprintf(
+		"investment config: Python raises %s here: %s", err.PythonException, err.Detail)
+}
+
+func investmentAttributeError(format string, args ...any) error {
+	return &InvestmentConfigError{
+		PythonException: "AttributeError",
+		Detail:          fmt.Sprintf(format, args...),
+	}
+}
+
+func investmentTypeError(format string, args ...any) error {
+	return &InvestmentConfigError{
+		PythonException: "TypeError",
+		Detail:          fmt.Sprintf(format, args...),
+	}
+}
+
+// investmentUnrepresentable is the DECLARED-divergence constructor: Python
+// proceeds and produces a value this port's types cannot hold. It carries no
+// exception class precisely so it can never be mistaken for a mirrored raise.
+func investmentUnrepresentable(format string, args ...any) error {
+	return &InvestmentConfigError{Detail: fmt.Sprintf(format, args...)}
+}
+
 // InvestmentClassification mirrors the Python dataclass of the same name.
+//
+// Three of its four fields are *string rather than string because Python can
+// and does put None in each of them: `id:`, `investment_area:` and
+// `project_stream:` are all read with `.get(key, default)`, so a key that is
+// PRESENT AND NULL returns None rather than the default. The Python dataclass
+// annotates investment_area and rule_id as `str`, but a dataclass does not
+// enforce annotations, so None reaches the call site regardless. A plain Go
+// string would have to invent "product"/"general"/"legacy_rule" there, which is
+// a silent value divergence in the fail-open direction.
 type InvestmentClassification struct {
-	InvestmentArea string  `json:"investment_area"`
+	InvestmentArea *string `json:"investment_area"`
 	ProjectStream  *string `json:"project_stream"`
 	Confidence     float64 `json:"confidence"`
-	RuleID         string  `json:"rule_id"`
+	RuleID         *string `json:"rule_id"`
 }
 
-// investmentRule is one entry of the config's `rules:` list. Every field is
-// optional in the file, so each is decoded through a pointer or a slice whose
-// nil-ness carries "the key was absent" -- which the matcher genuinely depends
-// on: an ABSENT `component` key is skipped, while a PRESENT one with an empty
-// list rejects everything.
+// investmentRule is one entry of the config's `rules:` list, held as raw nodes.
+// Nothing about a rule is interpreted at load time except its priority, because
+// Python interprets nothing else at load time either: `_load_rules` only sorts,
+// so a rule whose `match:` is null is inert until classify() actually REACHES
+// it, and a rule whose `output:` is null is inert until it MATCHES. Interpreting
+// eagerly here would move those raises earlier than Python's and turn a config
+// that Python classifies fine into a Go-side load failure.
 type investmentRule struct {
-	ID       string                `yaml:"id"`
-	Priority *int                  `yaml:"priority"`
-	Match    *investmentRuleMatch  `yaml:"match"`
-	Output   *investmentRuleOutput `yaml:"output"`
-}
-
-type investmentRuleMatch struct {
-	Always     *bool     `yaml:"always"`
-	Label      *[]string `yaml:"label"`
-	PathPrefix *[]string `yaml:"path_prefix"`
-	Component  *[]string `yaml:"component"`
-}
-
-type investmentRuleOutput struct {
-	InvestmentArea *string `yaml:"investment_area"`
-	ProjectStream  *string `yaml:"project_stream"`
+	id       *yaml.Node
+	priority *yaml.Node
+	match    *yaml.Node
+	output   *yaml.Node
+	// sortKey is `x.get("priority", 100)` as a float, valid only when
+	// priorityKind is investmentPriorityNumeric.
+	sortKey      float64
+	priorityKind investmentPriorityKind
 }
 
 // InvestmentArtifact is the classifier's input. Python passes a plain dict and
@@ -85,10 +197,16 @@ type InvestmentArtifact struct {
 	// dead on that path; it stays here because the field is what makes that
 	// deadness a property of the CALLER rather than of this engine.
 	Paths []string
-	// Component is always "" from the work-item call site: WorkItem has no
-	// `component` attribute, so `getattr(item, "component", "")` cannot return
-	// anything else.
-	Component string
+	// Component is a POINTER because Python reads it with
+	// `artifact.get("component")` -- no default -- so an absent key yields None,
+	// which is a different value from "" for both the `in` membership test AND
+	// the bare-string containment path (`None in "analytics"` raises where
+	// `"" in "analytics"` is True). The work-item call site always supplies the
+	// key, and always as "" (WorkItem has no `component` attribute, so
+	// `getattr(item, "component", "")` cannot return anything else), so nil is
+	// unreachable from production -- but the contract this ports can express it
+	// and so must this.
+	Component *string
 	// Read by neither engine. See the type comment.
 	Title    string
 	Provider string
@@ -114,13 +232,33 @@ func NewInvestmentClassifier(configPath string) (*InvestmentClassifier, error) {
 		}
 		return nil, err
 	}
-	var document struct {
-		Rules []investmentRule `yaml:"rules"`
-	}
-	if err := yaml.Unmarshal(contents, &document); err != nil {
+	var root yaml.Node
+	if err := yaml.Unmarshal(contents, &root); err != nil {
+		// Declared divergence 3: a document yaml.v3's PARSER rejects. Note that
+		// duplicate mapping keys do NOT land here -- yaml.v3 only rejects those
+		// when decoding into a typed value, and this decodes into a Node.
 		return nil, fmt.Errorf("investment config %s: %w", configPath, err)
 	}
-	rules := append([]investmentRule(nil), document.Rules...)
+	investmentApplyPyYAMLBooleans(&root)
+	document := investmentDocumentBody(&root)
+	if document == nil || document.Tag == yamlNullTag {
+		// An empty or comment-only file is `yaml.safe_load(...) is None`, and
+		// `data.get("rules", [])` is then an attribute lookup on None.
+		return nil, investmentAttributeError(
+			"'NoneType' object has no attribute 'get': %s parsed to nothing", configPath)
+	}
+	if document.Kind != yaml.MappingNode {
+		return nil, investmentAttributeError(
+			"'%s' object has no attribute 'get': %s is not a mapping",
+			investmentPythonTypeName(document), configPath)
+	}
+	rules, err := investmentDecodeRules(investmentMappingValue(document, "rules"))
+	if err != nil {
+		return nil, err
+	}
+	if err := investmentResolvePriorities(rules); err != nil {
+		return nil, err
+	}
 	// Python sorts with sorted(), which is STABLE, and the checked-in config
 	// relies on that: 37 of its 44 rules share priority 10 and a further 2
 	// share priority 30. Among equal priorities the FILE ORDER decides which
@@ -128,62 +266,236 @@ func NewInvestmentClassifier(configPath string) (*InvestmentClassifier, error) {
 	// so an unstable sort would silently change the answer for any artifact
 	// matching more than one priority-10 rule. sort.Slice is NOT stable.
 	sort.SliceStable(rules, func(left, right int) bool {
-		return investmentRulePriority(rules[left]) < investmentRulePriority(rules[right])
+		return rules[left].sortKey < rules[right].sortKey
 	})
 	return &InvestmentClassifier{rules: rules}, nil
 }
 
-func investmentRulePriority(rule investmentRule) int {
-	if rule.Priority == nil {
-		return legacyDefaultRulePriority
+// investmentDecodeRules mirrors `sorted(data.get("rules", []), key=...)`'s
+// treatment of whatever sits under `rules:`. sorted() ITERATES its argument and
+// calls `.get` on every element, so the shape of `rules` decides between a
+// TypeError (not iterable at all) and an AttributeError (iterable, but its
+// elements are not dicts) -- both measured against the real Python.
+func investmentDecodeRules(node *yaml.Node) ([]investmentRule, error) {
+	if node == nil {
+		// `data.get("rules", [])` -- an absent key is an empty list, not an error.
+		return nil, nil
 	}
-	return *rule.Priority
+	elements, err := investmentIterate(node)
+	if err != nil {
+		return nil, err
+	}
+	rules := make([]investmentRule, 0, len(elements))
+	for _, element := range elements {
+		element = investmentResolveAlias(element)
+		if element == nil || element.Kind != yaml.MappingNode {
+			// sorted()'s key function runs on every element BEFORE any
+			// comparison, so a non-dict rule raises at load even for a
+			// single-element list.
+			return nil, investmentAttributeError(
+				"'%s' object has no attribute 'get': a rules entry is not a mapping",
+				investmentPythonTypeName(element))
+		}
+		rules = append(rules, investmentRule{
+			id:       investmentMappingValue(element, "id"),
+			priority: investmentMappingValue(element, "priority"),
+			match:    investmentMappingValue(element, "match"),
+			output:   investmentMappingValue(element, "output"),
+		})
+	}
+	return rules, nil
+}
+
+// investmentResolvePriorities computes `x.get("priority", 100)` for every rule
+// and reproduces WHEN sorted() blows up on the result.
+//
+// The subtlety that makes this worth its own function: sorted() computes every
+// key first and only then compares, so a single rule with `priority:` null does
+// NOT raise -- there is nothing to compare it against. Two rules do. Measured
+// on the real Python both ways; an "any null priority is fatal" shortcut would
+// refuse a config Python classifies fine.
+func investmentResolvePriorities(rules []investmentRule) error {
+	for index := range rules {
+		key, kind := investmentPrioritySortKey(rules[index].priority)
+		rules[index].sortKey = key
+		rules[index].priorityKind = kind
+	}
+	// With fewer than two rules sorted() never calls the comparator, so
+	// nothing about the key's type or spelling can matter yet.
+	if len(rules) < 2 {
+		return nil
+	}
+	for _, rule := range rules {
+		switch rule.priorityKind {
+		case investmentPriorityNotComparable:
+			return investmentTypeError(
+				"'<' not supported between instances of 'int' and '%s': a rule's "+
+					"priority is not a number and there is more than one rule to order",
+				investmentPythonTypeName(rule.priority))
+		case investmentPriorityAmbiguous:
+			return investmentUnrepresentable(
+				"priority %q is octal to PyYAML's YAML 1.1 resolver and decimal to "+
+					"yaml.v3's 1.2 one, so no ordering here is the mirror",
+				investmentResolveAlias(rule.priority).Value)
+		}
+	}
+	return nil
+}
+
+// investmentPriorityKind is how `x.get("priority", 100)` behaves as a sort key.
+type investmentPriorityKind int
+
+const (
+	// Python compares it fine and both resolvers agree on its value.
+	investmentPriorityNumeric investmentPriorityKind = iota
+	// Python raises on the first comparison (null, a string, a container).
+	investmentPriorityNotComparable
+	// Both engines sort, but they would sort DIFFERENTLY -- a declared
+	// divergence rather than a mirrored raise, and so refused separately.
+	investmentPriorityAmbiguous
+)
+
+// investmentPrioritySortKey returns the numeric sort key and how Python would
+// treat it. bool counts as numeric because Python's bool IS an int subclass, so
+// `priority: true` sorts as 1 rather than raising.
+func investmentPrioritySortKey(node *yaml.Node) (float64, investmentPriorityKind) {
+	if node == nil {
+		return legacyDefaultRulePriority, investmentPriorityNumeric
+	}
+	node = investmentResolveAlias(node)
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return 0, investmentPriorityNotComparable
+	}
+	switch node.Tag {
+	case yamlIntTag:
+		// A leading zero is the one integer literal the two resolvers read
+		// differently: PyYAML's YAML 1.1 makes `010` OCTAL (8), yaml.v3's 1.2
+		// makes it decimal 10. Sorting by either is a guess, and the wrong
+		// guess reorders rules silently. No rule in the checked-in config has
+		// one.
+		digits := strings.TrimLeft(node.Value, "-+")
+		if len(digits) > 1 && digits[0] == '0' {
+			return 0, investmentPriorityAmbiguous
+		}
+	case yamlFloatTag, yamlBoolTag:
+	default:
+		return 0, investmentPriorityNotComparable
+	}
+	var number float64
+	if err := node.Decode(&number); err != nil {
+		return 0, investmentPriorityNotComparable
+	}
+	return number, investmentPriorityNumeric
 }
 
 // Classify mirrors InvestmentClassifier.classify: first matching rule wins, and
 // an unmatched artifact falls back to the legacy product/general bucket with
 // confidence 0.0 rather than to anything unknown-like.
+//
+// It returns an error because Python RAISES here for several config shapes, and
+// which rule the artifact reaches decides whether it does: a rule with a null
+// `match:` is harmless until classify() gets to it, and a rule with a null
+// `output:` is harmless until it MATCHES. Both are pinned by cases that
+// classify the same file with and without reaching the offending rule.
 func (classifier *InvestmentClassifier) Classify(
 	artifact InvestmentArtifact,
-) InvestmentClassification {
+) (InvestmentClassification, error) {
 	for _, rule := range classifier.rules {
-		if !investmentRuleMatches(rule.Match, artifact) {
+		matched, err := investmentRuleMatches(rule.match, artifact)
+		if err != nil {
+			return InvestmentClassification{}, err
+		}
+		if !matched {
 			continue
 		}
-		area := legacyDefaultInvestmentArea
-		stream := legacyDefaultProjectStream
-		if rule.Output != nil {
-			if rule.Output.InvestmentArea != nil {
-				area = *rule.Output.InvestmentArea
-			}
-			if rule.Output.ProjectStream != nil {
-				stream = *rule.Output.ProjectStream
-			}
+		// Python evaluates `output = rule.get("output", {})` before the match
+		// test but only DEREFERENCES it after, and `.get` on a dict cannot
+		// raise -- so the null-output AttributeError is a property of matching,
+		// not of iterating.
+		area, stream, err := investmentRuleOutput(rule.output)
+		if err != nil {
+			return InvestmentClassification{}, err
 		}
-		id := rule.ID
-		if id == "" {
-			// Python: rule.get("id", "legacy_rule"). An id key that is present
-			// but empty is NOT the same as an absent one in Python; this port
-			// collapses them because YAML cannot distinguish a missing string
-			// from an empty one without another pointer, and no rule in the
-			// real config omits its id. Pinned by a synthetic-config case.
-			id = legacyUnnamedRuleID
+		id, err := investmentRuleID(rule.id)
+		if err != nil {
+			return InvestmentClassification{}, err
 		}
-		streamValue := stream
 		return InvestmentClassification{
 			InvestmentArea: area,
-			ProjectStream:  &streamValue,
+			ProjectStream:  stream,
 			Confidence:     1.0,
 			RuleID:         id,
-		}
+		}, nil
 	}
-	stream := legacyDefaultProjectStream
 	return InvestmentClassification{
-		InvestmentArea: legacyDefaultInvestmentArea,
-		ProjectStream:  &stream,
+		InvestmentArea: investmentString(legacyDefaultInvestmentArea),
+		ProjectStream:  investmentString(legacyDefaultProjectStream),
 		Confidence:     0.0,
-		RuleID:         legacyFallbackRuleID,
+		RuleID:         investmentString(legacyFallbackRuleID),
+	}, nil
+}
+
+// investmentRuleID mirrors `rule.get("id", "legacy_rule")`.
+//
+// Absent, present-and-null and present-and-empty are THREE different answers --
+// "legacy_rule", None and "" -- and each has its own oracle case. The previous
+// version of this port collapsed the first two into "legacy_rule" and claimed a
+// synthetic case pinned it; no such case existed, and the behaviour diverged.
+func investmentRuleID(node *yaml.Node) (*string, error) {
+	return investmentOptionalString(node, legacyUnnamedRuleID, "id")
+}
+
+// investmentRuleOutput mirrors the two `output.get(...)` reads.
+func investmentRuleOutput(node *yaml.Node) (*string, *string, error) {
+	if node == nil {
+		// `rule.get("output", {})` -- an absent block is {}, so both reads take
+		// their defaults.
+		return investmentString(legacyDefaultInvestmentArea),
+			investmentString(legacyDefaultProjectStream), nil
 	}
+	node = investmentResolveAlias(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, nil, investmentAttributeError(
+			"'%s' object has no attribute 'get': a matched rule's output block is "+
+				"not a mapping", investmentPythonTypeName(node))
+	}
+	area, err := investmentOptionalString(
+		investmentMappingValue(node, "investment_area"),
+		legacyDefaultInvestmentArea, "investment_area")
+	if err != nil {
+		return nil, nil, err
+	}
+	stream, err := investmentOptionalString(
+		investmentMappingValue(node, "project_stream"),
+		legacyDefaultProjectStream, "project_stream")
+	if err != nil {
+		return nil, nil, err
+	}
+	return area, stream, nil
+}
+
+// investmentOptionalString is the shared `.get(key, default)` for the three
+// fields that reach InvestmentClassification as strings: absent yields the
+// default, explicit null yields None, a string yields itself.
+func investmentOptionalString(
+	node *yaml.Node, fallback string, key string,
+) (*string, error) {
+	if node == nil {
+		return investmentString(fallback), nil
+	}
+	node = investmentResolveAlias(node)
+	if node == nil || node.Tag == yamlNullTag {
+		return nil, nil
+	}
+	if node.Kind == yaml.ScalarNode && node.Tag == yamlStrTag {
+		return investmentString(node.Value), nil
+	}
+	// Declared divergence 1: Python would put this non-string straight into the
+	// dataclass. Coercing it to text here would be a silent value change.
+	return nil, investmentUnrepresentable(
+		"%s is a %s; Python would carry that value into InvestmentClassification "+
+			"unchanged and this port's *string cannot hold it",
+		key, investmentPythonTypeName(node))
 }
 
 // investmentRuleMatches mirrors `_matches`.
@@ -194,42 +506,75 @@ func (classifier *InvestmentClassifier) Classify(
 // including one with no labels at all. The real config expresses its catch-all
 // as `always: true` instead, so only a synthetic config reaches the empty-map
 // form; it is pinned there.
-func investmentRuleMatches(match *investmentRuleMatch, artifact InvestmentArtifact) bool {
+func investmentRuleMatches(match *yaml.Node, artifact InvestmentArtifact) (bool, error) {
 	if match == nil {
 		// `rule.get("match", {})` yields {} for an absent key, and {} matches
 		// everything by the rule above.
-		return true
+		return true, nil
+	}
+	match = investmentResolveAlias(match)
+	if match == nil || match.Kind != yaml.MappingNode {
+		// A null (or otherwise non-dict) `match:` is inert until classify()
+		// reaches this rule, and then `match_criteria.get("always")` raises.
+		return false, investmentAttributeError(
+			"'%s' object has no attribute 'get': a rule's match block is not a mapping",
+			investmentPythonTypeName(match))
 	}
 	// Python tests `match_criteria.get("always")` for TRUTHINESS, so
 	// `always: false` does not short-circuit -- it falls through to the
-	// remaining criteria exactly as an absent key would.
-	if match.Always != nil && *match.Always {
-		return true
+	// remaining criteria exactly as an absent key would. A non-empty string,
+	// including the `always: 'no'` that YAML would otherwise fold to false,
+	// IS truthy.
+	if investmentTruthy(investmentMappingValue(match, "always")) {
+		return true, nil
 	}
-	if match.Label != nil {
+	if label := investmentMappingValue(match, "label"); label != nil {
+		targets, err := investmentLoweredStrings(label)
+		if err != nil {
+			return false, err
+		}
 		labels := make(map[string]struct{}, len(artifact.Labels))
-		for _, label := range artifact.Labels {
-			labels[strings.ToLower(label)] = struct{}{}
+		for _, value := range artifact.Labels {
+			labels[strings.ToLower(value)] = struct{}{}
 		}
 		intersects := false
-		for _, target := range *match.Label {
-			if _, ok := labels[strings.ToLower(target)]; ok {
+		for _, target := range targets {
+			if _, ok := labels[target]; ok {
 				intersects = true
 				break
 			}
 		}
 		if !intersects {
-			return false
+			return false, nil
 		}
 	}
-	if match.PathPrefix != nil {
+	if prefixes := investmentMappingValue(match, "path_prefix"); prefixes != nil {
 		// Reads artifact PATHS, not path_prefix. The work-item call site
 		// supplies none, so this arm rejects every artifact reaching it from
 		// that path -- the reason three real rules are dead.
+		//
+		// The prefix list is resolved INSIDE the loop over artifact paths,
+		// exactly where Python's inner `for prefix in target_prefixes` sits.
+		// That is load-bearing, not stylistic: with a null `path_prefix:` and
+		// an artifact carrying no paths, Python never enters the inner loop and
+		// never raises -- it just rejects. Hoisting the resolution would refuse
+		// a config Python classifies. Both directions are pinned by cases over
+		// the same file.
 		found := false
 		for _, path := range artifact.Paths {
-			for _, prefix := range *match.PathPrefix {
-				if strings.HasPrefix(path, prefix) {
+			targets, err := investmentIterate(prefixes)
+			if err != nil {
+				return false, err
+			}
+			for _, target := range targets {
+				target = investmentResolveAlias(target)
+				if target == nil || target.Kind != yaml.ScalarNode || target.Tag != yamlStrTag {
+					return false, investmentTypeError(
+						"startswith first arg must be str or a tuple of str, not %s: a "+
+							"path_prefix entry is not a string",
+						investmentPythonTypeName(target))
+				}
+				if strings.HasPrefix(path, target.Value) {
 					found = true
 					break
 				}
@@ -239,23 +584,297 @@ func investmentRuleMatches(match *investmentRuleMatch, artifact InvestmentArtifa
 			}
 		}
 		if !found {
-			return false
+			return false, nil
 		}
 	}
-	if match.Component != nil {
-		// Exact membership, NOT case-folded -- unlike the label arm. From the
-		// work-item call site the component is always "", so a rule whose list
-		// does not literally contain "" can never fire.
-		matched := false
-		for _, candidate := range *match.Component {
-			if candidate == artifact.Component {
-				matched = true
-				break
+	if component := investmentMappingValue(match, "component"); component != nil {
+		contains, err := investmentComponentContains(component, artifact.Component)
+		if err != nil {
+			return false, err
+		}
+		if !contains {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// investmentComponentContains mirrors
+// `artifact.get("component") not in match_criteria["component"]`, negated.
+//
+// `in` is overloaded in Python and the config's shape picks the meaning. A LIST
+// (or dict) is membership -- exact equality, NOT case-folded, unlike the label
+// arm. A bare STRING is substring containment, which is a latent Python bug
+// this mirrors rather than fixes: `component: analytics` matches the work-item
+// call site's "" for every artifact, because "" is a substring of everything.
+func investmentComponentContains(node *yaml.Node, component *string) (bool, error) {
+	node = investmentResolveAlias(node)
+	if node == nil || node.Tag == yamlNullTag {
+		return false, investmentTypeError(
+			"argument of type 'NoneType' is not a container or iterable: a rule's " +
+				"component criterion is null")
+	}
+	if node.Kind == yaml.ScalarNode && node.Tag == yamlStrTag {
+		if component == nil {
+			return false, investmentTypeError(
+				"'in <string>' requires string as left operand, not NoneType: the " +
+					"artifact has no component key and the criterion is a bare string")
+		}
+		return strings.Contains(node.Value, *component), nil
+	}
+	candidates, err := investmentIterate(node)
+	if err != nil {
+		// `x in 5` reports containment, not iteration, so the message differs
+		// from investmentIterate's even though the class is the same.
+		return false, investmentTypeError(
+			"argument of type '%s' is not iterable: a rule's component criterion "+
+				"is not a container", investmentPythonTypeName(node))
+	}
+	for _, candidate := range candidates {
+		candidate = investmentResolveAlias(candidate)
+		if candidate == nil {
+			continue
+		}
+		if candidate.Tag == yamlNullTag {
+			if component == nil {
+				return true, nil
 			}
+			continue
 		}
-		if !matched {
-			return false
+		if candidate.Kind == yaml.ScalarNode && candidate.Tag == yamlStrTag &&
+			component != nil && candidate.Value == *component {
+			return true, nil
 		}
 	}
-	return true
+	return false, nil
+}
+
+// investmentLoweredStrings mirrors
+// `set(lbl.lower() for lbl in match_criteria["label"])`.
+//
+// The generator is consumed in full before the intersection is taken, so a
+// non-string entry raises even when an earlier entry would have matched.
+func investmentLoweredStrings(node *yaml.Node) ([]string, error) {
+	entries, err := investmentIterate(node)
+	if err != nil {
+		return nil, err
+	}
+	lowered := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		entry = investmentResolveAlias(entry)
+		if entry == nil || entry.Kind != yaml.ScalarNode || entry.Tag != yamlStrTag {
+			return nil, investmentAttributeError(
+				"'%s' object has no attribute 'lower': a label entry is not a string",
+				investmentPythonTypeName(entry))
+		}
+		lowered = append(lowered, strings.ToLower(entry.Value))
+	}
+	return lowered, nil
+}
+
+// investmentIterate mirrors `for x in obj` over a safe_load'ed value: a list
+// yields its items, a dict yields its KEYS, and a string yields its CHARACTERS
+// (which is why a bare-string `label:` silently matches single letters rather
+// than the word). Anything else is not iterable and raises TypeError.
+func investmentIterate(node *yaml.Node) ([]*yaml.Node, error) {
+	node = investmentResolveAlias(node)
+	if node == nil || node.Tag == yamlNullTag {
+		return nil, investmentTypeError("'NoneType' object is not iterable")
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Content, nil
+	case yaml.MappingNode:
+		keys := make([]*yaml.Node, 0, len(node.Content)/2)
+		seen := make(map[string]struct{}, len(node.Content)/2)
+		for index := 0; index+1 < len(node.Content); index += 2 {
+			key := node.Content[index]
+			if _, duplicate := seen[key.Value]; duplicate {
+				continue
+			}
+			seen[key.Value] = struct{}{}
+			keys = append(keys, key)
+		}
+		return keys, nil
+	case yaml.ScalarNode:
+		if node.Tag != yamlStrTag {
+			return nil, investmentTypeError(
+				"'%s' object is not iterable", investmentPythonTypeName(node))
+		}
+		characters := make([]*yaml.Node, 0, len(node.Value))
+		for _, character := range node.Value {
+			characters = append(characters, &yaml.Node{
+				Kind: yaml.ScalarNode, Tag: yamlStrTag, Value: string(character),
+			})
+		}
+		return characters, nil
+	default:
+		return nil, investmentTypeError(
+			"'%s' object is not iterable", investmentPythonTypeName(node))
+	}
+}
+
+// investmentTruthy mirrors Python truthiness for a safe_load'ed value, which is
+// what `if match_criteria.get("always")` actually tests. An absent key is None
+// and therefore false; so are false, 0, "" and the empty container.
+func investmentTruthy(node *yaml.Node) bool {
+	node = investmentResolveAlias(node)
+	if node == nil || node.Tag == yamlNullTag {
+		return false
+	}
+	switch node.Kind {
+	case yaml.SequenceNode, yaml.MappingNode:
+		return len(node.Content) > 0
+	case yaml.ScalarNode:
+		switch node.Tag {
+		case yamlBoolTag:
+			var value bool
+			return node.Decode(&value) == nil && value
+		case yamlIntTag, yamlFloatTag:
+			var value float64
+			return node.Decode(&value) == nil && value != 0
+		default:
+			return node.Value != ""
+		}
+	default:
+		return true
+	}
+}
+
+// investmentPyYAMLBooleans are the plain scalars PyYAML's resolver reads as
+// BOOLEANS and yaml.v3's does not.
+//
+// PyYAML implements YAML 1.1, whose bool set is
+// yes/no/on/off/true/false in three casings each; yaml.v3 implements the YAML
+// 1.2 core schema, where only true/false are boolean and everything else is an
+// ordinary string. That difference is not cosmetic here, and it is not
+// symmetric either -- it was fail-open in the arm that matters most:
+//
+//	match:
+//	  always: no
+//
+// is False to Python, so the rule falls through to its remaining criteria; to
+// yaml.v3 it is the non-empty string "no", which is TRUTHY, so the rule
+// short-circuits and MATCHES EVERY ARTIFACT. One unquoted word in the config
+// and the Go engine classifies everything under one rule while Python does not.
+// The same difference makes `label: [no]` a bool (which has no .lower(), so
+// Python raises) rather than a label that simply never matches.
+//
+// Normalising here, once, over the whole document is deliberate: doing it at
+// each read site would leave whichever site was added last silently on the 1.2
+// reading. Only PLAIN scalars are rewritten -- a quoted "no" is a string to both
+// resolvers, and an explicitly tagged `!!str no` carries TaggedStyle, so both
+// keep their string reading.
+//
+// Residual, NOT mirrored and not plausible in this config: the two resolvers
+// also disagree about YAML 1.1 sexagesimals (`1:30` is 90 to PyYAML, a string
+// to yaml.v3) and about plain timestamps (`2024-01-02` is a date to PyYAML,
+// which this port then refuses as unrepresentable). Both land on Go refusing or
+// rejecting rather than inventing a value. Leading-zero integers are refused
+// explicitly; see investmentPrioritySortKey.
+var investmentPyYAMLBooleans = map[string]string{
+	"yes": "true", "Yes": "true", "YES": "true",
+	"on": "true", "On": "true", "ON": "true",
+	"no": "false", "No": "false", "NO": "false",
+	"off": "false", "Off": "false", "OFF": "false",
+}
+
+func investmentApplyPyYAMLBooleans(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	if node.Kind == yaml.ScalarNode && node.Tag == yamlStrTag && node.Style == 0 {
+		if canonical, ok := investmentPyYAMLBooleans[node.Value]; ok {
+			node.Tag = yamlBoolTag
+			node.Value = canonical
+		}
+	}
+	// Aliases carry no Content, so this cannot cycle; the anchor itself is
+	// reached once, in place, wherever it is defined.
+	for _, child := range node.Content {
+		investmentApplyPyYAMLBooleans(child)
+	}
+}
+
+// investmentDocumentBody unwraps the document node yaml.Unmarshal produces.
+// A file that is empty or only comments leaves the root node zero-valued, which
+// is how "safe_load returned None" is detected without confusing it with an
+// explicit `{}`.
+func investmentDocumentBody(root *yaml.Node) *yaml.Node {
+	if root == nil || root.Kind == 0 {
+		return nil
+	}
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			return nil
+		}
+		return investmentResolveAlias(root.Content[0])
+	}
+	return investmentResolveAlias(root)
+}
+
+// investmentMappingValue returns the value for `key`, or nil when the key is
+// absent -- the distinction the whole node-walking decode exists to preserve.
+//
+// The LAST occurrence wins, because a duplicate mapping key is not an error in
+// PyYAML: it silently keeps the last one. yaml.v3's typed decoder rejects the
+// document instead, which is why this walks Content rather than decoding.
+func investmentMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	var found *yaml.Node
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			found = mapping.Content[index+1]
+		}
+	}
+	return found
+}
+
+// investmentResolveAlias follows a YAML alias to its anchor, as PyYAML does
+// before any of the above ever sees the value.
+func investmentResolveAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
+}
+
+// investmentPythonTypeName names the Python type `yaml.safe_load` would have
+// produced for a node, so a mirrored exception's message says what Python's
+// says. Only the CLASS is compared by the oracle; this is for the human reading
+// the failure.
+func investmentPythonTypeName(node *yaml.Node) string {
+	if node == nil {
+		return "NoneType"
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return "list"
+	case yaml.MappingNode:
+		return "dict"
+	}
+	switch node.Tag {
+	case yamlNullTag:
+		return "NoneType"
+	case yamlBoolTag:
+		return "bool"
+	case yamlIntTag:
+		return "int"
+	case yamlFloatTag:
+		return "float"
+	case yamlStrTag:
+		return "str"
+	case yamlSeqTag:
+		return "list"
+	case yamlMapTag:
+		return "dict"
+	default:
+		return strings.TrimPrefix(node.Tag, "!!")
+	}
+}
+
+func investmentString(value string) *string {
+	return &value
 }

--- a/internal/providersync/investment_classifier.go
+++ b/internal/providersync/investment_classifier.go
@@ -1,0 +1,261 @@
+package providersync
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Go port of the legacy rule-based investment classifier
+// (analytics/investment.py). It is a DEPRECATED path in Python -- the canonical
+// Investment View is WorkUnit-based -- and this port exists only to serve the
+// legacy daily investment_* destinations, exactly as the Python one does.
+//
+// The rules are read from the REAL config file rather than transcribed into Go.
+// A transcribed copy is a second, unversioned source of truth: the same defect
+// class that left the derived-destination integration tests asserting against a
+// pre-053 enum while production emitted values the copy could not represent. The
+// path is supplied by the caller, mirroring Python's `InvestmentClassifier(
+// config_path)`, so both engines can be pointed at one file and compared.
+//
+// Per D16 this mirrors Python bug-for-bug. Four of the 44 rules in the checked-in
+// config are UNREACHABLE from the work-item call site, and that is reproduced
+// rather than corrected; see investmentClassifierUnreachableRules in the tests,
+// which fails if a future config edit revives one.
+
+const (
+	legacyDefaultInvestmentArea = "product"
+	legacyDefaultProjectStream  = "general"
+	// legacyDefaultRulePriority mirrors `x.get("priority", 100)`: a rule with no
+	// priority sorts as 100, which is AFTER the 40-and-below rules and BEFORE
+	// the 999 catch-all.
+	legacyDefaultRulePriority = 100
+	legacyFallbackRuleID      = "legacy_default"
+	legacyUnnamedRuleID       = "legacy_rule"
+)
+
+// InvestmentClassification mirrors the Python dataclass of the same name.
+type InvestmentClassification struct {
+	InvestmentArea string  `json:"investment_area"`
+	ProjectStream  *string `json:"project_stream"`
+	Confidence     float64 `json:"confidence"`
+	RuleID         string  `json:"rule_id"`
+}
+
+// investmentRule is one entry of the config's `rules:` list. Every field is
+// optional in the file, so each is decoded through a pointer or a slice whose
+// nil-ness carries "the key was absent" -- which the matcher genuinely depends
+// on: an ABSENT `component` key is skipped, while a PRESENT one with an empty
+// list rejects everything.
+type investmentRule struct {
+	ID       string                `yaml:"id"`
+	Priority *int                  `yaml:"priority"`
+	Match    *investmentRuleMatch  `yaml:"match"`
+	Output   *investmentRuleOutput `yaml:"output"`
+}
+
+type investmentRuleMatch struct {
+	Always     *bool     `yaml:"always"`
+	Label      *[]string `yaml:"label"`
+	PathPrefix *[]string `yaml:"path_prefix"`
+	Component  *[]string `yaml:"component"`
+}
+
+type investmentRuleOutput struct {
+	InvestmentArea *string `yaml:"investment_area"`
+	ProjectStream  *string `yaml:"project_stream"`
+}
+
+// InvestmentArtifact is the classifier's input. Python passes a plain dict and
+// the call site (job_work_items.py:1377) supplies exactly four keys: labels,
+// component, title and provider.
+//
+// Title and Provider are carried here even though NOTHING reads them, because
+// the Python matcher does not read them either -- it inspects only labels,
+// paths and component. Dropping them would make the Go signature quietly
+// narrower than the contract it ports, and the docstring's claim that `title`
+// and `epic` participate would then have no visible counter-evidence.
+type InvestmentArtifact struct {
+	Labels []string
+	// Paths is what the matcher's path_prefix arm reads. The work-item call
+	// site never populates it, which is precisely why every path_prefix rule is
+	// dead on that path; it stays here because the field is what makes that
+	// deadness a property of the CALLER rather than of this engine.
+	Paths []string
+	// Component is always "" from the work-item call site: WorkItem has no
+	// `component` attribute, so `getattr(item, "component", "")` cannot return
+	// anything else.
+	Component string
+	// Read by neither engine. See the type comment.
+	Title    string
+	Provider string
+}
+
+// InvestmentClassifier holds the priority-ordered rules.
+type InvestmentClassifier struct {
+	rules []investmentRule
+}
+
+// NewInvestmentClassifier mirrors `InvestmentClassifier.__init__` +
+// `_load_rules`, including its MISSING-FILE behaviour: Python logs a warning
+// and returns an empty rule list rather than raising, so a classifier built
+// against an absent path still answers, always with the legacy default. That
+// is reproduced instead of failing closed, because failing closed here would
+// change which rows the legacy destinations emit.
+func NewInvestmentClassifier(configPath string) (*InvestmentClassifier, error) {
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Python: logger.warning(...); return []
+			return &InvestmentClassifier{rules: nil}, nil
+		}
+		return nil, err
+	}
+	var document struct {
+		Rules []investmentRule `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		return nil, fmt.Errorf("investment config %s: %w", configPath, err)
+	}
+	rules := append([]investmentRule(nil), document.Rules...)
+	// Python sorts with sorted(), which is STABLE, and the checked-in config
+	// relies on that: 37 of its 44 rules share priority 10 and a further 2
+	// share priority 30. Among equal priorities the FILE ORDER decides which
+	// rule classify() reaches first, and classify() returns on first match --
+	// so an unstable sort would silently change the answer for any artifact
+	// matching more than one priority-10 rule. sort.Slice is NOT stable.
+	sort.SliceStable(rules, func(left, right int) bool {
+		return investmentRulePriority(rules[left]) < investmentRulePriority(rules[right])
+	})
+	return &InvestmentClassifier{rules: rules}, nil
+}
+
+func investmentRulePriority(rule investmentRule) int {
+	if rule.Priority == nil {
+		return legacyDefaultRulePriority
+	}
+	return *rule.Priority
+}
+
+// Classify mirrors InvestmentClassifier.classify: first matching rule wins, and
+// an unmatched artifact falls back to the legacy product/general bucket with
+// confidence 0.0 rather than to anything unknown-like.
+func (classifier *InvestmentClassifier) Classify(
+	artifact InvestmentArtifact,
+) InvestmentClassification {
+	for _, rule := range classifier.rules {
+		if !investmentRuleMatches(rule.Match, artifact) {
+			continue
+		}
+		area := legacyDefaultInvestmentArea
+		stream := legacyDefaultProjectStream
+		if rule.Output != nil {
+			if rule.Output.InvestmentArea != nil {
+				area = *rule.Output.InvestmentArea
+			}
+			if rule.Output.ProjectStream != nil {
+				stream = *rule.Output.ProjectStream
+			}
+		}
+		id := rule.ID
+		if id == "" {
+			// Python: rule.get("id", "legacy_rule"). An id key that is present
+			// but empty is NOT the same as an absent one in Python; this port
+			// collapses them because YAML cannot distinguish a missing string
+			// from an empty one without another pointer, and no rule in the
+			// real config omits its id. Pinned by a synthetic-config case.
+			id = legacyUnnamedRuleID
+		}
+		streamValue := stream
+		return InvestmentClassification{
+			InvestmentArea: area,
+			ProjectStream:  &streamValue,
+			Confidence:     1.0,
+			RuleID:         id,
+		}
+	}
+	stream := legacyDefaultProjectStream
+	return InvestmentClassification{
+		InvestmentArea: legacyDefaultInvestmentArea,
+		ProjectStream:  &stream,
+		Confidence:     0.0,
+		RuleID:         legacyFallbackRuleID,
+	}
+}
+
+// investmentRuleMatches mirrors `_matches`.
+//
+// The structure matters as much as the conditions: each arm is a REJECTION
+// test, and a criterion that is absent is not tested at all. So an EMPTY
+// `match: {}` reaches the final `return true` and matches every artifact --
+// including one with no labels at all. The real config expresses its catch-all
+// as `always: true` instead, so only a synthetic config reaches the empty-map
+// form; it is pinned there.
+func investmentRuleMatches(match *investmentRuleMatch, artifact InvestmentArtifact) bool {
+	if match == nil {
+		// `rule.get("match", {})` yields {} for an absent key, and {} matches
+		// everything by the rule above.
+		return true
+	}
+	// Python tests `match_criteria.get("always")` for TRUTHINESS, so
+	// `always: false` does not short-circuit -- it falls through to the
+	// remaining criteria exactly as an absent key would.
+	if match.Always != nil && *match.Always {
+		return true
+	}
+	if match.Label != nil {
+		labels := make(map[string]struct{}, len(artifact.Labels))
+		for _, label := range artifact.Labels {
+			labels[strings.ToLower(label)] = struct{}{}
+		}
+		intersects := false
+		for _, target := range *match.Label {
+			if _, ok := labels[strings.ToLower(target)]; ok {
+				intersects = true
+				break
+			}
+		}
+		if !intersects {
+			return false
+		}
+	}
+	if match.PathPrefix != nil {
+		// Reads artifact PATHS, not path_prefix. The work-item call site
+		// supplies none, so this arm rejects every artifact reaching it from
+		// that path -- the reason three real rules are dead.
+		found := false
+		for _, path := range artifact.Paths {
+			for _, prefix := range *match.PathPrefix {
+				if strings.HasPrefix(path, prefix) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if match.Component != nil {
+		// Exact membership, NOT case-folded -- unlike the label arm. From the
+		// work-item call site the component is always "", so a rule whose list
+		// does not literally contain "" can never fire.
+		matched := false
+		for _, candidate := range *match.Component {
+			if candidate == artifact.Component {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providersync/investment_classifier.go
+++ b/internal/providersync/investment_classifier.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -78,13 +79,22 @@ import (
 //     as octal and yaml.v3's 1.2 reads as decimal. Both engines sort; neither
 //     order is the mirror.
 //  4. A merge key whose anchor chain refers back to its own mapping.
+//  5. A SEXAGESIMAL priority (`1:30`), which PyYAML resolves to the number 90
+//     and yaml.v3 leaves as a string. Both engines sort; the orders differ.
+//     Note this is a divergence only for PRIORITY -- the same literal in a
+//     `label` list is a MIRRORED AttributeError (an int has no .lower()), and
+//     as an id or output value it is refused as unrepresentable, because
+//     Python's value there is the int 90.
+//  6. An all-DATE set of priorities. PyYAML resolves a plain `2024-01-02` to
+//     datetime.date and orders dates among themselves; a date beside an int
+//     still raises in Python and is mirrored as a TypeError.
 //
-// All four are Go-erroring-where-Python-proceeds, which is the loud/safe
+// All six are Go-erroring-where-Python-proceeds, which is the loud/safe
 // direction: the job fails visibly rather than emitting a row Python would not
 // have. None of them occurs in the checked-in config, and each is pinned by the
-// analytics/investment/declared_divergence oracle pair -- which asserts the
-// divergence STILL EXISTS, so making the engines agree without deleting the
-// declaration fails the build rather than leaving a stale note behind.
+// analytics/investment/divergence oracle pair -- which asserts the divergence
+// STILL EXISTS, so making the engines agree without deleting the declaration
+// fails the build rather than leaving a stale note behind.
 //
 // One residual is NOT a declared divergence because no instance of it is known:
 // the two YAML PARSERS could in principle disagree at the syntax level. Every
@@ -106,13 +116,14 @@ const (
 // YAML resolved tags this file distinguishes. Compared as strings rather than
 // re-derived per call site so a typo cannot silently make a branch dead.
 const (
-	yamlNullTag  = "!!null"
-	yamlBoolTag  = "!!bool"
-	yamlIntTag   = "!!int"
-	yamlFloatTag = "!!float"
-	yamlStrTag   = "!!str"
-	yamlSeqTag   = "!!seq"
-	yamlMapTag   = "!!map"
+	yamlNullTag      = "!!null"
+	yamlBoolTag      = "!!bool"
+	yamlIntTag       = "!!int"
+	yamlFloatTag     = "!!float"
+	yamlStrTag       = "!!str"
+	yamlSeqTag       = "!!seq"
+	yamlTimestampTag = "!!timestamp"
+	yamlMapTag       = "!!map"
 )
 
 // InvestmentConfigError is returned for every config/artifact combination on
@@ -354,7 +365,7 @@ func investmentResolvePriorities(rules []investmentRule) error {
 	// port CLAIM a mirrored TypeError for an all-string config Python sorts
 	// happily -- a false mirror, which is worse than an admitted divergence.
 	groups := map[string]bool{}
-	ambiguous := false
+	declared := ""
 	for _, rule := range rules {
 		if rule.priorityKind == investmentPriorityUnorderable {
 			return investmentTypeError(
@@ -363,8 +374,20 @@ func investmentResolvePriorities(rules []investmentRule) error {
 					"more than one rule to order",
 				investmentPythonTypeName(rule.priority))
 		}
-		if rule.priorityKind == investmentPriorityAmbiguousNumeric {
-			ambiguous = true
+		// Every kind below is one Python CAN order among its own type; what
+		// differs is whether this port can reproduce that order. Each records
+		// why not, and the mixed-type check still runs first, because a mixed
+		// config is a mirrored raise no matter which kinds are mixed.
+		switch rule.priorityKind {
+		case investmentPriorityAmbiguousNumeric:
+			declared = "a priority is written with a leading zero, which is octal to " +
+				"PyYAML's YAML 1.1 resolver and decimal to yaml.v3's 1.2 one"
+		case investmentPrioritySexagesimal:
+			declared = "a priority is written in YAML 1.1 sexagesimal (`1:30`), which " +
+				"PyYAML resolves to the number 90 and yaml.v3 leaves as a string"
+		case investmentPriorityDate:
+			declared = "every priority is a date, which PyYAML resolves to " +
+				"datetime.date and orders among its own type"
 		}
 		groups[investmentPriorityPythonType(rule.priorityKind)] = true
 	}
@@ -380,11 +403,9 @@ func investmentResolvePriorities(rules []investmentRule) error {
 				"this port orders only numbers, so it refuses rather than impose an "+
 				"order Python would not produce", investmentSortedQuoted(groups))
 	}
-	if ambiguous {
+	if declared != "" {
 		return investmentUnrepresentable(
-			"a priority is written with a leading zero, which is octal to PyYAML's " +
-				"YAML 1.1 resolver and decimal to yaml.v3's 1.2 one, so no ordering " +
-				"here is the mirror")
+			"%s, so no ordering here is the mirror", declared)
 	}
 	return nil
 }
@@ -413,6 +434,14 @@ const (
 	investmentPriorityString
 	// A sequence. Python orders these lexicographically among themselves too.
 	investmentPrioritySequence
+	// YAML 1.1 sexagesimal (`1:30`). PyYAML resolves it to the INT 90, so it
+	// groups with the other ints -- `1:30` beside `9` sorts in Python and must
+	// not be reported as a mixed-type raise -- but yaml.v3 sees a string, so
+	// the ORDER cannot be reproduced. Declared, like the octal case.
+	investmentPrioritySexagesimal
+	// A plain timestamp. PyYAML resolves it to datetime.date, which orders
+	// among dates and raises against an int.
+	investmentPriorityDate
 	// null or a mapping: Python raises on the first comparison, even against
 	// another value of the same type (`None < None` and `{} < {}` both raise).
 	investmentPriorityUnorderable
@@ -427,7 +456,12 @@ func investmentPriorityPythonType(kind investmentPriorityKind) string {
 		return "str"
 	case investmentPrioritySequence:
 		return "list"
+	case investmentPriorityDate:
+		return "date"
 	default:
+		// Numeric, ambiguous-numeric and sexagesimal are all `int` (or float)
+		// to Python, which is why a sexagesimal priority beside a plain one is
+		// NOT a mixed-type raise.
 		return "int"
 	}
 }
@@ -451,6 +485,38 @@ func investmentPrioritySortKey(node *yaml.Node) (float64, investmentPriorityKind
 		return 0, investmentPriorityUnorderable
 	}
 	switch node.Tag {
+	case yamlBoolTag:
+		// Python's bool IS an int subclass, so `priority: true` sorts as 1
+		// alongside ordinary ints rather than raising -- measured:
+		// sorted([True, 2]) succeeds, and a `priority: true` rule really does
+		// order before a `priority: 9` one. This case exists because
+		// node.Decode(&float64) REFUSES a !!bool, which sent every boolean
+		// priority to Unorderable and made this port CLAIM a Python TypeError
+		// that Python does not raise. The comment above said bool was numeric
+		// while the code disagreed; this is what makes the comment true.
+		var flag bool
+		if err := node.Decode(&flag); err != nil {
+			return 0, investmentPriorityUnorderable
+		}
+		if flag {
+			return 1, investmentPriorityNumeric
+		}
+		return 0, investmentPriorityNumeric
+	case yamlTimestampTag:
+		// PyYAML resolves a plain `2024-01-02` to datetime.date, and dates
+		// order fine AMONG THEMSELVES (measured: two date priorities sort;
+		// a date beside an int raises). Go has no ordering to offer that is
+		// Python's, so an all-date config is a declared divergence -- while a
+		// MIXED one still reaches the mirrored TypeError below, because the
+		// group check sees two types.
+		return 0, investmentPriorityDate
+	case investmentSexagesimalTag:
+		// `1:30` is the INT 90 to PyYAML's YAML 1.1 resolver and a plain
+		// string to yaml.v3's 1.2 one, so it sorts as a number on one side
+		// and not at all on the other. It groups with "int" because that is
+		// the Python TYPE -- `1:30` beside `9` sorts in Python and must not be
+		// reported as a mixed-type TypeError.
+		return 0, investmentPrioritySexagesimal
 	case yamlStrTag:
 		return 0, investmentPriorityString
 	case yamlIntTag:
@@ -463,7 +529,7 @@ func investmentPrioritySortKey(node *yaml.Node) (float64, investmentPriorityKind
 		if len(digits) > 1 && digits[0] == '0' {
 			return 0, investmentPriorityAmbiguousNumeric
 		}
-	case yamlFloatTag, yamlBoolTag:
+	case yamlFloatTag:
 	default:
 		// A null, or a scalar carrying some other tag (a plain timestamp, say).
 		return 0, investmentPriorityUnorderable
@@ -984,6 +1050,35 @@ var investmentPyYAMLBooleans = map[string]string{
 	"off": "false", "Off": "false", "OFF": "false",
 }
 
+// investmentSexagesimalInt and investmentSexagesimalFloat are PyYAML's own
+// resolver patterns, transcribed rather than approximated -- a broader pattern
+// would retag legitimate strings and a narrower one would miss real cases.
+// Measured against PyYAML: `1:30`->90, `99:59`->5999, `1:30.5`->90.5, while
+// `0:30` (leading zero), `1:60` (group above 59) and `:30` stay strings.
+var (
+	investmentSexagesimalInt   = regexp.MustCompile(`^[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+$`)
+	investmentSexagesimalFloat = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*$`)
+)
+
+// investmentSexagesimalTag marks a plain scalar PyYAML reads as a NUMBER and
+// yaml.v3 leaves as a string. It is retagged during normalisation, once, rather
+// than sniffed at each read site, for the same reason the booleans are: the
+// read site added last would otherwise keep the YAML 1.2 reading.
+//
+// Retagging (rather than resolving the value) is what makes all three places
+// this literal can appear land where Python lands, and the three differ:
+//
+//   - as a `priority`, both engines can sort but would sort DIFFERENTLY, so it
+//     is a declared divergence (see investmentPrioritySexagesimal);
+//   - as a `label` entry, Python raises AttributeError because an int has no
+//     .lower() -- so the tag check in investmentLoweredStrings MIRRORS it
+//     exactly, where a bare string would have been lowered and silently
+//     matched nothing. That one was fail-open;
+//   - as an `id` or output value, Python yields the int 90 where a *string
+//     cannot, so it refuses as an unrepresentable value rather than silently
+//     emitting "1:30".
+const investmentSexagesimalTag = "!!pyyaml-sexagesimal"
+
 func investmentApplyPyYAMLBooleans(node *yaml.Node) {
 	if node == nil {
 		return
@@ -992,6 +1087,9 @@ func investmentApplyPyYAMLBooleans(node *yaml.Node) {
 		if canonical, ok := investmentPyYAMLBooleans[node.Value]; ok {
 			node.Tag = yamlBoolTag
 			node.Value = canonical
+		} else if investmentSexagesimalInt.MatchString(node.Value) ||
+			investmentSexagesimalFloat.MatchString(node.Value) {
+			node.Tag = investmentSexagesimalTag
 		}
 	}
 	// Aliases carry no Content, so this cannot cycle; the anchor itself is
@@ -1075,6 +1173,12 @@ func investmentPythonTypeName(node *yaml.Node) string {
 		return "list"
 	case yamlMapTag:
 		return "dict"
+	case investmentSexagesimalTag:
+		// PyYAML resolved it to a number, so a message about it must say what
+		// Python would say -- "'int' object has no attribute 'lower'".
+		return "int"
+	case yamlTimestampTag:
+		return "date"
 	default:
 		return strings.TrimPrefix(node.Tag, "!!")
 	}

--- a/internal/providersync/investment_classifier_oracle_test.go
+++ b/internal/providersync/investment_classifier_oracle_test.go
@@ -1,29 +1,29 @@
 package providersync
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 )
 
-// Both sides resolve a config NAME to the same path, so neither engine can be
-// handed rules the other never saw. The primary cases use the REAL config the
-// production call site loads; the synthetic one covers only the matcher forms
-// the real file never expresses.
+// Both sides resolve a config NAME to the same path by the same RULE, not
+// through a table each maintains separately: "real" is the file production
+// loads, and every other name is <name>.yaml under one testdata directory.
+// A per-name table on each side is a drift surface -- a case pointed at a name
+// the two sides spell differently would compare two different files and still
+// look green. See testdata/oracle_pairs/_investment_helpers.py for the Python
+// half of the same rule.
 func investmentConfigPath(t *testing.T, name string) string {
 	t.Helper()
 	root := investmentRepoRoot(t)
-	switch name {
-	case "real":
+	if name == "real" {
 		return filepath.Join(root, "src/dev_health_ops/config/investment_areas.yaml")
-	case "quirks":
-		return filepath.Join(root, "internal/providersync/testdata/investment_configs/quirks.yaml")
-	case "missing":
-		return filepath.Join(root, "internal/providersync/testdata/investment_configs/nope.yaml")
-	default:
-		t.Fatalf("unknown investment config %q", name)
-		return ""
 	}
+	return filepath.Join(
+		root, "internal/providersync/testdata/investment_configs", name+".yaml")
 }
 
 // investmentRepoRoot walks up from THIS source file rather than from the test's
@@ -38,11 +38,27 @@ func investmentRepoRoot(t *testing.T) string {
 	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
 }
 
+// The "missing" config case is the ONLY way to observe the 0.0/legacy_default
+// fallback, because the real config's `always: true` catch-all makes it
+// unreachable there. That case is only meaningful while the file genuinely does
+// not exist: if someone ever creates it, the case silently starts measuring an
+// ordinary load and the fallback goes untested while still reading as covered.
+func TestInvestmentMissingConfigIsActuallyMissing(t *testing.T) {
+	t.Parallel()
+	path := investmentConfigPath(t, "missing")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("%s exists (stat err %v), so the missing-config case no longer "+
+			"measures the missing-file branch", path, err)
+	}
+}
+
 func investmentOracleCases() []oracleCase {
 	return []oracleCase{
 		{
-			// REAL CONFIG, ordinary label path: "security" is a sec_* label at
-			// priority 10, the band where 37 rules tie.
+			// REAL CONFIG, ordinary label path. "security" resolves to
+			// sec_general, the SOLE rule at priority 20 -- not a member of the
+			// 37-rule tie at priority 10, which is what the tie cases below
+			// exercise.
 			ID: "real_label_security",
 			Input: map[string]any{
 				"Config":   "real",
@@ -71,15 +87,21 @@ func investmentOracleCases() []oracleCase {
 			},
 		},
 		{
-			// REAL CONFIG + the production component value. WorkItem has no
-			// `component` attribute, so the call site always passes "". This
-			// pins that data_component (match: ['Data Platform','Analytics'])
-			// does NOT fire even for an artifact whose other labels are absent.
-			ID: "real_component_empty_cannot_match",
+			// REAL CONFIG, and the asymmetry between the two arms: the COMPONENT
+			// arm is exact-match, NOT case-folded like the label arm.
+			// data_component lists 'Analytics', and this lower-case "analytics"
+			// must therefore fall through to the catch-all.
+			//
+			// An earlier version of this case passed Component:"" -- byte for
+			// byte the same artifact as real_no_labels_hits_always_catchall
+			// above, so it could not fail for any reason that case would not
+			// also fail for, and the case-sensitivity of the component arm was
+			// untested while this case's name implied otherwise.
+			ID: "real_component_lowercase_analytics_cannot_match",
 			Input: map[string]any{
 				"Config": "real",
 				"Artifact": map[string]any{
-					"Labels": []any{}, "Component": "",
+					"Labels": []any{}, "Component": "analytics",
 				},
 			},
 		},
@@ -87,7 +109,9 @@ func investmentOracleCases() []oracleCase {
 			// REAL CONFIG with a component value that WOULD match
 			// data_component if the call site could ever produce it. It cannot
 			// -- this case exists to show the rule is dead because of the
-			// CALLER, not because the matcher is broken.
+			// CALLER, not because the matcher is broken. Paired with the
+			// lower-case case above, it also pins that the exact spelling is
+			// what decides.
 			ID: "real_component_data_platform_would_match",
 			Input: map[string]any{
 				"Config": "real",
@@ -155,6 +179,21 @@ func investmentOracleCases() []oracleCase {
 			},
 		},
 		{
+			// QUIRK, and the counterpart to the case above: the SAME rule and
+			// the SAME labels, with the `component` key ABSENT rather than "".
+			// Python reads it with `artifact.get("component")` -- no default --
+			// so absent is None, and `None not in ["", "Data Platform"]` is
+			// true: the rule rejects and the artifact falls to the catch-all.
+			// This is what makes InvestmentArtifact.Component a POINTER; with a
+			// plain string the two states are indistinguishable and this case
+			// would return the previous one's answer.
+			ID: "quirks_component_absent_key_is_not_the_empty_string",
+			Input: map[string]any{
+				"Config":   "quirks",
+				"Artifact": map[string]any{"Labels": []any{"componentcase"}},
+			},
+		},
+		{
 			// QUIRK: the path_prefix arm WORKS when the caller supplies paths.
 			// The work-item call site never does, which is what makes the three
 			// real path_prefix rules dead from that path.
@@ -191,6 +230,158 @@ func investmentOracleCases() []oracleCase {
 			},
 		},
 		{
+			// `id:` PRESENT and NULL -> rule_id is None. Not "legacy_rule", and
+			// not "". The previous port collapsed this into "legacy_rule" and
+			// claimed a case pinned it; none existed.
+			ID: "ids_present_and_null_is_none",
+			Input: map[string]any{
+				"Config":   "ids",
+				"Artifact": map[string]any{"Labels": []any{"idnull"}},
+			},
+		},
+		{
+			// `id: ""` -> rule_id is the empty string, again not "legacy_rule".
+			ID: "ids_present_and_empty_stays_empty",
+			Input: map[string]any{
+				"Config":   "ids",
+				"Artifact": map[string]any{"Labels": []any{"idempty"}},
+			},
+		},
+		{
+			// `id` ABSENT -> and only now is it "legacy_rule". These three cases
+			// are only distinguishable because the rule's id is decoded as a
+			// node rather than a string.
+			ID: "ids_absent_is_legacy_rule",
+			Input: map[string]any{
+				"Config":   "ids",
+				"Artifact": map[string]any{"Labels": []any{"idabsent"}},
+			},
+		},
+		{
+			// NULL values inside an output block: `.get(key, DEFAULT)` returns
+			// None for a present-but-null key, so BOTH fields are None rather
+			// than product/general -- despite the Python dataclass annotating
+			// investment_area as `str`. The same artifact also traverses an
+			// earlier rule whose whole `output:` block is null WITHOUT matching
+			// it, which pins that the null-output AttributeError is a property
+			// of matching and not of iteration.
+			ID: "output_null_values_are_none_not_defaults",
+			Input: map[string]any{
+				"Config":   "output_nulls",
+				"Artifact": map[string]any{"Labels": []any{"nullvalues"}},
+			},
+		},
+		{
+			// `priority:` PRESENT and NULL with exactly ONE rule. sorted()
+			// computes every key up front but never compares a single element,
+			// so Python does NOT raise. The two-rule form is a refusal case;
+			// this pair is what stops "any null priority is fatal" from passing
+			// as a mirror.
+			ID: "priority_null_single_rule_does_not_raise",
+			Input: map[string]any{
+				"Config":   "priority_null_single",
+				"Artifact": map[string]any{"Labels": []any{"lonely"}},
+			},
+		},
+		{
+			// `path_prefix:` PRESENT and NULL, with an artifact carrying NO
+			// paths. Python resolves the prefix list inside the loop over the
+			// artifact's paths, so the loop body never runs and the arm merely
+			// rejects. The same file WITH paths is a refusal case.
+			ID: "path_prefix_null_without_paths_only_rejects",
+			Input: map[string]any{
+				"Config":   "path_prefix_null",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// A DUPLICATE mapping key. PyYAML keeps the LAST silently, so
+			// rule_id is "second". yaml.v3's typed decoder rejects the document
+			// outright, which is why the port walks nodes -- this was a declared
+			// divergence before that change and is a mirrored quirk after it.
+			ID: "duplicate_id_key_keeps_the_last",
+			Input: map[string]any{
+				"Config":   "duplicate_ids",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// A BARE STRING `component:` makes `in` mean SUBSTRING CONTAINMENT.
+			// "analy" is a strict substring of "analytics" and is not equal to
+			// it, so a mirror that used equality would reject here.
+			ID: "bare_string_component_is_substring_containment",
+			Input: map[string]any{
+				"Config": "bare_component",
+				"Artifact": map[string]any{
+					"Labels": []any{"barecomponent"}, "Component": "analy",
+				},
+			},
+		},
+		{
+			// The negative half: a component that is NOT a substring rejects,
+			// so the case above is not passing merely because the arm was
+			// skipped.
+			ID: "bare_string_component_rejects_a_non_substring",
+			Input: map[string]any{
+				"Config": "bare_component",
+				"Artifact": map[string]any{
+					"Labels": []any{"barecomponent"}, "Component": "zzz",
+				},
+			},
+		},
+		{
+			// A BARE STRING `label:` is ITERATED, so the target set is the
+			// string's characters: the single letter "s" matches `label:
+			// security`.
+			ID: "bare_string_label_iterates_characters",
+			Input: map[string]any{
+				"Config":   "bare_label",
+				"Artifact": map[string]any{"Labels": []any{"s"}},
+			},
+		},
+		{
+			// ...and the whole word does NOT, which is what proves the previous
+			// case measured character iteration rather than an ordinary match.
+			ID: "bare_string_label_does_not_match_the_whole_word",
+			Input: map[string]any{
+				"Config":   "bare_label",
+				"Artifact": map[string]any{"Labels": []any{"security"}},
+			},
+		},
+		{
+			// `always:` holding a non-empty STRING is TRUTHY and short-circuits
+			// to a match -- including the quoted "no" that YAML would otherwise
+			// resolve to the boolean false. Contrast
+			// quirks_always_false_falls_through, where it is a real boolean.
+			ID: "always_non_empty_string_is_truthy",
+			Input: map[string]any{
+				"Config":   "always_truthy_string",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// An UNQUOTED `always: no` is the BOOLEAN false to PyYAML's YAML 1.1
+			// resolver, so the rule does not short-circuit and falls through to
+			// its label criterion -- which this artifact satisfies.
+			ID: "always_unquoted_no_is_false_and_falls_through",
+			Input: map[string]any{
+				"Config":   "always_unquoted_no",
+				"Artifact": map[string]any{"Labels": []any{"unquotedno"}},
+			},
+		},
+		{
+			// The half that catches the resolver difference. To yaml.v3's YAML
+			// 1.2 core schema the same word is the non-empty STRING "no", which
+			// is TRUTHY: an unnormalised port short-circuits here and classifies
+			// EVERY artifact under this rule. This case must fall to
+			// legacy_default.
+			ID: "always_unquoted_no_does_not_short_circuit",
+			Input: map[string]any{
+				"Config":   "always_unquoted_no",
+				"Artifact": map[string]any{"Labels": []any{"something-else"}},
+			},
+		},
+		{
 			// MISSING CONFIG: Python warns and classifies with an EMPTY rule
 			// list rather than raising, so this is the ONLY way to observe the
 			// 0.0 / legacy_default fallback -- the real config's `always`
@@ -211,16 +402,215 @@ func TestInvestmentClassifierMatchesLivePythonProduction(t *testing.T) {
 		investmentOracleCases(),
 		func(t *testing.T, input map[string]any) InvestmentClassification {
 			t.Helper()
+			// A refusal here is itself a divergence -- Python classified this
+			// case, so Go refusing it is the declared, loud direction and must
+			// stop the run. The message names the config AND the artifact
+			// because those two together identify the case: t.Fatal fires while
+			// the row is being BUILT, before the comparator has opened the
+			// per-case subtest that would otherwise supply the name, and two
+			// cases in this list can share a config file.
 			classifier, err := NewInvestmentClassifier(
 				investmentConfigPath(t, input["Config"].(string)),
 			)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("load config %q for artifact %v: %v",
+					input["Config"], input["Artifact"], err)
 			}
-			return classifier.Classify(investmentOracleArtifact(input))
+			classification, err := classifier.Classify(investmentOracleArtifact(input))
+			if err != nil {
+				t.Fatalf("classify config %q for artifact %v: %v",
+					input["Config"], input["Artifact"], err)
+			}
+			return classification
 		},
 		nil,
 	)
+}
+
+// investmentRefusalRow is the compared surface of the refusal pair: the NAME of
+// the Python exception class, which the Go side reproduces from its own
+// *InvestmentConfigError. Comparing the class rather than a bare "both refused"
+// boolean is what makes a Go engine that refuses everything for one blanket
+// reason fail -- Python's AttributeError (dereferencing a None as a dict) and
+// TypeError (iterating or comparing one) are two different bugs in the same
+// file, and a port that cannot tell them apart has not mirrored either.
+// The classification fields ride along, and must all be nil: a port that
+// refused and still produced a classification would differ here. They are
+// compared rather than declared as exclusions because they are absent for a
+// reason that belongs to the DATA (neither engine produced one), not to the
+// pair.
+type investmentRefusalRow struct {
+	Raises         string   `json:"raises"`
+	InvestmentArea *string  `json:"investment_area"`
+	ProjectStream  *string  `json:"project_stream"`
+	Confidence     *float64 `json:"confidence"`
+	RuleID         *string  `json:"rule_id"`
+}
+
+func investmentRefusalCases() []oracleCase {
+	return []oracleCase{
+		// --- shapes that raise at LOAD ---
+		{
+			// A zero-byte file: safe_load returns None and `data.get(...)` is
+			// an attribute lookup on None. A typed Go decode read this as "no
+			// rules" and happily returned product/general/0.0/legacy_default.
+			ID:    "raises_empty_file",
+			Input: map[string]any{"Config": "raises_empty"},
+		},
+		{
+			// The same None, from a file that has bytes in it. Separate case
+			// because a reader would not expect a file with content to parse to
+			// nothing, and a decode that special-cased "zero length" would pass
+			// the case above while failing this one.
+			ID:    "raises_comment_only_file",
+			Input: map[string]any{"Config": "raises_comments_only"},
+		},
+		{
+			// `rules:` PRESENT and NULL. The `.get` default is NOT applied,
+			// because the key exists, so sorted() is handed None.
+			ID:    "raises_rules_key_present_and_null",
+			Input: map[string]any{"Config": "raises_rules_null"},
+		},
+		{
+			// The document is a list, so `data.get` is an attribute lookup on a
+			// list rather than on None -- a different Python type reaching the
+			// same failure, which a decode that only checked for null would
+			// miss.
+			ID:    "raises_document_is_a_list",
+			Input: map[string]any{"Config": "raises_document_is_list"},
+		},
+		{
+			// A rules ENTRY that is not a mapping. sorted() applies its key
+			// function to every element before comparing anything, so this
+			// raises at load even with a single entry.
+			ID:    "raises_rule_entry_is_not_a_mapping",
+			Input: map[string]any{"Config": "raises_rule_not_mapping"},
+		},
+		{
+			// `priority:` PRESENT and NULL with TWO rules, so sorted() actually
+			// compares. Its single-rule counterpart is a classify case that must
+			// NOT raise.
+			ID:    "raises_null_priority_with_two_rules",
+			Input: map[string]any{"Config": "raises_priority_null"},
+		},
+		// --- shapes that raise at CLASSIFY ---
+		{
+			// `match:` PRESENT and NULL. A typed decode read this as "no match
+			// block", which matches EVERYTHING: the rule FIRED and returned a
+			// classification where Python raises. That is the worst shape in
+			// this list -- not a wrong value, an invented one.
+			ID:    "raises_null_match_block",
+			Input: map[string]any{"Config": "raises_match_null"},
+		},
+		{
+			// `output:` PRESENT and NULL on a rule that MATCHES.
+			ID:    "raises_null_output_block_on_a_matching_rule",
+			Input: map[string]any{"Config": "raises_output_null"},
+		},
+		{
+			// `label:` PRESENT and NULL: the arm runs because the key exists,
+			// and the generator iterates None.
+			ID:    "raises_null_label_list",
+			Input: map[string]any{"Config": "raises_label_null"},
+		},
+		{
+			// A label entry YAML resolves to a BOOLEAN -- `no` is False to
+			// PyYAML, not the string "no" -- and False has no .lower(). The
+			// artifact carries no labels, which pins that the whole generator is
+			// consumed before any intersection is taken.
+			ID:    "raises_boolean_label_entry",
+			Input: map[string]any{"Config": "raises_label_bool"},
+		},
+		{
+			// The same arm with an INT entry. Its own case so the bool case
+			// cannot stand in for it.
+			ID:    "raises_integer_label_entry",
+			Input: map[string]any{"Config": "raises_label_int"},
+		},
+		{
+			// `component:` PRESENT and NULL: `x not in None` is a containment
+			// test against something that is not a container.
+			ID:    "raises_null_component_list",
+			Input: map[string]any{"Config": "raises_component_null"},
+		},
+		{
+			// `path_prefix:` PRESENT and NULL, WITH paths on the artifact. The
+			// same file with no paths is a classify case that must not raise:
+			// Python resolves the prefix list inside the loop over the
+			// artifact's paths, so the raise belongs to the artifact, not to the
+			// config.
+			ID: "raises_null_path_prefix_only_when_paths_are_supplied",
+			Input: map[string]any{
+				"Config": "path_prefix_null",
+				"Artifact": map[string]any{
+					"Paths": []any{"services/api/handler.go"},
+				},
+			},
+		},
+	}
+}
+
+func TestInvestmentClassifierRefusesWhatLivePythonRefuses(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"analytics/investment/refusal",
+		investmentRefusalCases(),
+		func(t *testing.T, input map[string]any) investmentRefusalRow {
+			t.Helper()
+			return investmentRefusalRow{
+				Raises: investmentGoRefusal(t, input),
+			}
+		},
+		nil,
+	)
+}
+
+// investmentGoRefusal returns the Python exception class this port claims for a
+// case, or a DESCRIPTION of what it did instead. It never returns "" for a
+// non-refusal: the description is compared against Python's class name and
+// therefore fails loudly, carrying the classification Go invented into the
+// failure message rather than reporting a bare inequality.
+func investmentGoRefusal(t *testing.T, input map[string]any) string {
+	t.Helper()
+	classifier, err := NewInvestmentClassifier(
+		investmentConfigPath(t, input["Config"].(string)),
+	)
+	if err == nil {
+		var classification InvestmentClassification
+		classification, err = classifier.Classify(investmentOracleArtifact(input))
+		if err == nil {
+			return fmt.Sprintf(
+				"<no refusal: classified as %s>",
+				investmentDescribeClassification(classification))
+		}
+	}
+	var configError *InvestmentConfigError
+	if !errors.As(err, &configError) {
+		return fmt.Sprintf("<not a mirrored refusal: %v>", err)
+	}
+	if configError.PythonException == "" {
+		// A declared divergence is Go refusing where Python PROCEEDS. Letting
+		// one satisfy a refusal case would be the framework agreeing with
+		// itself: the case says Python raises, and this says it does not.
+		return fmt.Sprintf("<declared divergence, not a mirror: %s>", configError.Detail)
+	}
+	return configError.PythonException
+}
+
+func investmentDescribeClassification(classification InvestmentClassification) string {
+	return fmt.Sprintf(
+		"area=%s stream=%s confidence=%v rule=%s",
+		investmentDescribeString(classification.InvestmentArea),
+		investmentDescribeString(classification.ProjectStream),
+		classification.Confidence,
+		investmentDescribeString(classification.RuleID))
+}
+
+func investmentDescribeString(value *string) string {
+	if value == nil {
+		return "None"
+	}
+	return fmt.Sprintf("%q", *value)
 }
 
 func investmentOracleArtifact(input map[string]any) InvestmentArtifact {
@@ -229,16 +619,18 @@ func investmentOracleArtifact(input map[string]any) InvestmentArtifact {
 	if raw == nil {
 		return artifact
 	}
-	for _, label := range investmentOracleStrings(raw, "Labels") {
-		artifact.Labels = append(artifact.Labels, label)
-	}
-	// Paths is left nil unless the case sets it, matching the production call
-	// site, which supplies no paths at all.
+	artifact.Labels = investmentOracleStrings(raw, "Labels")
+	// Paths and Component are populated ONLY when the case sets them, matching
+	// _investment_helpers.artifact on the Python side. The production call site
+	// always supplies component (always "") and never supplies paths, and an
+	// ABSENT key is a different value from "" for the membership test and a
+	// different control flow for the path arm -- defaulting either here would
+	// make those states unreachable from any case.
 	if _, present := raw["Paths"]; present {
 		artifact.Paths = investmentOracleStrings(raw, "Paths")
 	}
 	if value, ok := raw["Component"].(string); ok {
-		artifact.Component = value
+		artifact.Component = investmentString(value)
 	}
 	if value, ok := raw["Title"].(string); ok {
 		artifact.Title = value

--- a/internal/providersync/investment_classifier_oracle_test.go
+++ b/internal/providersync/investment_classifier_oracle_test.go
@@ -1,0 +1,262 @@
+package providersync
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Both sides resolve a config NAME to the same path, so neither engine can be
+// handed rules the other never saw. The primary cases use the REAL config the
+// production call site loads; the synthetic one covers only the matcher forms
+// the real file never expresses.
+func investmentConfigPath(t *testing.T, name string) string {
+	t.Helper()
+	root := investmentRepoRoot(t)
+	switch name {
+	case "real":
+		return filepath.Join(root, "src/dev_health_ops/config/investment_areas.yaml")
+	case "quirks":
+		return filepath.Join(root, "internal/providersync/testdata/investment_configs/quirks.yaml")
+	case "missing":
+		return filepath.Join(root, "internal/providersync/testdata/investment_configs/nope.yaml")
+	default:
+		t.Fatalf("unknown investment config %q", name)
+		return ""
+	}
+}
+
+// investmentRepoRoot walks up from THIS source file rather than from the test's
+// working directory, so the path does not depend on how the test was invoked.
+func investmentRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate the oracle test source file")
+	}
+	// internal/providersync/<this file> -> repo root
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+}
+
+func investmentOracleCases() []oracleCase {
+	return []oracleCase{
+		{
+			// REAL CONFIG, ordinary label path: "security" is a sec_* label at
+			// priority 10, the band where 37 rules tie.
+			ID: "real_label_security",
+			Input: map[string]any{
+				"Config":   "real",
+				"Artifact": map[string]any{"Labels": []any{"security"}},
+			},
+		},
+		{
+			// REAL CONFIG, no labels at all: every label rule rejects, and the
+			// only rule left is product_default (priority 999, `always: true`).
+			// Confidence must be 1.0 and the rule id product_default -- NOT the
+			// 0.0/legacy_default fallback, which this config can never reach
+			// BECAUSE of that catch-all.
+			ID: "real_no_labels_hits_always_catchall",
+			Input: map[string]any{
+				"Config":   "real",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// REAL CONFIG, label casing. The label arm lower-cases BOTH sides,
+			// so a shouty label still matches a lower-case rule.
+			ID: "real_label_is_case_folded",
+			Input: map[string]any{
+				"Config":   "real",
+				"Artifact": map[string]any{"Labels": []any{"SECURITY"}},
+			},
+		},
+		{
+			// REAL CONFIG + the production component value. WorkItem has no
+			// `component` attribute, so the call site always passes "". This
+			// pins that data_component (match: ['Data Platform','Analytics'])
+			// does NOT fire even for an artifact whose other labels are absent.
+			ID: "real_component_empty_cannot_match",
+			Input: map[string]any{
+				"Config": "real",
+				"Artifact": map[string]any{
+					"Labels": []any{}, "Component": "",
+				},
+			},
+		},
+		{
+			// REAL CONFIG with a component value that WOULD match
+			// data_component if the call site could ever produce it. It cannot
+			// -- this case exists to show the rule is dead because of the
+			// CALLER, not because the matcher is broken.
+			ID: "real_component_data_platform_would_match",
+			Input: map[string]any{
+				"Config": "real",
+				"Artifact": map[string]any{
+					"Labels": []any{}, "Component": "Data Platform",
+				},
+			},
+		},
+		{
+			// REAL CONFIG, STABLE SORT where it actually bites. This artifact
+			// carries labels matching FOUR different priority-10 rules
+			// (sec_auth, infra_k8s, qual_test, prod_feat). 37 rules tie at that
+			// priority in the real file, so an unstable sort genuinely permutes
+			// them and the first-match winner changes. The synthetic 3-rule tie
+			// below is too small to force Go's sort to reorder; this is the
+			// case that measures the constraint.
+			ID: "real_multiple_priority_10_matches_first_in_file_wins",
+			Input: map[string]any{
+				"Config": "real",
+				"Artifact": map[string]any{
+					"Labels": []any{"feature", "testing", "kubernetes", "auth"},
+				},
+			},
+		},
+		{
+			// QUIRK: the EMPTY match:{} catch-all, reached only when nothing
+			// above it matches. Without this case the lowest-priority rule in
+			// the synthetic config would never be exercised.
+			ID: "quirks_empty_match_is_the_catchall",
+			Input: map[string]any{
+				"Config":   "quirks",
+				"Artifact": map[string]any{"Labels": []any{"matches-no-rule"}},
+			},
+		},
+		{
+			// QUIRK: STABLE SORT. Three rules tie at priority 10 and all three
+			// match "shared"; the FIRST in file order must win. An unstable
+			// sort could return any of the three.
+			ID: "quirks_equal_priority_first_in_file_wins",
+			Input: map[string]any{
+				"Config":   "quirks",
+				"Artifact": map[string]any{"Labels": []any{"shared"}},
+			},
+		},
+		{
+			// QUIRK: `always: false` is tested for TRUTHINESS, so it does not
+			// short-circuit; the rule falls through to its (absent) remaining
+			// criteria and therefore matches everything anyway.
+			ID: "quirks_always_false_falls_through",
+			Input: map[string]any{
+				"Config":   "quirks",
+				"Artifact": map[string]any{"Labels": []any{"alwaysfalse"}},
+			},
+		},
+		{
+			// QUIRK: a component rule whose list contains "" is the ONLY shape
+			// that can fire from the work-item call site. Labels are chosen so
+			// the earlier tie rules do not shadow it.
+			ID: "quirks_component_empty_string_matches",
+			Input: map[string]any{
+				"Config": "quirks",
+				"Artifact": map[string]any{
+					"Labels": []any{"componentcase"}, "Component": "",
+				},
+			},
+		},
+		{
+			// QUIRK: the path_prefix arm WORKS when the caller supplies paths.
+			// The work-item call site never does, which is what makes the three
+			// real path_prefix rules dead from that path.
+			ID: "quirks_path_prefix_matches_when_paths_supplied",
+			Input: map[string]any{
+				"Config": "quirks",
+				"Artifact": map[string]any{
+					"Labels": []any{"pathcase"},
+					"Paths":  []any{"services/api/handler.go"},
+				},
+			},
+		},
+		{
+			// QUIRK: a rule with NO priority key sorts as 100.
+			ID: "quirks_missing_priority_defaults_to_100",
+			Input: map[string]any{
+				"Config": "quirks",
+				"Artifact": map[string]any{
+					"Labels": []any{"unprioritised"},
+				},
+			},
+		},
+		{
+			// QUIRK: a matched rule with NO output block falls back to the
+			// legacy product/general values while keeping confidence 1.0 and
+			// its OWN rule id -- which is what distinguishes it from the
+			// no-match fallback that uses "legacy_default" and 0.0.
+			ID: "quirks_matched_rule_without_output",
+			Input: map[string]any{
+				"Config": "quirks",
+				"Artifact": map[string]any{
+					"Labels": []any{"nooutput"},
+				},
+			},
+		},
+		{
+			// MISSING CONFIG: Python warns and classifies with an EMPTY rule
+			// list rather than raising, so this is the ONLY way to observe the
+			// 0.0 / legacy_default fallback -- the real config's `always`
+			// catch-all makes it unreachable there.
+			ID: "missing_config_falls_back_to_legacy_default",
+			Input: map[string]any{
+				"Config":   "missing",
+				"Artifact": map[string]any{"Labels": []any{"security"}},
+			},
+		},
+	}
+}
+
+func TestInvestmentClassifierMatchesLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"analytics/investment/classify",
+		investmentOracleCases(),
+		func(t *testing.T, input map[string]any) InvestmentClassification {
+			t.Helper()
+			classifier, err := NewInvestmentClassifier(
+				investmentConfigPath(t, input["Config"].(string)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return classifier.Classify(investmentOracleArtifact(input))
+		},
+		nil,
+	)
+}
+
+func investmentOracleArtifact(input map[string]any) InvestmentArtifact {
+	raw, _ := input["Artifact"].(map[string]any)
+	artifact := InvestmentArtifact{Provider: "github"}
+	if raw == nil {
+		return artifact
+	}
+	for _, label := range investmentOracleStrings(raw, "Labels") {
+		artifact.Labels = append(artifact.Labels, label)
+	}
+	// Paths is left nil unless the case sets it, matching the production call
+	// site, which supplies no paths at all.
+	if _, present := raw["Paths"]; present {
+		artifact.Paths = investmentOracleStrings(raw, "Paths")
+	}
+	if value, ok := raw["Component"].(string); ok {
+		artifact.Component = value
+	}
+	if value, ok := raw["Title"].(string); ok {
+		artifact.Title = value
+	}
+	if value, ok := raw["Provider"].(string); ok {
+		artifact.Provider = value
+	}
+	return artifact
+}
+
+func investmentOracleStrings(raw map[string]any, key string) []string {
+	values, ok := raw[key].([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.(string))
+	}
+	return result
+}

--- a/internal/providersync/investment_classifier_oracle_test.go
+++ b/internal/providersync/investment_classifier_oracle_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"testing"
 )
@@ -272,6 +273,78 @@ func investmentOracleCases() []oracleCase {
 			},
 		},
 		{
+			// ONE null output value at a time. The both-null case above cannot
+			// tell a port that reads project_stream correctly from one that
+			// reads neither -- a single case over a compound condition reports
+			// coverage it does not have. This one pins project_stream (F5) with
+			// investment_area holding an ordinary value beside it.
+			ID: "output_null_project_stream_only",
+			Input: map[string]any{
+				"Config":   "output_nulls",
+				"Artifact": map[string]any{"Labels": []any{"streamnull"}},
+			},
+		},
+		{
+			// ...and its mirror image, pinning investment_area alone. Python
+			// annotates that field `str` and does not enforce it, so None
+			// reaches the call site regardless.
+			ID: "output_null_investment_area_only",
+			Input: map[string]any{
+				"Config":   "output_nulls",
+				"Artifact": map[string]any{"Labels": []any{"areanull"}},
+			},
+		},
+		{
+			// A YAML MERGE KEY, resolved: the rule matches on the merged label
+			// list exactly as PyYAML's constructor makes it.
+			ID: "merge_key_is_resolved_into_the_match_block",
+			Input: map[string]any{
+				"Config":   "merge_keys",
+				"Artifact": map[string]any{"Labels": []any{"merged-label"}},
+			},
+		},
+		{
+			// The half that catches an UNRESOLVED merge, and the reason merges
+			// are mirrored rather than declared. A port that leaves `<<` as an
+			// ordinary key sees a match block with no criteria, which matches
+			// EVERY artifact -- so it returns merged_area here, where Python
+			// falls to legacy_default. Fail-open, and invisible without this
+			// case.
+			ID: "merge_key_unresolved_would_match_every_artifact",
+			Input: map[string]any{
+				"Config":   "merge_keys",
+				"Artifact": map[string]any{"Labels": []any{"not-the-merged-label"}},
+			},
+		},
+		{
+			// MERGE PRECEDENCE: an explicit key beats a merged one even though
+			// the `<<` comes first in the mapping. Under last-wins-by-position
+			// the merged label would survive and this artifact would miss.
+			ID: "merge_explicit_key_beats_merged_key",
+			Input: map[string]any{
+				"Config":   "merge_precedence",
+				"Artifact": map[string]any{"Labels": []any{"explicit"}},
+			},
+		},
+		{
+			// ...and the overridden rule really is overridden: "from-first"
+			// falls past it to the list-merge rule below.
+			ID: "merge_overridden_label_no_longer_matches",
+			Input: map[string]any{
+				"Config":   "merge_precedence",
+				"Artifact": map[string]any{"Labels": []any{"from-first"}},
+			},
+		},
+		{
+			// MERGE PRECEDENCE in a list: `<<: [*first, *second]` keeps the
+			// FIRST source's label, so the second's must not match at all.
+			ID: "merge_first_list_source_beats_the_second",
+			Input: map[string]any{
+				"Config":   "merge_precedence",
+				"Artifact": map[string]any{"Labels": []any{"from-second"}},
+			},
+		},
+		{
 			// `priority:` PRESENT and NULL with exactly ONE rule. sorted()
 			// computes every key up front but never compares a single element,
 			// so Python does NOT raise. The two-rule form is a refusal case;
@@ -493,6 +566,25 @@ func investmentRefusalCases() []oracleCase {
 			ID:    "raises_null_priority_with_two_rules",
 			Input: map[string]any{"Config": "raises_priority_null"},
 		},
+		{
+			// MIXED priority types: one int, one string. Python compares only
+			// WITHIN a type, so sorted() raises -- while an ALL-string config
+			// sorts fine and is a declared divergence instead. Without this case
+			// "non-numeric priority" is one undifferentiated branch, and the
+			// port could claim a mirrored TypeError for the config Python
+			// happily sorts.
+			ID:    "raises_mixed_int_and_string_priorities",
+			Input: map[string]any{"Config": "raises_mixed_priority_types"},
+		},
+		{
+			// A `<<` whose value is neither a mapping nor a list of mappings.
+			// PyYAML raises while CONSTRUCTING the document, so this dies before
+			// _load_rules runs at all -- and it is the only case here whose
+			// exception class is neither AttributeError nor TypeError, which is
+			// what stops the phase-and-class value from being guessable.
+			ID:    "raises_merge_source_is_not_a_mapping",
+			Input: map[string]any{"Config": "raises_merge_source_not_a_mapping"},
+		},
 		// --- shapes that raise at CLASSIFY ---
 		{
 			// `match:` PRESENT and NULL. A typed decode read this as "no match
@@ -570,12 +662,21 @@ func TestInvestmentClassifierRefusesWhatLivePythonRefuses(t *testing.T) {
 // non-refusal: the description is compared against Python's class name and
 // therefore fails loudly, carrying the classification Go invented into the
 // failure message rather than reporting a bare inequality.
+// The value is PHASE-QUALIFIED ("construct:TypeError", "classify:AttributeError")
+// because which of the two raises is a real property of the config shape, not an
+// implementation detail: `rules:` null dies in _load_rules, while `match:` null
+// LOADS FINE and dies only once classify() reaches that rule. A port that
+// refuses the right file for the right exception class at the wrong moment
+// rejects a classifier Python is willing to construct, and comparing the class
+// alone would let that pass as agreement.
 func investmentGoRefusal(t *testing.T, input map[string]any) string {
 	t.Helper()
+	phase := "construct"
 	classifier, err := NewInvestmentClassifier(
 		investmentConfigPath(t, input["Config"].(string)),
 	)
 	if err == nil {
+		phase = "classify"
 		var classification InvestmentClassification
 		classification, err = classifier.Classify(investmentOracleArtifact(input))
 		if err == nil {
@@ -586,7 +687,7 @@ func investmentGoRefusal(t *testing.T, input map[string]any) string {
 	}
 	var configError *InvestmentConfigError
 	if !errors.As(err, &configError) {
-		return fmt.Sprintf("<not a mirrored refusal: %v>", err)
+		return fmt.Sprintf("<%s: not a mirrored refusal: %v>", phase, err)
 	}
 	if configError.PythonException == "" {
 		// A declared divergence is Go refusing where Python PROCEEDS. Letting
@@ -594,7 +695,144 @@ func investmentGoRefusal(t *testing.T, input map[string]any) string {
 		// itself: the case says Python raises, and this says it does not.
 		return fmt.Sprintf("<declared divergence, not a mirror: %s>", configError.Detail)
 	}
-	return configError.PythonException
+	return phase + ":" + configError.PythonException
+}
+
+// investmentDeclaredDivergenceRow asserts the RELATIONSHIP between the engines
+// for a shape this port declares it does not mirror, rather than either
+// engine's answer.
+//
+// Relation carries a sentinel both sides emit only when their own half holds --
+// Python classified, and this port refused with a DECLARED refusal. The rows
+// therefore match only when the whole declaration is still true. A divergence
+// that lives only in a comment decays silently the day someone makes the
+// engines agree; this one fails the build instead.
+//
+// GoRefusal is declared through the harness's goOnlyFields mechanism, which
+// enforces both directions of its own claim: it fails if the field ever shows
+// up on the Python side, and it fails if it never shows up on the Go side.
+type investmentDeclaredDivergenceRow struct {
+	Relation  string  `json:"relation"`
+	GoRefusal *string `json:"go_refusal"`
+}
+
+func investmentDeclaredDivergenceCases() []oracleCase {
+	return []oracleCase{
+		{
+			// `id: 7` -- Python's rule_id is the int 7, in a field its own
+			// dataclass annotates `str`.
+			ID:    "declared_rule_id_is_not_a_string",
+			Input: map[string]any{"Config": "declared_id_not_a_string"},
+		},
+		{
+			// The same shape on an output field: `investment_area: true`.
+			ID:    "declared_investment_area_is_not_a_string",
+			Input: map[string]any{"Config": "declared_area_not_a_string"},
+		},
+		{
+			// Every priority is a string, so they share one orderable Python
+			// type and sorted() succeeds lexicographically. Its neighbours are
+			// mirrored TypeErrors -- a null priority, or a mixed int/str
+			// config -- which is what makes this a divergence rather than a
+			// missing branch.
+			ID:    "declared_all_string_priorities_sort_lexicographically",
+			Input: map[string]any{"Config": "declared_string_priorities"},
+		},
+		{
+			// A leading-zero priority: octal 8 to PyYAML, decimal 10 to
+			// yaml.v3, so the two engines order the rules differently.
+			ID:    "declared_leading_zero_priority_is_octal_to_pyyaml",
+			Input: map[string]any{"Config": "declared_octal_priority"},
+		},
+		{
+			// A merge key pointing at its own mapping. PyYAML builds a
+			// self-referential dict and classifies; this port refuses rather
+			// than recurse.
+			ID:    "declared_merge_key_cycle",
+			Input: map[string]any{"Config": "declared_merge_cycle"},
+		},
+	}
+}
+
+func TestInvestmentClassifierDeclaredDivergencesStillDiverge(t *testing.T) {
+	sentinel := investmentDivergenceSentinel(t)
+	compareRowsAgainstPythonOracle(
+		t,
+		"analytics/investment/divergence",
+		investmentDeclaredDivergenceCases(),
+		func(t *testing.T, input map[string]any) investmentDeclaredDivergenceRow {
+			t.Helper()
+			return investmentGoDeclaredDivergence(t, sentinel, input)
+		},
+		map[string]string{
+			"go_refusal": "the text of this port's refusal. It exists on the Go " +
+				"side only BY CONSTRUCTION -- Python classifies these shapes, which " +
+				"is half of what each case asserts -- so the harness's own check " +
+				"that a goOnlyField never appears on the Python side is itself an " +
+				"assertion that the divergence still has the shape claimed.",
+		},
+	)
+}
+
+func investmentGoDeclaredDivergence(
+	t *testing.T, sentinel string, input map[string]any,
+) investmentDeclaredDivergenceRow {
+	t.Helper()
+	classifier, err := NewInvestmentClassifier(
+		investmentConfigPath(t, input["Config"].(string)),
+	)
+	var classification InvestmentClassification
+	if err == nil {
+		classification, err = classifier.Classify(investmentOracleArtifact(input))
+	}
+	if err == nil {
+		return investmentDeclaredDivergenceRow{
+			Relation: fmt.Sprintf(
+				"<BOTH ENGINES CLASSIFY (%s): the declared divergence is GONE. If "+
+					"that is deliberate, delete the declaration in "+
+					"investment_classifier.go and the PR body and move this case to "+
+					"the classify pair -- do not leave a note describing a divergence "+
+					"that no longer exists>",
+				investmentDescribeClassification(classification)),
+		}
+	}
+	var configError *InvestmentConfigError
+	if !errors.As(err, &configError) {
+		return investmentDeclaredDivergenceRow{
+			Relation: fmt.Sprintf("<refused with an unclassified error: %v>", err),
+		}
+	}
+	if configError.PythonException != "" {
+		return investmentDeclaredDivergenceRow{
+			Relation: fmt.Sprintf(
+				"<refused as a MIRROR of Python %s, but Python classified this "+
+					"config -- a mirrored refusal cannot stand in for a declared one>",
+				configError.PythonException),
+		}
+	}
+	detail := configError.Detail
+	return investmentDeclaredDivergenceRow{Relation: sentinel, GoRefusal: &detail}
+}
+
+// investmentDivergenceSentinel reads the sentinel out of the Python pair rather
+// than restating it in Go. Hand-copying it would put the agreed sentence in two
+// places, and the copy that drifts is the one nobody reads.
+func investmentDivergenceSentinel(t *testing.T) string {
+	t.Helper()
+	source := filepath.Join(investmentRepoRoot(t),
+		"internal/providersync/testdata/oracle_pairs/analytics_investment_divergence.py")
+	contents, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := regexp.MustCompile(`(?m)^DIVERGENCE_HOLDS = "([^"]+)"$`).
+		FindSubmatch(contents)
+	if match == nil {
+		t.Fatalf("no DIVERGENCE_HOLDS assignment found in %s -- the Go side cannot "+
+			"emit a sentinel it cannot read, and hard-coding a copy here is what "+
+			"this lookup exists to avoid", source)
+	}
+	return string(match[1])
 }
 
 func investmentDescribeClassification(classification InvestmentClassification) string {

--- a/internal/providersync/investment_classifier_oracle_test.go
+++ b/internal/providersync/investment_classifier_oracle_test.go
@@ -345,6 +345,52 @@ func investmentOracleCases() []oracleCase {
 			},
 		},
 		{
+			// A BOOLEAN priority. Python's bool IS an int subclass, so `true`
+			// sorts as 1 -- BEFORE the 9 beside it -- rather than raising.
+			// Routing bool to "Python cannot order this" made the port claim a
+			// TypeError Python does not raise, which is the false-mirror class:
+			// PythonException is the load-bearing field of the refusal pair, so
+			// a wrong value there asserts Python does something it does not.
+			ID: "bool_priority_sorts_as_one",
+			Input: map[string]any{
+				"Config":   "bool_priorities",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// Pins the VALUE of `true`, not merely that it is numeric. Python's
+			// True == 1, so the priority-0 rule sorts first and answers. File
+			// order is load-bearing: the true rule is written first, so a port
+			// decoding True as 0 would tie them and the stable sort would hand
+			// the answer to the true rule. bool_priorities.yaml cannot catch
+			// that -- 0 and 1 both sort before 9 -- and a wrong-value decode
+			// SURVIVED against it until this case existed.
+			ID: "bool_true_priority_is_exactly_one",
+			Input: map[string]any{
+				"Config":   "bool_true_is_one",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// The mirror image: False == 0, not 1.
+			ID: "bool_false_priority_is_exactly_zero",
+			Input: map[string]any{
+				"Config":   "bool_false_is_zero",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
+			// The same path reached through THIS PORT's OWN normalisation:
+			// unquoted `yes` is a YAML 1.1 boolean, and the bool pass here
+			// manufactures the !!bool node. So the fix has to hold for a node
+			// this file created, not only for a literal `true` yaml.v3 tagged.
+			ID: "normalised_yes_priority_sorts_as_one",
+			Input: map[string]any{
+				"Config":   "yes_priorities",
+				"Artifact": map[string]any{"Labels": []any{}},
+			},
+		},
+		{
 			// `priority:` PRESENT and NULL with exactly ONE rule. sorted()
 			// computes every key up front but never compares a single element,
 			// so Python does NOT raise. The two-rule form is a refusal case;
@@ -577,6 +623,23 @@ func investmentRefusalCases() []oracleCase {
 			Input: map[string]any{"Config": "raises_mixed_priority_types"},
 		},
 		{
+			// A DATE priority beside an INT one. Python compares only within a
+			// type, so this raises -- while an ALL-date config sorts cleanly and
+			// is a declared divergence. The two together stop "date" from being
+			// one undifferentiated branch.
+			ID:    "raises_date_priority_beside_an_int",
+			Input: map[string]any{"Config": "raises_date_and_int_priorities"},
+		},
+		{
+			// A SEXAGESIMAL in a label list. PyYAML resolves `1:30` to the int
+			// 90, and an int has no .lower(). This was FAIL-OPEN before the
+			// literal was recognised: yaml.v3 leaves it a string, so the port
+			// lower-cased it, matched nothing, and quietly classified where
+			// Python refuses.
+			ID:    "raises_sexagesimal_label_entry",
+			Input: map[string]any{"Config": "raises_sexagesimal_label"},
+		},
+		{
 			// A `<<` whose value is neither a mapping nor a list of mappings.
 			// PyYAML raises while CONSTRUCTING the document, so this dies before
 			// _load_rules runs at all -- and it is the only case here whose
@@ -743,6 +806,28 @@ func investmentDeclaredDivergenceCases() []oracleCase {
 			// yaml.v3, so the two engines order the rules differently.
 			ID:    "declared_leading_zero_priority_is_octal_to_pyyaml",
 			Input: map[string]any{"Config": "declared_octal_priority"},
+		},
+		{
+			// Every priority is a DATE. PyYAML resolves plain `2024-01-02` to
+			// datetime.date and orders dates among themselves, so the 2023 rule
+			// answers; this port has no ordering to offer that is Python's.
+			ID:    "declared_all_date_priorities_order_among_dates",
+			Input: map[string]any{"Config": "declared_date_priorities"},
+		},
+		{
+			// A SEXAGESIMAL priority. `1:30` is the int 90 to PyYAML and a
+			// string to yaml.v3, so Python sorts 9 first and this port cannot
+			// reproduce the order. Note it is NOT a mixed-type raise -- 90 is an
+			// int, so it shares an ordering group with 9.
+			ID:    "declared_sexagesimal_priority_is_ninety_to_pyyaml",
+			Input: map[string]any{"Config": "declared_sexagesimal_priority"},
+		},
+		{
+			// The same literal as a rule ID, where Python's value is the NUMBER
+			// 90 and a *string cannot hold it. Refusing is loud; emitting
+			// "1:30" would be a silent wrong value.
+			ID:    "declared_sexagesimal_rule_id_is_a_number",
+			Input: map[string]any{"Config": "declared_sexagesimal_id"},
 		},
 		{
 			// A merge key pointing at its own mapping. PyYAML builds a

--- a/internal/providersync/investment_classifier_reachability_test.go
+++ b/internal/providersync/investment_classifier_reachability_test.go
@@ -1,0 +1,112 @@
+package providersync
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Four of the 44 rules in the checked-in investment config CANNOT fire from the
+// work-item call site (job_work_items.py:1377-1383), which supplies only
+// labels, component, title and provider:
+//
+//   - infra_path, docs_path, test_path match on path_prefix, and the call site
+//     passes no `paths` key at all, so the matcher's path arm rejects every
+//     artifact reaching it from there.
+//   - data_component matches component ['Data Platform', 'Analytics'], and
+//     WorkItem has no `component` attribute, so `getattr(item, "component", "")`
+//     is always "" -- which is not in that list.
+//
+// This is a TRIPWIRE, not documentation. Deadness asserted in a comment rots
+// the moment someone edits the YAML; deadness asserted here fails the build.
+// It is deliberately two-directional: a rule that stops being dead fails, AND a
+// rule that disappears or is renamed fails, because either means this list has
+// drifted from the config it describes.
+//
+// It reads the REAL config. Pointing it at a fixture would make it agree with
+// itself, which is the defect class this whole lane has been removing.
+func TestInvestmentClassifierUnreachableRulesStayUnreachable(t *testing.T) {
+	// Rule id -> why it cannot fire from the work-item call site.
+	unreachable := map[string]string{
+		"infra_path":     "path_prefix, and the call site supplies no paths",
+		"docs_path":      "path_prefix, and the call site supplies no paths",
+		"test_path":      "path_prefix, and the call site supplies no paths",
+		"data_component": "component list excludes \"\", the only value the call site can produce",
+	}
+
+	contents, err := os.ReadFile(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Rules []investmentRule `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Rules) == 0 {
+		t.Fatal("the real config parsed to zero rules; every assertion below would be vacuous")
+	}
+
+	// The artifact the work-item call site actually builds: labels vary, but
+	// paths is ABSENT and component is ALWAYS "". Anything a rule needs beyond
+	// this is unreachable from that path by construction.
+	callSiteArtifact := func(labels []string) InvestmentArtifact {
+		return InvestmentArtifact{Labels: labels, Component: "", Paths: nil}
+	}
+
+	seen := map[string]bool{}
+	for _, rule := range document.Rules {
+		reason, declaredDead := unreachable[rule.ID]
+		if !declaredDead {
+			continue
+		}
+		seen[rule.ID] = true
+
+		// Feed the rule EVERY label it could want, so the only thing that can
+		// still reject it is the criterion this test says is unsatisfiable.
+		// Without this the rule might be failing for a boring reason and the
+		// assertion would prove nothing about the criterion named in `reason`.
+		var labels []string
+		if rule.Match != nil && rule.Match.Label != nil {
+			labels = append(labels, *rule.Match.Label...)
+		}
+		if investmentRuleMatches(rule.Match, callSiteArtifact(labels)) {
+			t.Errorf("rule %q is now REACHABLE from the work-item call site, but this "+
+				"test and the PR body both claim it is dead (%s). Either the config "+
+				"changed or the call site did; update both, do not delete this case.",
+				rule.ID, reason)
+		}
+	}
+
+	for id := range unreachable {
+		if !seen[id] {
+			t.Errorf("rule %q is declared unreachable here but no longer exists in the "+
+				"real config -- this list has drifted from the file it describes", id)
+		}
+	}
+}
+
+// The counterpart assertion: the matcher arms those dead rules use are NOT
+// broken, they are merely unfed. Without this, "dead" and "the matcher cannot
+// match anything" would be indistinguishable, and a genuinely broken path or
+// component arm would read as expected deadness.
+func TestInvestmentClassifierDeadArmsWorkWhenFed(t *testing.T) {
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// data_component fires the moment a component it lists is supplied.
+	if got := classifier.Classify(InvestmentArtifact{Component: "Data Platform"}); got.RuleID != "data_component" {
+		t.Errorf("component arm: rule_id = %q, want data_component -- the arm itself "+
+			"must work, or the unreachability claim above is about a broken matcher "+
+			"rather than an unfed one", got.RuleID)
+	}
+	// A path_prefix rule fires the moment paths are supplied. docs_path is used
+	// because its prefixes are the least likely to collide with a label rule.
+	if got := classifier.Classify(InvestmentArtifact{Paths: []string{"docs/guide.md"}}); got.RuleID != "docs_path" {
+		t.Error("path arm: no path_prefix rule fired for a docs/ path, so the " +
+			"unreachability claim above may be masking a broken path matcher")
+	}
+}

--- a/internal/providersync/investment_classifier_reachability_test.go
+++ b/internal/providersync/investment_classifier_reachability_test.go
@@ -1,33 +1,152 @@
 package providersync
 
 import (
-	"os"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
 
+// investmentRealConfigRuleCount is the only place the "44 rules" figure quoted
+// in the PR body and in this package's comments is allowed to live, and it is
+// ASSERTED against the real file below rather than narrated. A count that only
+// appears in prose is a claim; a count the build checks is a measurement.
+const investmentRealConfigRuleCount = 44
+
+// investmentCallSitePremise is what the production sources say about the
+// artifact the work-item call site builds. Both fields are REFLECTED from real
+// Python (testdata/python_investment_call_site.py), never transcribed.
+type investmentCallSitePremise struct {
+	CallSiteArtifactKeys []string `json:"call_site_artifact_keys"`
+	WorkItemFields       []string `json:"work_item_fields"`
+}
+
+func (premise investmentCallSitePremise) hasArtifactKey(name string) bool {
+	return investmentContains(premise.CallSiteArtifactKeys, name)
+}
+
+func investmentContains(values []string, name string) bool {
+	for _, value := range values {
+		if value == name {
+			return true
+		}
+	}
+	return false
+}
+
+// investmentReflectCallSite executes the reflector against the two real
+// production files.
+//
+// It needs Python, so it runs under ci/check_go.sh's live-python-oracles stage
+// rather than under a bare `go test` -- both are in the `fast` verb. That cost
+// buys the thing an in-Go transcription could not: the premise below is the
+// PRODUCTION code's, not this test's copy of it.
+func investmentReflectCallSite(t *testing.T) investmentCallSitePremise {
+	t.Helper()
+	python := pythonExecutable(t)
+	root := investmentRepoRoot(t)
+	output, err := exec.Command(
+		python,
+		filepath.Join(root, "internal/providersync/testdata/python_investment_call_site.py"),
+		filepath.Join(root, "src/dev_health_ops/metrics/job_work_items.py"),
+		filepath.Join(root, "src/dev_health_ops/models/work_items.py"),
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("reflect the investment call site: %v: %s", err, output)
+	}
+	var premise investmentCallSitePremise
+	if err := json.Unmarshal(output, &premise); err != nil {
+		t.Fatalf("decode the call-site reflection: %v: %s", err, output)
+	}
+	if len(premise.CallSiteArtifactKeys) == 0 || len(premise.WorkItemFields) == 0 {
+		t.Fatalf("call-site reflection came back empty (%s); every assertion "+
+			"derived from it would be vacuously true", output)
+	}
+	return premise
+}
+
+// TestInvestmentCallSiteArtifactPremiseHolds is the derivation the deadness
+// tripwire below stands on, and the reason it is a separate test is that it
+// must fail with its OWN name when the premise moves.
+//
+// Both facts come from production Python:
+//
+//   - the call site (metrics/job_work_items.py:1377) passes exactly labels,
+//     component, title and provider -- so `paths` is absent, which is what
+//     kills the three path_prefix rules;
+//   - WorkItem declares no `component` field, so that call site's
+//     `getattr(item, "component", "")` cannot return anything but "" -- which
+//     is what kills data_component.
+//
+// The previous version of this file hand-wrote `InvestmentArtifact{Component:
+// "", Paths: nil}` with no derivation at all. Adding a `component` field to
+// WorkItem would have made data_component live while this test went on passing,
+// because it was asserting against its own transcription of the premise instead
+// of against the premise.
+func TestInvestmentCallSiteArtifactPremiseHolds(t *testing.T) {
+	premise := investmentReflectCallSite(t)
+
+	want := []string{"component", "labels", "provider", "title"}
+	got := append([]string(nil), premise.CallSiteArtifactKeys...)
+	sort.Strings(got)
+	if len(got) != len(want) || !investmentStringsEqual(got, want) {
+		t.Errorf("the work-item call site now builds its artifact from %v, not %v. "+
+			"Every deadness claim in this file is derived from that key set -- "+
+			"re-derive them rather than adjusting this list to match.", got, want)
+	}
+	if premise.hasArtifactKey("paths") {
+		t.Error("the call site now supplies `paths`, so the three path_prefix rules " +
+			"this file calls dead are live. Update the tripwire and the PR body.")
+	}
+	if investmentContains(premise.WorkItemFields, "component") {
+		t.Error("WorkItem now declares a `component` field, so the call site's " +
+			"getattr(item, \"component\", \"\") no longer always returns \"\" and " +
+			"data_component can fire. Update the tripwire and the PR body.")
+	}
+}
+
+// investmentCallSiteArtifact builds the artifact the work-item call site
+// actually produces, FROM the reflected premise rather than from a constant.
+func investmentCallSiteArtifact(
+	t *testing.T, premise investmentCallSitePremise, labels []string,
+) InvestmentArtifact {
+	t.Helper()
+	artifact := InvestmentArtifact{Labels: labels}
+	if premise.hasArtifactKey("component") {
+		// Present in the dict literal, and WorkItem has no field to source it
+		// from, so `getattr(item, "component", "")` yields the default. The
+		// premise test above is what keeps that second half true.
+		artifact.Component = investmentString("")
+	}
+	if premise.hasArtifactKey("paths") {
+		t.Fatal("the call site supplies `paths`, so this helper can no longer " +
+			"derive the artifact it is meant to reproduce")
+	}
+	return artifact
+}
+
 // Four of the 44 rules in the checked-in investment config CANNOT fire from the
-// work-item call site (job_work_items.py:1377-1383), which supplies only
-// labels, component, title and provider:
+// work-item call site. This test DERIVES that set by running every rule in the
+// real file against the real call-site artifact, and then asserts the derived
+// set equals the four this lane claims -- rather than asserting only that four
+// named rules fail, which would say nothing about the other forty.
 //
-//   - infra_path, docs_path, test_path match on path_prefix, and the call site
-//     passes no `paths` key at all, so the matcher's path arm rejects every
-//     artifact reaching it from there.
-//   - data_component matches component ['Data Platform', 'Analytics'], and
-//     WorkItem has no `component` attribute, so `getattr(item, "component", "")`
-//     is always "" -- which is not in that list.
-//
-// This is a TRIPWIRE, not documentation. Deadness asserted in a comment rots
-// the moment someone edits the YAML; deadness asserted here fails the build.
-// It is deliberately two-directional: a rule that stops being dead fails, AND a
-// rule that disappears or is renamed fails, because either means this list has
-// drifted from the config it describes.
+// It is a TRIPWIRE, not documentation. Deadness asserted in a comment rots the
+// moment someone edits the YAML; deadness asserted here fails the build. Set
+// equality makes it two-directional for free: a rule that stops being dead
+// fails, a rule that BECOMES dead fails, and a renamed or deleted rule fails,
+// because all three change the derived set.
 //
 // It reads the REAL config. Pointing it at a fixture would make it agree with
 // itself, which is the defect class this whole lane has been removing.
 func TestInvestmentClassifierUnreachableRulesStayUnreachable(t *testing.T) {
-	// Rule id -> why it cannot fire from the work-item call site.
+	premise := investmentReflectCallSite(t)
+
+	// Rule id -> why it cannot fire from the work-item call site. The reasons
+	// are for the human reading a failure; the SET is what is asserted.
 	unreachable := map[string]string{
 		"infra_path":     "path_prefix, and the call site supplies no paths",
 		"docs_path":      "path_prefix, and the call site supplies no paths",
@@ -35,57 +154,85 @@ func TestInvestmentClassifierUnreachableRulesStayUnreachable(t *testing.T) {
 		"data_component": "component list excludes \"\", the only value the call site can produce",
 	}
 
-	contents, err := os.ReadFile(investmentConfigPath(t, "real"))
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	var document struct {
-		Rules []investmentRule `yaml:"rules"`
-	}
-	if err := yaml.Unmarshal(contents, &document); err != nil {
-		t.Fatal(err)
-	}
-	if len(document.Rules) == 0 {
-		t.Fatal("the real config parsed to zero rules; every assertion below would be vacuous")
+	if len(classifier.rules) != investmentRealConfigRuleCount {
+		t.Fatalf("the real config now has %d rules, not %d -- the deadness set "+
+			"below was derived against the %d-rule file and must be re-derived",
+			len(classifier.rules), investmentRealConfigRuleCount,
+			investmentRealConfigRuleCount)
 	}
 
-	// The artifact the work-item call site actually builds: labels vary, but
-	// paths is ABSENT and component is ALWAYS "". Anything a rule needs beyond
-	// this is unreachable from that path by construction.
-	callSiteArtifact := func(labels []string) InvestmentArtifact {
-		return InvestmentArtifact{Labels: labels, Component: "", Paths: nil}
-	}
-
-	seen := map[string]bool{}
-	for _, rule := range document.Rules {
-		reason, declaredDead := unreachable[rule.ID]
-		if !declaredDead {
-			continue
+	var dead []string
+	for _, rule := range classifier.rules {
+		id, err := investmentRuleID(rule.id)
+		if err != nil || id == nil {
+			t.Fatalf("the real config has a rule whose id cannot be read (%v); "+
+				"deadness cannot be attributed without one", err)
 		}
-		seen[rule.ID] = true
-
-		// Feed the rule EVERY label it could want, so the only thing that can
-		// still reject it is the criterion this test says is unsatisfiable.
-		// Without this the rule might be failing for a boring reason and the
-		// assertion would prove nothing about the criterion named in `reason`.
-		var labels []string
-		if rule.Match != nil && rule.Match.Label != nil {
-			labels = append(labels, *rule.Match.Label...)
+		// Feed the rule EVERY label it declares, so the only thing that can
+		// still reject it is a criterion the call site cannot satisfy. Without
+		// this a rule might be failing for a boring reason and the assertion
+		// would prove nothing about the criterion named in `unreachable`.
+		artifact := investmentCallSiteArtifact(t, premise, investmentDeclaredLabels(t, rule.match))
+		matched, err := investmentRuleMatches(rule.match, artifact)
+		if err != nil {
+			t.Fatalf("rule %q errored against the call-site artifact: %v -- the real "+
+				"config must classify cleanly", *id, err)
 		}
-		if investmentRuleMatches(rule.Match, callSiteArtifact(labels)) {
-			t.Errorf("rule %q is now REACHABLE from the work-item call site, but this "+
-				"test and the PR body both claim it is dead (%s). Either the config "+
-				"changed or the call site did; update both, do not delete this case.",
-				rule.ID, reason)
+		if !matched {
+			dead = append(dead, *id)
 		}
 	}
+	sort.Strings(dead)
 
+	want := make([]string, 0, len(unreachable))
 	for id := range unreachable {
-		if !seen[id] {
-			t.Errorf("rule %q is declared unreachable here but no longer exists in the "+
-				"real config -- this list has drifted from the file it describes", id)
+		want = append(want, id)
+	}
+	sort.Strings(want)
+	if !investmentStringsEqual(dead, want) {
+		t.Errorf("the rules unreachable from the work-item call site are now %v, "+
+			"but this lane and the PR body both claim %v (reasons: %v). Either the "+
+			"config changed or the call site did; update both, do not delete this "+
+			"case.", dead, want, unreachable)
+	}
+}
+
+// investmentDeclaredLabels reads a rule's own `label:` list so the deadness
+// derivation can feed the rule everything it asks for.
+func investmentDeclaredLabels(t *testing.T, match *yaml.Node) []string {
+	t.Helper()
+	if match == nil {
+		return nil
+	}
+	node := investmentMappingValue(match, "label")
+	if node == nil {
+		return nil
+	}
+	entries, err := investmentIterate(node)
+	if err != nil {
+		t.Fatalf("read a real rule's label list: %v", err)
+	}
+	labels := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		labels = append(labels, entry.Value)
+	}
+	return labels
+}
+
+func investmentStringsEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
 		}
 	}
+	return true
 }
 
 // The counterpart assertion: the matcher arms those dead rules use are NOT
@@ -93,20 +240,31 @@ func TestInvestmentClassifierUnreachableRulesStayUnreachable(t *testing.T) {
 // match anything" would be indistinguishable, and a genuinely broken path or
 // component arm would read as expected deadness.
 func TestInvestmentClassifierDeadArmsWorkWhenFed(t *testing.T) {
+	t.Parallel()
 	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	// data_component fires the moment a component it lists is supplied.
-	if got := classifier.Classify(InvestmentArtifact{Component: "Data Platform"}); got.RuleID != "data_component" {
-		t.Errorf("component arm: rule_id = %q, want data_component -- the arm itself "+
+	got, err := classifier.Classify(
+		InvestmentArtifact{Component: investmentString("Data Platform")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RuleID == nil || *got.RuleID != "data_component" {
+		t.Errorf("component arm: rule_id = %s, want data_component -- the arm itself "+
 			"must work, or the unreachability claim above is about a broken matcher "+
-			"rather than an unfed one", got.RuleID)
+			"rather than an unfed one", investmentDescribeString(got.RuleID))
 	}
 	// A path_prefix rule fires the moment paths are supplied. docs_path is used
 	// because its prefixes are the least likely to collide with a label rule.
-	if got := classifier.Classify(InvestmentArtifact{Paths: []string{"docs/guide.md"}}); got.RuleID != "docs_path" {
-		t.Error("path arm: no path_prefix rule fired for a docs/ path, so the " +
-			"unreachability claim above may be masking a broken path matcher")
+	got, err = classifier.Classify(InvestmentArtifact{Paths: []string{"docs/guide.md"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RuleID == nil || *got.RuleID != "docs_path" {
+		t.Errorf("path arm: rule_id = %s, want docs_path -- no path_prefix rule fired "+
+			"for a docs/ path, so the unreachability claim above may be masking a "+
+			"broken path matcher", investmentDescribeString(got.RuleID))
 	}
 }

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -671,7 +671,7 @@ func asTaggedValue(value any) (taggedValue, bool) {
 // directive's file list drifted out of sync with what oracleDivergences
 // actually executes.
 //
-//go:embed testdata/python_generic_row_oracle.py testdata/oracle_registry.py testdata/python_oracle_loader.py testdata/field_reflection.py testdata/oracle_pairs/*.py
+//go:embed testdata/python_generic_row_oracle.py testdata/oracle_registry.py testdata/python_oracle_loader.py testdata/field_reflection.py testdata/python_investment_call_site.py testdata/oracle_pairs/*.py
 var embeddedOracleSources embed.FS
 
 func assertOracleSourcesUnchangedSinceBuild(t *testing.T) {

--- a/internal/providersync/testdata/field_reflection.py
+++ b/internal/providersync/testdata/field_reflection.py
@@ -178,6 +178,46 @@ def typed_dict_field_names(source: str, class_name: str) -> frozenset[str]:
     )
 
 
+def call_dict_literal_keys(source: str, method_name: str) -> frozenset[str]:
+    """Return the string keys of the dict literal passed to ``x.method_name({...})``.
+
+    Some contracts are stated by a CALL rather than by a type: the investment
+    classifier's production call site builds its artifact as an inline dict
+    literal argument, and which keys that literal does NOT contain is exactly
+    what makes three config rules unreachable. ``dict_literal_keys`` cannot see
+    it -- there is no named variable and no return statement to anchor on -- so
+    a test wanting that premise had no choice but to transcribe it, which is how
+    it rots the day the call site gains a key.
+
+    Raises when the call is absent or its first positional argument is not a
+    non-empty string-keyed dict literal, rather than returning an empty set: a
+    silently empty premise makes every assertion built on it vacuously true.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            not isinstance(node, ast.Call)
+            or not isinstance(node.func, ast.Attribute)
+            or node.func.attr != method_name
+            or not node.args
+            or not isinstance(node.args[0], ast.Dict)
+        ):
+            continue
+        keys = {
+            key.value
+            for key in node.args[0].keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        if keys:
+            return frozenset(keys)
+    raise ValueError(
+        f"call_dict_literal_keys: no `.{method_name}(...)` call taking a "
+        "non-empty string-keyed dict literal was found in the given source -- "
+        "the call site has moved or changed shape, and every premise derived "
+        "from it must be re-derived rather than silently emptied"
+    )
+
+
 def dict_assigned_keys(
     source: str, function_name: str, dict_var_name: str
 ) -> frozenset[str]:

--- a/internal/providersync/testdata/investment_configs/always_truthy_string.yaml
+++ b/internal/providersync/testdata/investment_configs/always_truthy_string.yaml
@@ -1,0 +1,11 @@
+# `always:` holding a non-empty STRING. Python tests the key for TRUTHINESS,
+# and every non-empty string is truthy -- including the one YAML would fold to
+# false if it were unquoted. Contrast quirks.yaml, where `always: false` is a
+# real boolean and falls through.
+rules:
+  - id: truthy_string_always
+    priority: 10
+    match:
+      always: "no"
+    output:
+      investment_area: truthy_string_area

--- a/internal/providersync/testdata/investment_configs/always_unquoted_no.yaml
+++ b/internal/providersync/testdata/investment_configs/always_unquoted_no.yaml
@@ -1,0 +1,18 @@
+# `always:` holding an UNQUOTED `no`. PyYAML implements YAML 1.1, where that
+# is the BOOLEAN false, so the rule does NOT short-circuit and falls through to
+# its label criterion. yaml.v3 implements the 1.2 core schema, where it is the
+# non-empty STRING "no" -- which is truthy, so an unnormalised Go port would
+# short-circuit and match EVERY artifact under this one rule.
+#
+# The label criterion is what makes the difference observable: the two cases
+# over this file differ only in whether the label matches, and a port that
+# short-circuited would return the same answer for both.
+rules:
+  - id: unquoted_no_always
+    priority: 10
+    match:
+      always: no
+      label: ["unquotedno"]
+    output:
+      investment_area: unquoted_no_area
+      project_stream: unquoted_no_stream

--- a/internal/providersync/testdata/investment_configs/bare_component.yaml
+++ b/internal/providersync/testdata/investment_configs/bare_component.yaml
@@ -1,0 +1,16 @@
+# A BARE STRING `component:`. `in` against a string is SUBSTRING containment,
+# not membership -- a latent Python bug this mirrors rather than fixes, because
+# it means the work-item call site (component always "") matches this rule for
+# EVERY artifact: "" is a substring of everything.
+#
+# The label guard is what keeps that from swallowing the other cases in this
+# directory, and it matters that the label arm is tested BEFORE the component
+# arm -- an artifact with no component key would otherwise raise here.
+rules:
+  - id: bare_component
+    priority: 10
+    match:
+      label: ["barecomponent"]
+      component: analytics
+    output:
+      investment_area: bare_component_area

--- a/internal/providersync/testdata/investment_configs/bare_label.yaml
+++ b/internal/providersync/testdata/investment_configs/bare_label.yaml
@@ -1,0 +1,10 @@
+# A BARE STRING `label:`. The generator iterates the string, so the target set
+# is its CHARACTERS -- the single letter "s" matches and the whole word
+# "security" does not. Mirrored, not declared.
+rules:
+  - id: bare_label
+    priority: 10
+    match:
+      label: security
+    output:
+      investment_area: bare_label_area

--- a/internal/providersync/testdata/investment_configs/bool_false_is_zero.yaml
+++ b/internal/providersync/testdata/investment_configs/bool_false_is_zero.yaml
@@ -1,0 +1,17 @@
+# The mirror image, pinning that a FALSE priority is 0 and not 1.
+# Python: False == 0, so the false rule sorts before the priority-1 rule and
+# answers. A port decoding False as 1 would tie them, and the stable sort would
+# hand the answer to the rule written first -- the 1 rule.
+rules:
+  - id: one_rule
+    priority: 1
+    match:
+      always: true
+    output:
+      investment_area: one_area
+  - id: false_rule
+    priority: false
+    match:
+      always: true
+    output:
+      investment_area: false_area

--- a/internal/providersync/testdata/investment_configs/bool_priorities.yaml
+++ b/internal/providersync/testdata/investment_configs/bool_priorities.yaml
@@ -1,0 +1,16 @@
+# A BOOLEAN priority. Python bool IS an int subclass, so True sorts as 1 --
+# BEFORE the 9 below -- rather than raising. Both engines must agree here; this
+# is the case that catches a port routing bool to "Python cannot order this".
+rules:
+  - id: bool_priority
+    priority: true
+    match:
+      always: true
+    output:
+      investment_area: bool_area
+  - id: int_priority
+    priority: 9
+    match:
+      always: true
+    output:
+      investment_area: int_area

--- a/internal/providersync/testdata/investment_configs/bool_true_is_one.yaml
+++ b/internal/providersync/testdata/investment_configs/bool_true_is_one.yaml
@@ -1,0 +1,20 @@
+# Pins the VALUE of a true priority, not merely that it is numeric.
+# Python: True == 1, so the priority-0 rule sorts FIRST and answers.
+#
+# File order is load-bearing: the true rule is written first, so a port that
+# decoded True as 0 would tie the two and the STABLE sort would hand the answer
+# to the true rule instead. bool_priorities.yaml cannot catch that -- 0 and 1
+# both sort before 9 -- which is exactly how a wrong-value decode survived.
+rules:
+  - id: true_rule
+    priority: true
+    match:
+      always: true
+    output:
+      investment_area: true_area
+  - id: zero_rule
+    priority: 0
+    match:
+      always: true
+    output:
+      investment_area: zero_area

--- a/internal/providersync/testdata/investment_configs/declared_area_not_a_string.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_area_not_a_string.yaml
@@ -1,0 +1,9 @@
+# DECLARED DIVERGENCE 1, other field: `investment_area` is a BOOL. Python puts
+# True into a field annotated `str`.
+rules:
+  - id: bool_area
+    priority: 10
+    match:
+      always: true
+    output:
+      investment_area: true

--- a/internal/providersync/testdata/investment_configs/declared_date_priorities.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_date_priorities.yaml
@@ -1,0 +1,18 @@
+# DECLARED DIVERGENCE: every priority is a DATE. PyYAML resolves a plain
+# 2024-01-02 to datetime.date and orders dates among themselves, so the 2023
+# rule sorts first and answers. This port has no ordering to offer that is
+# Pythons, so it refuses. Contrast raises_date_and_int_priorities.yaml, where
+# a date beside an int makes Python itself raise.
+rules:
+  - id: later_date
+    priority: 2024-01-02
+    match:
+      always: true
+    output:
+      investment_area: later_date_area
+  - id: earlier_date
+    priority: 2023-01-02
+    match:
+      always: true
+    output:
+      investment_area: earlier_date_area

--- a/internal/providersync/testdata/investment_configs/declared_id_not_a_string.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_id_not_a_string.yaml
@@ -1,0 +1,9 @@
+# DECLARED DIVERGENCE 1: `id` is an INT. `rule.get("id", "legacy_rule")`
+# returns the int, and the Python dataclass does not enforce its `str`
+# annotation, so rule_id reaches the call site as 7. A *string cannot hold that,
+# and coercing it to "7" would be a silent value change, so this port refuses.
+rules:
+  - id: 7
+    priority: 10
+    match:
+      always: true

--- a/internal/providersync/testdata/investment_configs/declared_merge_cycle.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_merge_cycle.yaml
@@ -1,0 +1,11 @@
+# DECLARED DIVERGENCE 4: a merge key whose anchor is the mapping that carries
+# it. PyYAML builds a SELF-REFERENTIAL dict and does not raise -- the rule ends
+# up with a match block holding `id` and `match`, no recognised criteria, so it
+# matches everything. This port detects the cycle and refuses rather than
+# recurse.
+rules:
+  - &self
+    id: cyclic_merge
+    priority: 10
+    match:
+      <<: *self

--- a/internal/providersync/testdata/investment_configs/declared_octal_priority.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_octal_priority.yaml
@@ -1,0 +1,17 @@
+# DECLARED DIVERGENCE 3: a LEADING-ZERO integer priority. PyYAML YAML 1.1
+# reads 010 as octal 8, which sorts BEFORE the 9 below; yaml.v3 YAML 1.2 reads
+# it as decimal 10, which sorts after. Both engines sort; neither order is the
+# mirror, so this port refuses instead of picking one.
+rules:
+  - id: octal_or_decimal
+    priority: 010
+    match:
+      always: true
+    output:
+      investment_area: octal_area
+  - id: plainly_nine
+    priority: 9
+    match:
+      always: true
+    output:
+      investment_area: nine_area

--- a/internal/providersync/testdata/investment_configs/declared_sexagesimal_id.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_sexagesimal_id.yaml
@@ -1,0 +1,8 @@
+# DECLARED DIVERGENCE: a sexagesimal as a rule ID. PyYAML resolves it to the
+# int 90, so rule_id is the NUMBER 90 -- which a *string cannot hold. Refusing
+# is the loud direction; emitting "1:30" would be a silent wrong value.
+rules:
+  - id: 1:30
+    priority: 10
+    match:
+      always: true

--- a/internal/providersync/testdata/investment_configs/declared_sexagesimal_priority.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_sexagesimal_priority.yaml
@@ -1,0 +1,20 @@
+# DECLARED DIVERGENCE: a YAML 1.1 SEXAGESIMAL priority. `1:30` is the int 90
+# to PyYAML and a plain string to yaml.v3, so Python sorts 9 before 90 and
+# answers with the int rule, while this port cannot reproduce that order.
+#
+# It is NOT a mixed-type raise: 1:30 is an int to Python, so it sits in the
+# same ordering group as 9. A port that grouped it as a string would claim a
+# TypeError Python does not raise.
+rules:
+  - id: sexagesimal_priority
+    priority: 1:30
+    match:
+      always: true
+    output:
+      investment_area: sexagesimal_area
+  - id: plain_nine
+    priority: 9
+    match:
+      always: true
+    output:
+      investment_area: nine_area

--- a/internal/providersync/testdata/investment_configs/declared_string_priorities.yaml
+++ b/internal/providersync/testdata/investment_configs/declared_string_priorities.yaml
@@ -1,0 +1,20 @@
+# DECLARED DIVERGENCE 2: EVERY rule priority is a string, so they share one
+# orderable Python type and sorted() succeeds lexicographically ("a" before
+# "b"). This port orders only numbers and refuses rather than impose an order
+# Python would not produce.
+#
+# Contrast raises_priority_null.yaml (a null, which Python cannot order at all)
+# and a MIXED int/str config, both of which are mirrored TypeErrors.
+rules:
+  - id: b_priority
+    priority: "b"
+    match:
+      always: true
+    output:
+      investment_area: b_area
+  - id: a_priority
+    priority: "a"
+    match:
+      always: true
+    output:
+      investment_area: a_area

--- a/internal/providersync/testdata/investment_configs/duplicate_ids.yaml
+++ b/internal/providersync/testdata/investment_configs/duplicate_ids.yaml
@@ -1,0 +1,11 @@
+# A DUPLICATE mapping key. PyYAML silently keeps the LAST one; yaml.v3 rejects
+# the document when decoding into a typed value, which is why the port walks
+# yaml.Nodes instead. Mirrored, not declared.
+rules:
+  - id: first
+    id: second
+    priority: 10
+    match:
+      always: true
+    output:
+      investment_area: duplicate_area

--- a/internal/providersync/testdata/investment_configs/ids.yaml
+++ b/internal/providersync/testdata/investment_configs/ids.yaml
@@ -1,0 +1,18 @@
+# The three answers `rule.get("id", "legacy_rule")` can give. An earlier
+# version of this port collapsed the first two into "legacy_rule" and claimed a
+# case pinned it; none existed, and absent-vs-null genuinely diverged.
+rules:
+  # PRESENT and NULL -> rule_id is None, not "legacy_rule".
+  - id:
+    priority: 10
+    match:
+      label: ["idnull"]
+  # PRESENT and EMPTY -> rule_id is "", not "legacy_rule".
+  - id: ""
+    priority: 20
+    match:
+      label: ["idempty"]
+  # ABSENT -> and only now is it "legacy_rule".
+  - priority: 30
+    match:
+      label: ["idabsent"]

--- a/internal/providersync/testdata/investment_configs/merge_keys.yaml
+++ b/internal/providersync/testdata/investment_configs/merge_keys.yaml
@@ -1,0 +1,20 @@
+# A YAML MERGE KEY. PyYAML's constructor resolves `<<` into the mapping before
+# the classifier sees a dict, so this rule matches on the merged label list.
+#
+# A node walk that treats `<<` as an ordinary key finds a match block with NO
+# criteria -- and a match block with no criteria reaches `_matches`'s final
+# `return True` and matches EVERY artifact. That is fail-open, which is why the
+# port resolves merges rather than declaring them: the two cases over this file
+# differ only in whether the merged label is present, and an unresolved port
+# returns the same answer for both.
+defaults: &shared_criteria
+  label: ["merged-label"]
+
+rules:
+  - id: merged_rule
+    priority: 10
+    match:
+      <<: *shared_criteria
+    output:
+      investment_area: merged_area
+      project_stream: merged_stream

--- a/internal/providersync/testdata/investment_configs/merge_precedence.yaml
+++ b/internal/providersync/testdata/investment_configs/merge_precedence.yaml
@@ -1,0 +1,33 @@
+# PyYAML's merge PRECEDENCE, which is not the obvious one and is measured
+# rather than assumed:
+#
+#   - an EXPLICIT key beats a merged one wherever it sits in the mapping,
+#     including AFTER the `<<`;
+#   - for `<<: [*a, *b]`, the FIRST source wins a key both define.
+#
+# Getting either backwards silently changes which rule fires, so both are
+# pinned by cases whose answers differ under the wrong rule.
+first: &first
+  label: ["from-first"]
+second: &second
+  label: ["from-second"]
+
+rules:
+  # The merged `label` is OVERRIDDEN by the explicit one below it. Under
+  # last-wins-by-position the merged value would survive and this rule would
+  # answer for "from-first" instead.
+  - id: explicit_beats_merged
+    priority: 10
+    match:
+      <<: *first
+      label: ["explicit"]
+    output:
+      investment_area: explicit_area
+  # Two sources define `label`; the FIRST wins. Under last-wins this rule would
+  # match "from-second" and not "from-first".
+  - id: first_source_beats_second
+    priority: 20
+    match:
+      <<: [*first, *second]
+    output:
+      investment_area: first_source_area

--- a/internal/providersync/testdata/investment_configs/output_nulls.yaml
+++ b/internal/providersync/testdata/investment_configs/output_nulls.yaml
@@ -19,3 +19,23 @@ rules:
     output:
       investment_area:
       project_stream:
+
+  # ONE null value at a time, so each field's handling is measured on its own.
+  # The both-null rule above cannot distinguish a port that reads
+  # project_stream correctly from one that reads neither: a single case over a
+  # compound condition is exactly the shape that reports coverage it does not
+  # have.
+  - id: null_project_stream_only
+    priority: 30
+    match:
+      label: ["streamnull"]
+    output:
+      investment_area: stream_null_area
+      project_stream:
+  - id: null_investment_area_only
+    priority: 40
+    match:
+      label: ["areanull"]
+    output:
+      investment_area:
+      project_stream: area_null_stream

--- a/internal/providersync/testdata/investment_configs/output_nulls.yaml
+++ b/internal/providersync/testdata/investment_configs/output_nulls.yaml
@@ -1,0 +1,21 @@
+# NULL values inside an output block. `output.get("investment_area", DEFAULT)`
+# returns None for a present-but-null key -- the default is not applied -- so
+# both fields reach InvestmentClassification as None despite the dataclass
+# annotating investment_area as `str`.
+#
+# The first rule is a null output BLOCK that does not match. It is here to
+# prove the null-output AttributeError is a property of MATCHING and not of
+# being iterated past: this file must classify cleanly.
+rules:
+  - id: never_fires_with_null_output
+    priority: 10
+    match:
+      label: ["neverfires"]
+    output:
+  - id: null_output_values
+    priority: 20
+    match:
+      label: ["nullvalues"]
+    output:
+      investment_area:
+      project_stream:

--- a/internal/providersync/testdata/investment_configs/path_prefix_null.yaml
+++ b/internal/providersync/testdata/investment_configs/path_prefix_null.yaml
@@ -1,0 +1,10 @@
+# `path_prefix:` PRESENT and NULL. Python resolves the prefix list INSIDE the
+# loop over the artifact paths, so this file raises only for an artifact that
+# actually carries paths; with none, the inner loop never runs and the arm just
+# rejects. Both directions are cases over THIS file, which is what makes the
+# raise a property of the artifact rather than of the config.
+rules:
+  - id: null_path_prefix
+    priority: 10
+    match:
+      path_prefix:

--- a/internal/providersync/testdata/investment_configs/priority_null_single.yaml
+++ b/internal/providersync/testdata/investment_configs/priority_null_single.yaml
@@ -1,0 +1,13 @@
+# `priority:` PRESENT and NULL with exactly ONE rule. sorted() computes every
+# key before it compares anything, and with one element it never compares -- so
+# Python does NOT raise here, and neither may this port. The two-rule form is
+# raises_priority_null.yaml; the pair is what stops "any null priority is fatal"
+# from passing as a mirror.
+rules:
+  - id: lonely
+    priority:
+    match:
+      label: ["lonely"]
+    output:
+      investment_area: lonely_area
+      project_stream: lonely_stream

--- a/internal/providersync/testdata/investment_configs/quirks.yaml
+++ b/internal/providersync/testdata/investment_configs/quirks.yaml
@@ -1,0 +1,108 @@
+# Synthetic investment config, for the matcher forms the REAL config never
+# reaches. It is deliberately small: the real file
+# (src/dev_health_ops/config/investment_areas.yaml) is the primary oracle input
+# and covers the ordinary label path with its own 44 rules. This one exists
+# only for the quirks that file cannot express.
+#
+# Rule ORDER is load-bearing for the stable-sort cases, and so are the
+# priorities: every quirk rule below carries a DISTINCT label so it cannot
+# shadow a lower-priority one. An earlier draft gave the always:false rule no
+# label, which made it match everything at priority 50 and silently swallow the
+# priority-100, -950 and -960 cases -- three cases that still passed while
+# testing something other than their names. Keep each quirk uniquely reachable.
+rules:
+  # STABLE SORT: three rules share priority 10 and all three match the label
+  # "shared". classify() returns on FIRST match, so the winner is decided by
+  # file order among equals -- which only a STABLE sort preserves. If Go used
+  # sort.Slice, any of the three could win.
+  - id: tie_first
+    priority: 10
+    match:
+      label: ["shared"]
+    output:
+      investment_area: tie_area_first
+      project_stream: tie_stream_first
+  - id: tie_second
+    priority: 10
+    match:
+      label: ["shared"]
+    output:
+      investment_area: tie_area_second
+      project_stream: tie_stream_second
+  - id: tie_third
+    priority: 10
+    match:
+      label: ["shared"]
+    output:
+      investment_area: tie_area_third
+      project_stream: tie_stream_third
+
+  # ALWAYS: FALSE is tested for TRUTHINESS, so it does NOT short-circuit to a
+  # match -- it falls through to the remaining criteria exactly as an absent
+  # key would. The label is what makes this measurable: if `always: false` were
+  # (wrongly) treated as a match, this rule would fire for EVERY artifact and
+  # every case below would return it instead of its own rule.
+  - id: always_false_falls_through_to_label
+    priority: 20
+    match:
+      always: false
+      label: ["alwaysfalse"]
+    output:
+      investment_area: always_false_area
+      project_stream: always_false_stream
+
+  # COMPONENT containing the empty string. From the work-item call site the
+  # component is ALWAYS "", so this is the only shape of component rule that
+  # can ever fire from that path. The real config's data_component lists
+  # ['Data Platform', 'Analytics'] and therefore cannot.
+  - id: component_accepts_empty
+    priority: 30
+    match:
+      label: ["componentcase"]
+      component: ["", "Data Platform"]
+    output:
+      investment_area: component_area
+      project_stream: component_stream
+
+  # PATH_PREFIX, reachable ONLY when the caller supplies paths. The work-item
+  # call site never does. This rule exists so the arm is proven to work when
+  # fed, which is what makes "dead from that call site" a statement about the
+  # CALLER rather than about the matcher.
+  - id: path_reachable_when_fed
+    priority: 40
+    match:
+      label: ["pathcase"]
+      path_prefix: ["services/api/"]
+    output:
+      investment_area: path_area
+      project_stream: path_stream
+
+  # NO PRIORITY KEY: sorts as 100 via `x.get("priority", 100)` -- after every
+  # rule above and before the two catch-alls below.
+  - id: no_priority_defaults_to_100
+    match:
+      label: ["unprioritised"]
+    output:
+      investment_area: default_priority_area
+      project_stream: default_priority_stream
+
+  # OUTPUT omitted entirely: both fields fall back to the legacy defaults
+  # (product/general) while confidence is still 1.0 and the rule id is this
+  # rule's OWN -- not "legacy_default", which only the no-match fallback uses.
+  # That distinction is the whole point of this rule, and it must sit ABOVE the
+  # empty-match catch-all to be reachable at all.
+  - id: matched_but_no_output
+    priority: 950
+    match:
+      label: ["nooutput"]
+
+  # EMPTY match:{} matches EVERYTHING -- it reaches the final return-true
+  # without testing anything. The real config expresses its catch-all as
+  # `always: true`, so this form is only reachable here. Lowest priority, so it
+  # answers only when nothing above matched.
+  - id: empty_match_matches_everything
+    priority: 960
+    match: {}
+    output:
+      investment_area: empty_match_area
+      project_stream: empty_match_stream

--- a/internal/providersync/testdata/investment_configs/raises_comments_only.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_comments_only.yaml
@@ -1,0 +1,4 @@
+# This file is ONLY comments, so yaml.safe_load returns None exactly as it
+# does for a zero-byte file -- and `data.get("rules", [])` is then an attribute
+# lookup on None. Kept separate from raises_empty.yaml because a reader would
+# reasonably expect a file with content in it to parse to something.

--- a/internal/providersync/testdata/investment_configs/raises_component_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_component_null.yaml
@@ -1,0 +1,7 @@
+# `component:` PRESENT and NULL. `x not in None` is a containment test
+# against None, which is not a container.
+rules:
+  - id: null_component
+    priority: 10
+    match:
+      component:

--- a/internal/providersync/testdata/investment_configs/raises_date_and_int_priorities.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_date_and_int_priorities.yaml
@@ -1,0 +1,12 @@
+# MIRRORED TypeError: a DATE priority beside an INT one. Python compares only
+# within a type, so this raises where the all-date file sorts cleanly. The two
+# files together are what stop "date" from being one undifferentiated branch.
+rules:
+  - id: dated
+    priority: 2024-01-02
+    match:
+      always: true
+  - id: numbered
+    priority: 9
+    match:
+      always: true

--- a/internal/providersync/testdata/investment_configs/raises_document_is_list.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_document_is_list.yaml
@@ -1,0 +1,4 @@
+# The document is a LIST, not a mapping, so `data.get` is an attribute lookup
+# on a list.
+- id: a
+- id: b

--- a/internal/providersync/testdata/investment_configs/raises_label_bool.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_label_bool.yaml
@@ -1,0 +1,9 @@
+# A label entry YAML resolves to a BOOLEAN. `no` is not the string "no" to
+# PyYAML, it is False, and False has no .lower(). The whole generator is
+# consumed before the intersection is taken, so this raises even for an
+# artifact carrying no labels at all.
+rules:
+  - id: bool_label
+    priority: 10
+    match:
+      label: [no]

--- a/internal/providersync/testdata/investment_configs/raises_label_int.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_label_int.yaml
@@ -1,0 +1,7 @@
+# A label entry that is an INT. Same arm, same generator, different type name
+# in the message -- kept as its own file so the bool case cannot pass for it.
+rules:
+  - id: int_label
+    priority: 10
+    match:
+      label: [1]

--- a/internal/providersync/testdata/investment_configs/raises_label_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_label_null.yaml
@@ -1,0 +1,7 @@
+# `label:` PRESENT and NULL. `"label" in match_criteria` is true, so the arm
+# runs, and the generator iterates None.
+rules:
+  - id: null_label
+    priority: 10
+    match:
+      label:

--- a/internal/providersync/testdata/investment_configs/raises_match_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_match_null.yaml
@@ -1,0 +1,8 @@
+# `match:` PRESENT and NULL. Inert until classify() REACHES this rule, and
+# then `match_criteria.get("always")` is an attribute lookup on None. A typed
+# decode read this as "no match block", which matches EVERYTHING -- the rule
+# fired and returned a classification where Python raises.
+rules:
+  - id: null_match
+    priority: 10
+    match:

--- a/internal/providersync/testdata/investment_configs/raises_merge_source_not_a_mapping.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_merge_source_not_a_mapping.yaml
@@ -1,0 +1,8 @@
+# `<<` whose value is neither a mapping nor a list of mappings. PyYAML raises
+# ConstructorError while CONSTRUCTING the document, so this dies in the
+# construct phase, before _load_rules ever runs.
+rules:
+  - id: bad_merge
+    priority: 10
+    match:
+      <<: 5

--- a/internal/providersync/testdata/investment_configs/raises_mixed_priority_types.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_mixed_priority_types.yaml
@@ -1,0 +1,14 @@
+# MIXED priority types: one int, one string. Python compares only WITHIN a
+# type, so sorted() raises here -- unlike declared_string_priorities.yaml,
+# where every priority is a string and sorted() succeeds. This file is what
+# stops "non-numeric priority" from being one undifferentiated branch: one of
+# the two shapes is a mirrored raise and the other is a declared divergence.
+rules:
+  - id: numeric_priority
+    priority: 10
+    match:
+      always: true
+  - id: string_priority
+    priority: "ten"
+    match:
+      always: true

--- a/internal/providersync/testdata/investment_configs/raises_output_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_output_null.yaml
@@ -1,0 +1,14 @@
+# `output:` PRESENT and NULL on a rule that MATCHES. Python evaluates
+# `rule.get("output", {})` before the match test but only dereferences it
+# after, so this raises exactly when the rule fires. The second rule proves
+# the file itself is loadable.
+rules:
+  - id: null_output
+    priority: 10
+    match:
+      always: true
+    output:
+  - id: unreached
+    priority: 20
+    match:
+      always: true

--- a/internal/providersync/testdata/investment_configs/raises_priority_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_priority_null.yaml
@@ -1,0 +1,12 @@
+# `priority:` PRESENT and NULL, with a SECOND rule so sorted() actually has to
+# compare. See raises_priority_null_single.yaml for the same key with one rule,
+# where Python does NOT raise.
+rules:
+  - id: null_priority
+    priority:
+    match:
+      label: ["anything"]
+  - id: ordinary
+    priority: 10
+    match:
+      label: ["other"]

--- a/internal/providersync/testdata/investment_configs/raises_priority_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_priority_null.yaml
@@ -1,5 +1,5 @@
 # `priority:` PRESENT and NULL, with a SECOND rule so sorted() actually has to
-# compare. See raises_priority_null_single.yaml for the same key with one rule,
+# compare. See priority_null_single.yaml for the same key with one rule,
 # where Python does NOT raise.
 rules:
   - id: null_priority

--- a/internal/providersync/testdata/investment_configs/raises_rule_not_mapping.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_rule_not_mapping.yaml
@@ -1,0 +1,5 @@
+# A rules ENTRY that is not a mapping. sorted() applies its key function to
+# every element before comparing anything, so this raises at LOAD time even
+# though there is only one entry.
+rules:
+  - just_a_string

--- a/internal/providersync/testdata/investment_configs/raises_rules_null.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_rules_null.yaml
@@ -1,0 +1,4 @@
+# `rules:` PRESENT and NULL. `data.get("rules", [])` returns None -- the
+# default is not applied, because the key exists -- and sorted(None) raises.
+# This is the shape a typed Go decode collapsed into "no rules at all".
+rules:

--- a/internal/providersync/testdata/investment_configs/raises_sexagesimal_label.yaml
+++ b/internal/providersync/testdata/investment_configs/raises_sexagesimal_label.yaml
@@ -1,0 +1,14 @@
+# MIRRORED AttributeError: a SEXAGESIMAL in a label list. PyYAML resolves it
+# to the int 90, and an int has no .lower(), so the generator raises before any
+# intersection is taken.
+#
+# This was FAIL-OPEN before the sexagesimal literal was recognised: yaml.v3
+# leaves `1:30` a string, so the port lower-cased it, matched nothing, and
+# quietly classified where Python refuses.
+rules:
+  - id: sexagesimal_label
+    priority: 10
+    match:
+      label: [1:30]
+    output:
+      investment_area: sexagesimal_label_area

--- a/internal/providersync/testdata/investment_configs/yes_priorities.yaml
+++ b/internal/providersync/testdata/investment_configs/yes_priorities.yaml
@@ -1,0 +1,17 @@
+# The same thing reached through THIS PORT S OWN normalisation: unquoted `yes`
+# is a YAML 1.1 boolean to PyYAML, and the bool pass here manufactures a !!bool
+# from it. So the bool priority path must work for a node this file created,
+# not only for a literal `true` yaml.v3 tagged itself.
+rules:
+  - id: yes_priority
+    priority: yes
+    match:
+      always: true
+    output:
+      investment_area: yes_area
+  - id: int_priority
+    priority: 9
+    match:
+      always: true
+    output:
+      investment_area: int_area

--- a/internal/providersync/testdata/oracle_pairs/_investment_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_investment_helpers.py
@@ -1,0 +1,73 @@
+"""Shared case plumbing for the two investment classifier oracle pairs.
+
+Both pairs -- ``analytics/investment/classify`` (the config shapes both engines
+CLASSIFY) and ``analytics/investment/refusal`` (the config shapes both engines
+REFUSE) -- resolve the same config names to the same files and build the same
+artifact from the same case keys. Keeping that in one module is not tidiness:
+if the two pairs resolved names independently, a refusal case could be pointed
+at a different file from the classify case that is supposed to be its
+counterpart, and the "same file, different artifact" pairs (path_prefix_null,
+bare_component) would stop proving what their names claim.
+
+The leading underscore keeps this out of ci/check_go.sh's pair enumeration --
+it is a helper, not a registered pair, and must not be expected to produce an
+execution proof of its own.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+
+# The file production actually loads (job_work_items.py:448).
+REAL_CONFIG = REPO_ROOT / "src/dev_health_ops/config/investment_areas.yaml"
+
+# Everything else resolves by NAME under one directory, rather than through a
+# hand-maintained dict on each side. A per-name table drifts: a case pointed at
+# a name the Go side spells differently would silently compare two different
+# files. The Go side (investmentConfigPath) applies exactly this rule.
+CONFIG_DIR = REPO_ROOT / "internal/providersync/testdata/investment_configs"
+
+
+def config_path(name: str) -> pathlib.Path:
+    """Resolve a case's config NAME to a path.
+
+    "missing" is not special-cased: it resolves like every other name, to a
+    file that is deliberately not checked in. Python logs a warning and
+    classifies with an EMPTY rule list rather than raising, which is the only
+    way to observe the 0.0/legacy_default fallback at all -- the real config's
+    catch-all otherwise makes it unreachable.
+    """
+    if name == "real":
+        return REAL_CONFIG
+    return CONFIG_DIR / f"{name}.yaml"
+
+
+def artifact(case: dict[str, Any]) -> dict[str, Any]:
+    """Build the artifact dict for one case.
+
+    ``labels``, ``title`` and ``provider`` are exactly what the production call
+    site supplies (job_work_items.py:1377-1383).
+
+    ``component`` and ``paths`` are supplied ONLY when the case sets them, and
+    that is the point rather than an economy. The call site always passes
+    ``component`` (always ""), and never passes ``paths`` -- but the matcher
+    reads both with ``artifact.get(...)``, and an ABSENT key yields None, which
+    is a different value from "" for the membership test and a different
+    control flow for the path arm. Defaulting them here would make those two
+    states unreachable from any case and leave the Go pointer fields with
+    nothing measuring them.
+    """
+    case_artifact = case.get("Artifact") or {}
+    built: dict[str, Any] = {
+        "labels": list(case_artifact.get("Labels") or []),
+        "title": case_artifact.get("Title", ""),
+        "provider": case_artifact.get("Provider", "github"),
+    }
+    if "Component" in case_artifact:
+        built["component"] = case_artifact["Component"]
+    if case_artifact.get("Paths") is not None:
+        built["paths"] = list(case_artifact["Paths"])
+    return built

--- a/internal/providersync/testdata/oracle_pairs/analytics_investment_classify.py
+++ b/internal/providersync/testdata/oracle_pairs/analytics_investment_classify.py
@@ -5,29 +5,31 @@ from the production dataclass rather than hand-listed.
 
 Nothing is reimplemented. The real ``InvestmentClassifier`` is constructed
 against a real config FILE and its real ``classify`` is called; the only thing
-the case chooses is WHICH file. Both sides resolve the same two names to the
-same two paths, so neither engine can be handed rules the other never saw:
-
-  "real"   -> src/dev_health_ops/config/investment_areas.yaml, the file
-              production actually loads (job_work_items.py:448)
-  "quirks" -> internal/providersync/testdata/investment_configs/quirks.yaml,
-              for the matcher forms the real file never expresses
+the case chooses is WHICH file and WHICH artifact. Both sides resolve the same
+names to the same paths (see _investment_helpers.config_path), so neither
+engine can be handed rules the other never saw.
 
 Pointing the primary cases at the REAL config is deliberate. A synthetic-only
 oracle proves the two implementations agree about a file neither of them will
 ever load in production, which is the same class of defect as a hand-typed
 schema agreeing with itself.
+
+This pair covers only the config shapes both engines CLASSIFY. The shapes on
+which Python RAISES are the sibling pair, analytics_investment_refusal.py --
+they cannot live here, because a raising case has no
+``InvestmentClassification`` to compare and the registry's completeness check
+correctly refuses a row missing the dataclass's fields.
 """
 
 from __future__ import annotations
 
 import contextlib
 import io
-import pathlib
 from typing import Any
 
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs import _investment_helpers
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
     install_minimal_oracle_imports,
 )
@@ -38,29 +40,12 @@ from dev_health_ops.analytics.investment import (  # noqa: E402
     InvestmentClassifier,
 )
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+REPO_ROOT = _investment_helpers.REPO_ROOT
 SOURCE = REPO_ROOT / "src/dev_health_ops/analytics/investment.py"
-
-_CONFIGS = {
-    "real": REPO_ROOT / "src/dev_health_ops/config/investment_areas.yaml",
-    "quirks": REPO_ROOT
-    / "internal/providersync/testdata/investment_configs/quirks.yaml",
-    # A path that does not exist. Python logs a warning and classifies with an
-    # EMPTY rule list rather than raising, so every artifact falls to the legacy
-    # default. Reproduced rather than corrected.
-    "missing": REPO_ROOT
-    / "internal/providersync/testdata/investment_configs/nope.yaml",
-}
 
 
 def _fields() -> frozenset[str]:
     return dataclass_field_names(SOURCE.read_text(), "InvestmentClassification")
-
-
-def _config_path(name: str) -> pathlib.Path:
-    if name not in _CONFIGS:
-        raise AssertionError(f"unknown investment config {name!r}")
-    return _CONFIGS[name]
 
 
 def _build_row(case: dict[str, Any]) -> dict[str, Any]:
@@ -72,22 +57,10 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
         contextlib.redirect_stdout(io.StringIO()),
         contextlib.redirect_stderr(io.StringIO()),
     ):
-        classifier = InvestmentClassifier(_config_path(str(case["Config"])))
-    artifact_case = case.get("Artifact") or {}
-    # Exactly the keys the production call site supplies
-    # (job_work_items.py:1377-1383), plus "paths", which that call site does
-    # NOT supply and which the matcher nonetheless reads. Passing it only when
-    # the case sets it keeps the default shape identical to production while
-    # still allowing the path_prefix arm to be exercised deliberately.
-    artifact: dict[str, Any] = {
-        "labels": list(artifact_case.get("Labels") or []),
-        "component": artifact_case.get("Component", ""),
-        "title": artifact_case.get("Title", ""),
-        "provider": artifact_case.get("Provider", "github"),
-    }
-    if artifact_case.get("Paths") is not None:
-        artifact["paths"] = list(artifact_case["Paths"])
-    result = classifier.classify(artifact)
+        classifier = InvestmentClassifier(
+            _investment_helpers.config_path(str(case["Config"]))
+        )
+    result = classifier.classify(_investment_helpers.artifact(case))
     return {name: getattr(result, name) for name in sorted(_fields())}
 
 

--- a/internal/providersync/testdata/oracle_pairs/analytics_investment_classify.py
+++ b/internal/providersync/testdata/oracle_pairs/analytics_investment_classify.py
@@ -1,0 +1,100 @@
+"""Live Python oracle for the legacy rule-based investment classifier.
+
+Compared surface: every field ``InvestmentClassification`` declares, reflected
+from the production dataclass rather than hand-listed.
+
+Nothing is reimplemented. The real ``InvestmentClassifier`` is constructed
+against a real config FILE and its real ``classify`` is called; the only thing
+the case chooses is WHICH file. Both sides resolve the same two names to the
+same two paths, so neither engine can be handed rules the other never saw:
+
+  "real"   -> src/dev_health_ops/config/investment_areas.yaml, the file
+              production actually loads (job_work_items.py:448)
+  "quirks" -> internal/providersync/testdata/investment_configs/quirks.yaml,
+              for the matcher forms the real file never expresses
+
+Pointing the primary cases at the REAL config is deliberate. A synthetic-only
+oracle proves the two implementations agree about a file neither of them will
+ever load in production, which is the same class of defect as a hand-typed
+schema agreeing with itself.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
+
+from dev_health_ops.analytics.investment import (  # noqa: E402
+    InvestmentClassifier,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+SOURCE = REPO_ROOT / "src/dev_health_ops/analytics/investment.py"
+
+_CONFIGS = {
+    "real": REPO_ROOT / "src/dev_health_ops/config/investment_areas.yaml",
+    "quirks": REPO_ROOT
+    / "internal/providersync/testdata/investment_configs/quirks.yaml",
+    # A path that does not exist. Python logs a warning and classifies with an
+    # EMPTY rule list rather than raising, so every artifact falls to the legacy
+    # default. Reproduced rather than corrected.
+    "missing": REPO_ROOT
+    / "internal/providersync/testdata/investment_configs/nope.yaml",
+}
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SOURCE.read_text(), "InvestmentClassification")
+
+
+def _config_path(name: str) -> pathlib.Path:
+    if name not in _CONFIGS:
+        raise AssertionError(f"unknown investment config {name!r}")
+    return _CONFIGS[name]
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    # The missing-config path calls logger.warning, and ANY byte written to the
+    # captured streams lands in front of this oracle's JSON and breaks the
+    # decode. The warning is production behaviour worth exercising, so it is
+    # silenced here rather than avoided by dropping the case.
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        classifier = InvestmentClassifier(_config_path(str(case["Config"])))
+    artifact_case = case.get("Artifact") or {}
+    # Exactly the keys the production call site supplies
+    # (job_work_items.py:1377-1383), plus "paths", which that call site does
+    # NOT supply and which the matcher nonetheless reads. Passing it only when
+    # the case sets it keeps the default shape identical to production while
+    # still allowing the path_prefix arm to be exercised deliberately.
+    artifact: dict[str, Any] = {
+        "labels": list(artifact_case.get("Labels") or []),
+        "component": artifact_case.get("Component", ""),
+        "title": artifact_case.get("Title", ""),
+        "provider": artifact_case.get("Provider", "github"),
+    }
+    if artifact_case.get("Paths") is not None:
+        artifact["paths"] = list(artifact_case["Paths"])
+    result = classifier.classify(artifact)
+    return {name: getattr(result, name) for name in sorted(_fields())}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="analytics/investment/classify",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/analytics_investment_divergence.py
+++ b/internal/providersync/testdata/oracle_pairs/analytics_investment_divergence.py
@@ -1,0 +1,103 @@
+"""Live Python oracle asserting each DECLARED divergence still exists.
+
+A divergence recorded only in a comment and a PR description is a claim, and a
+claim decays silently: the day someone makes the two engines agree -- or the day
+one of them changes and they stop agreeing in a NEW way -- the note stays behind
+and reads as current. That is the same defect class as an inaccurate coverage
+claim, and this repository already has the machinery to prevent it.
+
+So each declared divergence is a CASE here, and what the case asserts is the
+RELATIONSHIP between the engines rather than either engine's answer:
+
+  Python CLASSIFIES this config, and the Go port REFUSES it, and the refusal is
+  a DECLARED one (InvestmentConfigError.PythonException == "") rather than a
+  mirrored raise.
+
+Both halves are measured live on their own side. The compared field, ``relation``,
+is a sentinel string each side emits only when its half holds, so the rows match
+only when the whole relationship does. If the port is later taught to mirror one
+of these shapes, its side stops emitting the sentinel and this fails loudly,
+naming the case and telling the reader to delete the declaration -- instead of
+leaving prose behind that no longer describes anything.
+
+The classification fields are declared in ``excluded_fields`` rather than
+compared, and that declaration is load-bearing in the harness's own terms:
+Python's rows genuinely carry them (it classified), so the exclusion is
+currently-effective rather than stale, and comparing them against the Go side's
+nothing would just be restating the divergence as a diff.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs import _investment_helpers
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
+
+from dev_health_ops.analytics.investment import (  # noqa: E402
+    InvestmentClassifier,
+)
+
+SOURCE = _investment_helpers.REPO_ROOT / "src/dev_health_ops/analytics/investment.py"
+
+# The exact string both sides must produce for the relationship to hold. Kept
+# here, in the Python pair, and referenced by name from Go: one definition, so
+# the two cannot drift into agreeing about different sentences.
+DIVERGENCE_HOLDS = "python classifies; this port declares a divergence and refuses"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SOURCE.read_text(), "InvestmentClassification")
+
+
+_EXCLUSION_REASON = (
+    "on a DECLARED-divergence shape Python classifies and the Go port refuses, "
+    "so this field exists on the Python side only. Comparing it would restate "
+    "the divergence as a field diff; the divergence itself is asserted by the "
+    "'relation' field, which fails if either half stops holding. Every "
+    "classification field is compared exhaustively by the "
+    "analytics/investment/classify pair."
+)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        try:
+            classifier = InvestmentClassifier(
+                _investment_helpers.config_path(str(case["Config"]))
+            )
+            result = classifier.classify(_investment_helpers.artifact(case))
+        except Exception as exception:  # noqa: BLE001
+            raise AssertionError(
+                f"case {case['id']!r} declares that PYTHON CLASSIFIES this config "
+                f"and the Go port refuses it, but Python itself raised "
+                f"{type(exception).__name__}. If that is now correct, this is a "
+                "mirrored refusal and the case belongs on the "
+                "analytics/investment/refusal pair -- it must not stay here, "
+                "where it would assert a divergence that no longer has the shape "
+                "it claims."
+            ) from exception
+    row: dict[str, Any] = {name: getattr(result, name) for name in _fields()}
+    row["relation"] = DIVERGENCE_HOLDS
+    return row
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="analytics/investment/divergence",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={name: _EXCLUSION_REASON for name in _fields()},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/analytics_investment_refusal.py
+++ b/internal/providersync/testdata/oracle_pairs/analytics_investment_refusal.py
@@ -1,0 +1,101 @@
+"""Live Python oracle for the config shapes the investment classifier REFUSES.
+
+Compared surface: ``raises`` -- the NAME of the exception class the real
+``InvestmentClassifier`` raises for a given config file and artifact.
+
+Why this exists as its own pair rather than as more cases on
+analytics/investment/classify: on these inputs Python produces no
+``InvestmentClassification`` at all, and the classify pair's cases are all about
+comparing one. Keeping them apart keeps two different questions apart -- "do
+both engines produce the same classification" and "do both engines refuse, for
+the same reason" -- and lets each fail with its own name.
+
+The classification fields are still emitted here, as None on both sides, rather
+than declared as excluded_fields: they are absent because NEITHER engine
+produced a classification, which is itself the thing worth comparing.
+
+Why the exception CLASS and not merely a "both refused" boolean: the direction
+of a divergence is what D16 grades. A boolean would pass a Go engine that
+refuses every malformed file for one blanket reason, which is indistinguishable
+from a port that never learned which shapes Python actually rejects. The class
+name is the coarsest value that still fails when the Go port refuses for the
+wrong reason -- Python raises AttributeError where it dereferences a None as a
+dict, and TypeError where it iterates or compares one, and those are two
+genuinely different bugs in the same config file.
+
+Every case here is EXECUTED against the real classifier: if a case's config
+does not in fact raise, this fails loudly rather than reporting a tidy
+"no exception".
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs import _investment_helpers
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+)
+
+install_minimal_oracle_imports()
+
+from dev_health_ops.analytics.investment import (  # noqa: E402
+    InvestmentClassifier,
+)
+
+SOURCE = _investment_helpers.REPO_ROOT / "src/dev_health_ops/analytics/investment.py"
+
+
+# The reflected set stays tied to the production dataclass, so that ADDING a
+# field to InvestmentClassification fails this pair too and forces a decision
+# about what the refusal path owes it -- rather than letting the refusal pair
+# quietly opt out of the contract the classify pair is held to. It is also what
+# _build_row emits its all-None row from, so the two cannot drift.
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SOURCE.read_text(), "InvestmentClassification")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    # A missing config logs a warning, and any byte on the captured streams
+    # lands in front of this oracle's JSON and breaks the decode.
+    try:
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            classifier = InvestmentClassifier(
+                _investment_helpers.config_path(str(case["Config"]))
+            )
+            result = classifier.classify(_investment_helpers.artifact(case))
+    except Exception as exception:  # noqa: BLE001 -- the exception IS the measurement
+        # Every classification field is emitted, and emitted as None, rather
+        # than declared as an excluded_field. They are not absent from this
+        # boundary for a reason peculiar to the pair -- they are absent because
+        # NEITHER engine produced one, and that is itself worth comparing:
+        # a Go port that refused and still returned a classification would
+        # differ here. Excluding them would also have been a stale exclusion,
+        # since a declared exclusion must match a key some row actually carries.
+        row: dict[str, Any] = {name: None for name in _fields()}
+        row["raises"] = type(exception).__name__
+        return row
+    raise AssertionError(
+        f"case {case['id']!r} is registered as a REFUSAL case, but the real "
+        f"Python classifier returned {result!r} for config "
+        f"{case['Config']!r}. Either the config file stopped being malformed "
+        "or the case belongs on the analytics/investment/classify pair -- do "
+        "not soften this into a reported 'no exception', which would let the "
+        "Go side agree with a refusal Python never made."
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="analytics/investment/refusal",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/analytics_investment_refusal.py
+++ b/internal/providersync/testdata/oracle_pairs/analytics_investment_refusal.py
@@ -59,9 +59,31 @@ def _fields() -> frozenset[str]:
     return dataclass_field_names(SOURCE.read_text(), "InvestmentClassification")
 
 
+def _refusal(phase: str, exception: BaseException) -> dict[str, Any]:
+    # Every classification field is emitted, and emitted as None, rather than
+    # declared as an excluded_field. They are not absent from this boundary for
+    # a reason peculiar to the pair -- they are absent because NEITHER engine
+    # produced one, and that is itself worth comparing: a Go port that refused
+    # and still returned a classification would differ here. Excluding them
+    # would also have been a stale exclusion, since a declared exclusion must
+    # match a key some row actually carries.
+    row: dict[str, Any] = {name: None for name in _fields()}
+    row["raises"] = f"{phase}:{type(exception).__name__}"
+    return row
+
+
 def _build_row(case: dict[str, Any]) -> dict[str, Any]:
     # A missing config logs a warning, and any byte on the captured streams
     # lands in front of this oracle's JSON and breaks the decode.
+    #
+    # Construction and classification are caught SEPARATELY, and the phase is
+    # part of the compared value. Which of the two raises is a real property of
+    # the shape, not an implementation detail: `rules:` null dies in
+    # _load_rules, while `match:` null LOADS FINE and dies later, only once
+    # classify() reaches that rule. A port that refuses the right config for the
+    # right exception class but at the wrong moment has not mirrored it -- it
+    # would reject a classifier Python is willing to construct -- and with only
+    # the class compared, that error would pass as agreement.
     try:
         with (
             contextlib.redirect_stdout(io.StringIO()),
@@ -70,18 +92,12 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
             classifier = InvestmentClassifier(
                 _investment_helpers.config_path(str(case["Config"]))
             )
-            result = classifier.classify(_investment_helpers.artifact(case))
     except Exception as exception:  # noqa: BLE001 -- the exception IS the measurement
-        # Every classification field is emitted, and emitted as None, rather
-        # than declared as an excluded_field. They are not absent from this
-        # boundary for a reason peculiar to the pair -- they are absent because
-        # NEITHER engine produced one, and that is itself worth comparing:
-        # a Go port that refused and still returned a classification would
-        # differ here. Excluding them would also have been a stale exclusion,
-        # since a declared exclusion must match a key some row actually carries.
-        row: dict[str, Any] = {name: None for name in _fields()}
-        row["raises"] = type(exception).__name__
-        return row
+        return _refusal("construct", exception)
+    try:
+        result = classifier.classify(_investment_helpers.artifact(case))
+    except Exception as exception:  # noqa: BLE001 -- the exception IS the measurement
+        return _refusal("classify", exception)
     raise AssertionError(
         f"case {case['id']!r} is registered as a REFUSAL case, but the real "
         f"Python classifier returned {result!r} for config "

--- a/internal/providersync/testdata/python_investment_call_site.py
+++ b/internal/providersync/testdata/python_investment_call_site.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Reflect the two premises the investment reachability tripwire stands on.
+
+The tripwire claims four of the real config's 44 rules cannot fire from the
+work-item call site. That claim rests entirely on two facts about PRODUCTION
+code, neither of which lives in the config file:
+
+  1. the call site builds its artifact as an inline dict literal whose keys are
+     exactly ``labels``, ``component``, ``title`` and ``provider`` -- so
+     ``paths`` is absent, and the matcher's path_prefix arm rejects every
+     artifact reaching it from there;
+  2. ``WorkItem`` declares no ``component`` field, so the call site's
+     ``getattr(item, "component", "")`` cannot return anything but ``""``.
+
+Both were previously hand-transcribed into the Go test as
+``InvestmentArtifact{Component: "", Paths: nil}``, with no derivation. Adding a
+``component`` field to ``WorkItem`` would have made the dead rules live while
+the test went on passing, because the test was asserting against its own copy
+of the premise rather than against the premise. Emitting both from the real
+sources makes that model change fail the tripwire loudly.
+
+Usage: python_investment_call_site.py <call_site.py> <work_items.py>
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+
+def _load_field_reflection():
+    module_path = pathlib.Path(__file__).resolve().parent / "field_reflection.py"
+    spec = importlib.util.spec_from_file_location(
+        "dev_health_field_reflection", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    reflection = _load_field_reflection()
+    call_site = pathlib.Path(sys.argv[1]).resolve()
+    work_items = pathlib.Path(sys.argv[2]).resolve()
+    payload = {
+        "call_site_artifact_keys": sorted(
+            reflection.call_dict_literal_keys(call_site.read_text(), "classify")
+        ),
+        "work_item_fields": sorted(
+            reflection.dataclass_field_names(work_items.read_text(), "WorkItem")
+        ),
+    }
+    json.dump(payload, sys.stdout, sort_keys=True, separators=(",", ":"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Ports the legacy rule-based investment classifier (`analytics/investment.py`) to Go. This is **PR-B, engine 1 of 2** — the `StatusMapping` port (`providers/status_mapping.py`) is split into its own lane and follows separately.

**Targets `feat/go-worker-runtime-migration` only — never `main`. No route activation:** nothing here is wired to a route, `contracts/` and `deploy/` are untouched, and no migration is added. The classifier is a pure function over a config file plus an artifact.

## Why this reads the real config instead of transcribing it

There was no YAML reader anywhere in the Go tree (`yaml.v3` was an indirect dependency only; the existing Go config embeds are JSON), and `go:embed` cannot reach `src/dev_health_ops/config/` from a Go package. The tempting shortcut was to transcribe the 44 rules into Go.

That shortcut rebuilds the exact defect class the previous PR in this lane spent a review round deleting: a hand-typed copy of a schema that silently drifts from the real one. So the port takes a config **path**, exactly as `InvestmentClassifier(config_path)` does, and both engines are pointed at **one file** and compared. `yaml.v3` moves indirect → direct: one line in `go.mod`, `go.sum` unchanged. Packaging the YAML for a deployed worker is an activation concern and this PR activates nothing.

## Why the config is decoded as `yaml.Node` and not into typed structs

Python reads the file with `yaml.safe_load` into plain dicts, and every lookup is `d.get(key, default)`. That makes an **explicit null** and an **absent key** two different things everywhere: `priority:` yields `None` and blows up the sort, while an absent `priority` yields `100`; `match:` yields `None` and blows up `_matches`, while an absent `match` yields `{}` and matches everything.

A typed decode — *including one using a pointer per field* — collapses those two, because yaml.v3 decodes an explicit null into the same `nil` a missing key leaves behind. The first version of this port did exactly that, and returned a plausible `product`/`general`/`0.0`/`legacy_default` for eight config shapes on which Python **raises** — and for `match:` null it was worse than a wrong value: the rule **fired**, inventing a classification. That is fail-open in the one direction D16 calls unacceptable, since during coexistence both engines read the same file.

The document is now walked as `yaml.Node`s, where *absent*, *present-and-null* and *present-with-a-value* are three distinguishable states. Every shape Python raises on returns an `*InvestmentConfigError` naming the exception **class** Python raises for it.

### The refusal oracle compares the exception class, not a boolean

A second pair, `analytics/investment/refusal` (15 cases), executes the real `InvestmentClassifier` against the same files and compares a **phase-qualified** exception name — `construct:TypeError`, `classify:AttributeError` — against what the Go port produces. The phase is part of the compared value because *which* call raises is a real property of the shape: `rules:` null dies inside `_load_rules`, while `match:` null loads fine and dies only once `classify()` reaches that rule. A port that refuses the right file for the right class at the wrong moment rejects a classifier Python is willing to construct, and comparing the class alone let that pass as agreement. A "both refused" boolean would pass a port that refuses every malformed file for one blanket reason, which is indistinguishable from one that never learned which shapes Python rejects. Python raises `AttributeError` where it dereferences a `None` **as a dict** and `TypeError` where it **iterates or compares** one — two different bugs in the same file.

Shapes pinned, each in its own config file: empty file, comment-only file, `rules:` null, document-is-a-list, a non-mapping rules entry, `priority:` null (with two rules), **mixed int/str priorities**, a **non-mapping merge source**, `match:` null, `output:` null on a *matching* rule, `label:` null, a boolean `label` entry, an int `label` entry, `component:` null, and `path_prefix:` null *with paths supplied*.

The merge-source case is the only one whose class is neither `AttributeError` nor `TypeError` (PyYAML raises `ConstructorError`, during document construction), which is what stops the phase-and-class value from being guessable from the shape.

Three of those raise **conditionally**, and the classify pair holds the other half of each pair so the condition is measured rather than assumed:

| shape | raises | does **not** raise |
| --- | --- | --- |
| `priority:` null | two rules — `sorted()` compares | one rule — `sorted()` never calls the comparator |
| `output:` null | the rule matches | the rule is traversed but rejects |
| `path_prefix:` null | the artifact carries paths | it carries none, so Python never enters the inner loop |

## A third fail-open divergence this surfaced: PyYAML is YAML 1.1, yaml.v3 is 1.2

Unquoted `no`/`yes`/`on`/`off` are **booleans** to PyYAML and ordinary **strings** to yaml.v3's core schema. That is not cosmetic here:

```yaml
match:
  always: no
```

is `False` to Python, so the rule falls through to its remaining criteria — and the truthy string `"no"` to yaml.v3, so the rule **short-circuits and matches every artifact**. One unquoted word and the Go engine classifies everything under one rule. The same difference turns `label: [no]` from a bool (no `.lower()`, so Python raises) into a label that merely never matches.

Plain scalars in PyYAML's bool set are now normalised once over the whole document, before anything reads it — doing it per read site would leave whichever site was added last on the 1.2 reading. Quoted and explicitly-tagged scalars keep their string reading. Pinned by a two-case pair over one file that differ only in whether the label matches, so a short-circuiting port returns the same answer for both.

## Quirks mirrored bug-for-bug (D16), each pinned by a case

1. **`sorted()` is STABLE and the real config depends on it.** 37 of the config's 44 rules tie at priority 10, and 2 more tie at 30, while `classify()` returns on **first match** — so file order decides the winner among equals. Go's `sort.Slice` is not stable; this uses `sort.SliceStable`.
2. **An empty `match: {}` matches everything.** Every criterion is a *rejection* test and an absent one is not tested, so `{}` reaches the final `return True`.
3. **`always: false` does not short-circuit.** It is tested for truthiness, so it falls through exactly as an absent key would. A non-empty string is truthy, including a quoted `"no"`.
4. **`rule.get("id", "legacy_rule")` has three answers, not two.** Absent → `legacy_rule`, present-and-null → `None`, present-and-empty → `""`. An earlier revision collapsed the first two and carried a comment claiming a synthetic case pinned it; no such case existed and the behaviour genuinely diverged. Same three-way split for `investment_area` and `project_stream`, which is why those reach `InvestmentClassification` as `*string` — the Python dataclass annotates `investment_area: str` and does not enforce it, so `None` reaches the call site.
5. **A bare-string `component:` is substring containment**, not membership — so the call site's `""` matches *any* such rule, `""` being a substring of everything. Mirrored, and pinned by a substring-that-is-not-equal (`"analy"` vs `analytics`) plus a non-substring that must reject.
6. **A bare-string `label:` is iterated as characters**, so the single letter `s` matches `label: security` and the whole word does not. Both halves pinned.
7. **A duplicate mapping key silently keeps the LAST.** yaml.v3's *typed* decoder rejects such a document; its node decoder does not, which is one more reason this walks nodes.
8. **`title` and `epic` are named in the docstring and read by nothing.** The call site (`metrics/job_work_items.py:1377-1383`) passes `title` **and** `provider`, both unread, and never passes `epic`. The docstring also documents a `path_prefix` artifact key while the matcher reads `paths`.
9. **A missing config file warns and yields an empty rule list** rather than raising — the only way to observe the `0.0`/`legacy_default` fallback, since the real config's catch-all otherwise makes it unreachable. A guard test asserts that file really is absent, so the case cannot quietly start measuring an ordinary load.
10. **`artifact.get("component")` has no default**, so an absent key is `None` — a different value from `""` for the membership test, and a different outcome for the bare-string path (`None in "analytics"` raises). `InvestmentArtifact.Component` is therefore a `*string`, with both states pinned against the same rule.

## Declared divergences are asserted, not narrated

A divergence recorded only in a comment and a PR description is a claim, and claims decay: the day someone makes the two engines agree, the note stays behind and still reads as current. That is the same defect class as an inaccurate coverage claim. So a third pair, `analytics/investment/divergence` (5 cases), asserts the **relationship** rather than either engine's answer:

> Python **classifies** this config, **and** the Go port **refuses** it, **and** the refusal is a *declared* one (`InvestmentConfigError.PythonException == ""`) rather than a mirrored raise.

Both halves are measured live on their own side. The compared field is a sentinel each side emits only when its half holds, so the rows match only when the whole relationship does — teach the port to mirror one of these and its side emits `<BOTH ENGINES CLASSIFY … the declared divergence is GONE>` instead, naming the case and telling the reader to delete the declaration. The sentinel is **read out of the Python pair** by the Go side rather than restated, so there is no second copy to drift.

It uses the harness's own declared-exclusion machinery in both directions: the classification fields sit in `excluded_fields` (non-stale, because Python's rows genuinely carry them), and the Go-side refusal text sits in `goOnlyFields`, whose check that it *never appears on the Python side* is itself half of what each case asserts.

| # | shape | Python | this port |
| --- | --- | --- | --- |
| 1 | a non-string scalar where a string value is expected (`id: 7`, `investment_area: true`) | puts the int/bool straight into the dataclass, whose annotations are unenforced | refuses rather than coerce to `"7"` |
| 2 | every rule's priority shares one orderable non-numeric type (all strings, all lists) | sorts lexicographically | orders only numbers, so it refuses rather than impose an order Python would not produce |
| 3 | a leading-zero integer priority (`010`) | octal `8` to PyYAML's YAML 1.1 resolver | decimal `10` to yaml.v3's 1.2 — neither order is the mirror, so it refuses |
| 4 | a merge key whose anchor chain points at its own mapping | builds a self-referential dict and classifies | detects the cycle and refuses |

All four are Go-erroring-where-Python-proceeds — the loud/safe direction — and none occurs in the checked-in config. Two divergences an earlier revision declared are now **mirrored** instead (the duplicate mapping key and the bare-string `component:`), because node-walking made both a few lines each.

One residual is deliberately **not** listed as a declared divergence: the two YAML *parsers* could in principle disagree at the syntax level. Every candidate tried lands the same way on both (a tab indent is rejected by each), so this is recorded as a risk rather than a claim — there is nothing to pin, and a table entry with no case behind it is exactly what this section exists to prevent.

## Two defects found while substantiating those declarations

**Merge keys were not resolved at all, and the direction was fail-open.** PyYAML's constructor expands `<<: *anchor` before the classifier ever sees a dict. The node walk treated `<<` as an ordinary key, so

```yaml
match:
  <<: *shared_criteria
```

had, to this port, a match block with **no criteria** — and a match block with no criteria reaches `_matches`'s final `return True` and **matches every artifact**, where Python matches only those carrying the merged labels. Now resolved, with PyYAML's precedence measured rather than assumed: an explicit key beats a merged one wherever it sits (including *after* the `<<`), and for `<<: [*a, *b]` the **first** source wins a key both define. Three cases pin the precedence, each with an answer that changes under the wrong rule.

**A false mirror in the priority sort.** The port claimed Python raises `TypeError` whenever a priority was not numeric. Python compares *within* a type: `sorted(["b","a"])` and `sorted([[2],[1]])` both succeed, while `sorted([1,"a"])`, `sorted([None,None])` and `sorted([{},{}])` all raise. So an all-string config sorts happily and the port was claiming a mirrored raise for it — worse than an admitted divergence, because a reader who sees "mirrored" stops checking. The two are now separated: **mixed** types are a mirrored `TypeError` with their own refusal case, **all-string** is a declared divergence with its own. Mutation testing is what surfaced this — a planted defect survived because *no case measured the mixed-type claim at all*.

## Four of the 44 real rules are DEAD from the work-item call site

| rule | why it cannot fire |
| --- | --- |
| `infra_path` | `path_prefix`, and the call site supplies no `paths` key |
| `docs_path` | same |
| `test_path` | same |
| `data_component` | `component: ['Data Platform','Analytics']`, but `WorkItem` has no `component` attribute, so `getattr(item,"component","")` is always `""` |

This is asserted as a **tripwire against the real config**, not narrated in a comment, and the whole claim is now **derived rather than transcribed**:

- The premise — that the call site's artifact keys are exactly `labels`/`component`/`title`/`provider`, and that `WorkItem` declares no `component` field — is **reflected from the two real Python sources** (`field_reflection.call_dict_literal_keys` + `dataclass_field_names`). The previous version hand-wrote `InvestmentArtifact{Component: "", Paths: nil}` with no derivation at all: adding a `component` field to `WorkItem` would have made `data_component` live while the test went on passing, because it asserted against its own copy of the premise. Verified by planting exactly that field and watching the test go red.
- The dead **set** is derived by running all 44 rules against that artifact and compared for **equality**, not by checking that four named rules fail — which would have said nothing about the other forty. Set equality makes it two-directional for free: a rule that stops being dead, one that *becomes* dead, and one renamed or deleted all change the derived set.
- The rule **count** is asserted against the file, so the "44 rules" figure in this description is a measurement rather than prose.

It is paired with a counterpart test proving those matcher arms **work when fed** — a component value the rule lists, and a path matching a `path_prefix`. Without that, "dead" and "the matcher is broken" would be indistinguishable.

## The measurements that changed the design

The stable-sort quirk is proven by mutation: `sort.SliceStable` → `sort.Slice` **kills** `real_multiple_priority_10_matches_first_in_file_wins` with `python=sec_auth` vs `go=infra_k8s`. But the synthetic 3-rule tie **survived the same mutation** — three elements are too few to make Go's sort reorder. Had the quirk been pinned only on a small synthetic fixture, which is the natural way to write it, the constraint would have been unmeasured while reading as fully covered. The killing case therefore uses the **real 44-rule config**.

A second process catch worth recording: the first draft of the synthetic config gave the `always: false` rule no label, so it matched everything at priority 50 and silently swallowed the priority-100/950/960 rules. Three cases passed while testing something other than their names. It was caught only by dumping the resolved `rule_id` per case instead of trusting green.

A third: the refusal pair's classification fields were first declared as `excluded_fields`, which the framework correctly rejected as *stale* — a declared exclusion must match a key some row actually carries. They are now emitted as `None` on both sides and compared, which is a real assertion: a port that refused and still produced a classification differs there.

## Related

**CHAOS-3505** — filed from this lane's analysis of the *second* engine: `load_status_mapping` hardcodes `("jira","github","gitlab")`, so the `linear` section checked into `config/status_mapping.yaml` is silently ignored, and `STATUS_MAPPING_PATH` overrides an explicitly-passed `path` argument. Neither is touched here; both are pinned by the follow-up `StatusMapping` PR, which mirrors them bug-for-bug per D16.

## Evidence

**56 oracle cases** executing the real `InvestmentClassifier`, across three pairs:

- `analytics/investment/classify` — **36** cases over 14 configs: 6 against the real production config, 8 against `quirks.yaml`, 21 across 11 further synthetic configs, 1 against a missing path.
- `analytics/investment/refusal` — **15** cases, comparing a phase-qualified Python exception name against the Go refusal.
- `analytics/investment/divergence` — **5** cases, asserting each declared divergence still exists.

Plus 4 tripwire/guard tests (call-site premise, derived dead set, dead-arms-work-when-fed, missing-config-is-missing).

**Every new guard was observed failing before being trusted** — 29 planted defects across two rounds, each confirmed to kill the specific case claiming to cover it, at the right assertion. Round one covered the fail-open null `match:`, an undiscriminated refusal class, absent-vs-null rule ids, output nulls falling back to defaults, a case-folded component arm, a defaulted absent component, first-wins duplicate keys, equality instead of containment, an un-normalised YAML 1.1 bool, a hoisted `path_prefix` resolution, a `component` field added to `WorkItem`, `data_component` made reachable, a 45th rule, and the missing config file created. Round two covered unexpanded merge keys, both merge-precedence rules, a swallowed merge error, both halves of the phase value, project_stream's null handling alone, a silently-mirrored declared divergence, a declared divergence downgraded to a false mirror, and the mixed-priority claim. Round one was **re-run against the refactored code** rather than trusted from before it, since anchors drift. Two round-two mutations initially survived: one was an invalid mutation targeting the wrong loop, the other a genuine missing case, now added.

Every mutation was restored and the restore verified by **sha256 of the file contents**, not by `git diff` or a rebuild.

`ci/check_go.sh fast` exits **0**: `gofmt` clean, `go vet` clean, `go vet -tags=integration` clean, full `go test ./...`, and the live-Python-oracle stage (`-count=1`, both `DEV_HEALTH_LIVE_PYTHON_ORACLES` and `DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR` set) with an execution proof recorded for every checked-in oracle pair including all three new ones.

## The oracles did not check WHICH checkout's Python they were comparing against

Raised as an environment warning by another lane, then reproduced here directly.

`pythonExecutable` falls back to `python3` from `PATH`. On this machine that shim is a pyenv virtualenv editable-installed against a **different worktree**. With `PYTHONPATH` unset, the investment oracle executed `ops-worktrees/chaos-3219-compose-env/src/dev_health_ops/analytics/investment.py` while reading **this** worktree's config and testdata — half the comparison from one checkout, half from another — and the suite reported `ok`.

This was never a gate failure: `ci/check_go.sh` sets `PYTHONPATH="${ROOT}/src"`, so the producer is always correct through the gate (verified by running the gate with `PYTHON` explicitly *unset* — still exit 0). It is a trap for a bare `go test` with the opt-in env vars, and a green run is exactly the output that stops anyone looking.

`pythonExecutable` now asserts the interpreter resolves `dev_health_ops` inside this checkout and names both paths when it does not. `find_spec` locates the package without executing it, so the check can neither disturb nor be disturbed by the stub namespace `python_oracle_loader.py` installs; the result is cached, so the whole package pays for one subprocess. Observed failing against the real mis-resolution before being trusted.

**Interpreter provenance for the evidence in this PR:** every oracle run reported here executed `<worktree>/.venv/bin/python` (3.14.6), pinned via `PYTHON`, resolving `dev_health_ops` from this worktree's `src/`. The full matrix was additionally re-run under the *ambient* interpreter (3.13.14) with a correct `PYTHONPATH` and produced identical rows, so the compared exception classes and phases are not an artefact of one interpreter version.
